### PR TITLE
fix: listpayments --count_total_payments should honor --creation_date_start and --creation_date_end

### DIFF
--- a/channeldb/payments.go
+++ b/channeldb/payments.go
@@ -596,10 +596,10 @@ func (d *DB) QueryPayments(query PaymentsQuery) (PaymentsResponse, error) {
 		// Counting the total number of payments is expensive, since we
 		// literally have to traverse the cursor linearly, which can
 		// take quite a while. So it's an optional query parameter.
-		// It will only take effect if CreationDateStart and
-		// CreationDateEnd are not specified.
 		if query.CountTotal && query.CreationDateStart == 0 &&
 			query.CreationDateEnd == 0 {
+			// It will only take effect if CreationDateStart and
+			// CreationDateEnd are not specified.
 			var (
 				totalPayments uint64
 				err           error

--- a/channeldb/payments.go
+++ b/channeldb/payments.go
@@ -596,8 +596,10 @@ func (d *DB) QueryPayments(query PaymentsQuery) (PaymentsResponse, error) {
 		// Counting the total number of payments is expensive, since we
 		// literally have to traverse the cursor linearly, which can
 		// take quite a while. So it's an optional query parameter.
-		if query.CountTotal && query.CreationDateStart != 0 &&
-			query.CreationDateEnd != 0 {
+		// It will only take effect if CreationDateStart and
+		// CreationDateEnd are not specified.
+		if query.CountTotal && query.CreationDateStart == 0 &&
+			query.CreationDateEnd == 0 {
 			var (
 				totalPayments uint64
 				err           error

--- a/channeldb/payments.go
+++ b/channeldb/payments.go
@@ -596,7 +596,8 @@ func (d *DB) QueryPayments(query PaymentsQuery) (PaymentsResponse, error) {
 		// Counting the total number of payments is expensive, since we
 		// literally have to traverse the cursor linearly, which can
 		// take quite a while. So it's an optional query parameter.
-		if query.CountTotal {
+		if query.CountTotal && query.CreationDateStart != 0 &&
+			query.CreationDateEnd != 0 {
 			var (
 				totalPayments uint64
 				err           error

--- a/channeldb/payments_test.go
+++ b/channeldb/payments_test.go
@@ -477,7 +477,7 @@ func TestQueryPayments(t *testing.T) {
 			query: PaymentsQuery{
 				CreationDateStart: 3,
 				CreationDateEnd:   5,
-				CountTotal: true,
+				CountTotal:        true,
 			},
 			firstIndex:     3,
 			lastIndex:      5,

--- a/channeldb/payments_test.go
+++ b/channeldb/payments_test.go
@@ -472,6 +472,17 @@ func TestQueryPayments(t *testing.T) {
 			lastIndex:      5,
 			expectedSeqNrs: []uint64{3, 4, 5},
 		},
+		{
+			name: "query max transcation with start and end creation time",
+			query: PaymentsQuery{
+				CreationDateStart: 3,
+				CreationDateEnd:   5,
+				CountTotal: true,
+			},
+			firstIndex:     3,
+			lastIndex:      5,
+			expectedSeqNrs: []uint64{3, 4, 5},
+		},
 	}
 
 	for _, tt := range tests {

--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -21,6 +21,11 @@
 - [Contributors (Alphabetical Order)](#contributors-alphabetical-order)
 
 # Bug Fixes
+* [Fix a bug](https://github.com/lightningnetwork/lnd/pull/8565) where 
+  `listpayments --count_total_payments` flag disregarded `--creation_date_start`
+  and `--creation_date_end`. The payments between the dates would be queried
+  instead of the total payments if the dates were supplied.
+
 * [Fix a bug](https://github.com/lightningnetwork/lnd/pull/8097) where
   `sendcoins` command with `--sweepall` flag would not show the correct amount.
 


### PR DESCRIPTION
## Change Description
Fixes https://github.com/lightningnetwork/lnd/issues/8530

Add extra check for the creation start and end date
Only query all payments if those are not specified.

Added check for `totalCount` in existing test cases where the `CountTotal` flag isn't set.


## Steps to Test
Run unit tests and integration tests

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Enhanced payment query capabilities to include filtering by creation date range.

- **Tests**
	- Added test for querying payments with specified start and end creation dates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->