### PR TITLE
docs: add template for 0.17.4

### DIFF
--- a/docs/release-notes/release-notes-0.17.4.md
+++ b/docs/release-notes/release-notes-0.17.4.md
@@ -1,0 +1,42 @@
+# Release Notes
+- [Bug Fixes](#bug-fixes)
+- [New Features](#new-features)
+    - [Functional Enhancements](#functional-enhancements)
+    - [RPC Additions](#rpc-additions)
+    - [lncli Additions](#lncli-additions)
+- [Improvements](#improvements)
+    - [Functional Updates](#functional-updates)
+    - [RPC Updates](#rpc-updates)
+    - [lncli Updates](#lncli-updates)
+    - [Breaking Changes](#breaking-changes)
+    - [Performance Improvements](#performance-improvements)
+- [Technical and Architectural Updates](#technical-and-architectural-updates)
+    - [BOLT Spec Updates](#bolt-spec-updates)
+    - [Testing](#testing)
+    - [Database](#database)
+    - [Code Health](#code-health)
+    - [Tooling and Documentation](#tooling-and-documentation)
+
+# Bug Fixes
+
+# New Features
+## Functional Enhancements
+## RPC Additions
+## lncli Additions
+
+# Improvements
+## Functional Updates
+## RPC Updates
+## lncli Updates
+## Code Health
+## Breaking Changes
+## Performance Improvements
+
+# Technical and Architectural Updates
+## BOLT Spec Updates
+## Testing
+## Database
+## Code Health
+## Tooling and Documentation
+
+# Contributors (Alphabetical Order)


### PR DESCRIPTION
Adding this so that each 0.17.4 PR can just add a single entry rather than needing to add the whole template since nothing has been merged yet. 