### PR TITLE
contractcourt: make sure the startup process can be finished

### DIFF
--- a/contractcourt/utxonursery.go
+++ b/contractcourt/utxonursery.go
@@ -284,15 +284,13 @@ func (u *UtxoNursery) Start() error {
 	// point forward, we must close the nursery's quit channel if we detect
 	// any failures during startup to ensure they terminate.
 	if err := u.reloadPreschool(); err != nil {
-		close(u.quit)
-		return err
+		log.Errorf("UtxoNursery unable to reload preschool: %v", err)
 	}
 
 	// 3. Replay all crib and kindergarten outputs up to the current best
 	// height.
 	if err := u.reloadClasses(uint32(bestHeight)); err != nil {
-		close(u.quit)
-		return err
+		log.Errorf("UtxoNursery unable to reload classes: %v", err)
 	}
 
 	// Start watching for new blocks, as this will drive the nursery store's

--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -90,6 +90,9 @@
   precision issue when querying payments and invoices using the start and end
   date filters.
 
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/8519) an issue that
+  `lnd` may refuse to start up due to errors returned from `UtxoNursery`.
+
 # New Features
 ## Functional Enhancements
 


### PR DESCRIPTION
This commit makes sure the startup process won't fail due to errors returned from reloading unfinished sweeps. It's likely to happen as by the time the node is restarted, the sweep txns may already be confirmed.

Fixes #8383