### PR TITLE
[EZ Review]: avoid leaking pointers to authoritative ChannelPoint

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -1169,7 +1169,7 @@ func (c *OpenChannel) fullSync(tx kvdb.RwTx) error {
 		return ErrChanAlreadyExists
 	}
 
-	cid := lnwire.NewChanIDFromOutPoint(&c.FundingOutpoint)
+	cid := lnwire.NewChanIDFromOutPoint(c.FundingOutpoint)
 	if cidBucket.Get(cid[:]) != nil {
 		return ErrChanAlreadyExists
 	}
@@ -1574,7 +1574,7 @@ func (c *OpenChannel) ChanSyncMsg() (*lnwire.ChannelReestablish, error) {
 
 	return &lnwire.ChannelReestablish{
 		ChanID: lnwire.NewChanIDFromOutPoint(
-			&c.FundingOutpoint,
+			c.FundingOutpoint,
 		),
 		NextLocalCommitHeight:  nextLocalCommitHeight,
 		RemoteCommitTailHeight: remoteChainTipHeight,

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -704,7 +704,7 @@ func (c *ChannelStateDB) FetchChannelByID(tx kvdb.RTx, id lnwire.ChannelID) (
 				return err
 			}
 
-			chanID := lnwire.NewChanIDFromOutPoint(&outPoint)
+			chanID := lnwire.NewChanIDFromOutPoint(outPoint)
 			if chanID != id {
 				return nil
 			}

--- a/channeldb/db_test.go
+++ b/channeldb/db_test.go
@@ -140,7 +140,7 @@ func TestFetchClosedChannelForID(t *testing.T) {
 		state.FundingOutpoint.Index = i
 
 		// We calculate the ChannelID and use it to fetch the summary.
-		cid := lnwire.NewChanIDFromOutPoint(&state.FundingOutpoint)
+		cid := lnwire.NewChanIDFromOutPoint(state.FundingOutpoint)
 		fetchedSummary, err := cdb.FetchClosedChannelForID(cid)
 		if err != nil {
 			t.Fatalf("unable to fetch close summary: %v", err)
@@ -158,7 +158,7 @@ func TestFetchClosedChannelForID(t *testing.T) {
 	// As a final test we make sure that we get ErrClosedChannelNotFound
 	// for a ChannelID we didn't add to the DB.
 	state.FundingOutpoint.Index++
-	cid := lnwire.NewChanIDFromOutPoint(&state.FundingOutpoint)
+	cid := lnwire.NewChanIDFromOutPoint(state.FundingOutpoint)
 	_, err = cdb.FetchClosedChannelForID(cid)
 	if err != ErrClosedChannelNotFound {
 		t.Fatalf("expected ErrClosedChannelNotFound, instead got: %v", err)
@@ -240,7 +240,7 @@ func TestFetchChannel(t *testing.T) {
 	require.Equal(t, channelState, dbChannel)
 
 	// Next, attempt to fetch the channel by its channel ID.
-	chanID := lnwire.NewChanIDFromOutPoint(&channelState.FundingOutpoint)
+	chanID := lnwire.NewChanIDFromOutPoint(channelState.FundingOutpoint)
 	dbChannel, err = cdb.FetchChannelByID(nil, chanID)
 	require.NoError(t, err, "unable to fetch channel")
 
@@ -259,7 +259,7 @@ func TestFetchChannel(t *testing.T) {
 	_, err = cdb.FetchChannel(nil, channelState2.FundingOutpoint)
 	require.ErrorIs(t, err, ErrChannelNotFound)
 
-	chanID2 := lnwire.NewChanIDFromOutPoint(&channelState2.FundingOutpoint)
+	chanID2 := lnwire.NewChanIDFromOutPoint(channelState2.FundingOutpoint)
 	_, err = cdb.FetchChannelByID(nil, chanID2)
 	require.ErrorIs(t, err, ErrChannelNotFound)
 }

--- a/channeldb/forwarding_package_test.go
+++ b/channeldb/forwarding_package_test.go
@@ -141,7 +141,7 @@ func checkPkgFilterEncodeDecode(t *testing.T, i uint16, f *channeldb.PkgFilter) 
 }
 
 var (
-	chanID = lnwire.NewChanIDFromOutPoint(&wire.OutPoint{})
+	chanID = lnwire.NewChanIDFromOutPoint(wire.OutPoint{})
 
 	adds = []channeldb.LogUpdate{
 		{

--- a/contractcourt/breach_arbitrator_test.go
+++ b/contractcourt/breach_arbitrator_test.go
@@ -1010,7 +1010,7 @@ func initBreachedState(t *testing.T) (*BreachArbitrator,
 func TestBreachHandoffSuccess(t *testing.T) {
 	brar, alice, _, bobClose, contractBreaches := initBreachedState(t)
 
-	chanPoint := alice.ChanPoint
+	chanPoint := alice.ChannelPoint()
 
 	// Signal a spend of the funding transaction and wait for the close
 	// observer to exit.
@@ -1096,7 +1096,7 @@ func TestBreachHandoffFail(t *testing.T) {
 
 	// Signal the notifier to dispatch spend notifications of the funding
 	// transaction using the transaction from bob's closing summary.
-	chanPoint := alice.ChanPoint
+	chanPoint := alice.ChannelPoint()
 	processACK := make(chan error)
 	breach := &ContractBreachEvent{
 		ChanPoint: *chanPoint,
@@ -1560,7 +1560,7 @@ func testBreachSpends(t *testing.T, test breachTest) {
 	var (
 		height       = bobClose.ChanSnapshot.CommitHeight
 		forceCloseTx = bobClose.CloseTx
-		chanPoint    = alice.ChanPoint
+		chanPoint    = alice.ChannelPoint()
 		publTx       = make(chan *wire.MsgTx)
 		publErr      error
 		publMtx      sync.Mutex
@@ -1764,7 +1764,7 @@ func testBreachSpends(t *testing.T, test breachTest) {
 	}
 
 	// Assert that the channel is fully resolved.
-	assertBrarCleanup(t, brar, alice.ChanPoint, alice.State().Db)
+	assertBrarCleanup(t, brar, alice.ChannelPoint(), alice.State().Db)
 }
 
 // TestBreachDelayedJusticeConfirmation tests that the breach arbiter will
@@ -1777,7 +1777,7 @@ func TestBreachDelayedJusticeConfirmation(t *testing.T) {
 		height       = bobClose.ChanSnapshot.CommitHeight
 		blockHeight  = int32(10)
 		forceCloseTx = bobClose.CloseTx
-		chanPoint    = alice.ChanPoint
+		chanPoint    = alice.ChannelPoint()
 		publTx       = make(chan *wire.MsgTx)
 	)
 
@@ -1965,7 +1965,7 @@ func TestBreachDelayedJusticeConfirmation(t *testing.T) {
 	}
 
 	// Assert that the channel is fully resolved.
-	assertBrarCleanup(t, brar, alice.ChanPoint, alice.State().Db)
+	assertBrarCleanup(t, brar, alice.ChannelPoint(), alice.State().Db)
 }
 
 // findInputIndex returns the index of the input that spends from the given
@@ -2081,12 +2081,12 @@ func assertPendingClosed(t *testing.T, c *lnwallet.LightningChannel) {
 	require.NoError(t, err, "unable to load pending closed channels")
 
 	for _, chanSummary := range closedChans {
-		if chanSummary.ChanPoint == *c.ChanPoint {
+		if chanSummary.ChanPoint == *c.ChannelPoint() {
 			return
 		}
 	}
 
-	t.Fatalf("channel %v was not marked pending closed", c.ChanPoint)
+	t.Fatalf("channel %v was not marked pending closed", c.ChannelPoint())
 }
 
 // assertNotPendingClosed checks that the channel has not been marked pending
@@ -2098,9 +2098,9 @@ func assertNotPendingClosed(t *testing.T, c *lnwallet.LightningChannel) {
 	require.NoError(t, err, "unable to load pending closed channels")
 
 	for _, chanSummary := range closedChans {
-		if chanSummary.ChanPoint == *c.ChanPoint {
+		if chanSummary.ChanPoint == *c.ChannelPoint() {
 			t.Fatalf("channel %v was marked pending closed",
-				c.ChanPoint)
+				c.ChannelPoint())
 		}
 	}
 }

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1748,8 +1748,9 @@ func (d *AuthenticatedGossiper) processChanPolicyUpdate(
 			// update with the peer's alias. We do this after
 			// updateChannel so that the alias isn't persisted to
 			// the database.
-			op := &edgeInfo.Info.ChannelPoint
-			chanID := lnwire.NewChanIDFromOutPoint(op)
+			chanID := lnwire.NewChanIDFromOutPoint(
+				edgeInfo.Info.ChannelPoint,
+			)
 
 			var defaultAlias lnwire.ShortChannelID
 			foundAlias, _ := d.cfg.GetAlias(chanID)

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -698,7 +698,7 @@ func (f *Manager) start() error {
 	}
 
 	for _, channel := range allChannels {
-		chanID := lnwire.NewChanIDFromOutPoint(&channel.FundingOutpoint)
+		chanID := lnwire.NewChanIDFromOutPoint(channel.FundingOutpoint)
 
 		// For any channels that were in a pending state when the
 		// daemon was last connected, the Funding Manager will
@@ -1113,7 +1113,7 @@ func (f *Manager) stateStep(channel *channeldb.OpenChannel,
 	channelState channelOpeningState,
 	updateChan chan<- *lnrpc.OpenStatusUpdate) error {
 
-	chanID := lnwire.NewChanIDFromOutPoint(&channel.FundingOutpoint)
+	chanID := lnwire.NewChanIDFromOutPoint(channel.FundingOutpoint)
 	log.Debugf("Channel(%v) with ShortChanID %v has opening state %v",
 		chanID, shortChanID, channelState)
 
@@ -1273,7 +1273,7 @@ func (f *Manager) advancePendingChannelState(
 
 		// Find and close the discoverySignal for this channel such
 		// that ChannelReady messages will be processed.
-		chanID := lnwire.NewChanIDFromOutPoint(&channel.FundingOutpoint)
+		chanID := lnwire.NewChanIDFromOutPoint(channel.FundingOutpoint)
 		discoverySignal, ok := f.localDiscoverySignals.Load(chanID)
 		if ok {
 			close(discoverySignal)
@@ -1339,7 +1339,7 @@ func (f *Manager) advancePendingChannelState(
 	}
 
 	// Success, funding transaction was confirmed.
-	chanID := lnwire.NewChanIDFromOutPoint(&channel.FundingOutpoint)
+	chanID := lnwire.NewChanIDFromOutPoint(channel.FundingOutpoint)
 	log.Debugf("ChannelID(%v) is now fully confirmed! "+
 		"(shortChanID=%v)", chanID, confChannel.shortChanID)
 
@@ -2246,7 +2246,7 @@ func (f *Manager) continueFundingAccept(resCtx *reservationWithCtx,
 	// properly synchronize with the writeHandler goroutine, we add a new
 	// channel to the barriers map which will be closed once the channel is
 	// fully open.
-	channelID := lnwire.NewChanIDFromOutPoint(outPoint)
+	channelID := lnwire.NewChanIDFromOutPoint(*outPoint)
 	log.Debugf("Creating chan barrier for ChanID(%v)", channelID)
 
 	// The next message that advances the funding flow will reference the
@@ -2421,7 +2421,7 @@ func (f *Manager) fundeeProcessFundingCreated(peer lnpeer.Peer,
 	// properly synchronize with the writeHandler goroutine, we add a new
 	// channel to the barriers map which will be closed once the channel is
 	// fully open.
-	channelID := lnwire.NewChanIDFromOutPoint(&fundingOut)
+	channelID := lnwire.NewChanIDFromOutPoint(fundingOut)
 	log.Debugf("Creating chan barrier for ChanID(%v)", channelID)
 
 	fundingSigned := &lnwire.FundingSigned{}
@@ -2582,7 +2582,7 @@ func (f *Manager) funderProcessFundingSigned(peer lnpeer.Peer,
 	// process the channel confirmation fully before we receive a
 	// channel_ready message.
 	fundingPoint := resCtx.reservation.FundingOutpoint()
-	permChanID := lnwire.NewChanIDFromOutPoint(fundingPoint)
+	permChanID := lnwire.NewChanIDFromOutPoint(*fundingPoint)
 	f.localDiscoverySignals.Store(permChanID, make(chan struct{}))
 
 	// We have to store the forwardingPolicy before the reservation context
@@ -2788,7 +2788,7 @@ func (f *Manager) fundingTimeout(c *channeldb.OpenChannel,
 
 		// Create channel identifier and set the channel ID.
 		cid := newChanIdentifier(pendingID)
-		cid.setChanID(lnwire.NewChanIDFromOutPoint(&c.FundingOutpoint))
+		cid.setChanID(lnwire.NewChanIDFromOutPoint(c.FundingOutpoint))
 
 		// TODO(halseth): should this send be made
 		// reliable?
@@ -2953,7 +2953,7 @@ func (f *Manager) waitForFundingConfirmation(
 
 	fundingPoint := completeChan.FundingOutpoint
 	log.Infof("ChannelPoint(%v) is now active: ChannelID(%v)",
-		fundingPoint, lnwire.NewChanIDFromOutPoint(&fundingPoint))
+		fundingPoint, lnwire.NewChanIDFromOutPoint(fundingPoint))
 
 	// With the block height and the transaction index known, we can
 	// construct the compact chanID which is used on the network to unique
@@ -3071,7 +3071,7 @@ func (f *Manager) handleFundingConfirmation(
 	confChannel *confirmedChannel) error {
 
 	fundingPoint := completeChan.FundingOutpoint
-	chanID := lnwire.NewChanIDFromOutPoint(&fundingPoint)
+	chanID := lnwire.NewChanIDFromOutPoint(fundingPoint)
 
 	// TODO(roasbeef): ideally persistent state update for chan above
 	// should be abstracted
@@ -3147,7 +3147,7 @@ func (f *Manager) handleFundingConfirmation(
 func (f *Manager) sendChannelReady(completeChan *channeldb.OpenChannel,
 	channel *lnwallet.LightningChannel) error {
 
-	chanID := lnwire.NewChanIDFromOutPoint(&completeChan.FundingOutpoint)
+	chanID := lnwire.NewChanIDFromOutPoint(completeChan.FundingOutpoint)
 
 	var peerKey [33]byte
 	copy(peerKey[:], completeChan.IdentityPub.SerializeCompressed())
@@ -3374,7 +3374,7 @@ func (f *Manager) addToRouterGraph(completeChan *channeldb.OpenChannel,
 	peerAlias *lnwire.ShortChannelID,
 	ourPolicy *models.ChannelEdgePolicy) error {
 
-	chanID := lnwire.NewChanIDFromOutPoint(&completeChan.FundingOutpoint)
+	chanID := lnwire.NewChanIDFromOutPoint(completeChan.FundingOutpoint)
 
 	fwdMinHTLC, fwdMaxHTLC := f.extractAnnounceParams(completeChan)
 
@@ -3465,7 +3465,7 @@ func (f *Manager) annAfterSixConfs(completeChan *channeldb.OpenChannel,
 		}
 
 		chanID := lnwire.NewChanIDFromOutPoint(
-			&completeChan.FundingOutpoint,
+			completeChan.FundingOutpoint,
 		)
 		pubKey := peer.PubKey()
 		log.Debugf("Sending our NodeAnnouncement for "+
@@ -3530,7 +3530,7 @@ func (f *Manager) annAfterSixConfs(completeChan *channeldb.OpenChannel,
 		}
 
 		fundingPoint := completeChan.FundingOutpoint
-		chanID := lnwire.NewChanIDFromOutPoint(&fundingPoint)
+		chanID := lnwire.NewChanIDFromOutPoint(fundingPoint)
 
 		log.Infof("Announcing ChannelPoint(%v), short_chan_id=%v",
 			&fundingPoint, shortChanID)
@@ -3964,7 +3964,7 @@ func (f *Manager) handleChannelReadyReceived(channel *channeldb.OpenChannel,
 	scid *lnwire.ShortChannelID, pendingChanID [32]byte,
 	updateChan chan<- *lnrpc.OpenStatusUpdate) error {
 
-	chanID := lnwire.NewChanIDFromOutPoint(&channel.FundingOutpoint)
+	chanID := lnwire.NewChanIDFromOutPoint(channel.FundingOutpoint)
 
 	// Since we've sent+received funding locked at this point, we
 	// can clean up the pending musig2 nonce state.
@@ -3981,7 +3981,7 @@ func (f *Manager) handleChannelReadyReceived(channel *channeldb.OpenChannel,
 		// we'll just return, letting the next iteration of the loop
 		// check again.
 		var defaultAlias lnwire.ShortChannelID
-		chanID := lnwire.NewChanIDFromOutPoint(&channel.FundingOutpoint)
+		chanID := lnwire.NewChanIDFromOutPoint(channel.FundingOutpoint)
 		foundAlias, _ := f.cfg.AliasManager.GetPeerAlias(chanID)
 		if foundAlias == defaultAlias {
 			return nil
@@ -4876,7 +4876,7 @@ func (f *Manager) pruneZombieReservations() {
 		log.Warnf(err.Error())
 
 		chanID := lnwire.NewChanIDFromOutPoint(
-			resCtx.reservation.FundingOutpoint(),
+			*resCtx.reservation.FundingOutpoint(),
 		)
 
 		// Create channel identifier and set the channel ID.

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -3365,7 +3365,7 @@ func TestFundingManagerCustomChannelParameters(t *testing.T) {
 		t, alice, bob, func(node *testNode, msg *newChannelMsg) bool {
 			aliceDB := alice.fundingMgr.cfg.ChannelDB
 			chanID := lnwire.NewChanIDFromOutPoint(
-				&msg.channel.FundingOutpoint,
+				msg.channel.FundingOutpoint,
 			)
 
 			if node == alice {

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -221,7 +221,7 @@ type ChannelLink interface {
 	IsUnadvertised() bool
 
 	// ChannelPoint returns the channel outpoint for the channel link.
-	ChannelPoint() *wire.OutPoint
+	ChannelPoint() wire.OutPoint
 
 	// ShortChanID returns the short channel ID for the channel link. The
 	// short channel ID encodes the exact location in the main chain that

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -2602,8 +2602,7 @@ func (l *channelLink) UpdateShortChanID() (lnwire.ShortChannelID, error) {
 //
 // NOTE: Part of the ChannelLink interface.
 func (l *channelLink) ChanID() lnwire.ChannelID {
-	chanPoint := l.channel.ChannelPoint()
-	return lnwire.NewChanIDFromOutPoint(&chanPoint)
+	return lnwire.NewChanIDFromOutPoint(l.channel.ChannelPoint())
 }
 
 // Bandwidth returns the total amount that can flow through the channel link at

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1371,7 +1371,7 @@ func (l *channelLink) htlcManager() {
 			// TODO(roasbeef): remove all together
 			go func() {
 				chanPoint := l.channel.ChannelPoint()
-				l.cfg.Peer.WipeChannel(chanPoint)
+				l.cfg.Peer.WipeChannel(&chanPoint)
 			}()
 
 			return
@@ -2559,7 +2559,8 @@ func (l *channelLink) PeerPubKey() [33]byte {
 // ChannelPoint returns the channel outpoint for the channel link.
 // NOTE: Part of the ChannelLink interface.
 func (l *channelLink) ChannelPoint() *wire.OutPoint {
-	return l.channel.ChannelPoint()
+	chanPoint := l.channel.ChannelPoint()
+	return &chanPoint
 }
 
 // ShortChanID returns the short channel ID for the channel link. The short
@@ -2601,7 +2602,8 @@ func (l *channelLink) UpdateShortChanID() (lnwire.ShortChannelID, error) {
 //
 // NOTE: Part of the ChannelLink interface.
 func (l *channelLink) ChanID() lnwire.ChannelID {
-	return lnwire.NewChanIDFromOutPoint(l.channel.ChannelPoint())
+	chanPoint := l.channel.ChannelPoint()
+	return lnwire.NewChanIDFromOutPoint(&chanPoint)
 }
 
 // Bandwidth returns the total amount that can flow through the channel link at

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1090,8 +1090,8 @@ func (l *channelLink) htlcManager() {
 	// ActiveLinkEvent. We'll also defer an inactive link notification for
 	// when the link exits to ensure that every active notification is
 	// matched by an inactive one.
-	l.cfg.NotifyActiveLink(*l.ChannelPoint())
-	defer l.cfg.NotifyInactiveLinkEvent(*l.ChannelPoint())
+	l.cfg.NotifyActiveLink(l.ChannelPoint())
+	defer l.cfg.NotifyInactiveLinkEvent(l.ChannelPoint())
 
 	// TODO(roasbeef): need to call wipe chan whenever D/C?
 
@@ -1215,8 +1215,8 @@ func (l *channelLink) htlcManager() {
 	// we can go ahead and send the active channel notification. We'll also
 	// defer the inactive notification for when the link exits to ensure
 	// that every active notification is matched by an inactive one.
-	l.cfg.NotifyActiveChannel(*l.ChannelPoint())
-	defer l.cfg.NotifyInactiveChannel(*l.ChannelPoint())
+	l.cfg.NotifyActiveChannel(l.ChannelPoint())
+	defer l.cfg.NotifyInactiveChannel(l.ChannelPoint())
 
 	// With the channel states synced, we now reset the mailbox to ensure
 	// we start processing all unacked packets in order. This is done here
@@ -2558,9 +2558,8 @@ func (l *channelLink) PeerPubKey() [33]byte {
 
 // ChannelPoint returns the channel outpoint for the channel link.
 // NOTE: Part of the ChannelLink interface.
-func (l *channelLink) ChannelPoint() *wire.OutPoint {
-	chanPoint := l.channel.ChannelPoint()
-	return &chanPoint
+func (l *channelLink) ChannelPoint() wire.OutPoint {
+	return l.channel.ChannelPoint()
 }
 
 // ShortChanID returns the short channel ID for the channel link. The short

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -3762,7 +3762,8 @@ func TestChannelRetransmission(t *testing.T) {
 			t.Fatalf("unable to create channel: %v", err)
 		}
 
-		chanID := lnwire.NewChanIDFromOutPoint(channels.aliceToBob.ChannelPoint())
+		chanPoint := channels.aliceToBob.ChannelPoint()
+		chanID := lnwire.NewChanIDFromOutPoint(&chanPoint)
 		serverErr := make(chan error, 4)
 
 		aliceInterceptor := createInterceptorFunc("[alice] <-- [bob]",

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1497,7 +1497,7 @@ func TestChannelLinkMultiHopUnknownNextHop(t *testing.T) {
 	// back the payment to Alice since he is unaware of Carol when the
 	// payment comes across.
 	bobChanID := lnwire.NewChanIDFromOutPoint(
-		&channels.bobToCarol.State().FundingOutpoint,
+		channels.bobToCarol.ChannelPoint(),
 	)
 	n.bobServer.htlcSwitch.RemoveLink(bobChanID)
 
@@ -3763,7 +3763,7 @@ func TestChannelRetransmission(t *testing.T) {
 		}
 
 		chanPoint := channels.aliceToBob.ChannelPoint()
-		chanID := lnwire.NewChanIDFromOutPoint(&chanPoint)
+		chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
 		serverErr := make(chan error, 4)
 
 		aliceInterceptor := createInterceptorFunc("[alice] <-- [bob]",

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -907,7 +907,10 @@ func (f *mockChannelLink) PeerPubKey() [33]byte {
 	return f.peer.PubKey()
 }
 
-func (f *mockChannelLink) ChannelPoint() *wire.OutPoint                 { return &wire.OutPoint{} }
+func (f *mockChannelLink) ChannelPoint() wire.OutPoint {
+	return wire.OutPoint{}
+}
+
 func (f *mockChannelLink) Stop()                                        {}
 func (f *mockChannelLink) EligibleToForward() bool                      { return f.eligible }
 func (f *mockChannelLink) MayAddOutgoingHtlc(lnwire.MilliSatoshi) error { return nil }

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -621,7 +621,7 @@ func (s *Switch) UpdateForwardingPolicies(
 
 	// Update each link in chanPolicies.
 	for targetLink, policy := range chanPolicies {
-		cid := lnwire.NewChanIDFromOutPoint(&targetLink)
+		cid := lnwire.NewChanIDFromOutPoint(targetLink)
 
 		link, ok := s.linkIndex[cid]
 		if !ok {
@@ -1797,7 +1797,7 @@ out:
 		// relevant link (if it exists) so the channel can be
 		// cooperatively closed (if possible).
 		case req := <-s.chanCloseRequests:
-			chanID := lnwire.NewChanIDFromOutPoint(req.ChanPoint)
+			chanID := lnwire.NewChanIDFromOutPoint(*req.ChanPoint)
 
 			s.indexMtx.RLock()
 			link, ok := s.linkIndex[chanID]

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -73,7 +73,7 @@ func genID() (lnwire.ChannelID, lnwire.ShortChannelID) {
 	hash1, _ := chainhash.NewHash(bytes.Repeat(scratch[:], 4))
 
 	chanPoint1 := wire.NewOutPoint(hash1, uint32(id))
-	chanID1 := lnwire.NewChanIDFromOutPoint(chanPoint1)
+	chanID1 := lnwire.NewChanIDFromOutPoint(*chanPoint1)
 	aliceChanID := lnwire.NewShortChanIDFromInt(id)
 
 	return chanID1, aliceChanID

--- a/lnrpc/invoicesrpc/addinvoice.go
+++ b/lnrpc/invoicesrpc/addinvoice.go
@@ -731,7 +731,7 @@ func shouldIncludeChannel(cfg *SelectHopHintsCfg,
 	}
 
 	chanID := lnwire.NewChanIDFromOutPoint(
-		&channel.FundingOutpoint,
+		channel.FundingOutpoint,
 	)
 
 	hopHintInfo := newHopHintInfo(channel, cfg.IsChannelActive(chanID))

--- a/lnrpc/invoicesrpc/addinvoice_test.go
+++ b/lnrpc/invoicesrpc/addinvoice_test.go
@@ -120,7 +120,7 @@ var shouldIncludeChannelTestCases = []struct {
 		fundingOutpoint := wire.OutPoint{
 			Index: 0,
 		}
-		chanID := lnwire.NewChanIDFromOutPoint(&fundingOutpoint)
+		chanID := lnwire.NewChanIDFromOutPoint(fundingOutpoint)
 		h.Mock.On(
 			"IsChannelActive", chanID,
 		).Once().Return(true)
@@ -137,7 +137,7 @@ var shouldIncludeChannelTestCases = []struct {
 		fundingOutpoint := wire.OutPoint{
 			Index: 0,
 		}
-		chanID := lnwire.NewChanIDFromOutPoint(&fundingOutpoint)
+		chanID := lnwire.NewChanIDFromOutPoint(fundingOutpoint)
 		h.Mock.On(
 			"IsChannelActive", chanID,
 		).Once().Return(false)
@@ -154,7 +154,7 @@ var shouldIncludeChannelTestCases = []struct {
 		fundingOutpoint := wire.OutPoint{
 			Index: 0,
 		}
-		chanID := lnwire.NewChanIDFromOutPoint(&fundingOutpoint)
+		chanID := lnwire.NewChanIDFromOutPoint(fundingOutpoint)
 
 		h.Mock.On(
 			"IsChannelActive", chanID,
@@ -178,7 +178,7 @@ var shouldIncludeChannelTestCases = []struct {
 		fundingOutpoint := wire.OutPoint{
 			Index: 0,
 		}
-		chanID := lnwire.NewChanIDFromOutPoint(&fundingOutpoint)
+		chanID := lnwire.NewChanIDFromOutPoint(fundingOutpoint)
 
 		h.Mock.On(
 			"IsChannelActive", chanID,
@@ -213,7 +213,7 @@ var shouldIncludeChannelTestCases = []struct {
 		fundingOutpoint := wire.OutPoint{
 			Index: 0,
 		}
-		chanID := lnwire.NewChanIDFromOutPoint(&fundingOutpoint)
+		chanID := lnwire.NewChanIDFromOutPoint(fundingOutpoint)
 
 		h.Mock.On(
 			"IsChannelActive", chanID,
@@ -251,7 +251,7 @@ var shouldIncludeChannelTestCases = []struct {
 		fundingOutpoint := wire.OutPoint{
 			Index: 0,
 		}
-		chanID := lnwire.NewChanIDFromOutPoint(&fundingOutpoint)
+		chanID := lnwire.NewChanIDFromOutPoint(fundingOutpoint)
 
 		h.Mock.On(
 			"IsChannelActive", chanID,
@@ -289,7 +289,7 @@ var shouldIncludeChannelTestCases = []struct {
 		fundingOutpoint := wire.OutPoint{
 			Index: 1,
 		}
-		chanID := lnwire.NewChanIDFromOutPoint(&fundingOutpoint)
+		chanID := lnwire.NewChanIDFromOutPoint(fundingOutpoint)
 
 		h.Mock.On(
 			"IsChannelActive", chanID,
@@ -340,7 +340,7 @@ var shouldIncludeChannelTestCases = []struct {
 		fundingOutpoint := wire.OutPoint{
 			Index: 1,
 		}
-		chanID := lnwire.NewChanIDFromOutPoint(&fundingOutpoint)
+		chanID := lnwire.NewChanIDFromOutPoint(fundingOutpoint)
 
 		h.Mock.On(
 			"IsChannelActive", chanID,
@@ -385,7 +385,7 @@ var shouldIncludeChannelTestCases = []struct {
 		fundingOutpoint := wire.OutPoint{
 			Index: 1,
 		}
-		chanID := lnwire.NewChanIDFromOutPoint(&fundingOutpoint)
+		chanID := lnwire.NewChanIDFromOutPoint(fundingOutpoint)
 
 		h.Mock.On(
 			"IsChannelActive", chanID,
@@ -538,7 +538,7 @@ var populateHopHintsTestCases = []struct {
 		"hop hints allowed",
 	setupMock: func(h *hopHintsConfigMock) {
 		fundingOutpoint := wire.OutPoint{Index: 9}
-		chanID := lnwire.NewChanIDFromOutPoint(&fundingOutpoint)
+		chanID := lnwire.NewChanIDFromOutPoint(fundingOutpoint)
 		allChannels := []*channeldb.OpenChannel{
 			{
 				FundingOutpoint: fundingOutpoint,
@@ -584,7 +584,7 @@ var populateHopHintsTestCases = []struct {
 	name: "populate hop hints stops when we reached the targeted bandwidth",
 	setupMock: func(h *hopHintsConfigMock) {
 		fundingOutpoint := wire.OutPoint{Index: 9}
-		chanID := lnwire.NewChanIDFromOutPoint(&fundingOutpoint)
+		chanID := lnwire.NewChanIDFromOutPoint(fundingOutpoint)
 		remoteBalance := lnwire.MilliSatoshi(10_000_000)
 		allChannels := []*channeldb.OpenChannel{
 			{
@@ -635,7 +635,7 @@ var populateHopHintsTestCases = []struct {
 		"remote balance frist",
 	setupMock: func(h *hopHintsConfigMock) {
 		fundingOutpoint := wire.OutPoint{Index: 9}
-		chanID := lnwire.NewChanIDFromOutPoint(&fundingOutpoint)
+		chanID := lnwire.NewChanIDFromOutPoint(fundingOutpoint)
 		remoteBalance := lnwire.MilliSatoshi(10_000_000)
 		allChannels := []*channeldb.OpenChannel{
 			// Because the channels with higher remote balance have
@@ -829,11 +829,11 @@ func setupMockTwoChannels(h *hopHintsConfigMock) (lnwire.ChannelID,
 	lnwire.ChannelID) {
 
 	fundingOutpoint1 := wire.OutPoint{Index: 9}
-	chanID1 := lnwire.NewChanIDFromOutPoint(&fundingOutpoint1)
+	chanID1 := lnwire.NewChanIDFromOutPoint(fundingOutpoint1)
 	remoteBalance1 := lnwire.MilliSatoshi(10_000_000)
 
 	fundingOutpoint2 := wire.OutPoint{Index: 2}
-	chanID2 := lnwire.NewChanIDFromOutPoint(&fundingOutpoint2)
+	chanID2 := lnwire.NewChanIDFromOutPoint(fundingOutpoint2)
 	remoteBalance2 := lnwire.MilliSatoshi(1_000_000)
 
 	allChannels := []*channeldb.OpenChannel{

--- a/lnwallet/chancloser/chancloser.go
+++ b/lnwallet/chancloser/chancloser.go
@@ -269,7 +269,7 @@ func NewChanCloser(cfg ChanCloseCfg, deliveryScript []byte,
 	closeReq *htlcswitch.ChanClose, locallyInitiated bool) *ChanCloser {
 
 	chanPoint := cfg.Channel.ChannelPoint()
-	cid := lnwire.NewChanIDFromOutPoint(&chanPoint)
+	cid := lnwire.NewChanIDFromOutPoint(chanPoint)
 	return &ChanCloser{
 		closeReq:            closeReq,
 		state:               closeIdle,

--- a/lnwallet/chancloser/chancloser.go
+++ b/lnwallet/chancloser/chancloser.go
@@ -268,11 +268,12 @@ func NewChanCloser(cfg ChanCloseCfg, deliveryScript []byte,
 	idealFeePerKw chainfee.SatPerKWeight, negotiationHeight uint32,
 	closeReq *htlcswitch.ChanClose, locallyInitiated bool) *ChanCloser {
 
-	cid := lnwire.NewChanIDFromOutPoint(cfg.Channel.ChannelPoint())
+	chanPoint := cfg.Channel.ChannelPoint()
+	cid := lnwire.NewChanIDFromOutPoint(&chanPoint)
 	return &ChanCloser{
 		closeReq:            closeReq,
 		state:               closeIdle,
-		chanPoint:           *cfg.Channel.ChannelPoint(),
+		chanPoint:           chanPoint,
 		cid:                 cid,
 		cfg:                 cfg,
 		negotiationHeight:   negotiationHeight,

--- a/lnwallet/chancloser/chancloser_test.go
+++ b/lnwallet/chancloser/chancloser_test.go
@@ -146,8 +146,8 @@ type mockChannel struct {
 	remoteKey keychain.KeyDescriptor
 }
 
-func (m *mockChannel) ChannelPoint() *wire.OutPoint {
-	return &m.chanPoint
+func (m *mockChannel) ChannelPoint() wire.OutPoint {
+	return m.chanPoint
 }
 
 func (m *mockChannel) MarkCoopBroadcasted(*wire.MsgTx, bool) error {

--- a/lnwallet/chancloser/interface.go
+++ b/lnwallet/chancloser/interface.go
@@ -29,7 +29,7 @@ type CoopFeeEstimator interface {
 // closing process.
 type Channel interface { //nolint:interfacebloat
 	// ChannelPoint returns the channel point of the target channel.
-	ChannelPoint() *wire.OutPoint
+	ChannelPoint() wire.OutPoint
 
 	// MarkCoopBroadcasted persistently marks that the channel close
 	// transaction has been broadcast.

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -3560,7 +3560,7 @@ func (lc *LightningChannel) createCommitDiff(
 	// used on the wire to identify this channel. We'll use this shortly
 	// when recording the exact CommitSig message that we'll be sending
 	// out.
-	chanID := lnwire.NewChanIDFromOutPoint(&lc.channelState.FundingOutpoint)
+	chanID := lnwire.NewChanIDFromOutPoint(lc.channelState.FundingOutpoint)
 
 	var (
 		logUpdates        []channeldb.LogUpdate
@@ -3680,7 +3680,7 @@ func (lc *LightningChannel) createCommitDiff(
 		Commitment: *diskCommit,
 		CommitSig: &lnwire.CommitSig{
 			ChanID: lnwire.NewChanIDFromOutPoint(
-				&lc.channelState.FundingOutpoint,
+				lc.channelState.FundingOutpoint,
 			),
 			CommitSig: commitSig,
 			HtlcSigs:  htlcSigs,
@@ -3698,7 +3698,7 @@ func (lc *LightningChannel) createCommitDiff(
 func (lc *LightningChannel) getUnsignedAckedUpdates() []channeldb.LogUpdate {
 	// First, we need to convert the funding outpoint into the ID that's
 	// used on the wire to identify this channel.
-	chanID := lnwire.NewChanIDFromOutPoint(&lc.channelState.FundingOutpoint)
+	chanID := lnwire.NewChanIDFromOutPoint(lc.channelState.FundingOutpoint)
 
 	// Fetch the last remote update that we have signed for.
 	lastRemoteCommitted := lc.remoteCommitChain.tail().theirMessageIndex
@@ -4543,7 +4543,7 @@ func (lc *LightningChannel) ProcessChanSyncMsg(
 			case err == nil:
 				commitSig := &lnwire.CommitSig{
 					ChanID: lnwire.NewChanIDFromOutPoint(
-						&lc.channelState.FundingOutpoint,
+						lc.channelState.FundingOutpoint,
 					),
 					CommitSig:  newCommit.CommitSig,
 					HtlcSigs:   newCommit.HtlcSigs,
@@ -5571,7 +5571,7 @@ func (lc *LightningChannel) RevokeCurrentCommitment() (*lnwire.RevokeAndAck,
 		len(unsignedAckedUpdates))
 
 	revocationMsg.ChanID = lnwire.NewChanIDFromOutPoint(
-		&lc.channelState.FundingOutpoint,
+		lc.channelState.FundingOutpoint,
 	)
 
 	return revocationMsg, newCommitment.Htlcs, finalHtlcs, nil
@@ -5638,7 +5638,7 @@ func (lc *LightningChannel) ReceiveRevocation(revMsg *lnwire.RevokeAndAck) (
 	localChainTail := lc.localCommitChain.tail().height
 
 	source := lc.ShortChanID()
-	chanID := lnwire.NewChanIDFromOutPoint(&lc.channelState.FundingOutpoint)
+	chanID := lnwire.NewChanIDFromOutPoint(lc.channelState.FundingOutpoint)
 
 	// Determine the set of htlcs that can be forwarded as a result of
 	// having received the revocation. We will simultaneously construct the
@@ -8517,7 +8517,7 @@ func (lc *LightningChannel) generateRevocation(height uint64) (*lnwire.RevokeAnd
 
 	revocationMsg.NextRevocationKey = input.ComputeCommitmentPoint(nextCommitSecret[:])
 	revocationMsg.ChanID = lnwire.NewChanIDFromOutPoint(
-		&lc.channelState.FundingOutpoint,
+		lc.channelState.FundingOutpoint,
 	)
 
 	// If this is a taproot channel, then we also need to generate the

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -1260,9 +1260,6 @@ type LightningChannel struct {
 
 	isClosed bool
 
-	// ChanPoint is the funding outpoint of this channel.
-	ChanPoint *wire.OutPoint
-
 	// sigPool is a pool of workers that are capable of signing and
 	// validating signatures in parallel. This is utilized as an
 	// optimization to void serially signing or validating the HTLC
@@ -1412,7 +1409,6 @@ func NewLightningChannel(signer input.Signer,
 		commitBuilder:        NewCommitmentBuilder(state),
 		localUpdateLog:       localUpdateLog,
 		remoteUpdateLog:      remoteUpdateLog,
-		ChanPoint:            &state.FundingOutpoint,
 		Capacity:             state.Capacity,
 		taprootNonceProducer: taprootNonceProducer,
 		log:                  build.NewPrefixLog(logPrefix, walletLog),

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -6426,8 +6426,8 @@ func (lc *LightningChannel) ReceiveFailHTLC(htlcIndex uint64, reason []byte,
 // ChannelPoint returns the outpoint of the original funding transaction which
 // created this active channel. This outpoint is used throughout various
 // subsystems to uniquely identify an open channel.
-func (lc *LightningChannel) ChannelPoint() *wire.OutPoint {
-	return &lc.channelState.FundingOutpoint
+func (lc *LightningChannel) ChannelPoint() wire.OutPoint {
+	return lc.channelState.FundingOutpoint
 }
 
 // ShortChanID returns the short channel ID for the channel. The short channel

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -3052,7 +3052,7 @@ func TestChanSyncOweCommitment(t *testing.T) {
 	}
 
 	chanID := lnwire.NewChanIDFromOutPoint(
-		&aliceChannel.channelState.FundingOutpoint,
+		aliceChannel.channelState.FundingOutpoint,
 	)
 
 	// With the HTLC's applied to both update logs, we'll initiate a state
@@ -3419,7 +3419,7 @@ func testChanSyncOweRevocation(t *testing.T, chanType channeldb.ChannelType) {
 	require.NoError(t, err, "unable to create test channels")
 
 	chanID := lnwire.NewChanIDFromOutPoint(
-		&aliceChannel.channelState.FundingOutpoint,
+		aliceChannel.channelState.FundingOutpoint,
 	)
 
 	// We'll start the test with Bob extending a single HTLC to Alice, and
@@ -4682,7 +4682,7 @@ func TestChanSyncUnableToSync(t *testing.T) {
 	// state.
 	badChanSync := &lnwire.ChannelReestablish{
 		ChanID: lnwire.NewChanIDFromOutPoint(
-			&aliceChannel.channelState.FundingOutpoint,
+			aliceChannel.channelState.FundingOutpoint,
 		),
 		NextLocalCommitHeight:  1000,
 		RemoteCommitTailHeight: 9000,

--- a/lnwallet/transactions_test.go
+++ b/lnwallet/transactions_test.go
@@ -269,8 +269,7 @@ func addTestHtlcs(t *testing.T, remote, local *LightningChannel,
 		hash160map[hash160] = preimage
 
 		// Add htlc to the channel.
-		chanPoint := remote.ChannelPoint()
-		chanID := lnwire.NewChanIDFromOutPoint(&chanPoint)
+		chanID := lnwire.NewChanIDFromOutPoint(remote.ChannelPoint())
 
 		msg := &lnwire.UpdateAddHTLC{
 			Amount:      htlc.amount,

--- a/lnwallet/transactions_test.go
+++ b/lnwallet/transactions_test.go
@@ -269,7 +269,8 @@ func addTestHtlcs(t *testing.T, remote, local *LightningChannel,
 		hash160map[hash160] = preimage
 
 		// Add htlc to the channel.
-		chanID := lnwire.NewChanIDFromOutPoint(remote.ChannelPoint())
+		chanPoint := remote.ChannelPoint()
+		chanID := lnwire.NewChanIDFromOutPoint(&chanPoint)
 
 		msg := &lnwire.UpdateAddHTLC{
 			Amount:      htlc.amount,

--- a/lnwallet/transactions_test.go
+++ b/lnwallet/transactions_test.go
@@ -269,7 +269,7 @@ func addTestHtlcs(t *testing.T, remote, local *LightningChannel,
 		hash160map[hash160] = preimage
 
 		// Add htlc to the channel.
-		chanID := lnwire.NewChanIDFromOutPoint(remote.ChanPoint)
+		chanID := lnwire.NewChanIDFromOutPoint(remote.ChannelPoint())
 
 		msg := &lnwire.UpdateAddHTLC{
 			Amount:      htlc.amount,

--- a/lnwire/channel_id.go
+++ b/lnwire/channel_id.go
@@ -40,7 +40,7 @@ func (c ChannelID) String() string {
 // usable within the network. In order to convert the OutPoint into a ChannelID,
 // we XOR the lower 2-bytes of the txid within the OutPoint with the big-endian
 // serialization of the Index of the OutPoint, truncated to 2-bytes.
-func NewChanIDFromOutPoint(op *wire.OutPoint) ChannelID {
+func NewChanIDFromOutPoint(op wire.OutPoint) ChannelID {
 	// First we'll copy the txid of the outpoint into our channel ID slice.
 	var cid ChannelID
 	copy(cid[:], op.Hash[:])
@@ -85,7 +85,7 @@ func (c *ChannelID) GenPossibleOutPoints() [MaxFundingTxOutputs]wire.OutPoint {
 // IsChanPoint returns true if the OutPoint passed corresponds to the target
 // ChannelID.
 func (c ChannelID) IsChanPoint(op *wire.OutPoint) bool {
-	candidateCid := NewChanIDFromOutPoint(op)
+	candidateCid := NewChanIDFromOutPoint(*op)
 
 	return candidateCid == c
 }

--- a/lnwire/channel_id_test.go
+++ b/lnwire/channel_id_test.go
@@ -17,7 +17,7 @@ func TestChannelIDOutPointConversion(t *testing.T) {
 
 		// With the output index mutated, we'll convert it into a
 		// ChannelID.
-		cid := NewChanIDFromOutPoint(&testChanPoint)
+		cid := NewChanIDFromOutPoint(testChanPoint)
 
 		// Once the channel point has been converted to a channelID, it
 		// should recognize its original outpoint.
@@ -48,7 +48,7 @@ func TestGenPossibleOutPoints(t *testing.T) {
 	// We'll first convert out test outpoint into a ChannelID.
 	testChanPoint := *outpoint1
 	testChanPoint.Index = 24
-	chanID := NewChanIDFromOutPoint(&testChanPoint)
+	chanID := NewChanIDFromOutPoint(testChanPoint)
 
 	// With the chan ID created, we'll generate all possible root outpoints
 	// given this channel ID.

--- a/netann/chan_status_manager.go
+++ b/netann/chan_status_manager.go
@@ -391,7 +391,7 @@ func (m *ChanStatusManager) processEnableRequest(outpoint wire.OutPoint,
 
 	// Quickly check to see if the requested channel is active within the
 	// htlcswitch and return an error if it isn't.
-	chanID := lnwire.NewChanIDFromOutPoint(&outpoint)
+	chanID := lnwire.NewChanIDFromOutPoint(outpoint)
 	if !m.cfg.IsChannelActive(chanID) {
 		return ErrEnableInactiveChan
 	}
@@ -531,7 +531,7 @@ func (m *ChanStatusManager) markPendingInactiveChannels() {
 		// If our bookkeeping shows the channel as active, sample the
 		// htlcswitch to see if it believes the link is also active. If
 		// so, we will skip marking it as ChanStatusPendingDisabled.
-		chanID := lnwire.NewChanIDFromOutPoint(&c.FundingOutpoint)
+		chanID := lnwire.NewChanIDFromOutPoint(c.FundingOutpoint)
 		if m.cfg.IsChannelActive(chanID) {
 			continue
 		}

--- a/netann/chan_status_manager_test.go
+++ b/netann/chan_status_manager_test.go
@@ -391,7 +391,7 @@ func (h *testHarness) markActive(channels []*channeldb.OpenChannel) {
 	h.t.Helper()
 
 	for _, channel := range channels {
-		chanID := lnwire.NewChanIDFromOutPoint(&channel.FundingOutpoint)
+		chanID := lnwire.NewChanIDFromOutPoint(channel.FundingOutpoint)
 		h.htlcSwitch.SetStatus(chanID, true)
 	}
 }
@@ -402,7 +402,7 @@ func (h *testHarness) markInactive(channels []*channeldb.OpenChannel) {
 	h.t.Helper()
 
 	for _, channel := range channels {
-		chanID := lnwire.NewChanIDFromOutPoint(&channel.FundingOutpoint)
+		chanID := lnwire.NewChanIDFromOutPoint(channel.FundingOutpoint)
 		h.htlcSwitch.SetStatus(chanID, false)
 	}
 }

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -2817,16 +2817,16 @@ func chooseDeliveryScript(upfront,
 		return requested, nil
 	}
 
-	// If an upfront shutdown script was provided, and the user did not request
-	// a custom shutdown script, return the upfront address.
+	// If an upfront shutdown script was provided, and the user did not
+	// request a custom shutdown script, return the upfront address.
 	if len(requested) == 0 {
 		return upfront, nil
 	}
 
 	// If both an upfront shutdown script and a custom close script were
 	// provided, error if the user provided shutdown script does not match
-	// the upfront shutdown script (because closing out to a different script
-	// would violate upfront shutdown).
+	// the upfront shutdown script (because closing out to a different
+	// script would violate upfront shutdown).
 	if !bytes.Equal(upfront, requested) {
 		return nil, chancloser.ErrUpfrontShutdownScriptMismatch
 	}

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -3209,10 +3209,10 @@ func (p *Brontide) finalizeChanClosure(chanCloser *chancloser.ChanCloser) {
 
 	// First, we'll clear all indexes related to the channel in question.
 	chanPoint := chanCloser.Channel().ChannelPoint()
-	p.WipeChannel(chanPoint)
+	p.WipeChannel(&chanPoint)
 
 	// Also clear the activeChanCloses map of this channel.
-	cid := lnwire.NewChanIDFromOutPoint(chanPoint)
+	cid := lnwire.NewChanIDFromOutPoint(&chanPoint)
 	delete(p.activeChanCloses, cid)
 
 	// Next, we'll launch a goroutine which will request to be notified by
@@ -3247,7 +3247,7 @@ func (p *Brontide) finalizeChanClosure(chanCloser *chancloser.ChanCloser) {
 	}
 
 	go WaitForChanToClose(chanCloser.NegotiationHeight(), notifier, errChan,
-		chanPoint, &closingTxid, closingTx.TxOut[0].PkScript, func() {
+		&chanPoint, &closingTxid, closingTx.TxOut[0].PkScript, func() {
 			// Respond to the local subsystem which requested the
 			// channel closure.
 			if closeReq != nil {

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -834,7 +834,7 @@ func (p *Brontide) loadActiveChannels(chans []*channeldb.OpenChannel) (
 				}
 
 				chanID := lnwire.NewChanIDFromOutPoint(
-					&dbChan.FundingOutpoint,
+					dbChan.FundingOutpoint,
 				)
 
 				// Fetch the second commitment point to send in
@@ -870,7 +870,7 @@ func (p *Brontide) loadActiveChannels(chans []*channeldb.OpenChannel) (
 			return nil, err
 		}
 
-		chanPoint := &dbChan.FundingOutpoint
+		chanPoint := dbChan.FundingOutpoint
 
 		chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
 
@@ -932,7 +932,9 @@ func (p *Brontide) loadActiveChannels(chans []*channeldb.OpenChannel) (
 		// need to fetch its current link-layer forwarding policy from
 		// the database.
 		graph := p.cfg.ChannelGraph
-		info, p1, p2, err := graph.FetchChannelEdgesByOutpoint(chanPoint)
+		info, p1, p2, err := graph.FetchChannelEdgesByOutpoint(
+			&chanPoint,
+		)
 		if err != nil && err != channeldb.ErrEdgeNotFound {
 			return nil, err
 		}
@@ -1020,7 +1022,7 @@ func (p *Brontide) loadActiveChannels(chans []*channeldb.OpenChannel) (
 			}
 
 			chanID := lnwire.NewChanIDFromOutPoint(
-				&lnChan.State().FundingOutpoint,
+				lnChan.State().FundingOutpoint,
 			)
 
 			p.activeChanCloses[chanID] = chanCloser
@@ -1042,14 +1044,14 @@ func (p *Brontide) loadActiveChannels(chans []*channeldb.OpenChannel) (
 
 		// Subscribe to the set of on-chain events for this channel.
 		chainEvents, err := p.cfg.ChainArb.SubscribeChannelEvents(
-			*chanPoint,
+			chanPoint,
 		)
 		if err != nil {
 			return nil, err
 		}
 
 		err = p.addLink(
-			chanPoint, lnChan, forwardingPolicy, chainEvents,
+			&chanPoint, lnChan, forwardingPolicy, chainEvents,
 			true, shutdownMsg,
 		)
 		if err != nil {
@@ -1144,7 +1146,7 @@ func (p *Brontide) addLink(chanPoint *wire.OutPoint,
 	// links going by the same channel id. If one is found, we'll shut it
 	// down to ensure that the mailboxes are only ever under the control of
 	// one link.
-	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
+	chanID := lnwire.NewChanIDFromOutPoint(*chanPoint)
 	p.cfg.Switch.RemoveLink(chanID)
 
 	// With the channel link created, we'll now notify the htlc switch so
@@ -2912,7 +2914,7 @@ func (p *Brontide) restartCoopClose(lnChan *lnwallet.LightningChannel) (
 	// This does not need a mutex even though it is in a different
 	// goroutine since this is done before the channelManager goroutine is
 	// created.
-	chanID := lnwire.NewChanIDFromOutPoint(&c.FundingOutpoint)
+	chanID := lnwire.NewChanIDFromOutPoint(c.FundingOutpoint)
 	p.activeChanCloses[chanID] = chanCloser
 
 	// Create the Shutdown message.
@@ -2976,7 +2978,7 @@ func (p *Brontide) createChanCloser(channel *lnwallet.LightningChannel,
 // handleLocalCloseReq kicks-off the workflow to execute a cooperative or
 // forced unilateral closure of the channel initiated by a local subsystem.
 func (p *Brontide) handleLocalCloseReq(req *htlcswitch.ChanClose) {
-	chanID := lnwire.NewChanIDFromOutPoint(req.ChanPoint)
+	chanID := lnwire.NewChanIDFromOutPoint(*req.ChanPoint)
 
 	channel, ok := p.activeChannels.Load(chanID)
 
@@ -3099,7 +3101,7 @@ type linkFailureReport struct {
 func (p *Brontide) handleLinkFailure(failure linkFailureReport) {
 	// Retrieve the channel from the map of active channels. We do this to
 	// have access to it even after WipeChannel remove it from the map.
-	chanID := lnwire.NewChanIDFromOutPoint(&failure.chanPoint)
+	chanID := lnwire.NewChanIDFromOutPoint(failure.chanPoint)
 	lnChan, _ := p.activeChannels.Load(chanID)
 
 	// We begin by wiping the link, which will remove it from the switch,
@@ -3212,7 +3214,7 @@ func (p *Brontide) finalizeChanClosure(chanCloser *chancloser.ChanCloser) {
 	p.WipeChannel(&chanPoint)
 
 	// Also clear the activeChanCloses map of this channel.
-	cid := lnwire.NewChanIDFromOutPoint(&chanPoint)
+	cid := lnwire.NewChanIDFromOutPoint(chanPoint)
 	delete(p.activeChanCloses, cid)
 
 	// Next, we'll launch a goroutine which will request to be notified by
@@ -3302,7 +3304,7 @@ func WaitForChanToClose(bestHeight uint32, notifier chainntnfs.ChainNotifier,
 // WipeChannel removes the passed channel point from all indexes associated with
 // the peer and the switch.
 func (p *Brontide) WipeChannel(chanPoint *wire.OutPoint) {
-	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
+	chanID := lnwire.NewChanIDFromOutPoint(*chanPoint)
 
 	p.activeChannels.Delete(chanID)
 
@@ -3881,7 +3883,7 @@ func (p *Brontide) attachChannelEventSubscription() error {
 // updateNextRevocation updates the existing channel's next revocation if it's
 // nil.
 func (p *Brontide) updateNextRevocation(c *channeldb.OpenChannel) error {
-	chanPoint := &c.FundingOutpoint
+	chanPoint := c.FundingOutpoint
 	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
 
 	// Read the current channel.
@@ -3925,7 +3927,7 @@ func (p *Brontide) updateNextRevocation(c *channeldb.OpenChannel) error {
 // takes a `channeldb.OpenChannel`, creates a `lnwallet.LightningChannel` from
 // it and assembles it with a channel link.
 func (p *Brontide) addActiveChannel(c *lnpeer.NewChannel) error {
-	chanPoint := &c.FundingOutpoint
+	chanPoint := c.FundingOutpoint
 	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
 
 	// If we've reached this point, there are two possible scenarios.  If
@@ -3960,7 +3962,7 @@ func (p *Brontide) addActiveChannel(c *lnpeer.NewChannel) error {
 
 	// Next, we'll assemble a ChannelLink along with the necessary items it
 	// needs to function.
-	chainEvents, err := p.cfg.ChainArb.SubscribeChannelEvents(*chanPoint)
+	chainEvents, err := p.cfg.ChainArb.SubscribeChannelEvents(chanPoint)
 	if err != nil {
 		return fmt.Errorf("unable to subscribe to chain events: %w",
 			err)
@@ -3976,7 +3978,7 @@ func (p *Brontide) addActiveChannel(c *lnpeer.NewChannel) error {
 
 	// Create the link and add it to the switch.
 	err = p.addLink(
-		chanPoint, lnChan, initialPolicy, chainEvents,
+		&chanPoint, lnChan, initialPolicy, chainEvents,
 		shouldReestablish, fn.None[lnwire.Shutdown](),
 	)
 	if err != nil {
@@ -3992,7 +3994,7 @@ func (p *Brontide) addActiveChannel(c *lnpeer.NewChannel) error {
 // or init the next revocation for it.
 func (p *Brontide) handleNewActiveChannel(req *newChannelMsg) {
 	newChan := req.channel
-	chanPoint := &newChan.FundingOutpoint
+	chanPoint := newChan.FundingOutpoint
 	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
 
 	// Only update RemoteNextRevocation if the channel is in the

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -53,7 +53,8 @@ func TestPeerChannelClosureShutdownResponseLinkRemoved(t *testing.T) {
 	)
 	require.NoError(t, err, "unable to create test channels")
 
-	chanID := lnwire.NewChanIDFromOutPoint(bobChan.ChannelPoint())
+	chanPoint := bobChan.ChannelPoint()
+	chanID := lnwire.NewChanIDFromOutPoint(&chanPoint)
 
 	dummyDeliveryScript := genScript(t, p2wshAddress)
 
@@ -100,7 +101,8 @@ func TestPeerChannelClosureAcceptFeeResponder(t *testing.T) {
 	)
 	require.NoError(t, err, "unable to create test channels")
 
-	chanID := lnwire.NewChanIDFromOutPoint(bobChan.ChannelPoint())
+	chanPoint := bobChan.ChannelPoint()
+	chanID := lnwire.NewChanIDFromOutPoint(&chanPoint)
 
 	mockLink := newMockUpdateHandler(chanID)
 	mockSwitch.links = append(mockSwitch.links, mockLink)
@@ -204,7 +206,8 @@ func TestPeerChannelClosureAcceptFeeInitiator(t *testing.T) {
 	)
 	require.NoError(t, err, "unable to create test channels")
 
-	chanID := lnwire.NewChanIDFromOutPoint(bobChan.ChannelPoint())
+	chanPoint := bobChan.ChannelPoint()
+	chanID := lnwire.NewChanIDFromOutPoint(&chanPoint)
 	mockLink := newMockUpdateHandler(chanID)
 	mockSwitch.links = append(mockSwitch.links, mockLink)
 
@@ -215,7 +218,7 @@ func TestPeerChannelClosureAcceptFeeInitiator(t *testing.T) {
 	errChan := make(chan error, 1)
 	closeCommand := &htlcswitch.ChanClose{
 		CloseType:      contractcourt.CloseRegular,
-		ChanPoint:      bobChan.ChannelPoint(),
+		ChanPoint:      &chanPoint,
 		Updates:        updateChan,
 		TargetFeePerKw: 12500,
 		Err:            errChan,
@@ -327,7 +330,8 @@ func TestPeerChannelClosureFeeNegotiationsResponder(t *testing.T) {
 	)
 	require.NoError(t, err, "unable to create test channels")
 
-	chanID := lnwire.NewChanIDFromOutPoint(bobChan.ChannelPoint())
+	chanPoint := bobChan.ChannelPoint()
+	chanID := lnwire.NewChanIDFromOutPoint(&chanPoint)
 
 	mockLink := newMockUpdateHandler(chanID)
 	mockSwitch.links = append(mockSwitch.links, mockLink)
@@ -513,7 +517,8 @@ func TestPeerChannelClosureFeeNegotiationsInitiator(t *testing.T) {
 	)
 	require.NoError(t, err, "unable to create test channels")
 
-	chanID := lnwire.NewChanIDFromOutPoint(bobChan.ChannelPoint())
+	chanPoint := bobChan.ChannelPoint()
+	chanID := lnwire.NewChanIDFromOutPoint(&chanPoint)
 	mockLink := newMockUpdateHandler(chanID)
 	mockSwitch.links = append(mockSwitch.links, mockLink)
 
@@ -522,7 +527,7 @@ func TestPeerChannelClosureFeeNegotiationsInitiator(t *testing.T) {
 	errChan := make(chan error, 1)
 	closeCommand := &htlcswitch.ChanClose{
 		CloseType:      contractcourt.CloseRegular,
-		ChanPoint:      bobChan.ChannelPoint(),
+		ChanPoint:      &chanPoint,
 		Updates:        updateChan,
 		TargetFeePerKw: 12500,
 		Err:            errChan,
@@ -844,7 +849,7 @@ func TestCustomShutdownScript(t *testing.T) {
 			}
 
 			chanPoint := bobChan.ChannelPoint()
-			chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
+			chanID := lnwire.NewChanIDFromOutPoint(&chanPoint)
 			mockLink := newMockUpdateHandler(chanID)
 			mockSwitch.links = append(mockSwitch.links, mockLink)
 
@@ -854,7 +859,7 @@ func TestCustomShutdownScript(t *testing.T) {
 			errChan := make(chan error, 1)
 			closeCommand := htlcswitch.ChanClose{
 				CloseType:      contractcourt.CloseRegular,
-				ChanPoint:      chanPoint,
+				ChanPoint:      &chanPoint,
 				Updates:        updateChan,
 				TargetFeePerKw: 12500,
 				DeliveryScript: test.userCloseScript,

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -54,7 +54,7 @@ func TestPeerChannelClosureShutdownResponseLinkRemoved(t *testing.T) {
 	require.NoError(t, err, "unable to create test channels")
 
 	chanPoint := bobChan.ChannelPoint()
-	chanID := lnwire.NewChanIDFromOutPoint(&chanPoint)
+	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
 
 	dummyDeliveryScript := genScript(t, p2wshAddress)
 
@@ -102,7 +102,7 @@ func TestPeerChannelClosureAcceptFeeResponder(t *testing.T) {
 	require.NoError(t, err, "unable to create test channels")
 
 	chanPoint := bobChan.ChannelPoint()
-	chanID := lnwire.NewChanIDFromOutPoint(&chanPoint)
+	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
 
 	mockLink := newMockUpdateHandler(chanID)
 	mockSwitch.links = append(mockSwitch.links, mockLink)
@@ -207,7 +207,7 @@ func TestPeerChannelClosureAcceptFeeInitiator(t *testing.T) {
 	require.NoError(t, err, "unable to create test channels")
 
 	chanPoint := bobChan.ChannelPoint()
-	chanID := lnwire.NewChanIDFromOutPoint(&chanPoint)
+	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
 	mockLink := newMockUpdateHandler(chanID)
 	mockSwitch.links = append(mockSwitch.links, mockLink)
 
@@ -331,7 +331,7 @@ func TestPeerChannelClosureFeeNegotiationsResponder(t *testing.T) {
 	require.NoError(t, err, "unable to create test channels")
 
 	chanPoint := bobChan.ChannelPoint()
-	chanID := lnwire.NewChanIDFromOutPoint(&chanPoint)
+	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
 
 	mockLink := newMockUpdateHandler(chanID)
 	mockSwitch.links = append(mockSwitch.links, mockLink)
@@ -518,7 +518,7 @@ func TestPeerChannelClosureFeeNegotiationsInitiator(t *testing.T) {
 	require.NoError(t, err, "unable to create test channels")
 
 	chanPoint := bobChan.ChannelPoint()
-	chanID := lnwire.NewChanIDFromOutPoint(&chanPoint)
+	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
 	mockLink := newMockUpdateHandler(chanID)
 	mockSwitch.links = append(mockSwitch.links, mockLink)
 
@@ -849,7 +849,7 @@ func TestCustomShutdownScript(t *testing.T) {
 			}
 
 			chanPoint := bobChan.ChannelPoint()
-			chanID := lnwire.NewChanIDFromOutPoint(&chanPoint)
+			chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
 			mockLink := newMockUpdateHandler(chanID)
 			mockSwitch.links = append(mockSwitch.links, mockLink)
 
@@ -1218,7 +1218,7 @@ func TestUpdateNextRevocation(t *testing.T) {
 	// Test an error is returned when the chanID's corresponding channel is
 	// nil.
 	testChannel.FundingOutpoint = wire.OutPoint{Index: 1}
-	chanID := lnwire.NewChanIDFromOutPoint(&testChannel.FundingOutpoint)
+	chanID := lnwire.NewChanIDFromOutPoint(testChannel.FundingOutpoint)
 	alicePeer.activeChannels.Store(chanID, nil)
 
 	err = alicePeer.updateNextRevocation(testChannel)

--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -412,8 +412,7 @@ func createTestPeer(t *testing.T, notifier chainntnfs.ChainNotifier,
 	alicePeer := NewBrontide(*cfg)
 	alicePeer.remoteFeatures = lnwire.NewFeatureVector(nil, lnwire.Features)
 
-	chanPoint := channelAlice.ChannelPoint()
-	chanID := lnwire.NewChanIDFromOutPoint(&chanPoint)
+	chanID := lnwire.NewChanIDFromOutPoint(channelAlice.ChannelPoint())
 	alicePeer.activeChannels.Store(chanID, channelAlice)
 
 	alicePeer.wg.Add(1)

--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -412,7 +412,8 @@ func createTestPeer(t *testing.T, notifier chainntnfs.ChainNotifier,
 	alicePeer := NewBrontide(*cfg)
 	alicePeer.remoteFeatures = lnwire.NewFeatureVector(nil, lnwire.Features)
 
-	chanID := lnwire.NewChanIDFromOutPoint(channelAlice.ChannelPoint())
+	chanPoint := channelAlice.ChannelPoint()
+	chanID := lnwire.NewChanIDFromOutPoint(&chanPoint)
 	alicePeer.activeChannels.Store(chanID, channelAlice)
 
 	alicePeer.wg.Add(1)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2580,7 +2580,9 @@ func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 			//  * so only need to grab from database
 			peer.WipeChannel(&channel.FundingOutpoint)
 		} else {
-			chanID := lnwire.NewChanIDFromOutPoint(&channel.FundingOutpoint)
+			chanID := lnwire.NewChanIDFromOutPoint(
+				channel.FundingOutpoint,
+			)
 			r.server.htlcSwitch.RemoveLink(chanID)
 		}
 
@@ -2634,7 +2636,7 @@ func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 
 		// If the link is not known by the switch, we cannot gracefully close
 		// the channel.
-		channelID := lnwire.NewChanIDFromOutPoint(chanPoint)
+		channelID := lnwire.NewChanIDFromOutPoint(*chanPoint)
 		if _, err := r.server.htlcSwitch.GetLink(channelID); err != nil {
 			rpcsLog.Debugf("Trying to non-force close offline channel with "+
 				"chan_point=%v", chanPoint)
@@ -2953,7 +2955,7 @@ func (r *rpcServer) GetInfo(_ context.Context,
 
 	var activeChannels uint32
 	for _, channel := range openChannels {
-		chanID := lnwire.NewChanIDFromOutPoint(&channel.FundingOutpoint)
+		chanID := lnwire.NewChanIDFromOutPoint(channel.FundingOutpoint)
 		if r.server.htlcSwitch.HasActiveLink(chanID) {
 			activeChannels++
 		}
@@ -4221,7 +4223,7 @@ func (r *rpcServer) ListChannels(ctx context.Context,
 			peerOnline = true
 		}
 
-		channelID := lnwire.NewChanIDFromOutPoint(&chanPoint)
+		channelID := lnwire.NewChanIDFromOutPoint(chanPoint)
 		var linkActive bool
 		if link, err := r.server.htlcSwitch.GetLink(channelID); err == nil {
 			// A channel is only considered active if it is known
@@ -4313,7 +4315,7 @@ func createRPCOpenChannel(r *rpcServer, dbChannel *channeldb.OpenChannel,
 	nodePub := dbChannel.IdentityPub
 	nodeID := hex.EncodeToString(nodePub.SerializeCompressed())
 	chanPoint := dbChannel.FundingOutpoint
-	chanID := lnwire.NewChanIDFromOutPoint(&chanPoint)
+	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
 
 	// As this is required for display purposes, we'll calculate
 	// the weight of the commitment transaction. We also add on the

--- a/server.go
+++ b/server.go
@@ -1164,7 +1164,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		FeeEstimator: cc.FeeEstimator,
 		ChainIO:      cc.ChainIO,
 		MarkLinkInactive: func(chanPoint wire.OutPoint) error {
-			chanID := lnwire.NewChanIDFromOutPoint(&chanPoint)
+			chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
 			s.htlcSwitch.RemoveLink(chanID)
 			return nil
 		},
@@ -1421,7 +1421,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 			return s.chainArb.WatchNewChannel(channel)
 		},
 		ReportShortChanID: func(chanPoint wire.OutPoint) error {
-			cid := lnwire.NewChanIDFromOutPoint(&chanPoint)
+			cid := lnwire.NewChanIDFromOutPoint(chanPoint)
 			return s.htlcSwitch.UpdateShortChanID(cid)
 		},
 		RequiredRemoteChanReserve: func(chanAmt,
@@ -4633,7 +4633,7 @@ func (s *server) applyChannelUpdate(update *lnwire.ChannelUpdate,
 		defaultAlias lnwire.ShortChannelID
 	)
 
-	chanID := lnwire.NewChanIDFromOutPoint(op)
+	chanID := lnwire.NewChanIDFromOutPoint(*op)
 
 	// Fetch the peer's alias from the lnwire.ChannelID so it can be used
 	// in the ChannelUpdate if it hasn't been announced yet.

--- a/watchtower/wtclient/manager.go
+++ b/watchtower/wtclient/manager.go
@@ -780,7 +780,7 @@ func (m *Manager) handleChannelCloses(chanSub subscribe.Subscription) {
 			}
 
 			chanID := lnwire.NewChanIDFromOutPoint(
-				&event.CloseSummary.ChanPoint,
+				event.CloseSummary.ChanPoint,
 			)
 
 			log.Debugf("Received ClosedChannelEvent for "+


### PR DESCRIPTION
## Change Description
This change has a number of changes to change the way we handle OutPoint's from pointers to values. At a minimum, returning addresses inside of the `channeldb.OpenChannel` is dangerous because that is the source of truth for channel state. On top of that I changed the channel id constructor to take a value as well. That commit is less important but I included it anyway as I don't think we should be using pointers unless we have a really good reason to.

## Steps to Test
CI should handle it

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Transitioned from pointer to value usage for `ChanPoint` and `FundingOutpoint` across various files, enhancing consistency and efficiency.
  - Standardized the creation of channel IDs by directly passing `wire.OutPoint` or dereferencing it as needed, improving channel identification logic.

- **Bug Fixes**
  - Resolved channel identification issues to ensure accurate retrieval and management of channel information.

- **Tests**
  - Updated test cases to reflect the revised handling of channel points and identifiers, maintaining the reliability and correctness of tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->