### PR TITLE
Makefile: remove `loopvar` when running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ endif
 
 GOBUILD := $(LOOPVARFIX) go build -v
 GOINSTALL := $(LOOPVARFIX) go install -v
-GOTEST := $(LOOPVARFIX) go test
+GOTEST := go test
 
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -name "*pb.go" -not -name "*pb.gw.go" -not -name "*.pb.json.go")
 


### PR DESCRIPTION
Go `v1.21` added this new flag `GOEXPERIMENT=loopvar`, which is great, as it fixes [the bug when iterating loops](https://github.com/golang/go/discussions/56010). However, unless we decide to bump the minimal Go version requirement to `v1.21` and above, users may still run into this issue. Thus we should still test `Go`'s old behavior to be sure.

Of course the assumption is there's no difference when running `lnd`s built from different Go versions, except the `loopvar` behavior.