### PR TITLE
fix: clarify available commitment balance log message

### DIFF
--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -8366,11 +8366,11 @@ func (lc *LightningChannel) availableCommitmentBalance(view *htlcView,
 	if theirBalance < commitFeeWithHtlc && ourBalance >= nonDustHtlcAmt {
 		// see https://github.com/lightning/bolts/issues/728
 		ourReportedBalance := nonDustHtlcAmt - 1
-		lc.log.Infof("Reducing local balance (from %v to %v): "+
-			"remote side does not have enough funds (%v < %v) to "+
-			"pay for non-dust HTLC in case of unilateral close.",
-			ourBalance, ourReportedBalance, theirBalance,
-			commitFeeWithHtlc)
+		lc.log.Infof("Reducing local (reported) balance "+
+			"(from %v to %v): remote side does not have enough "+
+			"funds (%v < %v) to pay for non-dust HTLC in case of "+
+			"unilateral close.", ourBalance, ourReportedBalance,
+			theirBalance, commitFeeWithHtlc)
 		ourBalance = ourReportedBalance
 	}
 


### PR DESCRIPTION
## Change Description
This commit addresses clarification in the `availableCommitmentBalance` function in `lnwallet/channel.go` by adjusting the log message to better reflect the context of balance reduction.

Closes #8152 

## Steps to Test
N/A

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
