### PR TITLE
GitHub: separate build caches

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -4,6 +4,9 @@ inputs:
   go-version:
     description: "The version of Golang to set up"
     required: true
+  key-prefix:
+    description: "A prefix to use for the cache key, to separate cache entries from other workflows"
+    required: false
 
 runs:
   using: "composite"
@@ -27,10 +30,10 @@ runs:
           ~/.cache/go-build
           ~/Library/Caches/go-build
           ~\AppData\Local\go-build
-        key: ${{ runner.os }}-go-${{ inputs.go-version }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-${{ inputs.go-version }}-${{ inputs.key-prefix }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-${{ inputs.go-version }}-${{ github.job }}-
-          ${{ runner.os }}-go-${{ inputs.go-version }}-
+          ${{ runner.os }}-go-${{ inputs.go-version }}-${{ inputs.key-prefix }}-${{ github.job }}-
+          ${{ runner.os }}-go-${{ inputs.go-version }}-${{ inputs.key-prefix }}-
 
     - name: set GOPATH
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,6 +154,7 @@ jobs:
         uses: ./.github/actions/setup-go
         with:
           go-version: '${{ env.GO_VERSION }}'
+          key-prefix: cross-compile
 
       - name: build release for all architectures
         run: make release
@@ -211,6 +212,7 @@ jobs:
         uses: ./.github/actions/setup-go
         with:
           go-version: '${{ env.GO_VERSION }}'
+          key-prefix: unit-test
 
       - name: install bitcoind
         run: ./scripts/install_bitcoind.sh
@@ -266,6 +268,7 @@ jobs:
         uses: ./.github/actions/setup-go
         with:
           go-version: '${{ env.GO_VERSION }}'
+          key-prefix: integration-test
 
       - name: install bitcoind
         run: ./scripts/install_bitcoind.sh
@@ -302,6 +305,7 @@ jobs:
         uses: ./.github/actions/setup-go
         with:
           go-version: '${{ env.GO_VERSION }}'
+          key-prefix: integration-test
 
       - name: run itest
         run: make itest-parallel windows=1


### PR DESCRIPTION
To avoid build caches getting larger and larger, causing our builds to fail, we separate the caches of the different job types. If we don't separate them, then the caches can end up being a combination of the different jobs, which isn't useful (for example the build cache of the cross compilation build isn't useful in an integration test and vice versa).

NOTE: Not yet sure if this works, will assign review once it seems it does work as expected.