### PR TITLE
routerrpc: Add detailed info logging during a rescan

### DIFF
--- a/routing/router.go
+++ b/routing/router.go
@@ -854,10 +854,14 @@ func (r *ChannelRouter) syncGraphWithChain() error {
 
 		// Using the next height, request a manual block pruning from
 		// the chainview for the particular block hash.
+		log.Infof("Filtering block for closed channels, at height: %v",
+			int64(nextHeight))
 		nextHash, err := r.cfg.Chain.GetBlockHash(int64(nextHeight))
 		if err != nil {
 			return err
 		}
+		log.Tracef("Running block filter on block with hash: %v",
+			nextHash)
 		filterBlock, err := r.cfg.ChainView.FilterBlock(nextHash)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Change Description
https://github.com/lightningnetwork/lnd/issues/3658
During a rescan, which can happen for a variety of reasons, there is a section where LND is querying the chain backend for blocks and filtering transactions in order to update its DB. Prior to this change, the entire time that it spends querying the backend, there are little to no useful logs being generated, even at lower debuglevels.

This change tells the user via the log file what block height it is currently scanning so they get the sanity check that their node is not broken and stuck in a loop.

Things like block hash could also be logged, but at a lower level (debug/trace) if people desire that.

## Steps to Test
Steps for reviewers to follow to test the change.
Trigger a wallet rescan:
Start LND with this flag:
`lnd --reset-wallet-transactions`

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [X] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
