### PR TITLE
lnconfig: Support utilizing Environment Variables in `lnd.conf` for `rpcuser` and `rpcpass` fields.

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -52,3 +52,66 @@ func TestConfigToFlatMap(t *testing.T) {
 	require.Equal(t, redactedPassword, result["db.etcd.pass"])
 	require.Equal(t, redactedPassword, result["db.postgres.dsn"])
 }
+
+// TestSupplyEnvValue tests that the supplyEnvValue function works as
+// expected on the passed inputs.
+func TestSupplyEnvValue(t *testing.T) {
+	// Mock environment variables for testing.
+	t.Setenv("EXISTING_VAR", "existing_value")
+	t.Setenv("EMPTY_VAR", "")
+
+	tests := []struct {
+		input       string
+		expected    string
+		description string
+	}{
+		{
+			input:    "$EXISTING_VAR",
+			expected: "existing_value",
+			description: "Valid environment variable without " +
+				"default value",
+		},
+		{
+			input:    "${EXISTING_VAR:-default_value}",
+			expected: "existing_value",
+			description: "Valid environment variable with " +
+				"default value",
+		},
+		{
+			input:    "$NON_EXISTENT_VAR",
+			expected: "",
+			description: "Non-existent environment variable " +
+				"without default value",
+		},
+		{
+			input:    "${NON_EXISTENT_VAR:-default_value}",
+			expected: "default_value",
+			description: "Non-existent environment variable " +
+				"with default value",
+		},
+		{
+			input:    "$EMPTY_VAR",
+			expected: "",
+			description: "Empty environment variable without " +
+				"default value",
+		},
+		{
+			input:    "${EMPTY_VAR:-default_value}",
+			expected: "default_value",
+			description: "Empty environment variable with " +
+				"default value",
+		},
+		{
+			input:       "raw_input",
+			expected:    "raw_input",
+			description: "Raw input - no matching format",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			result := supplyEnvValue(test.input)
+			require.Equal(t, test.expected, result)
+		})
+	}
+}

--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -145,6 +145,9 @@
   funding operations and the new `PsbtCoinSelect` option of the `FundPsbt`
   RPC](https://github.com/lightningnetwork/lnd/pull/8378).
 
+* [Env Variables in lnd.conf](https://github.com/lightningnetwork/lnd/pull/8310)
+  Support utilizing the usage of environment variables in `lnd.conf` for `rpcuser` and `rpcpass` fields to better protect the secrets.
+
 ## RPC Additions
 
 * [Deprecated](https://github.com/lightningnetwork/lnd/pull/7175)


### PR DESCRIPTION
## Change Description
- Added `supplyEnvValue` function in `config.go` that returns The value of the specified environment variable, or the default value if provided, or the original input string if no matching variable is found or set.
- Called `supplyEnvValue` function in `parseRPCParams` function in `config.go` file where `rpcuser` and `rpcpass` fields are being parsed.

Fixes #8295

## Steps to Test
Added the test cases for `supplyEnvVale` in the `config_test.go` file covering the happy and sad paths.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
