### PR TITLE
input: fix `fatal error: concurrent map writes`

### DIFF
--- a/docs/release-notes/release-notes-0.17.3.md
+++ b/docs/release-notes/release-notes-0.17.3.md
@@ -1,0 +1,47 @@
+# Release Notes
+- [Bug Fixes](#bug-fixes)
+- [New Features](#new-features)
+  - [Functional Enhancements](#functional-enhancements)
+  - [RPC Additions](#rpc-additions)
+  - [lncli Additions](#lncli-additions)
+- [Improvements](#improvements)
+  - [Functional Updates](#functional-updates)
+  - [RPC Updates](#rpc-updates)
+  - [lncli Updates](#lncli-updates)
+  - [Breaking Changes](#breaking-changes)
+  - [Performance Improvements](#performance-improvements)
+ - [Technical and Architectural Updates](#technical-and-architectural-updates)
+   - [BOLT Spec Updates](#bolt-spec-updates)
+   - [Testing](#testing)
+   - [Database](#database)
+   - [Code Health](#code-health)
+   - [Tooling and Documentation](#tooling-and-documentation)
+
+# Bug Fixes
+
+* [Replaced](https://github.com/lightningnetwork/lnd/pull/8224)
+  `musig2Sessions` with a `SyncMap` used in `input` package to avoid concurrent
+  write to this map.
+
+# New Features
+## Functional Enhancements
+## RPC Additions
+## lncli Additions
+
+# Improvements
+## Functional Updates
+## RPC Updates
+## lncli Updates
+## Code Health
+## Breaking Changes
+## Performance Improvements
+
+# Technical and Architectural Updates
+## BOLT Spec Updates
+## Testing
+## Database
+## Code Health
+## Tooling and Documentation
+
+# Contributors (Alphabetical Order)
+* Yong Yu

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -495,7 +495,8 @@ func (h *HarnessTest) Shutdown(node *node.HarnessNode) {
 		return h.manager.shutdownNode(node)
 	}, DefaultTimeout)
 
-	require.NoErrorf(h, err, "unable to shutdown %v", node.Name())
+	require.NoErrorf(h, err, "unable to shutdown %v in %v", node.Name(),
+		h.manager.currentTestCase)
 }
 
 // SuspendNode stops the given node and returns a callback that can be used to


### PR DESCRIPTION
Found in this build failure [here](https://github.com/lightningnetwork/lnd/actions/runs/6983952648/job/19005955561?pr=8220), with trimmed logs,
```
2023-11-24 18:42:14.279 [INF] LNWL: Generating new musig2 sig for session=d413f8d90016497feb2b3ab7d4a9c24bcc4143c34a7ca6e42ab5192818f5beed, nonces=NoncePair(verification_nonce=02b2fd60a28bbb66839d5ccc47589513d60cdbc088a59131d7e825c10e33aff27b0281c5a51ac94a49a16fb80ea3aa8396fab7fe4bd5af25496a026328e41a8b8642, signing_nonce=02078f4cb5fb0f9f15e4979ba5fbd4bd5a33992ec9518cf9283238d699138d20ad02039e81f96c9ec7e2541e9b864d74992b9318b23933771ef5d9efd42adb3e97c5)
2023-11-24 18:42:14.279 [INF] LNWL: Generating new musig2 sig for session=6c8b4b33a72b585d6cc8f16b4e52fd49eeae829d986798d6711527fb281a4df7, nonces=NoncePair(verification_nonce=0391251fe1740ff35905c06bad3daad76ad1d8d72c09f6add4a7a78bae255e5f6f024c20e95a85934b643ce2e483ca649cf19b4faa2deca99c6d2e1cc5d4beeb0023, signing_nonce=023d78b1e48a1aa3d2bc8416cf5dc799cf582c082cd4b09be0212f46448e1e6d92037c867ee767ac466274b6c508d0fd4e628a22ad50902a6e6573359c854bb0c7cb)
fatal error: concurrent map writes

goroutine 1011 [running]:
github.com/lightningnetwork/lnd/input.(*MusigSessionManager).MuSig2CombineSig(0xc000010498, {0xd4, 0x13, 0xf8, 0xd9, 0x0, 0x16, 0x49, 0x7f, 0xeb, ...}, ...)
	/home/runner/work/lnd/lnd/input/musig2_session_manager.go:234 +0x3c5
github.com/lightningnetwork/lnd/lnwallet.(*MusigSession).CombineSigs(0xc001e91e00?, {0xc0000b1d70?, 0xf98c51c92e99335a?, 0x208d1399d6383228?})
	/home/runner/work/lnd/lnd/lnwallet/musig_session.go:509 +0x4e
github.com/lightningnetwork/lnd/lnwallet.(*LightningChannel).getSignedCommitTx(0xc001b142d0)
	/home/runner/work/lnd/lnd/lnwallet/channel.go:6319 +0x78f
github.com/lightningnetwork/lnd/lnwallet.(*LightningWallet).ValidateChannel(0xc00171aa80?, 0xc00171aa80, 0xc0023fa100)
	/home/runner/work/lnd/lnd/lnwallet/wallet.go:2479 +0x1b6
github.com/lightningnetwork/lnd/funding.(*Manager).waitForZeroConfChannel(0xc00019cb60, 0xc00171aa80, {0x3c, 0xdc, 0x9c, 0x8e, 0x99, 0x78, 0xbf, 0x7b, ...})
	/home/runner/work/lnd/lnd/funding/manager.go:3582 +0x154
github.com/lightningnetwork/lnd/funding.(*Manager).stateStep(0xc00019cb60, 0xc00171aa80, 0xc001a57541?, 0xc001cf3680, {0x3c, 0xdc, 0x9c, 0x8e, 0x99, 0x78, ...}, ...)
	/home/runner/work/lnd/lnd/funding/manager.go:1154 +0x253
github.com/lightningnetwork/lnd/funding.(*Manager).advanceFundingState(0xc00019cb60, 0xc00171aa80, {0x3c, 0xdc, 0x9c, 0x8e, 0x99, 0x78, 0xbf, 0x7b, ...}, ...)
	/home/runner/work/lnd/lnd/funding/manager.go:1063 +0x399
created by github.com/lightningnetwork/lnd/funding.(*Manager).fundeeProcessFundingCreated in goroutine 555
	/home/runner/work/lnd/lnd/funding/manager.go:2491 +0x146b
```

To fix it, we replace this `musig2Sessions` with a `SyncMap`.

The full trace is rather long, to view it, download the logs [here](https://github.com/lightningnetwork/lnd/actions/runs/6983952648?pr=8220).