### PR TITLE
lnrpc: Clarify payment_addr and payment_secret

### DIFF
--- a/lnrpc/invoicesrpc/invoices.pb.go
+++ b/lnrpc/invoicesrpc/invoices.pb.go
@@ -317,8 +317,9 @@ type AddHoldInvoiceResp struct {
 	// SubscribeInvoices call can use this to instantly get notified of all added
 	// invoices with an add_index greater than this one.
 	AddIndex uint64 `protobuf:"varint,2,opt,name=add_index,json=addIndex,proto3" json:"add_index,omitempty"`
-	// The payment address of the generated invoice. This value should be used
-	// in all payments for this invoice as we require it for end to end
+	// The payment address of the generated invoice. This is also called
+	// the payment secret in specifications (e.g. BOLT 11). This value should
+	// be used in all payments for this invoice as we require it for end to end
 	// security.
 	PaymentAddr []byte `protobuf:"bytes,3,opt,name=payment_addr,json=paymentAddr,proto3" json:"payment_addr,omitempty"`
 }

--- a/lnrpc/invoicesrpc/invoices.proto
+++ b/lnrpc/invoicesrpc/invoices.proto
@@ -138,8 +138,9 @@ message AddHoldInvoiceResp {
     uint64 add_index = 2;
 
     /*
-    The payment address of the generated invoice. This value should be used
-    in all payments for this invoice as we require it for end to end
+    The payment address of the generated invoice. This is also called
+    the payment secret in specifications (e.g. BOLT 11). This value should
+    be used in all payments for this invoice as we require it for end to end
     security.
     */
     bytes payment_addr = 3;

--- a/lnrpc/invoicesrpc/invoices.swagger.json
+++ b/lnrpc/invoicesrpc/invoices.swagger.json
@@ -300,7 +300,7 @@
         "payment_addr": {
           "type": "string",
           "format": "byte",
-          "description": "The payment address of the generated invoice. This value should be used\nin all payments for this invoice as we require it for end to end\nsecurity."
+          "description": "The payment address of the generated invoice. This is also called\nthe payment secret in specifications (e.g. BOLT 11). This value should\nbe used in all payments for this invoice as we require it for end to end\nsecurity."
         }
       }
     },
@@ -565,7 +565,7 @@
         "payment_addr": {
           "type": "string",
           "format": "byte",
-          "description": "The payment address of this invoice. This value will be used in MPP\npayments, and also for newer invoices that always require the MPP payload\nfor added end-to-end security.\nNote: Output only, don't specify for creating an invoice."
+          "description": "The payment address of this invoice. This is also called payment secret in\nspecifications (e.g. BOLT 11). This value will be used in MPP payments, and\nalso for newer invoices that always require the MPP payload for added\nend-to-end security.\nNote: Output only, don't specify for creating an invoice."
         },
         "is_amp": {
           "type": "boolean",

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -2258,7 +2258,8 @@ type SendRequest struct {
 	// the router will try to load destination features from the graph as a
 	// fallback.
 	DestFeatures []FeatureBit `protobuf:"varint,15,rep,packed,name=dest_features,json=destFeatures,proto3,enum=lnrpc.FeatureBit" json:"dest_features,omitempty"`
-	// The payment address of the generated invoice.
+	// The payment address of the generated invoice.  This is also called
+	// payment secret in specifications (e.g. BOLT 11).
 	PaymentAddr []byte `protobuf:"bytes,16,opt,name=payment_addr,json=paymentAddr,proto3" json:"payment_addr,omitempty"`
 }
 
@@ -10128,7 +10129,8 @@ type MPPRecord struct {
 	// A unique, random identifier used to authenticate the sender as the intended
 	// payer of a multi-path payment. The payment_addr must be the same for all
 	// subpayments, and match the payment_addr provided in the receiver's invoice.
-	// The same payment_addr must be used on all subpayments.
+	// The same payment_addr must be used on all subpayments. This is also called
+	// payment secret in specifications (e.g. BOLT 11).
 	PaymentAddr []byte `protobuf:"bytes,11,opt,name=payment_addr,json=paymentAddr,proto3" json:"payment_addr,omitempty"`
 	// The total amount in milli-satoshis being sent as part of a larger multi-path
 	// payment. The caller is responsible for ensuring subpayments to the same node
@@ -12396,9 +12398,10 @@ type Invoice struct {
 	// [EXPERIMENTAL].
 	// Note: Output only, don't specify for creating an invoice.
 	IsKeysend bool `protobuf:"varint,25,opt,name=is_keysend,json=isKeysend,proto3" json:"is_keysend,omitempty"`
-	// The payment address of this invoice. This value will be used in MPP
-	// payments, and also for newer invoices that always require the MPP payload
-	// for added end-to-end security.
+	// The payment address of this invoice. This is also called payment secret in
+	// specifications (e.g. BOLT 11). This value will be used in MPP payments, and
+	// also for newer invoices that always require the MPP payload for added
+	// end-to-end security.
 	// Note: Output only, don't specify for creating an invoice.
 	PaymentAddr []byte `protobuf:"bytes,26,opt,name=payment_addr,json=paymentAddr,proto3" json:"payment_addr,omitempty"`
 	// Signals whether or not this is an AMP invoice.
@@ -12879,9 +12882,9 @@ type AddInvoiceResponse struct {
 	// SubscribeInvoices call can use this to instantly get notified of all added
 	// invoices with an add_index greater than this one.
 	AddIndex uint64 `protobuf:"varint,16,opt,name=add_index,json=addIndex,proto3" json:"add_index,omitempty"`
-	// The payment address of the generated invoice. This value should be used
-	// in all payments for this invoice as we require it for end to end
-	// security.
+	// The payment address of the generated invoice. This is also called
+	// payment secret in specifications (e.g. BOLT 11). This value should be used
+	// in all payments for this invoice as we require it for end to end security.
 	PaymentAddr []byte `protobuf:"bytes,17,opt,name=payment_addr,json=paymentAddr,proto3" json:"payment_addr,omitempty"`
 }
 

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -884,7 +884,8 @@ message SendRequest {
     repeated FeatureBit dest_features = 15;
 
     /*
-    The payment address of the generated invoice.
+    The payment address of the generated invoice.  This is also called
+    payment secret in specifications (e.g. BOLT 11).
     */
     bytes payment_addr = 16;
 }
@@ -3197,7 +3198,8 @@ message MPPRecord {
     A unique, random identifier used to authenticate the sender as the intended
     payer of a multi-path payment. The payment_addr must be the same for all
     subpayments, and match the payment_addr provided in the receiver's invoice.
-    The same payment_addr must be used on all subpayments.
+    The same payment_addr must be used on all subpayments. This is also called
+    payment secret in specifications (e.g. BOLT 11).
     */
     bytes payment_addr = 11;
 
@@ -3776,9 +3778,10 @@ message Invoice {
     bool is_keysend = 25;
 
     /*
-    The payment address of this invoice. This value will be used in MPP
-    payments, and also for newer invoices that always require the MPP payload
-    for added end-to-end security.
+    The payment address of this invoice. This is also called payment secret in
+    specifications (e.g. BOLT 11). This value will be used in MPP payments, and
+    also for newer invoices that always require the MPP payload for added
+    end-to-end security.
     Note: Output only, don't specify for creating an invoice.
     */
     bytes payment_addr = 26;
@@ -3883,9 +3886,9 @@ message AddInvoiceResponse {
     uint64 add_index = 16;
 
     /*
-    The payment address of the generated invoice. This value should be used
-    in all payments for this invoice as we require it for end to end
-    security.
+    The payment address of the generated invoice. This is also called
+    payment secret in specifications (e.g. BOLT 11). This value should be used
+    in all payments for this invoice as we require it for end to end security.
     */
     bytes payment_addr = 17;
 }

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -3250,7 +3250,7 @@
         "payment_addr": {
           "type": "string",
           "format": "byte",
-          "description": "The payment address of the generated invoice. This value should be used\nin all payments for this invoice as we require it for end to end\nsecurity."
+          "description": "The payment address of the generated invoice. This is also called\npayment secret in specifications (e.g. BOLT 11). This value should be used\nin all payments for this invoice as we require it for end to end security."
         }
       }
     },
@@ -5407,7 +5407,7 @@
         "payment_addr": {
           "type": "string",
           "format": "byte",
-          "description": "The payment address of this invoice. This value will be used in MPP\npayments, and also for newer invoices that always require the MPP payload\nfor added end-to-end security.\nNote: Output only, don't specify for creating an invoice."
+          "description": "The payment address of this invoice. This is also called payment secret in\nspecifications (e.g. BOLT 11). This value will be used in MPP payments, and\nalso for newer invoices that always require the MPP payload for added\nend-to-end security.\nNote: Output only, don't specify for creating an invoice."
         },
         "is_amp": {
           "type": "boolean",
@@ -5715,7 +5715,7 @@
         "payment_addr": {
           "type": "string",
           "format": "byte",
-          "description": "A unique, random identifier used to authenticate the sender as the intended\npayer of a multi-path payment. The payment_addr must be the same for all\nsubpayments, and match the payment_addr provided in the receiver's invoice.\nThe same payment_addr must be used on all subpayments."
+          "description": "A unique, random identifier used to authenticate the sender as the intended\npayer of a multi-path payment. The payment_addr must be the same for all\nsubpayments, and match the payment_addr provided in the receiver's invoice.\nThe same payment_addr must be used on all subpayments. This is also called\npayment secret in specifications (e.g. BOLT 11)."
         },
         "total_amt_msat": {
           "type": "string",
@@ -7052,7 +7052,7 @@
         "payment_addr": {
           "type": "string",
           "format": "byte",
-          "description": "The payment address of the generated invoice."
+          "description": "The payment address of the generated invoice.  This is also called\npayment secret in specifications (e.g. BOLT 11)."
         }
       }
     },

--- a/lnrpc/routerrpc/router.pb.go
+++ b/lnrpc/routerrpc/router.pb.go
@@ -480,6 +480,7 @@ type SendPaymentRequest struct {
 	// any channel may be used.
 	OutgoingChanIds []uint64 `protobuf:"varint,19,rep,packed,name=outgoing_chan_ids,json=outgoingChanIds,proto3" json:"outgoing_chan_ids,omitempty"`
 	// An optional payment addr to be included within the last hop of the route.
+	// This is also called payment secret in specifications (e.g. BOLT 11).
 	PaymentAddr []byte `protobuf:"bytes,20,opt,name=payment_addr,json=paymentAddr,proto3" json:"payment_addr,omitempty"`
 	// The largest payment split that should be attempted when making a payment if
 	// splitting is necessary. Setting this value will effectively cause lnd to
@@ -2099,6 +2100,7 @@ type BuildRouteRequest struct {
 	// pubkey.
 	HopPubkeys [][]byte `protobuf:"bytes,4,rep,name=hop_pubkeys,json=hopPubkeys,proto3" json:"hop_pubkeys,omitempty"`
 	// An optional payment addr to be included within the last hop of the route.
+	// This is also called payment secret in specifications (e.g. BOLT 11).
 	PaymentAddr []byte `protobuf:"bytes,5,opt,name=payment_addr,json=paymentAddr,proto3" json:"payment_addr,omitempty"`
 }
 

--- a/lnrpc/routerrpc/router.proto
+++ b/lnrpc/routerrpc/router.proto
@@ -306,7 +306,10 @@ message SendPaymentRequest {
     */
     repeated uint64 outgoing_chan_ids = 19;
 
-    // An optional payment addr to be included within the last hop of the route.
+    /*
+    An optional payment addr to be included within the last hop of the route.
+    This is also called payment secret in specifications (e.g. BOLT 11).
+    */
     bytes payment_addr = 20;
 
     /*
@@ -659,7 +662,10 @@ message BuildRouteRequest {
     */
     repeated bytes hop_pubkeys = 4;
 
-    // An optional payment addr to be included within the last hop of the route.
+    /*
+    An optional payment addr to be included within the last hop of the route.
+    This is also called payment secret in specifications (e.g. BOLT 11).
+    */
     bytes payment_addr = 5;
 }
 

--- a/lnrpc/routerrpc/router.swagger.json
+++ b/lnrpc/routerrpc/router.swagger.json
@@ -927,7 +927,7 @@
         "payment_addr": {
           "type": "string",
           "format": "byte",
-          "description": "A unique, random identifier used to authenticate the sender as the intended\npayer of a multi-path payment. The payment_addr must be the same for all\nsubpayments, and match the payment_addr provided in the receiver's invoice.\nThe same payment_addr must be used on all subpayments."
+          "description": "A unique, random identifier used to authenticate the sender as the intended\npayer of a multi-path payment. The payment_addr must be the same for all\nsubpayments, and match the payment_addr provided in the receiver's invoice.\nThe same payment_addr must be used on all subpayments. This is also called\npayment secret in specifications (e.g. BOLT 11)."
         },
         "total_amt_msat": {
           "type": "string",
@@ -1173,7 +1173,7 @@
         "payment_addr": {
           "type": "string",
           "format": "byte",
-          "description": "An optional payment addr to be included within the last hop of the route."
+          "description": "An optional payment addr to be included within the last hop of the route.\nThis is also called payment secret in specifications (e.g. BOLT 11)."
         }
       }
     },
@@ -1774,7 +1774,7 @@
         "payment_addr": {
           "type": "string",
           "format": "byte",
-          "description": "An optional payment addr to be included within the last hop of the route."
+          "description": "An optional payment addr to be included within the last hop of the route.\nThis is also called payment secret in specifications (e.g. BOLT 11)."
         },
         "max_shard_size_msat": {
           "type": "string",


### PR DESCRIPTION
Fix #7438, adding clarification statements in lnrpc proto files. Originally proposed by daredevil3435 in PR #7873 and PR #7885.

## Change Description
The usage of "payment address" over "payment secret" appears to have caused some confusion among users.  This PR attempts to provide a minimal change to provide clarity, focusing on comment wording rather than functional code changes.
As PR #7885 appears to be dormant, this PR attempts to move forward with the clarification changes.

## Steps to Test
Possibly N/A, comment update.  `make rpc` is successful.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
