### PR TITLE
multi: upgrade new taproot TLVs to use tlv.OptionalRecordT 

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -1551,7 +1551,7 @@ func (c *OpenChannel) ChanSyncMsg() (*lnwire.ChannelReestablish, error) {
 	// If this is a taproot channel, then we'll need to generate our next
 	// verification nonce to send to the remote party. They'll use this to
 	// sign the next update to our commitment transaction.
-	var nextTaprootNonce *lnwire.Musig2Nonce
+	var nextTaprootNonce lnwire.OptMusig2NonceTLV
 	if c.ChanType.IsTaproot() {
 		taprootRevProducer, err := DeriveMusig2Shachain(
 			c.RevocationProducer,
@@ -1569,7 +1569,7 @@ func (c *OpenChannel) ChanSyncMsg() (*lnwire.ChannelReestablish, error) {
 				"nonce: %w", err)
 		}
 
-		nextTaprootNonce = (*lnwire.Musig2Nonce)(&nextNonce.PubNonce)
+		nextTaprootNonce = lnwire.SomeMusig2Nonce(nextNonce.PubNonce)
 	}
 
 	return &lnwire.ChannelReestablish{

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -48,6 +48,14 @@ var (
 	//
 	// NOTE: for itest, this value is changed to 10ms.
 	checkPeerChannelReadyInterval = 1 * time.Second
+
+	// errNoLocalNonce is returned when a local nonce is not found in the
+	// expected TLV.
+	errNoLocalNonce = fmt.Errorf("local nonce not found")
+
+	// errNoPartialSig is returned when a partial sig is not found in the
+	// expected TLV.
+	errNoPartialSig = fmt.Errorf("partial sig not found")
 )
 
 // WriteOutpoint writes an outpoint to an io.Writer. This is not the same as
@@ -1801,17 +1809,17 @@ func (f *Manager) fundeeProcessOpenChannel(peer lnpeer.Peer,
 	}
 
 	if resCtx.reservation.IsTaproot() {
-		if msg.LocalNonce == nil {
-			err := fmt.Errorf("local nonce not set for taproot " +
-				"chan")
-			log.Error(err)
-			f.failFundingFlow(
-				resCtx.peer, cid, err,
-			)
+		localNonce, err := msg.LocalNonce.UnwrapOrErrV(errNoLocalNonce)
+		if err != nil {
+			log.Error(errNoLocalNonce)
+
+			f.failFundingFlow(resCtx.peer, cid, errNoLocalNonce)
+
+			return
 		}
 
 		remoteContribution.LocalNonce = &musig2.Nonces{
-			PubNonce: *msg.LocalNonce,
+			PubNonce: localNonce,
 		}
 	}
 
@@ -1826,13 +1834,6 @@ func (f *Manager) fundeeProcessOpenChannel(peer lnpeer.Peer,
 		msg.PendingChannelID)
 	log.Debugf("Remote party accepted commitment constraints: %v",
 		spew.Sdump(remoteContribution.ChannelConfig.ChannelConstraints))
-
-	var localNonce *lnwire.Musig2Nonce
-	if commitType.IsTaproot() {
-		localNonce = (*lnwire.Musig2Nonce)(
-			&ourContribution.LocalNonce.PubNonce,
-		)
-	}
 
 	// With the initiator's contribution recorded, respond with our
 	// contribution in the next message of the workflow.
@@ -1854,7 +1855,12 @@ func (f *Manager) fundeeProcessOpenChannel(peer lnpeer.Peer,
 		UpfrontShutdownScript: ourContribution.UpfrontShutdown,
 		ChannelType:           chanType,
 		LeaseExpiry:           msg.LeaseExpiry,
-		LocalNonce:            localNonce,
+	}
+
+	if commitType.IsTaproot() {
+		fundingAccept.LocalNonce = lnwire.SomeMusig2Nonce(
+			ourContribution.LocalNonce.PubNonce,
+		)
 	}
 
 	if err := peer.SendMessage(true, &fundingAccept); err != nil {
@@ -2044,15 +2050,17 @@ func (f *Manager) funderProcessAcceptChannel(peer lnpeer.Peer,
 	}
 
 	if resCtx.reservation.IsTaproot() {
-		if msg.LocalNonce == nil {
-			err := fmt.Errorf("local nonce not set for taproot " +
-				"chan")
-			log.Error(err)
-			f.failFundingFlow(resCtx.peer, cid, err)
+		localNonce, err := msg.LocalNonce.UnwrapOrErrV(errNoLocalNonce)
+		if err != nil {
+			log.Error(errNoLocalNonce)
+
+			f.failFundingFlow(resCtx.peer, cid, errNoLocalNonce)
+
+			return
 		}
 
 		remoteContribution.LocalNonce = &musig2.Nonces{
-			PubNonce: *msg.LocalNonce,
+			PubNonce: localNonce,
 		}
 	}
 
@@ -2263,7 +2271,9 @@ func (f *Manager) continueFundingAccept(resCtx *reservationWithCtx,
 			return
 		}
 
-		fundingCreated.PartialSig = partialSig.ToWireSig()
+		fundingCreated.PartialSig = lnwire.MaybePartialSigWithNonce(
+			partialSig.ToWireSig(),
+		)
 	} else {
 		fundingCreated.CommitSig, err = lnwire.NewSigFromSignature(sig)
 		if err != nil {
@@ -2317,14 +2327,15 @@ func (f *Manager) fundeeProcessFundingCreated(peer lnpeer.Peer,
 	// our internal input.Signature type.
 	var commitSig input.Signature
 	if resCtx.reservation.IsTaproot() {
-		if msg.PartialSig == nil {
-			log.Errorf("partial sig not included: %v", err)
+		partialSig, err := msg.PartialSig.UnwrapOrErrV(errNoPartialSig)
+		if err != nil {
 			f.failFundingFlow(peer, cid, err)
+
 			return
 		}
 
 		commitSig = new(lnwallet.MusigPartialSig).FromWireSig(
-			msg.PartialSig,
+			&partialSig,
 		)
 	} else {
 		commitSig, err = msg.CommitSig.ToSignature()
@@ -2408,7 +2419,9 @@ func (f *Manager) fundeeProcessFundingCreated(peer lnpeer.Peer,
 			return
 		}
 
-		fundingSigned.PartialSig = partialSig.ToWireSig()
+		fundingSigned.PartialSig = lnwire.MaybePartialSigWithNonce(
+			partialSig.ToWireSig(),
+		)
 	} else {
 		fundingSigned.CommitSig, err = lnwire.NewSigFromSignature(sig)
 		if err != nil {
@@ -2565,14 +2578,15 @@ func (f *Manager) funderProcessFundingSigned(peer lnpeer.Peer,
 	// our internal input.Signature type.
 	var commitSig input.Signature
 	if resCtx.reservation.IsTaproot() {
-		if msg.PartialSig == nil {
-			log.Errorf("partial sig not included: %v", err)
+		partialSig, err := msg.PartialSig.UnwrapOrErrV(errNoPartialSig)
+		if err != nil {
 			f.failFundingFlow(peer, cid, err)
+
 			return
 		}
 
 		commitSig = new(lnwallet.MusigPartialSig).FromWireSig(
-			msg.PartialSig,
+			&partialSig,
 		)
 	} else {
 		commitSig, err = msg.CommitSig.ToSignature()
@@ -3153,8 +3167,8 @@ func (f *Manager) sendChannelReady(completeChan *channeldb.OpenChannel,
 		}
 		f.nonceMtx.Unlock()
 
-		channelReadyMsg.NextLocalNonce = (*lnwire.Musig2Nonce)(
-			&localNonce.PubNonce,
+		channelReadyMsg.NextLocalNonce = lnwire.SomeMusig2Nonce(
+			localNonce.PubNonce,
 		)
 	}
 
@@ -3824,11 +3838,9 @@ func (f *Manager) handleChannelReady(peer lnpeer.Peer, //nolint:funlen
 			channelReadyMsg.AliasScid = &alias
 
 			if firstVerNonce != nil {
-				wireNonce := (*lnwire.Musig2Nonce)(
-					&firstVerNonce.PubNonce,
+				channelReadyMsg.NextLocalNonce = lnwire.SomeMusig2Nonce( //nolint:lll
+					firstVerNonce.PubNonce,
 				)
-
-				channelReadyMsg.NextLocalNonce = wireNonce
 			}
 
 			err = peer.SendMessage(true, channelReadyMsg)
@@ -3873,8 +3885,13 @@ func (f *Manager) handleChannelReady(peer lnpeer.Peer, //nolint:funlen
 		log.Infof("ChanID(%v): applying local+remote musig2 nonces",
 			chanID)
 
-		if msg.NextLocalNonce == nil {
-			log.Errorf("remote nonces are nil")
+		remoteNonce, err := msg.NextLocalNonce.UnwrapOrErrV(
+			errNoLocalNonce,
+		)
+		if err != nil {
+			cid := newChanIdentifier(msg.ChanID)
+			f.failFundingFlow(peer, cid, err)
+
 			return
 		}
 
@@ -3882,7 +3899,7 @@ func (f *Manager) handleChannelReady(peer lnpeer.Peer, //nolint:funlen
 			chanOpts,
 			lnwallet.WithLocalMusigNonces(localNonce),
 			lnwallet.WithRemoteMusigNonces(&musig2.Nonces{
-				PubNonce: *msg.NextLocalNonce,
+				PubNonce: remoteNonce,
 			}),
 		)
 	}
@@ -4714,13 +4731,6 @@ func (f *Manager) handleInitFundingMsg(msg *InitFundingMsg) {
 	log.Infof("Starting funding workflow with %v for pending_id(%x), "+
 		"committype=%v", msg.Peer.Address(), chanID, commitType)
 
-	var localNonce *lnwire.Musig2Nonce
-	if commitType.IsTaproot() {
-		localNonce = (*lnwire.Musig2Nonce)(
-			&ourContribution.LocalNonce.PubNonce,
-		)
-	}
-
 	fundingOpen := lnwire.OpenChannel{
 		ChainHash:             *f.cfg.Wallet.Cfg.NetParams.GenesisHash,
 		PendingChannelID:      chanID,
@@ -4743,8 +4753,14 @@ func (f *Manager) handleInitFundingMsg(msg *InitFundingMsg) {
 		UpfrontShutdownScript: shutdown,
 		ChannelType:           chanType,
 		LeaseExpiry:           leaseExpiry,
-		LocalNonce:            localNonce,
 	}
+
+	if commitType.IsTaproot() {
+		fundingOpen.LocalNonce = lnwire.SomeMusig2Nonce(
+			ourContribution.LocalNonce.PubNonce,
+		)
+	}
+
 	if err := msg.Peer.SendMessage(true, &fundingOpen); err != nil {
 		e := fmt.Errorf("unable to send funding request message: %v",
 			err)

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/lightningnetwork/lnd/kvdb v1.4.5
 	github.com/lightningnetwork/lnd/queue v1.1.1
 	github.com/lightningnetwork/lnd/ticker v1.1.1
-	github.com/lightningnetwork/lnd/tlv v1.2.1
+	github.com/lightningnetwork/lnd/tlv v1.2.3
 	github.com/lightningnetwork/lnd/tor v1.1.2
 	github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796
 	github.com/miekg/dns v1.1.43

--- a/go.sum
+++ b/go.sum
@@ -438,8 +438,8 @@ github.com/lightningnetwork/lnd/queue v1.1.1 h1:99ovBlpM9B0FRCGYJo6RSFDlt8/vOkQQ
 github.com/lightningnetwork/lnd/queue v1.1.1/go.mod h1:7A6nC1Qrm32FHuhx/mi1cieAiBZo5O6l8IBIoQxvkz4=
 github.com/lightningnetwork/lnd/ticker v1.1.1 h1:J/b6N2hibFtC7JLV77ULQp++QLtCwT6ijJlbdiZFbSM=
 github.com/lightningnetwork/lnd/ticker v1.1.1/go.mod h1:waPTRAAcwtu7Ji3+3k+u/xH5GHovTsCoSVpho0KDvdA=
-github.com/lightningnetwork/lnd/tlv v1.2.1 h1:zV6nBuPNKthAnDc2UR8D8RK+408w3eumRsiJFf3ukyU=
-github.com/lightningnetwork/lnd/tlv v1.2.1/go.mod h1:GJ1JLyA7FWJsjJ2zKJe9+urxwYi15GweC8c509mUfCs=
+github.com/lightningnetwork/lnd/tlv v1.2.3 h1:If5ibokA/UoCBGuCKaY6Vn2SJU0l9uAbehCnhTZjEP8=
+github.com/lightningnetwork/lnd/tlv v1.2.3/go.mod h1:zDkmqxOczP6LaLTvSFDQ1SJUfHcQRCMKFj93dn3eMB8=
 github.com/lightningnetwork/lnd/tor v1.1.2 h1:3zv9z/EivNFaMF89v3ciBjCS7kvCj4ZFG7XvD2Qq0/k=
 github.com/lightningnetwork/lnd/tor v1.1.2/go.mod h1:j7T9uJ2NLMaHwE7GiBGnpYLn4f7NRoTM6qj+ul6/ycA=
 github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796 h1:sjOGyegMIhvgfq5oaue6Td+hxZuf3tDC8lAPrFldqFw=

--- a/lnwallet/chancloser/chancloser_test.go
+++ b/lnwallet/chancloser/chancloser_test.go
@@ -541,11 +541,9 @@ func TestTaprootFastClose(t *testing.T) {
 	require.True(t, oShutdown.IsSome())
 	require.True(t, oClosingSigned.IsNone())
 
-	bobShutdown := oShutdown.UnsafeFromSome()
-
 	// Alice should process the shutdown message, and create a closing
 	// signed of her own.
-	oShutdown, err = aliceCloser.ReceiveShutdown(bobShutdown)
+	oShutdown, err = aliceCloser.ReceiveShutdown(oShutdown.UnwrapOrFail(t))
 	require.NoError(t, err)
 	oClosingSigned, err = aliceCloser.BeginNegotiation()
 	require.NoError(t, err)
@@ -554,7 +552,7 @@ func TestTaprootFastClose(t *testing.T) {
 	require.True(t, oShutdown.IsNone())
 	require.True(t, oClosingSigned.IsSome())
 
-	aliceClosingSigned := oClosingSigned.UnsafeFromSome()
+	aliceClosingSigned := oClosingSigned.UnwrapOrFail(t)
 
 	// Next, Bob will process the closing signed message, and send back a
 	// new one that should match exactly the offer Alice sent.
@@ -564,7 +562,7 @@ func TestTaprootFastClose(t *testing.T) {
 	require.NotNil(t, tx)
 	require.True(t, oClosingSigned.IsSome())
 
-	bobClosingSigned := oClosingSigned.UnsafeFromSome()
+	bobClosingSigned := oClosingSigned.UnwrapOrFail(t)
 
 	// At this point, Bob has accepted the offer, so he can broadcast the
 	// closing transaction, and considers the channel closed.
@@ -597,7 +595,7 @@ func TestTaprootFastClose(t *testing.T) {
 	require.NotNil(t, tx)
 	require.True(t, oClosingSigned.IsSome())
 
-	aliceClosingSigned = oClosingSigned.UnsafeFromSome()
+	aliceClosingSigned = oClosingSigned.UnwrapOrFail(t)
 
 	// Alice should now also broadcast her closing transaction.
 	_, err = lnutils.RecvOrTimeout(broadcastSignal, time.Second*1)

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -2875,10 +2875,10 @@ func assertNoChanSyncNeeded(t *testing.T, aliceChannel *LightningChannel,
 	// nonces.
 	if aliceChannel.channelState.ChanType.IsTaproot() {
 		aliceChannel.pendingVerificationNonce = &musig2.Nonces{
-			PubNonce: *aliceChanSyncMsg.LocalNonce,
+			PubNonce: aliceChanSyncMsg.LocalNonce.UnwrapOrFailV(t),
 		}
 		bobChannel.pendingVerificationNonce = &musig2.Nonces{
-			PubNonce: *bobChanSyncMsg.LocalNonce,
+			PubNonce: bobChanSyncMsg.LocalNonce.UnwrapOrFailV(t),
 		}
 	}
 
@@ -3486,10 +3486,10 @@ func testChanSyncOweRevocation(t *testing.T, chanType channeldb.ChannelType) {
 	// nonces.
 	if chanType.IsTaproot() {
 		aliceChannel.pendingVerificationNonce = &musig2.Nonces{
-			PubNonce: *aliceSyncMsg.LocalNonce,
+			PubNonce: aliceSyncMsg.LocalNonce.UnwrapOrFail(t).Val,
 		}
 		bobChannel.pendingVerificationNonce = &musig2.Nonces{
-			PubNonce: *bobSyncMsg.LocalNonce,
+			PubNonce: bobSyncMsg.LocalNonce.UnwrapOrFail(t).Val,
 		}
 	}
 
@@ -3548,10 +3548,10 @@ func testChanSyncOweRevocation(t *testing.T, chanType channeldb.ChannelType) {
 	// nonces.
 	if chanType.IsTaproot() {
 		aliceChannel.pendingVerificationNonce = &musig2.Nonces{
-			PubNonce: *aliceSyncMsg.LocalNonce,
+			PubNonce: aliceSyncMsg.LocalNonce.UnwrapOrFailV(t),
 		}
 		bobChannel.pendingVerificationNonce = &musig2.Nonces{
-			PubNonce: *bobSyncMsg.LocalNonce,
+			PubNonce: bobSyncMsg.LocalNonce.UnwrapOrFailV(t),
 		}
 	}
 
@@ -3671,10 +3671,10 @@ func testChanSyncOweRevocationAndCommit(t *testing.T,
 	// nonces.
 	if chanType.IsTaproot() {
 		aliceChannel.pendingVerificationNonce = &musig2.Nonces{
-			PubNonce: *aliceSyncMsg.LocalNonce,
+			PubNonce: aliceSyncMsg.LocalNonce.UnwrapOrFailV(t),
 		}
 		bobChannel.pendingVerificationNonce = &musig2.Nonces{
-			PubNonce: *bobSyncMsg.LocalNonce,
+			PubNonce: bobSyncMsg.LocalNonce.UnwrapOrFailV(t),
 		}
 	}
 
@@ -3751,10 +3751,10 @@ func testChanSyncOweRevocationAndCommit(t *testing.T,
 	// nonces.
 	if chanType.IsTaproot() {
 		aliceChannel.pendingVerificationNonce = &musig2.Nonces{
-			PubNonce: *aliceSyncMsg.LocalNonce,
+			PubNonce: aliceSyncMsg.LocalNonce.UnwrapOrFailV(t),
 		}
 		bobChannel.pendingVerificationNonce = &musig2.Nonces{
-			PubNonce: *bobSyncMsg.LocalNonce,
+			PubNonce: bobSyncMsg.LocalNonce.UnwrapOrFailV(t),
 		}
 	}
 
@@ -3888,10 +3888,10 @@ func testChanSyncOweRevocationAndCommitForceTransition(t *testing.T,
 	// nonces.
 	if chanType.IsTaproot() {
 		aliceChannel.pendingVerificationNonce = &musig2.Nonces{
-			PubNonce: *aliceSyncMsg.LocalNonce,
+			PubNonce: aliceSyncMsg.LocalNonce.UnwrapOrFailV(t),
 		}
 		bobChannel.pendingVerificationNonce = &musig2.Nonces{
-			PubNonce: *bobSyncMsg.LocalNonce,
+			PubNonce: bobSyncMsg.LocalNonce.UnwrapOrFailV(t),
 		}
 	}
 

--- a/lnwire/closing_complete.go
+++ b/lnwire/closing_complete.go
@@ -50,9 +50,9 @@ type ClosingComplete struct {
 // decodeClosingSigs decodes the closing sig TLV records in the passed
 // ExtraOpaqueData.
 func decodeClosingSigs(c *ClosingSigs, tlvRecords ExtraOpaqueData) error {
-	sig1 := tlv.ZeroRecordT[tlv.TlvType1, Sig]()
-	sig2 := tlv.ZeroRecordT[tlv.TlvType2, Sig]()
-	sig3 := tlv.ZeroRecordT[tlv.TlvType3, Sig]()
+	sig1 := c.CloserNoClosee.Zero()
+	sig2 := c.NoCloserClosee.Zero()
+	sig3 := c.CloserAndClosee.Zero()
 
 	typeMap, err := tlvRecords.ExtractRecords(&sig1, &sig2, &sig3)
 	if err != nil {

--- a/lnwire/funding_signed.go
+++ b/lnwire/funding_signed.go
@@ -24,7 +24,7 @@ type FundingSigned struct {
 	//
 	// NOTE: This field is only populated if a musig2 taproot channel is
 	// being signed for. In this case, the above Sig type MUST be blank.
-	PartialSig *PartialSigWithNonce
+	PartialSig OptPartialSigWithNonceTLV
 
 	// ExtraData is the set of data that was appended to this message to
 	// fill out the full maximum transport message size. These fields can
@@ -43,9 +43,9 @@ var _ Message = (*FundingSigned)(nil)
 // This is part of the lnwire.Message interface.
 func (f *FundingSigned) Encode(w *bytes.Buffer, pver uint32) error {
 	recordProducers := make([]tlv.RecordProducer, 0, 1)
-	if f.PartialSig != nil {
-		recordProducers = append(recordProducers, f.PartialSig)
-	}
+	f.PartialSig.WhenSome(func(sig PartialSigWithNonceTLV) {
+		recordProducers = append(recordProducers, &sig)
+	})
 	err := EncodeMessageExtraData(&f.ExtraData, recordProducers...)
 	if err != nil {
 		return err
@@ -78,17 +78,15 @@ func (f *FundingSigned) Decode(r io.Reader, pver uint32) error {
 		return err
 	}
 
-	var (
-		partialSig PartialSigWithNonce
-	)
+	partialSig := f.PartialSig.Zero()
 	typeMap, err := tlvRecords.ExtractRecords(&partialSig)
 	if err != nil {
 		return err
 	}
 
 	// Set the corresponding TLV types if they were included in the stream.
-	if val, ok := typeMap[PartialSigWithNonceRecordType]; ok && val == nil {
-		f.PartialSig = &partialSig
+	if val, ok := typeMap[f.PartialSig.TlvType()]; ok && val == nil {
+		f.PartialSig = tlv.SomeRecordT(partialSig)
 	}
 
 	if len(tlvRecords) != 0 {


### PR DESCRIPTION
In this commit, we update new Taproot related TLVs (nonces, partial sig,
sig with nonce, etc). Along the way we were able to get rid of some
boiler plate, but most importantly, we're able to better protect against
API misuse (using a nonce that isn't initialized, etc) with the new
options API. In some areas this introduces a bit of extra boiler plate,
and where applicable I used some new helper functions to help cut down
on the noise.

**Note to reviewers**: this is done as a single commit, as changing the API
breaks all callers, so if we want things to compile it needs to be in a
wumbo commit.


### TODO 

- [x] Update unit tests 
- [x] Use added type aliases and helper functions uniformly 