### PR TITLE
Fix case where Opening Channels get stuck forever.

### DIFF
--- a/docs/release-notes/release-notes-0.17.4.md
+++ b/docs/release-notes/release-notes-0.17.4.md
@@ -19,6 +19,12 @@
 
 # Bug Fixes
 
+* [Fix the removal of failed
+  channels](https://github.com/lightningnetwork/lnd/pull/8406). When a pending
+  channel opening was pruned from memory no more channels were able to be
+  created nor accepted. This PR fixes this issue and enhances the test suite
+  for this behavior.
+
 # New Features
 ## Functional Enhancements
 ## RPC Additions

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -562,4 +562,8 @@ var allTestCases = []*lntest.TestCase{
 		Name:     "removetx",
 		TestFunc: testRemoveTx,
 	},
+	{
+		Name:     "fail funding flow psbt",
+		TestFunc: testPsbtChanFundingFailFlow,
+	},
 }

--- a/lncfg/config.go
+++ b/lncfg/config.go
@@ -5,6 +5,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 const (
@@ -67,6 +68,14 @@ const (
 	// peer and a block arriving during that round trip to trigger force
 	// closure.
 	DefaultOutgoingCltvRejectDelta = DefaultOutgoingBroadcastDelta + 3
+
+	// DefaultReservationTimeout is the default time we wait until we remove
+	// an unfinished (zombiestate) open channel flow from memory.
+	DefaultReservationTimeout = 10 * time.Minute
+
+	// DefaultZombieSweeperInterval is the default time interval at which
+	// unfinished (zombiestate) open channel flows are purged from memory.
+	DefaultZombieSweeperInterval = 1 * time.Minute
 )
 
 // CleanAndExpandPath expands environment variables and leading ~ in the

--- a/lncfg/dev.go
+++ b/lncfg/dev.go
@@ -2,7 +2,9 @@
 
 package lncfg
 
-import "time"
+import (
+	"time"
+)
 
 // IsDevBuild returns a bool to indicate whether we are in a development
 // environment.
@@ -20,4 +22,14 @@ type DevConfig struct{}
 // build.
 func (d *DevConfig) ChannelReadyWait() time.Duration {
 	return 0
+}
+
+// GetReservationTimeout returns the config value for `ReservationTimeout`.
+func (d *DevConfig) GetReservationTimeout() time.Duration {
+	return DefaultReservationTimeout
+}
+
+// GetZombieSweeperInterval returns the config value for`ZombieSweeperInterval`.
+func (d *DevConfig) GetZombieSweeperInterval() time.Duration {
+	return DefaultZombieSweeperInterval
 }

--- a/lncfg/dev_integration.go
+++ b/lncfg/dev_integration.go
@@ -2,7 +2,9 @@
 
 package lncfg
 
-import "time"
+import (
+	"time"
+)
 
 // IsDevBuild returns a bool to indicate whether we are in a development
 // environment.
@@ -18,9 +20,29 @@ func IsDevBuild() bool {
 //nolint:lll
 type DevConfig struct {
 	ProcessChannelReadyWait time.Duration `long:"processchannelreadywait" description:"Time to sleep before processing remote node's channel_ready message."`
+	ReservationTimeout      time.Duration `long:"reservationtimeout" description:"The maximum time we keep a pending channel open flow in memory."`
+	ZombieSweeperInterval   time.Duration `long:"zombiesweeperinterval" description:"The time interval at which channel opening flows are evaluated for zombie status."`
 }
 
 // ChannelReadyWait returns the config value `ProcessChannelReadyWait`.
 func (d *DevConfig) ChannelReadyWait() time.Duration {
 	return d.ProcessChannelReadyWait
+}
+
+// GetReservationTimeout returns the config value for `ReservationTimeout`.
+func (d *DevConfig) GetReservationTimeout() time.Duration {
+	if d.ReservationTimeout == 0 {
+		return DefaultReservationTimeout
+	}
+
+	return d.ReservationTimeout
+}
+
+// GetZombieSweeperInterval returns the config value for`ZombieSweeperInterval`.
+func (d *DevConfig) GetZombieSweeperInterval() time.Duration {
+	if d.ZombieSweeperInterval == 0 {
+		return DefaultZombieSweeperInterval
+	}
+
+	return d.ZombieSweeperInterval
 }

--- a/lntest/harness_assertion.go
+++ b/lntest/harness_assertion.go
@@ -289,6 +289,16 @@ func (h *HarnessTest) ReceiveOpenChannelUpdate(
 	return update
 }
 
+// ReceiveOpenChannelError waits for the expected error during the open channel
+// flow from the peer or times out.
+func (h *HarnessTest) ReceiveOpenChannelError(
+	stream rpc.OpenChanClient, expectedErr error) {
+
+	_, err := h.receiveOpenChannelUpdate(stream)
+	require.Contains(h, err.Error(), expectedErr.Error(),
+		"error not matched")
+}
+
 // receiveOpenChannelUpdate waits until a message or an error is received on
 // the stream or the timeout is reached.
 //

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -506,8 +506,9 @@ func NewBrontide(cfg Config) *Brontide {
 		activeChannels: &lnutils.SyncMap[
 			lnwire.ChannelID, *lnwallet.LightningChannel,
 		]{},
-		newActiveChannel:  make(chan *newChannelMsg, 1),
-		newPendingChannel: make(chan *newChannelMsg, 1),
+		newActiveChannel:     make(chan *newChannelMsg, 1),
+		newPendingChannel:    make(chan *newChannelMsg, 1),
+		removePendingChannel: make(chan *newChannelMsg),
 
 		activeMsgStreams:   make(map[lnwire.ChannelID]*msgStream),
 		activeChanCloses:   make(map[lnwire.ChannelID]*chancloser.ChanCloser),

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -2,6 +2,7 @@ package peer
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/lightningnetwork/lnd/contractcourt"
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/lntest/mock"
+	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chancloser"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -1450,4 +1452,89 @@ func TestStartupWriteMessageRace(t *testing.T) {
 			t.Fatalf("Failed to send all messages during startup")
 		}
 	}
+}
+
+// TestRemovePendingChannel checks that we are able to remove a pending channel
+// successfully from the peers channel map. This also makes sure the
+// removePendingChannel is initialized so we don't send to a nil channel and
+// get stuck.
+func TestRemovePendingChannel(t *testing.T) {
+	t.Parallel()
+
+	// Set up parameters for createTestPeer.
+	notifier := &mock.ChainNotifier{
+		SpendChan: make(chan *chainntnfs.SpendDetail),
+		EpochChan: make(chan *chainntnfs.BlockEpoch),
+		ConfChan:  make(chan *chainntnfs.TxConfirmation),
+	}
+	broadcastTxChan := make(chan *wire.MsgTx)
+	mockSwitch := &mockMessageSwitch{}
+
+	// createTestPeer creates a peer and a channel with that peer.
+	peer, _, err := createTestPeer(
+		t, notifier, broadcastTxChan, noUpdate, mockSwitch,
+	)
+	require.NoError(t, err, "unable to create test channel")
+
+	// Add a pending channel to the peer Alice.
+	errChan := make(chan error, 1)
+	pendingChanID := lnwire.ChannelID{1}
+	req := &newChannelMsg{
+		channelID: pendingChanID,
+		err:       errChan,
+	}
+
+	select {
+	case peer.newPendingChannel <- req:
+		// Operation completed successfully
+	case <-time.After(timeout):
+		t.Fatalf("not able to remove pending channel")
+	}
+
+	// Make sure the channel was added as a pending channel.
+	// The peer was already created with one active channel therefore the
+	// `activeChannels` had already one channel prior to adding the new one.
+	// The `addedChannels` map only tracks new channels in the current life
+	// cycle therefore the initial channel is not part of it.
+	err = wait.NoError(func() error {
+		if peer.activeChannels.Len() == 2 &&
+			peer.addedChannels.Len() == 1 {
+
+			return nil
+		}
+
+		return fmt.Errorf("pending channel not successfully added")
+	}, wait.DefaultTimeout)
+
+	require.NoError(t, err)
+
+	// Now try to remove it, the errChan needs to be reopened because it was
+	// closed during the pending channel registration above.
+	errChan = make(chan error, 1)
+	req = &newChannelMsg{
+		channelID: pendingChanID,
+		err:       errChan,
+	}
+
+	select {
+	case peer.removePendingChannel <- req:
+		// Operation completed successfully
+	case <-time.After(timeout):
+		t.Fatalf("not able to remove pending channel")
+	}
+
+	// Make sure the pending channel is successfully removed from both
+	// channel maps.
+	// The initial channel between the peer is still active at this point.
+	err = wait.NoError(func() error {
+		if peer.activeChannels.Len() == 1 &&
+			peer.addedChannels.Len() == 0 {
+
+			return nil
+		}
+
+		return fmt.Errorf("pending channel not successfully removed")
+	}, wait.DefaultTimeout)
+
+	require.NoError(t, err)
 }

--- a/server.go
+++ b/server.go
@@ -1270,6 +1270,12 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		return ourPolicy, err
 	}
 
+	// For the reservationTimeout and the zombieSweeperInterval different
+	// values are set in case we are in a dev environment so enhance test
+	// capacilities.
+	reservationTimeout := lncfg.DefaultReservationTimeout
+	zombieSweeperInterval := lncfg.DefaultZombieSweeperInterval
+
 	// Get the development config for funding manager. If we are not in
 	// development mode, this would be nil.
 	var devCfg *funding.DevConfig
@@ -1277,6 +1283,13 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		devCfg = &funding.DevConfig{
 			ProcessChannelReadyWait: cfg.Dev.ChannelReadyWait(),
 		}
+
+		reservationTimeout = cfg.Dev.GetReservationTimeout()
+		zombieSweeperInterval = cfg.Dev.GetZombieSweeperInterval()
+
+		srvrLog.Debugf("Using the dev config for the fundingMgr: %v, "+
+			"reservationTimeout=%v, zombieSweeperInterval=%v",
+			devCfg, reservationTimeout, zombieSweeperInterval)
 	}
 
 	//nolint:lll
@@ -1436,8 +1449,8 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 			// channel bandwidth.
 			return uint16(input.MaxHTLCNumber / 2)
 		},
-		ZombieSweeperInterval:         1 * time.Minute,
-		ReservationTimeout:            10 * time.Minute,
+		ZombieSweeperInterval:         zombieSweeperInterval,
+		ReservationTimeout:            reservationTimeout,
 		MinChanSize:                   btcutil.Amount(cfg.MinChanSize),
 		MaxChanSize:                   btcutil.Amount(cfg.MaxChanSize),
 		MaxPendingChannels:            cfg.MaxPendingChannels,


### PR DESCRIPTION
Fixes #8362 and I also #8251

So basically the `removePendingChannel ` channel was not initialized causing our `reservationCoordinator ` to get stuck forever. So after one call of the `failFundingFlow ` we would not be able to accept or open any new channels.

It did not panic because `nil` channels are acutally quite useful in golang to merge 2 channels for more information read:

https://medium.com/justforfunc/why-are-there-nil-channels-in-go-9877cc0b2308


I will add an itest to test the successful removal of a failed channel opening.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new configuration options for improved channel management.
	- Added the ability to set custom timeouts for reservations and intervals for zombie channel sweeping.

- **Bug Fixes**
	- Fixed an issue with the removal of failed channels in the Lightning Network Daemon to enhance error handling.

- **Tests**
	- Implemented new test cases to validate the failure of channel funding and the removal of pending channels.

- **Documentation**
	- Updated release notes with details on the latest fixes and configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->