### PR TITLE
lnrpc: fix typo in rpc docs

### DIFF
--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -329,7 +329,7 @@ service Lightning {
     optionally specify the add_index and/or the settle_index. If the add_index
     is specified, then we'll first start by sending add invoice events for all
     invoices with an add_index greater than the specified value. If the
-    settle_index is specified, the next, we'll send out all settle events for
+    settle_index is specified, then next, we'll send out all settle events for
     invoices with a settle_index greater than the specified value. One or both
     of these fields can be set. If no fields are set, then we'll only send out
     the latest add/settle events.

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -1831,7 +1831,7 @@
     },
     "/v1/invoices/subscribe": {
       "get": {
-        "summary": "SubscribeInvoices returns a uni-directional stream (server -\u003e client) for\nnotifying the client of newly added/settled invoices. The caller can\noptionally specify the add_index and/or the settle_index. If the add_index\nis specified, then we'll first start by sending add invoice events for all\ninvoices with an add_index greater than the specified value. If the\nsettle_index is specified, the next, we'll send out all settle events for\ninvoices with a settle_index greater than the specified value. One or both\nof these fields can be set. If no fields are set, then we'll only send out\nthe latest add/settle events.",
+        "summary": "SubscribeInvoices returns a uni-directional stream (server -\u003e client) for\nnotifying the client of newly added/settled invoices. The caller can\noptionally specify the add_index and/or the settle_index. If the add_index\nis specified, then we'll first start by sending add invoice events for all\ninvoices with an add_index greater than the specified value. If the\nsettle_index is specified, then next, we'll send out all settle events for\ninvoices with a settle_index greater than the specified value. One or both\nof these fields can be set. If no fields are set, then we'll only send out\nthe latest add/settle events.",
         "operationId": "Lightning_SubscribeInvoices",
         "responses": {
           "200": {

--- a/lnrpc/lightning_grpc.pb.go
+++ b/lnrpc/lightning_grpc.pb.go
@@ -233,7 +233,7 @@ type LightningClient interface {
 	// optionally specify the add_index and/or the settle_index. If the add_index
 	// is specified, then we'll first start by sending add invoice events for all
 	// invoices with an add_index greater than the specified value. If the
-	// settle_index is specified, the next, we'll send out all settle events for
+	// settle_index is specified, then next, we'll send out all settle events for
 	// invoices with a settle_index greater than the specified value. One or both
 	// of these fields can be set. If no fields are set, then we'll only send out
 	// the latest add/settle events.
@@ -1554,7 +1554,7 @@ type LightningServer interface {
 	// optionally specify the add_index and/or the settle_index. If the add_index
 	// is specified, then we'll first start by sending add invoice events for all
 	// invoices with an add_index greater than the specified value. If the
-	// settle_index is specified, the next, we'll send out all settle events for
+	// settle_index is specified, then next, we'll send out all settle events for
 	// invoices with a settle_index greater than the specified value. One or both
 	// of these fields can be set. If no fields are set, then we'll only send out
 	// the latest add/settle events.


### PR DESCRIPTION
## Change Description
Fix typo originally suggested in #8236 . This PR replaces that one

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
