### PR TITLE
htlcswitch+peer+lnwire: pull weeds

### DIFF
--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -7,7 +7,6 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/invoices"
-	"github.com/lightningnetwork/lnd/lnpeer"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -262,9 +261,9 @@ type ChannelLink interface {
 	// total sent/received milli-satoshis.
 	Stats() (uint64, lnwire.MilliSatoshi, lnwire.MilliSatoshi)
 
-	// Peer returns the representation of remote peer with which we have
-	// the channel link opened.
-	Peer() lnpeer.Peer
+	// Peer returns the serialized public key of remote peer with which we
+	// have the channel link opened.
+	PeerPubKey() [33]byte
 
 	// AttachMailBox delivers an active MailBox to the link. The MailBox may
 	// have buffered messages.

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -92,13 +92,6 @@ type ChannelLinkConfig struct {
 	// allowing the link to open and close circuits.
 	Circuits CircuitModifier
 
-	// Switch provides a reference to the HTLC switch, we only use this in
-	// testing to access circuit operations not typically exposed by the
-	// CircuitModifier.
-	//
-	// TODO(conner): remove after refactoring htlcswitch testing framework.
-	Switch *Switch
-
 	// BestHeight returns the best known height.
 	BestHeight func() uint32
 

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -2552,8 +2552,8 @@ func (l *channelLink) updateCommitTx() error {
 // channel link opened.
 //
 // NOTE: Part of the ChannelLink interface.
-func (l *channelLink) Peer() lnpeer.Peer {
-	return l.cfg.Peer
+func (l *channelLink) PeerPubKey() [33]byte {
+	return l.cfg.Peer.PubKey()
 }
 
 // ChannelPoint returns the channel outpoint for the channel link.

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -320,9 +320,6 @@ type channelLink struct {
 	// updates.
 	channel *lnwallet.LightningChannel
 
-	// shortChanID is the most up to date short channel ID for the link.
-	shortChanID lnwire.ShortChannelID
-
 	// cfg is a structure which carries all dependable fields/handlers
 	// which may affect behaviour of the service.
 	cfg ChannelLinkConfig
@@ -455,7 +452,6 @@ func NewChannelLink(cfg ChannelLinkConfig,
 	return &channelLink{
 		cfg:                 cfg,
 		channel:             channel,
-		shortChanID:         channel.ShortChanID(),
 		hodlMap:             make(map[models.CircuitKey]hodlHtlc),
 		hodlQueue:           queue.NewConcurrentQueue(10),
 		log:                 build.NewPrefixLog(logPrefix, log),
@@ -2202,7 +2198,7 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 		for id, settled := range finalHTLCs {
 			l.cfg.HtlcNotifier.NotifyFinalHtlcEvent(
 				models.CircuitKey{
-					ChanID: l.shortChanID,
+					ChanID: l.ShortChanID(),
 					HtlcID: id,
 				},
 				channeldb.FinalHtlcInfo{
@@ -2582,7 +2578,7 @@ func (l *channelLink) ShortChanID() lnwire.ShortChannelID {
 	l.RLock()
 	defer l.RUnlock()
 
-	return l.shortChanID
+	return l.channel.ShortChanID()
 }
 
 // UpdateShortChanID updates the short channel ID for a link. This may be

--- a/htlcswitch/link_isolated_test.go
+++ b/htlcswitch/link_isolated_test.go
@@ -13,9 +13,10 @@ import (
 type linkTestContext struct {
 	t *testing.T
 
-	aliceLink  ChannelLink
-	bobChannel *lnwallet.LightningChannel
-	aliceMsgs  <-chan lnwire.Message
+	aliceSwitch *Switch
+	aliceLink   ChannelLink
+	bobChannel  *lnwallet.LightningChannel
+	aliceMsgs   <-chan lnwire.Message
 }
 
 // sendHtlcBobToAlice sends an HTLC from Bob to Alice, that pays to a preimage
@@ -39,7 +40,7 @@ func (l *linkTestContext) sendHtlcAliceToBob(htlcID int,
 
 	l.t.Helper()
 
-	circuitMap := l.aliceLink.(*channelLink).cfg.Switch.circuits
+	circuitMap := l.aliceSwitch.circuits
 	fwdActions, err := circuitMap.CommitCircuits(
 		&PaymentCircuit{
 			Incoming: CircuitKey{

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -891,10 +891,22 @@ func (f *mockChannelLink) Start() error {
 	return nil
 }
 
-func (f *mockChannelLink) ChanID() lnwire.ChannelID                     { return f.chanID }
-func (f *mockChannelLink) ShortChanID() lnwire.ShortChannelID           { return f.shortChanID }
-func (f *mockChannelLink) Bandwidth() lnwire.MilliSatoshi               { return 99999999 }
-func (f *mockChannelLink) Peer() lnpeer.Peer                            { return f.peer }
+func (f *mockChannelLink) ChanID() lnwire.ChannelID {
+	return f.chanID
+}
+
+func (f *mockChannelLink) ShortChanID() lnwire.ShortChannelID {
+	return f.shortChanID
+}
+
+func (f *mockChannelLink) Bandwidth() lnwire.MilliSatoshi {
+	return 99999999
+}
+
+func (f *mockChannelLink) PeerPubKey() [33]byte {
+	return f.peer.PubKey()
+}
+
 func (f *mockChannelLink) ChannelPoint() *wire.OutPoint                 { return &wire.OutPoint{} }
 func (f *mockChannelLink) Stop()                                        {}
 func (f *mockChannelLink) EligibleToForward() bool                      { return f.eligible }

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -1147,7 +1147,7 @@ func (s *Switch) handlePacketForward(packet *htlcPacket) error {
 
 			return s.failAddPacket(packet, linkError)
 		}
-		targetPeerKey := targetLink.Peer().PubKey()
+		targetPeerKey := targetLink.PeerPubKey()
 		interfaceLinks, _ := s.getLinks(targetPeerKey)
 		s.indexMtx.RUnlock()
 
@@ -1810,9 +1810,9 @@ out:
 			}
 			s.indexMtx.RUnlock()
 
-			peerPub := link.Peer().PubKey()
+			peerPub := link.PeerPubKey()
 			log.Debugf("Requesting local channel close: peer=%v, "+
-				"chan_id=%x", link.Peer(), chanID[:])
+				"chan_id=%x", link.PeerPubKey(), chanID[:])
 
 			go s.cfg.LocalChannelClose(peerPub[:], req)
 
@@ -2335,7 +2335,7 @@ func (s *Switch) addLiveLink(link ChannelLink) {
 
 	// Next we'll add the link to the interface index so we can
 	// quickly look up all the channels for a particular node.
-	peerPub := link.Peer().PubKey()
+	peerPub := link.PeerPubKey()
 	if _, ok := s.interfaceIndex[peerPub]; !ok {
 		s.interfaceIndex[peerPub] = make(map[lnwire.ChannelID]ChannelLink)
 	}
@@ -2610,7 +2610,7 @@ func (s *Switch) removeLink(chanID lnwire.ChannelID) ChannelLink {
 
 	// If the link has been added to the peer index, then we'll move to
 	// delete the entry within the index.
-	peerPub := link.Peer().PubKey()
+	peerPub := link.PeerPubKey()
 	if peerIndex, ok := s.interfaceIndex[peerPub]; ok {
 		delete(peerIndex, link.ChanID())
 

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -5263,9 +5263,11 @@ func testSwitchHandlePacketForward(t *testing.T, zeroConf, private,
 	t.Parallel()
 
 	// Create a link for Alice that we'll add to the switch.
-	aliceLink, _, _, _, _, err :=
+	harness, err :=
 		newSingleLinkTestHarness(t, btcutil.SatoshiPerBitcoin, 0)
 	require.NoError(t, err)
+
+	aliceLink := harness.aliceLink
 
 	s, err := initSwitchWithTempDB(t, testStartingHeight)
 	if err != nil {

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -5313,7 +5313,6 @@ func testSwitchHandlePacketForward(t *testing.T, zeroConf, private,
 	if zeroConf {
 		// Store the alias in the shortChanID field and mark the real
 		// scid in the database.
-		aliceChannelLink.shortChanID = aliceAlias
 		err = aliceChannelState.MarkRealScid(aliceScid)
 		require.NoError(t, err)
 

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -1129,7 +1129,6 @@ func (h *hopNetwork) createChannelLink(server, peer *mockServer,
 
 	link := NewChannelLink(
 		ChannelLinkConfig{
-			Switch:        server.htlcSwitch,
 			BestHeight:    server.htlcSwitch.BestHeight,
 			FwrdingPolicy: h.globalPolicy,
 			Peer:          peer,

--- a/lnwire/message.go
+++ b/lnwire/message.go
@@ -193,6 +193,11 @@ type Message interface {
 // LinkUpdater is an interface implemented by most messages in BOLT 2 that are
 // allowed to update the channel state.
 type LinkUpdater interface {
+	// All LinkUpdater messages are messages and so we embed the interface
+	// so that we can treat it as a message if all we know about it is that
+	// it is a LinkUpdater message.
+	Message
+
 	// TargetChanID returns the channel id of the link for which this
 	// message is intended.
 	TargetChanID() ChannelID

--- a/lnwire/message.go
+++ b/lnwire/message.go
@@ -190,6 +190,14 @@ type Message interface {
 	MsgType() MessageType
 }
 
+// LinkUpdater is an interface implemented by most messages in BOLT 2 that are
+// allowed to update the channel state.
+type LinkUpdater interface {
+	// TargetChanID returns the channel id of the link for which this
+	// message is intended.
+	TargetChanID() ChannelID
+}
+
 // makeEmptyMessage creates a new empty message of the proper concrete type
 // based on the passed message type.
 func makeEmptyMessage(msgType MessageType) (Message, error) {

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -1750,7 +1750,7 @@ out:
 		// will consider them as link updates and send them to
 		// chanStream. These messages will be queued inside chanStream
 		// if the channel is not active yet.
-		case LinkUpdater:
+		case lnwire.LinkUpdater:
 			targetChan = msg.TargetChanID()
 			isLinkUpdate = p.hasChannel(targetChan)
 

--- a/peer/interfaces.go
+++ b/peer/interfaces.go
@@ -34,14 +34,6 @@ type messageSwitch interface {
 		error)
 }
 
-// LinkUpdater is an interface implemented by most messages in BOLT 2 that are
-// allowed to update the channel state.
-type LinkUpdater interface {
-	// TargetChanID returns the channel id of the link for which this message
-	// is intended.
-	TargetChanID() lnwire.ChannelID
-}
-
 // MessageConn is an interface implemented by anything that delivers
 // an lnwire.Message using a net.Conn interface.
 type MessageConn interface {


### PR DESCRIPTION
## Change Description
In the process of trying to hack dynamic commitments into the htlcswitch package I discovered some weeds that I decided to pull. A lot of these commits stand alone but I fully recommend we make all of these changes.

## Steps to Test
All of these should be semantics invariant, so existing tests should be sufficient.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `LinkUpdater` interface for BOLT 2 messages that can update the channel state.
- **Refactor**
	- Modified the `Peer()` method across various interfaces and implementations to return the serialized public key instead of the full peer object.
	- Simplified the handling of peer public keys in the `Switch` struct by using direct references.
	- Adjusted test setups and variable naming to align with the changes in peer information handling and channel link configurations.
- **Chores**
	- Removed obsolete references and assignments related to `Switch` in channel configurations and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->