### PR TITLE
lnwallet/reservation: change minNumHtlc to 3

### DIFF
--- a/lnwallet/reservation.go
+++ b/lnwallet/reservation.go
@@ -848,7 +848,7 @@ func VerifyConstraints(c *channeldb.ChannelConstraints,
 
 	// Fail if we consider maxHtlcs too small. If this is too small we
 	// cannot offer many HTLCs to the remote.
-	const minNumHtlc = 5
+	const minNumHtlc = 3
 	if c.MaxAcceptedHtlcs < minNumHtlc {
 		return ErrMaxHtlcNumTooSmall(c.MaxAcceptedHtlcs, minNumHtlc)
 	}


### PR DESCRIPTION
## Change Description
Change minNumHtlc from 5 to 3

## Steps to Test
- Try to open a channel to `020d1617e27ac022395352f2b3774969593d3d6ddff6fb117d820a9dda8da45217@23.88.103.101:40009`, it should fail if minNumHtlc = 5 with `[lncli] rpc error: code = Unknown desc = maxHtlcs is too small: 3, min is 5`
- With new change it should not fail anymore

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
