### PR TITLE
docs: fix typo "paren" to "parenthesis" in `code_formatting_rules.md` [skip ci]

### DIFF
--- a/docs/code_formatting_rules.md
+++ b/docs/code_formatting_rules.md
@@ -124,8 +124,8 @@ myKey := "0214cd678a565041d00e6cf8d62ef8add33b4af4786fb2beb87b366a2e1" +
 ### Wrapping long function calls
 
 When wrapping a line that contains a function call as the unwrapped line exceeds
-the column limit, the close paren should be placed on its own line.
-Additionally, all arguments should begin in a new line after the open paren.
+the column limit, the close parenthesis should be placed on its own line.
+Additionally, all arguments should begin in a new line after the open parenthesis.
 
 **WRONG**
 ```go


### PR DESCRIPTION
## Change Description
docs: fix typo "paren" to "parenthesis" in `code_formatting_rules.md` [skip ci]

### Code Style and Documentation
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.