### PR TITLE
 Expose `cltv_expiry` flag of `addinvoice` to cli

### DIFF
--- a/cmd/lncli/cmd_invoice.go
+++ b/cmd/lncli/cmd_invoice.go
@@ -60,6 +60,14 @@ var addInvoiceCommand = cli.Command{
 				"specified, an expiry of " +
 				"86400 seconds (24 hours) is implied.",
 		},
+		cli.Uint64Flag{
+			Name: "cltv_expiry_delta",
+			Usage: "The minimum CLTV delta to use for the final " +
+				"hop. If this is set to 0, the default value " +
+				"is used. The default value for " +
+				"cltv_expiry_delta is configured by the " +
+				"'bitcoin.timelockdelta' option.",
+		},
 		cli.BoolFlag{
 			Name: "private",
 			Usage: "encode routing hints in the invoice with " +
@@ -127,6 +135,7 @@ func addInvoice(ctx *cli.Context) error {
 		DescriptionHash: descHash,
 		FallbackAddr:    ctx.String("fallback_addr"),
 		Expiry:          ctx.Int64("expiry"),
+		CltvExpiry:      ctx.Uint64("cltv_expiry_delta"),
 		Private:         ctx.Bool("private"),
 		IsAmp:           ctx.Bool("amp"),
 	}

--- a/cmd/lncli/invoicesrpc_active.go
+++ b/cmd/lncli/invoicesrpc_active.go
@@ -184,6 +184,14 @@ var addHoldInvoiceCommand = cli.Command{
 				"specified, an expiry of " +
 				"86400 seconds (24 hours) is implied.",
 		},
+		cli.Uint64Flag{
+			Name: "cltv_expiry_delta",
+			Usage: "The minimum CLTV delta to use for the final " +
+				"hop. If this is set to 0, the default value " +
+				"is used. The default value for " +
+				"cltv_expiry_delta is configured by the " +
+				"'bitcoin.timelockdelta' option.",
+		},
 		cli.BoolFlag{
 			Name: "private",
 			Usage: "encode routing hints in the invoice with " +
@@ -241,6 +249,7 @@ func addHoldInvoice(ctx *cli.Context) error {
 		DescriptionHash: descHash,
 		FallbackAddr:    ctx.String("fallback_addr"),
 		Expiry:          ctx.Int64("expiry"),
+		CltvExpiry:      ctx.Uint64("cltv_expiry_delta"),
 		Private:         ctx.Bool("private"),
 	}
 

--- a/docs/release-notes/release-notes-0.18.1.md
+++ b/docs/release-notes/release-notes-0.18.1.md
@@ -24,6 +24,10 @@
 ## RPC Additions
 ## lncli Additions
 
+* [Added](https://github.com/lightningnetwork/lnd/pull/8491) the `cltv_expiry`
+  argument to `addinvoice` and `addholdinvoice`, allowing users to set the
+  `min_final_cltv_expiry_delta`
+
 # Improvements
 ## Functional Updates
 ## RPC Updates

--- a/lnrpc/invoicesrpc/addinvoice.go
+++ b/lnrpc/invoicesrpc/addinvoice.go
@@ -367,7 +367,7 @@ func AddInvoice(ctx context.Context, cfg *AddInvoiceConfig,
 		if invoice.CltvExpiry < routing.MinCLTVDelta {
 			return nil, nil, fmt.Errorf("CLTV delta of %v must be "+
 				"greater than minimum of %v",
-				routing.MinCLTVDelta, invoice.CltvExpiry)
+				invoice.CltvExpiry, routing.MinCLTVDelta)
 		}
 
 		options = append(options,


### PR DESCRIPTION
This PR allows users of the `lncli` RPC interface to set the `min_final_cltv_expiry_delta` described in BOLT's [11](https://github.com/lightning/bolts/blob/master/11-payment-encoding.md#tagged-fields), [7](https://github.com/lightning/bolts/blob/master/07-routing-gossip.md#tagged-fields), and [2](https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#cltv_expiry_delta-selection) by setting the `cltv_expiry` flag when calling either `addinvoice` or `addholdinvoice`.

It also fixes an error message in `lnrpc/invoicesrpc/addinvoice.go` which printed the user-set `CltvExpiry` and the minimum allowed `CltvExpiry` in the wrong order when a value that was too low was used.

I can add a release note if that seems like a good idea.

## Steps to Test
To test this change, run `addinvoice` or `addholdinvoice` and set a `cltv_expiry` value.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new option for setting the minimum CLTV delta for the final hop on invoices, enhancing flexibility for users.
- **Bug Fixes**
	- Improved the clarity and accuracy of error messages when setting a CLTV delta below the required minimum.
- **Tests**
	- Added tests to validate the functionality and error handling of the new CLTV delta setting on invoices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->