### PR TITLE
docs: preserve MINING_ADDRESS across docker-compose sessions

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -80,7 +80,8 @@ $  docker exec -i -t alice bash
 alice $  lncli --network=simnet newaddress np2wkh 
 
 # Recreate "btcd" node and set Alice's address as mining address:
-$  MINING_ADDRESS=<alice_address> docker-compose up -d btcd
+$  export MINING_ADDRESS=<alice_address>
+$  docker-compose up -d btcd
 
 # Generate 400 blocks (we need at least "100 >=" blocks because of coinbase 
 # block maturity and "300 ~=" in order to activate segwit):


### PR DESCRIPTION
I follow "Create lightning network cluster" in docker/README.md, but found some issue with as flowing. After some troubleshooting, I found why it happened.

```
weili@mbp14 docker % docker exec -it btcd /start-btcctl.sh generate 1
-32603: No payment addresses specified via --miningaddr
weili@mbp14 docker %
```

When initiating new containers using `docker-compose run`, the `MINING_ADDRESS` environment variable was found to reset to an empty state. This behavior resulted in failures when attempting to generate new blocks with `btcd`, as the mining address was not specified, throwing an error `-32603: No payment addresses specified via --miningaddr`.


Up btcd with MINING_ADDRESS inline, btcd container will setting the MINING_ADDRESS.
```
weili@mbp14 docker % MINING_ADDRESS=rm9kB619cF4EbBLEbt1JWXEMmUBdApCX4K docker-compose up -d btcd
[+] Running 1/1
 ✔ Container btcd  Started                                                                                                                                                                                     0.2s
weili@mbp14 docker % docker inspect btcd | jq '.[0].Config.Env'
[
  "MINING_ADDRESS=rm9kB619cF4EbBLEbt1JWXEMmUBdApCX4K", <------ /* value has setted */
  "RPCUSER",
  "RPCPASS",
  "NETWORK=simnet",
  "BTCD_DEBUG",
  "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
]
weili@mbp14 docker %
```

Up bob lnl with no MINING_ADDRESS, btcd container will reset the MINING_ADDRESS and mint block will failed with no mining address.
```
weili@mbp14 docker %weili@mbp14 docker % docker-compose run -d --name bob --volume simnet_lnd_bob:/root/.lnd lnd
[+] Creating 1/1
 ✔ Container btcd  Recreated                                                                                                                                                                                   0.2s
[+] Running 1/1
 ✔ Container btcd  Started                                                                                                                                                                                     0.2s
fe7bd00f860e88dc3fd3e8bdf15e1ece6521c24bfd464a1906d4a17b8a53b573
weili@mbp14 docker % docker inspect btcd | jq '.[0].Config.Env'
[
  "BTCD_DEBUG",
  "MINING_ADDRESS", <------ /* here is no value */
  "RPCUSER",
  "RPCPASS",
  "NETWORK=simnet",
  "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
]
weili@mbp14 docker % docker exec -it btcd /start-btcctl.sh generate 1
-32603: No payment addresses specified via --miningaddr
weili@mbp14 docker %
```

## Change Description

Export MINING_ADDRESS before docker-compose up to ensure it's retained for subsequent operations, fixing block generation errors due to missing mining addresses.
```
$  export MINING_ADDRESS=<alice_address>
$  docker-compose up -d btcd
```

## Steps to Test

Export MINING_ADDRESS and up bob, check if 
- MINING_ADDRESS is correct setting
- Mint block with no error

```
weili@mbp14 docker % export MINING_ADDRESS=rm9kB619cF4EbBLEbt1JWXEMmUBdApCX4K
weili@mbp14 docker % docker-compose run -d --name bob --volume simnet_lnd_bob:/root/.lnd lnd
[+] Creating 1/1
 ✔ Container btcd  Recreated                                                                                                                                                                                   0.2s
[+] Running 1/1
 ✔ Container btcd  Started                                                                                                                                                                                     0.2s
Error response from daemon: Conflict. The container name "/bob" is already in use by container "fe7bd00f860e88dc3fd3e8bdf15e1ece6521c24bfd464a1906d4a17b8a53b573". You have to remove (or rename) that container to be able to reuse that name.
weili@mbp14 docker % docker inspect btcd | jq '.[0].Config.Env'
[
  "BTCD_DEBUG",
  "MINING_ADDRESS=rm9kB619cF4EbBLEbt1JWXEMmUBdApCX4K",
  "RPCUSER",
  "RPCPASS",
  "NETWORK=simnet",
  "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
]
weili@mbp14 docker % docker exec -it btcd /start-btcctl.sh generate 1
[
  "104d94c24116dd423a0d2442edb722ae6ccd0072ff78e2d2845d4ae256b07d49"
]
```

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.