### PR TITLE
zpay32: Change min_final_cltv_expiry_delta.

### DIFF
--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -170,6 +170,13 @@
   be switched off using the new `protocol.no-timestamp-query-option` config 
   option. 
 
+* [Update min_final_cltv_expiry_delta](https://github.com/lightningnetwork/lnd/pull/8308).
+  This only effects external invoices which do not supply the 
+  min_final_cltv_expiry parameter. LND has NOT allowed the creation of invoices
+  with a lower min_final_cltv_expiry_delta value than 18 blocks since
+  LND 0.11.0.
+
+
 ## Testing
 
 * Added fuzz tests for [onion

--- a/zpay32/hophint.go
+++ b/zpay32/hophint.go
@@ -6,7 +6,10 @@ const (
 	// DefaultAssumedFinalCLTVDelta is the default value to be used as the
 	// final CLTV delta for a route if one is unspecified in the payment
 	// request.
-	DefaultAssumedFinalCLTVDelta = 9
+	// We adhere to the recommendation in BOLT 02 for terminal payments.
+	// See also:
+	// https://github.com/lightning/bolts/blob/master/02-peer-protocol.md
+	DefaultAssumedFinalCLTVDelta = 18
 )
 
 // HopHint is a routing hint that contains the minimum information of a channel


### PR DESCRIPTION
We already do not allow a `min_final_cltv_expiry_delta` for invoices lower than 18 and default to 80 when not specified:

https://github.com/lightningnetwork/lnd/blob/master/lnrpc/invoicesrpc/addinvoice.go#L364-L380.

Lately during a chat with CDecker we found out that CLN will not always provide a `min_cltv_expiry_delta` in their invoice. In that case we would default to 9 when paying the invoice which hower CLN would reject because the delta is too low for them.

So this PR is mostly to smoothen out some interoperability issues between CLN<=>LND


For more infos see: https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#cltv_expiry_delta-selection


Hmm looking at https://github.com/lightningnetwork/lnd/blob/master/lncfg/config.go we might analyse all our constants because I think we are still at an old spec level.

For example:

```
// DefaultIncomingBroadcastDelta defines the number of blocks before the
// expiry of an incoming htlc at which we force close the channel. We
// only go to chain if we also have the preimage to actually pull in the
// htlc. BOLT #2 suggests 7 blocks.
```

But I think now the value is also at 18:

```
the deadline for received HTLCs this node has fulfilled: the deadline after which the channel has to be failed and the HTLC fulfilled on-chain before its cltv_expiry. See steps 4-7 above, which imply a deadline of 2R+G+S blocks before cltv_expiry: 18 blocks is reasonable.
```

what do you think ?
