### PR TITLE
lnwallet: simplify status row

### DIFF
--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -7595,7 +7595,7 @@ func (lc *LightningChannel) ForceClose() (*LocalForceCloseSummary, error) {
 
 	// Set the channel state to indicate that the channel is now in a
 	// contested state.
-	lc.status = channelDispute
+	lc.status = channelClosed
 
 	return summary, nil
 }

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -159,30 +159,14 @@ func (e *ErrCommitSyncLocalDataLoss) Error() string {
 type channelState uint8
 
 const (
-	// channelPending indicates this channel is still going through the
-	// funding workflow, and isn't yet open.
-	channelPending channelState = iota // nolint: unused
-
 	// channelOpen represents an open, active channel capable of
 	// sending/receiving HTLCs.
-	channelOpen
-
-	// channelClosing represents a channel which is in the process of being
-	// closed.
-	channelClosing
+	channelOpen channelState = iota
 
 	// channelClosed represents a channel which has been fully closed. Note
 	// that before a channel can be closed, ALL pending HTLCs must be
 	// settled/removed.
 	channelClosed
-
-	// channelDispute indicates that an un-cooperative closure has been
-	// detected within the channel.
-	channelDispute
-
-	// channelPendingPayment indicates that there a currently outstanding
-	// HTLCs within the channel.
-	channelPendingPayment // nolint:unused
 )
 
 // PaymentHash represents the sha256 of a random value. This hash is used to
@@ -7852,10 +7836,6 @@ func (lc *LightningChannel) CreateCloseProposal(proposedFee btcutil.Amount,
 			return nil, nil, 0, err
 		}
 	}
-
-	// As everything checks out, indicate in the channel status that a
-	// channel closure has been initiated.
-	lc.status = channelClosing
 
 	closeTXID := closeTx.TxHash()
 	return sig, &closeTXID, ourBalance, nil

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -2147,8 +2147,8 @@ func TestCooperativeCloseDustAdherence(t *testing.T) {
 	}
 
 	resetChannelState := func() {
-		aliceChannel.status = channelOpen
-		bobChannel.status = channelOpen
+		aliceChannel.isClosed = false
+		bobChannel.isClosed = false
 	}
 
 	setBalances := func(aliceBalance, bobBalance lnwire.MilliSatoshi) {

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -2147,8 +2147,8 @@ func TestCooperativeCloseDustAdherence(t *testing.T) {
 	}
 
 	resetChannelState := func() {
-		aliceChannel.isClosed = false
-		bobChannel.isClosed = false
+		aliceChannel.ResetState()
+		bobChannel.ResetState()
 	}
 
 	setBalances := func(aliceBalance, bobBalance lnwire.MilliSatoshi) {


### PR DESCRIPTION
## Change Description
This PR works up to deleting a mostly useless field from lnwallet.LightningChannel. Unfortunately proving to ourselves that the field can be eliminated entirely is more involved and will be deferred to a later PR, but this one simplifies the field and makes it clearer how it is being used.

On a more philosophical note, enumerated statuses should be used very sparingly, and if they are used at all they should be foundational to the design of the component. This is because a status is usually a summary of a number of other dimensions of the structure.

## Steps to Test
Since this is a refactor, the bar for testing is ensuring that there are no regressions.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Simplified channel state management in the Lightning Network wallet, enhancing the reliability of channel closure processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->