### PR TITLE
htlcswitch: update fuzzPayload for route blinding

### DIFF
--- a/htlcswitch/hop/fuzz_test.go
+++ b/htlcswitch/hop/fuzz_test.go
@@ -88,7 +88,10 @@ func hopFromPayload(p *Payload) (*route.Hop, uint64) {
 		MPP:              p.MPP,
 		AMP:              p.AMP,
 		Metadata:         p.metadata,
+		EncryptedData:    p.encryptedData,
+		BlindingPoint:    p.blindingPoint,
 		CustomRecords:    p.customRecords,
+		TotalAmtMsat:     p.totalAmtMsat,
 	}, p.FwdInfo.NextHop.ToUint64()
 }
 


### PR DESCRIPTION
Route blinding added some new fields to hop.Payload and route.Hop, which we need to copy over to the fuzzPayload tests.

The fuzz tests quickly fail prior to this commit.