### PR TITLE
funding: ensure commit fee is >= minimum relay fee during channel open

### DIFF
--- a/funding/manager.go
+++ b/funding/manager.go
@@ -4532,6 +4532,12 @@ func (f *Manager) handleInitFundingMsg(msg *InitFundingMsg) {
 		commitFeePerKw = f.cfg.MaxAnchorsCommitFeeRate
 	}
 
+	// Ensure that the commitment feerate is above the minimum relay fee.
+	minRelayFee := f.cfg.FeeEstimator.RelayFeePerKW()
+	if commitFeePerKw < minRelayFee {
+		commitFeePerKw = minRelayFee
+	}
+
 	var scidFeatureVal bool
 	if hasFeatures(
 		msg.Peer.LocalFeatures(), msg.Peer.RemoteFeatures(),


### PR DESCRIPTION
For anchor channels, we were capping the feerate at MaxAnchorsCommitFeeRate. In a high-fee environment, the default value of MaxAnchorsCommitFeeRate would be too low and other implementations would reject the channel open. Fix that by ensuring that the commitment feerate is always >= minimum relay fee at channel open.

Fixes https://github.com/lightningnetwork/lnd/issues/8240