### PR TITLE
fix: fix typo "(cltv_expiry" to "(cltv_expiry)" in `channeldb/channel.go` [skip ci]

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -2214,7 +2214,7 @@ type HTLC struct {
 	// - 8 bytes (id)
 	// - 8 bytes (amount_msat)
 	// - 32 bytes (payment_hash)
-	// - 4 bytes (cltv_expiry
+	// - 4 bytes (cltv_expiry)
 	// - 1366 bytes (onion_routing_packet)
 	// = 64083 bytes maximum possible TLV stream
 	//


### PR DESCRIPTION
## Change Description
fix: fix typo "(cltv_expiry" to "(cltv_expiry)" in `channeldb/channel.go` [skip ci]

### Code Style and Documentation
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.
