### PR TITLE
[2/5]sweep: refactor fee estimation and introduce `UtxoAggregator`

### DIFF
--- a/channeldb/revocation_log.go
+++ b/channeldb/revocation_log.go
@@ -339,7 +339,7 @@ func serializeRevocationLog(w io.Writer, rl *RevocationLog) error {
 	}
 
 	// Write the tlv stream.
-	if err := writeTlvStream(w, tlvStream); err != nil {
+	if err := WriteTlvStream(w, tlvStream); err != nil {
 		return err
 	}
 
@@ -366,7 +366,7 @@ func serializeHTLCEntries(w io.Writer, htlcs []*HTLCEntry) error {
 		}
 
 		// Write the tlv stream.
-		if err := writeTlvStream(w, tlvStream); err != nil {
+		if err := WriteTlvStream(w, tlvStream); err != nil {
 			return err
 		}
 	}
@@ -403,7 +403,7 @@ func deserializeRevocationLog(r io.Reader) (RevocationLog, error) {
 	}
 
 	// Read the tlv stream.
-	parsedTypes, err := readTlvStream(r, tlvStream)
+	parsedTypes, err := ReadTlvStream(r, tlvStream)
 	if err != nil {
 		return rl, err
 	}
@@ -439,7 +439,7 @@ func deserializeHTLCEntries(r io.Reader) ([]*HTLCEntry, error) {
 		}
 
 		// Read the HTLC entry.
-		if _, err := readTlvStream(r, tlvStream); err != nil {
+		if _, err := ReadTlvStream(r, tlvStream); err != nil {
 			// We've reached the end when hitting an EOF.
 			if err == io.ErrUnexpectedEOF {
 				break
@@ -462,9 +462,9 @@ func deserializeHTLCEntries(r io.Reader) ([]*HTLCEntry, error) {
 	return htlcs, nil
 }
 
-// writeTlvStream is a helper function that encodes the tlv stream into the
+// WriteTlvStream is a helper function that encodes the tlv stream into the
 // writer.
-func writeTlvStream(w io.Writer, s *tlv.Stream) error {
+func WriteTlvStream(w io.Writer, s *tlv.Stream) error {
 	var b bytes.Buffer
 	if err := s.Encode(&b); err != nil {
 		return err
@@ -482,9 +482,9 @@ func writeTlvStream(w io.Writer, s *tlv.Stream) error {
 	return nil
 }
 
-// readTlvStream is a helper function that decodes the tlv stream from the
+// ReadTlvStream is a helper function that decodes the tlv stream from the
 // reader.
-func readTlvStream(r io.Reader, s *tlv.Stream) (tlv.TypeMap, error) {
+func ReadTlvStream(r io.Reader, s *tlv.Stream) (tlv.TypeMap, error) {
 	var bodyLen uint64
 
 	// Read the stream's length.

--- a/channeldb/revocation_log_test.go
+++ b/channeldb/revocation_log_test.go
@@ -137,7 +137,7 @@ func TestWriteTLVStream(t *testing.T) {
 
 	// Write the tlv stream.
 	buf := bytes.NewBuffer([]byte{})
-	err = writeTlvStream(buf, ts)
+	err = WriteTlvStream(buf, ts)
 	require.NoError(t, err)
 
 	// Check the bytes are written as expected.
@@ -157,7 +157,7 @@ func TestReadTLVStream(t *testing.T) {
 
 	// Read the tlv stream.
 	buf := bytes.NewBuffer(testValueBytes)
-	_, err = readTlvStream(buf, ts)
+	_, err = ReadTlvStream(buf, ts)
 	require.NoError(t, err)
 
 	// Check the bytes are read as expected.
@@ -180,7 +180,7 @@ func TestReadTLVStreamErr(t *testing.T) {
 
 	// Read the tlv stream.
 	buf := bytes.NewBuffer(b)
-	_, err = readTlvStream(buf, ts)
+	_, err = ReadTlvStream(buf, ts)
 	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
 
 	// Check the bytes are not read.

--- a/contractcourt/anchor_resolver.go
+++ b/contractcourt/anchor_resolver.go
@@ -115,7 +115,7 @@ func (c *anchorResolver) Resolve() (ContractResolver, error) {
 	resultChan, err := c.Sweeper.SweepInput(
 		&anchorInput,
 		sweep.Params{
-			Fee: sweep.FeePreference{
+			Fee: sweep.FeeEstimateInfo{
 				FeeRate: relayFeeRate,
 			},
 		},

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1359,7 +1359,7 @@ func (c *ChannelArbitrator) sweepAnchors(anchors *lnwallet.AnchorResolutions,
 		_, err = c.cfg.Sweeper.SweepInput(
 			&anchorInput,
 			sweep.Params{
-				Fee: sweep.FeePreference{
+				Fee: sweep.FeeEstimateInfo{
 					ConfTarget: deadline,
 				},
 				Force:          force,

--- a/contractcourt/commit_sweep_resolver.go
+++ b/contractcourt/commit_sweep_resolver.go
@@ -351,7 +351,7 @@ func (c *commitSweepResolver) Resolve() (ContractResolver, error) {
 	// sweeper.
 	c.log.Infof("sweeping commit output")
 
-	feePref := sweep.FeePreference{ConfTarget: commitOutputConfTarget}
+	feePref := sweep.FeeEstimateInfo{ConfTarget: commitOutputConfTarget}
 	resultChan, err := c.Sweeper.SweepInput(inp, sweep.Params{Fee: feePref})
 	if err != nil {
 		c.log.Errorf("unable to sweep input: %v", err)

--- a/contractcourt/commit_sweep_resolver_test.go
+++ b/contractcourt/commit_sweep_resolver_test.go
@@ -141,7 +141,7 @@ func (s *mockSweeper) SweepInput(input input.Input, params sweep.Params) (
 }
 
 func (s *mockSweeper) CreateSweepTx(inputs []input.Input,
-	feePref sweep.FeePreference) (*wire.MsgTx, error) {
+	feePref sweep.FeeEstimateInfo) (*wire.MsgTx, error) {
 
 	// We will wait for the test to supply the sweep tx to return.
 	sweepTx := <-s.createSweepTxChan

--- a/contractcourt/commit_sweep_resolver_test.go
+++ b/contractcourt/commit_sweep_resolver_test.go
@@ -140,8 +140,8 @@ func (s *mockSweeper) SweepInput(input input.Input, params sweep.Params) (
 	return result, nil
 }
 
-func (s *mockSweeper) CreateSweepTx(inputs []input.Input, feePref sweep.FeePreference,
-	currentBlockHeight uint32) (*wire.MsgTx, error) {
+func (s *mockSweeper) CreateSweepTx(inputs []input.Input,
+	feePref sweep.FeePreference) (*wire.MsgTx, error) {
 
 	// We will wait for the test to supply the sweep tx to return.
 	sweepTx := <-s.createSweepTxChan

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -263,7 +263,7 @@ func (h *htlcSuccessResolver) broadcastReSignedSuccessTx() (
 		_, err := h.Sweeper.SweepInput(
 			&secondLevelInput,
 			sweep.Params{
-				Fee: sweep.FeePreference{
+				Fee: sweep.FeeEstimateInfo{
 					ConfTarget: secondLevelConfTarget,
 				},
 			},
@@ -375,7 +375,7 @@ func (h *htlcSuccessResolver) broadcastReSignedSuccessTx() (
 	_, err = h.Sweeper.SweepInput(
 		inp,
 		sweep.Params{
-			Fee: sweep.FeePreference{
+			Fee: sweep.FeeEstimateInfo{
 				ConfTarget: sweepConfTarget,
 			},
 		},
@@ -436,7 +436,7 @@ func (h *htlcSuccessResolver) resolveRemoteCommitOutput() (
 		var err error
 		h.sweepTx, err = h.Sweeper.CreateSweepTx(
 			[]input.Input{inp},
-			sweep.FeePreference{
+			sweep.FeeEstimateInfo{
 				ConfTarget: sweepConfTarget,
 			},
 		)

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -432,17 +432,13 @@ func (h *htlcSuccessResolver) resolveRemoteCommitOutput() (
 		// transaction, that we'll use to move these coins back into
 		// the backing wallet.
 		//
-		// TODO: Set tx lock time to current block height instead of
-		// zero. Will be taken care of once sweeper implementation is
-		// complete.
-		//
 		// TODO: Use time-based sweeper and result chan.
 		var err error
 		h.sweepTx, err = h.Sweeper.CreateSweepTx(
 			[]input.Input{inp},
 			sweep.FeePreference{
 				ConfTarget: sweepConfTarget,
-			}, 0,
+			},
 		)
 		if err != nil {
 			return nil, err

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -486,7 +486,7 @@ func (h *htlcTimeoutResolver) sweepSecondLevelTx() error {
 	_, err := h.Sweeper.SweepInput(
 		inp,
 		sweep.Params{
-			Fee: sweep.FeePreference{
+			Fee: sweep.FeeEstimateInfo{
 				ConfTarget: secondLevelConfTarget,
 			},
 			Force: true,
@@ -702,7 +702,7 @@ func (h *htlcTimeoutResolver) handleCommitSpend(
 		_, err = h.Sweeper.SweepInput(
 			inp,
 			sweep.Params{
-				Fee: sweep.FeePreference{
+				Fee: sweep.FeeEstimateInfo{
 					ConfTarget: sweepConfTarget,
 				},
 			},

--- a/contractcourt/interfaces.go
+++ b/contractcourt/interfaces.go
@@ -53,7 +53,7 @@ type UtxoSweeper interface {
 	// that spends from them. This method also makes an accurate fee
 	// estimate before generating the required witnesses.
 	CreateSweepTx(inputs []input.Input,
-		feePref sweep.FeePreference) (*wire.MsgTx, error)
+		feePref sweep.FeeEstimateInfo) (*wire.MsgTx, error)
 
 	// RelayFeePerKW returns the minimum fee rate required for transactions
 	// to be relayed.

--- a/contractcourt/interfaces.go
+++ b/contractcourt/interfaces.go
@@ -52,8 +52,8 @@ type UtxoSweeper interface {
 	// CreateSweepTx accepts a list of inputs and signs and generates a txn
 	// that spends from them. This method also makes an accurate fee
 	// estimate before generating the required witnesses.
-	CreateSweepTx(inputs []input.Input, feePref sweep.FeePreference,
-		currentBlockHeight uint32) (*wire.MsgTx, error)
+	CreateSweepTx(inputs []input.Input,
+		feePref sweep.FeePreference) (*wire.MsgTx, error)
 
 	// RelayFeePerKW returns the minimum fee rate required for transactions
 	// to be relayed.

--- a/contractcourt/utxonursery.go
+++ b/contractcourt/utxonursery.go
@@ -823,7 +823,7 @@ func (u *UtxoNursery) sweepMatureOutputs(classHeight uint32,
 	utxnLog.Infof("Sweeping %v CSV-delayed outputs with sweep tx for "+
 		"height %v", len(kgtnOutputs), classHeight)
 
-	feePref := sweep.FeePreference{ConfTarget: kgtnOutputConfTarget}
+	feePref := sweep.FeeEstimateInfo{ConfTarget: kgtnOutputConfTarget}
 	for _, output := range kgtnOutputs {
 		// Create local copy to prevent pointer to loop variable to be
 		// passed in with disastrous consequences.

--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -179,6 +179,8 @@
   [MinConf](https://github.com/lightningnetwork/lnd/pull/8097)(minimum number
   of confirmations) has been added to the `WalletBalance` RPC call.
 
+* TODO
+
 ## lncli Updates
 
 * [Documented all available lncli commands](https://github.com/lightningnetwork/lnd/pull/8181).

--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -261,6 +261,10 @@
 * [Refactor InvoiceDB](https://github.com/lightningnetwork/lnd/pull/8081) to
   eliminate the use of `ScanInvoices`.
 
+* [Expanded SweeperStore](https://github.com/lightningnetwork/lnd/pull/8147) to
+  also store the feerate, fees paid, and whether it's published or not for a
+  given sweeping transaction.
+
 ## Code Health
 
 * [Remove database pointers](https://github.com/lightningnetwork/lnd/pull/8117) 

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -81,6 +81,7 @@ func (m *mockPreimageCache) SubscribeUpdates(
 	return nil, nil
 }
 
+// TODO(yy): replace it with chainfee.MockEstimator.
 type mockFeeEstimator struct {
 	byteFeeIn chan chainfee.SatPerKWeight
 	relayFee  chan chainfee.SatPerKWeight

--- a/lnrpc/rpc_utils.go
+++ b/lnrpc/rpc_utils.go
@@ -222,7 +222,7 @@ func CalculateFeeRate(satPerByte, satPerVByte uint64, targetConf uint32,
 
 	// Based on the passed fee related parameters, we'll determine an
 	// appropriate fee rate for this transaction.
-	feePref := sweep.FeePreference{
+	feePref := sweep.FeeEstimateInfo{
 		ConfTarget: targetConf,
 		FeeRate:    satPerKw,
 	}

--- a/lnrpc/rpc_utils.go
+++ b/lnrpc/rpc_utils.go
@@ -222,12 +222,12 @@ func CalculateFeeRate(satPerByte, satPerVByte uint64, targetConf uint32,
 
 	// Based on the passed fee related parameters, we'll determine an
 	// appropriate fee rate for this transaction.
-	feeRate, err := sweep.DetermineFeePerKw(
-		estimator, sweep.FeePreference{
-			ConfTarget: targetConf,
-			FeeRate:    satPerKw,
-		},
-	)
+	feePref := sweep.FeePreference{
+		ConfTarget: targetConf,
+		FeeRate:    satPerKw,
+	}
+	// TODO(yy): need to pass the configed max fee here.
+	feeRate, err := feePref.Estimate(estimator, 0)
 	if err != nil {
 		return feeRate, err
 	}

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -956,7 +956,7 @@ func (w *WalletKit) BumpFee(ctx context.Context,
 			in.SatPerByte * 1000,
 		).FeePerKWeight()
 	}
-	feePreference := sweep.FeePreference{
+	feePreference := sweep.FeeEstimateInfo{
 		ConfTarget: uint32(in.TargetConf),
 		FeeRate:    satPerKw,
 	}

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -875,7 +875,13 @@ func (w *WalletKit) PendingSweeps(ctx context.Context,
 		broadcastAttempts := uint32(pendingInput.BroadcastAttempts)
 		nextBroadcastHeight := uint32(pendingInput.NextBroadcastHeight)
 
-		requestedFee := pendingInput.Params.Fee
+		feePref := pendingInput.Params.Fee
+		requestedFee, ok := feePref.(sweep.FeeEstimateInfo)
+		if !ok {
+			return nil, fmt.Errorf("unknown fee preference type: "+
+				"%v", feePref)
+		}
+
 		requestedFeeRate := uint64(requestedFee.FeeRate.FeePerVByte())
 
 		rpcPendingSweeps = append(rpcPendingSweeps, &PendingSweep{

--- a/lnwallet/chainfee/mocks.go
+++ b/lnwallet/chainfee/mocks.go
@@ -1,6 +1,8 @@
 package chainfee
 
-import "github.com/stretchr/testify/mock"
+import (
+	"github.com/stretchr/testify/mock"
+)
 
 type mockFeeSource struct {
 	mock.Mock
@@ -14,4 +16,51 @@ func (m *mockFeeSource) GetFeeMap() (map[uint32]uint32, error) {
 	args := m.Called()
 
 	return args.Get(0).(map[uint32]uint32), args.Error(1)
+}
+
+// MockEstimator implements the `Estimator` interface and is used by
+// other packages for mock testing.
+type MockEstimator struct {
+	mock.Mock
+}
+
+// Compile time assertion that MockEstimator implements Estimator.
+var _ Estimator = (*MockEstimator)(nil)
+
+// EstimateFeePerKW takes in a target for the number of blocks until an initial
+// confirmation and returns the estimated fee expressed in sat/kw.
+func (m *MockEstimator) EstimateFeePerKW(
+	numBlocks uint32) (SatPerKWeight, error) {
+
+	args := m.Called(numBlocks)
+
+	if args.Get(0) == nil {
+		return 0, args.Error(1)
+	}
+
+	return args.Get(0).(SatPerKWeight), args.Error(1)
+}
+
+// Start signals the Estimator to start any processes or goroutines it needs to
+// perform its duty.
+func (m *MockEstimator) Start() error {
+	args := m.Called()
+
+	return args.Error(0)
+}
+
+// Stop stops any spawned goroutines and cleans up the resources used by the
+// fee estimator.
+func (m *MockEstimator) Stop() error {
+	args := m.Called()
+
+	return args.Error(0)
+}
+
+// RelayFeePerKW returns the minimum fee rate required for transactions to be
+// relayed. This is also the basis for calculation of the dust limit.
+func (m *MockEstimator) RelayFeePerKW() SatPerKWeight {
+	args := m.Called()
+
+	return args.Get(0).(SatPerKWeight)
 }

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1174,7 +1174,7 @@ func (r *rpcServer) EstimateFee(ctx context.Context,
 	// Query the fee estimator for the fee rate for the given confirmation
 	// target.
 	target := in.TargetConf
-	feePref := sweep.FeePreference{
+	feePref := sweep.FeeEstimateInfo{
 		ConfTarget: uint32(target),
 	}
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1174,11 +1174,13 @@ func (r *rpcServer) EstimateFee(ctx context.Context,
 	// Query the fee estimator for the fee rate for the given confirmation
 	// target.
 	target := in.TargetConf
-	feePerKw, err := sweep.DetermineFeePerKw(
-		r.server.cc.FeeEstimator, sweep.FeePreference{
-			ConfTarget: uint32(target),
-		},
-	)
+	feePref := sweep.FeePreference{
+		ConfTarget: uint32(target),
+	}
+
+	// Since we are providing an fee estimation as an RPC response, there's
+	// no need to set a max feerate here, so we use 0.
+	feePerKw, err := feePref.Estimate(r.server.cc.FeeEstimator, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/server.go
+++ b/server.go
@@ -1059,6 +1059,10 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		return nil, err
 	}
 
+	aggregator := sweep.NewSimpleUtxoAggregator(
+		cc.FeeEstimator, cfg.Sweeper.MaxFeeRate.FeePerKWeight(),
+	)
+
 	s.sweeper = sweep.New(&sweep.UtxoSweeperConfig{
 		FeeEstimator:         cc.FeeEstimator,
 		GenSweepScript:       newSweepPkScriptGen(cc.Wallet),
@@ -1071,7 +1075,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		MaxSweepAttempts:     sweep.DefaultMaxSweepAttempts,
 		NextAttemptDeltaFunc: sweep.DefaultNextAttemptDeltaFunc,
 		MaxFeeRate:           cfg.Sweeper.MaxFeeRate,
-		FeeRateBucketSize:    sweep.DefaultFeeRateBucketSize,
+		Aggregator:           aggregator,
 	})
 
 	s.utxoNursery = contractcourt.NewUtxoNursery(&contractcourt.NurseryConfig{

--- a/server.go
+++ b/server.go
@@ -1061,7 +1061,6 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 
 	s.sweeper = sweep.New(&sweep.UtxoSweeperConfig{
 		FeeEstimator:         cc.FeeEstimator,
-		DetermineFeePerKw:    sweep.DetermineFeePerKw,
 		GenSweepScript:       newSweepPkScriptGen(cc.Wallet),
 		Signer:               cc.Wallet.Cfg.Signer,
 		Wallet:               newSweeperWallet(cc.Wallet),

--- a/sweep/aggregator.go
+++ b/sweep/aggregator.go
@@ -1,0 +1,345 @@
+package sweep
+
+import (
+	"sort"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+)
+
+const (
+	// DefaultFeeRateBucketSize is the default size of fee rate buckets
+	// we'll use when clustering inputs into buckets with similar fee rates
+	// within the SimpleAggregator.
+	//
+	// Given a minimum relay fee rate of 1 sat/vbyte, a multiplier of 10
+	// would result in the following fee rate buckets up to the maximum fee
+	// rate:
+	//
+	//   #1: min = 1 sat/vbyte, max = 10 sat/vbyte
+	//   #2: min = 11 sat/vbyte, max = 20 sat/vbyte...
+	DefaultFeeRateBucketSize = 10
+)
+
+// UtxoAggregator defines an interface that takes a list of inputs and
+// aggregate them into groups. Each group is used as the inputs to create a
+// sweeping transaction.
+type UtxoAggregator interface {
+	// ClusterInputs takes a list of inputs and groups them into clusters.
+	ClusterInputs(pendingInputs) []inputCluster
+}
+
+type SimpleAggregator struct {
+	// FeeEstimator is used when crafting sweep transactions to estimate
+	// the necessary fee relative to the expected size of the sweep
+	// transaction.
+	FeeEstimator chainfee.Estimator
+
+	// MaxFeeRate is the the maximum fee rate allowed within the
+	// SimpleAggregator.
+	MaxFeeRate chainfee.SatPerKWeight
+
+	// FeeRateBucketSize is the default size of fee rate buckets we'll use
+	// when clustering inputs into buckets with similar fee rates within
+	// the SimpleAggregator.
+	//
+	// Given a minimum relay fee rate of 1 sat/vbyte, a fee rate bucket
+	// size of 10 would result in the following fee rate buckets up to the
+	// maximum fee rate:
+	//
+	//   #1: min = 1 sat/vbyte, max (exclusive) = 11 sat/vbyte
+	//   #2: min = 11 sat/vbyte, max (exclusive) = 21 sat/vbyte...
+	FeeRateBucketSize int
+}
+
+// Compile-time constraint to ensure SimpleAggregator implements UtxoAggregator.
+var _ UtxoAggregator = (*SimpleAggregator)(nil)
+
+// NewSimpleUtxoAggregator creates a new instance of a SimpleAggregator.
+func NewSimpleUtxoAggregator(estimator chainfee.Estimator,
+	max chainfee.SatPerKWeight) *SimpleAggregator {
+
+	return &SimpleAggregator{
+		FeeEstimator:      estimator,
+		MaxFeeRate:        max,
+		FeeRateBucketSize: DefaultFeeRateBucketSize,
+	}
+}
+
+// createInputClusters creates a list of input clusters from the set of pending
+// inputs known by the UtxoSweeper. It clusters inputs by
+// 1) Required tx locktime
+// 2) Similar fee rates.
+func (s *SimpleAggregator) ClusterInputs(inputs pendingInputs) []inputCluster {
+	// We start by getting the inputs clusters by locktime. Since the
+	// inputs commit to the locktime, they can only be clustered together
+	// if the locktime is equal.
+	lockTimeClusters, nonLockTimeInputs := s.clusterByLockTime(inputs)
+
+	// Cluster the the remaining inputs by sweep fee rate.
+	feeClusters := s.clusterBySweepFeeRate(nonLockTimeInputs)
+
+	// Since the inputs that we clustered by fee rate don't commit to a
+	// specific locktime, we can try to merge a locktime cluster with a fee
+	// cluster.
+	return zipClusters(lockTimeClusters, feeClusters)
+}
+
+// clusterByLockTime takes the given set of pending inputs and clusters those
+// with equal locktime together. Each cluster contains a sweep fee rate, which
+// is determined by calculating the average fee rate of all inputs within that
+// cluster. In addition to the created clusters, inputs that did not specify a
+// required lock time are returned.
+func (s *SimpleAggregator) clusterByLockTime(
+	inputs pendingInputs) ([]inputCluster, pendingInputs) {
+
+	locktimes := make(map[uint32]pendingInputs)
+	rem := make(pendingInputs)
+
+	// Go through all inputs and check if they require a certain locktime.
+	for op, input := range inputs {
+		lt, ok := input.RequiredLockTime()
+		if !ok {
+			rem[op] = input
+			continue
+		}
+
+		// Check if we already have inputs with this locktime.
+		cluster, ok := locktimes[lt]
+		if !ok {
+			cluster = make(pendingInputs)
+		}
+
+		// Get the fee rate based on the fee preference. If an error is
+		// returned, we'll skip sweeping this input for this round of
+		// cluster creation and retry it when we create the clusters
+		// from the pending inputs again.
+		feeRate, err := input.params.Fee.Estimate(
+			s.FeeEstimator, s.MaxFeeRate,
+		)
+		if err != nil {
+			log.Warnf("Skipping input %v: %v", op, err)
+			continue
+		}
+
+		log.Debugf("Adding input %v to cluster with locktime=%v, "+
+			"feeRate=%v", op, lt, feeRate)
+
+		// Attach the fee rate to the input.
+		input.lastFeeRate = feeRate
+
+		// Update the cluster about the updated input.
+		cluster[op] = input
+		locktimes[lt] = cluster
+	}
+
+	// We'll then determine the sweep fee rate for each set of inputs by
+	// calculating the average fee rate of the inputs within each set.
+	inputClusters := make([]inputCluster, 0, len(locktimes))
+	for lt, cluster := range locktimes {
+		lt := lt
+
+		var sweepFeeRate chainfee.SatPerKWeight
+		for _, input := range cluster {
+			sweepFeeRate += input.lastFeeRate
+		}
+
+		sweepFeeRate /= chainfee.SatPerKWeight(len(cluster))
+		inputClusters = append(inputClusters, inputCluster{
+			lockTime:     &lt,
+			sweepFeeRate: sweepFeeRate,
+			inputs:       cluster,
+		})
+	}
+
+	return inputClusters, rem
+}
+
+// clusterBySweepFeeRate takes the set of pending inputs within the UtxoSweeper
+// and clusters those together with similar fee rates. Each cluster contains a
+// sweep fee rate, which is determined by calculating the average fee rate of
+// all inputs within that cluster.
+func (s *SimpleAggregator) clusterBySweepFeeRate(
+	inputs pendingInputs) []inputCluster {
+
+	bucketInputs := make(map[int]*bucketList)
+	inputFeeRates := make(map[wire.OutPoint]chainfee.SatPerKWeight)
+
+	// First, we'll group together all inputs with similar fee rates. This
+	// is done by determining the fee rate bucket they should belong in.
+	for op, input := range inputs {
+		feeRate, err := input.params.Fee.Estimate(
+			s.FeeEstimator, s.MaxFeeRate,
+		)
+		if err != nil {
+			log.Warnf("Skipping input %v: %v", op, err)
+			continue
+		}
+
+		// Only try to sweep inputs with an unconfirmed parent if the
+		// current sweep fee rate exceeds the parent tx fee rate. This
+		// assumes that such inputs are offered to the sweeper solely
+		// for the purpose of anchoring down the parent tx using cpfp.
+		parentTx := input.UnconfParent()
+		if parentTx != nil {
+			parentFeeRate :=
+				chainfee.SatPerKWeight(parentTx.Fee*1000) /
+					chainfee.SatPerKWeight(parentTx.Weight)
+
+			if parentFeeRate >= feeRate {
+				log.Debugf("Skipping cpfp input %v: "+
+					"fee_rate=%v, parent_fee_rate=%v", op,
+					feeRate, parentFeeRate)
+
+				continue
+			}
+		}
+
+		feeGroup := s.bucketForFeeRate(feeRate)
+
+		// Create a bucket list for this fee rate if there isn't one
+		// yet.
+		buckets, ok := bucketInputs[feeGroup]
+		if !ok {
+			buckets = &bucketList{}
+			bucketInputs[feeGroup] = buckets
+		}
+
+		// Request the bucket list to add this input. The bucket list
+		// will take into account exclusive group constraints.
+		buckets.add(input)
+
+		input.lastFeeRate = feeRate
+		inputFeeRates[op] = feeRate
+	}
+
+	// We'll then determine the sweep fee rate for each set of inputs by
+	// calculating the average fee rate of the inputs within each set.
+	inputClusters := make([]inputCluster, 0, len(bucketInputs))
+	for _, buckets := range bucketInputs {
+		for _, inputs := range buckets.buckets {
+			var sweepFeeRate chainfee.SatPerKWeight
+			for op := range inputs {
+				sweepFeeRate += inputFeeRates[op]
+			}
+			sweepFeeRate /= chainfee.SatPerKWeight(len(inputs))
+			inputClusters = append(inputClusters, inputCluster{
+				sweepFeeRate: sweepFeeRate,
+				inputs:       inputs,
+			})
+		}
+	}
+
+	return inputClusters
+}
+
+// bucketForFeeReate determines the proper bucket for a fee rate. This is done
+// in order to batch inputs with similar fee rates together.
+func (s *SimpleAggregator) bucketForFeeRate(
+	feeRate chainfee.SatPerKWeight) int {
+
+	relayFeeRate := s.FeeEstimator.RelayFeePerKW()
+
+	// Create an isolated bucket for sweeps at the minimum fee rate. This
+	// is to prevent very small outputs (anchors) from becoming
+	// uneconomical if their fee rate would be averaged with higher fee
+	// rate inputs in a regular bucket.
+	if feeRate == relayFeeRate {
+		return 0
+	}
+
+	return 1 + int(feeRate-relayFeeRate)/s.FeeRateBucketSize
+}
+
+// mergeClusters attempts to merge cluster a and b if they are compatible. The
+// new cluster will have the locktime set if a or b had a locktime set, and a
+// sweep fee rate that is the maximum of a and b's. If the two clusters are not
+// compatible, they will be returned unchanged.
+func mergeClusters(a, b inputCluster) []inputCluster {
+	newCluster := inputCluster{}
+
+	switch {
+	// Incompatible locktimes, return the sets without merging them.
+	case a.lockTime != nil && b.lockTime != nil &&
+		*a.lockTime != *b.lockTime:
+
+		return []inputCluster{a, b}
+
+	case a.lockTime != nil:
+		newCluster.lockTime = a.lockTime
+
+	case b.lockTime != nil:
+		newCluster.lockTime = b.lockTime
+	}
+
+	if a.sweepFeeRate > b.sweepFeeRate {
+		newCluster.sweepFeeRate = a.sweepFeeRate
+	} else {
+		newCluster.sweepFeeRate = b.sweepFeeRate
+	}
+
+	newCluster.inputs = make(pendingInputs)
+
+	for op, in := range a.inputs {
+		newCluster.inputs[op] = in
+	}
+
+	for op, in := range b.inputs {
+		newCluster.inputs[op] = in
+	}
+
+	return []inputCluster{newCluster}
+}
+
+// zipClusters merges pairwise clusters from as and bs such that cluster a from
+// as is merged with a cluster from bs that has at least the fee rate of a.
+// This to ensure we don't delay confirmation by decreasing the fee rate (the
+// lock time inputs are typically second level HTLC transactions, that are time
+// sensitive).
+func zipClusters(as, bs []inputCluster) []inputCluster {
+	// Sort the clusters by decreasing fee rates.
+	sort.Slice(as, func(i, j int) bool {
+		return as[i].sweepFeeRate >
+			as[j].sweepFeeRate
+	})
+	sort.Slice(bs, func(i, j int) bool {
+		return bs[i].sweepFeeRate >
+			bs[j].sweepFeeRate
+	})
+
+	var (
+		finalClusters []inputCluster
+		j             int
+	)
+
+	// Go through each cluster in as, and merge with the next one from bs
+	// if it has at least the fee rate needed.
+	for i := range as {
+		a := as[i]
+
+		switch {
+		// If the fee rate for the next one from bs is at least a's, we
+		// merge.
+		case j < len(bs) && bs[j].sweepFeeRate >= a.sweepFeeRate:
+			merged := mergeClusters(a, bs[j])
+			finalClusters = append(finalClusters, merged...)
+
+			// Increment j for the next round.
+			j++
+
+		// We did not merge, meaning all the remaining clusters from bs
+		// have lower fee rate. Instead we add a directly to the final
+		// clusters.
+		default:
+			finalClusters = append(finalClusters, a)
+		}
+	}
+
+	// Add any remaining clusters from bs.
+	for ; j < len(bs); j++ {
+		b := bs[j]
+		finalClusters = append(finalClusters, b)
+	}
+
+	return finalClusters
+}

--- a/sweep/aggregator_test.go
+++ b/sweep/aggregator_test.go
@@ -1,0 +1,423 @@
+package sweep
+
+import (
+	"errors"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	"github.com/stretchr/testify/require"
+)
+
+//nolint:lll
+var (
+	testInputsA = pendingInputs{
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 0}: &pendingInput{},
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 1}: &pendingInput{},
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 2}: &pendingInput{},
+	}
+
+	testInputsB = pendingInputs{
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 10}: &pendingInput{},
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 11}: &pendingInput{},
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 12}: &pendingInput{},
+	}
+
+	testInputsC = pendingInputs{
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 0}:  &pendingInput{},
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 1}:  &pendingInput{},
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 2}:  &pendingInput{},
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 10}: &pendingInput{},
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 11}: &pendingInput{},
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 12}: &pendingInput{},
+	}
+)
+
+// TestMergeClusters check that we properly can merge clusters together,
+// according to their required locktime.
+func TestMergeClusters(t *testing.T) {
+	t.Parallel()
+
+	lockTime1 := uint32(100)
+	lockTime2 := uint32(200)
+
+	testCases := []struct {
+		name string
+		a    inputCluster
+		b    inputCluster
+		res  []inputCluster
+	}{
+		{
+			name: "max fee rate",
+			a: inputCluster{
+				sweepFeeRate: 5000,
+				inputs:       testInputsA,
+			},
+			b: inputCluster{
+				sweepFeeRate: 7000,
+				inputs:       testInputsB,
+			},
+			res: []inputCluster{
+				{
+					sweepFeeRate: 7000,
+					inputs:       testInputsC,
+				},
+			},
+		},
+		{
+			name: "same locktime",
+			a: inputCluster{
+				lockTime:     &lockTime1,
+				sweepFeeRate: 5000,
+				inputs:       testInputsA,
+			},
+			b: inputCluster{
+				lockTime:     &lockTime1,
+				sweepFeeRate: 7000,
+				inputs:       testInputsB,
+			},
+			res: []inputCluster{
+				{
+					lockTime:     &lockTime1,
+					sweepFeeRate: 7000,
+					inputs:       testInputsC,
+				},
+			},
+		},
+		{
+			name: "diff locktime",
+			a: inputCluster{
+				lockTime:     &lockTime1,
+				sweepFeeRate: 5000,
+				inputs:       testInputsA,
+			},
+			b: inputCluster{
+				lockTime:     &lockTime2,
+				sweepFeeRate: 7000,
+				inputs:       testInputsB,
+			},
+			res: []inputCluster{
+				{
+					lockTime:     &lockTime1,
+					sweepFeeRate: 5000,
+					inputs:       testInputsA,
+				},
+				{
+					lockTime:     &lockTime2,
+					sweepFeeRate: 7000,
+					inputs:       testInputsB,
+				},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		merged := mergeClusters(test.a, test.b)
+		if !reflect.DeepEqual(merged, test.res) {
+			t.Fatalf("[%s] unexpected result: %v",
+				test.name, spew.Sdump(merged))
+		}
+	}
+}
+
+// TestZipClusters tests that we can merge lists of inputs clusters correctly.
+func TestZipClusters(t *testing.T) {
+	t.Parallel()
+
+	createCluster := func(inp pendingInputs,
+		f chainfee.SatPerKWeight) inputCluster {
+
+		return inputCluster{
+			sweepFeeRate: f,
+			inputs:       inp,
+		}
+	}
+
+	testCases := []struct {
+		name string
+		as   []inputCluster
+		bs   []inputCluster
+		res  []inputCluster
+	}{
+		{
+			name: "merge A into B",
+			as: []inputCluster{
+				createCluster(testInputsA, 5000),
+			},
+			bs: []inputCluster{
+				createCluster(testInputsB, 7000),
+			},
+			res: []inputCluster{
+				createCluster(testInputsC, 7000),
+			},
+		},
+		{
+			name: "A can't merge with B",
+			as: []inputCluster{
+				createCluster(testInputsA, 7000),
+			},
+			bs: []inputCluster{
+				createCluster(testInputsB, 5000),
+			},
+			res: []inputCluster{
+				createCluster(testInputsA, 7000),
+				createCluster(testInputsB, 5000),
+			},
+		},
+		{
+			name: "empty bs",
+			as: []inputCluster{
+				createCluster(testInputsA, 7000),
+			},
+			bs: []inputCluster{},
+			res: []inputCluster{
+				createCluster(testInputsA, 7000),
+			},
+		},
+		{
+			name: "empty as",
+			as:   []inputCluster{},
+			bs: []inputCluster{
+				createCluster(testInputsB, 5000),
+			},
+			res: []inputCluster{
+				createCluster(testInputsB, 5000),
+			},
+		},
+
+		{
+			name: "zip 3xA into 3xB",
+			as: []inputCluster{
+				createCluster(testInputsA, 5000),
+				createCluster(testInputsA, 5000),
+				createCluster(testInputsA, 5000),
+			},
+			bs: []inputCluster{
+				createCluster(testInputsB, 7000),
+				createCluster(testInputsB, 7000),
+				createCluster(testInputsB, 7000),
+			},
+			res: []inputCluster{
+				createCluster(testInputsC, 7000),
+				createCluster(testInputsC, 7000),
+				createCluster(testInputsC, 7000),
+			},
+		},
+		{
+			name: "zip A into 3xB",
+			as: []inputCluster{
+				createCluster(testInputsA, 2500),
+			},
+			bs: []inputCluster{
+				createCluster(testInputsB, 3000),
+				createCluster(testInputsB, 2000),
+				createCluster(testInputsB, 1000),
+			},
+			res: []inputCluster{
+				createCluster(testInputsC, 3000),
+				createCluster(testInputsB, 2000),
+				createCluster(testInputsB, 1000),
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		zipped := zipClusters(test.as, test.bs)
+		if !reflect.DeepEqual(zipped, test.res) {
+			t.Fatalf("[%s] unexpected result: %v",
+				test.name, spew.Sdump(zipped))
+		}
+	}
+}
+
+// TestClusterByLockTime tests the method clusterByLockTime works as expected.
+func TestClusterByLockTime(t *testing.T) {
+	t.Parallel()
+
+	// Create a mock FeePreference.
+	mockFeePref := &MockFeePreference{}
+
+	// Create a test param with a dummy fee preference. This is needed so
+	// `feeRateForPreference` won't throw an error.
+	param := Params{Fee: mockFeePref}
+
+	// We begin the test by creating three clusters of inputs, the first
+	// cluster has a locktime of 1, the second has a locktime of 2, and the
+	// final has no locktime.
+	lockTime1 := uint32(1)
+	lockTime2 := uint32(2)
+
+	// Create cluster one, which has a locktime of 1.
+	input1LockTime1 := &input.MockInput{}
+	input2LockTime1 := &input.MockInput{}
+	input1LockTime1.On("RequiredLockTime").Return(lockTime1, true)
+	input2LockTime1.On("RequiredLockTime").Return(lockTime1, true)
+
+	// Create cluster two, which has a locktime of 2.
+	input3LockTime2 := &input.MockInput{}
+	input4LockTime2 := &input.MockInput{}
+	input3LockTime2.On("RequiredLockTime").Return(lockTime2, true)
+	input4LockTime2.On("RequiredLockTime").Return(lockTime2, true)
+
+	// Create cluster three, which has no locktime.
+	input5NoLockTime := &input.MockInput{}
+	input6NoLockTime := &input.MockInput{}
+	input5NoLockTime.On("RequiredLockTime").Return(uint32(0), false)
+	input6NoLockTime.On("RequiredLockTime").Return(uint32(0), false)
+
+	// With the inner Input being mocked, we can now create the pending
+	// inputs.
+	input1 := &pendingInput{Input: input1LockTime1, params: param}
+	input2 := &pendingInput{Input: input2LockTime1, params: param}
+	input3 := &pendingInput{Input: input3LockTime2, params: param}
+	input4 := &pendingInput{Input: input4LockTime2, params: param}
+	input5 := &pendingInput{Input: input5NoLockTime, params: param}
+	input6 := &pendingInput{Input: input6NoLockTime, params: param}
+
+	// Create the pending inputs map, which will be passed to the method
+	// under test.
+	//
+	// NOTE: we don't care the actual outpoint values as long as they are
+	// unique.
+	inputs := pendingInputs{
+		wire.OutPoint{Index: 1}: input1,
+		wire.OutPoint{Index: 2}: input2,
+		wire.OutPoint{Index: 3}: input3,
+		wire.OutPoint{Index: 4}: input4,
+		wire.OutPoint{Index: 5}: input5,
+		wire.OutPoint{Index: 6}: input6,
+	}
+
+	// Create expected clusters so we can shorten the line length in the
+	// test cases below.
+	cluster1 := pendingInputs{
+		wire.OutPoint{Index: 1}: input1,
+		wire.OutPoint{Index: 2}: input2,
+	}
+	cluster2 := pendingInputs{
+		wire.OutPoint{Index: 3}: input3,
+		wire.OutPoint{Index: 4}: input4,
+	}
+
+	// cluster3 should be the remaining inputs since they don't have
+	// locktime.
+	cluster3 := pendingInputs{
+		wire.OutPoint{Index: 5}: input5,
+		wire.OutPoint{Index: 6}: input6,
+	}
+
+	const (
+		// Set the min fee rate to be 1000 sat/kw.
+		minFeeRate = chainfee.SatPerKWeight(1000)
+
+		// Set the max fee rate to be 10,000 sat/kw.
+		maxFeeRate = chainfee.SatPerKWeight(10_000)
+	)
+
+	// Create a test aggregator.
+	s := NewSimpleUtxoAggregator(nil, maxFeeRate)
+
+	testCases := []struct {
+		name string
+		// setupMocker takes a testing fee rate and makes a mocker over
+		// `Estimate` that always return the testing fee rate.
+		setupMocker             func()
+		testFeeRate             chainfee.SatPerKWeight
+		expectedClusters        []inputCluster
+		expectedRemainingInputs pendingInputs
+	}{
+		{
+			// Test a successful case where the locktime clusters
+			// are created and the no-locktime cluster is returned
+			// as the remaining inputs.
+			name: "successfully create clusters",
+			setupMocker: func() {
+				// Expect the four inputs with locktime to call
+				// this method.
+				mockFeePref.On("Estimate", nil, maxFeeRate).
+					Return(minFeeRate+1, nil).Times(4)
+			},
+			// Use a fee rate above the min value so we don't hit
+			// an error when performing fee estimation.
+			//
+			// TODO(yy): we should customize the returned fee rate
+			// for each input to further test the averaging logic.
+			// Or we can split the method into two, one for
+			// grouping the clusters and the other for averaging
+			// the fee rates so it's easier to be tested.
+			testFeeRate: minFeeRate + 1,
+			expectedClusters: []inputCluster{
+				{
+					lockTime:     &lockTime1,
+					sweepFeeRate: minFeeRate + 1,
+					inputs:       cluster1,
+				},
+				{
+					lockTime:     &lockTime2,
+					sweepFeeRate: minFeeRate + 1,
+					inputs:       cluster2,
+				},
+			},
+			expectedRemainingInputs: cluster3,
+		},
+		{
+			// Test that when the input is skipped when the fee
+			// estimation returns an error.
+			name: "error from fee estimation",
+			setupMocker: func() {
+				mockFeePref.On("Estimate", nil, maxFeeRate).
+					Return(chainfee.SatPerKWeight(0),
+						errors.New("dummy")).Times(4)
+			},
+
+			// Use a fee rate below the min value so we hit an
+			// error when performing fee estimation.
+			testFeeRate:      minFeeRate - 1,
+			expectedClusters: []inputCluster{},
+			// Remaining inputs should stay untouched.
+			expectedRemainingInputs: cluster3,
+		},
+	}
+
+	//nolint:paralleltest
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			// Apply the test fee rate so `feeRateForPreference` is
+			// mocked to return the specified value.
+			tc.setupMocker()
+
+			// Call the method under test.
+			clusters, remainingInputs := s.clusterByLockTime(inputs)
+
+			// Sort by locktime as the order is not guaranteed.
+			sort.Slice(clusters, func(i, j int) bool {
+				return *clusters[i].lockTime <
+					*clusters[j].lockTime
+			})
+
+			// Validate the values are returned as expected.
+			require.Equal(t, tc.expectedClusters, clusters)
+			require.Equal(t, tc.expectedRemainingInputs,
+				remainingInputs,
+			)
+
+			// Assert the mocked methods are called as expeceted.
+			input1LockTime1.AssertExpectations(t)
+			input2LockTime1.AssertExpectations(t)
+			input3LockTime2.AssertExpectations(t)
+			input4LockTime2.AssertExpectations(t)
+			input5NoLockTime.AssertExpectations(t)
+			input6NoLockTime.AssertExpectations(t)
+
+			// Assert the mocked methods are called as expeceted.
+			mockFeePref.AssertExpectations(t)
+		})
+	}
+}

--- a/sweep/fee_estimator_mock_test.go
+++ b/sweep/fee_estimator_mock_test.go
@@ -9,6 +9,8 @@ import (
 // mockFeeEstimator implements a mock fee estimator. It closely resembles
 // lnwallet.StaticFeeEstimator with the addition that fees can be changed for
 // testing purposes in a thread safe manner.
+//
+// TODO(yy): replace it with chainfee.MockEstimator once it's merged.
 type mockFeeEstimator struct {
 	feePerKW chainfee.SatPerKWeight
 

--- a/sweep/mocks.go
+++ b/sweep/mocks.go
@@ -27,3 +27,18 @@ func (m *MockFeePreference) Estimate(estimator chainfee.Estimator,
 
 	return args.Get(0).(chainfee.SatPerKWeight), args.Error(1)
 }
+
+type mockUtxoAggregator struct {
+	mock.Mock
+}
+
+// Compile-time constraint to ensure mockUtxoAggregator implements
+// UtxoAggregator.
+var _ UtxoAggregator = (*mockUtxoAggregator)(nil)
+
+// ClusterInputs takes a list of inputs and groups them into clusters.
+func (m *mockUtxoAggregator) ClusterInputs(pendingInputs) []inputCluster {
+	args := m.Called(pendingInputs{})
+
+	return args.Get(0).([]inputCluster)
+}

--- a/sweep/mocks.go
+++ b/sweep/mocks.go
@@ -1,0 +1,29 @@
+package sweep
+
+import (
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockFeePreference struct {
+	mock.Mock
+}
+
+// Compile-time constraint to ensure MockFeePreference implements FeePreference.
+var _ FeePreference = (*MockFeePreference)(nil)
+
+func (m *MockFeePreference) String() string {
+	return "mock fee preference"
+}
+
+func (m *MockFeePreference) Estimate(estimator chainfee.Estimator,
+	maxFeeRate chainfee.SatPerKWeight) (chainfee.SatPerKWeight, error) {
+
+	args := m.Called(estimator, maxFeeRate)
+
+	if args.Get(0) == nil {
+		return 0, args.Error(1)
+	}
+
+	return args.Get(0).(chainfee.SatPerKWeight), args.Error(1)
+}

--- a/sweep/store.go
+++ b/sweep/store.go
@@ -39,8 +39,8 @@ type SweeperStore interface {
 	// hash.
 	IsOurTx(hash chainhash.Hash) (bool, error)
 
-	// NotifyPublishTx signals that we are about to publish a tx.
-	NotifyPublishTx(*wire.MsgTx) error
+	// StoreTx stores a tx hash we are about to publish.
+	StoreTx(chainhash.Hash) error
 
 	// ListSweeps lists all the sweeps we have successfully published.
 	ListSweeps() ([]chainhash.Hash, error)
@@ -147,8 +147,8 @@ func migrateTxHashes(tx kvdb.RwTx, txHashesBucket kvdb.RwBucket,
 	return nil
 }
 
-// NotifyPublishTx signals that we are about to publish a tx.
-func (s *sweeperStore) NotifyPublishTx(sweepTx *wire.MsgTx) error {
+// StoreTx stores that we are about to publish a tx.
+func (s *sweeperStore) StoreTx(txid chainhash.Hash) error {
 	return kvdb.Update(s.db, func(tx kvdb.RwTx) error {
 
 		txHashesBucket := tx.ReadWriteBucket(txHashesBucketKey)
@@ -156,9 +156,7 @@ func (s *sweeperStore) NotifyPublishTx(sweepTx *wire.MsgTx) error {
 			return errNoTxHashesBucket
 		}
 
-		hash := sweepTx.TxHash()
-
-		return txHashesBucket.Put(hash[:], []byte{})
+		return txHashesBucket.Put(txid[:], []byte{})
 	}, func() {})
 }
 

--- a/sweep/store.go
+++ b/sweep/store.go
@@ -122,6 +122,13 @@ type SweeperStore interface {
 
 	// ListSweeps lists all the sweeps we have successfully published.
 	ListSweeps() ([]chainhash.Hash, error)
+
+	// GetTx queries the database to find the tx that matches the given
+	// txid. Returns ErrTxNotFound if it cannot be found.
+	GetTx(hash chainhash.Hash) (*TxRecord, error)
+
+	// DeleteTx removes a tx specified by the hash from the store.
+	DeleteTx(hash chainhash.Hash) error
 }
 
 type sweeperStore struct {
@@ -314,6 +321,65 @@ func (s *sweeperStore) ListSweeps() ([]chainhash.Hash, error) {
 	}
 
 	return sweepTxns, nil
+}
+
+// GetTx queries the database to find the tx that matches the given txid.
+// Returns ErrTxNotFound if it cannot be found.
+func (s *sweeperStore) GetTx(txid chainhash.Hash) (*TxRecord, error) {
+	// Create a record.
+	tr := &TxRecord{}
+
+	var err error
+	err = kvdb.View(s.db, func(tx kvdb.RTx) error {
+		txHashesBucket := tx.ReadBucket(txHashesBucketKey)
+		if txHashesBucket == nil {
+			return errNoTxHashesBucket
+		}
+
+		txBytes := txHashesBucket.Get(txid[:])
+		if txBytes == nil {
+			return ErrTxNotFound
+		}
+
+		// For old records, we'd get an empty byte slice here. We can
+		// assume it's already been published. Although it's possible
+		// to calculate the fees and fee rate used here, we skip it as
+		// it's unlikely we'd perform RBF on these old sweeping
+		// transactions.
+		//
+		// TODO(yy): remove this check once migration is added.
+		if len(txBytes) == 0 {
+			tr.Published = true
+			return nil
+		}
+
+		tr, err = deserializeTxRecord(bytes.NewReader(txBytes))
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}, func() {})
+	if err != nil {
+		return nil, err
+	}
+
+	// Attach the txid to the record.
+	tr.Txid = txid
+
+	return tr, nil
+}
+
+// DeleteTx removes the given tx from db.
+func (s *sweeperStore) DeleteTx(txid chainhash.Hash) error {
+	return kvdb.Update(s.db, func(tx kvdb.RwTx) error {
+		txHashesBucket := tx.ReadWriteBucket(txHashesBucketKey)
+		if txHashesBucket == nil {
+			return errNoTxHashesBucket
+		}
+
+		return txHashesBucket.Delete(txid[:])
+	}, func() {})
 }
 
 // Compile-time constraint to ensure sweeperStore implements SweeperStore.

--- a/sweep/store.go
+++ b/sweep/store.go
@@ -4,17 +4,20 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"io"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/tlv"
 )
 
 var (
 	// txHashesBucketKey is the key that points to a bucket containing the
 	// hashes of all sweep txes that were published successfully.
 	//
-	// maps: txHash -> empty slice
+	// maps: txHash -> TxRecord
 	txHashesBucketKey = []byte("sweeper-tx-hashes")
 
 	// utxnChainPrefix is the bucket prefix for nursery buckets.
@@ -31,7 +34,82 @@ var (
 	byteOrder = binary.BigEndian
 
 	errNoTxHashesBucket = errors.New("tx hashes bucket does not exist")
+
+	// ErrTxNotFound is returned when querying using a txid that's not
+	// found in our db.
+	ErrTxNotFound = errors.New("tx not found")
 )
+
+// TxRecord specifies a record of a tx that's stored in the database.
+type TxRecord struct {
+	// Txid is the sweeping tx's txid.
+	Txid chainhash.Hash
+
+	// FeeRate is the fee rate of the sweeping tx, unit is sats/kw.
+	FeeRate uint64
+
+	// Fee is the fee of the sweeping tx, unit is sat.
+	Fee uint64
+
+	// Published indicates whether the tx has been published.
+	Published bool
+}
+
+// toTlvStream converts TxRecord into a tlv representation.
+func (t *TxRecord) toTlvStream() (*tlv.Stream, error) {
+	const (
+		// A set of tlv type definitions used to serialize TxRecord.
+		// We define it here instead of the head of the file to avoid
+		// naming conflicts.
+		//
+		// NOTE: A migration should be added whenever the existing type
+		// changes.
+		//
+		// NOTE: Txid is stored as the key, so it's not included here.
+		feeRateType tlv.Type = 0
+		feeType     tlv.Type = 1
+		boolType    tlv.Type = 2
+	)
+
+	return tlv.NewStream(
+		tlv.MakeBigSizeRecord(feeRateType, &t.FeeRate),
+		tlv.MakeBigSizeRecord(feeType, &t.Fee),
+		tlv.MakePrimitiveRecord(boolType, &t.Published),
+	)
+}
+
+// serializeTxRecord serializes a TxRecord based on tlv format.
+func serializeTxRecord(w io.Writer, tx *TxRecord) error {
+	// Create the tlv stream.
+	tlvStream, err := tx.toTlvStream()
+	if err != nil {
+		return err
+	}
+
+	// Write the tlv stream.
+	return channeldb.WriteTlvStream(w, tlvStream)
+}
+
+// deserializeTxRecord deserializes a TxRecord based on tlv format.
+func deserializeTxRecord(r io.Reader) (*TxRecord, error) {
+	var tx TxRecord
+
+	// Create the tlv stream.
+	tlvStream, err := tx.toTlvStream()
+	if err != nil {
+		return nil, err
+	}
+
+	// Read the tlv stream.
+	if _, err := channeldb.ReadTlvStream(r, tlvStream); err != nil {
+		// We've reached the end when hitting an EOF.
+		if errors.Is(err, io.ErrUnexpectedEOF) {
+			return nil, err
+		}
+	}
+
+	return &tx, nil
+}
 
 // SweeperStore stores published txes.
 type SweeperStore interface {
@@ -40,7 +118,7 @@ type SweeperStore interface {
 	IsOurTx(hash chainhash.Hash) (bool, error)
 
 	// StoreTx stores a tx hash we are about to publish.
-	StoreTx(chainhash.Hash) error
+	StoreTx(*TxRecord) error
 
 	// ListSweeps lists all the sweeps we have successfully published.
 	ListSweeps() ([]chainhash.Hash, error)
@@ -83,6 +161,8 @@ func NewSweeperStore(db kvdb.Backend, chainHash *chainhash.Hash) (
 
 // migrateTxHashes migrates nursery finalized txes to the tx hashes bucket. This
 // is not implemented as a database migration, to keep the downgrade path open.
+//
+// TODO(yy): delete this function once nursery is removed.
 func migrateTxHashes(tx kvdb.RwTx, txHashesBucket kvdb.RwBucket,
 	chainHash *chainhash.Hash) error {
 
@@ -138,7 +218,24 @@ func migrateTxHashes(tx kvdb.RwTx, txHashesBucket kvdb.RwBucket,
 		log.Debugf("Inserting nursery tx %v in hash list "+
 			"(height=%v)", hash, byteOrder.Uint32(k))
 
-		return txHashesBucket.Put(hash[:], []byte{})
+		// Create the transaction record. Since this is an old record,
+		// we can assume it's already been published. Although it's
+		// possible to calculate the fees and fee rate used here, we
+		// skip it as it's unlikely we'd perform RBF on these old
+		// sweeping transactions.
+		tr := &TxRecord{
+			Txid:      hash,
+			Published: true,
+		}
+
+		// Serialize tx record.
+		var b bytes.Buffer
+		err = serializeTxRecord(&b, tr)
+		if err != nil {
+			return err
+		}
+
+		return txHashesBucket.Put(tr.Txid[:], b.Bytes())
 	})
 	if err != nil {
 		return err
@@ -148,15 +245,21 @@ func migrateTxHashes(tx kvdb.RwTx, txHashesBucket kvdb.RwBucket,
 }
 
 // StoreTx stores that we are about to publish a tx.
-func (s *sweeperStore) StoreTx(txid chainhash.Hash) error {
+func (s *sweeperStore) StoreTx(tr *TxRecord) error {
 	return kvdb.Update(s.db, func(tx kvdb.RwTx) error {
-
 		txHashesBucket := tx.ReadWriteBucket(txHashesBucketKey)
 		if txHashesBucket == nil {
 			return errNoTxHashesBucket
 		}
 
-		return txHashesBucket.Put(txid[:], []byte{})
+		// Serialize tx record.
+		var b bytes.Buffer
+		err := serializeTxRecord(&b, tr)
+		if err != nil {
+			return err
+		}
+
+		return txHashesBucket.Put(tr.Txid[:], b.Bytes())
 	}, func() {})
 }
 

--- a/sweep/store_mock.go
+++ b/sweep/store_mock.go
@@ -41,5 +41,16 @@ func (s *MockSweeperStore) ListSweeps() ([]chainhash.Hash, error) {
 	return txns, nil
 }
 
+// GetTx queries the database to find the tx that matches the given txid.
+// Returns ErrTxNotFound if it cannot be found.
+func (s *MockSweeperStore) GetTx(hash chainhash.Hash) (*TxRecord, error) {
+	return nil, ErrTxNotFound
+}
+
+// DeleteTx removes the given tx from db.
+func (s *MockSweeperStore) DeleteTx(txid chainhash.Hash) error {
+	return nil
+}
+
 // Compile-time constraint to ensure MockSweeperStore implements SweeperStore.
 var _ SweeperStore = (*MockSweeperStore)(nil)

--- a/sweep/store_mock.go
+++ b/sweep/store_mock.go
@@ -25,8 +25,8 @@ func (s *MockSweeperStore) IsOurTx(hash chainhash.Hash) (bool, error) {
 }
 
 // StoreTx stores a tx we are about to publish.
-func (s *MockSweeperStore) StoreTx(txid chainhash.Hash) error {
-	s.ourTxes[txid] = struct{}{}
+func (s *MockSweeperStore) StoreTx(tr *TxRecord) error {
+	s.ourTxes[tr.Txid] = struct{}{}
 
 	return nil
 }

--- a/sweep/store_mock.go
+++ b/sweep/store_mock.go
@@ -2,54 +2,58 @@ package sweep
 
 import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/stretchr/testify/mock"
 )
 
 // MockSweeperStore is a mock implementation of sweeper store. This type is
 // exported, because it is currently used in nursery tests too.
 type MockSweeperStore struct {
-	ourTxes map[chainhash.Hash]struct{}
+	mock.Mock
 }
 
 // NewMockSweeperStore returns a new instance.
 func NewMockSweeperStore() *MockSweeperStore {
-	return &MockSweeperStore{
-		ourTxes: make(map[chainhash.Hash]struct{}),
-	}
+	return &MockSweeperStore{}
 }
 
-// IsOurTx determines whether a tx is published by us, based on its
-// hash.
+// IsOurTx determines whether a tx is published by us, based on its hash.
 func (s *MockSweeperStore) IsOurTx(hash chainhash.Hash) (bool, error) {
-	_, ok := s.ourTxes[hash]
-	return ok, nil
+	args := s.Called(hash)
+
+	return args.Bool(0), args.Error(1)
 }
 
 // StoreTx stores a tx we are about to publish.
 func (s *MockSweeperStore) StoreTx(tr *TxRecord) error {
-	s.ourTxes[tr.Txid] = struct{}{}
-
-	return nil
+	args := s.Called(tr)
+	return args.Error(0)
 }
 
 // ListSweeps lists all the sweeps we have successfully published.
 func (s *MockSweeperStore) ListSweeps() ([]chainhash.Hash, error) {
-	var txns []chainhash.Hash
-	for tx := range s.ourTxes {
-		txns = append(txns, tx)
-	}
+	args := s.Called()
 
-	return txns, nil
+	return args.Get(0).([]chainhash.Hash), args.Error(1)
 }
 
 // GetTx queries the database to find the tx that matches the given txid.
 // Returns ErrTxNotFound if it cannot be found.
 func (s *MockSweeperStore) GetTx(hash chainhash.Hash) (*TxRecord, error) {
-	return nil, ErrTxNotFound
+	args := s.Called(hash)
+
+	tr := args.Get(0)
+	if tr != nil {
+		return args.Get(0).(*TxRecord), args.Error(1)
+	}
+
+	return nil, args.Error(1)
 }
 
 // DeleteTx removes the given tx from db.
 func (s *MockSweeperStore) DeleteTx(txid chainhash.Hash) error {
-	return nil
+	args := s.Called(txid)
+
+	return args.Error(0)
 }
 
 // Compile-time constraint to ensure MockSweeperStore implements SweeperStore.

--- a/sweep/store_mock.go
+++ b/sweep/store_mock.go
@@ -2,7 +2,6 @@ package sweep
 
 import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
 )
 
 // MockSweeperStore is a mock implementation of sweeper store. This type is
@@ -25,10 +24,9 @@ func (s *MockSweeperStore) IsOurTx(hash chainhash.Hash) (bool, error) {
 	return ok, nil
 }
 
-// NotifyPublishTx signals that we are about to publish a tx.
-func (s *MockSweeperStore) NotifyPublishTx(tx *wire.MsgTx) error {
-	txHash := tx.TxHash()
-	s.ourTxes[txHash] = struct{}{}
+// StoreTx stores a tx we are about to publish.
+func (s *MockSweeperStore) StoreTx(txid chainhash.Hash) error {
+	s.ourTxes[txid] = struct{}{}
 
 	return nil
 }

--- a/sweep/store_test.go
+++ b/sweep/store_test.go
@@ -50,7 +50,7 @@ func testStore(t *testing.T, createStore func() (SweeperStore, error)) {
 		},
 	})
 
-	err = store.NotifyPublishTx(&tx1)
+	err = store.StoreTx(tx1.TxHash())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func testStore(t *testing.T, createStore func() (SweeperStore, error)) {
 		},
 	})
 
-	err = store.NotifyPublishTx(&tx2)
+	err = store.StoreTx(tx2.TxHash())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1163,7 +1163,7 @@ func (s *UtxoSweeper) sweep(inputs inputSet, feeRate chainfee.SatPerKWeight,
 	}
 
 	// Create sweep tx.
-	tx, err := createSweepTx(
+	tx, _, err := createSweepTx(
 		inputs, nil, s.currentOutputScript, uint32(currentHeight),
 		feeRate, s.cfg.MaxFeeRate.FeePerKWeight(), s.cfg.Signer,
 	)
@@ -1467,10 +1467,12 @@ func (s *UtxoSweeper) CreateSweepTx(inputs []input.Input, feePref FeePreference,
 		return nil, err
 	}
 
-	return createSweepTx(
+	tx, _, err := createSweepTx(
 		inputs, nil, pkScript, currentBlockHeight, feePerKw,
 		s.cfg.MaxFeeRate.FeePerKWeight(), s.cfg.Signer,
 	)
+
+	return tx, err
 }
 
 // DefaultNextAttemptDeltaFunc is the default calculation for next sweep attempt

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -68,7 +68,7 @@ type Params struct {
 	// Fee is the fee preference of the client who requested the input to be
 	// swept. If a confirmation target is specified, then we'll map it into
 	// a fee rate whenever we attempt to cluster inputs for a sweep.
-	Fee FeeEstimateInfo
+	Fee FeePreference
 
 	// Force indicates whether the input should be swept regardless of
 	// whether it is economical to do so.
@@ -84,7 +84,7 @@ type ParamsUpdate struct {
 	// Fee is the fee preference of the client who requested the input to be
 	// swept. If a confirmation target is specified, then we'll map it into
 	// a fee rate whenever we attempt to cluster inputs for a sweep.
-	Fee FeeEstimateInfo
+	Fee FeePreference
 
 	// Force indicates whether the input should be swept regardless of
 	// whether it is economical to do so.

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -20,20 +20,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 )
 
-const (
-	// DefaultFeeRateBucketSize is the default size of fee rate buckets
-	// we'll use when clustering inputs into buckets with similar fee rates
-	// within the UtxoSweeper.
-	//
-	// Given a minimum relay fee rate of 1 sat/vbyte, a multiplier of 10
-	// would result in the following fee rate buckets up to the maximum fee
-	// rate:
-	//
-	//   #1: min = 1 sat/vbyte, max = 10 sat/vbyte
-	//   #2: min = 11 sat/vbyte, max = 20 sat/vbyte...
-	DefaultFeeRateBucketSize = 10
-)
-
 var (
 	// ErrRemoteSpend is returned in case an output that we try to sweep is
 	// confirmed in a tx of the remote party.
@@ -292,17 +278,9 @@ type UtxoSweeperConfig struct {
 	// UtxoSweeper.
 	MaxFeeRate chainfee.SatPerVByte
 
-	// FeeRateBucketSize is the default size of fee rate buckets we'll use
-	// when clustering inputs into buckets with similar fee rates within the
-	// UtxoSweeper.
-	//
-	// Given a minimum relay fee rate of 1 sat/vbyte, a fee rate bucket size
-	// of 10 would result in the following fee rate buckets up to the
-	// maximum fee rate:
-	//
-	//   #1: min = 1 sat/vbyte, max (exclusive) = 11 sat/vbyte
-	//   #2: min = 11 sat/vbyte, max (exclusive) = 21 sat/vbyte...
-	FeeRateBucketSize int
+	// Aggregator is used to group inputs into clusters based on its
+	// implemention-specific strategy.
+	Aggregator UtxoAggregator
 }
 
 // Result is the struct that is pushed through the result channel. Callers can
@@ -720,280 +698,6 @@ func (s *UtxoSweeper) sweepCluster(cluster inputCluster) error {
 
 		return nil
 	})
-}
-
-// bucketForFeeReate determines the proper bucket for a fee rate. This is done
-// in order to batch inputs with similar fee rates together.
-func (s *UtxoSweeper) bucketForFeeRate(
-	feeRate chainfee.SatPerKWeight) int {
-
-	// Create an isolated bucket for sweeps at the minimum fee rate. This is
-	// to prevent very small outputs (anchors) from becoming uneconomical if
-	// their fee rate would be averaged with higher fee rate inputs in a
-	// regular bucket.
-	if feeRate == s.relayFeeRate {
-		return 0
-	}
-
-	return 1 + int(feeRate-s.relayFeeRate)/s.cfg.FeeRateBucketSize
-}
-
-// createInputClusters creates a list of input clusters from the set of pending
-// inputs known by the UtxoSweeper. It clusters inputs by
-// 1) Required tx locktime
-// 2) Similar fee rates.
-func (s *UtxoSweeper) createInputClusters() []inputCluster {
-	inputs := s.pendingInputs
-
-	// We start by getting the inputs clusters by locktime. Since the
-	// inputs commit to the locktime, they can only be clustered together
-	// if the locktime is equal.
-	lockTimeClusters, nonLockTimeInputs := s.clusterByLockTime(inputs)
-
-	// Cluster the the remaining inputs by sweep fee rate.
-	feeClusters := s.clusterBySweepFeeRate(nonLockTimeInputs)
-
-	// Since the inputs that we clustered by fee rate don't commit to a
-	// specific locktime, we can try to merge a locktime cluster with a fee
-	// cluster.
-	return zipClusters(lockTimeClusters, feeClusters)
-}
-
-// clusterByLockTime takes the given set of pending inputs and clusters those
-// with equal locktime together. Each cluster contains a sweep fee rate, which
-// is determined by calculating the average fee rate of all inputs within that
-// cluster. In addition to the created clusters, inputs that did not specify a
-// required lock time are returned.
-func (s *UtxoSweeper) clusterByLockTime(inputs pendingInputs) ([]inputCluster,
-	pendingInputs) {
-
-	locktimes := make(map[uint32]pendingInputs)
-	rem := make(pendingInputs)
-
-	// Go through all inputs and check if they require a certain locktime.
-	for op, input := range inputs {
-		lt, ok := input.RequiredLockTime()
-		if !ok {
-			rem[op] = input
-			continue
-		}
-
-		// Check if we already have inputs with this locktime.
-		cluster, ok := locktimes[lt]
-		if !ok {
-			cluster = make(pendingInputs)
-		}
-
-		// Get the fee rate based on the fee preference. If an error is
-		// returned, we'll skip sweeping this input for this round of
-		// cluster creation and retry it when we create the clusters
-		// from the pending inputs again.
-		feeRate, err := input.params.Fee.Estimate(
-			s.cfg.FeeEstimator, s.cfg.MaxFeeRate.FeePerKWeight(),
-		)
-		if err != nil {
-			log.Warnf("Skipping input %v: %v", op, err)
-			continue
-		}
-
-		log.Debugf("Adding input %v to cluster with locktime=%v, "+
-			"feeRate=%v", op, lt, feeRate)
-
-		// Attach the fee rate to the input.
-		input.lastFeeRate = feeRate
-
-		// Update the cluster about the updated input.
-		cluster[op] = input
-		locktimes[lt] = cluster
-	}
-
-	// We'll then determine the sweep fee rate for each set of inputs by
-	// calculating the average fee rate of the inputs within each set.
-	inputClusters := make([]inputCluster, 0, len(locktimes))
-	for lt, cluster := range locktimes {
-		lt := lt
-
-		var sweepFeeRate chainfee.SatPerKWeight
-		for _, input := range cluster {
-			sweepFeeRate += input.lastFeeRate
-		}
-
-		sweepFeeRate /= chainfee.SatPerKWeight(len(cluster))
-		inputClusters = append(inputClusters, inputCluster{
-			lockTime:     &lt,
-			sweepFeeRate: sweepFeeRate,
-			inputs:       cluster,
-		})
-	}
-
-	return inputClusters, rem
-}
-
-// clusterBySweepFeeRate takes the set of pending inputs within the UtxoSweeper
-// and clusters those together with similar fee rates. Each cluster contains a
-// sweep fee rate, which is determined by calculating the average fee rate of
-// all inputs within that cluster.
-func (s *UtxoSweeper) clusterBySweepFeeRate(inputs pendingInputs) []inputCluster {
-	bucketInputs := make(map[int]*bucketList)
-	inputFeeRates := make(map[wire.OutPoint]chainfee.SatPerKWeight)
-
-	// First, we'll group together all inputs with similar fee rates. This
-	// is done by determining the fee rate bucket they should belong in.
-	for op, input := range inputs {
-		feeRate, err := input.params.Fee.Estimate(
-			s.cfg.FeeEstimator, s.cfg.MaxFeeRate.FeePerKWeight(),
-		)
-		if err != nil {
-			log.Warnf("Skipping input %v: %v", op, err)
-			continue
-		}
-
-		// Only try to sweep inputs with an unconfirmed parent if the
-		// current sweep fee rate exceeds the parent tx fee rate. This
-		// assumes that such inputs are offered to the sweeper solely
-		// for the purpose of anchoring down the parent tx using cpfp.
-		parentTx := input.UnconfParent()
-		if parentTx != nil {
-			parentFeeRate :=
-				chainfee.SatPerKWeight(parentTx.Fee*1000) /
-					chainfee.SatPerKWeight(parentTx.Weight)
-
-			if parentFeeRate >= feeRate {
-				log.Debugf("Skipping cpfp input %v: fee_rate=%v, "+
-					"parent_fee_rate=%v", op, feeRate,
-					parentFeeRate)
-
-				continue
-			}
-		}
-
-		feeGroup := s.bucketForFeeRate(feeRate)
-
-		// Create a bucket list for this fee rate if there isn't one
-		// yet.
-		buckets, ok := bucketInputs[feeGroup]
-		if !ok {
-			buckets = &bucketList{}
-			bucketInputs[feeGroup] = buckets
-		}
-
-		// Request the bucket list to add this input. The bucket list
-		// will take into account exclusive group constraints.
-		buckets.add(input)
-
-		input.lastFeeRate = feeRate
-		inputFeeRates[op] = feeRate
-	}
-
-	// We'll then determine the sweep fee rate for each set of inputs by
-	// calculating the average fee rate of the inputs within each set.
-	inputClusters := make([]inputCluster, 0, len(bucketInputs))
-	for _, buckets := range bucketInputs {
-		for _, inputs := range buckets.buckets {
-			var sweepFeeRate chainfee.SatPerKWeight
-			for op := range inputs {
-				sweepFeeRate += inputFeeRates[op]
-			}
-			sweepFeeRate /= chainfee.SatPerKWeight(len(inputs))
-			inputClusters = append(inputClusters, inputCluster{
-				sweepFeeRate: sweepFeeRate,
-				inputs:       inputs,
-			})
-		}
-	}
-
-	return inputClusters
-}
-
-// zipClusters merges pairwise clusters from as and bs such that cluster a from
-// as is merged with a cluster from bs that has at least the fee rate of a.
-// This to ensure we don't delay confirmation by decreasing the fee rate (the
-// lock time inputs are typically second level HTLC transactions, that are time
-// sensitive).
-func zipClusters(as, bs []inputCluster) []inputCluster {
-	// Sort the clusters by decreasing fee rates.
-	sort.Slice(as, func(i, j int) bool {
-		return as[i].sweepFeeRate >
-			as[j].sweepFeeRate
-	})
-	sort.Slice(bs, func(i, j int) bool {
-		return bs[i].sweepFeeRate >
-			bs[j].sweepFeeRate
-	})
-
-	var (
-		finalClusters []inputCluster
-		j             int
-	)
-
-	// Go through each cluster in as, and merge with the next one from bs
-	// if it has at least the fee rate needed.
-	for i := range as {
-		a := as[i]
-
-		switch {
-		// If the fee rate for the next one from bs is at least a's, we
-		// merge.
-		case j < len(bs) && bs[j].sweepFeeRate >= a.sweepFeeRate:
-			merged := mergeClusters(a, bs[j])
-			finalClusters = append(finalClusters, merged...)
-
-			// Increment j for the next round.
-			j++
-
-		// We did not merge, meaning all the remaining clusters from bs
-		// have lower fee rate. Instead we add a directly to the final
-		// clusters.
-		default:
-			finalClusters = append(finalClusters, a)
-		}
-	}
-
-	// Add any remaining clusters from bs.
-	for ; j < len(bs); j++ {
-		b := bs[j]
-		finalClusters = append(finalClusters, b)
-	}
-
-	return finalClusters
-}
-
-// mergeClusters attempts to merge cluster a and b if they are compatible. The
-// new cluster will have the locktime set if a or b had a locktime set, and a
-// sweep fee rate that is the maximum of a and b's. If the two clusters are not
-// compatible, they will be returned unchanged.
-func mergeClusters(a, b inputCluster) []inputCluster {
-	newCluster := inputCluster{}
-
-	switch {
-	// Incompatible locktimes, return the sets without merging them.
-	case a.lockTime != nil && b.lockTime != nil && *a.lockTime != *b.lockTime:
-		return []inputCluster{a, b}
-
-	case a.lockTime != nil:
-		newCluster.lockTime = a.lockTime
-
-	case b.lockTime != nil:
-		newCluster.lockTime = b.lockTime
-	}
-
-	if a.sweepFeeRate > b.sweepFeeRate {
-		newCluster.sweepFeeRate = a.sweepFeeRate
-	} else {
-		newCluster.sweepFeeRate = b.sweepFeeRate
-	}
-
-	newCluster.inputs = make(pendingInputs)
-
-	for op, in := range a.inputs {
-		newCluster.inputs[op] = in
-	}
-
-	for op, in := range b.inputs {
-		newCluster.inputs[op] = in
-	}
-
-	return []inputCluster{newCluster}
 }
 
 // signalAndRemove notifies the listeners of the final result of the input
@@ -1471,7 +1175,6 @@ func (s *UtxoSweeper) ListSweeps() ([]chainhash.Hash, error) {
 // handleNewInput processes a new input by registering spend notification and
 // scheduling sweeping for it.
 func (s *UtxoSweeper) handleNewInput(input *sweepInputMessage) {
-
 	outpoint := *input.input.OutPoint()
 	pendInput, pending := s.pendingInputs[outpoint]
 	if pending {
@@ -1636,7 +1339,7 @@ func (s *UtxoSweeper) handleSweep() {
 	// Before attempting to sweep them, we'll sort them in descending fee
 	// rate order. We do this to ensure any inputs which have had their fee
 	// rate bumped are broadcast first in order enforce the RBF policy.
-	inputClusters := s.createInputClusters()
+	inputClusters := s.cfg.Aggregator.ClusterInputs(s.pendingInputs)
 	sort.Slice(inputClusters, func(i, j int) bool {
 		return inputClusters[i].sweepFeeRate >
 			inputClusters[j].sweepFeeRate

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1163,7 +1163,7 @@ func (s *UtxoSweeper) sweep(inputs inputSet, feeRate chainfee.SatPerKWeight,
 	}
 
 	// Create sweep tx.
-	tx, _, err := createSweepTx(
+	tx, fee, err := createSweepTx(
 		inputs, nil, s.currentOutputScript, uint32(currentHeight),
 		feeRate, s.cfg.MaxFeeRate.FeePerKWeight(), s.cfg.Signer,
 	)
@@ -1171,12 +1171,18 @@ func (s *UtxoSweeper) sweep(inputs inputSet, feeRate chainfee.SatPerKWeight,
 		return fmt.Errorf("create sweep tx: %v", err)
 	}
 
+	tr := &TxRecord{
+		Txid:    tx.TxHash(),
+		FeeRate: uint64(feeRate),
+		Fee:     uint64(fee),
+	}
+
 	// Add tx before publication, so that we will always know that a spend
 	// by this tx is ours. Otherwise if the publish doesn't return, but did
 	// publish, we loose track of this tx. Even republication on startup
 	// doesn't prevent this, because that call returns a double spend error
 	// then and would also not add the hash to the store.
-	err = s.cfg.Store.StoreTx(tx.TxHash())
+	err = s.cfg.Store.StoreTx(tr)
 	if err != nil {
 		return fmt.Errorf("store tx: %w", err)
 	}
@@ -1195,6 +1201,16 @@ func (s *UtxoSweeper) sweep(inputs inputSet, feeRate chainfee.SatPerKWeight,
 	)
 	if err != nil {
 		return err
+	}
+
+	// Mark this tx in db once successfully published.
+	//
+	// NOTE: this will behave as an overwrite, which is fine as the record
+	// is small.
+	tr.Published = true
+	err = s.cfg.Store.StoreTx(tr)
+	if err != nil {
+		return fmt.Errorf("store tx: %w", err)
 	}
 
 	// If there's no error, remove the output script. Otherwise keep it so

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -43,10 +43,6 @@ var (
 	// for the configured max number of attempts.
 	ErrTooManyAttempts = errors.New("sweep failed after max attempts")
 
-	// ErrNoFeePreference is returned when we attempt to satisfy a sweep
-	// request from a client whom did not specify a fee preference.
-	ErrNoFeePreference = errors.New("no fee preference specified")
-
 	// ErrFeePreferenceTooLow is returned when the fee preference gives a
 	// fee rate that's below the relay fee rate.
 	ErrFeePreferenceTooLow = errors.New("fee preference too low")
@@ -253,10 +249,6 @@ type UtxoSweeperConfig struct {
 	// funds can be swept.
 	GenSweepScript func() ([]byte, error)
 
-	// DetermineFeePerKw determines the fee in sat/kw based on the given
-	// estimator and fee preference.
-	DetermineFeePerKw feeDeterminer
-
 	// FeeEstimator is used when crafting sweep transactions to estimate
 	// the necessary fee relative to the expected size of the sweep
 	// transaction.
@@ -446,7 +438,10 @@ func (s *UtxoSweeper) SweepInput(input input.Input,
 	}
 
 	// Ensure the client provided a sane fee preference.
-	if _, err := s.feeRateForPreference(params.Fee); err != nil {
+	_, err := params.Fee.Estimate(
+		s.cfg.FeeEstimator, s.cfg.MaxFeeRate.FeePerKWeight(),
+	)
+	if err != nil {
 		return nil, err
 	}
 
@@ -472,42 +467,6 @@ func (s *UtxoSweeper) SweepInput(input input.Input,
 	}
 
 	return sweeperInput.resultChan, nil
-}
-
-// feeRateForPreference returns a fee rate for the given fee preference. It
-// ensures that the fee rate respects the bounds of the UtxoSweeper.
-func (s *UtxoSweeper) feeRateForPreference(
-	feePreference FeePreference) (chainfee.SatPerKWeight, error) {
-
-	// Ensure a type of fee preference is specified to prevent using a
-	// default below.
-	if feePreference.FeeRate == 0 && feePreference.ConfTarget == 0 {
-		return 0, ErrNoFeePreference
-	}
-
-	feeRate, err := s.cfg.DetermineFeePerKw(
-		s.cfg.FeeEstimator, feePreference,
-	)
-	if err != nil {
-		return 0, err
-	}
-
-	if feeRate < s.relayFeeRate {
-		return 0, fmt.Errorf("%w: got %v, minimum is %v",
-			ErrFeePreferenceTooLow, feeRate, s.relayFeeRate)
-	}
-
-	// If the estimated fee rate is above the maximum allowed fee rate,
-	// default to the max fee rate.
-	if feeRate > s.cfg.MaxFeeRate.FeePerKWeight() {
-		log.Warnf("Estimated fee rate %v exceeds max allowed fee "+
-			"rate %v, using max fee rate instead", feeRate,
-			s.cfg.MaxFeeRate.FeePerKWeight())
-
-		return s.cfg.MaxFeeRate.FeePerKWeight(), nil
-	}
-
-	return feeRate, nil
 }
 
 // removeConflictSweepDescendants removes any transactions from the wallet that
@@ -829,7 +788,9 @@ func (s *UtxoSweeper) clusterByLockTime(inputs pendingInputs) ([]inputCluster,
 		// returned, we'll skip sweeping this input for this round of
 		// cluster creation and retry it when we create the clusters
 		// from the pending inputs again.
-		feeRate, err := s.feeRateForPreference(input.params.Fee)
+		feeRate, err := input.params.Fee.Estimate(
+			s.cfg.FeeEstimator, s.cfg.MaxFeeRate.FeePerKWeight(),
+		)
 		if err != nil {
 			log.Warnf("Skipping input %v: %v", op, err)
 			continue
@@ -879,7 +840,9 @@ func (s *UtxoSweeper) clusterBySweepFeeRate(inputs pendingInputs) []inputCluster
 	// First, we'll group together all inputs with similar fee rates. This
 	// is done by determining the fee rate bucket they should belong in.
 	for op, input := range inputs {
-		feeRate, err := s.feeRateForPreference(input.params.Fee)
+		feeRate, err := input.params.Fee.Estimate(
+			s.cfg.FeeEstimator, s.cfg.MaxFeeRate.FeePerKWeight(),
+		)
 		if err != nil {
 			log.Warnf("Skipping input %v: %v", op, err)
 			continue
@@ -1374,7 +1337,10 @@ func (s *UtxoSweeper) UpdateParams(input wire.OutPoint,
 	params ParamsUpdate) (chan Result, error) {
 
 	// Ensure the client provided a sane fee preference.
-	if _, err := s.feeRateForPreference(params.Fee); err != nil {
+	_, err := params.Fee.Estimate(
+		s.cfg.FeeEstimator, s.cfg.MaxFeeRate.FeePerKWeight(),
+	)
+	if err != nil {
 		return nil, err
 	}
 
@@ -1468,7 +1434,7 @@ func (s *UtxoSweeper) handleUpdateReq(req *updateReq) (
 func (s *UtxoSweeper) CreateSweepTx(inputs []input.Input,
 	feePref FeePreference) (*wire.MsgTx, error) {
 
-	feePerKw, err := s.cfg.DetermineFeePerKw(s.cfg.FeeEstimator, feePref)
+	feePerKw, err := DetermineFeePerKw(s.cfg.FeeEstimator, feePref)
 	if err != nil {
 		return nil, err
 	}

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1434,7 +1434,9 @@ func (s *UtxoSweeper) handleUpdateReq(req *updateReq) (
 func (s *UtxoSweeper) CreateSweepTx(inputs []input.Input,
 	feePref FeePreference) (*wire.MsgTx, error) {
 
-	feePerKw, err := DetermineFeePerKw(s.cfg.FeeEstimator, feePref)
+	feePerKw, err := feePref.Estimate(
+		s.cfg.FeeEstimator, s.cfg.MaxFeeRate.FeePerKWeight(),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1176,9 +1176,9 @@ func (s *UtxoSweeper) sweep(inputs inputSet, feeRate chainfee.SatPerKWeight,
 	// publish, we loose track of this tx. Even republication on startup
 	// doesn't prevent this, because that call returns a double spend error
 	// then and would also not add the hash to the store.
-	err = s.cfg.Store.NotifyPublishTx(tx)
+	err = s.cfg.Store.StoreTx(tx.TxHash())
 	if err != nil {
-		return fmt.Errorf("notify publish tx: %v", err)
+		return fmt.Errorf("store tx: %w", err)
 	}
 
 	// Reschedule the inputs that we just tried to sweep. This is done in

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -236,6 +236,10 @@ type UtxoSweeper struct {
 
 	quit chan struct{}
 	wg   sync.WaitGroup
+
+	// currentHeight is the best known height of the main chain. This is
+	// updated whenever a new block epoch is received.
+	currentHeight int32
 }
 
 // feeDeterminer defines an alias to the function signature of
@@ -596,10 +600,9 @@ func (s *UtxoSweeper) collector(blockEpochs <-chan *chainntnfs.BlockEpoch) {
 	// We registered for the block epochs with a nil request. The notifier
 	// should send us the current best block immediately. So we need to wait
 	// for it here because we need to know the current best height.
-	var bestHeight int32
 	select {
 	case bestBlock := <-blockEpochs:
-		bestHeight = bestBlock.Height
+		s.currentHeight = bestBlock.Height
 
 	case <-s.quit:
 		return
@@ -617,7 +620,7 @@ func (s *UtxoSweeper) collector(blockEpochs <-chan *chainntnfs.BlockEpoch) {
 		// we are already trying to sweep this input and if not, set up
 		// a listener to spend and schedule a sweep.
 		case input := <-s.newInputs:
-			s.handleNewInput(input, bestHeight)
+			s.handleNewInput(input)
 
 		// A spend of one of our inputs is detected. Signal sweep
 		// results to the caller(s).
@@ -632,7 +635,7 @@ func (s *UtxoSweeper) collector(blockEpochs <-chan *chainntnfs.BlockEpoch) {
 		// A new external request has been received to bump the fee rate
 		// of a given input.
 		case req := <-s.updateReqs:
-			resultChan, err := s.handleUpdateReq(req, bestHeight)
+			resultChan, err := s.handleUpdateReq(req)
 			req.responseChan <- &updateResp{
 				resultChan: resultChan,
 				err:        err,
@@ -641,7 +644,7 @@ func (s *UtxoSweeper) collector(blockEpochs <-chan *chainntnfs.BlockEpoch) {
 		// The timer expires and we are going to (re)sweep.
 		case <-ticker.C:
 			log.Debugf("Sweep ticker ticks, attempt sweeping...")
-			s.handleSweep(bestHeight)
+			s.handleSweep()
 
 		// A new block comes in, update the bestHeight.
 		case epoch, ok := <-blockEpochs:
@@ -649,7 +652,7 @@ func (s *UtxoSweeper) collector(blockEpochs <-chan *chainntnfs.BlockEpoch) {
 				return
 			}
 
-			bestHeight = epoch.Height
+			s.currentHeight = epoch.Height
 
 			log.Debugf("New block: height=%v, sha=%v",
 				epoch.Height, epoch.Hash)
@@ -698,15 +701,13 @@ func (s *UtxoSweeper) removeExclusiveGroup(group uint64) {
 }
 
 // sweepCluster tries to sweep the given input cluster.
-func (s *UtxoSweeper) sweepCluster(cluster inputCluster,
-	currentHeight int32) error {
-
+func (s *UtxoSweeper) sweepCluster(cluster inputCluster) error {
 	// Execute the sweep within a coin select lock. Otherwise the coins
 	// that we are going to spend may be selected for other transactions
 	// like funding of a channel.
 	return s.cfg.Wallet.WithCoinSelectLock(func() error {
 		// Examine pending inputs and try to construct lists of inputs.
-		allSets, newSets, err := s.getInputLists(cluster, currentHeight)
+		allSets, newSets, err := s.getInputLists(cluster)
 		if err != nil {
 			return fmt.Errorf("examine pending inputs: %w", err)
 		}
@@ -719,9 +720,7 @@ func (s *UtxoSweeper) sweepCluster(cluster inputCluster,
 		// creating an RBF for the new inputs, we'd sweep this set
 		// first.
 		for _, inputs := range allSets {
-			errAllSets = s.sweep(
-				inputs, cluster.sweepFeeRate, currentHeight,
-			)
+			errAllSets = s.sweep(inputs, cluster.sweepFeeRate)
 			// TODO(yy): we should also find out which set created
 			// this error. If there are new inputs in this set, we
 			// should give it a second chance by sweeping them
@@ -754,9 +753,7 @@ func (s *UtxoSweeper) sweepCluster(cluster inputCluster,
 		// when sweeping a given set, we'd log the error and sweep the
 		// next set.
 		for _, inputs := range newSets {
-			err := s.sweep(
-				inputs, cluster.sweepFeeRate, currentHeight,
-			)
+			err := s.sweep(inputs, cluster.sweepFeeRate)
 			if err != nil {
 				log.Errorf("sweep new inputs: %w", err)
 			}
@@ -1079,8 +1076,8 @@ func (s *UtxoSweeper) signalAndRemove(outpoint *wire.OutPoint, result Result) {
 // and will be bundled with future inputs if possible. It returns two list -
 // one containing all inputs and the other containing only the new inputs. If
 // there's no retried inputs, the first set returned will be empty.
-func (s *UtxoSweeper) getInputLists(cluster inputCluster,
-	currentHeight int32) ([]inputSet, []inputSet, error) {
+func (s *UtxoSweeper) getInputLists(
+	cluster inputCluster) ([]inputSet, []inputSet, error) {
 
 	// Filter for inputs that need to be swept. Create two lists: all
 	// sweepable inputs and a list containing only the new, never tried
@@ -1102,7 +1099,7 @@ func (s *UtxoSweeper) getInputLists(cluster inputCluster,
 	for _, input := range cluster.inputs {
 		// Skip inputs that have a minimum publish height that is not
 		// yet reached.
-		if input.minPublishHeight > currentHeight {
+		if input.minPublishHeight > s.currentHeight {
 			continue
 		}
 
@@ -1143,15 +1140,15 @@ func (s *UtxoSweeper) getInputLists(cluster inputCluster,
 	}
 
 	log.Debugf("Sweep candidates at height=%v: total_num_pending=%v, "+
-		"total_num_new=%v", currentHeight, len(allSets), len(newSets))
+		"total_num_new=%v", s.currentHeight, len(allSets), len(newSets))
 
 	return allSets, newSets, nil
 }
 
 // sweep takes a set of preselected inputs, creates a sweep tx and publishes the
 // tx. The output address is only marked as used if the publish succeeds.
-func (s *UtxoSweeper) sweep(inputs inputSet, feeRate chainfee.SatPerKWeight,
-	currentHeight int32) error {
+func (s *UtxoSweeper) sweep(inputs inputSet,
+	feeRate chainfee.SatPerKWeight) error {
 
 	// Generate an output script if there isn't an unused script available.
 	if s.currentOutputScript == nil {
@@ -1164,7 +1161,7 @@ func (s *UtxoSweeper) sweep(inputs inputSet, feeRate chainfee.SatPerKWeight,
 
 	// Create sweep tx.
 	tx, fee, err := createSweepTx(
-		inputs, nil, s.currentOutputScript, uint32(currentHeight),
+		inputs, nil, s.currentOutputScript, uint32(s.currentHeight),
 		feeRate, s.cfg.MaxFeeRate.FeePerKWeight(), s.cfg.Signer,
 	)
 	if err != nil {
@@ -1190,10 +1187,10 @@ func (s *UtxoSweeper) sweep(inputs inputSet, feeRate chainfee.SatPerKWeight,
 	// Reschedule the inputs that we just tried to sweep. This is done in
 	// case the following publish fails, we'd like to update the inputs'
 	// publish attempts and rescue them in the next sweep.
-	s.rescheduleInputs(tx.TxIn, currentHeight)
+	s.rescheduleInputs(tx.TxIn)
 
 	log.Debugf("Publishing sweep tx %v, num_inputs=%v, height=%v",
-		tx.TxHash(), len(tx.TxIn), currentHeight)
+		tx.TxHash(), len(tx.TxIn), s.currentHeight)
 
 	// Publish the sweeping tx with customized label.
 	err = s.cfg.Wallet.PublishTransaction(
@@ -1225,8 +1222,7 @@ func (s *UtxoSweeper) sweep(inputs inputSet, feeRate chainfee.SatPerKWeight,
 // increments the `publishAttempts` and calculates the next broadcast height
 // for each input. When the publishAttempts exceeds MaxSweepAttemps(10), this
 // input will be removed.
-func (s *UtxoSweeper) rescheduleInputs(inputs []*wire.TxIn,
-	currentHeight int32) {
+func (s *UtxoSweeper) rescheduleInputs(inputs []*wire.TxIn) {
 
 	// Reschedule sweep.
 	for _, input := range inputs {
@@ -1251,7 +1247,7 @@ func (s *UtxoSweeper) rescheduleInputs(inputs []*wire.TxIn,
 			pi.publishAttempts,
 		)
 
-		pi.minPublishHeight = currentHeight + nextAttemptDelta
+		pi.minPublishHeight = s.currentHeight + nextAttemptDelta
 
 		log.Debugf("Rescheduling input %v after %v attempts at "+
 			"height %v (delta %v)", input.PreviousOutPoint,
@@ -1412,7 +1408,7 @@ func (s *UtxoSweeper) UpdateParams(input wire.OutPoint,
 //   - Ensure we don't combine this input with any other unconfirmed inputs that
 //     did not exist in the original sweep transaction, resulting in an invalid
 //     replacement transaction.
-func (s *UtxoSweeper) handleUpdateReq(req *updateReq, bestHeight int32) (
+func (s *UtxoSweeper) handleUpdateReq(req *updateReq) (
 	chan Result, error) {
 
 	// If the UtxoSweeper is already trying to sweep this input, then we can
@@ -1445,7 +1441,7 @@ func (s *UtxoSweeper) handleUpdateReq(req *updateReq, bestHeight int32) (
 	// NOTE: The UtxoSweeper is not yet offered time-locked inputs, so the
 	// check for broadcast attempts is redundant at the moment.
 	if pendingInput.publishAttempts > 0 {
-		pendingInput.minPublishHeight = bestHeight
+		pendingInput.minPublishHeight = s.currentHeight
 	}
 
 	resultChan := make(chan Result, 1)
@@ -1469,8 +1465,8 @@ func (s *UtxoSweeper) handleUpdateReq(req *updateReq, bestHeight int32) (
 // - Make handling re-orgs easier.
 // - Thwart future possible fee sniping attempts.
 // - Make us blend in with the bitcoind wallet.
-func (s *UtxoSweeper) CreateSweepTx(inputs []input.Input, feePref FeePreference,
-	currentBlockHeight uint32) (*wire.MsgTx, error) {
+func (s *UtxoSweeper) CreateSweepTx(inputs []input.Input,
+	feePref FeePreference) (*wire.MsgTx, error) {
 
 	feePerKw, err := s.cfg.DetermineFeePerKw(s.cfg.FeeEstimator, feePref)
 	if err != nil {
@@ -1484,7 +1480,7 @@ func (s *UtxoSweeper) CreateSweepTx(inputs []input.Input, feePref FeePreference,
 	}
 
 	tx, _, err := createSweepTx(
-		inputs, nil, pkScript, currentBlockHeight, feePerKw,
+		inputs, nil, pkScript, uint32(s.currentHeight), feePerKw,
 		s.cfg.MaxFeeRate.FeePerKWeight(), s.cfg.Signer,
 	)
 
@@ -1506,8 +1502,7 @@ func (s *UtxoSweeper) ListSweeps() ([]chainhash.Hash, error) {
 
 // handleNewInput processes a new input by registering spend notification and
 // scheduling sweeping for it.
-func (s *UtxoSweeper) handleNewInput(input *sweepInputMessage,
-	bestHeight int32) {
+func (s *UtxoSweeper) handleNewInput(input *sweepInputMessage) {
 
 	outpoint := *input.input.OutPoint()
 	pendInput, pending := s.pendingInputs[outpoint]
@@ -1525,7 +1520,7 @@ func (s *UtxoSweeper) handleNewInput(input *sweepInputMessage,
 	pendInput = &pendingInput{
 		listeners:        []chan Result{input.resultChan},
 		Input:            input.input,
-		minPublishHeight: bestHeight,
+		minPublishHeight: s.currentHeight,
 		params:           input.params,
 	}
 	s.pendingInputs[outpoint] = pendInput
@@ -1668,7 +1663,7 @@ func (s *UtxoSweeper) handleInputSpent(spend *chainntnfs.SpendDetail) {
 
 // handleSweep is called when the ticker fires. It will create clusters and
 // attempt to create and publish the sweeping transactions.
-func (s *UtxoSweeper) handleSweep(bestHeight int32) {
+func (s *UtxoSweeper) handleSweep() {
 	// We'll attempt to cluster all of our inputs with similar fee rates.
 	// Before attempting to sweep them, we'll sort them in descending fee
 	// rate order. We do this to ensure any inputs which have had their fee
@@ -1680,7 +1675,7 @@ func (s *UtxoSweeper) handleSweep(bestHeight int32) {
 	})
 
 	for _, cluster := range inputClusters {
-		err := s.sweepCluster(cluster, bestHeight)
+		err := s.sweepCluster(cluster)
 		if err != nil {
 			log.Errorf("input cluster sweep: %v", err)
 		}

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -68,7 +68,7 @@ type Params struct {
 	// Fee is the fee preference of the client who requested the input to be
 	// swept. If a confirmation target is specified, then we'll map it into
 	// a fee rate whenever we attempt to cluster inputs for a sweep.
-	Fee FeePreference
+	Fee FeeEstimateInfo
 
 	// Force indicates whether the input should be swept regardless of
 	// whether it is economical to do so.
@@ -84,7 +84,7 @@ type ParamsUpdate struct {
 	// Fee is the fee preference of the client who requested the input to be
 	// swept. If a confirmation target is specified, then we'll map it into
 	// a fee rate whenever we attempt to cluster inputs for a sweep.
-	Fee FeePreference
+	Fee FeeEstimateInfo
 
 	// Force indicates whether the input should be swept regardless of
 	// whether it is economical to do so.
@@ -241,7 +241,7 @@ type UtxoSweeper struct {
 // feeDeterminer defines an alias to the function signature of
 // `DetermineFeePerKw`.
 type feeDeterminer func(chainfee.Estimator,
-	FeePreference) (chainfee.SatPerKWeight, error)
+	FeeEstimateInfo) (chainfee.SatPerKWeight, error)
 
 // UtxoSweeperConfig contains dependencies of UtxoSweeper.
 type UtxoSweeperConfig struct {
@@ -1432,7 +1432,7 @@ func (s *UtxoSweeper) handleUpdateReq(req *updateReq) (
 // - Thwart future possible fee sniping attempts.
 // - Make us blend in with the bitcoind wallet.
 func (s *UtxoSweeper) CreateSweepTx(inputs []input.Input,
-	feePref FeePreference) (*wire.MsgTx, error) {
+	feePref FeeEstimateInfo) (*wire.MsgTx, error) {
 
 	feePerKw, err := feePref.Estimate(
 		s.cfg.FeeEstimator, s.cfg.MaxFeeRate.FeePerKWeight(),

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -2530,7 +2530,7 @@ func TestGetInputLists(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			allSets, newSets, err := s.getInputLists(tc.cluster, 0)
+			allSets, newSets, err := s.getInputLists(tc.cluster)
 			require.NoError(t, err)
 
 			if tc.expectNilNewSet {

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -31,7 +31,7 @@ var (
 
 	testMaxInputsPerTx = 3
 
-	defaultFeePref = Params{Fee: FeePreference{ConfTarget: 1}}
+	defaultFeePref = Params{Fee: FeeEstimateInfo{ConfTarget: 1}}
 )
 
 type sweeperTestContext struct {
@@ -432,7 +432,7 @@ func TestWalletUtxo(t *testing.T) {
 
 	_, err := ctx.sweeper.SweepInput(
 		&dustInput,
-		Params{Fee: FeePreference{FeeRate: chainfee.FeePerKwFloor}},
+		Params{Fee: FeeEstimateInfo{FeeRate: chainfee.FeePerKwFloor}},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -926,11 +926,11 @@ func TestDifferentFeePreferences(t *testing.T) {
 	// with the higher fee preference, and the last with the lower. We do
 	// this to ensure the sweeper can broadcast distinct transactions for
 	// each sweep with a different fee preference.
-	lowFeePref := FeePreference{ConfTarget: 12}
+	lowFeePref := FeeEstimateInfo{ConfTarget: 12}
 	lowFeeRate := chainfee.SatPerKWeight(5000)
 	ctx.estimator.blocksToFee[lowFeePref.ConfTarget] = lowFeeRate
 
-	highFeePref := FeePreference{ConfTarget: 6}
+	highFeePref := FeeEstimateInfo{ConfTarget: 6}
 	highFeeRate := chainfee.SatPerKWeight(10000)
 	ctx.estimator.blocksToFee[highFeePref.ConfTarget] = highFeeRate
 
@@ -995,12 +995,12 @@ func TestPendingInputs(t *testing.T) {
 		highFeeRate = 10000
 	)
 
-	lowFeePref := FeePreference{
+	lowFeePref := FeeEstimateInfo{
 		ConfTarget: 12,
 	}
 	ctx.estimator.blocksToFee[lowFeePref.ConfTarget] = lowFeeRate
 
-	highFeePref := FeePreference{
+	highFeePref := FeeEstimateInfo{
 		ConfTarget: 6,
 	}
 	ctx.estimator.blocksToFee[highFeePref.ConfTarget] = highFeeRate
@@ -1060,7 +1060,7 @@ func TestPendingInputs(t *testing.T) {
 func TestBumpFeeRBF(t *testing.T) {
 	ctx := createSweeperTestContext(t)
 
-	lowFeePref := FeePreference{ConfTarget: 144}
+	lowFeePref := FeeEstimateInfo{ConfTarget: 144}
 	lowFeeRate := chainfee.FeePerKwFloor
 	ctx.estimator.blocksToFee[lowFeePref.ConfTarget] = lowFeeRate
 
@@ -1095,7 +1095,7 @@ func TestBumpFeeRBF(t *testing.T) {
 	assertTxFeeRate(t, &lowFeeTx, lowFeeRate, changePk, &input)
 
 	// We'll then attempt to bump its fee rate.
-	highFeePref := FeePreference{ConfTarget: 6}
+	highFeePref := FeeEstimateInfo{ConfTarget: 6}
 	highFeeRate := DefaultMaxFeeRate.FeePerKWeight()
 	ctx.estimator.blocksToFee[highFeePref.ConfTarget] = highFeeRate
 
@@ -1132,7 +1132,7 @@ func TestExclusiveGroup(t *testing.T) {
 		exclusiveGroup := uint64(1)
 		result, err := ctx.sweeper.SweepInput(
 			spendableInputs[i], Params{
-				Fee:            FeePreference{ConfTarget: 6},
+				Fee:            FeeEstimateInfo{ConfTarget: 6},
 				ExclusiveGroup: &exclusiveGroup,
 			},
 		)
@@ -1209,7 +1209,7 @@ func TestCpfp(t *testing.T) {
 		},
 	)
 
-	feePref := FeePreference{ConfTarget: 6}
+	feePref := FeeEstimateInfo{ConfTarget: 6}
 	result, err := ctx.sweeper.SweepInput(
 		&input, Params{Fee: feePref, Force: true},
 	)
@@ -1564,7 +1564,7 @@ func TestLockTimes(t *testing.T) {
 
 		result, err := ctx.sweeper.SweepInput(
 			inp, Params{
-				Fee: FeePreference{ConfTarget: 6},
+				Fee: FeeEstimateInfo{ConfTarget: 6},
 			},
 		)
 		if err != nil {
@@ -1582,7 +1582,7 @@ func TestLockTimes(t *testing.T) {
 		inp := spendableInputs[i+numSweeps*2]
 		result, err := ctx.sweeper.SweepInput(
 			inp, Params{
-				Fee: FeePreference{ConfTarget: 6},
+				Fee: FeeEstimateInfo{ConfTarget: 6},
 			},
 		)
 		if err != nil {
@@ -2027,7 +2027,7 @@ func TestRequiredTxOuts(t *testing.T) {
 			for _, inp := range testCase.inputs {
 				result, err := ctx.sweeper.SweepInput(
 					inp, Params{
-						Fee: FeePreference{ConfTarget: 6},
+						Fee: FeeEstimateInfo{ConfTarget: 6},
 					},
 				)
 				if err != nil {
@@ -2141,7 +2141,7 @@ func TestClusterByLockTime(t *testing.T) {
 
 	// Create a test param with a dummy fee preference. This is needed so
 	// `feeRateForPreference` won't throw an error.
-	param := Params{Fee: FeePreference{ConfTarget: 1}}
+	param := Params{Fee: FeeEstimateInfo{ConfTarget: 1}}
 
 	// We begin the test by creating three clusters of inputs, the first
 	// cluster has a locktime of 1, the second has a locktime of 2, and the
@@ -2316,7 +2316,7 @@ func TestGetInputLists(t *testing.T) {
 
 	// Create a test param with a dummy fee preference. This is needed so
 	// `feeRateForPreference` won't throw an error.
-	param := Params{Fee: FeePreference{ConfTarget: 1}}
+	param := Params{Fee: FeeEstimateInfo{ConfTarget: 1}}
 
 	// Create a mock input and mock all the methods used in this test.
 	testInput := &input.MockInput{}

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -1,11 +1,8 @@
 package sweep
 
 import (
-	"errors"
 	"os"
-	"reflect"
 	"runtime/pprof"
-	"sort"
 	"testing"
 	"time"
 
@@ -14,7 +11,6 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/input"
@@ -121,6 +117,10 @@ func createSweeperTestContext(t *testing.T) *sweeperTestContext {
 
 	estimator := newMockFeeEstimator(10000, chainfee.FeePerKwFloor)
 
+	aggregator := NewSimpleUtxoAggregator(
+		estimator, DefaultMaxFeeRate.FeePerKWeight(),
+	)
+
 	ctx := &sweeperTestContext{
 		notifier:    notifier,
 		publishChan: backend.publishChan,
@@ -149,8 +149,8 @@ func createSweeperTestContext(t *testing.T) *sweeperTestContext {
 			// Use delta func without random factor.
 			return 1 << uint(attempts-1)
 		},
-		MaxFeeRate:        DefaultMaxFeeRate,
-		FeeRateBucketSize: DefaultFeeRateBucketSize,
+		MaxFeeRate: DefaultMaxFeeRate,
+		Aggregator: aggregator,
 	})
 
 	ctx.sweeper.Start()
@@ -384,9 +384,7 @@ func TestDust(t *testing.T) {
 	dustInput := createTestInput(5260, input.CommitmentTimeLock)
 
 	_, err := ctx.sweeper.SweepInput(&dustInput, defaultFeePref)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// No sweep transaction is expected now. The sweeper should recognize
 	// that the sweep output will not be relayed and not generate the tx. It
@@ -398,18 +396,13 @@ func TestDust(t *testing.T) {
 	largeInput := createTestInput(100000, input.CommitmentTimeLock)
 
 	_, err = ctx.sweeper.SweepInput(&largeInput, defaultFeePref)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// The second input brings the sweep output above the dust limit. We
 	// expect a sweep tx now.
 
 	sweepTx := ctx.receiveTx()
-	if len(sweepTx.TxIn) != 2 {
-		t.Fatalf("Expected tx to sweep 2 inputs, but contains %v "+
-			"inputs instead", len(sweepTx.TxIn))
-	}
+	require.Len(t, sweepTx.TxIn, 2, "unexpected num of tx inputs")
 
 	ctx.backend.mine()
 
@@ -1249,224 +1242,6 @@ func TestCpfp(t *testing.T) {
 	ctx.finish(1)
 }
 
-var (
-	testInputsA = pendingInputs{
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 0}: &pendingInput{},
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 1}: &pendingInput{},
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 2}: &pendingInput{},
-	}
-
-	testInputsB = pendingInputs{
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 10}: &pendingInput{},
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 11}: &pendingInput{},
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 12}: &pendingInput{},
-	}
-
-	testInputsC = pendingInputs{
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 0}:  &pendingInput{},
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 1}:  &pendingInput{},
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 2}:  &pendingInput{},
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 10}: &pendingInput{},
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 11}: &pendingInput{},
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 12}: &pendingInput{},
-	}
-)
-
-// TestMergeClusters check that we properly can merge clusters together,
-// according to their required locktime.
-func TestMergeClusters(t *testing.T) {
-	t.Parallel()
-
-	lockTime1 := uint32(100)
-	lockTime2 := uint32(200)
-
-	testCases := []struct {
-		name string
-		a    inputCluster
-		b    inputCluster
-		res  []inputCluster
-	}{
-		{
-			name: "max fee rate",
-			a: inputCluster{
-				sweepFeeRate: 5000,
-				inputs:       testInputsA,
-			},
-			b: inputCluster{
-				sweepFeeRate: 7000,
-				inputs:       testInputsB,
-			},
-			res: []inputCluster{
-				{
-					sweepFeeRate: 7000,
-					inputs:       testInputsC,
-				},
-			},
-		},
-		{
-			name: "same locktime",
-			a: inputCluster{
-				lockTime:     &lockTime1,
-				sweepFeeRate: 5000,
-				inputs:       testInputsA,
-			},
-			b: inputCluster{
-				lockTime:     &lockTime1,
-				sweepFeeRate: 7000,
-				inputs:       testInputsB,
-			},
-			res: []inputCluster{
-				{
-					lockTime:     &lockTime1,
-					sweepFeeRate: 7000,
-					inputs:       testInputsC,
-				},
-			},
-		},
-		{
-			name: "diff locktime",
-			a: inputCluster{
-				lockTime:     &lockTime1,
-				sweepFeeRate: 5000,
-				inputs:       testInputsA,
-			},
-			b: inputCluster{
-				lockTime:     &lockTime2,
-				sweepFeeRate: 7000,
-				inputs:       testInputsB,
-			},
-			res: []inputCluster{
-				{
-					lockTime:     &lockTime1,
-					sweepFeeRate: 5000,
-					inputs:       testInputsA,
-				},
-				{
-					lockTime:     &lockTime2,
-					sweepFeeRate: 7000,
-					inputs:       testInputsB,
-				},
-			},
-		},
-	}
-
-	for _, test := range testCases {
-		merged := mergeClusters(test.a, test.b)
-		if !reflect.DeepEqual(merged, test.res) {
-			t.Fatalf("[%s] unexpected result: %v",
-				test.name, spew.Sdump(merged))
-		}
-	}
-}
-
-// TestZipClusters tests that we can merge lists of inputs clusters correctly.
-func TestZipClusters(t *testing.T) {
-	t.Parallel()
-
-	createCluster := func(inp pendingInputs, f chainfee.SatPerKWeight) inputCluster {
-		return inputCluster{
-			sweepFeeRate: f,
-			inputs:       inp,
-		}
-	}
-
-	testCases := []struct {
-		name string
-		as   []inputCluster
-		bs   []inputCluster
-		res  []inputCluster
-	}{
-		{
-			name: "merge A into B",
-			as: []inputCluster{
-				createCluster(testInputsA, 5000),
-			},
-			bs: []inputCluster{
-				createCluster(testInputsB, 7000),
-			},
-			res: []inputCluster{
-				createCluster(testInputsC, 7000),
-			},
-		},
-		{
-			name: "A can't merge with B",
-			as: []inputCluster{
-				createCluster(testInputsA, 7000),
-			},
-			bs: []inputCluster{
-				createCluster(testInputsB, 5000),
-			},
-			res: []inputCluster{
-				createCluster(testInputsA, 7000),
-				createCluster(testInputsB, 5000),
-			},
-		},
-		{
-			name: "empty bs",
-			as: []inputCluster{
-				createCluster(testInputsA, 7000),
-			},
-			bs: []inputCluster{},
-			res: []inputCluster{
-				createCluster(testInputsA, 7000),
-			},
-		},
-		{
-			name: "empty as",
-			as:   []inputCluster{},
-			bs: []inputCluster{
-				createCluster(testInputsB, 5000),
-			},
-			res: []inputCluster{
-				createCluster(testInputsB, 5000),
-			},
-		},
-
-		{
-			name: "zip 3xA into 3xB",
-			as: []inputCluster{
-				createCluster(testInputsA, 5000),
-				createCluster(testInputsA, 5000),
-				createCluster(testInputsA, 5000),
-			},
-			bs: []inputCluster{
-				createCluster(testInputsB, 7000),
-				createCluster(testInputsB, 7000),
-				createCluster(testInputsB, 7000),
-			},
-			res: []inputCluster{
-				createCluster(testInputsC, 7000),
-				createCluster(testInputsC, 7000),
-				createCluster(testInputsC, 7000),
-			},
-		},
-		{
-			name: "zip A into 3xB",
-			as: []inputCluster{
-				createCluster(testInputsA, 2500),
-			},
-			bs: []inputCluster{
-				createCluster(testInputsB, 3000),
-				createCluster(testInputsB, 2000),
-				createCluster(testInputsB, 1000),
-			},
-			res: []inputCluster{
-				createCluster(testInputsC, 3000),
-				createCluster(testInputsB, 2000),
-				createCluster(testInputsB, 1000),
-			},
-		},
-	}
-
-	for _, test := range testCases {
-		zipped := zipClusters(test.as, test.bs)
-		if !reflect.DeepEqual(zipped, test.res) {
-			t.Fatalf("[%s] unexpected result: %v",
-				test.name, spew.Sdump(zipped))
-		}
-	}
-}
-
 type testInput struct {
 	*input.BaseInput
 
@@ -2138,198 +1913,6 @@ func TestSweeperShutdownHandling(t *testing.T) {
 		spendableInputs[0], defaultFeePref,
 	)
 	require.Error(t, err)
-}
-
-// TestClusterByLockTime tests the method clusterByLockTime works as expected.
-func TestClusterByLockTime(t *testing.T) {
-	t.Parallel()
-
-	// Create a mock FeePreference.
-	mockFeePref := &MockFeePreference{}
-
-	// Create a test param with a dummy fee preference. This is needed so
-	// `feeRateForPreference` won't throw an error.
-	param := Params{Fee: mockFeePref}
-
-	// We begin the test by creating three clusters of inputs, the first
-	// cluster has a locktime of 1, the second has a locktime of 2, and the
-	// final has no locktime.
-	lockTime1 := uint32(1)
-	lockTime2 := uint32(2)
-
-	// Create cluster one, which has a locktime of 1.
-	input1LockTime1 := &input.MockInput{}
-	input2LockTime1 := &input.MockInput{}
-	input1LockTime1.On("RequiredLockTime").Return(lockTime1, true)
-	input2LockTime1.On("RequiredLockTime").Return(lockTime1, true)
-
-	// Create cluster two, which has a locktime of 2.
-	input3LockTime2 := &input.MockInput{}
-	input4LockTime2 := &input.MockInput{}
-	input3LockTime2.On("RequiredLockTime").Return(lockTime2, true)
-	input4LockTime2.On("RequiredLockTime").Return(lockTime2, true)
-
-	// Create cluster three, which has no locktime.
-	input5NoLockTime := &input.MockInput{}
-	input6NoLockTime := &input.MockInput{}
-	input5NoLockTime.On("RequiredLockTime").Return(uint32(0), false)
-	input6NoLockTime.On("RequiredLockTime").Return(uint32(0), false)
-
-	// With the inner Input being mocked, we can now create the pending
-	// inputs.
-	input1 := &pendingInput{Input: input1LockTime1, params: param}
-	input2 := &pendingInput{Input: input2LockTime1, params: param}
-	input3 := &pendingInput{Input: input3LockTime2, params: param}
-	input4 := &pendingInput{Input: input4LockTime2, params: param}
-	input5 := &pendingInput{Input: input5NoLockTime, params: param}
-	input6 := &pendingInput{Input: input6NoLockTime, params: param}
-
-	// Create the pending inputs map, which will be passed to the method
-	// under test.
-	//
-	// NOTE: we don't care the actual outpoint values as long as they are
-	// unique.
-	inputs := pendingInputs{
-		wire.OutPoint{Index: 1}: input1,
-		wire.OutPoint{Index: 2}: input2,
-		wire.OutPoint{Index: 3}: input3,
-		wire.OutPoint{Index: 4}: input4,
-		wire.OutPoint{Index: 5}: input5,
-		wire.OutPoint{Index: 6}: input6,
-	}
-
-	// Create expected clusters so we can shorten the line length in the
-	// test cases below.
-	cluster1 := pendingInputs{
-		wire.OutPoint{Index: 1}: input1,
-		wire.OutPoint{Index: 2}: input2,
-	}
-	cluster2 := pendingInputs{
-		wire.OutPoint{Index: 3}: input3,
-		wire.OutPoint{Index: 4}: input4,
-	}
-
-	// cluster3 should be the remaining inputs since they don't have
-	// locktime.
-	cluster3 := pendingInputs{
-		wire.OutPoint{Index: 5}: input5,
-		wire.OutPoint{Index: 6}: input6,
-	}
-
-	// Set the min fee rate to be 1000 sat/kw.
-	const minFeeRate = chainfee.SatPerKWeight(1000)
-
-	// Create a test sweeper.
-	s := New(&UtxoSweeperConfig{
-		MaxFeeRate: minFeeRate.FeePerVByte() * 10,
-	})
-
-	// Set the relay fee to be the minFeeRate. Any fee rate below the
-	// minFeeRate will cause an error to be returned.
-	s.relayFeeRate = minFeeRate
-
-	testCases := []struct {
-		name string
-		// setupMocker takes a testing fee rate and makes a mocker over
-		// `Estimate` that always return the testing fee rate.
-		setupMocker             func()
-		testFeeRate             chainfee.SatPerKWeight
-		expectedClusters        []inputCluster
-		expectedRemainingInputs pendingInputs
-	}{
-		{
-			// Test a successful case where the locktime clusters
-			// are created and the no-locktime cluster is returned
-			// as the remaining inputs.
-			name: "successfully create clusters",
-			setupMocker: func() {
-				mockFeePref.On("Estimate",
-					s.cfg.FeeEstimator,
-					s.cfg.MaxFeeRate.FeePerKWeight(),
-				// Expect the four inputs with locktime to call
-				// this method.
-				).Return(minFeeRate+1, nil).Times(4)
-			},
-			// Use a fee rate above the min value so we don't hit
-			// an error when performing fee estimation.
-			//
-			// TODO(yy): we should customize the returned fee rate
-			// for each input to further test the averaging logic.
-			// Or we can split the method into two, one for
-			// grouping the clusters and the other for averaging
-			// the fee rates so it's easier to be tested.
-			testFeeRate: minFeeRate + 1,
-			expectedClusters: []inputCluster{
-				{
-					lockTime:     &lockTime1,
-					sweepFeeRate: minFeeRate + 1,
-					inputs:       cluster1,
-				},
-				{
-					lockTime:     &lockTime2,
-					sweepFeeRate: minFeeRate + 1,
-					inputs:       cluster2,
-				},
-			},
-			expectedRemainingInputs: cluster3,
-		},
-		{
-			// Test that when the input is skipped when the fee
-			// estimation returns an error.
-			name: "error from fee estimation",
-			setupMocker: func() {
-				mockFeePref.On("Estimate",
-					s.cfg.FeeEstimator,
-					s.cfg.MaxFeeRate.FeePerKWeight(),
-				).Return(chainfee.SatPerKWeight(0),
-					errors.New("dummy")).Times(4)
-			},
-
-			// Use a fee rate below the min value so we hit an
-			// error when performing fee estimation.
-			testFeeRate:      minFeeRate - 1,
-			expectedClusters: []inputCluster{},
-			// Remaining inputs should stay untouched.
-			expectedRemainingInputs: cluster3,
-		},
-	}
-
-	//nolint:paralleltest
-	for _, tc := range testCases {
-		tc := tc
-
-		t.Run(tc.name, func(t *testing.T) {
-			// Apply the test fee rate so `feeRateForPreference` is
-			// mocked to return the specified value.
-			tc.setupMocker()
-
-			// Call the method under test.
-			clusters, remainingInputs := s.clusterByLockTime(inputs)
-
-			// Sort by locktime as the order is not guaranteed.
-			sort.Slice(clusters, func(i, j int) bool {
-				return *clusters[i].lockTime <
-					*clusters[j].lockTime
-			})
-
-			// Validate the values are returned as expected.
-			require.Equal(t, tc.expectedClusters, clusters)
-			require.Equal(t, tc.expectedRemainingInputs,
-				remainingInputs,
-			)
-
-			// Assert the mocked methods are called as expected.
-			input1LockTime1.AssertExpectations(t)
-			input2LockTime1.AssertExpectations(t)
-			input3LockTime2.AssertExpectations(t)
-			input4LockTime2.AssertExpectations(t)
-			input5NoLockTime.AssertExpectations(t)
-			input6NoLockTime.AssertExpectations(t)
-
-			// Assert the mocked methods are called as expeceted.
-			mockFeePref.AssertExpectations(t)
-		})
-	}
 }
 
 // TestGetInputLists checks that the expected input sets are returned based on

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -1,6 +1,7 @@
 package sweep
 
 import (
+	"errors"
 	"os"
 	"reflect"
 	"runtime/pprof"
@@ -335,7 +336,9 @@ func TestSuccess(t *testing.T) {
 	ctx := createSweeperTestContext(t)
 
 	// Sweeping an input without a fee preference should result in an error.
-	_, err := ctx.sweeper.SweepInput(spendableInputs[0], Params{})
+	_, err := ctx.sweeper.SweepInput(spendableInputs[0], Params{
+		Fee: &FeeEstimateInfo{},
+	})
 	if err != ErrNoFeePreference {
 		t.Fatalf("expected ErrNoFeePreference, got %v", err)
 	}
@@ -1100,7 +1103,9 @@ func TestBumpFeeRBF(t *testing.T) {
 	ctx.estimator.blocksToFee[highFeePref.ConfTarget] = highFeeRate
 
 	// We should expect to see an error if a fee preference isn't provided.
-	_, err = ctx.sweeper.UpdateParams(*input.OutPoint(), ParamsUpdate{})
+	_, err = ctx.sweeper.UpdateParams(*input.OutPoint(), ParamsUpdate{
+		Fee: &FeeEstimateInfo{},
+	})
 	if err != ErrNoFeePreference {
 		t.Fatalf("expected ErrNoFeePreference, got %v", err)
 	}
@@ -2139,9 +2144,12 @@ func TestSweeperShutdownHandling(t *testing.T) {
 func TestClusterByLockTime(t *testing.T) {
 	t.Parallel()
 
+	// Create a mock FeePreference.
+	mockFeePref := &MockFeePreference{}
+
 	// Create a test param with a dummy fee preference. This is needed so
 	// `feeRateForPreference` won't throw an error.
-	param := Params{Fee: FeeEstimateInfo{ConfTarget: 1}}
+	param := Params{Fee: mockFeePref}
 
 	// We begin the test by creating three clusters of inputs, the first
 	// cluster has a locktime of 1, the second has a locktime of 2, and the
@@ -2220,15 +2228,11 @@ func TestClusterByLockTime(t *testing.T) {
 	// minFeeRate will cause an error to be returned.
 	s.relayFeeRate = minFeeRate
 
-	// applyFeeRate takes a testing fee rate and makes a mocker over
-	// DetermineFeePerKw that always return the testing fee rate. This
-	// mocked method is then attached to the sweeper.
-	applyFeeRate := func(feeRate chainfee.SatPerKWeight) {
-		// TODO(yy): fix the test here.
-	}
-
 	testCases := []struct {
-		name                    string
+		name string
+		// setupMocker takes a testing fee rate and makes a mocker over
+		// `Estimate` that always return the testing fee rate.
+		setupMocker             func()
 		testFeeRate             chainfee.SatPerKWeight
 		expectedClusters        []inputCluster
 		expectedRemainingInputs pendingInputs
@@ -2238,6 +2242,14 @@ func TestClusterByLockTime(t *testing.T) {
 			// are created and the no-locktime cluster is returned
 			// as the remaining inputs.
 			name: "successfully create clusters",
+			setupMocker: func() {
+				mockFeePref.On("Estimate",
+					s.cfg.FeeEstimator,
+					s.cfg.MaxFeeRate.FeePerKWeight(),
+				// Expect the four inputs with locktime to call
+				// this method.
+				).Return(minFeeRate+1, nil).Times(4)
+			},
 			// Use a fee rate above the min value so we don't hit
 			// an error when performing fee estimation.
 			//
@@ -2265,6 +2277,14 @@ func TestClusterByLockTime(t *testing.T) {
 			// Test that when the input is skipped when the fee
 			// estimation returns an error.
 			name: "error from fee estimation",
+			setupMocker: func() {
+				mockFeePref.On("Estimate",
+					s.cfg.FeeEstimator,
+					s.cfg.MaxFeeRate.FeePerKWeight(),
+				).Return(chainfee.SatPerKWeight(0),
+					errors.New("dummy")).Times(4)
+			},
+
 			// Use a fee rate below the min value so we hit an
 			// error when performing fee estimation.
 			testFeeRate:      minFeeRate - 1,
@@ -2281,7 +2301,7 @@ func TestClusterByLockTime(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Apply the test fee rate so `feeRateForPreference` is
 			// mocked to return the specified value.
-			applyFeeRate(tc.testFeeRate)
+			tc.setupMocker()
 
 			// Call the method under test.
 			clusters, remainingInputs := s.clusterByLockTime(inputs)
@@ -2305,6 +2325,9 @@ func TestClusterByLockTime(t *testing.T) {
 			input4LockTime2.AssertExpectations(t)
 			input5NoLockTime.AssertExpectations(t)
 			input6NoLockTime.AssertExpectations(t)
+
+			// Assert the mocked methods are called as expeceted.
+			mockFeePref.AssertExpectations(t)
 		})
 	}
 }

--- a/sweep/txgenerator.go
+++ b/sweep/txgenerator.go
@@ -20,6 +20,10 @@ var (
 	// allowed in a single sweep tx. If more need to be swept, multiple txes
 	// are created and published.
 	DefaultMaxInputsPerTx = 100
+
+	// ErrLocktimeConflict is returned when inputs have different
+	// transaction nLockTime values are included in the same transaction.
+	ErrLocktimeConflict = errors.New("incompatible locktime")
 )
 
 // txInput is an interface that provides the input data required for tx
@@ -140,13 +144,13 @@ func generateInputPartitionings(sweepableInputs []txInput,
 func createSweepTx(inputs []input.Input, outputs []*wire.TxOut,
 	changePkScript []byte, currentBlockHeight uint32,
 	feePerKw, maxFeeRate chainfee.SatPerKWeight,
-	signer input.Signer) (*wire.MsgTx, error) {
+	signer input.Signer) (*wire.MsgTx, btcutil.Amount, error) {
 
 	inputs, estimator, err := getWeightEstimate(
 		inputs, outputs, feePerKw, maxFeeRate, changePkScript,
 	)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	txFee := estimator.fee()
@@ -188,7 +192,7 @@ func createSweepTx(inputs []input.Input, outputs []*wire.TxOut,
 			// If another input commits to a different locktime,
 			// they cannot be combined in the same transaction.
 			if locktime != -1 && locktime != int32(lt) {
-				return nil, fmt.Errorf("incompatible locktime")
+				return nil, 0, ErrLocktimeConflict
 			}
 
 			locktime = int32(lt)
@@ -213,7 +217,7 @@ func createSweepTx(inputs []input.Input, outputs []*wire.TxOut,
 
 		if lt, ok := o.RequiredLockTime(); ok {
 			if locktime != -1 && locktime != int32(lt) {
-				return nil, fmt.Errorf("incompatible locktime")
+				return nil, 0, ErrLocktimeConflict
 			}
 
 			locktime = int32(lt)
@@ -229,7 +233,7 @@ func createSweepTx(inputs []input.Input, outputs []*wire.TxOut,
 	}
 
 	if requiredOutput+txFee > totalInput {
-		return nil, fmt.Errorf("insufficient input to create sweep "+
+		return nil, 0, fmt.Errorf("insufficient input to create sweep "+
 			"tx: input_sum=%v, output_sum=%v", totalInput,
 			requiredOutput+txFee)
 	}
@@ -270,12 +274,12 @@ func createSweepTx(inputs []input.Input, outputs []*wire.TxOut,
 	// classes if fees are too low.
 	btx := btcutil.NewTx(sweepTx)
 	if err := blockchain.CheckTransactionSanity(btx); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	prevInputFetcher, err := input.MultiPrevOutFetcher(inputs)
 	if err != nil {
-		return nil, fmt.Errorf("error creating prev input fetcher "+
+		return nil, 0, fmt.Errorf("error creating prev input fetcher "+
 			"for hash cache: %v", err)
 	}
 	hashCache := txscript.NewTxSigHashes(sweepTx, prevInputFetcher)
@@ -293,7 +297,8 @@ func createSweepTx(inputs []input.Input, outputs []*wire.TxOut,
 		sweepTx.TxIn[idx].Witness = inputScript.Witness
 
 		if len(inputScript.SigScript) != 0 {
-			sweepTx.TxIn[idx].SignatureScript = inputScript.SigScript
+			sweepTx.TxIn[idx].SignatureScript =
+				inputScript.SigScript
 		}
 
 		return nil
@@ -301,7 +306,7 @@ func createSweepTx(inputs []input.Input, outputs []*wire.TxOut,
 
 	for idx, inp := range idxs {
 		if err := addInputScript(idx, inp); err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 	}
 
@@ -315,7 +320,7 @@ func createSweepTx(inputs []input.Input, outputs []*wire.TxOut,
 		estimator.parentsWeight,
 	)
 
-	return sweepTx, nil
+	return sweepTx, txFee, nil
 }
 
 // getWeightEstimate returns a weight estimate for the given inputs.

--- a/sweep/walletsweep.go
+++ b/sweep/walletsweep.go
@@ -30,9 +30,9 @@ var (
 	ErrFeePreferenceConflict = errors.New("fee preference conflict")
 )
 
-// FeePreference allows callers to express their time value for inclusion of a
-// transaction into a block via either a confirmation target, or a fee rate.
-type FeePreference struct {
+// FeeEstimateInfo allows callers to express their time value for inclusion of
+// a transaction into a block via either a confirmation target, or a fee rate.
+type FeeEstimateInfo struct {
 	// ConfTarget if non-zero, signals a fee preference expressed in the
 	// number of desired blocks between first broadcast, and confirmation.
 	ConfTarget uint32
@@ -43,7 +43,7 @@ type FeePreference struct {
 }
 
 // String returns a human-readable string of the fee preference.
-func (p FeePreference) String() string {
+func (p FeeEstimateInfo) String() string {
 	if p.ConfTarget != 0 {
 		return fmt.Sprintf("%v blocks", p.ConfTarget)
 	}
@@ -53,7 +53,7 @@ func (p FeePreference) String() string {
 // Estimate returns a fee rate for the given fee preference. It ensures that
 // the fee rate respects the bounds of the relay fee and the max fee rates, if
 // specified.
-func (f FeePreference) Estimate(estimator chainfee.Estimator,
+func (f FeeEstimateInfo) Estimate(estimator chainfee.Estimator,
 	maxFeeRate chainfee.SatPerKWeight) (chainfee.SatPerKWeight, error) {
 
 	var (

--- a/sweep/walletsweep.go
+++ b/sweep/walletsweep.go
@@ -319,7 +319,7 @@ func CraftSweepAllTx(feeRate, maxFeeRate chainfee.SatPerKWeight,
 
 	// Finally, we'll ask the sweeper to craft a sweep transaction which
 	// respects our fee preference and targets all the UTXOs of the wallet.
-	sweepTx, err := createSweepTx(
+	sweepTx, _, err := createSweepTx(
 		inputsToSweep, txOuts, changePkScript, blockHeight,
 		feeRate, maxFeeRate, signer,
 	)

--- a/sweep/walletsweep.go
+++ b/sweep/walletsweep.go
@@ -30,6 +30,24 @@ var (
 	ErrFeePreferenceConflict = errors.New("fee preference conflict")
 )
 
+// FeePreference defines an interface that allows the caller to specify how the
+// fee rate should be handled. Depending on the implementation, the fee rate
+// can either be specified directly, or via a conf target which relies on the
+// chain backend(`bitcoind`) to give a fee estimation, or a customized fee
+// function which handles fee calculation based on the specified
+// urgency(deadline).
+type FeePreference interface {
+	// String returns a human-readable string of the fee preference.
+	String() string
+
+	// Estimate takes a fee estimator and a max allowed fee rate and
+	// returns a fee rate for the given fee preference. It ensures that the
+	// fee rate respects the bounds of the relay fee and the specified max
+	// fee rates.
+	Estimate(chainfee.Estimator,
+		chainfee.SatPerKWeight) (chainfee.SatPerKWeight, error)
+}
+
 // FeeEstimateInfo allows callers to express their time value for inclusion of
 // a transaction into a block via either a confirmation target, or a fee rate.
 type FeeEstimateInfo struct {
@@ -42,12 +60,15 @@ type FeeEstimateInfo struct {
 	FeeRate chainfee.SatPerKWeight
 }
 
+// Compile-time constraint to ensure FeeEstimateInfo implements FeePreference.
+var _ FeePreference = (*FeeEstimateInfo)(nil)
+
 // String returns a human-readable string of the fee preference.
-func (p FeeEstimateInfo) String() string {
-	if p.ConfTarget != 0 {
-		return fmt.Sprintf("%v blocks", p.ConfTarget)
+func (f FeeEstimateInfo) String() string {
+	if f.ConfTarget != 0 {
+		return fmt.Sprintf("%v blocks", f.ConfTarget)
 	}
-	return p.FeeRate.String()
+	return f.FeeRate.String()
 }
 
 // Estimate returns a fee rate for the given fee preference. It ensures that

--- a/sweep/walletsweep_test.go
+++ b/sweep/walletsweep_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestFeePreferenceEstimate checks `Estimate` method works as expected.
-func TestFeePreferenceEstimate(t *testing.T) {
+// TestFeeEstimateInfo checks `Estimate` method works as expected.
+func TestFeeEstimateInfo(t *testing.T) {
 	t.Parallel()
 
 	dummyErr := errors.New("dummy")
@@ -42,7 +42,7 @@ func TestFeePreferenceEstimate(t *testing.T) {
 	testCases := []struct {
 		name            string
 		setupMocker     func()
-		feePref         FeePreference
+		feePref         FeeEstimateInfo
 		expectedFeeRate chainfee.SatPerKWeight
 		expectedErr     error
 	}{
@@ -50,14 +50,14 @@ func TestFeePreferenceEstimate(t *testing.T) {
 			// When the fee preference is empty, we should see an
 			// error.
 			name:        "empty fee preference",
-			feePref:     FeePreference{},
+			feePref:     FeeEstimateInfo{},
 			expectedErr: ErrNoFeePreference,
 		},
 		{
 			// When the fee preference has conflicts, we should see
 			// an error.
 			name: "conflict fee preference",
-			feePref: FeePreference{
+			feePref: FeeEstimateInfo{
 				FeeRate:    validFeeRate,
 				ConfTarget: conf,
 			},
@@ -72,12 +72,12 @@ func TestFeePreferenceEstimate(t *testing.T) {
 					chainfee.SatPerKWeight(0), dummyErr,
 				).Once()
 			},
-			feePref:     FeePreference{ConfTarget: conf},
+			feePref:     FeeEstimateInfo{ConfTarget: conf},
 			expectedErr: dummyErr,
 		},
 		{
-			// When FeePreference uses a too small value, we should
-			// return an error.
+			// When FeeEstimateInfo uses a too small value, we
+			// should return an error.
 			name: "fee rate below relay fee rate",
 			setupMocker: func() {
 				// Mock the relay fee rate.
@@ -85,11 +85,11 @@ func TestFeePreferenceEstimate(t *testing.T) {
 					chainfee.SatPerKWeight(relayFeeRate),
 				).Once()
 			},
-			feePref:     FeePreference{FeeRate: relayFeeRate - 1},
+			feePref:     FeeEstimateInfo{FeeRate: relayFeeRate - 1},
 			expectedErr: ErrFeePreferenceTooLow,
 		},
 		{
-			// When FeePreference gives a too large value, we
+			// When FeeEstimateInfo gives a too large value, we
 			// should cap it at the max fee rate.
 			name: "fee rate above max fee rate",
 			setupMocker: func() {
@@ -98,7 +98,7 @@ func TestFeePreferenceEstimate(t *testing.T) {
 					chainfee.SatPerKWeight(relayFeeRate),
 				).Once()
 			},
-			feePref:         FeePreference{FeeRate: maxFeeRate + 1},
+			feePref:         FeeEstimateInfo{FeeRate: maxFeeRate + 1},
 			expectedFeeRate: maxFeeRate,
 		},
 		{
@@ -115,7 +115,7 @@ func TestFeePreferenceEstimate(t *testing.T) {
 					chainfee.SatPerKWeight(relayFeeRate),
 				).Once()
 			},
-			feePref:         FeePreference{ConfTarget: conf},
+			feePref:         FeeEstimateInfo{ConfTarget: conf},
 			expectedFeeRate: validFeeRate,
 		},
 	}

--- a/sweep/walletsweep_test.go
+++ b/sweep/walletsweep_test.go
@@ -2,6 +2,7 @@ package sweep
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -15,106 +16,133 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestDetermineFeePerKw tests that given a fee preference, the
-// DetermineFeePerKw will properly map it to a concrete fee in sat/kw.
-func TestDetermineFeePerKw(t *testing.T) {
+// TestFeePreferenceEstimate checks `Estimate` method works as expected.
+func TestFeePreferenceEstimate(t *testing.T) {
 	t.Parallel()
 
-	defaultFee := chainfee.SatPerKWeight(999)
-	relayFee := chainfee.SatPerKWeight(300)
+	dummyErr := errors.New("dummy")
 
-	feeEstimator := newMockFeeEstimator(defaultFee, relayFee)
+	const (
+		// Set the relay fee rate to be 10 sat/kw.
+		relayFeeRate = 10
 
-	// We'll populate two items in the internal map which is used to query
-	// a fee based on a confirmation target: the default conf target, and
-	// an arbitrary conf target. We'll ensure below that both of these are
-	// properly
-	feeEstimator.blocksToFee[50] = 300
-	feeEstimator.blocksToFee[defaultNumBlocksEstimate] = 1000
+		// Set the max fee rate to be 1000 sat/vb.
+		maxFeeRate = 1000
+
+		// Create a valid fee rate to test the success case.
+		validFeeRate = (relayFeeRate + maxFeeRate) / 2
+
+		// Set the test conf target to be 1.
+		conf uint32 = 1
+	)
+
+	// Create a mock fee estimator.
+	estimator := &chainfee.MockEstimator{}
 
 	testCases := []struct {
-		// feePref is the target fee preference for this case.
-		feePref FeePreference
-
-		// fee is the value the DetermineFeePerKw should return given
-		// the FeePreference above
-		fee chainfee.SatPerKWeight
-
-		// fail determines if this test case should fail or not.
-		fail bool
+		name            string
+		setupMocker     func()
+		feePref         FeePreference
+		expectedFeeRate chainfee.SatPerKWeight
+		expectedErr     error
 	}{
-		// A fee rate below the floor should error out.
 		{
-			feePref: FeePreference{
-				FeeRate: chainfee.SatPerKWeight(99),
-			},
-			fail: true,
+			// When the fee preference is empty, we should see an
+			// error.
+			name:        "empty fee preference",
+			feePref:     FeePreference{},
+			expectedErr: ErrNoFeePreference,
 		},
-
-		// A fee rate below the relay fee should error out.
 		{
+			// When the fee preference has conflicts, we should see
+			// an error.
+			name: "conflict fee preference",
 			feePref: FeePreference{
-				FeeRate: chainfee.SatPerKWeight(299),
+				FeeRate:    validFeeRate,
+				ConfTarget: conf,
 			},
-			fail: true,
+			expectedErr: ErrFeePreferenceConflict,
 		},
-
-		// A fee rate above the floor, should pass through and return
-		// the target fee rate.
 		{
-			feePref: FeePreference{
-				FeeRate: 900,
+			// When an error is returned from the fee estimator, we
+			// we should return it.
+			name: "error from Estimator",
+			setupMocker: func() {
+				estimator.On("EstimateFeePerKW", conf).Return(
+					chainfee.SatPerKWeight(0), dummyErr,
+				).Once()
 			},
-			fee: 900,
+			feePref:     FeePreference{ConfTarget: conf},
+			expectedErr: dummyErr,
 		},
-
-		// A specified confirmation target should cause the function to
-		// query the estimator which will return our value specified
-		// above.
 		{
-			feePref: FeePreference{
-				ConfTarget: 50,
+			// When FeePreference uses a too small value, we should
+			// return an error.
+			name: "fee rate below relay fee rate",
+			setupMocker: func() {
+				// Mock the relay fee rate.
+				estimator.On("RelayFeePerKW").Return(
+					chainfee.SatPerKWeight(relayFeeRate),
+				).Once()
 			},
-			fee: 300,
+			feePref:     FeePreference{FeeRate: relayFeeRate - 1},
+			expectedErr: ErrFeePreferenceTooLow,
 		},
-
-		// If the caller doesn't specify any values at all, then we
-		// should query for the default conf target.
 		{
-			feePref: FeePreference{},
-			fee:     1000,
-		},
-
-		// Both conf target and fee rate are set, we should return with
-		// an error.
-		{
-			feePref: FeePreference{
-				ConfTarget: 50,
-				FeeRate:    90000,
+			// When FeePreference gives a too large value, we
+			// should cap it at the max fee rate.
+			name: "fee rate above max fee rate",
+			setupMocker: func() {
+				// Mock the relay fee rate.
+				estimator.On("RelayFeePerKW").Return(
+					chainfee.SatPerKWeight(relayFeeRate),
+				).Once()
 			},
-			fee:  300,
-			fail: true,
+			feePref:         FeePreference{FeeRate: maxFeeRate + 1},
+			expectedFeeRate: maxFeeRate,
+		},
+		{
+			// When Estimator gives a sane fee rate, we should
+			// return it without any error.
+			name: "success",
+			setupMocker: func() {
+				estimator.On("EstimateFeePerKW", conf).Return(
+					chainfee.SatPerKWeight(validFeeRate),
+					nil).Once()
+
+				// Mock the relay fee rate.
+				estimator.On("RelayFeePerKW").Return(
+					chainfee.SatPerKWeight(relayFeeRate),
+				).Once()
+			},
+			feePref:         FeePreference{ConfTarget: conf},
+			expectedFeeRate: validFeeRate,
 		},
 	}
-	for i, testCase := range testCases {
-		targetFee, err := DetermineFeePerKw(
-			feeEstimator, testCase.feePref,
-		)
-		switch {
-		case testCase.fail && err != nil:
-			continue
 
-		case testCase.fail && err == nil:
-			t.Fatalf("expected failure for #%v", i)
+	for _, tc := range testCases {
+		tc := tc
 
-		case !testCase.fail && err != nil:
-			t.Fatalf("unable to estimate fee; %v", err)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup the mockers if specified.
+			if tc.setupMocker != nil {
+				tc.setupMocker()
+			}
 
-		if targetFee != testCase.fee {
-			t.Fatalf("#%v: wrong fee: expected %v got %v", i,
-				testCase.fee, targetFee)
-		}
+			// Call the function under test.
+			feerate, err := tc.feePref.Estimate(
+				estimator, maxFeeRate,
+			)
+
+			// Assert the expected error.
+			require.ErrorIs(t, err, tc.expectedErr)
+
+			// Assert the expected feerate.
+			require.Equal(t, tc.expectedFeeRate, feerate)
+
+			// Assert the mockers.
+			estimator.AssertExpectations(t)
+		})
 	}
 }
 


### PR DESCRIPTION
This PR prepares for #? by refactoring the fee estimation and clustering logic,
- `FeePreference` is now an interface, which makes it possible to implement different fee estimation logics and more importantly, makes it easier to write unit tests as we now mock its behavior.
- Added `UtxoAggregator` as an interface that defines how the inputs should be grouped. The original clustering logic is refactored into the `SimpleAggregator`, that defines a simple strategy that implements this interface, which groups the inputs into clusters based on fee rates and locktime values.