### PR TITLE
lnwallet: remove redundant unused fields

### DIFF
--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -1323,15 +1323,6 @@ type LightningChannel struct {
 	localUpdateLog  *updateLog
 	remoteUpdateLog *updateLog
 
-	// LocalFundingKey is the public key under control by the wallet that
-	// was used for the 2-of-2 funding output which created this channel.
-	LocalFundingKey *btcec.PublicKey
-
-	// RemoteFundingKey is the public key for the remote channel counter
-	// party  which used for the 2-of-2 funding output which created this
-	// channel.
-	RemoteFundingKey *btcec.PublicKey
-
 	// log is a channel-specific logging instance.
 	log btclog.Logger
 
@@ -1448,8 +1439,6 @@ func NewLightningChannel(signer input.Signer,
 		remoteUpdateLog:      remoteUpdateLog,
 		ChanPoint:            &state.FundingOutpoint,
 		Capacity:             state.Capacity,
-		LocalFundingKey:      state.LocalChanCfg.MultiSigKey.PubKey,
-		RemoteFundingKey:     state.RemoteChanCfg.MultiSigKey.PubKey,
 		taprootNonceProducer: taprootNonceProducer,
 		log:                  build.NewPrefixLog(logPrefix, walletLog),
 		opts:                 opts,


### PR DESCRIPTION
## Change Description
This removes two fields from lnwallet.LightningChannel that were redundant. Removing them revealed that there was a single reference to those fields that constructed them and did not use them thereafter. The same information is reflected in the OpenChannel substructure so we have good a priori reason to believe they are redundant. Unit testing confirms this. Itests should too.

## Steps to Test
CI should handle it.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the `LightningChannel` structure for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->