### PR TITLE
channeldb: fix db name in test

### DIFF
--- a/channeldb/db_test.go
+++ b/channeldb/db_test.go
@@ -33,7 +33,7 @@ func TestOpenWithCreate(t *testing.T) {
 
 	// Next, open thereby creating channeldb for the first time.
 	dbPath := filepath.Join(tempDirName, "cdb")
-	backend, cleanup, err := kvdb.GetTestBackend(dbPath, "cdb")
+	backend, cleanup, err := kvdb.GetTestBackend(dbPath, dbName)
 	require.NoError(t, err, "unable to get test db backend")
 	t.Cleanup(cleanup)
 

--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -283,6 +283,9 @@
 * Added fuzz tests for [onion
   errors](https://github.com/lightningnetwork/lnd/pull/7669).
 
+* Fixed the db name [in a channeldb
+  test](https://github.com/lightningnetwork/lnd/pull/8462).
+
 ## Database
 
 * [Add context to InvoiceDB


### PR DESCRIPTION
Prior to this change, two database files were actually initialized (cdb and channel.db), therefore the test was not actually exercising what it meant to.


!lightninglabs-deploy mute