### PR TITLE
sweeper: Prevent nil pointer reference crash in logging

### DIFF
--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -446,13 +446,21 @@ func (s *UtxoSweeper) SweepInput(input input.Input,
 		return nil, err
 	}
 
-	absoluteTimeLock, _ := input.RequiredLockTime()
+	var (
+		parentInfo          = ""
+		unconfParent        = input.UnconfParent()
+		absoluteTimeLock, _ = input.RequiredLockTime()
+	)
+	if unconfParent != nil {
+		parentInfo = fmt.Sprintf("parent=(%v), ", unconfParent)
+	}
+
 	log.Infof("Sweep request received: out_point=%v, witness_type=%v, "+
-		"relative_time_lock=%v, absolute_time_lock=%v, amount=%v, "+
-		"parent=(%v), params=(%v)", input.OutPoint(),
+		"relative_time_lock=%v, absolute_time_lock=%v, amount=%v, %s"+
+		"params=(%v)", input.OutPoint(),
 		input.WitnessType(), input.BlocksToMaturity(), absoluteTimeLock,
-		btcutil.Amount(input.SignDesc().Output.Value),
-		input.UnconfParent(), params)
+		btcutil.Amount(input.SignDesc().Output.Value), parentInfo,
+		params)
 
 	sweeperInput := &sweepInputMessage{
 		input:      input,


### PR DESCRIPTION
## Change Description

Hey.
I'm running into a very peculiar crash regarding `bumpFee` on Neutrino.

`bumpFee` in turn calls sweeper's `SweepInput`.
The faulty code is the logging of `input.UnconfParent()`, as it will be `nil` on Neutrino (it doesn't know unconfirmed stuff) which the logger does not like.

Though I'm surprised this crash is not present elsewhere, as the logging itself is faulty regardless. It tries to directly use `UnconfParent() *TxInfo`, which I assume would be `nil` if there's no unconfirmed parent, regardless of backend used.

That's my understanding of things, if you know more feel free to correct me.

The sweeper itself handles any `UnconfParent()` usage correctly.

Cheers.

## Steps to Test

Try fee bumping a channel opening with Neutrino as backend. It will crash without this fix.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
