### PR TITLE
fn: experimental async API

### DIFF
--- a/fn/async.go
+++ b/fn/async.go
@@ -1,0 +1,110 @@
+package fn
+
+import (
+	"context"
+	"errors"
+)
+
+// Async represents an action whose results are being computed outside this
+// control thread.
+type Async[A any] interface {
+	// Await may be called to block on the completion of the remote
+	// computation.
+	Await() (*A, error)
+
+	// Cancel may be called to abandon the remote computation.
+	Cancel()
+}
+
+var (
+	// ContextCancelled indicates that this Async was cancelled because the
+	// surrounding context was being torn down.
+	ContextCancelled = errors.New("context cancelled")
+)
+
+// RunAsyncWithCancel is a function that will transform a synchronous function
+// and make it a cancellable asynchronous call. This can be useful if the
+// function in the argument can block indefinitely and the calling context needs
+// a way to abandon waiting for it to complete.
+func RunAsyncWithCancel[A any](ctx context.Context,
+	f func(ctx context.Context) (*A, error)) Async[A] {
+
+	localCtx, cancel := context.WithCancel(ctx)
+
+	a := async[A]{
+		ctx:    localCtx,
+		cancel: cancel,
+		res:    make(chan *A, 1),
+		err:    make(chan error, 1),
+	}
+
+	go func() {
+		res, err := f(localCtx)
+
+		// If the error we get back from f is non-nil we try to send an
+		// err back on the err channel, bailing if we're being
+		// cancelled.
+		if err != nil {
+			select {
+			case a.err <- err:
+			case <-a.ctx.Done():
+			}
+
+			return
+		}
+
+		// Otherwise we will send the result back on the result channel,
+		// bailing if we were cancelled.
+		select {
+		case a.res <- res:
+		case <-a.ctx.Done():
+		}
+	}()
+
+	return &a
+}
+
+// RunAsync runs the argument closure asynchronously without pinning the action
+// to a calling context.
+func RunAsync[A any](f func() (*A, error)) Async[A] {
+	return RunAsyncWithCancel(
+		context.Background(),
+		func(_ context.Context) (*A, error) {
+			return f()
+		},
+	)
+}
+
+// Await may be called to block on the completion of the remote computation.
+func (a *async[A]) Await() (*A, error) {
+	select {
+	case r := <-a.res:
+		return r, nil
+	case e := <-a.err:
+		return nil, e
+	case <-a.ctx.Done():
+		return nil, ContextCancelled
+	}
+}
+
+// Cancel may be called to abandon the remote computation.
+func (a *async[A]) Cancel() {
+	a.cancel()
+}
+
+type async[A any] struct {
+	// contextCancel is a receive only signal that we use to pin the async
+	// action to the context, making it such that we don't have dangling
+	// actions.
+	ctx context.Context
+
+	// cancel is a function that can be used to abort the asynchronous
+	// action.
+	cancel context.CancelFunc
+
+	// res is the channel we will send the non-error result back over.
+	res chan *A
+
+	// err is the channel we will send an error result back over.
+	err chan error
+}


### PR DESCRIPTION
## Change Description
This is an attempt to give us some better building blocks for controlling threads of execution. It was inspired by [this PR review](https://github.com/lightningnetwork/lnd/pull/8151#discussion_r1397699095).

This PR is intentionally submitted for review despite being incomplete so that it can seek concept/approach ACKs. If we like it. I'll clean up the docs and go through the itests and change them to use this API.

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
