### PR TITLE
docs: fix typos [skip ci]

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -28,7 +28,7 @@ healthcheck.torconnection.internal=xxx
 ```
 Read more about the usage of the flags in the `sample-lnd.conf`.
 
-## LN Peer-to-Peer Netowrk
+## LN Peer-to-Peer Network
 
 ### Bitcoin Blockheaders in Ping Messages
 

--- a/docs/release-notes/release-notes-0.16.1.md
+++ b/docs/release-notes/release-notes-0.16.1.md
@@ -76,7 +76,7 @@ https://github.com/lightningnetwork/lnd/pull/7359)
   renamed](https://github.com/lightningnetwork/lnd/pull/7517) to
   `channel_ready` internally to match the specs update. This should not change
   anything for the users since the message type(36) stays unchanged, except in
-  the logging all the appearance of `funding_locked` replated experssion is
+  the logging all the appearance of `funding_locked` replated expression is
   replaced with `channel_ready`.
 
 ## Bug Fixes

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1139,7 +1139,7 @@
 
 [routerrpc]
 
-; Probability estimator used for pathfinding. Two estimators are availabe:
+; Probability estimator used for pathfinding. Two estimators are available:
 ; apriori and bimodal.
 ; Note that the bimodal estimator is experimental.
 ; Default:


### PR DESCRIPTION
## Change Description
Docs: fix typos

### Code Style and Documentation
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

