### PR TITLE
multi: RBF signalling

### DIFF
--- a/contractcourt/commit_sweep_resolver_test.go
+++ b/contractcourt/commit_sweep_resolver_test.go
@@ -141,7 +141,7 @@ func (s *mockSweeper) SweepInput(input input.Input, params sweep.Params) (
 }
 
 func (s *mockSweeper) CreateSweepTx(inputs []input.Input, feePref sweep.FeePreference,
-	currentBlockHeight uint32) (*wire.MsgTx, error) {
+	currentBlockHeight uint32, enableRBF bool) (*wire.MsgTx, error) {
 
 	// We will wait for the test to supply the sweep tx to return.
 	sweepTx := <-s.createSweepTxChan

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -437,12 +437,13 @@ func (h *htlcSuccessResolver) resolveRemoteCommitOutput() (
 		// complete.
 		//
 		// TODO: Use time-based sweeper and result chan.
+
 		var err error
 		h.sweepTx, err = h.Sweeper.CreateSweepTx(
 			[]input.Input{inp},
 			sweep.FeePreference{
 				ConfTarget: sweepConfTarget,
-			}, 0,
+			}, 0, false,
 		)
 		if err != nil {
 			return nil, err

--- a/contractcourt/interfaces.go
+++ b/contractcourt/interfaces.go
@@ -53,7 +53,7 @@ type UtxoSweeper interface {
 	// that spends from them. This method also makes an accurate fee
 	// estimate before generating the required witnesses.
 	CreateSweepTx(inputs []input.Input, feePref sweep.FeePreference,
-		currentBlockHeight uint32) (*wire.MsgTx, error)
+		currentBlockHeight uint32, enableRBF bool) (*wire.MsgTx, error)
 
 	// RelayFeePerKW returns the minimum fee rate required for transactions
 	// to be relayed.

--- a/funding/batch_test.go
+++ b/funding/batch_test.go
@@ -119,6 +119,7 @@ func (h *testHarness) parseRequest(
 		RemoteCsvDelay: uint16(in.RemoteCsvDelay),
 		MinConfs:       in.MinConfs,
 		MaxLocalCsv:    uint16(in.MaxLocalCsv),
+		EnableRBF:      true,
 	}, nil
 }
 

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -223,6 +223,10 @@ type InitFundingMsg struct {
 	// Private determines whether or not this channel will be private.
 	Private bool
 
+	// EnableRBF is a boolen which if true sets transaction inputs
+	// to signal RBF
+	EnableRBF bool
+
 	// MinHtlcIn is the minimum incoming HTLC that we accept.
 	MinHtlcIn lnwire.MilliSatoshi
 
@@ -1580,6 +1584,7 @@ func (f *Manager) fundeeProcessOpenChannel(peer lnpeer.Peer,
 		ZeroConf:         zeroConf,
 		OptionScidAlias:  scid,
 		ScidAliasFeature: scidFeatureVal,
+		EnableRBF:        false,
 	}
 
 	reservation, err := f.cfg.Wallet.InitChannelReservation(req)
@@ -4564,6 +4569,7 @@ func (f *Manager) handleInitFundingMsg(msg *InitFundingMsg) {
 		OptionScidAlias:   scid,
 		ScidAliasFeature:  scidFeatureVal,
 		Memo:              msg.Memo,
+		EnableRBF:         msg.EnableRBF,
 	}
 
 	reservation, err := f.cfg.Wallet.InitChannelReservation(req)

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -1028,7 +1028,7 @@ func (b *BtcWallet) CreateSimpleTx(outputs []*wire.TxOut,
 
 	return b.wallet.CreateSimpleTx(
 		nil, defaultAccount, outputs, minConfs, feeSatPerKB,
-		b.cfg.CoinSelectionStrategy, dryRun,
+		b.cfg.CoinSelectionStrategy, dryRun, base.WithRBF(),
 	)
 }
 

--- a/lnwallet/btcwallet/psbt.go
+++ b/lnwallet/btcwallet/psbt.go
@@ -106,7 +106,7 @@ func (b *BtcWallet) FundPsbt(packet *psbt.Packet, minConfs int32,
 		accountNum = account
 	}
 
-	var opts []wallet.TxCreateOption
+	opts := []wallet.TxCreateOption{wallet.WithRBF()}
 	if changeScope != nil {
 		opts = append(opts, wallet.WithCustomChangeScope(changeScope))
 	}

--- a/lnwallet/chanfunding/assembler.go
+++ b/lnwallet/chanfunding/assembler.go
@@ -115,6 +115,10 @@ type Request struct {
 	// output. By definition, this'll also use segwit v1 (taproot) for the
 	// funding output.
 	Musig2 bool
+
+	// EnableRBF is a boolen which if true sets transaction inputs
+	// to signal RBF
+	EnableRBF bool
 }
 
 // Intent is returned by an Assembler and represents the base functionality the

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -195,6 +195,10 @@ type InitFundingReserveMsg struct {
 	// negotiated.
 	ScidAliasFeature bool
 
+	// EnableRBF is a boolen which if true sets transaction inputs
+	// to signal RBF
+	EnableRBF bool
+
 	// Memo is any arbitrary information we wish to store locally about the
 	// channel that will be useful to our future selves.
 	Memo []byte
@@ -930,7 +934,8 @@ func (l *LightningWallet) handleFundingReserveRequest(req *InitFundingReserveMsg
 					TaprootPubkey, true, DefaultAccountName,
 				)
 			},
-			Musig2: req.CommitType == CommitmentTypeSimpleTaproot,
+			Musig2:    req.CommitType == CommitmentTypeSimpleTaproot,
+			EnableRBF: req.EnableRBF,
 		}
 		fundingIntent, err = req.ChanFunder.ProvisionChannel(
 			fundingReq,

--- a/pilot.go
+++ b/pilot.go
@@ -111,6 +111,7 @@ func (c *chanController) OpenChannel(target *btcec.PublicKey,
 		RemoteCsvDelay:   0,
 		MinConfs:         c.minConfs,
 		MaxValueInFlight: 0,
+		EnableRBF:        true,
 	}
 
 	updateStream, errChan := c.server.OpenChannel(req)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1288,6 +1288,9 @@ func (r *rpcServer) SendCoins(ctx context.Context,
 			return nil, err
 		}
 
+		// Set input sequences of sweep tx to signal RBF
+		enableRBF := true
+
 		// With the sweeper instance created, we can now generate a
 		// transaction that will sweep ALL outputs from the wallet in a
 		// single transaction. This will be generated in a concurrent
@@ -1297,7 +1300,7 @@ func (r *rpcServer) SendCoins(ctx context.Context,
 		sweepTxPkg, err := sweep.CraftSweepAllTx(
 			maxFeeRate, feePerKw, uint32(bestHeight), nil,
 			targetAddr, wallet, wallet, wallet.WalletController,
-			r.server.cc.Signer, minConfs,
+			r.server.cc.Signer, minConfs, enableRBF,
 		)
 		if err != nil {
 			return nil, err
@@ -1351,7 +1354,7 @@ func (r *rpcServer) SendCoins(ctx context.Context,
 				maxFeeRate, feePerKw, uint32(bestHeight),
 				outputs, targetAddr, wallet, wallet,
 				wallet.WalletController,
-				r.server.cc.Signer, minConfs,
+				r.server.cc.Signer, minConfs, true,
 			)
 			if err != nil {
 				return nil, err

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2218,6 +2218,7 @@ func (r *rpcServer) parseOpenChannelReq(in *lnrpc.OpenChannelRequest,
 		MinFundAmt:        minFundAmt,
 		Memo:              []byte(in.Memo),
 		Outpoints:         outpoints,
+		EnableRBF:         true,
 	}, nil
 }
 

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1152,6 +1152,7 @@ func (s *UtxoSweeper) sweep(inputs inputSet, feeRate chainfee.SatPerKWeight,
 	tx, err := createSweepTx(
 		inputs, nil, s.currentOutputScript, uint32(currentHeight),
 		feeRate, s.cfg.MaxFeeRate.FeePerKWeight(), s.cfg.Signer,
+		false,
 	)
 	if err != nil {
 		return fmt.Errorf("create sweep tx: %v", err)
@@ -1440,7 +1441,7 @@ func (s *UtxoSweeper) handleUpdateReq(req *updateReq, bestHeight int32) (
 // - Thwart future possible fee sniping attempts.
 // - Make us blend in with the bitcoind wallet.
 func (s *UtxoSweeper) CreateSweepTx(inputs []input.Input, feePref FeePreference,
-	currentBlockHeight uint32) (*wire.MsgTx, error) {
+	currentBlockHeight uint32, enableRBF bool) (*wire.MsgTx, error) {
 
 	feePerKw, err := s.cfg.DetermineFeePerKw(s.cfg.FeeEstimator, feePref)
 	if err != nil {
@@ -1455,7 +1456,7 @@ func (s *UtxoSweeper) CreateSweepTx(inputs []input.Input, feePref FeePreference,
 
 	return createSweepTx(
 		inputs, nil, pkScript, currentBlockHeight, feePerKw,
-		s.cfg.MaxFeeRate.FeePerKWeight(), s.cfg.Signer,
+		s.cfg.MaxFeeRate.FeePerKWeight(), s.cfg.Signer, enableRBF,
 	)
 }
 

--- a/sweep/walletsweep.go
+++ b/sweep/walletsweep.go
@@ -184,7 +184,8 @@ func CraftSweepAllTx(feeRate, maxFeeRate chainfee.SatPerKWeight,
 	blockHeight uint32, deliveryAddrs []DeliveryAddr,
 	changeAddr btcutil.Address, coinSelectLocker CoinSelectionLocker,
 	utxoSource UtxoSource, outpointLocker OutpointLocker,
-	signer input.Signer, minConfs int32) (*WalletSweepPackage, error) {
+	signer input.Signer, minConfs int32,
+	enableRBF bool) (*WalletSweepPackage, error) {
 
 	// TODO(roasbeef): turn off ATPL as well when available?
 
@@ -321,7 +322,7 @@ func CraftSweepAllTx(feeRate, maxFeeRate chainfee.SatPerKWeight,
 	// respects our fee preference and targets all the UTXOs of the wallet.
 	sweepTx, err := createSweepTx(
 		inputsToSweep, txOuts, changePkScript, blockHeight,
-		feeRate, maxFeeRate, signer,
+		feeRate, maxFeeRate, signer, enableRBF,
 	)
 	if err != nil {
 		unlockOutputs()


### PR DESCRIPTION
## Change Description
This pr addreses https://github.com/lightningnetwork/lnd/issues/8064 and implements [explicit RBF signalling](https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki) for the following commands:
- [x] `openchannel` (Including with `sweepall` flag)
- [x] `sendcoins`
- [x] `sendmany`
- [x] `psbt fund`
- [x] `batchopenchannel`
- [x] funding txs created by the autopilot 

It depends on and is blocked by https://github.com/btcsuite/btcwallet/pull/895

## Steps to Test
Run the commands. Check that created txs have inputs with a sequence of `4294967293`.