### PR TITLE
rpc: move diameter calc timing logs to trace log level

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -6340,7 +6340,8 @@ func (r *rpcServer) GetNetworkInfo(ctx context.Context,
 	}
 	start := time.Now()
 	diameter := simpleGraph.DiameterRadialCutoff()
-	rpcsLog.Infof("elapsed time for diameter (%d) calculation: %v", diameter,
+
+	rpcsLog.Tracef("elapsed time for diameter (%d) calculation: %v", diameter,
 		time.Since(start))
 
 	// TODO(roasbeef): also add oldest channel?


### PR DESCRIPTION
In this commit, we move the logs printed each time we calculate the diameter of the graph to the `trace` log level to reduce on log spam.

