### PR TITLE
peer: fix issue where we echo remote Shutdown

### DIFF
--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -3638,7 +3638,7 @@ func (p *Brontide) handleCloseMsg(msg *closeMsg) {
 			// the Shutdown message since we don't have to wait for
 			// commitment transaction synchronization.
 			if link == nil {
-				p.queueMsg(typed, nil)
+				p.queueMsg(&msg, nil)
 				return
 			}
 


### PR DESCRIPTION
## Change Description
This fixes an issue where we would just echo the same shutdown message back that we received from the remote in the case where the link was already removed from the switch.

## Steps to Test
New tests have been added that fail prior to the main code change presented here and pass afterwards.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
