### PR TITLE
Password-First Feature with Unlock Request on Wallet Initialization

### DIFF
--- a/cmd/lncli/cmd_walletunlocker.go
+++ b/cmd/lncli/cmd_walletunlocker.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -712,7 +711,7 @@ func createWatchOnly(ctx *cli.Context) error {
 	}
 
 	jsonFile := lncfg.CleanAndExpandPath(ctx.Args().First())
-	jsonBytes, err := ioutil.ReadFile(jsonFile)
+	jsonBytes, err := os.ReadFile(jsonFile)
 	if err != nil {
 		return fmt.Errorf("error reading JSON from file %v: %v",
 			jsonFile, err)

--- a/cmd/lncli/cmd_walletunlocker.go
+++ b/cmd/lncli/cmd_walletunlocker.go
@@ -477,13 +477,12 @@ var unlockCommand = cli.Command{
 
 func unlock(ctx *cli.Context) error {
 	ctxc := getContext()
-	client, cleanUp := getWalletUnlockerClient(ctx)
-	defer cleanUp()
 
 	var (
 		pw  []byte
 		err error
 	)
+
 	switch {
 	// Read the password from standard in as if it were a file. This should
 	// only be used if the password is piped into lncli from some sort of
@@ -505,6 +504,18 @@ func unlock(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// Wait for the wallet to reach the "LOCKED" state using a wait loop.
+	err = waitUntilStatus(ctxc, ctx, lnrpc.WalletState_LOCKED)
+	if err != nil {
+		return fmt.Errorf("error waiting for lnd RPC to become ready: "+
+			"%w", err)
+	}
+
+	// Get the wallet unlocker client and defer the cleanup function to
+	// close the connections.
+	client, cleanUp := getWalletUnlockerClient(ctx)
+	defer cleanUp()
 
 	args := ctx.Args()
 


### PR DESCRIPTION
## Change Description
Fix #7749

Change in `unlock` command
Introduced a wait loop immediately after asking password and waiting for Wallet_Locked status 

## Steps to Test
1. Restart lnd
2. Try to unlock using `lnci unlock`
3. The command will wait until the wallet reaches Locked status

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.
