### PR TITLE
fn: add UnsafeFromSome to Option API

### DIFF
--- a/fn/option.go
+++ b/fn/option.go
@@ -147,3 +147,12 @@ func (o Option[A]) Alt(o2 Option[A]) Option[A] {
 
 	return o2
 }
+
+// UnsafeFromSome can be used to extract the internal value. This will panic
+// if the value is None() though.
+func (o Option[A]) UnsafeFromSome() A {
+	if o.isSome {
+		return o.some
+	}
+	panic("Option was None()")
+}


### PR DESCRIPTION
## Change Description
We had an unsafe extraction API for Options to aid with unit test situations where we want to panic out if something is None. It should be noted that this should never be used outside tests. The API is prefixed with "Unsafe" to indicate very clearly not to use it in real code.

This blocks #8167 

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
