### PR TITLE
tlv: add new Zero method on RecordT

### DIFF
--- a/tlv/record_type.go
+++ b/tlv/record_type.go
@@ -87,6 +87,11 @@ func (t *RecordT[T, V]) TlvType() Type {
 	return t.recordType.TypeVal()
 }
 
+// Zero returns a zero value of the record type.
+func (t *RecordT[T, V]) Zero() RecordT[T, V] {
+	return ZeroRecordT[T, V]()
+}
+
 // OptionalRecordT is a high-order type that represents an optional TLV record.
 // This can be used when a TLV record doesn't always need to be present (ok to
 // be odd).


### PR DESCRIPTION
In this commit, we add a new `Zero` method for the `RecordT` type. This method allows a caller to create the zero record for a type without needing to reference the actual TLV type.

With this we go from this:
```go
sig1 := tlv.ZeroRecordT[tlv.TlvType1, Sig]()
```

To this:
```
sig1 := c.CloserNoClosee.Zero()
```
