### PR TITLE
itest: reproduce max new nodes hang bug

### DIFF
--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -6,6 +6,10 @@ import "github.com/lightningnetwork/lnd/lntest"
 
 var allTestCases = []*lntest.TestCase{
 	{
+		Name:     "max new nodes",
+		TestFunc: testMaxNewNodes,
+	},
+	{
 		Name:     "update channel status",
 		TestFunc: testUpdateChanStatus,
 	},

--- a/itest/lnd_misc_test.go
+++ b/itest/lnd_misc_test.go
@@ -1281,3 +1281,20 @@ func testNativeSQLNoMigration(ht *lntest.HarnessTest) {
 	alice.SetExtraArgs(nil)
 	require.NoError(ht, alice.Start(ht.Context()))
 }
+
+// testMaxNewNodes reproduces the issue where the maximum number of nodes that
+// can be created is limited to 6. Attempting to create a 7th node should result
+// in a hang.
+func testMaxNewNodes(ht *lntest.HarnessTest) {
+	// Create three new nodes.
+	ht.Log("Creating 6 new nodes")
+	ht.NewNode("node-1", nil)
+	ht.NewNode("node-2", nil)
+	ht.NewNode("node-3", nil)
+	ht.NewNode("node-4", nil)
+	ht.NewNode("node-5", nil)
+	ht.NewNode("node-6", nil)
+
+	ht.Log("Attempting to create a 7th node")
+	ht.NewNode("node-7", nil)
+}


### PR DESCRIPTION
In this commit adds an itest which reproduces a bug where attempting to add a seventh new LND node results in a hang.

This PR shouldn't be merged. I've created it as a draft to make that clear.
