### PR TITLE
routerrpc: make use of fee limit obvious in SendPaymentV2

### DIFF
--- a/lnrpc/routerrpc/router.proto
+++ b/lnrpc/routerrpc/router.proto
@@ -30,7 +30,10 @@ service Router {
     /*
     SendPaymentV2 attempts to route a payment described by the passed
     PaymentRequest to the final destination. The call returns a stream of
-    payment updates.
+    payment updates. When using this RPC, make sure to set a fee limit, as the
+    default routing fee limit is 0 sats. Without a non-zero fee limit only
+    routes without fees will be attempted which often fails with
+    FAILURE_REASON_NO_ROUTE.
     */
     rpc SendPaymentV2 (SendPaymentRequest) returns (stream lnrpc.Payment);
 

--- a/lnrpc/routerrpc/router.swagger.json
+++ b/lnrpc/routerrpc/router.swagger.json
@@ -392,7 +392,7 @@
     },
     "/v2/router/send": {
       "post": {
-        "summary": "SendPaymentV2 attempts to route a payment described by the passed\nPaymentRequest to the final destination. The call returns a stream of\npayment updates.",
+        "summary": "SendPaymentV2 attempts to route a payment described by the passed\nPaymentRequest to the final destination. The call returns a stream of\npayment updates. When using this RPC, make sure to set a fee limit, as the\ndefault routing fee limit is 0 sats. Without a non-zero fee limit only\nroutes without fees will be attempted which often fails with\nFAILURE_REASON_NO_ROUTE.",
         "operationId": "Router_SendPaymentV2",
         "responses": {
           "200": {

--- a/lnrpc/routerrpc/router_grpc.pb.go
+++ b/lnrpc/routerrpc/router_grpc.pb.go
@@ -21,7 +21,10 @@ const _ = grpc.SupportPackageIsVersion7
 type RouterClient interface {
 	// SendPaymentV2 attempts to route a payment described by the passed
 	// PaymentRequest to the final destination. The call returns a stream of
-	// payment updates.
+	// payment updates. When using this RPC, make sure to set a fee limit, as the
+	// default routing fee limit is 0 sats. Without a non-zero fee limit only
+	// routes without fees will be attempted which often fails with
+	// FAILURE_REASON_NO_ROUTE.
 	SendPaymentV2(ctx context.Context, in *SendPaymentRequest, opts ...grpc.CallOption) (Router_SendPaymentV2Client, error)
 	// lncli: `trackpayment`
 	// TrackPaymentV2 returns an update stream for the payment identified by the
@@ -454,7 +457,10 @@ func (c *routerClient) UpdateChanStatus(ctx context.Context, in *UpdateChanStatu
 type RouterServer interface {
 	// SendPaymentV2 attempts to route a payment described by the passed
 	// PaymentRequest to the final destination. The call returns a stream of
-	// payment updates.
+	// payment updates. When using this RPC, make sure to set a fee limit, as the
+	// default routing fee limit is 0 sats. Without a non-zero fee limit only
+	// routes without fees will be attempted which often fails with
+	// FAILURE_REASON_NO_ROUTE.
 	SendPaymentV2(*SendPaymentRequest, Router_SendPaymentV2Server) error
 	// lncli: `trackpayment`
 	// TrackPaymentV2 returns an update stream for the payment identified by the


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/lightning-terminal/issues/714.

Makes it more explicit that when no fee limit is set, the default limit of 0 sats is used which often results in `FAILURE_REASON_NO_ROUTE`.