### PR TITLE
[2/n] multi: prep MessageSignerRing for G175 messages

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -24,7 +24,6 @@ import (
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnpeer"
 	"github.com/lightningnetwork/lnd/lnutils"
-	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/multimutex"
 	"github.com/lightningnetwork/lnd/netann"
@@ -247,14 +246,14 @@ type Config struct {
 	// use to determine which messages need to be resent for a given peer.
 	MessageStore GossipMessageStore
 
-	// AnnSigner is an instance of the MessageSigner interface which will
-	// be used to manually sign any outgoing channel updates. The signer
-	// implementation should be backed by the public key of the backing
-	// Lightning node.
+	// AnnSigner is an instance of the MessageSignerRing interface which
+	// will be used to manually sign any outgoing channel updates. The
+	// signer implementation should be backed by the public key of the
+	// backing Lightning node.
 	//
 	// TODO(roasbeef): extract ann crafting + sign from fundingMgr into
 	// here?
-	AnnSigner lnwallet.MessageSigner
+	AnnSigner keychain.MessageSignerRing
 
 	// NumActiveSyncers is the number of peers for which we should have
 	// active syncers with. After reaching NumActiveSyncers, any future

--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -107,6 +107,12 @@
 
 * [Remove database pointers](https://github.com/lightningnetwork/lnd/pull/8117) 
   from channeldb schema structs.
+* In preparation for gossip 1.75 updates, we add a `SignMuSig2` method to the
+  MessageSignerRing interface, [then we pass around the MessageSignerRing
+  interface](https://github.com/lightningnetwork/lnd/pull/8163) to various 
+  systems that will need its `SignMuSig2` and `SignMessageSchnorr` methods for 
+  signing the upcoming gossip 1.75 messages. This includes the gossiper, the 
+  funding manager and the channel status manager.
 
 ## Tooling and Documentation
 

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -376,15 +375,8 @@ type Config struct {
 	// ChannelDB is the database that keeps track of all channel state.
 	ChannelDB *channeldb.ChannelStateDB
 
-	// SignMessage signs an arbitrary message with a given public key. The
-	// actual digest signed is the double sha-256 of the message. In the
-	// case that the private key corresponding to the passed public key
-	// cannot be located, then an error is returned.
-	//
-	// TODO(roasbeef): should instead pass on this responsibility to a
-	// distinct sub-system?
-	SignMessage func(keyLoc keychain.KeyLocator,
-		msg []byte, doubleHash bool) (*ecdsa.Signature, error)
+	// MessageSigner can be used to sign various wire messages.
+	MessageSigner keychain.MessageSignerRing
 
 	// CurrentNodeAnnouncement should return the latest, fully signed node
 	// announcement from the backing Lightning Network node with a fresh
@@ -4206,7 +4198,9 @@ func (f *Manager) newChanAnnouncement(localPubKey,
 	if err != nil {
 		return nil, err
 	}
-	sig, err := f.cfg.SignMessage(f.cfg.IDKeyLoc, chanUpdateMsg, true)
+	sig, err := f.cfg.MessageSigner.SignMessage(
+		f.cfg.IDKeyLoc, chanUpdateMsg, true,
+	)
 	if err != nil {
 		return nil, errors.Errorf("unable to generate channel "+
 			"update announcement signature: %v", err)
@@ -4228,12 +4222,14 @@ func (f *Manager) newChanAnnouncement(localPubKey,
 	if err != nil {
 		return nil, err
 	}
-	nodeSig, err := f.cfg.SignMessage(f.cfg.IDKeyLoc, chanAnnMsg, true)
+	nodeSig, err := f.cfg.MessageSigner.SignMessage(
+		f.cfg.IDKeyLoc, chanAnnMsg, true,
+	)
 	if err != nil {
 		return nil, errors.Errorf("unable to generate node "+
 			"signature for channel announcement: %v", err)
 	}
-	bitcoinSig, err := f.cfg.SignMessage(
+	bitcoinSig, err := f.cfg.MessageSigner.SignMessage(
 		localFundingKey.KeyLocator, chanAnnMsg, true,
 	)
 	if err != nil {

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -445,17 +445,13 @@ func createTestFundingManager(t *testing.T, privKey *btcec.PrivateKey,
 	chainedAcceptor := acpt.NewChainedAcceptor()
 
 	fundingCfg := Config{
-		IDKey:        privKey.PubKey(),
-		IDKeyLoc:     testKeyLoc,
-		Wallet:       lnw,
-		Notifier:     chainNotifier,
-		ChannelDB:    cdb,
-		FeeEstimator: estimator,
-		SignMessage: func(_ keychain.KeyLocator,
-			_ []byte, _ bool) (*ecdsa.Signature, error) {
-
-			return testSig, nil
-		},
+		IDKey:         privKey.PubKey(),
+		IDKeyLoc:      testKeyLoc,
+		Wallet:        lnw,
+		Notifier:      chainNotifier,
+		ChannelDB:     cdb,
+		FeeEstimator:  estimator,
+		MessageSigner: &mockSigner{},
 		SendAnnouncement: func(msg lnwire.Message,
 			_ ...discovery.OptionalMsgField) chan error {
 
@@ -608,17 +604,13 @@ func recreateAliceFundingManager(t *testing.T, alice *testNode) {
 	chainedAcceptor := acpt.NewChainedAcceptor()
 
 	f, err := NewFundingManager(Config{
-		IDKey:        oldCfg.IDKey,
-		IDKeyLoc:     oldCfg.IDKeyLoc,
-		Wallet:       oldCfg.Wallet,
-		Notifier:     oldCfg.Notifier,
-		ChannelDB:    oldCfg.ChannelDB,
-		FeeEstimator: oldCfg.FeeEstimator,
-		SignMessage: func(_ keychain.KeyLocator,
-			_ []byte, _ bool) (*ecdsa.Signature, error) {
-
-			return testSig, nil
-		},
+		IDKey:         oldCfg.IDKey,
+		IDKeyLoc:      oldCfg.IDKeyLoc,
+		Wallet:        oldCfg.Wallet,
+		Notifier:      oldCfg.Notifier,
+		ChannelDB:     oldCfg.ChannelDB,
+		FeeEstimator:  oldCfg.FeeEstimator,
+		MessageSigner: &mockSigner{},
 		SendAnnouncement: func(msg lnwire.Message,
 			_ ...discovery.OptionalMsgField) chan error {
 
@@ -4954,4 +4946,14 @@ func TestFundingManagerCoinbase(t *testing.T) {
 	// Check that they notify the breach arbiter and peer about the new
 	// channel.
 	assertHandleChannelReady(t, alice, bob)
+}
+
+type mockSigner struct {
+	keychain.MessageSignerRing
+}
+
+func (s *mockSigner) SignMessage(_ keychain.KeyLocator, _ []byte,
+	_ bool) (*ecdsa.Signature, error) {
+
+	return testSig, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -208,6 +208,8 @@ replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 // allows us to specify that as an option.
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display
 
+replace github.com/btcsuite/btcd/btcec/v2 => github.com/ellemouton/btcd/btcec/v2 v2.1.1-0.20231109093720-35e0f57c1096
+
 // If you change this please also update .github/pull_request_template.md and
 // docs/INSTALL.md.
 go 1.19

--- a/go.sum
+++ b/go.sum
@@ -76,11 +76,6 @@ github.com/btcsuite/btcd v0.23.0/go.mod h1:0QJIIN1wwIXF/3G/m87gIwGniDMDQqjVn4SZg
 github.com/btcsuite/btcd v0.23.1/go.mod h1:0QJIIN1wwIXF/3G/m87gIwGniDMDQqjVn4SZgnFpsYY=
 github.com/btcsuite/btcd v0.23.5-0.20230905170901-80f5a0ffdf36 h1:g/UbZ6iSzcUH9kEvC+rB8UBCqahmt69e8y6nCegczbg=
 github.com/btcsuite/btcd v0.23.5-0.20230905170901-80f5a0ffdf36/go.mod h1:0QJIIN1wwIXF/3G/m87gIwGniDMDQqjVn4SZgnFpsYY=
-github.com/btcsuite/btcd/btcec/v2 v2.1.0/go.mod h1:2VzYrv4Gm4apmbVVsSq5bqf1Ec8v56E48Vt0Y/umPgA=
-github.com/btcsuite/btcd/btcec/v2 v2.1.1/go.mod h1:ctjw4H1kknNJmRN4iP1R7bTQ+v3GJkZBd6mui8ZsAZE=
-github.com/btcsuite/btcd/btcec/v2 v2.1.3/go.mod h1:ctjw4H1kknNJmRN4iP1R7bTQ+v3GJkZBd6mui8ZsAZE=
-github.com/btcsuite/btcd/btcec/v2 v2.3.2 h1:5n0X6hX0Zk+6omWcihdYvdAlGf2DfasC0GMf7DClJ3U=
-github.com/btcsuite/btcd/btcec/v2 v2.3.2/go.mod h1:zYzJ8etWJQIv1Ogk7OzpWjowwOdXY1W/17j2MW85J04=
 github.com/btcsuite/btcd/btcutil v1.0.0/go.mod h1:Uoxwv0pqYWhD//tfTiipkxNfdhG9UrLwaeswfjfdF0A=
 github.com/btcsuite/btcd/btcutil v1.1.0/go.mod h1:5OapHB7A2hBBWLm48mmw4MOHNJCcUBTwmWH/0Jn8VHE=
 github.com/btcsuite/btcd/btcutil v1.1.1/go.mod h1:nbKlBMNm9FGsdvKvu0essceubPiAcI57pYBNnsLAa34=
@@ -187,6 +182,8 @@ github.com/dsnet/compress v0.0.1/go.mod h1:Aw8dCMJ7RioblQeTqt88akK31OvO8Dhf5Jflh
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/ellemouton/btcd/btcec/v2 v2.1.1-0.20231109093720-35e0f57c1096 h1:ZRbOFfz6rlOWhiEgKSw7+hQDoV//6IrA5a4VAiiO0Ls=
+github.com/ellemouton/btcd/btcec/v2 v2.1.1-0.20231109093720-35e0f57c1096/go.mod h1:zYzJ8etWJQIv1Ogk7OzpWjowwOdXY1W/17j2MW85J04=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/keychain/btcwallet.go
+++ b/keychain/btcwallet.go
@@ -7,6 +7,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcwallet/waddrmgr"
@@ -449,6 +450,28 @@ func (b *BtcWalletKeyRing) SignMessageCompact(keyLoc KeyLocator,
 		digest = chainhash.HashB(msg)
 	}
 	return ecdsa.SignCompact(privKey, digest, true)
+}
+
+// SignMuSig2 generates a MuSig2 partial signature given the passed key set,
+// secret nonce, public nonce, and private keys
+//
+// NOTE: This is part of the keychain.MessageSignerRing interface.
+func (b *BtcWalletKeyRing) SignMuSig2(secNonce [musig2.SecNonceSize]byte,
+	keyLoc KeyLocator, _ [][musig2.PubNonceSize]byte,
+	combinedNonce [musig2.PubNonceSize]byte, pubKeys []*btcec.PublicKey,
+	msg [32]byte, signOpts ...musig2.SignOption) (*musig2.PartialSignature,
+	error) {
+
+	privKey, err := b.DerivePrivKey(KeyDescriptor{
+		KeyLocator: keyLoc,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return musig2.Sign(
+		secNonce, privKey, combinedNonce, pubKeys, msg, signOpts...,
+	)
 }
 
 // SignMessageSchnorr uses the Schnorr signature algorithm to sign the given

--- a/keychain/btcwallet.go
+++ b/keychain/btcwallet.go
@@ -506,5 +506,6 @@ func (b *BtcWalletKeyRing) SignMessageSchnorr(keyLoc KeyLocator,
 	default:
 		digest = chainhash.HashB(msg)
 	}
+
 	return schnorr.Sign(privKey, digest)
 }

--- a/keychain/derivation.go
+++ b/keychain/derivation.go
@@ -6,6 +6,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 )
 
 const (
@@ -241,6 +242,14 @@ type MessageSignerRing interface {
 	SignMessageSchnorr(keyLoc KeyLocator, msg []byte,
 		doubleHash bool, taprootTweak []byte,
 		tag []byte) (*schnorr.Signature, error)
+
+	// SignMuSig2 generates a MuSig2 partial signature given the passed key
+	// set, secret nonce, public nonce, and private keys
+	SignMuSig2(secNonce [musig2.SecNonceSize]byte,
+		keyLoc KeyLocator, otherNonces [][musig2.PubNonceSize]byte,
+		combinedNonce [musig2.PubNonceSize]byte,
+		pubKeys []*btcec.PublicKey, msg [32]byte,
+		opts ...musig2.SignOption) (*musig2.PartialSignature, error)
 }
 
 // SingleKeyMessageSigner is an abstraction interface that hides the

--- a/keychain/derivation.go
+++ b/keychain/derivation.go
@@ -271,6 +271,20 @@ type SingleKeyMessageSigner interface {
 	// hashing it first, with the wrapped private key and returns the
 	// signature in the compact, public key recoverable format.
 	SignMessageCompact(message []byte, doubleHash bool) ([]byte, error)
+
+	// SignMuSig2 generates a MuSig2 partial signature given the passed key
+	// set, secret nonce, public nonce, and private keys.
+	SignMuSig2(secNonce [musig2.SecNonceSize]byte,
+		keyLoc KeyLocator, otherNonces [][musig2.PubNonceSize]byte,
+		combinedNonce [musig2.PubNonceSize]byte,
+		pubKeys []*btcec.PublicKey, msg [32]byte,
+		opts ...musig2.SignOption) (*musig2.PartialSignature, error)
+
+	// SignMessageSchnorr signs the given message, single or double SHA256
+	// hashing it first, with the private key described in the key locator
+	// and the optional Taproot tweak applied to the private key.
+	SignMessageSchnorr(keyLoc KeyLocator, msg []byte, doubleHash bool,
+		taprootTweak, tag []byte) (*schnorr.Signature, error)
 }
 
 // ECDHRing is an interface that abstracts away basic low-level ECDH shared key

--- a/keychain/signer.go
+++ b/keychain/signer.go
@@ -3,7 +3,10 @@ package keychain
 import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
 )
 
 func NewPubKeyMessageSigner(pubKey *btcec.PublicKey, keyLoc KeyLocator,
@@ -40,6 +43,25 @@ func (p *PubKeyMessageSigner) SignMessageCompact(msg []byte,
 	doubleHash bool) ([]byte, error) {
 
 	return p.digestSigner.SignMessageCompact(p.keyLoc, msg, doubleHash)
+}
+
+func (p *PubKeyMessageSigner) SignMuSig2(secNonce [97]byte, keyLoc KeyLocator,
+	otherNonces [][66]byte, combinedNonce [66]byte,
+	pubKeys []*btcec.PublicKey, msg [32]byte, opts ...musig2.SignOption) (
+	*musig2.PartialSignature, error) {
+
+	return p.digestSigner.SignMuSig2(
+		secNonce, keyLoc, otherNonces, combinedNonce, pubKeys, msg,
+		opts...,
+	)
+}
+
+func (p *PubKeyMessageSigner) SignMessageSchnorr(keyLoc KeyLocator, msg []byte,
+	doubleHash bool, taprootTweak, tag []byte) (*schnorr.Signature, error) {
+
+	return p.digestSigner.SignMessageSchnorr(
+		keyLoc, msg, doubleHash, taprootTweak, tag,
+	)
 }
 
 func NewPrivKeyMessageSigner(privKey *btcec.PrivateKey,
@@ -86,6 +108,39 @@ func (p *PrivKeyMessageSigner) SignMessageCompact(msg []byte,
 		digest = chainhash.HashB(msg)
 	}
 	return ecdsa.SignCompact(p.privKey, digest, true)
+}
+
+func (p *PrivKeyMessageSigner) SignMuSig2(secNonce [97]byte, _ KeyLocator,
+	_ [][66]byte, combinedNonce [66]byte,
+	pubKeys []*btcec.PublicKey, msg [32]byte, opts ...musig2.SignOption) (
+	*musig2.PartialSignature, error) {
+
+	return musig2.Sign(
+		secNonce, p.privKey, combinedNonce, pubKeys, msg, opts...,
+	)
+}
+
+func (p *PrivKeyMessageSigner) SignMessageSchnorr(_ KeyLocator, msg []byte,
+	doubleHash bool, taprootTweak, tag []byte) (*schnorr.Signature, error) {
+
+	// If a tag was provided, we need to take the tagged hash of the input.
+	var digest []byte
+	switch {
+	case len(tag) > 0:
+		taggedHash := chainhash.TaggedHash(tag, msg)
+		digest = taggedHash[:]
+	case doubleHash:
+		digest = chainhash.DoubleHashB(msg)
+	default:
+		digest = chainhash.HashB(msg)
+	}
+
+	privKey := p.privKey
+	if len(taprootTweak) > 0 {
+		privKey = txscript.TweakTaprootPrivKey(*privKey, taprootTweak)
+	}
+
+	return schnorr.Sign(privKey, digest)
 }
 
 var _ SingleKeyMessageSigner = (*PubKeyMessageSigner)(nil)

--- a/lnrpc/invoicesrpc/addinvoice.go
+++ b/lnrpc/invoicesrpc/addinvoice.go
@@ -450,7 +450,9 @@ func AddInvoice(ctx context.Context, cfg *AddInvoiceConfig,
 
 	payReqString, err := payReq.Encode(zpay32.MessageSigner{
 		SignCompact: func(msg []byte) ([]byte, error) {
-			return cfg.NodeSigner.SignMessageCompact(msg, false)
+			return cfg.NodeSigner.SignMessageCompactNoKeyLoc(
+				msg, false,
+			)
 		},
 	})
 	if err != nil {

--- a/lntest/mock/secretkeyring.go
+++ b/lntest/mock/secretkeyring.go
@@ -4,6 +4,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -94,4 +95,17 @@ func (s *SecretKeyRing) SignMessageSchnorr(_ keychain.KeyLocator,
 	}
 
 	return schnorr.Sign(privKey, digest)
+}
+
+// SignMuSig2 generates a MuSig2 partial signature given the passed key set,
+// secret nonce, public nonce, and private keys.
+func (s *SecretKeyRing) SignMuSig2(secNonce [musig2.SecNonceSize]byte,
+	_ keychain.KeyLocator, _ [][musig2.PubNonceSize]byte,
+	combinedNonce [musig2.PubNonceSize]byte, pubKeys []*btcec.PublicKey,
+	msg [32]byte, opts ...musig2.SignOption) (*musig2.PartialSignature,
+	error) {
+
+	return musig2.Sign(
+		secNonce, s.RootKey, combinedNonce, pubKeys, msg, opts...,
+	)
 }

--- a/lntest/mock/signer.go
+++ b/lntest/mock/signer.go
@@ -205,3 +205,91 @@ func (s *SingleSigner) SignMessage(keyLoc keychain.KeyLocator,
 	}
 	return ecdsa.Sign(s.Privkey, digest), nil
 }
+
+// SignMessageCompact signs the given message, single or double SHA256 hashing
+// it first, with the private key described in the key locator and returns the
+// signature in the compact, public key recoverable format.
+//
+// NOTE: This is part of the keychain.MessageSignerRing interface.
+func (s *SingleSigner) SignMessageCompact(keyLoc keychain.KeyLocator,
+	msg []byte, doubleHash bool) ([]byte, error) {
+
+	mockKeyLoc := s.KeyLoc
+	if s.KeyLoc.IsEmpty() {
+		mockKeyLoc = idKeyLoc
+	}
+
+	if keyLoc != mockKeyLoc {
+		return nil, fmt.Errorf("unknown public key")
+	}
+
+	var digest []byte
+	if doubleHash {
+		digest = chainhash.DoubleHashB(msg)
+	} else {
+		digest = chainhash.HashB(msg)
+	}
+
+	return ecdsa.SignCompact(s.Privkey, digest, true)
+}
+
+// SignMessageSchnorr signs the given message, single or double SHA256 hashing
+// it first, with the private key described in the key locator and the optional
+// Taproot tweak applied to the private key.
+//
+// NOTE: this is part of the keychain.MessageSignerRing interface.
+func (s *SingleSigner) SignMessageSchnorr(keyLoc keychain.KeyLocator,
+	msg []byte, doubleHash bool, taprootTweak, tag []byte) (
+	*schnorr.Signature, error) {
+
+	mockKeyLoc := s.KeyLoc
+	if s.KeyLoc.IsEmpty() {
+		mockKeyLoc = idKeyLoc
+	}
+
+	if keyLoc != mockKeyLoc {
+		return nil, fmt.Errorf("unknown public key")
+	}
+
+	privKey := s.Privkey
+	if len(taprootTweak) > 0 {
+		privKey = txscript.TweakTaprootPrivKey(*privKey, taprootTweak)
+	}
+
+	// If a tag was provided, we need to take the tagged hash of the input.
+	var digest []byte
+	switch {
+	case len(tag) > 0:
+		taggedHash := chainhash.TaggedHash(tag, msg)
+		digest = taggedHash[:]
+	case doubleHash:
+		digest = chainhash.DoubleHashB(msg)
+	default:
+		digest = chainhash.HashB(msg)
+	}
+
+	return schnorr.Sign(privKey, digest)
+}
+
+// SignMuSig2 generates a MuSig2 partial signature given the passed key set,
+// secret nonce, public nonce, and private keys
+//
+// NOTE: This is part of the keychain.MessageSignerRing interface.
+func (s *SingleSigner) SignMuSig2(secNonce [97]byte,
+	keyLoc keychain.KeyLocator, _ [][66]byte,
+	combinedNonce [66]byte, pubKeys []*btcec.PublicKey, msg [32]byte,
+	opts ...musig2.SignOption) (*musig2.PartialSignature, error) {
+
+	mockKeyLoc := s.KeyLoc
+	if s.KeyLoc.IsEmpty() {
+		mockKeyLoc = idKeyLoc
+	}
+
+	if keyLoc != mockKeyLoc {
+		return nil, fmt.Errorf("unknown public key")
+	}
+
+	return musig2.Sign(
+		secNonce, s.Privkey, combinedNonce, pubKeys, msg, opts...,
+	)
+}

--- a/netann/chan_status_manager.go
+++ b/netann/chan_status_manager.go
@@ -9,7 +9,6 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/keychain"
-	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
 
@@ -49,7 +48,7 @@ type ChanStatusConfig struct {
 	OurKeyLoc keychain.KeyLocator
 
 	// MessageSigner signs messages that validate under OurPubKey.
-	MessageSigner lnwallet.MessageSigner
+	MessageSigner keychain.MessageSignerRing
 
 	// IsChannelActive checks whether the channel identified by the provided
 	// ChannelID is considered active. This should only return true if the

--- a/netann/channel_update.go
+++ b/netann/channel_update.go
@@ -8,7 +8,6 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/keychain"
-	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
 
@@ -56,8 +55,9 @@ func ChanUpdSetTimestamp(update *lnwire.ChannelUpdate) {
 // monotonically increase from the prior.
 //
 // NOTE: This method modifies the given update.
-func SignChannelUpdate(signer lnwallet.MessageSigner, keyLoc keychain.KeyLocator,
-	update *lnwire.ChannelUpdate, mods ...ChannelUpdateModifier) error {
+func SignChannelUpdate(signer keychain.MessageSignerRing,
+	keyLoc keychain.KeyLocator, update *lnwire.ChannelUpdate,
+	mods ...ChannelUpdateModifier) error {
 
 	// Apply the requested changes to the channel update.
 	for _, modifier := range mods {

--- a/netann/channel_update_test.go
+++ b/netann/channel_update_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 type mockSigner struct {
+	keychain.MessageSignerRing
+
 	err error
 }
 
@@ -44,7 +46,7 @@ type updateDisableTest struct {
 	startEnabled bool
 	disable      bool
 	startTime    time.Time
-	signer       lnwallet.MessageSigner
+	signer       keychain.MessageSignerRing
 	expErr       error
 }
 

--- a/netann/node_signer.go
+++ b/netann/node_signer.go
@@ -3,9 +3,11 @@ package netann
 import (
 	"fmt"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/lightningnetwork/lnd/keychain"
-	"github.com/lightningnetwork/lnd/lnwallet"
 )
 
 // NodeSigner is an implementation of the MessageSigner interface backed by the
@@ -43,15 +45,73 @@ func (n *NodeSigner) SignMessage(keyLoc keychain.KeyLocator,
 	return sig, nil
 }
 
-// SignMessageCompact signs a single or double sha256 digest of the msg
+// SignMessageCompactNoKeyLoc signs a single or double sha256 digest of the msg
 // parameter under the resident node's private key. The returned signature is a
-// pubkey-recoverable signature.
-func (n *NodeSigner) SignMessageCompact(msg []byte, doubleHash bool) ([]byte,
-	error) {
+// pubkey-recoverable signature. No key locator is required for this since the
+// NodeSigner already has the key to sign with.
+func (n *NodeSigner) SignMessageCompactNoKeyLoc(msg []byte, doubleHash bool) (
+	[]byte, error) {
 
 	return n.keySigner.SignMessageCompact(msg, doubleHash)
 }
 
+// SignMessageCompact signs the given message, single or double SHA256 hashing
+// it first, with the private key described in the key locator and returns the
+// signature in the compact, public key recoverable format.
+//
+// NOTE: this is part of the keychain.MessageSignerRing interface.
+func (n *NodeSigner) SignMessageCompact(keyLoc keychain.KeyLocator, msg []byte,
+	doubleHash bool) ([]byte, error) {
+
+	// If this isn't our identity public key, then we'll exit early with an
+	// error as we can't sign with this key.
+	if keyLoc != n.keySigner.KeyLocator() {
+		return nil, fmt.Errorf("unknown public key locator")
+	}
+
+	return n.SignMessageCompactNoKeyLoc(msg, doubleHash)
+}
+
+// SignMessageSchnorr signs the given message, single or double SHA256 hashing
+// it first, with the private key described in the key locator and the optional
+// Taproot tweak applied to the private key.
+//
+// NOTE: this is part of the keychain.MessageSignerRing interface.
+func (n *NodeSigner) SignMessageSchnorr(keyLoc keychain.KeyLocator, msg []byte,
+	doubleHash bool, taprootTweak, tag []byte) (*schnorr.Signature, error) {
+
+	// If this isn't our identity public key, then we'll exit early with an
+	// error as we can't sign with this key.
+	if keyLoc != n.keySigner.KeyLocator() {
+		return nil, fmt.Errorf("unknown public key locator")
+	}
+
+	return n.keySigner.SignMessageSchnorr(
+		keyLoc, msg, doubleHash, taprootTweak, tag,
+	)
+}
+
+// SignMuSig2 generates a MuSig2 partial signature given the passed key set,
+// secret nonce, public nonce, and private keys
+//
+// NOTE: this is part of the keychain.MessageSignerRing interface.
+func (n *NodeSigner) SignMuSig2(secNonce [97]byte, keyLoc keychain.KeyLocator,
+	otherNonces [][66]byte, combinedNonce [66]byte,
+	pubKeys []*btcec.PublicKey, msg [32]byte, opts ...musig2.SignOption) (
+	*musig2.PartialSignature, error) {
+
+	// If this isn't our identity public key, then we'll exit early with an
+	// error as we can't sign with this key.
+	if keyLoc != n.keySigner.KeyLocator() {
+		return nil, fmt.Errorf("unknown public key locator")
+	}
+
+	return n.keySigner.SignMuSig2(
+		secNonce, keyLoc, otherNonces, combinedNonce, pubKeys, msg,
+		opts...,
+	)
+}
+
 // A compile time check to ensure that NodeSigner implements the MessageSigner
 // interface.
-var _ lnwallet.MessageSigner = (*NodeSigner)(nil)
+var _ keychain.MessageSignerRing = (*NodeSigner)(nil)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1572,7 +1572,7 @@ func (r *rpcServer) SignMessage(_ context.Context,
 	}
 
 	in.Msg = append(signedMsgPrefix, in.Msg...)
-	sigBytes, err := r.server.nodeSigner.SignMessageCompact(
+	sigBytes, err := r.server.nodeSigner.SignMessageCompactNoKeyLoc(
 		in.Msg, !in.SingleHash,
 	)
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -1290,10 +1290,10 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		UpdateLabel: func(hash chainhash.Hash, label string) error {
 			return cc.Wallet.LabelTransaction(hash, label, true)
 		},
-		Notifier:     cc.ChainNotifier,
-		ChannelDB:    s.chanStateDB,
-		FeeEstimator: cc.FeeEstimator,
-		SignMessage:  cc.MsgSigner.SignMessage,
+		Notifier:      cc.ChainNotifier,
+		ChannelDB:     s.chanStateDB,
+		FeeEstimator:  cc.FeeEstimator,
+		MessageSigner: cc.KeyRing,
 		CurrentNodeAnnouncement: func() (lnwire.NodeAnnouncement,
 			error) {
 


### PR DESCRIPTION
In preparation for gossip 1.75 updates, we add a `SignMuSig2` method to the
MessageSignerRing interface, then we pass around the MessageSignerRing
interface to various systems that will need its `SignMuSig2` and 
`SignMessageSchnorr` methods for signing the upcoming gossip 1.75 messages.
 This includes the gossiper, the funding manager and the channel status 
 manager.

Depends on [an update to btcd](https://github.com/btcsuite/btcd/pull/2058) to export the MuSig2 signing options. 

Part of the [Gossip 1.75 epic](https://github.com/lightningnetwork/lnd/issues/7961)