### PR TITLE
peer/test: fix race in TestHandleNewPendingChannel

### DIFF
--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -1183,18 +1183,6 @@ func TestHandleNewPendingChannel(t *testing.T) {
 	chanIDNotExist := lnwire.ChannelID{1}
 	chanIDPending := lnwire.ChannelID{2}
 
-	// Create a test brontide.
-	dummyConfig := Config{}
-	peer := NewBrontide(dummyConfig)
-
-	// Create the test state.
-	peer.activeChannels.Store(chanIDActive, &lnwallet.LightningChannel{})
-	peer.activeChannels.Store(chanIDPending, nil)
-
-	// Assert test state, we should have two channels store, one active and
-	// one pending.
-	require.Equal(t, 2, peer.activeChannels.Len())
-
 	testCases := []struct {
 		name   string
 		chanID lnwire.ChannelID
@@ -1234,9 +1222,22 @@ func TestHandleNewPendingChannel(t *testing.T) {
 			t.Parallel()
 			require := require.New(t)
 
-			// Get the number of channels before mutating the
-			// state.
-			numChans := peer.activeChannels.Len()
+			// Create a test brontide.
+			dummyConfig := Config{}
+			peer := NewBrontide(dummyConfig)
+
+			// Create the test state.
+			peer.activeChannels.Store(
+				chanIDActive, &lnwallet.LightningChannel{},
+			)
+			peer.activeChannels.Store(chanIDPending, nil)
+
+			// Assert test state, we should have two channels
+			// store, one active and one pending.
+			numChans := 2
+			require.EqualValues(
+				numChans, peer.activeChannels.Len(),
+			)
 
 			// Call the method.
 			peer.handleNewPendingChannel(req)


### PR DESCRIPTION
While flakehunting #8128, I ran into another flake in the `peer` tests: 
```
--- FAIL: TestHandleNewPendingChannel (0.00s)
--- FAIL: TestHandleNewPendingChannel/noop_on_active_channel (0.00s)
brontide_test.go:1250:
Error Trace:    /Users/carla/Work/lnd/peer/brontide_test.go:1250
Error:          Not equal:
expected: 2
actual  : 3
Test:           TestHandleNewPendingChannel/noop_on_active_channel
FAIL
FAIL    [github.com/lightningnetwork/lnd/peer](http://github.com/lightningnetwork/lnd/peer)    9.065s
```

We're not getting the number of channels that we expect because the parallel test cases are all updating the same peer. It can therefore be the case that: 
- `noop on active channel` checks how many channels we start with = 2
- `new channel should be added` checks how many channels we start with = 2
- `new channel should be added` adds a new channel (bumping the count to 3) 
- `noop on active channel` checks how many channels we end with an unexpectedly sees 3 channels

This all just depends on the order that the various test cases acquire the mutex for the underlying `sync.Map` that's used to track channels. Easy fix - just move state setup into test run. 