### PR TITLE
Remove `DefaultChannelConstraints` from PartialChainControl and lnwallet.Config

### DIFF
--- a/chainreg/chainregistry.go
+++ b/chainreg/chainregistry.go
@@ -200,19 +200,6 @@ type ChainControl struct {
 	Wallet *lnwallet.LightningWallet
 }
 
-// GenDefaultBtcConstraints generates the default set of channel constraints
-// that are to be used when funding a Bitcoin channel.
-func GenDefaultBtcConstraints() channeldb.ChannelConstraints {
-	// We use the dust limit for the maximally sized witness program with
-	// a 40-byte data push.
-	dustLimit := lnwallet.DustLimitForSize(input.UnknownWitnessSize)
-
-	return channeldb.ChannelConstraints{
-		DustLimit:        dustLimit,
-		MaxAcceptedHtlcs: input.MaxHTLCNumber / 2,
-	}
-}
-
 // NewPartialChainControl creates a new partial chain control that contains all
 // the parts that can be purely constructed from the passed in global
 // configuration and doesn't need any wallet instance yet.

--- a/chainreg/chainregistry.go
+++ b/chainreg/chainregistry.go
@@ -166,10 +166,6 @@ type PartialChainControl struct {
 
 	// MinHtlcIn is the minimum HTLC we will accept.
 	MinHtlcIn lnwire.MilliSatoshi
-
-	// ChannelConstraints is the set of default constraints that will be
-	// used for any incoming or outgoing channel reservation requests.
-	ChannelConstraints channeldb.ChannelConstraints
 }
 
 // ChainControl couples the three primary interfaces lnd utilizes for a
@@ -714,9 +710,6 @@ func NewPartialChainControl(cfg *Config) (*PartialChainControl, func(), error) {
 	if err := cc.FeeEstimator.Start(); err != nil {
 		return nil, nil, err
 	}
-
-	// Select the default channel constraints for the primary chain.
-	cc.ChannelConstraints = GenDefaultBtcConstraints()
 
 	return cc, ccCleanup, nil
 }

--- a/config_builder.go
+++ b/config_builder.go
@@ -686,15 +686,14 @@ func (d *DefaultWalletImpl) BuildChainControl(
 	// Create, and start the lnwallet, which handles the core payment
 	// channel logic, and exposes control via proxy state machines.
 	lnWalletConfig := lnwallet.Config{
-		Database:           partialChainControl.Cfg.ChanStateDB,
-		Notifier:           partialChainControl.ChainNotifier,
-		WalletController:   walletController,
-		Signer:             walletController,
-		FeeEstimator:       partialChainControl.FeeEstimator,
-		SecretKeyRing:      keyRing,
-		ChainIO:            walletController,
-		DefaultConstraints: chainreg.GenDefaultBtcConstraints(),
-		NetParams:          *walletConfig.NetParams,
+		Database:         partialChainControl.Cfg.ChanStateDB,
+		Notifier:         partialChainControl.ChainNotifier,
+		WalletController: walletController,
+		Signer:           walletController,
+		FeeEstimator:     partialChainControl.FeeEstimator,
+		SecretKeyRing:    keyRing,
+		ChainIO:          walletController,
+		NetParams:        *walletConfig.NetParams,
 	}
 
 	// The broadcast is already always active for neutrino nodes, so we
@@ -801,15 +800,14 @@ func (d *RPCSignerWalletImpl) BuildChainControl(
 	// Create, and start the lnwallet, which handles the core payment
 	// channel logic, and exposes control via proxy state machines.
 	lnWalletConfig := lnwallet.Config{
-		Database:           partialChainControl.Cfg.ChanStateDB,
-		Notifier:           partialChainControl.ChainNotifier,
-		WalletController:   rpcKeyRing,
-		Signer:             rpcKeyRing,
-		FeeEstimator:       partialChainControl.FeeEstimator,
-		SecretKeyRing:      rpcKeyRing,
-		ChainIO:            walletController,
-		DefaultConstraints: chainreg.GenDefaultBtcConstraints(),
-		NetParams:          *walletConfig.NetParams,
+		Database:         partialChainControl.Cfg.ChanStateDB,
+		Notifier:         partialChainControl.ChainNotifier,
+		WalletController: rpcKeyRing,
+		Signer:           rpcKeyRing,
+		FeeEstimator:     partialChainControl.FeeEstimator,
+		SecretKeyRing:    rpcKeyRing,
+		ChainIO:          walletController,
+		NetParams:        *walletConfig.NetParams,
 	}
 
 	// We've created the wallet configuration now, so we can finish

--- a/config_builder.go
+++ b/config_builder.go
@@ -693,7 +693,7 @@ func (d *DefaultWalletImpl) BuildChainControl(
 		FeeEstimator:       partialChainControl.FeeEstimator,
 		SecretKeyRing:      keyRing,
 		ChainIO:            walletController,
-		DefaultConstraints: partialChainControl.ChannelConstraints,
+		DefaultConstraints: chainreg.GenDefaultBtcConstraints(),
 		NetParams:          *walletConfig.NetParams,
 	}
 
@@ -808,7 +808,7 @@ func (d *RPCSignerWalletImpl) BuildChainControl(
 		FeeEstimator:       partialChainControl.FeeEstimator,
 		SecretKeyRing:      rpcKeyRing,
 		ChainIO:            walletController,
-		DefaultConstraints: partialChainControl.ChannelConstraints,
+		DefaultConstraints: chainreg.GenDefaultBtcConstraints(),
 		NetParams:          *walletConfig.NetParams,
 	}
 

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -360,15 +360,14 @@ func createTestWallet(cdb *channeldb.ChannelStateDB, netParams *chaincfg.Params,
 	estimator chainfee.Estimator) (*lnwallet.LightningWallet, error) {
 
 	wallet, err := lnwallet.NewLightningWallet(lnwallet.Config{
-		Database:           cdb,
-		Notifier:           notifier,
-		SecretKeyRing:      keyRing,
-		WalletController:   wc,
-		Signer:             signer,
-		ChainIO:            bio,
-		FeeEstimator:       estimator,
-		NetParams:          *netParams,
-		DefaultConstraints: chainreg.GenDefaultBtcConstraints(),
+		Database:         cdb,
+		Notifier:         notifier,
+		SecretKeyRing:    keyRing,
+		WalletController: wc,
+		Signer:           signer,
+		ChainIO:          bio,
+		FeeEstimator:     estimator,
+		NetParams:        *netParams,
 	})
 	if err != nil {
 		return nil, err

--- a/lnwallet/config.go
+++ b/lnwallet/config.go
@@ -49,10 +49,6 @@ type Config struct {
 	// used to lookup the existence of outputs within the UTXO set.
 	ChainIO BlockChainIO
 
-	// DefaultConstraints is the set of default constraints that will be
-	// used for any incoming or outgoing channel reservation requests.
-	DefaultConstraints channeldb.ChannelConstraints
-
 	// NetParams is the set of parameters that tells the wallet which chain
 	// it will be operating on.
 	NetParams chaincfg.Params

--- a/lnwallet/parameters.go
+++ b/lnwallet/parameters.go
@@ -80,3 +80,8 @@ func DustLimitForSize(scriptSize int) btcutil.Amount {
 
 	return dustlimit
 }
+
+// DustLimitUnknownWitness returns the dust limit for an UnknownWitnessSize.
+func DustLimitUnknownWitness() btcutil.Amount {
+	return DustLimitForSize(input.UnknownWitnessSize)
+}

--- a/lnwallet/reservation.go
+++ b/lnwallet/reservation.go
@@ -262,7 +262,7 @@ func NewChannelReservation(capacity, localFundingAmt btcutil.Amount,
 	}
 
 	// Used to cut down on verbosity.
-	defaultDust := wallet.Cfg.DefaultConstraints.DustLimit
+	defaultDust := DustLimitUnknownWitness()
 
 	// If we're the responder to a single-funder reservation, then we have
 	// no initial balance in the channel unless the remote party is pushing

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -356,14 +356,7 @@ func createTestWallet(tempTestDir string, miningNode *rpctest.Harness,
 		Signer:           signer,
 		ChainIO:          bio,
 		FeeEstimator:     chainfee.NewStaticEstimator(2500, 0),
-		DefaultConstraints: channeldb.ChannelConstraints{
-			DustLimit:        500,
-			MaxPendingAmount: lnwire.NewMSatFromSatoshis(btcutil.SatoshiPerBitcoin) * 100,
-			ChanReserve:      100,
-			MinHTLC:          400,
-			MaxAcceptedHtlcs: 900,
-		},
-		NetParams: *netParams,
+		NetParams:        *netParams,
 	}
 
 	wallet, err := lnwallet.NewLightningWallet(cfg)
@@ -458,7 +451,7 @@ func testDualFundingReservationWorkflow(miner *rpctest.Harness,
 	require.NoError(t, err, "unable to initialize funding reservation")
 	aliceChanReservation.SetNumConfsRequired(numReqConfs)
 	channelConstraints := &channeldb.ChannelConstraints{
-		DustLimit:        alice.Cfg.DefaultConstraints.DustLimit,
+		DustLimit:        lnwallet.DustLimitUnknownWitness(),
 		ChanReserve:      fundingAmount / 100,
 		MaxPendingAmount: lnwire.NewMSatFromSatoshis(fundingAmount),
 		MinHTLC:          1,
@@ -863,7 +856,7 @@ func testSingleFunderReservationWorkflow(miner *rpctest.Harness,
 	require.NoError(t, err, "unable to init channel reservation")
 	aliceChanReservation.SetNumConfsRequired(numReqConfs)
 	channelConstraints := &channeldb.ChannelConstraints{
-		DustLimit:        alice.Cfg.DefaultConstraints.DustLimit,
+		DustLimit:        lnwallet.DustLimitUnknownWitness(),
 		ChanReserve:      fundingAmt / 100,
 		MaxPendingAmount: lnwire.NewMSatFromSatoshis(fundingAmt),
 		MinHTLC:          1,

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -1363,7 +1363,8 @@ func (l *LightningWallet) initOurContribution(reservation *ChannelReservation,
 	)
 
 	reservation.partialState.RevocationProducer = producer
-	reservation.ourContribution.ChannelConstraints = l.Cfg.DefaultConstraints
+	reservation.ourContribution.ChannelConstraints.DustLimit =
+		DustLimitUnknownWitness()
 
 	// If taproot channels are active, then we'll generate our verification
 	// nonce here. We'll use this nonce to verify the signature for our


### PR DESCRIPTION
## Change Description
In an investigation on how `ChannelConstraints` were used throughout the codebase (in preparation for dynamic commitments), I stumbled on some dead code/data structures. This PR trims them to the smallest used set. In theory this should result in no semantics changes.

## Steps to Test
CI should handle finding any regressions

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
