### PR TITLE
lnwallet: fix logging.

### DIFF
--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -4438,7 +4438,7 @@ func (lc *LightningChannel) ProcessChanSyncMsg(
 	case msg.NextLocalCommitHeight > remoteTipHeight+1:
 		lc.log.Errorf("sync failed: remote's next commit height is %v, "+
 			"while we believe it is %v!",
-			msg.NextLocalCommitHeight, remoteTipHeight)
+			msg.NextLocalCommitHeight, remoteTipHeight+1)
 
 		return nil, nil, nil, ErrCannotSyncCommitChains
 
@@ -4446,7 +4446,7 @@ func (lc *LightningChannel) ProcessChanSyncMsg(
 	case msg.NextLocalCommitHeight <= remoteTailHeight:
 		lc.log.Errorf("sync failed: remote's next commit height is %v, "+
 			"while we believe it is %v!",
-			msg.NextLocalCommitHeight, remoteTipHeight)
+			msg.NextLocalCommitHeight, remoteTipHeight+1)
 
 		// They previously ACKed our current tail, and now they are
 		// waiting for it. They probably lost state.


### PR DESCRIPTION
## Change Description
Makes the logging in case of a mismatch of the remote `msg.NextLocalCommitHeight` more clear. Results from #8306


Current logging would report something like this which which is not quite right:

`sync failed: remote's next commit height is 0, while we believe it is 0!`

should be:

`sync failed: remote's next commit height is 0, while we believe it is 1!`


Fixes https://github.com/lightningnetwork/lnd/issues/8306
