### PR TITLE
watchtower: Add retry logic for fetching blocks

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -71,6 +71,10 @@
 
 ## Code Health
 
+* [Add retry logic](https://github.com/lightningnetwork/lnd/pull/8381) for
+  watchtower block fetching with a max number of attempts and exponential
+  back-off.
+
 * [Moved](https://github.com/lightningnetwork/lnd/pull/9138) profile related
   config settings to its own dedicated group. The old ones still work but will
   be removed in a future release.
@@ -124,6 +128,7 @@
 
 # Contributors (Alphabetical Order)
 
+* Animesh Bilthare
 * Boris Nagaev
 * CharlieZKSmith
 * Elle Mouton

--- a/watchtower/lookout/lookout_test.go
+++ b/watchtower/lookout/lookout_test.go
@@ -90,6 +90,9 @@ func TestLookoutBreachMatching(t *testing.T) {
 		DB:             db,
 		EpochRegistrar: backend,
 		Punisher:       punisher,
+		MinBackoff:     time.Second,
+		MaxBackoff:     time.Minute,
+		MaxNumRetries:  1,
 	})
 	if err := watcher.Start(); err != nil {
 		t.Fatalf("unable to start watcher: %v", err)

--- a/watchtower/standalone.go
+++ b/watchtower/standalone.go
@@ -3,6 +3,7 @@ package watchtower
 import (
 	"net"
 	"sync/atomic"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightningnetwork/lnd/brontide"
@@ -65,6 +66,9 @@ func New(cfg *Config) (*Standalone, error) {
 		DB:             cfg.DB,
 		EpochRegistrar: cfg.EpochRegistrar,
 		Punisher:       punisher,
+		MinBackoff:     time.Second,
+		MaxBackoff:     time.Minute,
+		MaxNumRetries:  5,
 	})
 
 	// Create a brontide listener on each of the provided listening


### PR DESCRIPTION


## Change Description
Fixes #8205 , This change sets the total retry attempt count for fetching blocks to 4 (1 original attempt + 3 Retries).

## Steps to Test
I'm uncertain about how reviewers might naturally replicate a scenario in which the backend fails to deliver blocks to lnd. For testing purposes, I introduced a probabilistic failure in the GetBlock function (by returning a non-nil error). Below is the code snippet I used to implement this probabilistic error injection. For the purposes of testing, I have used bitcoind as backend.
```
type MyCustomError struct {
	Msg string
}

func (e MyCustomError) Error() string {
	return fmt.Sprintf("Error: %s", e.Msg)
}

func (b *BtcWallet) GetBlock(blockHash *chainhash.Hash) (*wire.MsgBlock, error) {
	rand.Seed(time.Now().UnixNano())
	randomNumber := rand.Intn(100) + 1
	_, ok := b.chain.(*chain.NeutrinoClient)
	if !ok {
		k, v := b.blockCache.GetBlock(blockHash, b.chain.GetBlock)
		if randomNumber < 20 {
			return k, v
		}
		return k, MyCustomError{Msg: "Animesh: Pseudo Error"}
	}

	// For the neutrino implementation of lnwallet.BlockChainIO the neutrino
	// GetBlock function can be called directly since it uses the same block
	// cache. However, it does not lock the block cache mutex for the given
	// block hash and so that is done here.
	b.blockCache.HashMutex.Lock(lntypes.Hash(*blockHash))
	defer b.blockCache.HashMutex.Unlock(lntypes.Hash(*blockHash))

	return b.chain.GetBlock(blockHash)
}
```
### Testing

![image](https://github.com/lightningnetwork/lnd/assets/44436898/7455d6f4-3709-4358-bdfd-7481d2b377e2)

This represents a scenario when block is finally fetched after all the attempts have been exhausted.

![image](https://github.com/lightningnetwork/lnd/assets/44436898/4a6cb226-e5ba-45b4-bf96-469adf0085fa)

This represents a scenario when block is fetched after 2 attempts (1 original + 1 retry) have been exhausted.

![image](https://github.com/lightningnetwork/lnd/assets/44436898/8893ca3e-dafe-48f5-b775-3c7d5da75c40)

This represents a scenario when block fetching fails.

I've been contemplating the practicality of implementing a unit test for this function. Given that we'll be mocking the `GetBlock` function to return either a nil or a non-nil error, I'm curious about the overall usefulness of such a test. Could someone help clarify if there's a significant benefit to this approach? I'm open to insights or suggestions on how we might enhance the testing strategy for this part of the code.
