### PR TITLE
routing+routerrpc: remove redudant error check

### DIFF
--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -872,9 +872,16 @@ func (s *Server) trackPayment(subscription routing.ControlTowerSubscriber,
 		stream.Context(), subscription, noInflightUpdates, stream.Send,
 	)
 
+	// If the context is canceled, we don't return an error.
 	if errors.Is(err, context.Canceled) {
-		log.Debugf("Payment stream %v canceled", identifier)
+		log.Infof("Payment stream %v canceled", identifier)
+
+		return nil
 	}
+
+	// Otherwise, we will log and return the error as the stream has
+	// received an error from the payment lifecycle.
+	log.Errorf("TrackPayment got error for payment %x: %v", identifier, err)
 
 	return err
 }

--- a/routing/router.go
+++ b/routing/router.go
@@ -2386,7 +2386,7 @@ func (r *ChannelRouter) SendPayment(payment *LightningPayment) ([32]byte,
 // SendPaymentAsync is the non-blocking version of SendPayment. The payment
 // result needs to be retrieved via the control tower.
 func (r *ChannelRouter) SendPaymentAsync(payment *LightningPayment,
-	ps PaymentSession, st shards.ShardTracker) error {
+	ps PaymentSession, st shards.ShardTracker) {
 
 	// Since this is the first time this payment is being made, we pass nil
 	// for the existing attempt.
@@ -2406,8 +2406,6 @@ func (r *ChannelRouter) SendPaymentAsync(payment *LightningPayment,
 				payment.Identifier(), err)
 		}
 	}()
-
-	return nil
 }
 
 // spewPayment returns a log closures that provides a spewed string


### PR DESCRIPTION
Fix #8344 

Since `SendPaymentAsync` now never returns an error, there's no need to catch it and check it in `SendPaymentV2`.