### PR TITLE
make: use Golang build and module cache for linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,11 @@ ifneq ($(workers),)
 LINT_WORKERS = --concurrency=$(workers)
 endif
 
-DOCKER_TOOLS = docker run --rm -v $$(pwd):/build lnd-tools
+DOCKER_TOOLS = docker run \
+  --rm \
+  -v $(shell bash -c "go env GOCACHE || (mkdir -p /tmp/go-cache; echo /tmp/go-cache)"):/tmp/build/.cache \
+  -v $(shell bash -c "go env GOMODCACHE || (mkdir -p /tmp/go-modcache; echo /tmp/go-modcache)"):/tmp/build/.modcache \
+  -v $$(pwd):/build lnd-tools
 
 GREEN := "\\033[0;32m"
 NC := "\\033[0m"


### PR DESCRIPTION
This commit gives the linter container access to the local machine's build and module cache, drastically decreasing the run time of subsequent linter runs (no difference on first run with this change).

Back port from [Taproot Assets](https://github.com/lightninglabs/taproot-assets/blob/main/Makefile#L58) where we've been using this successfully for a while.
