### PR TITLE
multi: add ability to fund+use musig2 channels that commit to a tapscript root

### DIFF
--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -1523,14 +1523,14 @@ func TestKeyLocatorEncoding(t *testing.T) {
 		buf [8]byte
 	)
 
-	err := EKeyLocator(&b, &keyLoc, &buf)
+	err := eKeyLocator(&b, &keyLoc, &buf)
 	require.NoError(t, err, "unable to encode key locator")
 
 	// Next, we'll attempt to decode the bytes into a new KeyLocator.
 	r := bytes.NewReader(b.Bytes())
 	var decodedKeyLoc keychain.KeyLocator
 
-	err = DKeyLocator(r, &decodedKeyLoc, &buf, 8)
+	err = dKeyLocator(r, &decodedKeyLoc, &buf, 8)
 	require.NoError(t, err, "unable to decode key locator")
 
 	// Finally, we'll compare that the original KeyLocator and the decoded

--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/clock"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnmock"
@@ -171,7 +172,7 @@ func fundingPointOption(chanPoint wire.OutPoint) testChannelOption {
 }
 
 // channelIDOption is an option which sets the short channel ID of the channel.
-var channelIDOption = func(chanID lnwire.ShortChannelID) testChannelOption {
+func channelIDOption(chanID lnwire.ShortChannelID) testChannelOption {
 	return func(params *testChannelParams) {
 		params.channel.ShortChannelID = chanID
 	}
@@ -311,6 +312,9 @@ func createTestChannelState(t *testing.T, cdb *ChannelStateDB) *OpenChannel {
 	uniqueOutputIndex.Add(1)
 	op := wire.OutPoint{Hash: key, Index: uniqueOutputIndex.Load()}
 
+	var tapscriptRoot chainhash.Hash
+	copy(tapscriptRoot[:], bytes.Repeat([]byte{1}, 32))
+
 	return &OpenChannel{
 		ChanType:          SingleFunderBit | FrozenBit,
 		ChainHash:         key,
@@ -353,6 +357,7 @@ func createTestChannelState(t *testing.T, cdb *ChannelStateDB) *OpenChannel {
 		ThawHeight:              uint32(defaultPendingHeight),
 		InitialLocalBalance:     lnwire.MilliSatoshi(9000),
 		InitialRemoteBalance:    lnwire.MilliSatoshi(3000),
+		TapscriptRoot:           fn.Some(tapscriptRoot),
 	}
 }
 

--- a/contractcourt/chain_watcher.go
+++ b/contractcourt/chain_watcher.go
@@ -16,6 +16,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lnwallet"
 )
@@ -301,8 +302,11 @@ func (c *chainWatcher) Start() error {
 		err error
 	)
 	if chanState.ChanType.IsTaproot() {
+		fundingOpts := fn.MapOptionZ(
+			chanState.TapscriptRoot, lnwallet.TapscriptRootToOpt,
+		)
 		c.fundingPkScript, _, err = input.GenTaprootFundingScript(
-			localKey, remoteKey, 0,
+			localKey, remoteKey, 0, fundingOpts...,
 		)
 		if err != nil {
 			return err

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/discovery"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/labels"
@@ -2853,8 +2854,12 @@ func makeFundingScript(channel *channeldb.OpenChannel) ([]byte, error) {
 	remoteKey := channel.RemoteChanCfg.MultiSigKey.PubKey
 
 	if channel.ChanType.IsTaproot() {
+		fundingOpts := fn.MapOptionZ(
+			channel.TapscriptRoot, lnwallet.TapscriptRootToOpt,
+		)
 		pkScript, _, err := input.GenTaprootFundingScript(
 			localKey, remoteKey, int64(channel.Capacity),
+			fundingOpts...,
 		)
 		if err != nil {
 			return nil, err

--- a/lnwallet/chancloser/chancloser_test.go
+++ b/lnwallet/chancloser/chancloser_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnutils"
@@ -185,6 +186,7 @@ func (m *mockChannel) CreateCloseProposal(fee btcutil.Amount,
 				R: new(btcec.PublicKey),
 			},
 			lnwire.Musig2Nonce{}, lnwire.Musig2Nonce{}, nil,
+			fn.None[chainhash.Hash](),
 		), nil, 0, nil
 	}
 

--- a/lnwallet/chanfunding/interface.go
+++ b/lnwallet/chanfunding/interface.go
@@ -2,8 +2,10 @@ package chanfunding
 
 import (
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/wallet"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 )
 
@@ -116,6 +118,11 @@ type Request struct {
 	// output. By definition, this'll also use segwit v1 (taproot) for the
 	// funding output.
 	Musig2 bool
+
+	// TapscriptRoot is the root of the tapscript tree that will be used to
+	// create the funding output. This field will only be utilized if the
+	// Musig2 flag above is set to true.
+	TapscriptRoot fn.Option[chainhash.Hash]
 }
 
 // Intent is returned by an Assembler and represents the base functionality the

--- a/lnwallet/chanfunding/psbt_assembler.go
+++ b/lnwallet/chanfunding/psbt_assembler.go
@@ -534,6 +534,7 @@ func (p *PsbtAssembler) ProvisionChannel(req *Request) (Intent, error) {
 		ShimIntent: ShimIntent{
 			localFundingAmt: p.fundingAmt,
 			musig2:          req.Musig2,
+			tapscriptRoot:   req.TapscriptRoot,
 		},
 		State:         PsbtShimRegistered,
 		BasePsbt:      p.basePsbt,

--- a/lnwallet/chanfunding/wallet_assembler.go
+++ b/lnwallet/chanfunding/wallet_assembler.go
@@ -362,10 +362,10 @@ func (w *WalletAssembler) ProvisionChannel(r *Request) (Intent, error) {
 		// we will call the specialized coin selection function for
 		// that.
 		case r.FundUpToMaxAmt != 0 && r.MinFundAmt != 0:
-
-			// We need to ensure that manually selected coins, which
-			// are spent entirely on the channel funding, leave
-			// enough funds in the wallet to cover for a reserve.
+			// We need to ensure that manually selected coins,
+			// which are spent entirely on the channel funding,
+			// leave enough funds in the wallet to cover for a
+			// reserve.
 			reserve := r.WalletReserve
 			if len(manuallySelectedCoins) > 0 {
 				sumCoins := func(
@@ -386,8 +386,8 @@ func (w *WalletAssembler) ProvisionChannel(r *Request) (Intent, error) {
 
 				// If sufficient reserve funds are available we
 				// don't have to provide for it during coin
-				// selection. The manually selected coins can be
-				// spent entirely on the channel funding. If
+				// selection. The manually selected coins can
+				// be spent entirely on the channel funding. If
 				// the excess of coins cover the reserve
 				// partially then we have to provide for the
 				// rest during coin selection.
@@ -501,6 +501,7 @@ func (w *WalletAssembler) ProvisionChannel(r *Request) (Intent, error) {
 				localFundingAmt:  localContributionAmt,
 				remoteFundingAmt: r.RemoteAmt,
 				musig2:           r.Musig2,
+				tapscriptRoot:    r.TapscriptRoot,
 			},
 			InputCoins: selectedCoins,
 			coinLocker: w.cfg.CoinLocker,

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -26,6 +26,7 @@ import (
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/channeldb/models"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
@@ -1468,8 +1469,13 @@ func (lc *LightningChannel) createSignDesc() error {
 	remoteKey := chanState.RemoteChanCfg.MultiSigKey.PubKey
 
 	if chanState.ChanType.IsTaproot() {
+		fundingOpts := fn.MapOptionZ(
+			chanState.TapscriptRoot, TapscriptRootToOpt,
+		)
+
 		fundingPkScript, _, err = input.GenTaprootFundingScript(
 			localKey, remoteKey, int64(lc.channelState.Capacity),
+			fundingOpts...,
 		)
 		if err != nil {
 			return err
@@ -6487,11 +6493,15 @@ func (lc *LightningChannel) getSignedCommitTx() (*wire.MsgTx, error) {
 				"verification nonce: %w", err)
 		}
 
+		tapscriptTweak := fn.MapOption(TapscriptRootToTweak)(
+			lc.channelState.TapscriptRoot,
+		)
+
 		// Now that we have the local nonce, we'll re-create the musig
 		// session we had for this height.
 		musigSession := NewPartialMusigSession(
 			*localNonce, ourKey, theirKey, lc.Signer,
-			&lc.fundingOutput, LocalMusigCommit,
+			&lc.fundingOutput, LocalMusigCommit, tapscriptTweak,
 		)
 
 		var remoteSig lnwire.PartialSigWithNonce
@@ -9019,12 +9029,13 @@ func (lc *LightningChannel) InitRemoteMusigNonces(remoteNonce *musig2.Nonces,
 	// TODO(roasbeef): propagate rename of signing and verification nonces
 
 	sessionCfg := &MusigSessionCfg{
-		LocalKey:    localChanCfg.MultiSigKey,
-		RemoteKey:   remoteChanCfg.MultiSigKey,
-		LocalNonce:  *localNonce,
-		RemoteNonce: *remoteNonce,
-		Signer:      lc.Signer,
-		InputTxOut:  &lc.fundingOutput,
+		LocalKey:       localChanCfg.MultiSigKey,
+		RemoteKey:      remoteChanCfg.MultiSigKey,
+		LocalNonce:     *localNonce,
+		RemoteNonce:    *remoteNonce,
+		Signer:         lc.Signer,
+		InputTxOut:     &lc.fundingOutput,
+		TapscriptTweak: lc.channelState.TapscriptRoot,
 	}
 	lc.musigSessions = NewMusigPairSession(
 		sessionCfg,

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -385,6 +385,12 @@ func TestSimpleAddSettleWorkflow(t *testing.T) {
 		)
 	})
 
+	t.Run("taproot with tapscript root", func(t *testing.T) {
+		flags := (channeldb.SimpleTaprootFeatureBit |
+			channeldb.TapscriptRootBit)
+		testAddSettleWorkflow(t, true, flags, false)
+	})
+
 	t.Run("storeFinalHtlcResolutions=true", func(t *testing.T) {
 		testAddSettleWorkflow(t, false, 0, true)
 	})
@@ -823,6 +829,16 @@ func TestForceClose(t *testing.T) {
 			chanType: channeldb.SingleFunderTweaklessBit |
 				channeldb.AnchorOutputsBit |
 				channeldb.SimpleTaprootFeatureBit,
+			expectedCommitWeight: input.TaprootCommitWeight,
+			anchorAmt:            anchorSize * 2,
+		})
+	})
+	t.Run("taproot with tapscript root", func(t *testing.T) {
+		testForceClose(t, &forceCloseTestCase{
+			chanType: channeldb.SingleFunderTweaklessBit |
+				channeldb.AnchorOutputsBit |
+				channeldb.SimpleTaprootFeatureBit |
+				channeldb.TapscriptRootBit,
 			expectedCommitWeight: input.TaprootCommitWeight,
 			anchorAmt:            anchorSize * 2,
 		})

--- a/lnwallet/musig_session.go
+++ b/lnwallet/musig_session.go
@@ -8,8 +8,10 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -37,6 +39,12 @@ var (
 	ErrSessionNotFinalized = fmt.Errorf("musig2 session not finalized")
 )
 
+// tapscriptRootToSignOpt is a function that takes a tapscript root and returns
+// a musig2 sign opt that'll apply the tweak when signing+verifying.
+func tapscriptRootToSignOpt(root chainhash.Hash) musig2.SignOption {
+	return musig2.WithTaprootSignTweak(root[:])
+}
+
 // MusigPartialSig is a wrapper around the base musig2.PartialSignature type
 // that also includes information about the set of nonces used, and also the
 // signer. This allows us to implement the input.Signature interface, as that
@@ -54,18 +62,24 @@ type MusigPartialSig struct {
 
 	// signerKeys is the set of public keys of all signers.
 	signerKeys []*btcec.PublicKey
+
+	// tapscriptRoot is an optional tweak, that if specified, will be used
+	// instead of the normal BIP 86 tweak when validating the signature.
+	tapscriptTweak fn.Option[chainhash.Hash]
 }
 
 // NewMusigPartialSig creates a new musig partial signature.
 func NewMusigPartialSig(sig *musig2.PartialSignature,
 	signerNonce, combinedNonce lnwire.Musig2Nonce,
-	signerKeys []*btcec.PublicKey) *MusigPartialSig {
+	signerKeys []*btcec.PublicKey, tapscriptTweak fn.Option[chainhash.Hash],
+) *MusigPartialSig {
 
 	return &MusigPartialSig{
-		sig:           sig,
-		signerNonce:   signerNonce,
-		combinedNonce: combinedNonce,
-		signerKeys:    signerKeys,
+		sig:            sig,
+		signerNonce:    signerNonce,
+		combinedNonce:  combinedNonce,
+		signerKeys:     signerKeys,
+		tapscriptTweak: tapscriptTweak,
 	}
 }
 
@@ -135,9 +149,15 @@ func (p *MusigPartialSig) Verify(msg []byte, pub *btcec.PublicKey) bool {
 	var m [32]byte
 	copy(m[:], msg)
 
+	// If we have a tapscript tweak, then we'll use that as a tweak
+	// otherwise, we'll fall back to the normal BIP 86 sign tweak.
+	signOpts := fn.MapOption(tapscriptRootToSignOpt)(
+		p.tapscriptTweak,
+	).UnwrapOr(musig2.WithBip86SignTweak())
+
 	return p.sig.Verify(
 		p.signerNonce, p.combinedNonce, p.signerKeys, pub, m,
-		musig2.WithSortedKeys(), musig2.WithBip86SignTweak(),
+		musig2.WithSortedKeys(), signOpts,
 	)
 }
 
@@ -158,6 +178,14 @@ func (n *MusigNoncePair) String() string {
 	return fmt.Sprintf("NoncePair(verification_nonce=%x, "+
 		"signing_nonce=%x)", n.VerificationNonce.PubNonce[:],
 		n.SigningNonce.PubNonce[:])
+}
+
+// TapscriptRootToTweak is a function that takes a musig2 taproot tweak and
+// returns the root hash of the tapscript tree.
+func musig2TweakToRoot(tweak input.MuSig2Tweaks) chainhash.Hash {
+	var root chainhash.Hash
+	copy(root[:], tweak.TaprootTweak)
+	return root
 }
 
 // MusigSession abstracts over the details of a logical musig session. A single
@@ -197,6 +225,11 @@ type MusigSession struct {
 	// commitType tracks if this is the session for the local or remote
 	// commitment.
 	commitType MusigCommitType
+
+	// tapscriptTweak is an optional tweak, that if specified, will be used
+	// instead of the normal BIP 86 tweak when creating the musig2
+	// aggregate key and session.
+	tapscriptTweak fn.Option[input.MuSig2Tweaks]
 }
 
 // NewPartialMusigSession creates a new musig2 session given only the
@@ -205,7 +238,8 @@ type MusigSession struct {
 func NewPartialMusigSession(verificationNonce musig2.Nonces,
 	localKey, remoteKey keychain.KeyDescriptor,
 	signer input.MuSig2Signer, inputTxOut *wire.TxOut,
-	commitType MusigCommitType) *MusigSession {
+	commitType MusigCommitType,
+	tapscriptTweak fn.Option[input.MuSig2Tweaks]) *MusigSession {
 
 	signerKeys := []*btcec.PublicKey{localKey.PubKey, remoteKey.PubKey}
 
@@ -214,13 +248,14 @@ func NewPartialMusigSession(verificationNonce musig2.Nonces,
 	}
 
 	return &MusigSession{
-		nonces:     nonces,
-		remoteKey:  remoteKey,
-		localKey:   localKey,
-		inputTxOut: inputTxOut,
-		signerKeys: signerKeys,
-		signer:     signer,
-		commitType: commitType,
+		nonces:         nonces,
+		remoteKey:      remoteKey,
+		localKey:       localKey,
+		inputTxOut:     inputTxOut,
+		signerKeys:     signerKeys,
+		signer:         signer,
+		commitType:     commitType,
+		tapscriptTweak: tapscriptTweak,
 	}
 }
 
@@ -254,9 +289,9 @@ func (m *MusigSession) FinalizeSession(signingNonce musig2.Nonces) error {
 		remoteNonce = m.nonces.SigningNonce
 	}
 
-	tweakDesc := input.MuSig2Tweaks{
+	tweakDesc := m.tapscriptTweak.UnwrapOr(input.MuSig2Tweaks{
 		TaprootBIP0086Tweak: true,
-	}
+	})
 	m.session, err = m.signer.MuSig2CreateSession(
 		input.MuSig2Version100RC2, m.localKey.KeyLocator, m.signerKeys,
 		&tweakDesc, [][musig2.PubNonceSize]byte{remoteNonce.PubNonce},
@@ -351,8 +386,11 @@ func (m *MusigSession) SignCommit(tx *wire.MsgTx) (*MusigPartialSig, error) {
 		return nil, err
 	}
 
+	tapscriptRoot := fn.MapOption(musig2TweakToRoot)(m.tapscriptTweak)
+
 	return NewMusigPartialSig(
 		sig, m.session.PublicNonce, m.combinedNonce, m.signerKeys,
+		tapscriptRoot,
 	), nil
 }
 
@@ -364,7 +402,7 @@ func (m *MusigSession) Refresh(verificationNonce *musig2.Nonces,
 
 	return NewPartialMusigSession(
 		*verificationNonce, m.localKey, m.remoteKey, m.signer,
-		m.inputTxOut, m.commitType,
+		m.inputTxOut, m.commitType, m.tapscriptTweak,
 	), nil
 }
 
@@ -451,9 +489,11 @@ func (m *MusigSession) VerifyCommitSig(commitTx *wire.MsgTx,
 	// When we verify a commitment signature, we always assume that we're
 	// verifying a signature on our local commitment. Therefore, we'll use:
 	// their remote nonce, and also public key.
+	tapscriptRoot := fn.MapOption(musig2TweakToRoot)(m.tapscriptTweak)
 	partialSig := NewMusigPartialSig(
 		&musig2.PartialSignature{S: &sig.Sig},
 		m.nonces.SigningNonce.PubNonce, m.combinedNonce, m.signerKeys,
+		tapscriptRoot,
 	)
 
 	// With the partial sig loaded with the proper context, we'll now
@@ -537,6 +577,10 @@ type MusigSessionCfg struct {
 	// InputTxOut is the output that we're signing for. This will be the
 	// funding input.
 	InputTxOut *wire.TxOut
+
+	// TapscriptRoot is an optional tweak that can be used to modify the
+	// musig2 public key used in the session.
+	TapscriptTweak fn.Option[chainhash.Hash]
 }
 
 // MusigPairSession houses the two musig2 sessions needed to do funding and
@@ -561,13 +605,16 @@ func NewMusigPairSession(cfg *MusigSessionCfg) *MusigPairSession {
 	//
 	// Both sessions will be created using only the verification nonce for
 	// the local+remote party.
+	tapscriptTweak := fn.MapOption(TapscriptRootToTweak)(
+		cfg.TapscriptTweak,
+	)
 	localSession := NewPartialMusigSession(
-		cfg.LocalNonce, cfg.LocalKey, cfg.RemoteKey,
-		cfg.Signer, cfg.InputTxOut, LocalMusigCommit,
+		cfg.LocalNonce, cfg.LocalKey, cfg.RemoteKey, cfg.Signer,
+		cfg.InputTxOut, LocalMusigCommit, tapscriptTweak,
 	)
 	remoteSession := NewPartialMusigSession(
-		cfg.RemoteNonce, cfg.LocalKey, cfg.RemoteKey,
-		cfg.Signer, cfg.InputTxOut, RemoteMusigCommit,
+		cfg.RemoteNonce, cfg.LocalKey, cfg.RemoteKey, cfg.Signer,
+		cfg.InputTxOut, RemoteMusigCommit, tapscriptTweak,
 	)
 
 	return &MusigPairSession{

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -14,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
@@ -341,6 +342,21 @@ func CreateTestChannels(t *testing.T, chanType channeldb.ChannelType,
 		RemoteCommitment:        bobRemoteCommit,
 		Db:                      dbBob.ChannelStateDB(),
 		Packager:                channeldb.NewChannelPackager(shortChanID),
+	}
+
+	// If the channel type has a tapscript root, then we'll also specify
+	// one here to apply to both the channels.
+	if chanType.HasTapscriptRoot() {
+		var tapscriptRoot chainhash.Hash
+		_, err := io.ReadFull(rand.Reader, tapscriptRoot[:])
+		if err != nil {
+			return nil, nil, err
+		}
+
+		someRoot := fn.Some(tapscriptRoot)
+
+		aliceChannelState.TapscriptRoot = someRoot
+		bobChannelState.TapscriptRoot = someRoot
 	}
 
 	aliceSigner := input.NewMockSigner(aliceKeys, nil)

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -23,6 +23,7 @@ import (
 	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
@@ -199,6 +200,11 @@ type InitFundingReserveMsg struct {
 	// Memo is any arbitrary information we wish to store locally about the
 	// channel that will be useful to our future selves.
 	Memo []byte
+
+	// TapscriptRoot is the root of the tapscript tree that will be used to
+	// create the funding output. This is an optional field that should
+	// only be set for taproot channels,
+	TapscriptRoot fn.Option[chainhash.Hash]
 
 	// err is a channel in which all errors will be sent across. Will be
 	// nil if this initial set is successful.
@@ -2083,8 +2089,14 @@ func (l *LightningWallet) verifyCommitSig(res *ChannelReservation,
 		// already. If we're the responder in the funding flow, we may
 		// not have generated it already.
 		if res.musigSessions == nil {
+			fundingOpts := fn.MapOptionZ(
+				res.partialState.TapscriptRoot,
+				TapscriptRootToOpt,
+			)
+
 			_, fundingOutput, err := input.GenTaprootFundingScript(
 				localKey, remoteKey, channelValue,
+				fundingOpts...,
 			)
 			if err != nil {
 				return err
@@ -2324,8 +2336,13 @@ func (l *LightningWallet) handleSingleFunderSigs(req *addSingleFunderSigsMsg) {
 		fundingTxOut         *wire.TxOut
 	)
 	if chanType.IsTaproot() {
+		fundingOpts := fn.MapOptionZ(
+			pendingReservation.partialState.TapscriptRoot,
+			TapscriptRootToOpt,
+		)
 		fundingWitnessScript, fundingTxOut, err = input.GenTaprootFundingScript( //nolint:lll
 			ourKey.PubKey, theirKey.PubKey, channelValue,
+			fundingOpts...,
 		)
 	} else {
 		fundingWitnessScript, fundingTxOut, err = input.GenFundingPkScript( //nolint:lll
@@ -2448,6 +2465,14 @@ func TapscriptRootToOpt(root chainhash.Hash) []input.FundingScriptOpt {
 	return []input.FundingScriptOpt{input.WithTapscriptRoot(root)}
 }
 
+// TapscriptRootToTweak is a helper function that converts a tapscript root
+// into a tweak that can be used with the musig2 API.
+func TapscriptRootToTweak(root chainhash.Hash) input.MuSig2Tweaks {
+	return input.MuSig2Tweaks{
+		TaprootTweak: root[:],
+	}
+}
+
 // ValidateChannel will attempt to fully validate a newly mined channel, given
 // its funding transaction and existing channel state. If this method returns
 // an error, then the mined channel is invalid, and shouldn't be used.
@@ -2469,8 +2494,13 @@ func (l *LightningWallet) ValidateChannel(channelState *channeldb.OpenChannel,
 	// funding transaction, and also commitment validity.
 	var fundingScript []byte
 	if channelState.ChanType.IsTaproot() {
+		fundingOpts := fn.MapOptionZ(
+			channelState.TapscriptRoot, TapscriptRootToOpt,
+		)
+
 		fundingScript, _, err = input.GenTaprootFundingScript(
 			localKey, remoteKey, int64(channel.Capacity),
+			fundingOpts...,
 		)
 		if err != nil {
 			return err

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -2442,6 +2442,12 @@ func initStateHints(commit1, commit2 *wire.MsgTx,
 	return nil
 }
 
+// TapscriptRootToOpt is a helper function that converts a tapscript root into
+// the functional option we can use to pass into GenTaprootFundingScript.
+func TapscriptRootToOpt(root chainhash.Hash) []input.FundingScriptOpt {
+	return []input.FundingScriptOpt{input.WithTapscriptRoot(root)}
+}
+
 // ValidateChannel will attempt to fully validate a newly mined channel, given
 // its funding transaction and existing channel state. If this method returns
 // an error, then the mined channel is invalid, and shouldn't be used.

--- a/peer/musig_chan_closer.go
+++ b/peer/musig_chan_closer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chancloser"
@@ -43,10 +44,15 @@ func (m *MusigChanCloser) ProposalClosingOpts() (
 	}
 
 	localKey, remoteKey := m.channel.MultiSigKeys()
+
+	tapscriptTweak := fn.MapOption(lnwallet.TapscriptRootToTweak)(
+		m.channel.State().TapscriptRoot,
+	)
+
 	m.musigSession = lnwallet.NewPartialMusigSession(
 		*m.remoteNonce, localKey, remoteKey,
 		m.channel.Signer, m.channel.FundingTxOut(),
-		lnwallet.RemoteMusigCommit,
+		lnwallet.RemoteMusigCommit, tapscriptTweak,
 	)
 
 	err := m.musigSession.FinalizeSession(*m.localNonce)

--- a/routing/router.go
+++ b/routing/router.go
@@ -1549,6 +1549,8 @@ func makeFundingScript(bitcoinKey1, bitcoinKey2 []byte,
 			return nil, err
 		}
 
+		// TODO(roasbeef): add tapscript root to gossip v1.5
+
 		return fundingScript, nil
 	}
 


### PR DESCRIPTION
In this PR, we add the initial plumbing that'll allow users to create and use musig2 channels that also commit to a tapscript root. Along the way, we start to store a new optional tapscript root in the `channeldb.OpenChannel` struct within the existing TLV stream appended to the older hard coded byte stream. The musig2 session itself will now conditionally pass in a tapscript root to the key aggregation and signing operations. We've also hooked up the lower half of the funding flow (lnwallet reservations) as well to ensure the new field gets propagated all the way down the relevant call stacks. 