### PR TITLE
docs: fix typo and links

### DIFF
--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -95,7 +95,7 @@ Related: [`unit`](#unit)
 
 `flakehunter`
 -------------
-Runs the itegration test suite endlessly until a failure is detected.
+Runs the integration test suite endlessly until a failure is detected.
 
 Arguments:
 - `icase=<itestcase>`

--- a/docs/code_contribution_guidelines.md
+++ b/docs/code_contribution_guidelines.md
@@ -86,7 +86,7 @@ security and performance implications.
     - The original LN was written for a rather narrow audience, the paper may be a bit unapproachable to many. Thanks to the Bitcoin community, there exist many easily accessible supplemental resources which can help one see how all the pieces fit together from double-spend protection all the way up to commitment state transitions and Hash Time Locked Contracts (HTLCs): 
         - [Lightning Network Summary](https://lightning.network/lightning-network-summary.pdf)
         - [Understanding the Lightning Network 3-Part series](https://bitcoinmagazine.com/articles/understanding-the-lightning-network-part-building-a-bidirectional-payment-channel-1464710791) 
-        - [Deployable Lightning](https://github.com/ElementsProject/lightning/blob/master/doc/deployable-lightning.pdf) 
+        - [Deployable Lightning](https://github.com/ElementsProject/lightning/blob/master/doc/miscellaneous/deployable-lightning.pdf)
 
 
 Note that the core design of the Lightning Network has shifted over time as

--- a/docs/code_formatting_rules.md
+++ b/docs/code_formatting_rules.md
@@ -16,7 +16,8 @@ in `lnd` to help improve the overall readability.
 
 Blocks of code within `lnd` should be segmented into logical stanzas of
 operation. Such spacing makes the code easier to follow at a skim, and reduces
-unnecessary line noise. Coupled with the commenting scheme specified above,
+unnecessary line noise. Coupled with the commenting scheme specified in the
+[contribution guide](./code_contribution_guidelines.md#code-documentation-and-commenting),
 proper spacing allows readers to quickly scan code, extracting semantics quickly.
 Functions should _not_ just be laid out as a bare contiguous block of code.
 


### PR DESCRIPTION

## Change Description
- docs: fix makefile typo
- docs: fix contribution guide links

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

