### PR TITLE
tlv: simplify encoding functions

### DIFF
--- a/tlv/primitive.go
+++ b/tlv/primitive.go
@@ -68,9 +68,7 @@ var (
 // *uint8.
 func EUint8(w io.Writer, val interface{}, buf *[8]byte) error {
 	if i, ok := val.(*uint8); ok {
-		buf[0] = *i
-		_, err := w.Write(buf[:1])
-		return err
+		return EUint8T(w, *i, buf)
 	}
 	return NewTypeForEncodingErr(val, "uint8")
 }
@@ -88,9 +86,7 @@ func EUint8T(w io.Writer, val uint8, buf *[8]byte) error {
 // *uint16.
 func EUint16(w io.Writer, val interface{}, buf *[8]byte) error {
 	if i, ok := val.(*uint16); ok {
-		byteOrder.PutUint16(buf[:2], *i)
-		_, err := w.Write(buf[:2])
-		return err
+		return EUint16T(w, *i, buf)
 	}
 	return NewTypeForEncodingErr(val, "uint16")
 }
@@ -108,9 +104,7 @@ func EUint16T(w io.Writer, val uint16, buf *[8]byte) error {
 // *uint32.
 func EUint32(w io.Writer, val interface{}, buf *[8]byte) error {
 	if i, ok := val.(*uint32); ok {
-		byteOrder.PutUint32(buf[:4], *i)
-		_, err := w.Write(buf[:4])
-		return err
+		return EUint32T(w, *i, buf)
 	}
 	return NewTypeForEncodingErr(val, "uint32")
 }
@@ -128,9 +122,7 @@ func EUint32T(w io.Writer, val uint32, buf *[8]byte) error {
 // *uint64.
 func EUint64(w io.Writer, val interface{}, buf *[8]byte) error {
 	if i, ok := val.(*uint64); ok {
-		byteOrder.PutUint64(buf[:], *i)
-		_, err := w.Write(buf[:])
-		return err
+		return EUint64T(w, *i, buf)
 	}
 	return NewTypeForEncodingErr(val, "uint64")
 }
@@ -147,13 +139,7 @@ func EUint64T(w io.Writer, val uint64, buf *[8]byte) error {
 // EBool encodes a boolean. An error is returned if val is not a boolean.
 func EBool(w io.Writer, val interface{}, buf *[8]byte) error {
 	if i, ok := val.(*bool); ok {
-		if *i {
-			buf[0] = 1
-		} else {
-			buf[0] = 0
-		}
-		_, err := w.Write(buf[:1])
-		return err
+		return EBoolT(w, *i, buf)
 	}
 	return NewTypeForEncodingErr(val, "bool")
 }

--- a/tlv/truncated.go
+++ b/tlv/truncated.go
@@ -32,10 +32,7 @@ func SizeTUint16(v uint16) uint64 {
 // be omitted. An error is returned if val is not a *uint16.
 func ETUint16(w io.Writer, val interface{}, buf *[8]byte) error {
 	if t, ok := val.(*uint16); ok {
-		binary.BigEndian.PutUint16(buf[:2], *t)
-		numZeros := numLeadingZeroBytes16(*t)
-		_, err := w.Write(buf[numZeros:2])
-		return err
+		return ETUint16T(w, *t, buf)
 	}
 	return NewTypeForEncodingErr(val, "uint16")
 }
@@ -93,10 +90,7 @@ func SizeTUint32(v uint32) uint64 {
 // be omitted. An error is returned if val is not a *uint32.
 func ETUint32(w io.Writer, val interface{}, buf *[8]byte) error {
 	if t, ok := val.(*uint32); ok {
-		binary.BigEndian.PutUint32(buf[:4], *t)
-		numZeros := numLeadingZeroBytes32(*t)
-		_, err := w.Write(buf[numZeros:4])
-		return err
+		return ETUint32T(w, *t, buf)
 	}
 	return NewTypeForEncodingErr(val, "uint32")
 }
@@ -164,10 +158,7 @@ func SizeTUint64(v uint64) uint64 {
 // be omitted. An error is returned if val is not a *uint64.
 func ETUint64(w io.Writer, val interface{}, buf *[8]byte) error {
 	if t, ok := val.(*uint64); ok {
-		binary.BigEndian.PutUint64(buf[:], *t)
-		numZeros := numLeadingZeroBytes64(*t)
-		_, err := w.Write(buf[numZeros:])
-		return err
+		return ETUint64T(w, *t, buf)
 	}
 	return NewTypeForEncodingErr(val, "uint64")
 }


### PR DESCRIPTION
The typeless functions can directly call the typed functions after the type check.