### PR TITLE
fix: remove duplicate words [skip ci]

### DIFF
--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -741,7 +741,7 @@ func (l *LightningWallet) PsbtFundingVerify(pendingChanID [32]byte,
 			"reservation ID %v", pid)
 	}
 
-	// Now the the PSBT has been populated and verified, we can again check
+	// Now the PSBT has been populated and verified, we can again check
 	// whether the value reserved for anchor fee bumping is respected.
 	isPublic := pendingReservation.partialState.ChannelFlags&lnwire.FFAnnounceChannel != 0
 	hasAnchors := pendingReservation.partialState.ChanType.HasAnchors()
@@ -1145,7 +1145,7 @@ func (l *LightningWallet) CurrentNumAnchorChans() (int, error) {
 // CheckReservedValue checks whether publishing a transaction with the given
 // inputs and outputs would violate the value we reserve in the wallet for
 // bumping the fee of anchor channels. The numAnchorChans argument should be
-// set the the number of open anchor channels controlled by the wallet after
+// set the number of open anchor channels controlled by the wallet after
 // the transaction has been published.
 //
 // If the reserved value is violated, the returned error will be


### PR DESCRIPTION
There are some unnecessary duplicate words in the source file. Use this change to remove them. The CI can be skipped.

## Change Description
Description of change / link to associated issue.

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
