### PR TITLE
multi: replace `LockOutpoint` with `LeaseOutput`

### DIFF
--- a/cmd/lncli/walletrpc_active.go
+++ b/cmd/lncli/walletrpc_active.go
@@ -22,6 +22,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
+	"github.com/lightningnetwork/lnd/lnwallet/chanfunding"
 	"github.com/urfave/cli"
 )
 
@@ -1537,7 +1538,7 @@ func releaseOutput(ctx *cli.Context) error {
 		return fmt.Errorf("error parsing outpoint: %w", err)
 	}
 
-	lockID := walletrpc.LndInternalLockID[:]
+	lockID := chanfunding.LndInternalLockID[:]
 	lockIDStr := ctx.String("lockid")
 	if lockIDStr != "" {
 		var err error

--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -90,6 +90,11 @@
   precision issue when querying payments and invoices using the start and end
   date filters.
 
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/8496) an issue where
+  `locked_balance` is not updated in `WalletBalanceResponse` when outputs are
+  reserved for `OpenChannel` by using non-volatile leases instead of volatile
+  locks.
+
 # New Features
 ## Functional Enhancements
 
@@ -336,6 +341,7 @@
 
 # Contributors (Alphabetical Order)
 
+* Alex Akselrod
 * Amin Bashiri
 * Andras Banki-Horvath
 * BitcoinerCoderBob

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -570,4 +570,8 @@ var allTestCases = []*lntest.TestCase{
 		Name:     "coop close with htlcs",
 		TestFunc: testCoopCloseWithHtlcs,
 	},
+	{
+		Name:     "open channel locked balance",
+		TestFunc: testOpenChannelLockedBalance,
+	},
 }

--- a/lncfg/config.go
+++ b/lncfg/config.go
@@ -69,10 +69,6 @@ const (
 	// closure.
 	DefaultOutgoingCltvRejectDelta = DefaultOutgoingBroadcastDelta + 3
 
-	// DefaultReservationTimeout is the default time we wait until we remove
-	// an unfinished (zombiestate) open channel flow from memory.
-	DefaultReservationTimeout = 10 * time.Minute
-
 	// DefaultZombieSweeperInterval is the default time interval at which
 	// unfinished (zombiestate) open channel flows are purged from memory.
 	DefaultZombieSweeperInterval = 1 * time.Minute

--- a/lncfg/dev.go
+++ b/lncfg/dev.go
@@ -4,6 +4,8 @@ package lncfg
 
 import (
 	"time"
+
+	"github.com/lightningnetwork/lnd/lnwallet/chanfunding"
 )
 
 // IsDevBuild returns a bool to indicate whether we are in a development
@@ -37,7 +39,7 @@ func (d *DevConfig) GetUnsafeDisconnect() bool {
 
 // GetReservationTimeout returns the config value for `ReservationTimeout`.
 func (d *DevConfig) GetReservationTimeout() time.Duration {
-	return DefaultReservationTimeout
+	return chanfunding.DefaultReservationTimeout
 }
 
 // GetZombieSweeperInterval returns the config value for`ZombieSweeperInterval`.

--- a/lncfg/dev_integration.go
+++ b/lncfg/dev_integration.go
@@ -4,6 +4,8 @@ package lncfg
 
 import (
 	"time"
+
+	"github.com/lightningnetwork/lnd/lnwallet/chanfunding"
 )
 
 // IsDevBuild returns a bool to indicate whether we are in a development
@@ -33,7 +35,7 @@ func (d *DevConfig) ChannelReadyWait() time.Duration {
 // GetReservationTimeout returns the config value for `ReservationTimeout`.
 func (d *DevConfig) GetReservationTimeout() time.Duration {
 	if d.ReservationTimeout == 0 {
-		return DefaultReservationTimeout
+		return chanfunding.DefaultReservationTimeout
 	}
 
 	return d.ReservationTimeout

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -184,18 +184,6 @@ var (
 	// configuration file in this package.
 	DefaultWalletKitMacFilename = "walletkit.macaroon"
 
-	// LndInternalLockID is the binary representation of the SHA256 hash of
-	// the string "lnd-internal-lock-id" and is used for UTXO lock leases to
-	// identify that we ourselves are locking an UTXO, for example when
-	// giving out a funded PSBT. The ID corresponds to the hex value of
-	// ede19a92ed321a4705f8a1cccc1d4f6182545d4bb4fae08bd5937831b7e38f98.
-	LndInternalLockID = wtxmgr.LockID{
-		0xed, 0xe1, 0x9a, 0x92, 0xed, 0x32, 0x1a, 0x47,
-		0x05, 0xf8, 0xa1, 0xcc, 0xcc, 0x1d, 0x4f, 0x61,
-		0x82, 0x54, 0x5d, 0x4b, 0xb4, 0xfa, 0xe0, 0x8b,
-		0xd5, 0x93, 0x78, 0x31, 0xb7, 0xe3, 0x8f, 0x98,
-	}
-
 	// allWitnessTypes is a mapping between the witness types defined in the
 	// `input` package, and the witness types in the protobuf definition.
 	// This map is necessary because the native enum and the protobuf enum
@@ -482,7 +470,7 @@ func (w *WalletKit) LeaseOutput(ctx context.Context,
 
 	// Don't allow our internal ID to be used externally for locking. Only
 	// unlocking is allowed.
-	if lockID == LndInternalLockID {
+	if lockID == chanfunding.LndInternalLockID {
 		return nil, errors.New("reserved id cannot be used")
 	}
 
@@ -492,7 +480,7 @@ func (w *WalletKit) LeaseOutput(ctx context.Context,
 	}
 
 	// Use the specified lock duration or fall back to the default.
-	duration := DefaultLockDuration
+	duration := chanfunding.DefaultLockDuration
 	if req.ExpirationSeconds != 0 {
 		duration = time.Duration(req.ExpirationSeconds) * time.Second
 	}

--- a/lntest/mock/walletcontroller.go
+++ b/lntest/mock/walletcontroller.go
@@ -186,12 +186,6 @@ func (w *WalletController) ListTransactionDetails(int32, int32,
 	return nil, nil
 }
 
-// LockOutpoint currently does nothing.
-func (w *WalletController) LockOutpoint(o wire.OutPoint) {}
-
-// UnlockOutpoint currently does nothing.
-func (w *WalletController) UnlockOutpoint(o wire.OutPoint) {}
-
 // LeaseOutput returns the current time and a nil error.
 func (w *WalletController) LeaseOutput(wtxmgr.LockID, wire.OutPoint,
 	time.Duration) (time.Time, []byte, btcutil.Amount, error) {

--- a/lntest/wait/timeouts_remote_db.go
+++ b/lntest/wait/timeouts_remote_db.go
@@ -20,7 +20,7 @@ const (
 
 	// DefaultTimeout is a timeout that will be used for various wait
 	// scenarios where no custom timeout value is defined.
-	DefaultTimeout = time.Second * 30
+	DefaultTimeout = time.Second * 45
 
 	// AsyncBenchmarkTimeout is the timeout used when running the async
 	// payments benchmark.

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -1052,28 +1052,6 @@ func (b *BtcWallet) CreateSimpleTx(outputs []*wire.TxOut,
 	)
 }
 
-// LockOutpoint marks an outpoint as locked meaning it will no longer be deemed
-// as eligible for coin selection. Locking outputs are utilized in order to
-// avoid race conditions when selecting inputs for usage when funding a
-// channel.
-//
-// NOTE: This method requires the global coin selection lock to be held.
-//
-// This is a part of the WalletController interface.
-func (b *BtcWallet) LockOutpoint(o wire.OutPoint) {
-	b.wallet.LockOutpoint(o)
-}
-
-// UnlockOutpoint unlocks a previously locked output, marking it eligible for
-// coin selection.
-//
-// NOTE: This method requires the global coin selection lock to be held.
-//
-// This is a part of the WalletController interface.
-func (b *BtcWallet) UnlockOutpoint(o wire.OutPoint) {
-	b.wallet.UnlockOutpoint(o)
-}
-
 // LeaseOutput locks an output to the given ID, preventing it from being
 // available for any future coin selection attempts. The absolute time of the
 // lock's expiration is returned. The expiration of the lock can be extended by

--- a/lnwallet/chanfunding/assembler.go
+++ b/lnwallet/chanfunding/assembler.go
@@ -1,9 +1,12 @@
 package chanfunding
 
 import (
+	"time"
+
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/wallet"
+	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 )
 
@@ -34,18 +37,18 @@ type CoinSelectionLocker interface {
 	WithCoinSelectLock(func() error) error
 }
 
-// OutpointLocker allows a caller to lock/unlock an outpoint. When locked, the
-// outpoints shouldn't be used for any sort of channel funding of coin
-// selection. Locked outpoints are not expected to be persisted between
-// restarts.
-type OutpointLocker interface {
-	// LockOutpoint locks a target outpoint, rendering it unusable for coin
+// OutputLeaser allows a caller to lease/release an output. When leased, the
+// outputs shouldn't be used for any sort of channel funding or coin selection.
+// Leased outputs are expected to be persisted between restarts.
+type OutputLeaser interface {
+	// LeaseOutput leases a target output, rendering it unusable for coin
 	// selection.
-	LockOutpoint(o wire.OutPoint)
+	LeaseOutput(i wtxmgr.LockID, o wire.OutPoint, d time.Duration) (
+		time.Time, []byte, btcutil.Amount, error)
 
-	// UnlockOutpoint unlocks a target outpoint, allowing it to be used for
+	// ReleaseOutput releases a target output, allowing it to be used for
 	// coin selection once again.
-	UnlockOutpoint(o wire.OutPoint)
+	ReleaseOutput(i wtxmgr.LockID, o wire.OutPoint) error
 }
 
 // Request is a new request for funding a channel. The items in the struct

--- a/lnwallet/chanfunding/wallet_assembler.go
+++ b/lnwallet/chanfunding/wallet_assembler.go
@@ -3,6 +3,7 @@ package chanfunding
 import (
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
@@ -10,8 +11,32 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/wallet"
+	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
+)
+
+const (
+	// DefaultReservationTimeout is the default time we wait until we remove
+	// an unfinished (zombiestate) open channel flow from memory.
+	DefaultReservationTimeout = 10 * time.Minute
+
+	// DefaultLockDuration is the default duration used to lock outputs.
+	DefaultLockDuration = 10 * time.Minute
+)
+
+var (
+	// LndInternalLockID is the binary representation of the SHA256 hash of
+	// the string "lnd-internal-lock-id" and is used for UTXO lock leases to
+	// identify that we ourselves are locking an UTXO, for example when
+	// giving out a funded PSBT. The ID corresponds to the hex value of
+	// ede19a92ed321a4705f8a1cccc1d4f6182545d4bb4fae08bd5937831b7e38f98.
+	LndInternalLockID = wtxmgr.LockID{
+		0xed, 0xe1, 0x9a, 0x92, 0xed, 0x32, 0x1a, 0x47,
+		0x05, 0xf8, 0xa1, 0xcc, 0xcc, 0x1d, 0x4f, 0x61,
+		0x82, 0x54, 0x5d, 0x4b, 0xb4, 0xfa, 0xe0, 0x8b,
+		0xd5, 0x93, 0x78, 0x31, 0xb7, 0xe3, 0x8f, 0x98,
+	}
 )
 
 // FullIntent is an intent that is fully backed by the internal wallet. This

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -393,20 +393,6 @@ type WalletController interface {
 	ListTransactionDetails(startHeight, endHeight int32,
 		accountFilter string) ([]*TransactionDetail, error)
 
-	// LockOutpoint marks an outpoint as locked meaning it will no longer
-	// be deemed as eligible for coin selection. Locking outputs are
-	// utilized in order to avoid race conditions when selecting inputs for
-	// usage when funding a channel.
-	//
-	// NOTE: This method requires the global coin selection lock to be held.
-	LockOutpoint(o wire.OutPoint)
-
-	// UnlockOutpoint unlocks a previously locked output, marking it
-	// eligible for coin selection.
-	//
-	// NOTE: This method requires the global coin selection lock to be held.
-	UnlockOutpoint(o wire.OutPoint)
-
 	// LeaseOutput locks an output to the given ID, preventing it from being
 	// available for any future coin selection attempts. The absolute time
 	// of the lock's expiration is returned. The expiration of the lock can

--- a/lnwallet/mock.go
+++ b/lnwallet/mock.go
@@ -192,12 +192,6 @@ func (w *mockWalletController) ListTransactionDetails(int32, int32,
 	return nil, nil
 }
 
-// LockOutpoint currently does nothing.
-func (w *mockWalletController) LockOutpoint(o wire.OutPoint) {}
-
-// UnlockOutpoint currently does nothing.
-func (w *mockWalletController) UnlockOutpoint(o wire.OutPoint) {}
-
 // LeaseOutput returns the current time and a nil error.
 func (w *mockWalletController) LeaseOutput(wtxmgr.LockID, wire.OutPoint,
 	time.Duration) (time.Time, []byte, btcutil.Amount, error) {

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -2990,7 +2990,7 @@ func testSingleFunderExternalFundingTx(miner *rpctest.Harness,
 		chanfunding.WalletConfig{
 			CoinSource:            lnwallet.NewCoinSource(alice),
 			CoinSelectLocker:      alice,
-			CoinLocker:            alice,
+			CoinLeaser:            alice,
 			Signer:                alice.Cfg.Signer,
 			DustLimit:             600,
 			CoinSelectionStrategy: wallet.CoinSelectionLargest,

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -588,7 +588,7 @@ func (l *LightningWallet) ResetReservations() {
 	l.reservationIDs = make(map[[32]byte]uint64)
 
 	for outpoint := range l.lockedOutPoints {
-		l.UnlockOutpoint(outpoint)
+		_ = l.ReleaseOutput(chanfunding.LndInternalLockID, outpoint)
 	}
 	l.lockedOutPoints = make(map[wire.OutPoint]struct{})
 }
@@ -1425,7 +1425,10 @@ func (l *LightningWallet) handleFundingCancelRequest(req *fundingReserveCancelMs
 	// requests.
 	for _, unusedInput := range pendingReservation.ourContribution.Inputs {
 		delete(l.lockedOutPoints, unusedInput.PreviousOutPoint)
-		l.UnlockOutpoint(unusedInput.PreviousOutPoint)
+		_ = l.ReleaseOutput(
+			chanfunding.LndInternalLockID,
+			unusedInput.PreviousOutPoint,
+		)
 	}
 
 	// TODO(roasbeef): is it even worth it to keep track of unused keys?

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -851,7 +851,7 @@ func (l *LightningWallet) handleFundingReserveRequest(req *InitFundingReserveMsg
 		cfg := chanfunding.WalletConfig{
 			CoinSource:       &CoinSource{l},
 			CoinSelectLocker: l,
-			CoinLocker:       l,
+			CoinLeaser:       l,
 			Signer:           l.Cfg.Signer,
 			DustLimit: DustLimitForSize(
 				input.P2WSHSize,

--- a/server.go
+++ b/server.go
@@ -53,6 +53,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	"github.com/lightningnetwork/lnd/lnwallet/chanfunding"
 	"github.com/lightningnetwork/lnd/lnwallet/rpcwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/nat"
@@ -1276,7 +1277,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 	// For the reservationTimeout and the zombieSweeperInterval different
 	// values are set in case we are in a dev environment so enhance test
 	// capacilities.
-	reservationTimeout := lncfg.DefaultReservationTimeout
+	reservationTimeout := chanfunding.DefaultReservationTimeout
 	zombieSweeperInterval := lncfg.DefaultZombieSweeperInterval
 
 	// Get the development config for funding manager. If we are not in


### PR DESCRIPTION
## Change Description
This fixes #8476.

## Steps to Test
The first commit, containing an integration test, is sufficient to test the change. The integration test fails when run prior to merging the subsequent commits which fix the issue, and passes after.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an enhanced output leasing mechanism for more efficient handling of channel funding processes.

- **Refactor**
	- Updated and unified the output locking mechanism across the system to use the new `OutputLeaser` interface.
	- Removed obsolete locking and unlocking functionalities from various components.

- **Tests**
	- Added new test cases to verify the behavior of locked balance during channel opening processes.

- **Chores**
	- Cleaned up unused import statements and outdated references to improve code maintainability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->