### PR TITLE
GitHub: use bitcoind v27.0 for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ defaults:
     shell: bash
 
 env:
-  BITCOIN_VERSION: "26"
+  BITCOIN_VERSION: "27"
 
   # If you change this value, please change it in the following files as well:
   # /.travis.yml

--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -116,6 +116,9 @@
   their master key's
   fingerprint](https://github.com/lightningnetwork/lnd/pull/8630).
 
+* [Fixed a bug in `btcd` that caused an incompatibility with
+  `bitcoind v27.0`](https://github.com/lightningnetwork/lnd/pull/8573).
+
 # New Features
 ## Functional Enhancements
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/NebulousLabs/go-upnp v0.0.0-20180202185039-29b680b06c82
 	github.com/Yawning/aez v0.0.0-20211027044916-e49e68abd344
 	github.com/andybalholm/brotli v1.0.4
-	github.com/btcsuite/btcd v0.24.1-0.20240318151728-2fc99e0496d2
+	github.com/btcsuite/btcd v0.24.2-beta.rc1.0.20240403021926-ae5533602c46
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2
 	github.com/btcsuite/btcd/btcutil v1.1.5
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.8

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=
-github.com/btcsuite/btcd v0.24.1-0.20240318151728-2fc99e0496d2 h1:b7EiiYEZypI2id3516ptqjzhUfFAgNfF4YVtxikAg6Y=
-github.com/btcsuite/btcd v0.24.1-0.20240318151728-2fc99e0496d2/go.mod h1:5C8ChTkl5ejr3WHj8tkQSCmydiMEPB0ZhQhehpq7Dgg=
+github.com/btcsuite/btcd v0.24.2-beta.rc1.0.20240403021926-ae5533602c46 h1:tjpNTdZNQqE14menwDGAxWfzN0DFHVTXFEyEL8yvA/4=
+github.com/btcsuite/btcd v0.24.2-beta.rc1.0.20240403021926-ae5533602c46/go.mod h1:5C8ChTkl5ejr3WHj8tkQSCmydiMEPB0ZhQhehpq7Dgg=
 github.com/btcsuite/btcd/btcec/v2 v2.1.0/go.mod h1:2VzYrv4Gm4apmbVVsSq5bqf1Ec8v56E48Vt0Y/umPgA=
 github.com/btcsuite/btcd/btcec/v2 v2.1.3/go.mod h1:ctjw4H1kknNJmRN4iP1R7bTQ+v3GJkZBd6mui8ZsAZE=
 github.com/btcsuite/btcd/btcec/v2 v2.3.2 h1:5n0X6hX0Zk+6omWcihdYvdAlGf2DfasC0GMf7DClJ3U=

--- a/scripts/install_bitcoind.sh
+++ b/scripts/install_bitcoind.sh
@@ -10,7 +10,7 @@ if [ -z "$BITCOIND_VERSION" ]; then
   exit 1
 fi
 
-docker pull lightninglabs/bitcoin-core:$BITCOIND_VERSION
-CONTAINER_ID=$(docker create lightninglabs/bitcoin-core:$BITCOIND_VERSION)
-sudo docker cp $CONTAINER_ID:/opt/bitcoin-$BITCOIND_VERSION.0/bin/bitcoind /usr/local/bin/bitcoind
+docker pull lightninglabs/bitcoin-core:${BITCOIND_VERSION}
+CONTAINER_ID=$(docker create lightninglabs/bitcoin-core:${BITCOIND_VERSION})
+sudo docker cp $CONTAINER_ID:/opt/bitcoin-${BITCOIND_VERSION}.0/bin/bitcoind /usr/local/bin/bitcoind
 docker rm $CONTAINER_ID


### PR DESCRIPTION
With this PR we want to assert compatibility with `bitcoind v27.0` while it's still in RC.

Fixes #8571.
Depends on https://github.com/btcsuite/btcd/pull/2142.
