### PR TITLE
dont use sweeper unconfirmed utxos

### DIFF
--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -118,6 +118,14 @@
 
 * [Fixed a bug in `btcd` that caused an incompatibility with
   `bitcoind v27.0`](https://github.com/lightningnetwork/lnd/pull/8573).
+  
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/8609) a function call 
+  where arguments were swapped.
+
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/8545) utxo selection
+  for the internal channel funding flow (Single and Batch Funding Flow). Now
+  utxos which are unconfirmed and originated from the sweeper subsystem are not
+  selected because they bear the risk of being replaced (BIP 125 RBF).
 
 # New Features
 ## Functional Enhancements

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -556,6 +556,11 @@ func createTestFundingManager(t *testing.T, privKey *btcec.PrivateKey,
 			return nil, nil
 		},
 		AliasManager: aliasMgr,
+		// For unit tests we default to false meaning that no funds
+		// originated from the sweeper.
+		IsSweeperOutpoint: func(wire.OutPoint) bool {
+			return false
+		},
 	}
 
 	for _, op := range options {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.8
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
-	github.com/btcsuite/btcwallet v0.16.10-0.20240410030101-6fe19a472a62
+	github.com/btcsuite/btcwallet v0.16.10-0.20240404104514-b2f31f9045fb
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.3.4
 	github.com/btcsuite/btcwallet/wallet/txrules v1.2.1
 	github.com/btcsuite/btcwallet/walletdb v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0/go.mod h1:7SFka0XMvUgj3hfZtyd
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
-github.com/btcsuite/btcwallet v0.16.10-0.20240410030101-6fe19a472a62 h1:MtcTVTcDbGdTJhfDc7LLikojyl0PYtSRNLwoRaLVbWI=
-github.com/btcsuite/btcwallet v0.16.10-0.20240410030101-6fe19a472a62/go.mod h1:2C3Q/MhYAKmk7F+Tey6LfKtKRTdQsrCf8AAAzzDPmH4=
+github.com/btcsuite/btcwallet v0.16.10-0.20240404104514-b2f31f9045fb h1:qoIOlBPRZWtfpcbQlNFf67Wz8ZlXo+mxQc9Pnbm/iqU=
+github.com/btcsuite/btcwallet v0.16.10-0.20240404104514-b2f31f9045fb/go.mod h1:2C3Q/MhYAKmk7F+Tey6LfKtKRTdQsrCf8AAAzzDPmH4=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.4 h1:poyHFf7+5+RdxNp5r2T6IBRD7RyraUsYARYbp/7t4D8=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.4/go.mod h1:GETGDQuyq+VFfH1S/+/7slLM/9aNa4l7P4ejX6dJfb0=
 github.com/btcsuite/btcwallet/wallet/txrules v1.2.1 h1:UZo7YRzdHbwhK7Rhv3PO9bXgTxiOH45edK5qdsdiatk=

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -118,6 +118,14 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testBatchChanFunding,
 	},
 	{
+		Name:     "open channel with unstable utxos",
+		TestFunc: testChannelFundingWithUnstableUtxos,
+	},
+	{
+		Name:     "open psbt channel with unstable utxos",
+		TestFunc: testPsbtChanFundingWithUnstableUtxos,
+	},
+	{
 		Name:     "update channel policy",
 		TestFunc: testUpdateChannelPolicy,
 	},

--- a/itest/lnd_channel_funding_utxo_selection_test.go
+++ b/itest/lnd_channel_funding_utxo_selection_test.go
@@ -330,7 +330,8 @@ func runUtxoSelectionTestCase(ht *lntest.HarnessTest, alice,
 	// When re-selecting a spent output for funding another channel we
 	// expect the respective error message.
 	if tc.reuseUtxo {
-		expectedErrStr := fmt.Sprintf("outpoint already spent: %s:%d",
+		expectedErrStr := fmt.Sprintf("outpoint already spent or "+
+			"locked by another subsystem: %s:%d",
 			selectedOutpoints[0].TxidStr,
 			selectedOutpoints[0].OutputIndex)
 		expectedErr := fmt.Errorf(expectedErrStr)

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -1551,12 +1551,73 @@ func (w *WalletKit) fundPsbtInternalWallet(account string,
 				return err
 			}
 
+			// filterFn makes sure utxos which are unconfirmed and
+			// still used by the sweeper are not used.
+			filterFn := func(u *lnwallet.Utxo) bool {
+				// Confirmed utxos are always allowed.
+				if u.Confirmations > 0 {
+					return true
+				}
+
+				// Unconfirmed utxos in use by the sweeper are
+				// not stable to use because they can be
+				// replaced.
+				if w.cfg.Sweeper.IsSweeperOutpoint(u.OutPoint) {
+					log.Warnf("Cannot use unconfirmed "+
+						"utxo=%v because it is "+
+						"unstable and could be "+
+						"replaced", u.OutPoint)
+
+					return false
+				}
+
+				return true
+			}
+
+			eligible := fn.Filter(filterFn, utxos)
+
 			// Validate all inputs against our known list of UTXOs
 			// now.
-			err = verifyInputsUnspent(packet.UnsignedTx.TxIn, utxos)
+			err = verifyInputsUnspent(
+				packet.UnsignedTx.TxIn, eligible,
+			)
 			if err != nil {
 				return err
 			}
+		}
+
+		// currentHeight is needed to determine whether the internal
+		// wallet utxo is still unconfirmed.
+		_, currentHeight, err := w.cfg.Chain.GetBestBlock()
+		if err != nil {
+			return fmt.Errorf("unable to retrieve current "+
+				"height: %v", err)
+		}
+
+		// restrictUnstableUtxos is a filter function which disallows
+		// the usage of unconfirmed outputs published (still in use) by
+		// the sweeper.
+		restrictUnstableUtxos := func(utxo wtxmgr.Credit) bool {
+			// Wallet utxos which are unmined have a height
+			// of -1.
+			if utxo.Height != -1 && utxo.Height <= currentHeight {
+				// Confirmed utxos are always allowed.
+				return true
+			}
+
+			// Utxos used by the sweeper are not used for
+			// channel openings.
+			allowed := !w.cfg.Sweeper.IsSweeperOutpoint(
+				utxo.OutPoint,
+			)
+			if !allowed {
+				log.Warnf("Cannot use unconfirmed "+
+					"utxo=%v because it is "+
+					"unstable and could be "+
+					"replaced", utxo.OutPoint)
+			}
+
+			return allowed
 		}
 
 		// We made sure the input from the user is as sane as possible.
@@ -1564,8 +1625,8 @@ func (w *WalletKit) fundPsbtInternalWallet(account string,
 		// lock any coins but might still change the wallet DB by
 		// generating a new change address.
 		changeIndex, err := w.cfg.Wallet.FundPsbt(
-			packet, minConfs, feeSatPerKW, account,
-			keyScope, strategy,
+			packet, minConfs, feeSatPerKW, account, keyScope,
+			strategy, restrictUnstableUtxos,
 		)
 		if err != nil {
 			return fmt.Errorf("wallet couldn't fund PSBT: %w", err)

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -1574,12 +1574,12 @@ func (w *WalletKit) fundPsbtInternalWallet(account string,
 				return true
 			}
 
-			eligible := fn.Filter(filterFn, utxos)
+			eligibleUtxos := fn.Filter(filterFn, utxos)
 
 			// Validate all inputs against our known list of UTXOs
 			// now.
 			err = verifyInputsUnspent(
-				packet.UnsignedTx.TxIn, eligible,
+				packet.UnsignedTx.TxIn, eligibleUtxos,
 			)
 			if err != nil {
 				return err

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -1205,6 +1205,7 @@ func (h *HarnessTest) OpenChannelAssertErr(srcNode, destNode *node.HarnessNode,
 
 	// Receive an error to be sent from the stream.
 	_, err := h.receiveOpenChannelUpdate(respStream)
+	require.NotNil(h, err, "expected channel opening to fail")
 
 	// Use string comparison here as we haven't codified all the RPC errors
 	// yet.

--- a/lntest/mock/walletcontroller.go
+++ b/lntest/mock/walletcontroller.go
@@ -208,7 +208,8 @@ func (w *WalletController) ListLeasedOutputs() ([]*base.ListLeasedOutputResult,
 
 // FundPsbt currently does nothing.
 func (w *WalletController) FundPsbt(*psbt.Packet, int32, chainfee.SatPerKWeight,
-	string, *waddrmgr.KeyScope, base.CoinSelectionStrategy) (int32, error) {
+	string, *waddrmgr.KeyScope, base.CoinSelectionStrategy,
+	func(utxo wtxmgr.Credit) bool) (int32, error) {
 
 	return 0, nil
 }

--- a/lntest/rpc/wallet_kit.go
+++ b/lntest/rpc/wallet_kit.go
@@ -68,6 +68,16 @@ func (h *HarnessRPC) FundPsbt(
 	return resp
 }
 
+// FundPsbtAssertErr makes a RPC call to the node's FundPsbt and asserts an
+// error is returned.
+func (h *HarnessRPC) FundPsbtAssertErr(req *walletrpc.FundPsbtRequest) {
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	_, err := h.WalletKit.FundPsbt(ctxt, req)
+	require.Error(h, err, "expected error returned")
+}
+
 // FinalizePsbt makes a RPC call to node's FinalizePsbt and asserts.
 func (h *HarnessRPC) FinalizePsbt(
 	req *walletrpc.FinalizePsbtRequest) *walletrpc.FinalizePsbtResponse {

--- a/lnwallet/chanfunding/wallet_assembler.go
+++ b/lnwallet/chanfunding/wallet_assembler.go
@@ -334,7 +334,8 @@ func (w *WalletAssembler) ProvisionChannel(r *Request) (Intent, error) {
 		}
 		for _, coin := range manuallySelectedCoins {
 			if _, ok := unspent[coin.OutPoint]; !ok {
-				return fmt.Errorf("outpoint already spent: %v",
+				return fmt.Errorf("outpoint already spent or "+
+					"locked by another subsystem: %v",
 					coin.OutPoint)
 			}
 		}

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -468,7 +468,8 @@ type WalletController interface {
 	FundPsbt(packet *psbt.Packet, minConfs int32,
 		feeRate chainfee.SatPerKWeight, account string,
 		changeScope *waddrmgr.KeyScope,
-		strategy base.CoinSelectionStrategy) (int32, error)
+		strategy base.CoinSelectionStrategy,
+		allowUtxo func(wtxmgr.Credit) bool) (int32, error)
 
 	// SignPsbt expects a partial transaction with all inputs and outputs
 	// fully declared and tries to sign all unsigned inputs that have all

--- a/lnwallet/mock.go
+++ b/lnwallet/mock.go
@@ -217,7 +217,8 @@ func (w *mockWalletController) ListLeasedOutputs() (
 // FundPsbt currently does nothing.
 func (w *mockWalletController) FundPsbt(*psbt.Packet, int32,
 	chainfee.SatPerKWeight, string, *waddrmgr.KeyScope,
-	base.CoinSelectionStrategy) (int32, error) {
+	base.CoinSelectionStrategy, func(utxo wtxmgr.Credit) bool) (int32,
+	error) {
 
 	return 0, nil
 }

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -2947,6 +2947,11 @@ func waitForWalletSync(r *rpctest.Harness, w *lnwallet.LightningWallet) error {
 func testSingleFunderExternalFundingTx(miner *rpctest.Harness,
 	alice, bob *lnwallet.LightningWallet, t *testing.T) {
 
+	// Define a filter function without any restrictions.
+	allowUtxo := func(lnwallet.Utxo) bool {
+		return true
+	}
+
 	// First, we'll obtain multi-sig keys from both Alice and Bob which
 	// simulates them exchanging keys on a higher level.
 	aliceFundingKey, err := alice.DeriveNextKey(keychain.KeyFamilyMultiSig)
@@ -2964,7 +2969,7 @@ func testSingleFunderExternalFundingTx(miner *rpctest.Harness,
 	aliceChanFunder := chanfunding.NewWalletAssembler(
 		chanfunding.WalletConfig{
 			CoinSource: lnwallet.NewCoinSource(
-				alice, nil,
+				alice, allowUtxo,
 			),
 			CoinSelectLocker:      alice,
 			CoinLeaser:            alice,

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -2963,7 +2963,9 @@ func testSingleFunderExternalFundingTx(miner *rpctest.Harness,
 	// we'll create a new chanfunding.Assembler hacked by Alice's wallet.
 	aliceChanFunder := chanfunding.NewWalletAssembler(
 		chanfunding.WalletConfig{
-			CoinSource:            lnwallet.NewCoinSource(alice),
+			CoinSource: lnwallet.NewCoinSource(
+				alice, nil,
+			),
 			CoinSelectLocker:      alice,
 			CoinLeaser:            alice,
 			Signer:                alice.Cfg.Signer,

--- a/server.go
+++ b/server.go
@@ -1489,8 +1489,9 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		EnableUpfrontShutdown:         cfg.EnableUpfrontShutdown,
 		MaxAnchorsCommitFeeRate: chainfee.SatPerKVByte(
 			s.cfg.MaxCommitFeeRateAnchors * 1000).FeePerKWeight(),
-		DeleteAliasEdge: deleteAliasEdge,
-		AliasManager:    s.aliasMgr,
+		DeleteAliasEdge:   deleteAliasEdge,
+		AliasManager:      s.aliasMgr,
+		IsSweeperOutpoint: s.sweeper.IsSweeperOutpoint,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/8543
Fixes https://github.com/lightningnetwork/lnd/issues/8540

We will not use any unconfirmed funds which are labeled by the sweeper subsystem to open internal wallet funded channels.

Seems to be a quick win comparing the change scope ?


@yyforyongyu or is this fix already part of your sweeper series ?

Added an itest to verify this behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Improved UTXO selection for internal channel funding to enhance transaction security by excluding unconfirmed and labeled UTXOs.
	- Added a new test case to verify channel funding with labeled transactions, ensuring robustness against potential Replace-By-Fee (RBF) issues.
	- Introduced a method to fetch transaction labels from the wallet, aiding in transaction management and identification.

- **Bug Fixes**
	- Updated error messages to provide clearer information when a funding transaction is locked by the sweeper subsystem, improving user understanding of transaction status.

- **Tests**
	- Expanded testing suite to cover new functionalities and error handling improvements related to channel funding and UTXO selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->