### PR TITLE
funding: add timeout to channel batch funding

### DIFF
--- a/cmd/commands/main.go
+++ b/cmd/commands/main.go
@@ -459,6 +459,7 @@ func Main() {
 		disconnectCommand,
 		openChannelCommand,
 		batchOpenChannelCommand,
+		cancelPsbtCommand,
 		closeChannelCommand,
 		closeAllChannelsCommand,
 		abandonChannelCommand,

--- a/funding/batch.go
+++ b/funding/batch.go
@@ -572,10 +572,9 @@ func (b *Batcher) cleanup(ctx context.Context) {
 	// And finally clean up the funding shim for each channel that didn't
 	// make it into a pending state.
 	for _, channel := range b.channels {
-		if channel.isPending {
-			continue
-		}
-
+		// We need to cancel all funding intents that we created even
+		// though the channel might not be in the pending state. The
+		// peer might still be waiting for us to send an error msg.
 		err := b.cfg.Wallet.CancelFundingIntent(channel.pendingChanID)
 		if err != nil {
 			log.Debugf(errMsgTpl, "cancel funding shim", err)

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -2268,7 +2268,7 @@ func (f *Manager) waitForPsbt(intent *chanfunding.PsbtIntent,
 	peerKey := resCtx.peer.IdentityKey()
 	failFlow := func(errMsg string, cause error) {
 		log.Errorf("Unable to handle funding accept message "+
-			"for peer_key=%x, pending_chan_id=%x: %s: %v",
+			"for peer_key=%x, pending_chan_id=%v: %s: %v",
 			peerKey.SerializeCompressed(), cid.tempChanID, errMsg,
 			cause)
 		f.failFundingFlow(resCtx.peer, cid, cause)
@@ -2344,7 +2344,7 @@ func (f *Manager) waitForPsbt(intent *chanfunding.PsbtIntent,
 	// survive a restart as it's in memory only.
 	case <-f.quit:
 		log.Errorf("Unable to handle funding accept message "+
-			"for peer_key=%x, pending_chan_id=%x: funding manager "+
+			"for peer_key=%x, pending_chan_id=%v: funding manager "+
 			"shutting down", peerKey.SerializeCompressed(),
 			cid.tempChanID)
 		return


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/8362.

In this PR we add a context deadline for the batch channel funding process. This gracefully ends the funding process if one or more of the batche's peers are unresponsive.  Within the deadline window, the user can abort a pending batch opening via `Ctrl+C`. The blocking peers will be logged. An aborted batch will cancel all channel openings. The user has to restart with an adjusted batch.