### PR TITLE
contractcourt: fix pendingchannels representation.

### DIFF
--- a/contractcourt/htlc_outgoing_contest_resolver_test.go
+++ b/contractcourt/htlc_outgoing_contest_resolver_test.go
@@ -85,6 +85,7 @@ func TestHtlcOutgoingResolverRemoteClaim(t *testing.T) {
 	ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
 		SpendingTx:    spendTx,
 		SpenderTxHash: &spendHash,
+		SpentOutPoint: &wire.OutPoint{Index: 0},
 	}
 
 	// We expect the extracted preimage to be added to the witness beacon.

--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -62,6 +62,11 @@
   protects against the case where htlcs are added asynchronously resulting in
   stuck channels.
 
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/8369) a case where `lnd`
+  would show the wrong transaction outpoint for zero-fee htlcs when calling
+  `pendingchannels`. Now depending on the resolving stage the right outpoint
+  will be shown.
+
 # New Features
 ## Functional Enhancements
 


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/8328

So apparently there is no perfect fix for this mis-representation other than introducing a bigger change. The main problem currently is, that we would use the `ClaimOutpoint` also for zero-fee htlcs (anchor channels) when logging specifics for the corresponding HTLC resolver and when constructing the `pendingchannels` output. This lead to confusion because this `ClaimOutpoint` does not really exist and is just the txid of the `timeout/success` transaction before adding the fees to the transaction. Therefore this PR does 2 things, it keeps the `ClaimOutpoint` but swaps it before delivering the information to the caller via `pendingchannels`. Moreover it now shows the HTLC point for `Stage 1` tho only for `Anchor Channels` should we maybe also change this for `Non-Anchors` as well, there however the `ClaimPoint` is a valid Outpoint so we could also keep it there maybe ?
Moreover it replaces the logging of the `ClaimPoint` with the HTLC `RHash`. It's still not perfect imo because we do not show the `RHash` in the `pendingchannels` output therefore its a bit difficult to correlate the Resolver Logs to the specified unresolved HTLC ? However I think its better than having a wrong Outpoint in the logs which does not exist ?



Example before this change:

`lncli pendingchannels` : 

```
       {
            "channel":  {
                "remote_node_pub":  "0222f1f87821c77f6c21142cff0db054258a6714c0efbc88352fdc54a1e50150b4",
                "channel_point":  "442f5627801d9b83dc1836aed63ce441b18a36b2e468581875811b311908a393:0",
                "capacity":  "100000",
                "local_balance":  "85100",
                "remote_balance":  "1000",
                "local_chan_reserve_sat":  "0",
                "remote_chan_reserve_sat":  "0",
                "initiator":  "INITIATOR_LOCAL",
                "commitment_type":  "ANCHORS",
                "num_forwarding_packages":  "0",
                "chan_status_flags":  "",
                "private":  false,
                "memo":  ""
            },
            "closing_txid":  "180eeef054939be11dc4d6bf7a07317ca52501679658a32e9813d34116bbde53",
            "limbo_balance":  "10000",
            "maturity_height":  0,
            "blocks_til_maturity":  0,
            "recovered_balance":  "330",
            "pending_htlcs":  [
                {
                    "incoming":  false,
                    "amount":  "10000",
                    "outpoint":  "1c5871a67297b918a08972d9f44deee2814eb4b2496ae0550a9e6207e31e5d14:0",
                    "maturity_height":  1060,
                    "blocks_til_maturity":  46,
                    "stage":  2
                }
            ],
            "anchor":  "RECOVERED"
        }
```

the outpoint of the outgoing htlc does not exist and will never exist, so users get confused if they see this.

After this PR:

```
 {
            "channel":  {
                "remote_node_pub":  "0222f1f87821c77f6c21142cff0db054258a6714c0efbc88352fdc54a1e50150b4",
                "channel_point":  "442f5627801d9b83dc1836aed63ce441b18a36b2e468581875811b311908a393:0",
                "capacity":  "100000",
                "local_balance":  "85100",
                "remote_balance":  "1000",
                "local_chan_reserve_sat":  "0",
                "remote_chan_reserve_sat":  "0",
                "initiator":  "INITIATOR_LOCAL",
                "commitment_type":  "ANCHORS",
                "num_forwarding_packages":  "0",
                "chan_status_flags":  "",
                "private":  false,
                "memo":  ""
            },
            "closing_txid":  "180eeef054939be11dc4d6bf7a07317ca52501679658a32e9813d34116bbde53",
            "limbo_balance":  "10000",
            "maturity_height":  0,
            "blocks_til_maturity":  0,
            "recovered_balance":  "330",
            "pending_htlcs":  [
                {
                    "incoming":  false,
                    "amount":  "10000",
                    "outpoint":  "d73b352aae45250edac2a7729674984098678e3e247a2d32a53b0efb400fc0df:0",
                    "maturity_height":  1060,
                    "blocks_til_maturity":  46,
                    "stage":  2
                }
            ],
            "anchor":  "RECOVERED"
        }
    ],
    "waiting_close_channels":  []
```

where   d73b352aae45250edac2a7729674984098678e3e247a2d32a53b0efb400fc0df is the acutal second-level sweep transaction.

```
 bitcoin-cli getrawtransaction d73b352aae45250edac2a7729674984098678e3e247a2d32a53b0efb400fc0df
0200000000010253debb1641d313982ea35896670125a57c31077abfd6c41de19b9354f0ee0e18030000000001000000f6b12e17859009badb2db29093b81b6a576be91a796428bc92e7d55bcd8835d4000000000000000000021027000000000000220020958243b85f3b1c19375a76b5289dd9ec1881f32ea12adc2bd282b8ae47d9f218f628020000000000225120f58b3c5e54560f5dfefa17a98b91dd7d12b8400c547f4a9b6a5a62c5d224c1d9050047304402200f01366928715b679456b0bfaac62d4be5344f53c90e89839caf01791dc87981022026f2c258e199b718011c25f12efaa0caff42286c6d26d22b6ded048df72238db83483045022100bbf9b8f1523c3ea2f2acf247ffbbd4ffe4bacd8c5030853d3a8fca070ccc049d0220230b1c0ce067d426169c9b426172e96846a3fca4667efd0604cf5a92dfb8d7a301008876a91438d411cef4dfa1a39ffc3e2903504ba992063d2d8763ac67210306689cfe0d002ebdad74d66c223c328f89b759a39b5dea597ed3b70d26feb9937c820120876475527c2102376746fe6d5a06ba4c421a46f1e13cc004f0eb22289ac534d89c5f9737a758ce52ae67a9144aa745da38daff162ef9f8bf6957fbb1a6cf9d6188ac6851b275680140734cc29a16ffc8a1cadc835c11b4e356625dfd33bb8e1e0fb81a69b0f9eac76f44e98d9609b0fdf14edc8a2de313114a8716a3013f775675e5e717cd7250968994030000
```


