### PR TITLE
fn: create new sub-module

### DIFF
--- a/fn/go.mod
+++ b/fn/go.mod
@@ -1,0 +1,3 @@
+module github.com/lightningnetwork/lnd/fn
+
+go 1.19

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/clock v1.1.1
+	github.com/lightningnetwork/lnd/fn v0.0.0-00010101000000-000000000000
 	github.com/lightningnetwork/lnd/healthcheck v1.2.3
 	github.com/lightningnetwork/lnd/kvdb v1.4.4
 	github.com/lightningnetwork/lnd/queue v1.1.1
@@ -207,6 +208,8 @@ replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 // We want to format raw bytes as hex instead of base64. The forked version
 // allows us to specify that as an option.
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display
+
+replace github.com/lightningnetwork/lnd/fn => ./fn
 
 // If you change this please also update .github/pull_request_template.md and
 // docs/INSTALL.md.


### PR DESCRIPTION
In this commit, we make a new sub-module from the `fn` package. This lets other projects use it w/o pulling in all of lnd, and also other sub-packages within lnd.

Fixes https://github.com/lightningnetwork/lnd/issues/8216

