### PR TITLE
[CI]: Install protolint to enforce the protobuf style guide rules in the CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,6 +134,9 @@ jobs:
       - name: check go modules tidiness 
         run: make tidy-module-check
 
+      - name: lint proto files
+        run: make protolint
+
       - name: lint
         run: GOGC=50 make lint
 

--- a/.protolint.yaml
+++ b/.protolint.yaml
@@ -1,0 +1,70 @@
+# The example configuration file for the protolint is located here:
+# https://github.com/yoheimuta/protolint/blob/master/_example/config/.protolint.yaml
+---
+# Lint directives.
+lint:
+  # Linter rules.
+  # Run `protolint list` to see all available rules.
+  rules:
+    # Determines whether or not to include the default set of linters.
+    no_default: true
+
+    # Set the default to all linters. This option works the other way around as no_default does.
+    # If you want to enable this option, delete the comment out below and no_default.
+    # all_default: true.
+
+    # The specific linters to add.
+    add:
+      - MESSAGE_NAMES_UPPER_CAMEL_CASE
+      - MAX_LINE_LENGTH
+      - INDENT
+      - FILE_NAMES_LOWER_SNAKE_CASE
+      - IMPORTS_SORTED
+      - PACKAGE_NAME_LOWER_CASE
+      - ORDER
+      - SERVICES_HAVE_COMMENT
+      - RPCS_HAVE_COMMENT
+      - PROTO3_FIELDS_AVOID_REQUIRED
+      - PROTO3_GROUPS_AVOID
+      - SYNTAX_CONSISTENT
+      - RPC_NAMES_CASE
+      - QUOTE_CONSISTENT
+
+  # Linter rules option.
+  rules_option:
+    # MAX_LINE_LENGTH rule option.
+    max_line_length:
+      # Enforces a maximum line length.
+      max_chars: 80
+      # Specifies the character count for tab characters.
+      tab_chars: 2
+
+    # INDENT rule option.
+    indent:
+      # Available styles are 4(4-spaces), 2(2-spaces) or tab.
+      style: 4
+      # Specifies if it should stop considering and inserting new lines at the appropriate positions.
+      # when the inner elements are on the same line. Default is false.
+      not_insert_newline: true
+
+    # QUOTE_CONSISTENT rule option.
+    quote_consistent:
+      # Available quote are "double" or "single".
+      quote: double
+
+    # ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH rule option.
+    enum_field_names_zero_value_end_with:
+      suffix: INVALID
+
+    # SERVICE_NAMES_END_WITH rule option.
+    service_names_end_with:
+      text: Service
+
+    # REPEATED_FIELD_NAMES_PLURALIZED rule option.
+    ## The spec for each rules follows the implementation of https://github.com/gertd/go-pluralize.
+    ## Plus, you can refer to this rule's test code.
+    repeated_field_names_pluralized:
+      uncountable_rules:
+        - paper
+      irregular_rules:
+        Irregular: Regular

--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,11 @@ lint: docker-tools
 	@$(call print, "Linting source.")
 	$(DOCKER_TOOLS) golangci-lint run -v $(LINT_WORKERS)
 
+#? protolint: Lint proto files using protolint
+protolint:
+	@$(call print, "Linting proto files.")
+	docker run --rm --volume "$$(pwd):/workspace" --workdir /workspace yoheimuta/protolint lint lnrpc/
+
 #? tidy-module: Run `go mod` tidy for all modules
 tidy-module:
 	echo "Running 'go mod tidy' for all modules"

--- a/lnrpc/devrpc/dev.proto
+++ b/lnrpc/devrpc/dev.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-import "lightning.proto";
-
 package devrpc;
+
+import "lightning.proto";
 
 option go_package = "github.com/lightningnetwork/lnd/lnrpc/devrpc";
 

--- a/lnrpc/invoicesrpc/invoices.proto
+++ b/lnrpc/invoicesrpc/invoices.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-import "lightning.proto";
-
 package invoicesrpc;
+
+import "lightning.proto";
 
 option go_package = "github.com/lightningnetwork/lnd/lnrpc/invoicesrpc";
 

--- a/lnrpc/lnclipb/lncli.proto
+++ b/lnrpc/lnclipb/lncli.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-import "verrpc/verrpc.proto";
-
 package lnclipb;
+
+import "verrpc/verrpc.proto";
 
 option go_package = "github.com/lightningnetwork/lnd/lnrpc/lnclipb";
 

--- a/lnrpc/peersrpc/peers.proto
+++ b/lnrpc/peersrpc/peers.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-import "lightning.proto";
-
 package peersrpc;
+
+import "lightning.proto";
 
 option go_package = "github.com/lightningnetwork/lnd/lnrpc/peersrpc";
 

--- a/lnrpc/routerrpc/router.proto
+++ b/lnrpc/routerrpc/router.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-import "lightning.proto";
-
 package routerrpc;
+
+import "lightning.proto";
 
 option go_package = "github.com/lightningnetwork/lnd/lnrpc/routerrpc";
 

--- a/lnrpc/walletrpc/walletkit.proto
+++ b/lnrpc/walletrpc/walletkit.proto
@@ -1,9 +1,9 @@
 syntax = "proto3";
 
+package walletrpc;
+
 import "lightning.proto";
 import "signrpc/signer.proto";
-
-package walletrpc;
 
 option go_package = "github.com/lightningnetwork/lnd/lnrpc/walletrpc";
 

--- a/lnrpc/walletunlocker.proto
+++ b/lnrpc/walletunlocker.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-import "lightning.proto";
-
 package lnrpc;
+
+import "lightning.proto";
 
 option go_package = "github.com/lightningnetwork/lnd/lnrpc";
 


### PR DESCRIPTION
## Change Description
Install [protolint](https://github.com/yoheimuta/protolint) to enforce the protobuf style guide rules in the CI.

## Additional Context
Closes #8301

## Steps to Test
It could be tested either by running `./scripts/install_protolint.sh` script or in the `CI`.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
