### PR TITLE
github: bump pull-resquest-stats to v2.11.0

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -8,10 +8,11 @@ jobs:
   stats:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - name: Run pull request stats
-        uses: flowwer-dev/pull-request-stats@v2.5.0
+        uses: flowwer-dev/pull-request-stats@v2.11.0
         with:
           period: 30 # 30 days of review stats
           charts: true


### PR DESCRIPTION
In an attempt to fix the broken PR stats, this PR updates the version and sets the recommended permissions.