### PR TITLE
invoice+payment: fix timestamp precision for queries

### DIFF
--- a/channeldb/invoice_test.go
+++ b/channeldb/invoice_test.go
@@ -1407,7 +1407,7 @@ func TestQueryInvoices(t *testing.T) {
 		{
 			query: invpkg.InvoiceQuery{
 				NumMaxInvoices:  numInvoices,
-				CreationDateEnd: time.Unix(25, 0),
+				CreationDateEnd: 25,
 			},
 			expected: invoices[:25],
 		},
@@ -1415,7 +1415,7 @@ func TestQueryInvoices(t *testing.T) {
 		{
 			query: invpkg.InvoiceQuery{
 				NumMaxInvoices:    numInvoices,
-				CreationDateStart: time.Unix(26, 0),
+				CreationDateStart: 26,
 			},
 			expected: invoices[25:],
 		},
@@ -1424,7 +1424,7 @@ func TestQueryInvoices(t *testing.T) {
 			query: invpkg.InvoiceQuery{
 				PendingOnly:     true,
 				NumMaxInvoices:  numInvoices,
-				CreationDateEnd: time.Unix(25, 0),
+				CreationDateEnd: 25,
 			},
 			expected: pendingInvoices[:13],
 		},
@@ -1433,7 +1433,7 @@ func TestQueryInvoices(t *testing.T) {
 			query: invpkg.InvoiceQuery{
 				PendingOnly:       true,
 				NumMaxInvoices:    numInvoices,
-				CreationDateStart: time.Unix(26, 0),
+				CreationDateStart: 26,
 			},
 			expected: pendingInvoices[13:],
 		},
@@ -1442,7 +1442,7 @@ func TestQueryInvoices(t *testing.T) {
 			query: invpkg.InvoiceQuery{
 				IndexOffset:     20,
 				NumMaxInvoices:  numInvoices,
-				CreationDateEnd: time.Unix(30, 0),
+				CreationDateEnd: 30,
 			},
 			// Since we're skipping to invoice 20 and iterating
 			// to invoice 30, we'll expect those invoices.
@@ -1455,7 +1455,7 @@ func TestQueryInvoices(t *testing.T) {
 				IndexOffset:       21,
 				Reversed:          true,
 				NumMaxInvoices:    numInvoices,
-				CreationDateStart: time.Unix(11, 0),
+				CreationDateStart: 11,
 			},
 			// Since we're skipping to invoice 20 and iterating
 			// backward to invoice 10, we'll expect those invoices.
@@ -1465,8 +1465,8 @@ func TestQueryInvoices(t *testing.T) {
 		{
 			query: invpkg.InvoiceQuery{
 				NumMaxInvoices:    numInvoices,
-				CreationDateStart: time.Unix(11, 0),
-				CreationDateEnd:   time.Unix(20, 0),
+				CreationDateStart: 11,
+				CreationDateEnd:   20,
 			},
 			expected: invoices[10:20],
 		},
@@ -1475,8 +1475,8 @@ func TestQueryInvoices(t *testing.T) {
 			query: invpkg.InvoiceQuery{
 				PendingOnly:       true,
 				NumMaxInvoices:    numInvoices,
-				CreationDateStart: time.Unix(11, 0),
-				CreationDateEnd:   time.Unix(20, 0),
+				CreationDateStart: 11,
+				CreationDateEnd:   20,
 			},
 			expected: pendingInvoices[5:10],
 		},
@@ -1486,8 +1486,8 @@ func TestQueryInvoices(t *testing.T) {
 			query: invpkg.InvoiceQuery{
 				Reversed:          true,
 				NumMaxInvoices:    numInvoices,
-				CreationDateStart: time.Unix(11, 0),
-				CreationDateEnd:   time.Unix(20, 0),
+				CreationDateStart: 11,
+				CreationDateEnd:   20,
 			},
 			expected: invoices[10:20],
 		},
@@ -1498,8 +1498,8 @@ func TestQueryInvoices(t *testing.T) {
 				PendingOnly:       true,
 				Reversed:          true,
 				NumMaxInvoices:    numInvoices,
-				CreationDateStart: time.Unix(11, 0),
-				CreationDateEnd:   time.Unix(20, 0),
+				CreationDateStart: 11,
+				CreationDateEnd:   20,
 			},
 			expected: pendingInvoices[5:10],
 		},
@@ -1508,8 +1508,8 @@ func TestQueryInvoices(t *testing.T) {
 		{
 			query: invpkg.InvoiceQuery{
 				NumMaxInvoices:    numInvoices,
-				CreationDateStart: time.Unix(20, 0),
-				CreationDateEnd:   time.Unix(11, 0),
+				CreationDateStart: 20,
+				CreationDateEnd:   11,
 			},
 			expected: nil,
 		},

--- a/channeldb/payments_test.go
+++ b/channeldb/payments_test.go
@@ -438,7 +438,7 @@ func TestQueryPayments(t *testing.T) {
 				MaxPayments:       2,
 				Reversed:          false,
 				IncludeIncomplete: true,
-				CreationDateStart: time.Unix(0, 5),
+				CreationDateStart: 5,
 			},
 			firstIndex:     5,
 			lastIndex:      6,
@@ -452,7 +452,7 @@ func TestQueryPayments(t *testing.T) {
 				MaxPayments:       2,
 				Reversed:          false,
 				IncludeIncomplete: true,
-				CreationDateStart: time.Unix(0, 7),
+				CreationDateStart: 7,
 			},
 			firstIndex:     7,
 			lastIndex:      7,
@@ -465,8 +465,8 @@ func TestQueryPayments(t *testing.T) {
 				MaxPayments:       math.MaxUint64,
 				Reversed:          true,
 				IncludeIncomplete: true,
-				CreationDateStart: time.Unix(0, 3),
-				CreationDateEnd:   time.Unix(0, 5),
+				CreationDateStart: 3,
+				CreationDateEnd:   5,
 			},
 			firstIndex:     3,
 			lastIndex:      5,
@@ -509,7 +509,7 @@ func TestQueryPayments(t *testing.T) {
 				}
 				// Override creation time to allow for testing
 				// of CreationDateStart and CreationDateEnd.
-				info.CreationTime = time.Unix(0, int64(i+1))
+				info.CreationTime = time.Unix(int64(i+1), 0)
 
 				// Create a new payment entry in the database.
 				err = pControl.InitPayment(info.PaymentIdentifier, info)

--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -81,6 +81,10 @@
 * [Fixed](https://github.com/lightningnetwork/lnd/pull/7852) the payload size
   calculation in our pathfinder because blinded hops introduced new tlv records.
 
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/8432) a timestamp
+  precision issue when querying payments and invoices using the start and end
+  date filters.
+
 # New Features
 ## Functional Enhancements
 

--- a/invoices/interface.go
+++ b/invoices/interface.go
@@ -2,7 +2,6 @@ package invoices
 
 import (
 	"context"
-	"time"
 
 	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -126,13 +125,13 @@ type InvoiceQuery struct {
 	// from the IndexOffset and go backwards.
 	Reversed bool
 
-	// CreationDateStart, if set, filters out all invoices with a creation
-	// date greater than or euqal to it.
-	CreationDateStart time.Time
+	// CreationDateStart, expressed in Unix seconds, if set, filters out
+	// all invoices with a creation date greater than or equal to it.
+	CreationDateStart int64
 
 	// CreationDateEnd, if set, filters out all invoices with a creation
-	// date less than or euqal to it.
-	CreationDateEnd time.Time
+	// date less than or equal to it.
+	CreationDateEnd int64
 }
 
 // InvoiceSlice is the response to a invoice query. It includes the original

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -174,7 +174,7 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testUpdateNodeAnnouncement,
 	},
 	{
-		Name:     "list outgoing payments",
+		Name:     "list payments",
 		TestFunc: testListPayments,
 	},
 	{

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -5796,20 +5796,12 @@ func (r *rpcServer) ListInvoices(ctx context.Context,
 	// Next, we'll map the proto request into a format that is understood by
 	// the database.
 	q := invoices.InvoiceQuery{
-		IndexOffset:    req.IndexOffset,
-		NumMaxInvoices: req.NumMaxInvoices,
-		PendingOnly:    req.PendingOnly,
-		Reversed:       req.Reversed,
-	}
-
-	// Attach the start date if set.
-	if req.CreationDateStart != 0 {
-		q.CreationDateStart = time.Unix(int64(req.CreationDateStart), 0)
-	}
-
-	// Attach the end date if set.
-	if req.CreationDateEnd != 0 {
-		q.CreationDateEnd = time.Unix(int64(req.CreationDateEnd), 0)
+		IndexOffset:       req.IndexOffset,
+		NumMaxInvoices:    req.NumMaxInvoices,
+		PendingOnly:       req.PendingOnly,
+		Reversed:          req.Reversed,
+		CreationDateStart: int64(req.CreationDateStart),
+		CreationDateEnd:   int64(req.CreationDateEnd),
 	}
 
 	invoiceSlice, err := r.server.miscDB.QueryInvoices(ctx, q)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -6637,20 +6637,8 @@ func (r *rpcServer) ListPayments(ctx context.Context,
 		Reversed:          req.Reversed,
 		IncludeIncomplete: req.IncludeIncomplete,
 		CountTotal:        req.CountTotalPayments,
-	}
-
-	// Attach the start date if set.
-	if req.CreationDateStart != 0 {
-		query.CreationDateStart = time.Unix(
-			int64(req.CreationDateStart), 0,
-		)
-	}
-
-	// Attach the end date if set.
-	if req.CreationDateEnd != 0 {
-		query.CreationDateEnd = time.Unix(
-			int64(req.CreationDateEnd), 0,
-		)
+		CreationDateStart: int64(req.CreationDateStart),
+		CreationDateEnd:   int64(req.CreationDateEnd),
 	}
 
 	// If the maximum number of payments wasn't specified, then we'll


### PR DESCRIPTION
Reported by a user, that the `ListPayments` query cannot properly give back the results based on the timestamp filters. Turns out there's a precision issue, as the creation dates are saved in nanoseconds, but the filters use seconds, which may sometimes cause unexpected records being filtered. For instance, a user creates a payment at time `1706285122.897131000s`, and tries to filter it using `CreationEndDate = 1706285122s`, but the payment is saved using nanoseconds, so it's greater than the `CreationEndDate` by `0.897131000s`.

To see how the precision issue occurs, run the itest `list_payments` in the first commit.

This PR fixes it by making sure the comparison always use Unix timestamp in seconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed a timestamp precision issue when querying payments and invoices, ensuring results are now more accurate.
	- Ensured shutdown procedure compliance with BOLT2, particularly when HTLCs are present on the channel.
- **Refactor**
	- Unified date handling across the system by replacing `time.Time` with `int64` for date representations.
- **Tests**
	- Improved testing for payment and invoice listings, including better timestamp filter tests.
- **Documentation**
	- Updated release notes to reflect changes in timestamp handling and shutdown procedure compliance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->