### PR TITLE
buildroute use lnd default

### DIFF
--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -148,6 +148,9 @@
   the ability to specify multiple outgoing channel ids for the `sendpayment`
   command.
 
+* [Use the default LND value in the buildroute rpc command for the
+  final cltv delta](https://github.com/lightningnetwork/lnd/pull/8387).
+
 ## Code Health
 
 * [Remove Litecoin code](https://github.com/lightningnetwork/lnd/pull/7867).

--- a/lnrpc/routerrpc/router.proto
+++ b/lnrpc/routerrpc/router.proto
@@ -124,6 +124,10 @@ service Router {
     BuildRoute builds a fully specified route based on a list of hop public
     keys. It retrieves the relevant channel policies from the graph in order to
     calculate the correct fees and time locks.
+    Note that LND will use its default final_cltv_delta if no value is supplied.
+    Make sure to add the correct final_cltv_delta depending on the invoice
+    restriction. Moreover the caller has to make sure to provide the
+    payment_addr if the route is paying an invoice which signaled it.
     */
     rpc BuildRoute (BuildRouteRequest) returns (BuildRouteResponse);
 

--- a/lnrpc/routerrpc/router.swagger.json
+++ b/lnrpc/routerrpc/router.swagger.json
@@ -293,7 +293,7 @@
     },
     "/v2/router/route": {
       "post": {
-        "summary": "lncli: `buildroute`\nBuildRoute builds a fully specified route based on a list of hop public\nkeys. It retrieves the relevant channel policies from the graph in order to\ncalculate the correct fees and time locks.",
+        "summary": "lncli: `buildroute`\nBuildRoute builds a fully specified route based on a list of hop public\nkeys. It retrieves the relevant channel policies from the graph in order to\ncalculate the correct fees and time locks.\nNote that LND will use its default final_cltv_delta if no value is supplied.\nMake sure to add the correct final_cltv_delta depending on the invoice\nrestriction. Moreover the caller has to make sure to provide the\npayment_addr if the route is paying an invoice which signaled it.",
         "operationId": "Router_BuildRoute",
         "responses": {
           "200": {

--- a/lnrpc/routerrpc/router_grpc.pb.go
+++ b/lnrpc/routerrpc/router_grpc.pb.go
@@ -81,6 +81,10 @@ type RouterClient interface {
 	// BuildRoute builds a fully specified route based on a list of hop public
 	// keys. It retrieves the relevant channel policies from the graph in order to
 	// calculate the correct fees and time locks.
+	// Note that LND will use its default final_cltv_delta if no value is supplied.
+	// Make sure to add the correct final_cltv_delta depending on the invoice
+	// restriction. Moreover the caller has to make sure to provide the
+	// payment_addr if the route is paying an invoice which signaled it.
 	BuildRoute(ctx context.Context, in *BuildRouteRequest, opts ...grpc.CallOption) (*BuildRouteResponse, error)
 	// SubscribeHtlcEvents creates a uni-directional stream from the server to
 	// the client which delivers a stream of htlc events.
@@ -510,6 +514,10 @@ type RouterServer interface {
 	// BuildRoute builds a fully specified route based on a list of hop public
 	// keys. It retrieves the relevant channel policies from the graph in order to
 	// calculate the correct fees and time locks.
+	// Note that LND will use its default final_cltv_delta if no value is supplied.
+	// Make sure to add the correct final_cltv_delta depending on the invoice
+	// restriction. Moreover the caller has to make sure to provide the
+	// payment_addr if the route is paying an invoice which signaled it.
 	BuildRoute(context.Context, *BuildRouteRequest) (*BuildRouteResponse, error)
 	// SubscribeHtlcEvents creates a uni-directional stream from the server to
 	// the client which delivers a stream of htlc events.

--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -999,6 +999,12 @@ func (s *Server) BuildRoute(ctx context.Context,
 		payAddr = &backingPayAddr
 	}
 
+	if req.FinalCltvDelta == 0 {
+		req.FinalCltvDelta = int32(
+			s.cfg.RouterBackend.DefaultFinalCltvDelta,
+		)
+	}
+
 	// Build the route and return it to the caller.
 	route, err := s.cfg.Router.BuildRoute(
 		amt, hops, outgoingChan, req.FinalCltvDelta, payAddr,


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/8380.

Now the lncli does not provide a default value but we check on the lnd side and if its not provided we use the lnd default.

Moreover improves the docs.
