### PR TITLE
tls_manager: let REST proxy skip tls cert verification

### DIFF
--- a/docs/release-notes/release-notes-0.17.4.md
+++ b/docs/release-notes/release-notes-0.17.4.md
@@ -41,7 +41,10 @@
   nodes where the chain sync got lost because fetching of already pruned blocks
   from our peers was not garbage collected when the request failed.
 
-
+* Let the REST proxy [skip TLS 
+  verification](https://github.com/lightningnetwork/lnd/pull/8437) when 
+  connecting to the gRPC server to prevent invalid cert use when the ephemeral 
+  cert (used with the  `--tlsencryptkey` flag) expires. 
 
 # New Features
 ## Functional Enhancements

--- a/tls_manager.go
+++ b/tls_manager.go
@@ -131,32 +131,27 @@ func (t *TLSManager) getConfig() ([]grpc.ServerOption, []grpc.DialOption,
 	// and override the TLS config's GetCertificate function.
 	cleanUp := t.setUpLetsEncrypt(&certData, tlsCfg)
 
-	// If we're using the ephemeral certificate, we need to use the
-	// ephemeral cert path.
-	certPath := t.cfg.TLSCertPath
-	if t.ephemeralCertPath != "" {
-		certPath = t.ephemeralCertPath
-	}
-
 	// Now that we know that we have a certificate, let's generate the
 	// required config options.
-	restCreds, err := credentials.NewClientTLSFromFile(
-		certPath, "",
-	)
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
-
 	serverCreds := credentials.NewTLS(tlsCfg)
 	serverOpts := []grpc.ServerOption{grpc.Creds(serverCreds)}
 
-	// For our REST dial options, we'll still use TLS, but also increase
-	// the max message size that we'll decode to allow clients to hit
-	// endpoints which return more data such as the DescribeGraph call.
+	// For our REST dial options, we skip TLS verification, and we also
+	// increase the max message size that we'll decode to allow clients to
+	// hit endpoints which return more data such as the DescribeGraph call.
 	// We set this to 200MiB atm. Should be the same value as maxMsgRecvSize
 	// in cmd/lncli/main.go.
 	restDialOpts := []grpc.DialOption{
-		grpc.WithTransportCredentials(restCreds),
+		// We are forwarding the requests directly to the address of our
+		// own local listener. To not need to mess with the TLS
+		// certificate (which might be tricky if we're using Let's
+		// Encrypt or if the ephemeral tls cert is being used), we just
+		// skip the certificate verification. Injecting a malicious
+		// hostname into the listener address will result in an error
+		// on startup so this should be quite safe.
+		grpc.WithTransportCredentials(credentials.NewTLS(
+			&tls.Config{InsecureSkipVerify: true},
+		)),
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(lnrpc.MaxGrpcMsgSize),
 		),


### PR DESCRIPTION
Similarly to what is done in [LiT](https://github.com/lightninglabs/lightning-terminal/blob/20fa2c0915de0d43f793f4c22a140e514dcbdbad/terminal.go#L1454), we let the REST proxy skip TLS
verification when connecting to the gRPC server. This is necessary to fix [this](https://github.com/lightninglabs/lightning-terminal/issues/696) bug that appears in LiT that happens when the `--tlsencryptkey` flag is used. This flag results
in an ephemeral tls key&cert being used which is swapped out with the permanent tls key/cert once LND is unlocked. After a day, the ephemeral cert expires but the client continues trying to use that key. 

Since this is just LND connecting to itself, it should be fine to skip TLS verification here. 