### PR TITLE
lnwallet: perform mempool acceptance check before publishing

### DIFF
--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -548,9 +548,10 @@ func (c *ChainArbitrator) Start() error {
 		c.activeChannels[chanPoint] = channelArb
 
 		// Republish any closing transactions for this channel.
-		err = c.publishClosingTxs(channel)
+		err = c.republishClosingTxs(channel)
 		if err != nil {
-			return err
+			log.Errorf("Failed to republish closing txs for "+
+				"channel %v", chanPoint)
 		}
 	}
 
@@ -825,10 +826,10 @@ func (c *ChainArbitrator) dispatchBlocks(
 	}
 }
 
-// publishClosingTxs will load any stored cooperative or unilater closing
+// republishClosingTxs will load any stored cooperative or unilateral closing
 // transactions and republish them. This helps ensure propagation of the
 // transactions in the event that prior publications failed.
-func (c *ChainArbitrator) publishClosingTxs(
+func (c *ChainArbitrator) republishClosingTxs(
 	channel *channeldb.OpenChannel) error {
 
 	// If the channel has had its unilateral close broadcasted already,

--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -115,6 +115,12 @@
   without the user needing to publicly give away a lot of privacy-sensitive
   data.
 
+* When publishing transactions in `lnd`, all the transactions will now go
+  through [mempool acceptance
+  check](https://github.com/lightningnetwork/lnd/pull/8345) before being
+  broadcast. This means when a transaction has failed the `testmempoolaccept`
+  check by bitcoind or btcd, the broadcast won't be attempted.
+
 ## RPC Additions
 
 * [Deprecated](https://github.com/lightningnetwork/lnd/pull/7175)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.8
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
-	github.com/btcsuite/btcwallet v0.16.10-0.20231129183218-5df09dd43358
+	github.com/btcsuite/btcwallet v0.16.10-0.20240122184004-f1648e92097f
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.3.2
 	github.com/btcsuite/btcwallet/wallet/txrules v1.2.0
 	github.com/btcsuite/btcwallet/walletdb v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0/go.mod h1:7SFka0XMvUgj3hfZtyd
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
-github.com/btcsuite/btcwallet v0.16.10-0.20231129183218-5df09dd43358 h1:lZUSo6TISHUJQxpn/AniW5gqaN1iRNS87SDWvV3AHfg=
-github.com/btcsuite/btcwallet v0.16.10-0.20231129183218-5df09dd43358/go.mod h1:WSKhOJWUmUOHKCKEzdt+jWAHFAE/t4RqVbCwL2pEdiU=
+github.com/btcsuite/btcwallet v0.16.10-0.20240122184004-f1648e92097f h1:wtA3/5W+SAIQaWEuvnjMJqWEPjf2mWupXBB6KHbFKYA=
+github.com/btcsuite/btcwallet v0.16.10-0.20240122184004-f1648e92097f/go.mod h1:LzcW/LYkQLgDufv6Ouw4cOIW0YsY+A60MTtc61/OZTU=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.2 h1:etuLgGEojecsDOYTII8rYiGHjGyV5xTqsXi+ZQ715UU=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.2/go.mod h1:Zpk/LOb2sKqwP2lmHjaZT9AdaKsHPSbNLm2Uql5IQ/0=
 github.com/btcsuite/btcwallet/wallet/txrules v1.2.0 h1:BtEN5Empw62/RVnZ0VcJaVtVlBijnLlJY+dwjAye2Bg=

--- a/lnutils/errors.go
+++ b/lnutils/errors.go
@@ -1,0 +1,21 @@
+package lnutils
+
+import "errors"
+
+// ErrorAs behaves the same as `errors.As` except there's no need to declare
+// the target error as a variable first.
+// Instead of writing:
+//
+//	var targetErr *TargetErr
+//	errors.As(err, &targetErr)
+//
+// We can write:
+//
+//	lnutils.ErrorAs[*TargetErr](err)
+//
+// To save us from declaring the target error variable.
+func ErrorAs[Target error](err error) bool {
+	var targetErr Target
+
+	return errors.As(err, &targetErr)
+}

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -1915,7 +1915,17 @@ func testPublishTransaction(r *rpctest.Harness,
 		// TODO(roasbeef): we can't use Unwrap() here as TxRuleError
 		// doesn't define it
 		err := alice.PublishTransaction(testTx, labels.External)
-		require.Contains(t, err.Error(), "bad-txns-oversize")
+
+		errStr := "bad-txns-oversize"
+
+		// For neutrino backend, the error string in not mapped.
+		//
+		// TODO(yy): unify error matching in neutrino too.
+		if alice.BackEnd() == "neutrino" {
+			errStr = "serialized transaction is too big"
+		}
+
+		require.Contains(t, err.Error(), errStr)
 	})
 }
 

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -1472,15 +1472,20 @@ func testTransactionSubscriptions(miner *rpctest.Harness,
 	// We'll also ensure that the client is able to send our new
 	// notifications when we _create_ transactions ourselves that spend our
 	// own outputs.
-	b := txscript.NewScriptBuilder()
-	b.AddOp(txscript.OP_RETURN)
-	outputScript, err := b.Script()
-	require.NoError(t, err, "unable to make output script")
+	addr, err := alice.NewAddress(
+		lnwallet.WitnessPubKey, false,
+		lnwallet.DefaultAccountName,
+	)
+	require.NoError(t, err)
+
+	outputScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
 	burnOutput := wire.NewTxOut(outputAmt, outputScript)
 	tx, err := alice.SendOutputs(
 		[]*wire.TxOut{burnOutput}, 2500, 1, labels.External,
 	)
-	require.NoError(t, err, "unable to create burn tx")
+	require.NoError(t, err, "unable to create tx")
 	txid := tx.TxHash()
 	err = waitForMempoolTx(miner, &txid)
 	require.NoError(t, err, "tx not relayed to miner")

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -3259,9 +3259,15 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 		case "bitcoind":
 			// Start a bitcoind instance.
 			tempBitcoindDir := t.TempDir()
-			zmqBlockHost := "ipc:///" + tempBitcoindDir + "/blocks.socket"
-			zmqTxHost := "ipc:///" + tempBitcoindDir + "/tx.socket"
+
 			rpcPort := getFreePort()
+			zmqBlockPort := getFreePort()
+			zmqTxPort := getFreePort()
+			zmqBlockHost := fmt.Sprintf("tcp://127.0.0.1:%d",
+				zmqBlockPort)
+			zmqTxHost := fmt.Sprintf("tcp://127.0.0.1:%d",
+				zmqTxPort)
+
 			bitcoind := exec.Command(
 				"bitcoind",
 				"-datadir="+tempBitcoindDir,


### PR DESCRIPTION
This PR adds a mempool acceptance check before broadcasting a given transaction. To maintain the current behavior from
`BtcWallet.PublishTransaction`, the two errors, `ErrInMempool` and `ErrAlreadyConfirmed` returned from `TestMempoolAccept` are ignored.

Note that we choose to implement this method as an interface method on `chain.Interface` in `btcwallet` as we want to have this `TestMempoolAccept` being used as an independent check and can be used in other cases where we don't wanna publish transactions. However, we could implement this check in `btcwallet` instead in `PublishTransaction` here,
https://github.com/btcsuite/btcwallet/blob/5df09dd4335865dde2a9a6d94a26a7f5779af825/wallet/wallet.go#L3657-L3659
since every tx must pass this mempool acceptance check before it can be broadcast. This alternative approach, tho, do have a problem, that we need to pass the max feerate used by `testmempoolaccept` to `PublishTransaction` in `btcwallet`, which seems to be a larger change.


Depends on:
- https://github.com/btcsuite/btcd/pull/2053
- https://github.com/btcsuite/btcwallet/pull/899

Fixes https://github.com/lightningnetwork/lnd/issues/4760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented a new mempool acceptance check for transactions to enhance reliability of transaction broadcasting.

- **Improvements**
  - Improved error logging for issues encountered during the republishing of closing transactions.

- **Documentation**
  - Updated release notes to document the new mempool acceptance feature.

- **Refactor**
  - Renamed a method for better clarity in the transaction republishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->