### PR TITLE
wtclient: handle un-acked updates for exhausted sessions

### DIFF
--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -62,6 +62,9 @@
   protects against the case where htlcs are added asynchronously resulting in
   stuck channels.
 
+* [Properly handle un-acked updates for exhausted watchtower 
+  sessions](https://github.com/lightningnetwork/lnd/pull/8233)
+
 # New Features
 ## Functional Enhancements
 

--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -66,10 +66,14 @@ func (c *client) genSessionFilter(
 }
 
 // ExhaustedSessionFilter constructs a wtdb.ClientSessionFilterFn filter
-// function that will filter out any sessions that have been exhausted.
+// function that will filter out any sessions that have been exhausted. A
+// session is considered exhausted only if it has no un-acked updates and the
+// sequence number of the session is equal to the max updates of the session
+// policy.
 func ExhaustedSessionFilter() wtdb.ClientSessWithNumCommittedUpdatesFilterFn {
-	return func(session *wtdb.ClientSession, _ uint16) bool {
-		return session.SeqNum < session.Policy.MaxUpdates
+	return func(session *wtdb.ClientSession, numUnAcked uint16) bool {
+		return session.SeqNum < session.Policy.MaxUpdates ||
+			numUnAcked > 0
 	}
 }
 

--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -67,8 +67,8 @@ func (c *client) genSessionFilter(
 
 // ExhaustedSessionFilter constructs a wtdb.ClientSessionFilterFn filter
 // function that will filter out any sessions that have been exhausted.
-func ExhaustedSessionFilter() wtdb.ClientSessionFilterFn {
-	return func(session *wtdb.ClientSession) bool {
+func ExhaustedSessionFilter() wtdb.ClientSessWithNumCommittedUpdatesFilterFn {
+	return func(session *wtdb.ClientSession, _ uint16) bool {
 		return session.SeqNum < session.Policy.MaxUpdates
 	}
 }


### PR DESCRIPTION
This PR addresses an edge case that could lead to the "tower has un-acked updates" error 
when a user tries to remove a tower. See the issue [here](https://github.com/lightningnetwork/lnd/issues/6397). 

## The Issue:

Currently, if you call "remove tower", then only sessions from that tower that are loaded into memory on 
startup are terminated correctly. And we only load in sessions where `session.SeqNum < session.policy.MaxUpdates`. 
So the issue occurs when the session is technically exhausted _but_ there is still an un-acked update on disk. 
This means that we would not terminate such a session properly on tower removal and so would run into "tower has un-acked updates". 

## The Solution: 

So with this PR, we make sure to load a session into memory if there are still un-acked updates that it needs to deal with. 

## Flow of the PR: 

1. First, the bug is demonstrated through a test.
2. Then, we extend the session fetching filter function to also count the number of un-acked updates so that we can decide to load the session if there are un-acked updates. 
3. The test is then adjusted to show that the bug has been fixed