### PR TITLE
 [6/5]sweep: make sweeper ready to be used in `contractcourt`

### DIFF
--- a/contractcourt/breach_arbitrator.go
+++ b/contractcourt/breach_arbitrator.go
@@ -1102,8 +1102,8 @@ func (bo *breachedOutput) Amount() btcutil.Amount {
 
 // OutPoint returns the breached output's identifier that is to be included as a
 // transaction input.
-func (bo *breachedOutput) OutPoint() *wire.OutPoint {
-	return &bo.outpoint
+func (bo *breachedOutput) OutPoint() wire.OutPoint {
+	return bo.outpoint
 }
 
 // RequiredTxOut returns a non-nil TxOut if input commits to a certain
@@ -1547,7 +1547,7 @@ func (b *BreachArbitrator) sweepSpendableOutputsTxn(txWeight int64,
 	// transaction.
 	for _, inp := range inputs {
 		txn.AddTxIn(&wire.TxIn{
-			PreviousOutPoint: *inp.OutPoint(),
+			PreviousOutPoint: inp.OutPoint(),
 			Sequence:         inp.BlocksToMaturity(),
 		})
 	}
@@ -1641,7 +1641,7 @@ func taprootBriefcaseFromRetInfo(retInfo *retributionInfo) *taprootBriefcase {
 		case input.TaprootHtlcAcceptedRevoke:
 			fallthrough
 		case input.TaprootHtlcOfferedRevoke:
-			resID := newResolverID(*bo.OutPoint())
+			resID := newResolverID(bo.OutPoint())
 
 			var firstLevelTweak [32]byte
 			copy(firstLevelTweak[:], bo.signDesc.TapTweak)
@@ -1684,7 +1684,7 @@ func applyTaprootRetInfo(tapCase *taprootBriefcase,
 		case input.TaprootHtlcAcceptedRevoke:
 			fallthrough
 		case input.TaprootHtlcOfferedRevoke:
-			resID := newResolverID(*bo.OutPoint())
+			resID := newResolverID(bo.OutPoint())
 
 			tap1, ok := tapCase.TapTweaks.BreachedHtlcTweaks[resID]
 			if !ok {

--- a/contractcourt/breach_arbitrator_test.go
+++ b/contractcourt/breach_arbitrator_test.go
@@ -1202,8 +1202,13 @@ func TestBreachCreateJusticeTx(t *testing.T) {
 	for i, wt := range outputTypes {
 		// Create a fake breached output for each type, ensuring they
 		// have different outpoints for our logic to accept them.
+		//
+		// NOTE: although they are fake, we need to make sure the
+		// outputs are not empty values, otherwise they will be equal
+		// to `EmptyOutPoint` and `MultiPrevOutFetcher` will return an
+		// error.
 		op := breachedOutputs[0].outpoint
-		op.Index = uint32(i)
+		op.Index = uint32(1000 + i)
 		breachedOutputs[i] = makeBreachedOutput(
 			&op,
 			wt,

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -394,7 +394,7 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 				resolver := ctx.resolver.(*htlcSuccessResolver)
 				inp := <-resolver.Sweeper.(*mockSweeper).sweptInputs
 				op := inp.OutPoint()
-				if *op != commitOutpoint {
+				if op != commitOutpoint {
 					return fmt.Errorf("outpoint %v swept, "+
 						"expected %v", op,
 						commitOutpoint)
@@ -443,7 +443,7 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 					Hash:  reSignedHash,
 					Index: 1,
 				}
-				if *op != exp {
+				if op != exp {
 					return fmt.Errorf("swept outpoint %v, expected %v",
 						op, exp)
 				}

--- a/contractcourt/htlc_timeout_resolver_test.go
+++ b/contractcourt/htlc_timeout_resolver_test.go
@@ -1030,7 +1030,7 @@ func TestHtlcTimeoutSecondStageSweeper(t *testing.T) {
 				resolver := ctx.resolver.(*htlcTimeoutResolver)
 				inp := <-resolver.Sweeper.(*mockSweeper).sweptInputs
 				op := inp.OutPoint()
-				if *op != commitOutpoint {
+				if op != commitOutpoint {
 					return fmt.Errorf("outpoint %v swept, "+
 						"expected %v", op,
 						commitOutpoint)
@@ -1095,7 +1095,7 @@ func TestHtlcTimeoutSecondStageSweeper(t *testing.T) {
 					Hash:  reSignedHash,
 					Index: 1,
 				}
-				if *op != exp {
+				if op != exp {
 					return fmt.Errorf("wrong outpoint swept")
 				}
 
@@ -1205,7 +1205,7 @@ func TestHtlcTimeoutSecondStageSweeperRemoteSpend(t *testing.T) {
 				resolver := ctx.resolver.(*htlcTimeoutResolver)
 				inp := <-resolver.Sweeper.(*mockSweeper).sweptInputs
 				op := inp.OutPoint()
-				if *op != commitOutpoint {
+				if op != commitOutpoint {
 					return fmt.Errorf("outpoint %v swept, "+
 						"expected %v", op,
 						commitOutpoint)

--- a/contractcourt/nursery_store.go
+++ b/contractcourt/nursery_store.go
@@ -212,7 +212,7 @@ func prefixChainKey(sysPrefix []byte, hash *chainhash.Hash) ([]byte, error) {
 // outpoint with the provided state prefix. The returned bytes will be of the
 // form <prefix><outpoint>.
 func prefixOutputKey(statePrefix []byte,
-	outpoint *wire.OutPoint) ([]byte, error) {
+	outpoint wire.OutPoint) ([]byte, error) {
 
 	// Create a buffer to which we will first write the state prefix,
 	// followed by the outpoint.
@@ -221,7 +221,7 @@ func prefixOutputKey(statePrefix []byte,
 		return nil, err
 	}
 
-	err := writeOutpoint(&pfxOutputBuffer, outpoint)
+	err := writeOutpoint(&pfxOutputBuffer, &outpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/contractcourt/utxonursery.go
+++ b/contractcourt/utxonursery.go
@@ -1134,7 +1134,7 @@ func (c *ContractMaturityReport) AddLimboStage1TimeoutHtlc(baby *babyOutput) {
 
 	// TODO(roasbeef): bool to indicate stage 1 vs stage 2?
 	c.Htlcs = append(c.Htlcs, HtlcMaturityReport{
-		Outpoint:       *baby.OutPoint(),
+		Outpoint:       baby.OutPoint(),
 		Amount:         baby.Amount(),
 		MaturityHeight: baby.expiry,
 		Stage:          1,
@@ -1148,7 +1148,7 @@ func (c *ContractMaturityReport) AddLimboDirectHtlc(kid *kidOutput) {
 	c.LimboBalance += kid.Amount()
 
 	htlcReport := HtlcMaturityReport{
-		Outpoint:       *kid.OutPoint(),
+		Outpoint:       kid.OutPoint(),
 		Amount:         kid.Amount(),
 		MaturityHeight: kid.absoluteMaturity,
 		Stage:          2,
@@ -1164,7 +1164,7 @@ func (c *ContractMaturityReport) AddLimboStage1SuccessHtlc(kid *kidOutput) {
 	c.LimboBalance += kid.Amount()
 
 	c.Htlcs = append(c.Htlcs, HtlcMaturityReport{
-		Outpoint: *kid.OutPoint(),
+		Outpoint: kid.OutPoint(),
 		Amount:   kid.Amount(),
 		Stage:    1,
 	})
@@ -1176,7 +1176,7 @@ func (c *ContractMaturityReport) AddLimboStage2Htlc(kid *kidOutput) {
 	c.LimboBalance += kid.Amount()
 
 	htlcReport := HtlcMaturityReport{
-		Outpoint: *kid.OutPoint(),
+		Outpoint: kid.OutPoint(),
 		Amount:   kid.Amount(),
 		Stage:    2,
 	}
@@ -1197,7 +1197,7 @@ func (c *ContractMaturityReport) AddRecoveredHtlc(kid *kidOutput) {
 	c.RecoveredBalance += kid.Amount()
 
 	c.Htlcs = append(c.Htlcs, HtlcMaturityReport{
-		Outpoint:       *kid.OutPoint(),
+		Outpoint:       kid.OutPoint(),
 		Amount:         kid.Amount(),
 		MaturityHeight: kid.ConfHeight() + kid.BlocksToMaturity(),
 	})
@@ -1421,7 +1421,8 @@ func (k *kidOutput) Encode(w io.Writer) error {
 		return err
 	}
 
-	if err := writeOutpoint(w, k.OutPoint()); err != nil {
+	op := k.OutPoint()
+	if err := writeOutpoint(w, &op); err != nil {
 		return err
 	}
 	if err := writeOutpoint(w, k.OriginChanPoint()); err != nil {

--- a/contractcourt/utxonursery_test.go
+++ b/contractcourt/utxonursery_test.go
@@ -1065,7 +1065,7 @@ func newMockSweeperFull(t *testing.T) *mockSweeperFull {
 func (s *mockSweeperFull) sweepInput(input input.Input,
 	_ sweep.Params) (chan sweep.Result, error) {
 
-	log.Debugf("mockSweeper sweepInput called for %v", *input.OutPoint())
+	log.Debugf("mockSweeper sweepInput called for %v", input.OutPoint())
 
 	select {
 	case s.sweepChan <- input:
@@ -1077,7 +1077,7 @@ func (s *mockSweeperFull) sweepInput(input input.Input,
 	defer s.lock.Unlock()
 
 	c := make(chan sweep.Result, 1)
-	s.resultChans[*input.OutPoint()] = c
+	s.resultChans[input.OutPoint()] = c
 
 	return c, nil
 }

--- a/input/input.go
+++ b/input/input.go
@@ -9,6 +9,9 @@ import (
 	"github.com/lightningnetwork/lnd/lntypes"
 )
 
+// EmptyOutPoint is a zeroed outpoint.
+var EmptyOutPoint wire.OutPoint
+
 // Input represents an abstract UTXO which is to be spent using a sweeping
 // transaction. The method provided give the caller all information needed to
 // construct a valid input within a sweeping transaction to sweep this
@@ -16,7 +19,7 @@ import (
 type Input interface {
 	// Outpoint returns the reference to the output being spent, used to
 	// construct the corresponding transaction input.
-	OutPoint() *wire.OutPoint
+	OutPoint() wire.OutPoint
 
 	// RequiredTxOut returns a non-nil TxOut if input commits to a certain
 	// transaction output. This is used in the SINGLE|ANYONECANPAY case to
@@ -107,8 +110,8 @@ type inputKit struct {
 
 // OutPoint returns the breached output's identifier that is to be included as
 // a transaction input.
-func (i *inputKit) OutPoint() *wire.OutPoint {
-	return &i.outpoint
+func (i *inputKit) OutPoint() wire.OutPoint {
+	return i.outpoint
 }
 
 // RequiredTxOut returns a nil for the base input type.

--- a/input/mocks.go
+++ b/input/mocks.go
@@ -23,15 +23,11 @@ var _ Input = (*MockInput)(nil)
 
 // Outpoint returns the reference to the output being spent, used to construct
 // the corresponding transaction input.
-func (m *MockInput) OutPoint() *wire.OutPoint {
+func (m *MockInput) OutPoint() wire.OutPoint {
 	args := m.Called()
 	op := args.Get(0)
 
-	if op == nil {
-		return nil
-	}
-
-	return op.(*wire.OutPoint)
+	return op.(wire.OutPoint)
 }
 
 // RequiredTxOut returns a non-nil TxOut if input commits to a certain

--- a/input/taproot.go
+++ b/input/taproot.go
@@ -43,7 +43,7 @@ func MultiPrevOutFetcher(inputs []Input) (*txscript.MultiPrevOutFetcher, error) 
 		op := inp.OutPoint()
 		desc := inp.SignDesc()
 
-		if op == nil {
+		if op == EmptyOutPoint {
 			return nil, fmt.Errorf("missing input outpoint")
 		}
 
@@ -51,7 +51,7 @@ func MultiPrevOutFetcher(inputs []Input) (*txscript.MultiPrevOutFetcher, error) 
 			return nil, fmt.Errorf("missing input utxo information")
 		}
 
-		fetcher.AddPrevOut(*op, desc.Output)
+		fetcher.AddPrevOut(op, desc.Output)
 	}
 
 	return fetcher, nil

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -863,27 +863,27 @@ func (w *WalletKit) PendingSweeps(ctx context.Context,
 
 	// Retrieve all of the outputs the UtxoSweeper is currently trying to
 	// sweep.
-	pendingInputs, err := w.cfg.Sweeper.PendingInputs()
+	inputsMap, err := w.cfg.Sweeper.PendingInputs()
 	if err != nil {
 		return nil, err
 	}
 
 	// Convert them into their respective RPC format.
-	rpcPendingSweeps := make([]*PendingSweep, 0, len(pendingInputs))
-	for _, pendingInput := range pendingInputs {
-		witnessType, ok := allWitnessTypes[pendingInput.WitnessType]
+	rpcPendingSweeps := make([]*PendingSweep, 0, len(inputsMap))
+	for _, sweeperInput := range inputsMap {
+		witnessType, ok := allWitnessTypes[sweeperInput.WitnessType]
 		if !ok {
 			return nil, fmt.Errorf("unhandled witness type %v for "+
-				"input %v", pendingInput.WitnessType,
-				pendingInput.OutPoint)
+				"input %v", sweeperInput.WitnessType,
+				sweeperInput.OutPoint)
 		}
 
-		op := lnrpc.MarshalOutPoint(&pendingInput.OutPoint)
-		amountSat := uint32(pendingInput.Amount)
-		satPerVbyte := uint64(pendingInput.LastFeeRate.FeePerVByte())
-		broadcastAttempts := uint32(pendingInput.BroadcastAttempts)
+		op := lnrpc.MarshalOutPoint(&sweeperInput.OutPoint)
+		amountSat := uint32(sweeperInput.Amount)
+		satPerVbyte := uint64(sweeperInput.LastFeeRate.FeePerVByte())
+		broadcastAttempts := uint32(sweeperInput.BroadcastAttempts)
 
-		feePref := pendingInput.Params.Fee
+		feePref := sweeperInput.Params.Fee
 		requestedFee, ok := feePref.(sweep.FeeEstimateInfo)
 		if !ok {
 			return nil, fmt.Errorf("unknown fee preference type: "+
@@ -900,7 +900,7 @@ func (w *WalletKit) PendingSweeps(ctx context.Context,
 			BroadcastAttempts:    broadcastAttempts,
 			RequestedSatPerVbyte: requestedFeeRate,
 			RequestedConfTarget:  requestedFee.ConfTarget,
-			Force:                pendingInput.Params.Force,
+			Force:                sweeperInput.Params.Force,
 		})
 	}
 

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -883,25 +883,34 @@ func (w *WalletKit) PendingSweeps(ctx context.Context,
 		satPerVbyte := uint64(sweeperInput.LastFeeRate.FeePerVByte())
 		broadcastAttempts := uint32(sweeperInput.BroadcastAttempts)
 
-		feePref := sweeperInput.Params.Fee
-		requestedFee, ok := feePref.(sweep.FeeEstimateInfo)
-		if !ok {
-			return nil, fmt.Errorf("unknown fee preference type: "+
-				"%v", feePref)
+		ps := &PendingSweep{
+			Outpoint:          op,
+			WitnessType:       witnessType,
+			AmountSat:         amountSat,
+			SatPerVbyte:       satPerVbyte,
+			BroadcastAttempts: broadcastAttempts,
+			Force:             sweeperInput.Params.Force,
 		}
 
+		feePref := sweeperInput.Params.Fee
+
+		// If there's no fee preference specified, we can move to the
+		// next record.
+		if feePref == nil {
+			rpcPendingSweeps = append(rpcPendingSweeps, ps)
+			continue
+		}
+
+		requestedFee, ok := feePref.(sweep.FeeEstimateInfo)
+		if !ok {
+			return nil, fmt.Errorf("unknown fee "+
+				"preference type: "+"%v", feePref)
+		}
 		requestedFeeRate := uint64(requestedFee.FeeRate.FeePerVByte())
 
-		rpcPendingSweeps = append(rpcPendingSweeps, &PendingSweep{
-			Outpoint:             op,
-			WitnessType:          witnessType,
-			AmountSat:            amountSat,
-			SatPerVbyte:          satPerVbyte,
-			BroadcastAttempts:    broadcastAttempts,
-			RequestedSatPerVbyte: requestedFeeRate,
-			RequestedConfTarget:  requestedFee.ConfTarget,
-			Force:                sweeperInput.Params.Force,
-		})
+		ps.RequestedSatPerVbyte = requestedFeeRate
+		ps.RequestedConfTarget = requestedFee.ConfTarget
+		rpcPendingSweeps = append(rpcPendingSweeps, ps)
 	}
 
 	return &PendingSweepsResponse{

--- a/lnwallet/chainfee/estimator.go
+++ b/lnwallet/chainfee/estimator.go
@@ -17,11 +17,11 @@ import (
 )
 
 const (
-	// maxBlockTarget is the highest number of blocks confirmations that
+	// MaxBlockTarget is the highest number of blocks confirmations that
 	// a WebAPIEstimator will cache fees for. This number is chosen
 	// because it's the highest number of confs bitcoind will return a fee
 	// estimate for.
-	maxBlockTarget uint32 = 1008
+	MaxBlockTarget uint32 = 1008
 
 	// minBlockTarget is the lowest number of blocks confirmations that
 	// a WebAPIEstimator will cache fees for. Requesting an estimate for
@@ -463,11 +463,11 @@ func (b *BitcoindEstimator) Stop() error {
 func (b *BitcoindEstimator) EstimateFeePerKW(
 	numBlocks uint32) (SatPerKWeight, error) {
 
-	if numBlocks > maxBlockTarget {
+	if numBlocks > MaxBlockTarget {
 		log.Debugf("conf target %d exceeds the max value, "+
-			"use %d instead.", numBlocks, maxBlockTarget,
+			"use %d instead.", numBlocks, MaxBlockTarget,
 		)
-		numBlocks = maxBlockTarget
+		numBlocks = MaxBlockTarget
 	}
 
 	feeEstimate, err := b.fetchEstimate(numBlocks, b.feeMode)
@@ -761,8 +761,8 @@ func NewWebAPIEstimator(api WebAPIFeeSource, noCache bool) *WebAPIEstimator {
 func (w *WebAPIEstimator) EstimateFeePerKW(numBlocks uint32) (
 	SatPerKWeight, error) {
 
-	if numBlocks > maxBlockTarget {
-		numBlocks = maxBlockTarget
+	if numBlocks > MaxBlockTarget {
+		numBlocks = MaxBlockTarget
 	} else if numBlocks < minBlockTarget {
 		return 0, fmt.Errorf("conf target of %v is too low, minimum "+
 			"accepted is %v", numBlocks, minBlockTarget)

--- a/server.go
+++ b/server.go
@@ -1076,18 +1076,17 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 	})
 
 	s.sweeper = sweep.New(&sweep.UtxoSweeperConfig{
-		FeeEstimator:     cc.FeeEstimator,
-		GenSweepScript:   newSweepPkScriptGen(cc.Wallet),
-		Signer:           cc.Wallet.Cfg.Signer,
-		Wallet:           newSweeperWallet(cc.Wallet),
-		Mempool:          cc.MempoolNotifier,
-		Notifier:         cc.ChainNotifier,
-		Store:            sweeperStore,
-		MaxInputsPerTx:   sweep.DefaultMaxInputsPerTx,
-		MaxSweepAttempts: sweep.DefaultMaxSweepAttempts,
-		MaxFeeRate:       cfg.Sweeper.MaxFeeRate,
-		Aggregator:       aggregator,
-		Publisher:        s.txPublisher,
+		FeeEstimator:   cc.FeeEstimator,
+		GenSweepScript: newSweepPkScriptGen(cc.Wallet),
+		Signer:         cc.Wallet.Cfg.Signer,
+		Wallet:         newSweeperWallet(cc.Wallet),
+		Mempool:        cc.MempoolNotifier,
+		Notifier:       cc.ChainNotifier,
+		Store:          sweeperStore,
+		MaxInputsPerTx: sweep.DefaultMaxInputsPerTx,
+		MaxFeeRate:     cfg.Sweeper.MaxFeeRate,
+		Aggregator:     aggregator,
+		Publisher:      s.txPublisher,
 	})
 
 	s.utxoNursery = contractcourt.NewUtxoNursery(&contractcourt.NurseryConfig{

--- a/sweep/aggregator.go
+++ b/sweep/aggregator.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 )
@@ -123,7 +122,7 @@ func (c *inputCluster) createInputSets(maxFeeRate chainfee.SatPerKWeight,
 type UtxoAggregator interface {
 	// ClusterInputs takes a list of inputs and groups them into input
 	// sets. Each input set will be used to create a sweeping transaction.
-	ClusterInputs(InputsMap) []InputSet
+	ClusterInputs(inputs InputsMap, defaultDeadline int32) []InputSet
 }
 
 // SimpleAggregator aggregates inputs known by the Sweeper based on each
@@ -175,7 +174,7 @@ func NewSimpleUtxoAggregator(estimator chainfee.Estimator,
 // inputs known by the UtxoSweeper. It clusters inputs by
 // 1) Required tx locktime
 // 2) Similar fee rates.
-func (s *SimpleAggregator) ClusterInputs(inputs InputsMap) []InputSet {
+func (s *SimpleAggregator) ClusterInputs(inputs InputsMap, _ int32) []InputSet {
 	// We start by getting the inputs clusters by locktime. Since the
 	// inputs commit to the locktime, they can only be clustered together
 	// if the locktime is equal.
@@ -492,7 +491,7 @@ func NewBudgetAggregator(estimator chainfee.Estimator,
 }
 
 // clusterGroup defines an alias for a set of inputs that are to be grouped.
-type clusterGroup map[fn.Option[int32]][]SweeperInput
+type clusterGroup map[int32][]SweeperInput
 
 // ClusterInputs creates a list of input sets from pending inputs.
 // 1. filter out inputs whose budget cannot cover min relay fee.
@@ -502,7 +501,9 @@ type clusterGroup map[fn.Option[int32]][]SweeperInput
 // 5. optionally split a cluster if it exceeds the max input limit.
 // 6. create input sets from each of the clusters.
 // 7. create input sets for each of the exclusive inputs.
-func (b *BudgetAggregator) ClusterInputs(inputs InputsMap) []InputSet {
+func (b *BudgetAggregator) ClusterInputs(inputs InputsMap,
+	defaultDeadline int32) []InputSet {
+
 	// Filter out inputs that have a budget below min relay fee.
 	filteredInputs := b.filterInputs(inputs)
 
@@ -513,19 +514,25 @@ func (b *BudgetAggregator) ClusterInputs(inputs InputsMap) []InputSet {
 	// any cluster. These inputs can only be swept independently as there's
 	// no guarantee which input will be confirmed first, which means
 	// grouping exclusive inputs may jeopardize non-exclusive inputs.
-	exclusiveInputs := make(InputsMap)
+	exclusiveInputs := make(map[wire.OutPoint]clusterGroup)
 
 	// Iterate all the inputs and group them based on their specified
 	// deadline heights.
 	for _, input := range filteredInputs {
+		// Get deadline height, and use the specified default deadline
+		// height if it's not set.
+		height := input.params.DeadlineHeight.UnwrapOr(defaultDeadline)
+
 		// Put exclusive inputs in their own set.
 		if input.params.ExclusiveGroup != nil {
 			log.Tracef("Input %v is exclusive", input.OutPoint())
-			exclusiveInputs[input.OutPoint()] = input
+			exclusiveInputs[input.OutPoint()] = clusterGroup{
+				height: []SweeperInput{*input},
+			}
+
 			continue
 		}
 
-		height := input.params.DeadlineHeight
 		cluster, ok := clusters[height]
 		if !ok {
 			cluster = make([]SweeperInput, 0)
@@ -540,19 +547,21 @@ func (b *BudgetAggregator) ClusterInputs(inputs InputsMap) []InputSet {
 	// NOTE: cannot pre-allocate the slice since we don't know the number
 	// of input sets in advance.
 	inputSets := make([]InputSet, 0)
-	for _, cluster := range clusters {
+	for height, cluster := range clusters {
 		// Sort the inputs by their economical value.
 		sortedInputs := b.sortInputs(cluster)
 
 		// Create input sets from the cluster.
-		sets := b.createInputSets(sortedInputs)
+		sets := b.createInputSets(sortedInputs, height)
 		inputSets = append(inputSets, sets...)
 	}
 
 	// Create input sets from the exclusive inputs.
-	for _, input := range exclusiveInputs {
-		sets := b.createInputSets([]SweeperInput{*input})
-		inputSets = append(inputSets, sets...)
+	for _, cluster := range exclusiveInputs {
+		for height, input := range cluster {
+			sets := b.createInputSets(input, height)
+			inputSets = append(inputSets, sets...)
+		}
 	}
 
 	return inputSets
@@ -561,7 +570,9 @@ func (b *BudgetAggregator) ClusterInputs(inputs InputsMap) []InputSet {
 // createInputSet takes a set of inputs which share the same deadline height
 // and turns them into a list of `InputSet`, each set is then used to create a
 // sweep transaction.
-func (b *BudgetAggregator) createInputSets(inputs []SweeperInput) []InputSet {
+func (b *BudgetAggregator) createInputSets(inputs []SweeperInput,
+	deadlineHeight int32) []InputSet {
+
 	// sets holds the InputSets that we will return.
 	sets := make([]InputSet, 0)
 
@@ -582,7 +593,9 @@ func (b *BudgetAggregator) createInputSets(inputs []SweeperInput) []InputSet {
 		remainingInputs = remainingInputs[b.maxInputs:]
 
 		// Create an InputSet using the max allowed number of inputs.
-		set, err := NewBudgetInputSet(currentInputs)
+		set, err := NewBudgetInputSet(
+			currentInputs, deadlineHeight,
+		)
 		if err != nil {
 			log.Errorf("unable to create input set: %v", err)
 
@@ -594,7 +607,9 @@ func (b *BudgetAggregator) createInputSets(inputs []SweeperInput) []InputSet {
 
 	// Create an InputSet from the remaining inputs.
 	if len(remainingInputs) > 0 {
-		set, err := NewBudgetInputSet(remainingInputs)
+		set, err := NewBudgetInputSet(
+			remainingInputs, deadlineHeight,
+		)
 		if err != nil {
 			log.Errorf("unable to create input set: %v", err)
 			return nil

--- a/sweep/aggregator.go
+++ b/sweep/aggregator.go
@@ -521,7 +521,7 @@ func (b *BudgetAggregator) ClusterInputs(inputs InputsMap) []InputSet {
 		// Put exclusive inputs in their own set.
 		if input.params.ExclusiveGroup != nil {
 			log.Tracef("Input %v is exclusive", input.OutPoint())
-			exclusiveInputs[*input.OutPoint()] = input
+			exclusiveInputs[input.OutPoint()] = input
 			continue
 		}
 
@@ -655,7 +655,7 @@ func (b *BudgetAggregator) filterInputs(inputs InputsMap) InputsMap {
 			}
 		}
 
-		filteredInputs[*op] = pi
+		filteredInputs[op] = pi
 	}
 
 	return filteredInputs

--- a/sweep/aggregator_test.go
+++ b/sweep/aggregator_test.go
@@ -657,19 +657,19 @@ func TestBudgetAggregatorCreateInputSets(t *testing.T) {
 	pi1 := SweeperInput{
 		Input: mockInput1,
 		params: Params{
-			DeadlineHeight: fn.Some(int32(1)),
+			DeadlineHeight: fn.Some(testHeight),
 		},
 	}
 	pi2 := SweeperInput{
 		Input: mockInput2,
 		params: Params{
-			DeadlineHeight: fn.Some(int32(1)),
+			DeadlineHeight: fn.Some(testHeight),
 		},
 	}
 	pi3 := SweeperInput{
 		Input: mockInput3,
 		params: Params{
-			DeadlineHeight: fn.Some(int32(1)),
+			DeadlineHeight: fn.Some(testHeight),
 		},
 	}
 	pi4 := SweeperInput{
@@ -678,7 +678,7 @@ func TestBudgetAggregatorCreateInputSets(t *testing.T) {
 			// This input has a deadline height that is different
 			// from the other inputs. When grouped with other
 			// inputs, it will cause an error to be returned.
-			DeadlineHeight: fn.Some(int32(2)),
+			DeadlineHeight: fn.Some(testHeight + 1),
 		},
 	}
 

--- a/sweep/aggregator_test.go
+++ b/sweep/aggregator_test.go
@@ -19,25 +19,25 @@ import (
 
 //nolint:lll
 var (
-	testInputsA = pendingInputs{
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 0}: &pendingInput{},
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 1}: &pendingInput{},
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 2}: &pendingInput{},
+	testInputsA = InputsMap{
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 0}: &SweeperInput{},
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 1}: &SweeperInput{},
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 2}: &SweeperInput{},
 	}
 
-	testInputsB = pendingInputs{
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 10}: &pendingInput{},
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 11}: &pendingInput{},
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 12}: &pendingInput{},
+	testInputsB = InputsMap{
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 10}: &SweeperInput{},
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 11}: &SweeperInput{},
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 12}: &SweeperInput{},
 	}
 
-	testInputsC = pendingInputs{
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 0}:  &pendingInput{},
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 1}:  &pendingInput{},
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 2}:  &pendingInput{},
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 10}: &pendingInput{},
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 11}: &pendingInput{},
-		wire.OutPoint{Hash: chainhash.Hash{}, Index: 12}: &pendingInput{},
+	testInputsC = InputsMap{
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 0}:  &SweeperInput{},
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 1}:  &SweeperInput{},
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 2}:  &SweeperInput{},
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 10}: &SweeperInput{},
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 11}: &SweeperInput{},
+		wire.OutPoint{Hash: chainhash.Hash{}, Index: 12}: &SweeperInput{},
 	}
 )
 
@@ -132,7 +132,7 @@ func TestMergeClusters(t *testing.T) {
 func TestZipClusters(t *testing.T) {
 	t.Parallel()
 
-	createCluster := func(inp pendingInputs,
+	createCluster := func(inp InputsMap,
 		f chainfee.SatPerKWeight) inputCluster {
 
 		return inputCluster{
@@ -275,19 +275,19 @@ func TestClusterByLockTime(t *testing.T) {
 
 	// With the inner Input being mocked, we can now create the pending
 	// inputs.
-	input1 := &pendingInput{Input: input1LockTime1, params: param}
-	input2 := &pendingInput{Input: input2LockTime1, params: param}
-	input3 := &pendingInput{Input: input3LockTime2, params: param}
-	input4 := &pendingInput{Input: input4LockTime2, params: param}
-	input5 := &pendingInput{Input: input5NoLockTime, params: param}
-	input6 := &pendingInput{Input: input6NoLockTime, params: param}
+	input1 := &SweeperInput{Input: input1LockTime1, params: param}
+	input2 := &SweeperInput{Input: input2LockTime1, params: param}
+	input3 := &SweeperInput{Input: input3LockTime2, params: param}
+	input4 := &SweeperInput{Input: input4LockTime2, params: param}
+	input5 := &SweeperInput{Input: input5NoLockTime, params: param}
+	input6 := &SweeperInput{Input: input6NoLockTime, params: param}
 
 	// Create the pending inputs map, which will be passed to the method
 	// under test.
 	//
 	// NOTE: we don't care the actual outpoint values as long as they are
 	// unique.
-	inputs := pendingInputs{
+	inputs := InputsMap{
 		wire.OutPoint{Index: 1}: input1,
 		wire.OutPoint{Index: 2}: input2,
 		wire.OutPoint{Index: 3}: input3,
@@ -298,18 +298,18 @@ func TestClusterByLockTime(t *testing.T) {
 
 	// Create expected clusters so we can shorten the line length in the
 	// test cases below.
-	cluster1 := pendingInputs{
+	cluster1 := InputsMap{
 		wire.OutPoint{Index: 1}: input1,
 		wire.OutPoint{Index: 2}: input2,
 	}
-	cluster2 := pendingInputs{
+	cluster2 := InputsMap{
 		wire.OutPoint{Index: 3}: input3,
 		wire.OutPoint{Index: 4}: input4,
 	}
 
 	// cluster3 should be the remaining inputs since they don't have
 	// locktime.
-	cluster3 := pendingInputs{
+	cluster3 := InputsMap{
 		wire.OutPoint{Index: 5}: input5,
 		wire.OutPoint{Index: 6}: input6,
 	}
@@ -332,7 +332,7 @@ func TestClusterByLockTime(t *testing.T) {
 		setupMocker             func()
 		testFeeRate             chainfee.SatPerKWeight
 		expectedClusters        []inputCluster
-		expectedRemainingInputs pendingInputs
+		expectedRemainingInputs InputsMap
 	}{
 		{
 			// Test a successful case where the locktime clusters
@@ -518,33 +518,33 @@ func TestBudgetAggregatorFilterInputs(t *testing.T) {
 	})
 
 	// Create testing pending inputs.
-	inputs := pendingInputs{
+	inputs := InputsMap{
 		// The first input will be filtered out due to the error.
-		opErr: &pendingInput{
+		opErr: &SweeperInput{
 			Input: inpErr,
 		},
 
 		// The second input will be filtered out due to the budget.
-		opLow: &pendingInput{
+		opLow: &SweeperInput{
 			Input:  inpLow,
 			params: Params{Budget: budgetLow},
 		},
 
 		// The third input will be included.
-		opEqual: &pendingInput{
+		opEqual: &SweeperInput{
 			Input:  inpEqual,
 			params: Params{Budget: budgetEqual},
 		},
 
 		// The fourth input will be included.
-		opHigh: &pendingInput{
+		opHigh: &SweeperInput{
 			Input:  inpHigh,
 			params: Params{Budget: budgetHigh},
 		},
 
 		// The fifth input will be filtered out due to the dust
 		// required.
-		opDust: &pendingInput{
+		opDust: &SweeperInput{
 			Input:  inpDust,
 			params: Params{Budget: budgetHigh},
 		},
@@ -578,7 +578,7 @@ func TestBudgetAggregatorSortInputs(t *testing.T) {
 	)
 
 	// Create an input with the low budget but forced.
-	inputLowForce := pendingInput{
+	inputLowForce := SweeperInput{
 		params: Params{
 			Budget: budgetLow,
 			Force:  true,
@@ -586,14 +586,14 @@ func TestBudgetAggregatorSortInputs(t *testing.T) {
 	}
 
 	// Create an input with the low budget.
-	inputLow := pendingInput{
+	inputLow := SweeperInput{
 		params: Params{
 			Budget: budgetLow,
 		},
 	}
 
 	// Create an input with the high budget and forced.
-	inputHighForce := pendingInput{
+	inputHighForce := SweeperInput{
 		params: Params{
 			Budget: budgetHight,
 			Force:  true,
@@ -601,14 +601,14 @@ func TestBudgetAggregatorSortInputs(t *testing.T) {
 	}
 
 	// Create an input with the high budget.
-	inputHigh := pendingInput{
+	inputHigh := SweeperInput{
 		params: Params{
 			Budget: budgetHight,
 		},
 	}
 
 	// Create a testing pending inputs.
-	inputs := []pendingInput{
+	inputs := []SweeperInput{
 		inputLowForce,
 		inputLow,
 		inputHighForce,
@@ -652,25 +652,25 @@ func TestBudgetAggregatorCreateInputSets(t *testing.T) {
 	defer mockInput4.AssertExpectations(t)
 
 	// Create testing pending inputs.
-	pi1 := pendingInput{
+	pi1 := SweeperInput{
 		Input: mockInput1,
 		params: Params{
 			DeadlineHeight: fn.Some(int32(1)),
 		},
 	}
-	pi2 := pendingInput{
+	pi2 := SweeperInput{
 		Input: mockInput2,
 		params: Params{
 			DeadlineHeight: fn.Some(int32(1)),
 		},
 	}
-	pi3 := pendingInput{
+	pi3 := SweeperInput{
 		Input: mockInput3,
 		params: Params{
 			DeadlineHeight: fn.Some(int32(1)),
 		},
 	}
-	pi4 := pendingInput{
+	pi4 := SweeperInput{
 		Input: mockInput4,
 		params: Params{
 			// This input has a deadline height that is different
@@ -686,7 +686,7 @@ func TestBudgetAggregatorCreateInputSets(t *testing.T) {
 	// Create test cases.
 	testCases := []struct {
 		name            string
-		inputs          []pendingInput
+		inputs          []SweeperInput
 		setupMock       func()
 		expectedNumSets int
 	}{
@@ -694,7 +694,7 @@ func TestBudgetAggregatorCreateInputSets(t *testing.T) {
 			// When the number of inputs is below the max, a single
 			// input set is returned.
 			name:   "num inputs below max",
-			inputs: []pendingInput{pi1},
+			inputs: []SweeperInput{pi1},
 			setupMock: func() {
 				// Mock methods used in loggings.
 				mockInput1.On("WitnessType").Return(
@@ -708,7 +708,7 @@ func TestBudgetAggregatorCreateInputSets(t *testing.T) {
 			// When the number of inputs is equal to the max, a
 			// single input set is returned.
 			name:   "num inputs equal to max",
-			inputs: []pendingInput{pi1, pi2},
+			inputs: []SweeperInput{pi1, pi2},
 			setupMock: func() {
 				// Mock methods used in loggings.
 				mockInput1.On("WitnessType").Return(
@@ -727,7 +727,7 @@ func TestBudgetAggregatorCreateInputSets(t *testing.T) {
 			// When the number of inputs is above the max, multiple
 			// input sets are returned.
 			name:   "num inputs above max",
-			inputs: []pendingInput{pi1, pi2, pi3},
+			inputs: []SweeperInput{pi1, pi2, pi3},
 			setupMock: func() {
 				// Mock methods used in loggings.
 				mockInput1.On("WitnessType").Return(
@@ -751,7 +751,7 @@ func TestBudgetAggregatorCreateInputSets(t *testing.T) {
 			// error is returned from creating the first set, it
 			// shouldn't affect the remaining inputs.
 			name:   "num inputs above max with error",
-			inputs: []pendingInput{pi1, pi4, pi3},
+			inputs: []SweeperInput{pi1, pi4, pi3},
 			setupMock: func() {
 				// Mock methods used in loggings.
 				mockInput1.On("WitnessType").Return(
@@ -825,7 +825,7 @@ func TestBudgetInputSetClusterInputs(t *testing.T) {
 	)
 
 	// Create testing pending inputs.
-	inputs := make(pendingInputs)
+	inputs := make(InputsMap)
 
 	// For each deadline height, create two inputs with different budgets,
 	// one below the min fee rate and one above it. We should see the lower
@@ -879,7 +879,7 @@ func TestBudgetInputSetClusterInputs(t *testing.T) {
 		inpHigh2.On("RequiredTxOut").Return(nil)
 
 		// Add the low input, which should be filtered out.
-		inputs[opLow] = &pendingInput{
+		inputs[opLow] = &SweeperInput{
 			Input: inpLow,
 			params: Params{
 				Budget:         budgetLow,
@@ -888,14 +888,14 @@ func TestBudgetInputSetClusterInputs(t *testing.T) {
 		}
 
 		// Add the high inputs, which should be included.
-		inputs[opHigh1] = &pendingInput{
+		inputs[opHigh1] = &SweeperInput{
 			Input: inpHigh1,
 			params: Params{
 				Budget:         budgetHigh,
 				DeadlineHeight: deadline,
 			},
 		}
-		inputs[opHigh2] = &pendingInput{
+		inputs[opHigh2] = &SweeperInput{
 			Input: inpHigh2,
 			params: Params{
 				Budget:         budgetHigh,

--- a/sweep/aggregator_test.go
+++ b/sweep/aggregator_test.go
@@ -39,6 +39,8 @@ var (
 		wire.OutPoint{Hash: chainhash.Hash{}, Index: 11}: &SweeperInput{},
 		wire.OutPoint{Hash: chainhash.Hash{}, Index: 12}: &SweeperInput{},
 	}
+
+	testHeight = int32(800000)
 )
 
 // TestMergeClusters check that we properly can merge clusters together,
@@ -779,7 +781,7 @@ func TestBudgetAggregatorCreateInputSets(t *testing.T) {
 			tc.setupMock()
 
 			// Call the method under test.
-			result := b.createInputSets(tc.inputs)
+			result := b.createInputSets(tc.inputs, testHeight)
 
 			// Validate the expected number of input sets are
 			// returned.
@@ -938,7 +940,8 @@ func TestBudgetInputSetClusterInputs(t *testing.T) {
 	b := NewBudgetAggregator(estimator, DefaultMaxInputsPerTx)
 
 	// Call the method under test.
-	result := b.ClusterInputs(inputs)
+	defaultDeadline := testHeight + DefaultDeadlineDelta
+	result := b.ClusterInputs(inputs, defaultDeadline)
 
 	// We expect four input sets to be returned, one for each deadline and
 	// extra one for the exclusive input.
@@ -949,7 +952,7 @@ func TestBudgetInputSetClusterInputs(t *testing.T) {
 	require.Len(t, setExclusive.Inputs(), 1)
 
 	// Check the each of rest has exactly two inputs.
-	deadlines := make(map[fn.Option[int32]]struct{})
+	deadlines := make(map[int32]struct{})
 	for _, set := range result[:3] {
 		// We expect two inputs in each set.
 		require.Len(t, set.Inputs(), 2)
@@ -962,7 +965,7 @@ func TestBudgetInputSetClusterInputs(t *testing.T) {
 	}
 
 	// We expect to see all three deadlines.
-	require.Contains(t, deadlines, deadlineNone)
-	require.Contains(t, deadlines, deadline1)
-	require.Contains(t, deadlines, deadline2)
+	require.Contains(t, deadlines, defaultDeadline)
+	require.Contains(t, deadlines, deadline1.UnwrapOrFail(t))
+	require.Contains(t, deadlines, deadline2.UnwrapOrFail(t))
 }

--- a/sweep/aggregator_test.go
+++ b/sweep/aggregator_test.go
@@ -801,10 +801,10 @@ func TestBudgetInputSetClusterInputs(t *testing.T) {
 	wt := &input.MockWitnessType{}
 	defer wt.AssertExpectations(t)
 
-	// Mock the `SizeUpperBound` method to return the size six times since
-	// we are using nine inputs.
+	// Mock the `SizeUpperBound` method to return the size 10 times since
+	// we are using ten inputs.
 	const wtSize = 100
-	wt.On("SizeUpperBound").Return(wtSize, true, nil).Times(9)
+	wt.On("SizeUpperBound").Return(wtSize, true, nil).Times(10)
 	wt.On("String").Return("mock witness type")
 
 	// Mock the estimator to return a constant fee rate.
@@ -826,6 +826,36 @@ func TestBudgetInputSetClusterInputs(t *testing.T) {
 
 	// Create testing pending inputs.
 	inputs := make(InputsMap)
+
+	// Create a mock input that is exclusive.
+	inpExclusive := &input.MockInput{}
+	defer inpExclusive.AssertExpectations(t)
+
+	// We expect the high budget input to call this method three times,
+	// 1. in `filterInputs`
+	// 2. in `createInputSet`
+	// 3. when assigning the input to the exclusiveInputs.
+	// 4. when iterating the exclusiveInputs.
+	opExclusive := wire.OutPoint{Hash: chainhash.Hash{1, 2, 3, 4, 5}}
+	inpExclusive.On("OutPoint").Return(&opExclusive).Times(4)
+
+	// Mock the `WitnessType` method to return the witness type.
+	inpExclusive.On("WitnessType").Return(wt)
+
+	// Mock the `RequiredTxOut` to return nil.
+	inpExclusive.On("RequiredTxOut").Return(nil)
+
+	// Add the exclusive input to the inputs map. We expect this input to
+	// be in its own input set although it has deadline1.
+	exclusiveGroup := uint64(123)
+	inputs[opExclusive] = &SweeperInput{
+		Input: inpExclusive,
+		params: Params{
+			Budget:         budgetHigh,
+			DeadlineHeight: deadline1,
+			ExclusiveGroup: &exclusiveGroup,
+		},
+	}
 
 	// For each deadline height, create two inputs with different budgets,
 	// one below the min fee rate and one above it. We should see the lower
@@ -910,12 +940,17 @@ func TestBudgetInputSetClusterInputs(t *testing.T) {
 	// Call the method under test.
 	result := b.ClusterInputs(inputs)
 
-	// We expect three input sets to be returned, one for each deadline.
-	require.Len(t, result, 3)
+	// We expect four input sets to be returned, one for each deadline and
+	// extra one for the exclusive input.
+	require.Len(t, result, 4)
 
-	// Check each input set has exactly two inputs.
+	// The last set should be the exclusive input that has only one input.
+	setExclusive := result[3]
+	require.Len(t, setExclusive.Inputs(), 1)
+
+	// Check the each of rest has exactly two inputs.
 	deadlines := make(map[fn.Option[int32]]struct{})
-	for _, set := range result {
+	for _, set := range result[:3] {
 		// We expect two inputs in each set.
 		require.Len(t, set.Inputs(), 2)
 

--- a/sweep/aggregator_test.go
+++ b/sweep/aggregator_test.go
@@ -460,7 +460,7 @@ func TestBudgetAggregatorFilterInputs(t *testing.T) {
 
 	// Mock the `OutPoint` method to return a unique outpoint.
 	opErr := wire.OutPoint{Hash: chainhash.Hash{1}}
-	inpErr.On("OutPoint").Return(&opErr).Once()
+	inpErr.On("OutPoint").Return(opErr).Once()
 
 	// Mock the estimator to return a constant fee rate.
 	const minFeeRate = chainfee.SatPerKWeight(1000)
@@ -502,10 +502,10 @@ func TestBudgetAggregatorFilterInputs(t *testing.T) {
 	inpDust.On("WitnessType").Return(wt)
 
 	// Mock the `OutPoint` method to return the unique outpoint.
-	inpLow.On("OutPoint").Return(&opLow)
-	inpEqual.On("OutPoint").Return(&opEqual)
-	inpHigh.On("OutPoint").Return(&opHigh)
-	inpDust.On("OutPoint").Return(&opDust)
+	inpLow.On("OutPoint").Return(opLow)
+	inpEqual.On("OutPoint").Return(opEqual)
+	inpHigh.On("OutPoint").Return(opHigh)
+	inpDust.On("OutPoint").Return(opDust)
 
 	// Mock the `RequiredTxOut` to return nil.
 	inpEqual.On("RequiredTxOut").Return(nil)
@@ -700,7 +700,7 @@ func TestBudgetAggregatorCreateInputSets(t *testing.T) {
 				mockInput1.On("WitnessType").Return(
 					input.CommitmentAnchor)
 				mockInput1.On("OutPoint").Return(
-					&wire.OutPoint{Hash: chainhash.Hash{1}})
+					wire.OutPoint{Hash: chainhash.Hash{1}})
 			},
 			expectedNumSets: 1,
 		},
@@ -717,9 +717,9 @@ func TestBudgetAggregatorCreateInputSets(t *testing.T) {
 					input.CommitmentAnchor)
 
 				mockInput1.On("OutPoint").Return(
-					&wire.OutPoint{Hash: chainhash.Hash{1}})
+					wire.OutPoint{Hash: chainhash.Hash{1}})
 				mockInput2.On("OutPoint").Return(
-					&wire.OutPoint{Hash: chainhash.Hash{2}})
+					wire.OutPoint{Hash: chainhash.Hash{2}})
 			},
 			expectedNumSets: 1,
 		},
@@ -738,11 +738,11 @@ func TestBudgetAggregatorCreateInputSets(t *testing.T) {
 					input.CommitmentAnchor)
 
 				mockInput1.On("OutPoint").Return(
-					&wire.OutPoint{Hash: chainhash.Hash{1}})
+					wire.OutPoint{Hash: chainhash.Hash{1}})
 				mockInput2.On("OutPoint").Return(
-					&wire.OutPoint{Hash: chainhash.Hash{2}})
+					wire.OutPoint{Hash: chainhash.Hash{2}})
 				mockInput3.On("OutPoint").Return(
-					&wire.OutPoint{Hash: chainhash.Hash{3}})
+					wire.OutPoint{Hash: chainhash.Hash{3}})
 			},
 			expectedNumSets: 2,
 		},
@@ -760,11 +760,11 @@ func TestBudgetAggregatorCreateInputSets(t *testing.T) {
 					input.CommitmentAnchor)
 
 				mockInput1.On("OutPoint").Return(
-					&wire.OutPoint{Hash: chainhash.Hash{1}})
+					wire.OutPoint{Hash: chainhash.Hash{1}})
 				mockInput3.On("OutPoint").Return(
-					&wire.OutPoint{Hash: chainhash.Hash{3}})
+					wire.OutPoint{Hash: chainhash.Hash{3}})
 				mockInput4.On("OutPoint").Return(
-					&wire.OutPoint{Hash: chainhash.Hash{2}})
+					wire.OutPoint{Hash: chainhash.Hash{2}})
 			},
 			expectedNumSets: 1,
 		},
@@ -837,7 +837,7 @@ func TestBudgetInputSetClusterInputs(t *testing.T) {
 	// 3. when assigning the input to the exclusiveInputs.
 	// 4. when iterating the exclusiveInputs.
 	opExclusive := wire.OutPoint{Hash: chainhash.Hash{1, 2, 3, 4, 5}}
-	inpExclusive.On("OutPoint").Return(&opExclusive).Times(4)
+	inpExclusive.On("OutPoint").Return(opExclusive).Times(4)
 
 	// Mock the `WitnessType` method to return the witness type.
 	inpExclusive.On("WitnessType").Return(wt)
@@ -891,13 +891,13 @@ func TestBudgetInputSetClusterInputs(t *testing.T) {
 		//
 		// We expect the low budget input to call this method once in
 		// `filterInputs`.
-		inpLow.On("OutPoint").Return(&opLow).Once()
+		inpLow.On("OutPoint").Return(opLow).Once()
 
 		// We expect the high budget input to call this method three
 		// times, one in `filterInputs` and one in `createInputSet`,
 		// and one in `NewBudgetInputSet`.
-		inpHigh1.On("OutPoint").Return(&opHigh1).Times(3)
-		inpHigh2.On("OutPoint").Return(&opHigh2).Times(3)
+		inpHigh1.On("OutPoint").Return(opHigh1).Times(3)
+		inpHigh2.On("OutPoint").Return(opHigh2).Times(3)
 
 		// Mock the `WitnessType` method to return the witness type.
 		inpLow.On("WitnessType").Return(wt)

--- a/sweep/bucket_list.go
+++ b/sweep/bucket_list.go
@@ -1,10 +1,10 @@
 package sweep
 
 // bucket contains a set of inputs that are not mutually exclusive.
-type bucket pendingInputs
+type bucket InputsMap
 
 // tryAdd tries to add a new input to this bucket.
-func (b bucket) tryAdd(input *pendingInput) bool {
+func (b bucket) tryAdd(input *SweeperInput) bool {
 	exclusiveGroup := input.params.ExclusiveGroup
 	if exclusiveGroup != nil {
 		for _, input := range b {
@@ -40,7 +40,7 @@ type bucketList struct {
 
 // add adds a new input. If the input is not accepted by any of the existing
 // buckets, a new bucket will be created.
-func (b *bucketList) add(input *pendingInput) {
+func (b *bucketList) add(input *SweeperInput) {
 	for _, existingBucket := range b.buckets {
 		if existingBucket.tryAdd(input) {
 			return

--- a/sweep/bucket_list.go
+++ b/sweep/bucket_list.go
@@ -28,7 +28,7 @@ func (b bucket) tryAdd(input *SweeperInput) bool {
 		}
 	}
 
-	b[*input.OutPoint()] = input
+	b[input.OutPoint()] = input
 
 	return true
 }

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -996,7 +996,7 @@ func (t *TxPublisher) createSweepTx(inputs []input.Input, changePkScript []byte,
 
 		idxs = append(idxs, o)
 		sweepTx.AddTxIn(&wire.TxIn{
-			PreviousOutPoint: *o.OutPoint(),
+			PreviousOutPoint: o.OutPoint(),
 			Sequence:         o.BlocksToMaturity(),
 		})
 		sweepTx.AddTxOut(o.RequiredTxOut())
@@ -1011,7 +1011,7 @@ func (t *TxPublisher) createSweepTx(inputs []input.Input, changePkScript []byte,
 
 		idxs = append(idxs, o)
 		sweepTx.AddTxIn(&wire.TxIn{
-			PreviousOutPoint: *o.OutPoint(),
+			PreviousOutPoint: o.OutPoint(),
 			Sequence:         o.BlocksToMaturity(),
 		})
 	}

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -9,6 +9,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/davecgh/go-spew/spew"
@@ -28,6 +29,14 @@ var (
 	// ErrNotEnoughBudget is returned when the fee bumper decides the
 	// current budget cannot cover the fee.
 	ErrNotEnoughBudget = errors.New("not enough budget")
+
+	// ErrLocktimeImmature is returned when sweeping an input whose
+	// locktime is not reached.
+	ErrLocktimeImmature = errors.New("immature input")
+
+	// ErrTxNoOutput is returned when an output cannot be created during tx
+	// preparation, usually due to the output being dust.
+	ErrTxNoOutput = errors.New("tx has no output")
 )
 
 // Bumper defines an interface that can be used by other subsystems for fee
@@ -458,11 +467,8 @@ func (t *TxPublisher) createAndCheckTx(req *BumpRequest, f FeeFunction) (
 
 	// Create the sweep tx with max fee rate of 0 as the fee function
 	// guarantees the fee rate used here won't exceed the max fee rate.
-	//
-	// TODO(yy): refactor this function to not require a max fee rate.
-	tx, fee, err := createSweepTx(
-		req.Inputs, nil, req.DeliveryAddress, uint32(t.currentHeight),
-		f.FeeRate(), 0, t.cfg.Signer,
+	tx, fee, err := t.createSweepTx(
+		req.Inputs, req.DeliveryAddress, f.FeeRate(),
 	)
 	if err != nil {
 		return nil, 0, fmt.Errorf("create sweep tx: %w", err)
@@ -950,4 +956,233 @@ func calcCurrentConfTarget(currentHeight, deadline int32) uint32 {
 	}
 
 	return confTarget
+}
+
+// createSweepTx creates a sweeping tx based on the given inputs, change
+// address and fee rate.
+func (t *TxPublisher) createSweepTx(inputs []input.Input, changePkScript []byte,
+	feeRate chainfee.SatPerKWeight) (*wire.MsgTx, btcutil.Amount, error) {
+
+	// Validate and calculate the fee and change amount.
+	txFee, changeAmtOpt, locktimeOpt, err := prepareSweepTx(
+		inputs, changePkScript, feeRate, t.currentHeight,
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var (
+		// Create the sweep transaction that we will be building. We
+		// use version 2 as it is required for CSV.
+		sweepTx = wire.NewMsgTx(2)
+
+		// We'll add the inputs as we go so we know the final ordering
+		// of inputs to sign.
+		idxs []input.Input
+	)
+
+	// We start by adding all inputs that commit to an output. We do this
+	// since the input and output index must stay the same for the
+	// signatures to be valid.
+	for _, o := range inputs {
+		if o.RequiredTxOut() == nil {
+			continue
+		}
+
+		idxs = append(idxs, o)
+		sweepTx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: *o.OutPoint(),
+			Sequence:         o.BlocksToMaturity(),
+		})
+		sweepTx.AddTxOut(o.RequiredTxOut())
+	}
+
+	// Sum up the value contained in the remaining inputs, and add them to
+	// the sweep transaction.
+	for _, o := range inputs {
+		if o.RequiredTxOut() != nil {
+			continue
+		}
+
+		idxs = append(idxs, o)
+		sweepTx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: *o.OutPoint(),
+			Sequence:         o.BlocksToMaturity(),
+		})
+	}
+
+	// If there's a change amount, add it to the transaction.
+	changeAmtOpt.WhenSome(func(changeAmt btcutil.Amount) {
+		sweepTx.AddTxOut(&wire.TxOut{
+			PkScript: changePkScript,
+			Value:    int64(changeAmt),
+		})
+	})
+
+	// We'll default to using the current block height as locktime, if none
+	// of the inputs commits to a different locktime.
+	sweepTx.LockTime = uint32(locktimeOpt.UnwrapOr(t.currentHeight))
+
+	prevInputFetcher, err := input.MultiPrevOutFetcher(inputs)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error creating prev input fetcher "+
+			"for hash cache: %v", err)
+	}
+	hashCache := txscript.NewTxSigHashes(sweepTx, prevInputFetcher)
+
+	// With all the inputs in place, use each output's unique input script
+	// function to generate the final witness required for spending.
+	addInputScript := func(idx int, tso input.Input) error {
+		inputScript, err := tso.CraftInputScript(
+			t.cfg.Signer, sweepTx, hashCache, prevInputFetcher, idx,
+		)
+		if err != nil {
+			return err
+		}
+
+		sweepTx.TxIn[idx].Witness = inputScript.Witness
+
+		if len(inputScript.SigScript) == 0 {
+			return nil
+		}
+
+		sweepTx.TxIn[idx].SignatureScript = inputScript.SigScript
+
+		return nil
+	}
+
+	for idx, inp := range idxs {
+		if err := addInputScript(idx, inp); err != nil {
+			return nil, 0, err
+		}
+	}
+
+	log.Debugf("Created sweep tx %v for %v inputs", sweepTx.TxHash(),
+		len(inputs))
+
+	return sweepTx, txFee, nil
+}
+
+// prepareSweepTx returns the tx fee, an optional change amount and an optional
+// locktime after a series of validations:
+// 1. check the locktime has been reached.
+// 2. check the locktimes are the same.
+// 3. check the inputs cover the outputs.
+//
+// NOTE: if the change amount is below dust, it will be added to the tx fee.
+func prepareSweepTx(inputs []input.Input, changePkScript []byte,
+	feeRate chainfee.SatPerKWeight, currentHeight int32) (
+	btcutil.Amount, fn.Option[btcutil.Amount], fn.Option[int32], error) {
+
+	noChange := fn.None[btcutil.Amount]()
+	noLocktime := fn.None[int32]()
+
+	// Creating a weight estimator with nil outputs and zero max fee rate.
+	// We don't allow adding customized outputs in the sweeping tx, and the
+	// fee rate is already being managed before we get here.
+	inputs, estimator, err := getWeightEstimate(
+		inputs, nil, feeRate, 0, changePkScript,
+	)
+	if err != nil {
+		return 0, noChange, noLocktime, err
+	}
+
+	txFee := estimator.fee()
+
+	var (
+		// Track whether any of the inputs require a certain locktime.
+		locktime = int32(-1)
+
+		// We keep track of total input amount, and required output
+		// amount to use for calculating the change amount below.
+		totalInput     btcutil.Amount
+		requiredOutput btcutil.Amount
+	)
+
+	// Go through each input and check if the required lock times have
+	// reached and are the same.
+	for _, o := range inputs {
+		// If the input has a required output, we'll add it to the
+		// required output amount.
+		if o.RequiredTxOut() != nil {
+			requiredOutput += btcutil.Amount(
+				o.RequiredTxOut().Value,
+			)
+		}
+
+		// Update the total input amount.
+		totalInput += btcutil.Amount(o.SignDesc().Output.Value)
+
+		lt, ok := o.RequiredLockTime()
+
+		// Skip if the input doesn't require a lock time.
+		if !ok {
+			continue
+		}
+
+		// Check if the lock time has reached
+		if lt > uint32(currentHeight) {
+			return 0, noChange, noLocktime, ErrLocktimeImmature
+		}
+
+		// If another input commits to a different locktime, they
+		// cannot be combined in the same transaction.
+		if locktime != -1 && locktime != int32(lt) {
+			return 0, noChange, noLocktime, ErrLocktimeConflict
+		}
+
+		// Update the locktime for next iteration.
+		locktime = int32(lt)
+	}
+
+	// Make sure total output amount is less than total input amount.
+	if requiredOutput+txFee > totalInput {
+		return 0, noChange, noLocktime, fmt.Errorf("insufficient "+
+			"input to create sweep tx: input_sum=%v, "+
+			"output_sum=%v", totalInput, requiredOutput+txFee)
+	}
+
+	// The value remaining after the required output and fees is the
+	// change output.
+	changeAmt := totalInput - requiredOutput - txFee
+	changeAmtOpt := fn.Some(changeAmt)
+
+	// We'll calculate the dust limit for the given changePkScript since it
+	// is variable.
+	changeFloor := lnwallet.DustLimitForSize(len(changePkScript))
+
+	// If the change amount is dust, we'll move it into the fees.
+	if changeAmt < changeFloor {
+		log.Infof("Change amt %v below dustlimit %v, not adding "+
+			"change output", changeAmt, changeFloor)
+
+		// If there's no required output, and the change output is a
+		// dust, it means we are creating a tx without any outputs. In
+		// this case we'll return an error. This could happen when
+		// creating a tx that has an anchor as the only input.
+		if requiredOutput == 0 {
+			return 0, noChange, noLocktime, ErrTxNoOutput
+		}
+
+		// The dust amount is added to the fee.
+		txFee += changeAmt
+
+		// Set the change amount to none.
+		changeAmtOpt = fn.None[btcutil.Amount]()
+	}
+
+	// Optionally set the locktime.
+	locktimeOpt := fn.Some(locktime)
+	if locktime == -1 {
+		locktimeOpt = noLocktime
+	}
+
+	log.Debugf("Creating sweep tx for %v inputs (%s) using %v, "+
+		"tx_weight=%v, tx_fee=%v, locktime=%v, parents_count=%v, "+
+		"parents_fee=%v, parents_weight=%v, current_height=%v",
+		len(inputs), inputTypeSummary(inputs), feeRate,
+		estimator.weight(), txFee, locktimeOpt, len(estimator.parents),
+		estimator.parentsFee, estimator.parentsWeight, currentHeight)
+
+	return txFee, changeAmtOpt, locktimeOpt, nil
 }

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -132,13 +132,14 @@ func (r *BumpRequest) MaxFeeRateAllowed() (chainfee.SatPerKWeight, error) {
 	maxFeeRateAllowed := chainfee.NewSatPerKWeight(r.Budget, size)
 	if maxFeeRateAllowed > r.MaxFeeRate {
 		log.Debugf("Budget feerate %v exceeds MaxFeeRate %v, use "+
-			"MaxFeeRate instead", maxFeeRateAllowed, r.MaxFeeRate)
+			"MaxFeeRate instead, txWeight=%v", maxFeeRateAllowed,
+			r.MaxFeeRate, size)
 
 		return r.MaxFeeRate, nil
 	}
 
 	log.Debugf("Budget feerate %v below MaxFeeRate %v, use budget feerate "+
-		"instead", maxFeeRateAllowed, r.MaxFeeRate)
+		"instead, txWeight=%v", maxFeeRateAllowed, r.MaxFeeRate, size)
 
 	return maxFeeRateAllowed, nil
 }
@@ -360,6 +361,10 @@ func (t *TxPublisher) initializeFeeFunction(
 
 	// Get the initial conf target.
 	confTarget := calcCurrentConfTarget(t.currentHeight, req.DeadlineHeight)
+
+	log.Debugf("Initializing fee function with conf target=%v, budget=%v, "+
+		"maxFeeRateAllowed=%v", confTarget, req.Budget,
+		maxFeeRateAllowed)
 
 	// Initialize the fee function and return it.
 	//

--- a/sweep/fee_function.go
+++ b/sweep/fee_function.go
@@ -276,6 +276,16 @@ func (l *LinearFeeFunction) estimateFeeRate(
 		ConfTarget: confTarget,
 	}
 
+	// If the conf target is greater or equal to the max allowed value
+	// (1008), we will use the min relay fee instead.
+	if confTarget >= chainfee.MaxBlockTarget {
+		minFeeRate := l.estimator.RelayFeePerKW()
+		log.Debugf("Conf target %v is greater than max block target, "+
+			"using min relay fee rate %v", confTarget, minFeeRate)
+
+		return minFeeRate, nil
+	}
+
 	// endingFeeRate comes from budget/txWeight, which means the returned
 	// fee rate will always be capped by this value, hence we don't need to
 	// worry about overpay.

--- a/sweep/mock_test.go
+++ b/sweep/mock_test.go
@@ -342,7 +342,7 @@ type mockUtxoAggregator struct {
 var _ UtxoAggregator = (*mockUtxoAggregator)(nil)
 
 // ClusterInputs takes a list of inputs and groups them into clusters.
-func (m *mockUtxoAggregator) ClusterInputs(inputs pendingInputs) []InputSet {
+func (m *mockUtxoAggregator) ClusterInputs(inputs InputsMap) []InputSet {
 	args := m.Called(inputs)
 
 	return args.Get(0).([]InputSet)

--- a/sweep/mock_test.go
+++ b/sweep/mock_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
@@ -342,8 +341,10 @@ type mockUtxoAggregator struct {
 var _ UtxoAggregator = (*mockUtxoAggregator)(nil)
 
 // ClusterInputs takes a list of inputs and groups them into clusters.
-func (m *mockUtxoAggregator) ClusterInputs(inputs InputsMap) []InputSet {
-	args := m.Called(inputs)
+func (m *mockUtxoAggregator) ClusterInputs(inputs InputsMap,
+	defaultDeadline int32) []InputSet {
+
+	args := m.Called(inputs, defaultDeadline)
 
 	return args.Get(0).([]InputSet)
 }
@@ -484,10 +485,10 @@ func (m *MockInputSet) NeedWalletInput() bool {
 }
 
 // DeadlineHeight returns the deadline height for the set.
-func (m *MockInputSet) DeadlineHeight() fn.Option[int32] {
+func (m *MockInputSet) DeadlineHeight() int32 {
 	args := m.Called()
 
-	return args.Get(0).(fn.Option[int32])
+	return args.Get(0).(int32)
 }
 
 // Budget givens the total amount that can be used as fees by this input set.

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1622,6 +1622,9 @@ func (s *UtxoSweeper) monitorFeeBumpResult(resultChan <-chan *BumpResult) {
 					"fee bump monitor", r.Event,
 					r.Tx.TxHash())
 
+				// Cancel the rebroadcasting of the failed tx.
+				s.cfg.Wallet.CancelRebroadcast(r.Tx.TxHash())
+
 				return
 			}
 
@@ -1672,6 +1675,9 @@ func (s *UtxoSweeper) handleBumpEventTxReplaced(r *BumpResult) error {
 		log.Errorf("Fetch tx record for %v: %v", oldTxid, err)
 		return err
 	}
+
+	// Cancel the rebroadcasting of the replaced tx.
+	s.cfg.Wallet.CancelRebroadcast(oldTxid)
 
 	log.Infof("RBFed tx=%v(fee=%v sats, feerate=%v sats/kw) with new "+
 		"tx=%v(fee=%v, "+"feerate=%v)", record.Txid, record.Fee,

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -514,11 +514,15 @@ func (s *UtxoSweeper) SweepInput(input input.Input,
 	}
 
 	// Ensure the client provided a sane fee preference.
-	_, err := params.Fee.Estimate(
-		s.cfg.FeeEstimator, s.cfg.MaxFeeRate.FeePerKWeight(),
-	)
-	if err != nil {
-		return nil, err
+	//
+	// TODO(yy): remove this check?
+	if params.Fee != nil {
+		_, err := params.Fee.Estimate(
+			s.cfg.FeeEstimator, s.cfg.MaxFeeRate.FeePerKWeight(),
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	absoluteTimeLock, _ := input.RequiredLockTime()
@@ -1580,7 +1584,7 @@ func (s *UtxoSweeper) sweepPendingInputs(inputs InputsMap) {
 		}
 
 		if err != nil {
-			log.Errorf("Sweep new inputs: %v", err)
+			log.Errorf("Failed to sweep %v: %v", set, err)
 		}
 	}
 }

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1520,6 +1520,17 @@ func (s *UtxoSweeper) updateSweeperInputs() InputsMap {
 			continue
 		}
 
+		// If the input has a locktime that's not yet reached, we will
+		// skip this input and wait for the locktime to be reached.
+		locktime, _ := input.RequiredLockTime()
+		if uint32(s.currentHeight) < locktime {
+			log.Warnf("Skipping input %v due to locktime=%v not "+
+				"reached, current height is %v", op, locktime,
+				s.currentHeight)
+
+			continue
+		}
+
 		// If this input is new or has been failed to be published,
 		// we'd retry it. The assumption here is that when an error is
 		// returned from `PublishTransaction`, it means the tx has

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -179,10 +179,10 @@ type RBFInfo struct {
 	Fee btcutil.Amount
 }
 
-// pendingInput is created when an input reaches the main loop for the first
+// SweeperInput is created when an input reaches the main loop for the first
 // time. It wraps the input and tracks all relevant state that is needed for
 // sweeping.
-type pendingInput struct {
+type SweeperInput struct {
 	input.Input
 
 	// state tracks the current state of the input.
@@ -212,20 +212,20 @@ type pendingInput struct {
 }
 
 // String returns a human readable interpretation of the pending input.
-func (p *pendingInput) String() string {
+func (p *SweeperInput) String() string {
 	return fmt.Sprintf("%v (%v)", p.Input.OutPoint(), p.Input.WitnessType())
 }
 
 // parameters returns the sweep parameters for this input.
 //
 // NOTE: Part of the txInput interface.
-func (p *pendingInput) parameters() Params {
+func (p *SweeperInput) parameters() Params {
 	return p.params
 }
 
 // terminated returns a boolean indicating whether the input has reached a
 // final state.
-func (p *pendingInput) terminated() bool {
+func (p *SweeperInput) terminated() bool {
 	switch p.state {
 	// If the input has reached a final state, that it's either
 	// been swept, or failed, or excluded, we will remove it from
@@ -238,20 +238,20 @@ func (p *pendingInput) terminated() bool {
 	}
 }
 
-// pendingInputs is a type alias for a set of pending inputs.
-type pendingInputs = map[wire.OutPoint]*pendingInput
+// InputsMap is a type alias for a set of pending inputs.
+type InputsMap = map[wire.OutPoint]*SweeperInput
 
 // pendingSweepsReq is an internal message we'll use to represent an external
 // caller's intent to retrieve all of the pending inputs the UtxoSweeper is
 // attempting to sweep.
 type pendingSweepsReq struct {
-	respChan chan map[wire.OutPoint]*PendingInput
+	respChan chan map[wire.OutPoint]*PendingInputResponse
 	errChan  chan error
 }
 
-// PendingInput contains information about an input that is currently being
-// swept by the UtxoSweeper.
-type PendingInput struct {
+// PendingInputResponse contains information about an input that is currently
+// being swept by the UtxoSweeper.
+type PendingInputResponse struct {
 	// OutPoint is the identify outpoint of the input being swept.
 	OutPoint wire.OutPoint
 
@@ -309,7 +309,7 @@ type UtxoSweeper struct {
 
 	// inputs is the total set of inputs the UtxoSweeper has been requested
 	// to sweep.
-	inputs pendingInputs
+	inputs InputsMap
 
 	currentOutputScript []byte
 
@@ -408,7 +408,7 @@ func New(cfg *UtxoSweeperConfig) *UtxoSweeper {
 		updateReqs:        make(chan *updateReq),
 		pendingSweepsReqs: make(chan *pendingSweepsReq),
 		quit:              make(chan struct{}),
-		inputs:            make(pendingInputs),
+		inputs:            make(InputsMap),
 		bumpResultChan:    make(chan *BumpResult, 100),
 	}
 }
@@ -768,7 +768,7 @@ func (s *UtxoSweeper) removeExclusiveGroup(group uint64) {
 
 // signalResult notifies the listeners of the final result of the input sweep.
 // It also cancels any pending spend notification.
-func (s *UtxoSweeper) signalResult(pi *pendingInput, result Result) {
+func (s *UtxoSweeper) signalResult(pi *SweeperInput, result Result) {
 	op := pi.OutPoint()
 	listeners := pi.listeners
 
@@ -1012,8 +1012,10 @@ func (s *UtxoSweeper) monitorSpend(outpoint wire.OutPoint,
 
 // PendingInputs returns the set of inputs that the UtxoSweeper is currently
 // attempting to sweep.
-func (s *UtxoSweeper) PendingInputs() (map[wire.OutPoint]*PendingInput, error) {
-	respChan := make(chan map[wire.OutPoint]*PendingInput, 1)
+func (s *UtxoSweeper) PendingInputs() (
+	map[wire.OutPoint]*PendingInputResponse, error) {
+
+	respChan := make(chan map[wire.OutPoint]*PendingInputResponse, 1)
 	errChan := make(chan error, 1)
 	select {
 	case s.pendingSweepsReqs <- &pendingSweepsReq{
@@ -1037,26 +1039,26 @@ func (s *UtxoSweeper) PendingInputs() (map[wire.OutPoint]*PendingInput, error) {
 // handlePendingSweepsReq handles a request to retrieve all pending inputs the
 // UtxoSweeper is attempting to sweep.
 func (s *UtxoSweeper) handlePendingSweepsReq(
-	req *pendingSweepsReq) map[wire.OutPoint]*PendingInput {
+	req *pendingSweepsReq) map[wire.OutPoint]*PendingInputResponse {
 
-	pendingInputs := make(map[wire.OutPoint]*PendingInput, len(s.inputs))
-	for _, pendingInput := range s.inputs {
+	resps := make(map[wire.OutPoint]*PendingInputResponse, len(s.inputs))
+	for _, inp := range s.inputs {
 		// Only the exported fields are set, as we expect the response
 		// to only be consumed externally.
-		op := *pendingInput.OutPoint()
-		pendingInputs[op] = &PendingInput{
+		op := *inp.OutPoint()
+		resps[op] = &PendingInputResponse{
 			OutPoint:    op,
-			WitnessType: pendingInput.WitnessType(),
+			WitnessType: inp.WitnessType(),
 			Amount: btcutil.Amount(
-				pendingInput.SignDesc().Output.Value,
+				inp.SignDesc().Output.Value,
 			),
-			LastFeeRate:       pendingInput.lastFeeRate,
-			BroadcastAttempts: pendingInput.publishAttempts,
-			Params:            pendingInput.params,
+			LastFeeRate:       inp.lastFeeRate,
+			BroadcastAttempts: inp.publishAttempts,
+			Params:            inp.params,
 		}
 	}
 
-	return pendingInputs
+	return resps
 }
 
 // UpdateParams allows updating the sweep parameters of a pending input in the
@@ -1117,30 +1119,30 @@ func (s *UtxoSweeper) handleUpdateReq(req *updateReq) (
 	// batched with others which also have a similar fee rate, creating a
 	// higher fee rate transaction that replaces the original input's
 	// sweeping transaction.
-	pendingInput, ok := s.inputs[req.input]
+	sweeperInput, ok := s.inputs[req.input]
 	if !ok {
 		return nil, lnwallet.ErrNotMine
 	}
 
 	// Create the updated parameters struct. Leave the exclusive group
 	// unchanged.
-	newParams := pendingInput.params
+	newParams := sweeperInput.params
 	newParams.Fee = req.params.Fee
 	newParams.Force = req.params.Force
 
 	log.Debugf("Updating parameters for %v(state=%v) from (%v) to (%v)",
-		req.input, pendingInput.state, pendingInput.params, newParams)
+		req.input, sweeperInput.state, sweeperInput.params, newParams)
 
-	pendingInput.params = newParams
+	sweeperInput.params = newParams
 
 	// We need to reset the state so this input will be attempted again by
 	// our sweeper.
 	//
 	// TODO(yy): a dedicated state?
-	pendingInput.state = Init
+	sweeperInput.state = Init
 
 	resultChan := make(chan Result, 1)
-	pendingInput.listeners = append(pendingInput.listeners, resultChan)
+	sweeperInput.listeners = append(sweeperInput.listeners, resultChan)
 
 	return resultChan, nil
 }
@@ -1229,7 +1231,7 @@ func (s *UtxoSweeper) handleNewInput(input *sweepInputMessage) {
 	// Create a new pendingInput and initialize the listeners slice with
 	// the passed in result channel. If this input is offered for sweep
 	// again, the result channel will be appended to this slice.
-	pi = &pendingInput{
+	pi = &SweeperInput{
 		state:     state,
 		listeners: []chan Result{input.resultChan},
 		Input:     input.input,
@@ -1294,8 +1296,7 @@ func (s *UtxoSweeper) decideStateAndRBFInfo(op wire.OutPoint) (
 
 	// If the tx is not found in the store, it means it's not broadcast by
 	// us, hence we can't find the fee info. This is fine as, later on when
-	// this tx is confirmed, we will remove the input from our
-	// pendingInputs.
+	// this tx is confirmed, we will remove the input from our inputs.
 	if errors.Is(err, ErrTxNotFound) {
 		log.Warnf("Spending tx %v not found in sweeper store", txid)
 		return Published, fn.None[RBFInfo]()
@@ -1322,7 +1323,7 @@ func (s *UtxoSweeper) decideStateAndRBFInfo(op wire.OutPoint) (
 // handleExistingInput processes an input that is already known to the sweeper.
 // It will overwrite the params of the old input with the new ones.
 func (s *UtxoSweeper) handleExistingInput(input *sweepInputMessage,
-	oldInput *pendingInput) {
+	oldInput *SweeperInput) {
 
 	// Before updating the input details, check if an exclusive group was
 	// set. In case the same input is registered again without an exclusive
@@ -1412,9 +1413,9 @@ func (s *UtxoSweeper) markInputsSwept(tx *wire.MsgTx, isOurTx bool) {
 		outpoint := txIn.PreviousOutPoint
 
 		// Check if this input is known to us. It could probably be
-		// unknown if we canceled the registration, deleted from
-		// pendingInputs but the ntfn was in-flight already. Or this
-		// could be not one of our inputs.
+		// unknown if we canceled the registration, deleted from inputs
+		// map but the ntfn was in-flight already. Or this could be not
+		// one of our inputs.
 		input, ok := s.inputs[outpoint]
 		if !ok {
 			// It's very likely that a spending tx contains inputs
@@ -1460,7 +1461,7 @@ func (s *UtxoSweeper) markInputsSwept(tx *wire.MsgTx, isOurTx bool) {
 
 // markInputFailed marks the given input as failed and won't be retried. It
 // will also notify all the subscribers of this input.
-func (s *UtxoSweeper) markInputFailed(pi *pendingInput, err error) {
+func (s *UtxoSweeper) markInputFailed(pi *SweeperInput, err error) {
 	log.Errorf("Failed to sweep input: %v, error: %v", pi, err)
 
 	pi.state = Failed
@@ -1476,16 +1477,16 @@ func (s *UtxoSweeper) markInputFailed(pi *pendingInput, err error) {
 // updateSweeperInputs updates the sweeper's internal state and returns a map
 // of inputs to be swept. It will remove the inputs that are in final states,
 // and returns a map of inputs that have either state Init or PublishFailed.
-func (s *UtxoSweeper) updateSweeperInputs() pendingInputs {
+func (s *UtxoSweeper) updateSweeperInputs() InputsMap {
 	// Create a map of inputs to be swept.
-	inputs := make(pendingInputs)
+	inputs := make(InputsMap)
 
 	// Iterate the pending inputs and update the sweeper's state.
 	//
 	// TODO(yy): sweeper is made to communicate via go channels, so no
 	// locks are needed to access the map. However, it'd be safer if we
-	// turn this pendingInputs into a SyncMap in case we wanna add
-	// concurrent access to the map in the future.
+	// turn this inputs map into a SyncMap in case we wanna add concurrent
+	// access to the map in the future.
 	for op, input := range s.inputs {
 		// If the input has reached a final state, that it's either
 		// been swept, or failed, or excluded, we will remove it from
@@ -1524,7 +1525,7 @@ func (s *UtxoSweeper) updateSweeperInputs() pendingInputs {
 
 // sweepPendingInputs is called when the ticker fires. It will create clusters
 // and attempt to create and publish the sweeping transactions.
-func (s *UtxoSweeper) sweepPendingInputs(inputs pendingInputs) {
+func (s *UtxoSweeper) sweepPendingInputs(inputs InputsMap) {
 	// Cluster all of our inputs based on the specific Aggregator.
 	sets := s.cfg.Aggregator.ClusterInputs(inputs)
 

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -672,7 +672,7 @@ func (s *UtxoSweeper) collector(blockEpochs <-chan *chainntnfs.BlockEpoch) {
 		// A new external request has been received to retrieve all of
 		// the inputs we're currently attempting to sweep.
 		case req := <-s.pendingSweepsReqs:
-			req.respChan <- s.handlePendingSweepsReq(req)
+			s.handlePendingSweepsReq(req)
 
 		// A new external request has been received to bump the fee rate
 		// of a given input.
@@ -1056,6 +1056,13 @@ func (s *UtxoSweeper) handlePendingSweepsReq(
 			BroadcastAttempts: inp.publishAttempts,
 			Params:            inp.params,
 		}
+	}
+
+	select {
+	case req.respChan <- resps:
+	case <-s.quit:
+		log.Debug("Skipped sending pending sweep response due to " +
+			"UtxoSweeper shutting down")
 	}
 
 	return resps

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -502,10 +502,12 @@ func (s *UtxoSweeper) Stop() error {
 // cannot make a local copy in sweeper.
 //
 // TODO(yy): make sure the caller is using the Result chan.
-func (s *UtxoSweeper) SweepInput(input input.Input,
+func (s *UtxoSweeper) SweepInput(inp input.Input,
 	params Params) (chan Result, error) {
 
-	if input == nil || input.OutPoint() == nil || input.SignDesc() == nil {
+	if inp == nil || inp.OutPoint() == input.EmptyOutPoint ||
+		inp.SignDesc() == nil {
+
 		return nil, errors.New("nil input received")
 	}
 
@@ -521,16 +523,16 @@ func (s *UtxoSweeper) SweepInput(input input.Input,
 		}
 	}
 
-	absoluteTimeLock, _ := input.RequiredLockTime()
+	absoluteTimeLock, _ := inp.RequiredLockTime()
 	log.Infof("Sweep request received: out_point=%v, witness_type=%v, "+
 		"relative_time_lock=%v, absolute_time_lock=%v, amount=%v, "+
-		"parent=(%v), params=(%v), currentHeight=%v", input.OutPoint(),
-		input.WitnessType(), input.BlocksToMaturity(), absoluteTimeLock,
-		btcutil.Amount(input.SignDesc().Output.Value),
-		input.UnconfParent(), params, s.currentHeight)
+		"parent=(%v), params=(%v)", inp.OutPoint(), inp.WitnessType(),
+		inp.BlocksToMaturity(), absoluteTimeLock,
+		btcutil.Amount(inp.SignDesc().Output.Value),
+		inp.UnconfParent(), params)
 
 	sweeperInput := &sweepInputMessage{
-		input:      input,
+		input:      inp,
 		params:     params,
 		resultChan: make(chan Result, 1),
 	}
@@ -837,7 +839,7 @@ func (s *UtxoSweeper) sweep(set InputSet) error {
 	if err != nil {
 		outpoints := make([]wire.OutPoint, len(set.Inputs()))
 		for i, inp := range set.Inputs() {
-			outpoints[i] = *inp.OutPoint()
+			outpoints[i] = inp.OutPoint()
 		}
 
 		// TODO(yy): find out which input is causing the failure.
@@ -860,7 +862,7 @@ func (s *UtxoSweeper) sweep(set InputSet) error {
 func (s *UtxoSweeper) markInputsPendingPublish(set InputSet) {
 	// Reschedule sweep.
 	for _, input := range set.Inputs() {
-		pi, ok := s.inputs[*input.OutPoint()]
+		pi, ok := s.inputs[input.OutPoint()]
 		if !ok {
 			// It could be that this input is an additional wallet
 			// input that was attached. In that case there also
@@ -1045,7 +1047,7 @@ func (s *UtxoSweeper) handlePendingSweepsReq(
 	for _, inp := range s.inputs {
 		// Only the exported fields are set, as we expect the response
 		// to only be consumed externally.
-		op := *inp.OutPoint()
+		op := inp.OutPoint()
 		resps[op] = &PendingInputResponse{
 			OutPoint:    op,
 			WitnessType: inp.WitnessType(),
@@ -1220,7 +1222,7 @@ func (s *UtxoSweeper) mempoolLookup(op wire.OutPoint) fn.Option[wire.MsgTx] {
 // handleNewInput processes a new input by registering spend notification and
 // scheduling sweeping for it.
 func (s *UtxoSweeper) handleNewInput(input *sweepInputMessage) {
-	outpoint := *input.input.OutPoint()
+	outpoint := input.input.OutPoint()
 	pi, pending := s.inputs[outpoint]
 	if pending {
 		log.Debugf("Already has pending input %v received", outpoint)
@@ -1233,7 +1235,7 @@ func (s *UtxoSweeper) handleNewInput(input *sweepInputMessage) {
 	// This is a new input, and we want to query the mempool to see if this
 	// input has already been spent. If so, we'll start the input with
 	// state Published and attach the RBFInfo.
-	state, rbfInfo := s.decideStateAndRBFInfo(*input.input.OutPoint())
+	state, rbfInfo := s.decideStateAndRBFInfo(input.input.OutPoint())
 
 	// Create a new pendingInput and initialize the listeners slice with
 	// the passed in result channel. If this input is offered for sweep

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -36,11 +36,6 @@ var (
 	// it is/has already been stopped.
 	ErrSweeperShuttingDown = errors.New("utxo sweeper shutting down")
 
-	// DefaultMaxSweepAttempts specifies the default maximum number of times
-	// an input is included in a publish attempt before giving up and
-	// returning an error to the caller.
-	DefaultMaxSweepAttempts = 10
-
 	// DefaultDeadlineDelta defines a default deadline delta (1 week) to be
 	// used when sweeping inputs with no deadline pressure.
 	//
@@ -360,11 +355,6 @@ type UtxoSweeperConfig struct {
 	// in a single sweep tx. If more need to be swept, multiple txes are
 	// created and published.
 	MaxInputsPerTx uint32
-
-	// MaxSweepAttempts specifies the maximum number of times an input is
-	// included in a publish attempt before giving up and returning an error
-	// to the caller.
-	MaxSweepAttempts int
 
 	// MaxFeeRate is the maximum fee rate allowed within the UtxoSweeper.
 	MaxFeeRate chainfee.SatPerVByte

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -159,12 +159,11 @@ func createSweeperTestContext(t *testing.T) *sweeperTestContext {
 			script[1] = 20
 			return script, nil
 		},
-		FeeEstimator:     estimator,
-		MaxInputsPerTx:   testMaxInputsPerTx,
-		MaxSweepAttempts: testMaxSweepAttempts,
-		MaxFeeRate:       DefaultMaxFeeRate,
-		Aggregator:       aggregator,
-		Publisher:        mockBumper,
+		FeeEstimator:   estimator,
+		MaxInputsPerTx: testMaxInputsPerTx,
+		MaxFeeRate:     DefaultMaxFeeRate,
+		Aggregator:     aggregator,
+		Publisher:      mockBumper,
 	})
 
 	ctx.sweeper.Start()

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -264,7 +264,7 @@ func (ctx *sweeperTestContext) assertPendingInputs(inputs ...input.Input) {
 
 	inputSet := make(map[wire.OutPoint]struct{}, len(inputs))
 	for _, input := range inputs {
-		inputSet[*input.OutPoint()] = struct{}{}
+		inputSet[input.OutPoint()] = struct{}{}
 	}
 
 	inputsMap, err := ctx.sweeper.PendingInputs()
@@ -295,7 +295,7 @@ func assertTxSweepsInputs(t *testing.T, sweepTx *wire.MsgTx,
 	}
 	m := make(map[wire.OutPoint]struct{}, len(inputs))
 	for _, input := range inputs {
-		m[*input.OutPoint()] = struct{}{}
+		m[input.OutPoint()] = struct{}{}
 	}
 	for _, txIn := range sweepTx.TxIn {
 		if _, ok := m[txIn.PreviousOutPoint]; !ok {
@@ -322,7 +322,7 @@ func assertTxFeeRate(t *testing.T, tx *wire.MsgTx,
 
 	m := make(map[wire.OutPoint]input.Input, len(inputs))
 	for _, input := range inputs {
-		m[*input.OutPoint()] = input
+		m[input.OutPoint()] = input
 	}
 
 	var inputAmt int64
@@ -387,7 +387,7 @@ func TestSuccess(t *testing.T) {
 		// Create a fake sweep tx.
 		tx := &wire.MsgTx{
 			TxIn: []*wire.TxIn{{
-				PreviousOutPoint: *inp.OutPoint(),
+				PreviousOutPoint: inp.OutPoint(),
 			}},
 		}
 
@@ -473,8 +473,8 @@ func TestDust(t *testing.T) {
 		// Create a fake sweep tx.
 		tx := &wire.MsgTx{
 			TxIn: []*wire.TxIn{
-				{PreviousOutPoint: *largeInput.OutPoint()},
-				{PreviousOutPoint: *dustInput.OutPoint()},
+				{PreviousOutPoint: largeInput.OutPoint()},
+				{PreviousOutPoint: dustInput.OutPoint()},
 			},
 		}
 
@@ -541,7 +541,7 @@ func TestWalletUtxo(t *testing.T) {
 		// Create a fake sweep tx.
 		tx := &wire.MsgTx{
 			TxIn: []*wire.TxIn{
-				{PreviousOutPoint: *dustInput.OutPoint()},
+				{PreviousOutPoint: dustInput.OutPoint()},
 			},
 		}
 
@@ -615,8 +615,8 @@ func TestNegativeInput(t *testing.T) {
 		// Create a fake sweep tx.
 		tx := &wire.MsgTx{
 			TxIn: []*wire.TxIn{
-				{PreviousOutPoint: *largeInput.OutPoint()},
-				{PreviousOutPoint: *positiveInput.OutPoint()},
+				{PreviousOutPoint: largeInput.OutPoint()},
+				{PreviousOutPoint: positiveInput.OutPoint()},
 			},
 		}
 
@@ -675,9 +675,8 @@ func TestNegativeInput(t *testing.T) {
 		// Create a fake sweep tx.
 		tx := &wire.MsgTx{
 			TxIn: []*wire.TxIn{
-				{PreviousOutPoint: *negInput.OutPoint()},
-				{PreviousOutPoint: *secondLargeInput.
-					OutPoint()},
+				{PreviousOutPoint: negInput.OutPoint()},
+				{PreviousOutPoint: secondLargeInput.OutPoint()},
 			},
 		}
 
@@ -735,9 +734,9 @@ func TestChunks(t *testing.T) {
 		//nolint:lll
 		tx := &wire.MsgTx{
 			TxIn: []*wire.TxIn{
-				{PreviousOutPoint: *spendableInputs[0].OutPoint()},
-				{PreviousOutPoint: *spendableInputs[1].OutPoint()},
-				{PreviousOutPoint: *spendableInputs[2].OutPoint()},
+				{PreviousOutPoint: spendableInputs[0].OutPoint()},
+				{PreviousOutPoint: spendableInputs[1].OutPoint()},
+				{PreviousOutPoint: spendableInputs[2].OutPoint()},
 			},
 		}
 
@@ -764,8 +763,8 @@ func TestChunks(t *testing.T) {
 		//nolint:lll
 		tx := &wire.MsgTx{
 			TxIn: []*wire.TxIn{
-				{PreviousOutPoint: *spendableInputs[3].OutPoint()},
-				{PreviousOutPoint: *spendableInputs[4].OutPoint()},
+				{PreviousOutPoint: spendableInputs[3].OutPoint()},
+				{PreviousOutPoint: spendableInputs[4].OutPoint()},
 			},
 		}
 
@@ -838,7 +837,7 @@ func testRemoteSpend(t *testing.T, postSweep bool) {
 	// will be spent by the remote.
 	tx := &wire.MsgTx{
 		TxIn: []*wire.TxIn{
-			{PreviousOutPoint: *spendableInputs[1].OutPoint()},
+			{PreviousOutPoint: spendableInputs[1].OutPoint()},
 		},
 	}
 
@@ -874,7 +873,7 @@ func testRemoteSpend(t *testing.T, postSweep bool) {
 	// Spend the input with an unknown tx.
 	remoteTx := &wire.MsgTx{
 		TxIn: []*wire.TxIn{
-			{PreviousOutPoint: *(spendableInputs[0].OutPoint())},
+			{PreviousOutPoint: spendableInputs[0].OutPoint()},
 		},
 	}
 	err = ctx.backend.publishTransaction(remoteTx)
@@ -954,7 +953,7 @@ func TestIdempotency(t *testing.T) {
 		// Create a fake sweep tx.
 		tx := &wire.MsgTx{
 			TxIn: []*wire.TxIn{
-				{PreviousOutPoint: *input.OutPoint()},
+				{PreviousOutPoint: input.OutPoint()},
 			},
 		}
 
@@ -1039,7 +1038,7 @@ func TestRestart(t *testing.T) {
 		// Create a fake sweep tx.
 		tx := &wire.MsgTx{
 			TxIn: []*wire.TxIn{
-				{PreviousOutPoint: *input1.OutPoint()},
+				{PreviousOutPoint: input1.OutPoint()},
 			},
 		}
 
@@ -1082,7 +1081,7 @@ func TestRestart(t *testing.T) {
 		// Create a fake sweep tx.
 		tx := &wire.MsgTx{
 			TxIn: []*wire.TxIn{
-				{PreviousOutPoint: *input2.OutPoint()},
+				{PreviousOutPoint: input2.OutPoint()},
 			},
 		}
 
@@ -1170,7 +1169,7 @@ func TestRestartRemoteSpend(t *testing.T) {
 	// will be spent by the remote.
 	tx := &wire.MsgTx{
 		TxIn: []*wire.TxIn{
-			{PreviousOutPoint: *input2.OutPoint()},
+			{PreviousOutPoint: input2.OutPoint()},
 		},
 	}
 
@@ -1213,7 +1212,7 @@ func TestRestartRemoteSpend(t *testing.T) {
 
 	remoteTx := &wire.MsgTx{
 		TxIn: []*wire.TxIn{
-			{PreviousOutPoint: *input1.OutPoint()},
+			{PreviousOutPoint: input1.OutPoint()},
 		},
 	}
 	err = ctx.backend.publishTransaction(remoteTx)
@@ -1280,7 +1279,7 @@ func TestRestartConfirmed(t *testing.T) {
 		// Create a fake sweep tx.
 		tx := &wire.MsgTx{
 			TxIn: []*wire.TxIn{
-				{PreviousOutPoint: *input.OutPoint()},
+				{PreviousOutPoint: input.OutPoint()},
 			},
 		}
 
@@ -1349,7 +1348,7 @@ func TestRetry(t *testing.T) {
 		// Create a fake sweep tx.
 		tx := &wire.MsgTx{
 			TxIn: []*wire.TxIn{
-				{PreviousOutPoint: *inp0.OutPoint()},
+				{PreviousOutPoint: inp0.OutPoint()},
 			},
 		}
 
@@ -1384,7 +1383,7 @@ func TestRetry(t *testing.T) {
 		// Create a fake sweep tx.
 		tx := &wire.MsgTx{
 			TxIn: []*wire.TxIn{
-				{PreviousOutPoint: *inp1.OutPoint()},
+				{PreviousOutPoint: inp1.OutPoint()},
 			},
 		}
 
@@ -1464,8 +1463,8 @@ func TestDifferentFeePreferences(t *testing.T) {
 		// Create a fake sweep tx.
 		tx := &wire.MsgTx{
 			TxIn: []*wire.TxIn{
-				{PreviousOutPoint: *input1.OutPoint()},
-				{PreviousOutPoint: *input2.OutPoint()},
+				{PreviousOutPoint: input1.OutPoint()},
+				{PreviousOutPoint: input2.OutPoint()},
 			},
 		}
 
@@ -1491,7 +1490,7 @@ func TestDifferentFeePreferences(t *testing.T) {
 		// Create a fake sweep tx.
 		tx := &wire.MsgTx{
 			TxIn: []*wire.TxIn{
-				{PreviousOutPoint: *input3.OutPoint()},
+				{PreviousOutPoint: input3.OutPoint()},
 			},
 		}
 
@@ -1596,8 +1595,8 @@ func TestPendingInputs(t *testing.T) {
 		// Create a fake sweep tx.
 		tx := &wire.MsgTx{
 			TxIn: []*wire.TxIn{
-				{PreviousOutPoint: *input1.OutPoint()},
-				{PreviousOutPoint: *input2.OutPoint()},
+				{PreviousOutPoint: input1.OutPoint()},
+				{PreviousOutPoint: input2.OutPoint()},
 			},
 		}
 
@@ -1623,7 +1622,7 @@ func TestPendingInputs(t *testing.T) {
 		// Create a fake sweep tx.
 		tx := &wire.MsgTx{
 			TxIn: []*wire.TxIn{
-				{PreviousOutPoint: *input3.OutPoint()},
+				{PreviousOutPoint: input3.OutPoint()},
 			},
 		}
 
@@ -1707,7 +1706,7 @@ func TestExclusiveGroup(t *testing.T) {
 		// Create a fake sweep tx.
 		tx := &wire.MsgTx{
 			TxIn: []*wire.TxIn{
-				{PreviousOutPoint: *input1.OutPoint()},
+				{PreviousOutPoint: input1.OutPoint()},
 			},
 		}
 
@@ -1733,7 +1732,7 @@ func TestExclusiveGroup(t *testing.T) {
 		// Create a fake sweep tx.
 		tx := &wire.MsgTx{
 			TxIn: []*wire.TxIn{
-				{PreviousOutPoint: *input2.OutPoint()},
+				{PreviousOutPoint: input2.OutPoint()},
 			},
 		}
 
@@ -1759,7 +1758,7 @@ func TestExclusiveGroup(t *testing.T) {
 		// Create a fake sweep tx.
 		tx := &wire.MsgTx{
 			TxIn: []*wire.TxIn{
-				{PreviousOutPoint: *input3.OutPoint()},
+				{PreviousOutPoint: input3.OutPoint()},
 			},
 		}
 
@@ -1954,7 +1953,7 @@ func TestLockTimes(t *testing.T) {
 		}
 
 		op := inp.OutPoint()
-		inputs[*op] = inp
+		inputs[op] = inp
 
 		cluster, ok := clusters[lt]
 		if !ok {
@@ -1966,7 +1965,7 @@ func TestLockTimes(t *testing.T) {
 
 	for i := 0; i < 3; i++ {
 		inp := spendableInputs[i+numSweeps*2]
-		inputs[*inp.OutPoint()] = inp
+		inputs[inp.OutPoint()] = inp
 
 		lt := uint32(10 + (i % numSweeps))
 		clusters[lt] = append(clusters[lt], inp)
@@ -1982,7 +1981,7 @@ func TestLockTimes(t *testing.T) {
 		// Append the inputs.
 		for _, inp := range cluster {
 			txIn := &wire.TxIn{
-				PreviousOutPoint: *inp.OutPoint(),
+				PreviousOutPoint: inp.OutPoint(),
 			}
 			tx.TxIn = append(tx.TxIn, txIn)
 		}
@@ -2137,15 +2136,15 @@ func TestMarkInputsPendingPublish(t *testing.T) {
 	inputNotExist := &input.MockInput{}
 	defer inputNotExist.AssertExpectations(t)
 
-	inputNotExist.On("OutPoint").Return(&wire.OutPoint{Index: 0})
+	inputNotExist.On("OutPoint").Return(wire.OutPoint{Index: 0})
 
 	// inputInit specifies a newly created input.
 	inputInit := &input.MockInput{}
 	defer inputInit.AssertExpectations(t)
 
-	inputInit.On("OutPoint").Return(&wire.OutPoint{Index: 1})
+	inputInit.On("OutPoint").Return(wire.OutPoint{Index: 1})
 
-	s.inputs[*inputInit.OutPoint()] = &SweeperInput{
+	s.inputs[inputInit.OutPoint()] = &SweeperInput{
 		state: Init,
 	}
 
@@ -2153,9 +2152,9 @@ func TestMarkInputsPendingPublish(t *testing.T) {
 	inputPendingPublish := &input.MockInput{}
 	defer inputPendingPublish.AssertExpectations(t)
 
-	inputPendingPublish.On("OutPoint").Return(&wire.OutPoint{Index: 2})
+	inputPendingPublish.On("OutPoint").Return(wire.OutPoint{Index: 2})
 
-	s.inputs[*inputPendingPublish.OutPoint()] = &SweeperInput{
+	s.inputs[inputPendingPublish.OutPoint()] = &SweeperInput{
 		state: PendingPublish,
 	}
 
@@ -2163,9 +2162,9 @@ func TestMarkInputsPendingPublish(t *testing.T) {
 	inputTerminated := &input.MockInput{}
 	defer inputTerminated.AssertExpectations(t)
 
-	inputTerminated.On("OutPoint").Return(&wire.OutPoint{Index: 3})
+	inputTerminated.On("OutPoint").Return(wire.OutPoint{Index: 3})
 
-	s.inputs[*inputTerminated.OutPoint()] = &SweeperInput{
+	s.inputs[inputTerminated.OutPoint()] = &SweeperInput{
 		state: Excluded,
 	}
 
@@ -2181,16 +2180,14 @@ func TestMarkInputsPendingPublish(t *testing.T) {
 	require.Len(s.inputs, 3)
 
 	// We expect the init input's state to become pending publish.
-	require.Equal(PendingPublish,
-		s.inputs[*inputInit.OutPoint()].state)
+	require.Equal(PendingPublish, s.inputs[inputInit.OutPoint()].state)
 
 	// We expect the pending-publish to stay unchanged.
 	require.Equal(PendingPublish,
-		s.inputs[*inputPendingPublish.OutPoint()].state)
+		s.inputs[inputPendingPublish.OutPoint()].state)
 
 	// We expect the terminated to stay unchanged.
-	require.Equal(Excluded,
-		s.inputs[*inputTerminated.OutPoint()].state)
+	require.Equal(Excluded, s.inputs[inputTerminated.OutPoint()].state)
 }
 
 // TestMarkInputsPublished checks that given a list of inputs with different
@@ -2355,7 +2352,7 @@ func TestMarkInputsSwept(t *testing.T) {
 	defer mockInput.AssertExpectations(t)
 
 	// Mock the `OutPoint` to return a dummy outpoint.
-	mockInput.On("OutPoint").Return(&wire.OutPoint{Hash: chainhash.Hash{1}})
+	mockInput.On("OutPoint").Return(wire.OutPoint{Hash: chainhash.Hash{1}})
 
 	// Create a test sweeper.
 	s := New(&UtxoSweeperConfig{})
@@ -2639,7 +2636,7 @@ func TestMarkInputFailed(t *testing.T) {
 	defer mockInput.AssertExpectations(t)
 
 	// Mock the `OutPoint` to return a dummy outpoint.
-	mockInput.On("OutPoint").Return(&wire.OutPoint{Hash: chainhash.Hash{1}})
+	mockInput.On("OutPoint").Return(wire.OutPoint{Hash: chainhash.Hash{1}})
 
 	// Create a test sweeper.
 	s := New(&UtxoSweeperConfig{})

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -2147,7 +2147,7 @@ func TestMarkInputsPendingPublish(t *testing.T) {
 	inputInit.On("OutPoint").Return(&wire.OutPoint{Index: 1})
 
 	s.pendingInputs[*inputInit.OutPoint()] = &pendingInput{
-		state: StateInit,
+		state: Init,
 	}
 
 	// inputPendingPublish specifies an input that's about to be published.
@@ -2157,7 +2157,7 @@ func TestMarkInputsPendingPublish(t *testing.T) {
 	inputPendingPublish.On("OutPoint").Return(&wire.OutPoint{Index: 2})
 
 	s.pendingInputs[*inputPendingPublish.OutPoint()] = &pendingInput{
-		state: StatePendingPublish,
+		state: PendingPublish,
 	}
 
 	// inputTerminated specifies an input that's terminated.
@@ -2167,7 +2167,7 @@ func TestMarkInputsPendingPublish(t *testing.T) {
 	inputTerminated.On("OutPoint").Return(&wire.OutPoint{Index: 3})
 
 	s.pendingInputs[*inputTerminated.OutPoint()] = &pendingInput{
-		state: StateExcluded,
+		state: Excluded,
 	}
 
 	// Mark the test inputs. We expect the non-exist input and the
@@ -2182,20 +2182,20 @@ func TestMarkInputsPendingPublish(t *testing.T) {
 	require.Len(s.pendingInputs, 3)
 
 	// We expect the init input's state to become pending publish.
-	require.Equal(StatePendingPublish,
+	require.Equal(PendingPublish,
 		s.pendingInputs[*inputInit.OutPoint()].state)
 
 	// We expect the pending-publish to stay unchanged.
-	require.Equal(StatePendingPublish,
+	require.Equal(PendingPublish,
 		s.pendingInputs[*inputPendingPublish.OutPoint()].state)
 
 	// We expect the terminated to stay unchanged.
-	require.Equal(StateExcluded,
+	require.Equal(Excluded,
 		s.pendingInputs[*inputTerminated.OutPoint()].state)
 }
 
 // TestMarkInputsPublished checks that given a list of inputs with different
-// states, only the state `StatePendingPublish` will be marked as `Published`.
+// states, only the state `PendingPublish` will be marked as `Published`.
 func TestMarkInputsPublished(t *testing.T) {
 	t.Parallel()
 
@@ -2228,7 +2228,7 @@ func TestMarkInputsPublished(t *testing.T) {
 		PreviousOutPoint: wire.OutPoint{Index: 2},
 	}
 	s.pendingInputs[inputInit.PreviousOutPoint] = &pendingInput{
-		state: StateInit,
+		state: Init,
 	}
 
 	// inputPendingPublish specifies an input that's about to be published.
@@ -2236,7 +2236,7 @@ func TestMarkInputsPublished(t *testing.T) {
 		PreviousOutPoint: wire.OutPoint{Index: 3},
 	}
 	s.pendingInputs[inputPendingPublish.PreviousOutPoint] = &pendingInput{
-		state: StatePendingPublish,
+		state: PendingPublish,
 	}
 
 	// First, check that when an error is returned from db, it's properly
@@ -2266,11 +2266,11 @@ func TestMarkInputsPublished(t *testing.T) {
 	require.Len(s.pendingInputs, 2)
 
 	// We expect the init input's state to stay unchanged.
-	require.Equal(StateInit,
+	require.Equal(Init,
 		s.pendingInputs[inputInit.PreviousOutPoint].state)
 
 	// We expect the pending-publish input's is now marked as published.
-	require.Equal(StatePublished,
+	require.Equal(Published,
 		s.pendingInputs[inputPendingPublish.PreviousOutPoint].state)
 
 	// Assert mocked statements are executed as expected.
@@ -2278,7 +2278,7 @@ func TestMarkInputsPublished(t *testing.T) {
 }
 
 // TestMarkInputsPublishFailed checks that given a list of inputs with
-// different states, only the state `StatePendingPublish` will be marked as
+// different states, only the state `PendingPublish` will be marked as
 // `PublishFailed`.
 func TestMarkInputsPublishFailed(t *testing.T) {
 	t.Parallel()
@@ -2308,7 +2308,7 @@ func TestMarkInputsPublishFailed(t *testing.T) {
 		PreviousOutPoint: wire.OutPoint{Index: 2},
 	}
 	s.pendingInputs[inputInit.PreviousOutPoint] = &pendingInput{
-		state: StateInit,
+		state: Init,
 	}
 
 	// inputPendingPublish specifies an input that's about to be published.
@@ -2316,7 +2316,7 @@ func TestMarkInputsPublishFailed(t *testing.T) {
 		PreviousOutPoint: wire.OutPoint{Index: 3},
 	}
 	s.pendingInputs[inputPendingPublish.PreviousOutPoint] = &pendingInput{
-		state: StatePendingPublish,
+		state: PendingPublish,
 	}
 
 	// Mark the test inputs. We expect the non-exist input and the
@@ -2332,12 +2332,12 @@ func TestMarkInputsPublishFailed(t *testing.T) {
 	require.Len(s.pendingInputs, 2)
 
 	// We expect the init input's state to stay unchanged.
-	require.Equal(StateInit,
+	require.Equal(Init,
 		s.pendingInputs[inputInit.PreviousOutPoint].state)
 
 	// We expect the pending-publish input's is now marked as publish
 	// failed.
-	require.Equal(StatePublishFailed,
+	require.Equal(PublishFailed,
 		s.pendingInputs[inputPendingPublish.PreviousOutPoint].state)
 
 	// Assert mocked statements are executed as expected.
@@ -2345,7 +2345,7 @@ func TestMarkInputsPublishFailed(t *testing.T) {
 }
 
 // TestMarkInputsSwept checks that given a list of inputs with different
-// states, only the non-terminal state will be marked as `StateSwept`.
+// states, only the non-terminal state will be marked as `Swept`.
 func TestMarkInputsSwept(t *testing.T) {
 	t.Parallel()
 
@@ -2374,7 +2374,7 @@ func TestMarkInputsSwept(t *testing.T) {
 		PreviousOutPoint: wire.OutPoint{Index: 2},
 	}
 	s.pendingInputs[inputInit.PreviousOutPoint] = &pendingInput{
-		state: StateInit,
+		state: Init,
 		Input: mockInput,
 	}
 
@@ -2383,7 +2383,7 @@ func TestMarkInputsSwept(t *testing.T) {
 		PreviousOutPoint: wire.OutPoint{Index: 3},
 	}
 	s.pendingInputs[inputPendingPublish.PreviousOutPoint] = &pendingInput{
-		state: StatePendingPublish,
+		state: PendingPublish,
 		Input: mockInput,
 	}
 
@@ -2392,7 +2392,7 @@ func TestMarkInputsSwept(t *testing.T) {
 		PreviousOutPoint: wire.OutPoint{Index: 4},
 	}
 	s.pendingInputs[inputTerminated.PreviousOutPoint] = &pendingInput{
-		state: StateExcluded,
+		state: Excluded,
 		Input: mockInput,
 	}
 
@@ -2411,15 +2411,15 @@ func TestMarkInputsSwept(t *testing.T) {
 	require.Len(s.pendingInputs, 3)
 
 	// We expect the init input's state to become swept.
-	require.Equal(StateSwept,
+	require.Equal(Swept,
 		s.pendingInputs[inputInit.PreviousOutPoint].state)
 
 	// We expect the pending-publish becomes swept.
-	require.Equal(StateSwept,
+	require.Equal(Swept,
 		s.pendingInputs[inputPendingPublish.PreviousOutPoint].state)
 
 	// We expect the terminated to stay unchanged.
-	require.Equal(StateExcluded,
+	require.Equal(Excluded,
 		s.pendingInputs[inputTerminated.PreviousOutPoint].state)
 }
 
@@ -2479,13 +2479,13 @@ func TestUpdateSweeperInputs(t *testing.T) {
 	s := New(nil)
 
 	// Create a list of inputs using all the states.
-	input0 := &pendingInput{state: StateInit}
-	input1 := &pendingInput{state: StatePendingPublish}
-	input2 := &pendingInput{state: StatePublished}
-	input3 := &pendingInput{state: StatePublishFailed}
-	input4 := &pendingInput{state: StateSwept}
-	input5 := &pendingInput{state: StateExcluded}
-	input6 := &pendingInput{state: StateFailed}
+	input0 := &pendingInput{state: Init}
+	input1 := &pendingInput{state: PendingPublish}
+	input2 := &pendingInput{state: Published}
+	input3 := &pendingInput{state: PublishFailed}
+	input4 := &pendingInput{state: Swept}
+	input5 := &pendingInput{state: Excluded}
+	input6 := &pendingInput{state: Failed}
 
 	// Add the inputs to the sweeper. After the update, we should see the
 	// terminated inputs being removed.
@@ -2499,8 +2499,8 @@ func TestUpdateSweeperInputs(t *testing.T) {
 		{Index: 6}: input6,
 	}
 
-	// We expect the inputs with `StateSwept`, `StateExcluded`, and
-	// `StateFailed` to be removed.
+	// We expect the inputs with `Swept`, `Excluded`, and `Failed` to be
+	// removed.
 	expectedInputs := map[wire.OutPoint]*pendingInput{
 		{Index: 0}: input0,
 		{Index: 1}: input1,
@@ -2508,8 +2508,8 @@ func TestUpdateSweeperInputs(t *testing.T) {
 		{Index: 3}: input3,
 	}
 
-	// We expect only the inputs with `StateInit` and `StatePublishFailed`
-	// to be returned.
+	// We expect only the inputs with `Init` and `PublishFailed` to be
+	// returned.
 	expectedReturn := map[wire.OutPoint]*pendingInput{
 		{Index: 0}: input0,
 		{Index: 3}: input3,
@@ -2556,7 +2556,7 @@ func TestDecideStateAndRBFInfo(t *testing.T) {
 	// RBFInfo.
 	state, rbf := s.decideStateAndRBFInfo(op)
 	require.True(rbf.IsNone())
-	require.Equal(StateInit, state)
+	require.Equal(Init, state)
 
 	// Mock the mempool lookup to return a tx three times as we are calling
 	// attachAvailableRBFInfo three times.
@@ -2570,7 +2570,7 @@ func TestDecideStateAndRBFInfo(t *testing.T) {
 	// Although the db lookup failed, we expect the state to be Published.
 	state, rbf = s.decideStateAndRBFInfo(op)
 	require.True(rbf.IsNone())
-	require.Equal(StatePublished, state)
+	require.Equal(Published, state)
 
 	// Mock the store to return a db error.
 	dummyErr := errors.New("dummy error")
@@ -2579,7 +2579,7 @@ func TestDecideStateAndRBFInfo(t *testing.T) {
 	// Although the db lookup failed, we expect the state to be Published.
 	state, rbf = s.decideStateAndRBFInfo(op)
 	require.True(rbf.IsNone())
-	require.Equal(StatePublished, state)
+	require.Equal(Published, state)
 
 	// Mock the store to return a record.
 	tr := &TxRecord{
@@ -2600,7 +2600,7 @@ func TestDecideStateAndRBFInfo(t *testing.T) {
 	require.Equal(rbfInfo, rbf)
 
 	// Assert the state is updated.
-	require.Equal(StatePublished, state)
+	require.Equal(Published, state)
 }
 
 // TestMarkInputFailed checks that the input is marked as failed as expected.
@@ -2619,7 +2619,7 @@ func TestMarkInputFailed(t *testing.T) {
 
 	// Create a testing pending input.
 	pi := &pendingInput{
-		state: StateInit,
+		state: Init,
 		Input: mockInput,
 	}
 
@@ -2627,7 +2627,7 @@ func TestMarkInputFailed(t *testing.T) {
 	s.markInputFailed(pi, errors.New("dummy error"))
 
 	// Assert the state is updated.
-	require.Equal(t, StateFailed, pi.state)
+	require.Equal(t, Failed, pi.state)
 }
 
 // TestSweepPendingInputs checks that `sweepPendingInputs` correctly executes
@@ -2730,9 +2730,9 @@ func TestHandleBumpEventTxFailed(t *testing.T) {
 
 	// Construct the initial state for the sweeper.
 	s.pendingInputs = pendingInputs{
-		op1: &pendingInput{Input: input1, state: StatePendingPublish},
-		op2: &pendingInput{Input: input2, state: StatePendingPublish},
-		op3: &pendingInput{Input: input3, state: StatePendingPublish},
+		op1: &pendingInput{Input: input1, state: PendingPublish},
+		op2: &pendingInput{Input: input2, state: PendingPublish},
+		op3: &pendingInput{Input: input3, state: PendingPublish},
 	}
 
 	// Create a testing tx that spends the first two inputs.
@@ -2756,11 +2756,11 @@ func TestHandleBumpEventTxFailed(t *testing.T) {
 	require.ErrorIs(t, err, errDummy)
 
 	// Assert the states of the first two inputs are updated.
-	require.Equal(t, StatePublishFailed, s.pendingInputs[op1].state)
-	require.Equal(t, StatePublishFailed, s.pendingInputs[op2].state)
+	require.Equal(t, PublishFailed, s.pendingInputs[op1].state)
+	require.Equal(t, PublishFailed, s.pendingInputs[op2].state)
 
 	// Assert the state of the third input is not updated.
-	require.Equal(t, StatePendingPublish, s.pendingInputs[op3].state)
+	require.Equal(t, PendingPublish, s.pendingInputs[op3].state)
 
 	// Assert the non-existing input is not added to the pending inputs.
 	require.NotContains(t, s.pendingInputs, opNotExist)
@@ -2789,7 +2789,7 @@ func TestHandleBumpEventTxReplaced(t *testing.T) {
 
 	// Construct the initial state for the sweeper.
 	s.pendingInputs = pendingInputs{
-		op: &pendingInput{Input: inp, state: StatePendingPublish},
+		op: &pendingInput{Input: inp, state: PendingPublish},
 	}
 
 	// Create a testing tx that spends the input.
@@ -2853,7 +2853,7 @@ func TestHandleBumpEventTxReplaced(t *testing.T) {
 	require.NoError(t, err)
 
 	// Assert the state of the input is updated.
-	require.Equal(t, StatePublished, s.pendingInputs[op].state)
+	require.Equal(t, Published, s.pendingInputs[op].state)
 }
 
 // TestHandleBumpEventTxPublished checks that the sweeper correctly handles the
@@ -2879,7 +2879,7 @@ func TestHandleBumpEventTxPublished(t *testing.T) {
 
 	// Construct the initial state for the sweeper.
 	s.pendingInputs = pendingInputs{
-		op: &pendingInput{Input: inp, state: StatePendingPublish},
+		op: &pendingInput{Input: inp, state: PendingPublish},
 	}
 
 	// Create a testing tx that spends the input.
@@ -2907,7 +2907,7 @@ func TestHandleBumpEventTxPublished(t *testing.T) {
 	require.NoError(t, err)
 
 	// Assert the state of the input is updated.
-	require.Equal(t, StatePublished, s.pendingInputs[op].state)
+	require.Equal(t, Published, s.pendingInputs[op].state)
 }
 
 // TestMonitorFeeBumpResult checks that the fee bump monitor loop correctly
@@ -2931,7 +2931,7 @@ func TestMonitorFeeBumpResult(t *testing.T) {
 
 	// Construct the initial state for the sweeper.
 	s.pendingInputs = pendingInputs{
-		op: &pendingInput{Input: inp, state: StatePendingPublish},
+		op: &pendingInput{Input: inp, state: PendingPublish},
 	}
 
 	// Create a testing tx that spends the input.

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -2146,7 +2146,7 @@ func TestMarkInputsPendingPublish(t *testing.T) {
 
 	inputInit.On("OutPoint").Return(&wire.OutPoint{Index: 1})
 
-	s.pendingInputs[*inputInit.OutPoint()] = &pendingInput{
+	s.inputs[*inputInit.OutPoint()] = &pendingInput{
 		state: Init,
 	}
 
@@ -2156,7 +2156,7 @@ func TestMarkInputsPendingPublish(t *testing.T) {
 
 	inputPendingPublish.On("OutPoint").Return(&wire.OutPoint{Index: 2})
 
-	s.pendingInputs[*inputPendingPublish.OutPoint()] = &pendingInput{
+	s.inputs[*inputPendingPublish.OutPoint()] = &pendingInput{
 		state: PendingPublish,
 	}
 
@@ -2166,7 +2166,7 @@ func TestMarkInputsPendingPublish(t *testing.T) {
 
 	inputTerminated.On("OutPoint").Return(&wire.OutPoint{Index: 3})
 
-	s.pendingInputs[*inputTerminated.OutPoint()] = &pendingInput{
+	s.inputs[*inputTerminated.OutPoint()] = &pendingInput{
 		state: Excluded,
 	}
 
@@ -2179,19 +2179,19 @@ func TestMarkInputsPendingPublish(t *testing.T) {
 	s.markInputsPendingPublish(set)
 
 	// We expect unchanged number of pending inputs.
-	require.Len(s.pendingInputs, 3)
+	require.Len(s.inputs, 3)
 
 	// We expect the init input's state to become pending publish.
 	require.Equal(PendingPublish,
-		s.pendingInputs[*inputInit.OutPoint()].state)
+		s.inputs[*inputInit.OutPoint()].state)
 
 	// We expect the pending-publish to stay unchanged.
 	require.Equal(PendingPublish,
-		s.pendingInputs[*inputPendingPublish.OutPoint()].state)
+		s.inputs[*inputPendingPublish.OutPoint()].state)
 
 	// We expect the terminated to stay unchanged.
 	require.Equal(Excluded,
-		s.pendingInputs[*inputTerminated.OutPoint()].state)
+		s.inputs[*inputTerminated.OutPoint()].state)
 }
 
 // TestMarkInputsPublished checks that given a list of inputs with different
@@ -2216,7 +2216,7 @@ func TestMarkInputsPublished(t *testing.T) {
 	// Create three testing inputs.
 	//
 	// inputNotExist specifies an input that's not found in the sweeper's
-	// `pendingInputs` map.
+	// `inputs` map.
 	inputNotExist := &wire.TxIn{
 		PreviousOutPoint: wire.OutPoint{Index: 1},
 	}
@@ -2227,7 +2227,7 @@ func TestMarkInputsPublished(t *testing.T) {
 	inputInit := &wire.TxIn{
 		PreviousOutPoint: wire.OutPoint{Index: 2},
 	}
-	s.pendingInputs[inputInit.PreviousOutPoint] = &pendingInput{
+	s.inputs[inputInit.PreviousOutPoint] = &pendingInput{
 		state: Init,
 	}
 
@@ -2235,7 +2235,7 @@ func TestMarkInputsPublished(t *testing.T) {
 	inputPendingPublish := &wire.TxIn{
 		PreviousOutPoint: wire.OutPoint{Index: 3},
 	}
-	s.pendingInputs[inputPendingPublish.PreviousOutPoint] = &pendingInput{
+	s.inputs[inputPendingPublish.PreviousOutPoint] = &pendingInput{
 		state: PendingPublish,
 	}
 
@@ -2263,15 +2263,15 @@ func TestMarkInputsPublished(t *testing.T) {
 	require.NoError(err)
 
 	// We expect unchanged number of pending inputs.
-	require.Len(s.pendingInputs, 2)
+	require.Len(s.inputs, 2)
 
 	// We expect the init input's state to stay unchanged.
 	require.Equal(Init,
-		s.pendingInputs[inputInit.PreviousOutPoint].state)
+		s.inputs[inputInit.PreviousOutPoint].state)
 
 	// We expect the pending-publish input's is now marked as published.
 	require.Equal(Published,
-		s.pendingInputs[inputPendingPublish.PreviousOutPoint].state)
+		s.inputs[inputPendingPublish.PreviousOutPoint].state)
 
 	// Assert mocked statements are executed as expected.
 	mockStore.AssertExpectations(t)
@@ -2296,7 +2296,7 @@ func TestMarkInputsPublishFailed(t *testing.T) {
 	// Create three testing inputs.
 	//
 	// inputNotExist specifies an input that's not found in the sweeper's
-	// `pendingInputs` map.
+	// `inputs` map.
 	inputNotExist := &wire.TxIn{
 		PreviousOutPoint: wire.OutPoint{Index: 1},
 	}
@@ -2307,7 +2307,7 @@ func TestMarkInputsPublishFailed(t *testing.T) {
 	inputInit := &wire.TxIn{
 		PreviousOutPoint: wire.OutPoint{Index: 2},
 	}
-	s.pendingInputs[inputInit.PreviousOutPoint] = &pendingInput{
+	s.inputs[inputInit.PreviousOutPoint] = &pendingInput{
 		state: Init,
 	}
 
@@ -2315,7 +2315,7 @@ func TestMarkInputsPublishFailed(t *testing.T) {
 	inputPendingPublish := &wire.TxIn{
 		PreviousOutPoint: wire.OutPoint{Index: 3},
 	}
-	s.pendingInputs[inputPendingPublish.PreviousOutPoint] = &pendingInput{
+	s.inputs[inputPendingPublish.PreviousOutPoint] = &pendingInput{
 		state: PendingPublish,
 	}
 
@@ -2329,16 +2329,16 @@ func TestMarkInputsPublishFailed(t *testing.T) {
 	})
 
 	// We expect unchanged number of pending inputs.
-	require.Len(s.pendingInputs, 2)
+	require.Len(s.inputs, 2)
 
 	// We expect the init input's state to stay unchanged.
 	require.Equal(Init,
-		s.pendingInputs[inputInit.PreviousOutPoint].state)
+		s.inputs[inputInit.PreviousOutPoint].state)
 
 	// We expect the pending-publish input's is now marked as publish
 	// failed.
 	require.Equal(PublishFailed,
-		s.pendingInputs[inputPendingPublish.PreviousOutPoint].state)
+		s.inputs[inputPendingPublish.PreviousOutPoint].state)
 
 	// Assert mocked statements are executed as expected.
 	mockStore.AssertExpectations(t)
@@ -2364,7 +2364,7 @@ func TestMarkInputsSwept(t *testing.T) {
 	// Create three testing inputs.
 	//
 	// inputNotExist specifies an input that's not found in the sweeper's
-	// `pendingInputs` map.
+	// `inputs` map.
 	inputNotExist := &wire.TxIn{
 		PreviousOutPoint: wire.OutPoint{Index: 1},
 	}
@@ -2373,7 +2373,7 @@ func TestMarkInputsSwept(t *testing.T) {
 	inputInit := &wire.TxIn{
 		PreviousOutPoint: wire.OutPoint{Index: 2},
 	}
-	s.pendingInputs[inputInit.PreviousOutPoint] = &pendingInput{
+	s.inputs[inputInit.PreviousOutPoint] = &pendingInput{
 		state: Init,
 		Input: mockInput,
 	}
@@ -2382,7 +2382,7 @@ func TestMarkInputsSwept(t *testing.T) {
 	inputPendingPublish := &wire.TxIn{
 		PreviousOutPoint: wire.OutPoint{Index: 3},
 	}
-	s.pendingInputs[inputPendingPublish.PreviousOutPoint] = &pendingInput{
+	s.inputs[inputPendingPublish.PreviousOutPoint] = &pendingInput{
 		state: PendingPublish,
 		Input: mockInput,
 	}
@@ -2391,7 +2391,7 @@ func TestMarkInputsSwept(t *testing.T) {
 	inputTerminated := &wire.TxIn{
 		PreviousOutPoint: wire.OutPoint{Index: 4},
 	}
-	s.pendingInputs[inputTerminated.PreviousOutPoint] = &pendingInput{
+	s.inputs[inputTerminated.PreviousOutPoint] = &pendingInput{
 		state: Excluded,
 		Input: mockInput,
 	}
@@ -2408,19 +2408,19 @@ func TestMarkInputsSwept(t *testing.T) {
 	s.markInputsSwept(tx, true)
 
 	// We expect unchanged number of pending inputs.
-	require.Len(s.pendingInputs, 3)
+	require.Len(s.inputs, 3)
 
 	// We expect the init input's state to become swept.
 	require.Equal(Swept,
-		s.pendingInputs[inputInit.PreviousOutPoint].state)
+		s.inputs[inputInit.PreviousOutPoint].state)
 
 	// We expect the pending-publish becomes swept.
 	require.Equal(Swept,
-		s.pendingInputs[inputPendingPublish.PreviousOutPoint].state)
+		s.inputs[inputPendingPublish.PreviousOutPoint].state)
 
 	// We expect the terminated to stay unchanged.
 	require.Equal(Excluded,
-		s.pendingInputs[inputTerminated.PreviousOutPoint].state)
+		s.inputs[inputTerminated.PreviousOutPoint].state)
 }
 
 // TestMempoolLookup checks that the method `mempoolLookup` works as expected.
@@ -2489,7 +2489,7 @@ func TestUpdateSweeperInputs(t *testing.T) {
 
 	// Add the inputs to the sweeper. After the update, we should see the
 	// terminated inputs being removed.
-	s.pendingInputs = map[wire.OutPoint]*pendingInput{
+	s.inputs = map[wire.OutPoint]*pendingInput{
 		{Index: 0}: input0,
 		{Index: 1}: input1,
 		{Index: 2}: input2,
@@ -2522,7 +2522,7 @@ func TestUpdateSweeperInputs(t *testing.T) {
 	require.Equal(expectedReturn, inputs)
 
 	// Assert the sweeper inputs are as expected.
-	require.Equal(expectedInputs, s.pendingInputs)
+	require.Equal(expectedInputs, s.inputs)
 }
 
 // TestDecideStateAndRBFInfo checks that the expected state and RBFInfo are
@@ -2729,7 +2729,7 @@ func TestHandleBumpEventTxFailed(t *testing.T) {
 	defer input3.AssertExpectations(t)
 
 	// Construct the initial state for the sweeper.
-	s.pendingInputs = pendingInputs{
+	s.inputs = pendingInputs{
 		op1: &pendingInput{Input: input1, state: PendingPublish},
 		op2: &pendingInput{Input: input2, state: PendingPublish},
 		op3: &pendingInput{Input: input3, state: PendingPublish},
@@ -2756,14 +2756,14 @@ func TestHandleBumpEventTxFailed(t *testing.T) {
 	require.ErrorIs(t, err, errDummy)
 
 	// Assert the states of the first two inputs are updated.
-	require.Equal(t, PublishFailed, s.pendingInputs[op1].state)
-	require.Equal(t, PublishFailed, s.pendingInputs[op2].state)
+	require.Equal(t, PublishFailed, s.inputs[op1].state)
+	require.Equal(t, PublishFailed, s.inputs[op2].state)
 
 	// Assert the state of the third input is not updated.
-	require.Equal(t, PendingPublish, s.pendingInputs[op3].state)
+	require.Equal(t, PendingPublish, s.inputs[op3].state)
 
 	// Assert the non-existing input is not added to the pending inputs.
-	require.NotContains(t, s.pendingInputs, opNotExist)
+	require.NotContains(t, s.inputs, opNotExist)
 }
 
 // TestHandleBumpEventTxReplaced checks that the sweeper correctly handles the
@@ -2788,7 +2788,7 @@ func TestHandleBumpEventTxReplaced(t *testing.T) {
 	defer inp.AssertExpectations(t)
 
 	// Construct the initial state for the sweeper.
-	s.pendingInputs = pendingInputs{
+	s.inputs = pendingInputs{
 		op: &pendingInput{Input: inp, state: PendingPublish},
 	}
 
@@ -2853,7 +2853,7 @@ func TestHandleBumpEventTxReplaced(t *testing.T) {
 	require.NoError(t, err)
 
 	// Assert the state of the input is updated.
-	require.Equal(t, Published, s.pendingInputs[op].state)
+	require.Equal(t, Published, s.inputs[op].state)
 }
 
 // TestHandleBumpEventTxPublished checks that the sweeper correctly handles the
@@ -2878,7 +2878,7 @@ func TestHandleBumpEventTxPublished(t *testing.T) {
 	defer inp.AssertExpectations(t)
 
 	// Construct the initial state for the sweeper.
-	s.pendingInputs = pendingInputs{
+	s.inputs = pendingInputs{
 		op: &pendingInput{Input: inp, state: PendingPublish},
 	}
 
@@ -2907,7 +2907,7 @@ func TestHandleBumpEventTxPublished(t *testing.T) {
 	require.NoError(t, err)
 
 	// Assert the state of the input is updated.
-	require.Equal(t, Published, s.pendingInputs[op].state)
+	require.Equal(t, Published, s.inputs[op].state)
 }
 
 // TestMonitorFeeBumpResult checks that the fee bump monitor loop correctly
@@ -2930,7 +2930,7 @@ func TestMonitorFeeBumpResult(t *testing.T) {
 	defer inp.AssertExpectations(t)
 
 	// Construct the initial state for the sweeper.
-	s.pendingInputs = pendingInputs{
+	s.inputs = pendingInputs{
 		op: &pendingInput{Input: inp, state: PendingPublish},
 	}
 

--- a/sweep/tx_input_set.go
+++ b/sweep/tx_input_set.go
@@ -402,7 +402,7 @@ func (t *txInputSet) add(input input.Input, constraints addConstraints) bool {
 // up the utxo set even if it costs us some fees up front.  In the spirit of
 // minimizing any negative externalities we cause for the Bitcoin system as a
 // whole.
-func (t *txInputSet) addPositiveYieldInputs(sweepableInputs []*pendingInput) {
+func (t *txInputSet) addPositiveYieldInputs(sweepableInputs []*SweeperInput) {
 	for i, inp := range sweepableInputs {
 		// Apply relaxed constraints for force sweeps.
 		constraints := constraintsRegular
@@ -549,7 +549,7 @@ func createWalletTxInput(utxo *lnwallet.Utxo) (input.Input, error) {
 type BudgetInputSet struct {
 	// inputs is the set of inputs that have been added to the set after
 	// considering their economical contribution.
-	inputs []*pendingInput
+	inputs []*SweeperInput
 
 	// deadlineHeight is the height which the inputs in this set must be
 	// confirmed by.
@@ -561,7 +561,7 @@ var _ InputSet = (*BudgetInputSet)(nil)
 
 // validateInputs is used when creating new BudgetInputSet to ensure there are
 // no duplicate inputs and they all share the same deadline heights, if set.
-func validateInputs(inputs []pendingInput) error {
+func validateInputs(inputs []SweeperInput) error {
 	// Sanity check the input slice to ensure it's non-empty.
 	if len(inputs) == 0 {
 		return fmt.Errorf("inputs slice is empty")
@@ -597,7 +597,7 @@ func validateInputs(inputs []pendingInput) error {
 }
 
 // NewBudgetInputSet creates a new BudgetInputSet.
-func NewBudgetInputSet(inputs []pendingInput) (*BudgetInputSet, error) {
+func NewBudgetInputSet(inputs []SweeperInput) (*BudgetInputSet, error) {
 	// Validate the supplied inputs.
 	if err := validateInputs(inputs); err != nil {
 		return nil, err
@@ -611,7 +611,7 @@ func NewBudgetInputSet(inputs []pendingInput) (*BudgetInputSet, error) {
 	deadlineHeight := inputs[0].params.DeadlineHeight
 	bi := &BudgetInputSet{
 		deadlineHeight: deadlineHeight,
-		inputs:         make([]*pendingInput, 0, len(inputs)),
+		inputs:         make([]*SweeperInput, 0, len(inputs)),
 	}
 
 	for _, input := range inputs {
@@ -640,7 +640,7 @@ func (b *BudgetInputSet) String() string {
 }
 
 // addInput adds an input to the input set.
-func (b *BudgetInputSet) addInput(input pendingInput) {
+func (b *BudgetInputSet) addInput(input SweeperInput) {
 	b.inputs = append(b.inputs, &input)
 }
 
@@ -695,8 +695,8 @@ func (b *BudgetInputSet) NeedWalletInput() bool {
 }
 
 // copyInputs returns a copy of the slice of the inputs in the set.
-func (b *BudgetInputSet) copyInputs() []*pendingInput {
-	inputs := make([]*pendingInput, len(b.inputs))
+func (b *BudgetInputSet) copyInputs() []*SweeperInput {
+	inputs := make([]*SweeperInput, len(b.inputs))
 	copy(inputs, b.inputs)
 	return inputs
 }
@@ -745,7 +745,7 @@ func (b *BudgetInputSet) AddWalletInputs(wallet Wallet) error {
 			return err
 		}
 
-		pi := pendingInput{
+		pi := SweeperInput{
 			Input: input,
 			params: Params{
 				// Inherit the deadline height from the input

--- a/sweep/tx_input_set.go
+++ b/sweep/tx_input_set.go
@@ -568,7 +568,7 @@ func validateInputs(inputs []SweeperInput) error {
 	}
 
 	// dedupInputs is a map used to track unique outpoints of the inputs.
-	dedupInputs := make(map[*wire.OutPoint]struct{})
+	dedupInputs := make(map[wire.OutPoint]struct{})
 
 	// deadlineSet stores unique deadline heights.
 	deadlineSet := make(map[fn.Option[int32]]struct{})

--- a/sweep/tx_input_set.go
+++ b/sweep/tx_input_set.go
@@ -222,7 +222,7 @@ func (t *txInputSet) enoughInput() bool {
 	// We did not have enough input for a change output. Check if we have
 	// enough input to pay the fees for a transaction with no change
 	// output.
-	fee := t.weightEstimate(false).fee()
+	fee := t.weightEstimate(false).feeWithParent()
 	if t.inputTotal < t.requiredOutput+fee {
 		return false
 	}
@@ -289,7 +289,7 @@ func (t *txInputSet) addToState(inp input.Input,
 	newSet.inputTotal += value
 
 	// Recalculate the tx fee.
-	fee := newSet.weightEstimate(true).fee()
+	fee := newSet.weightEstimate(true).feeWithParent()
 
 	// Calculate the new output value.
 	if reqOut != nil {

--- a/sweep/tx_input_set_test.go
+++ b/sweep/tx_input_set_test.go
@@ -411,7 +411,7 @@ func TestNeedWalletInput(t *testing.T) {
 				// These two methods are only invoked when the
 				// unit test is running with a logger.
 				mockInput.On("OutPoint").Return(
-					&wire.OutPoint{Hash: chainhash.Hash{1}},
+					wire.OutPoint{Hash: chainhash.Hash{1}},
 				).Maybe()
 				mockInput.On("WitnessType").Return(
 					input.CommitmentAnchor,
@@ -632,7 +632,7 @@ func TestAddWalletInputSuccess(t *testing.T) {
 	//
 	// NOTE: these methods are not functional as they are only used for
 	// loggings in debug or trace mode so we use arbitrary values.
-	mockInput.On("OutPoint").Return(&wire.OutPoint{Hash: chainhash.Hash{1}})
+	mockInput.On("OutPoint").Return(wire.OutPoint{Hash: chainhash.Hash{1}})
 	mockInput.On("WitnessType").Return(input.CommitmentAnchor)
 
 	// Create a wallet utxo that cannot cover the budget.

--- a/sweep/tx_input_set_test.go
+++ b/sweep/tx_input_set_test.go
@@ -282,21 +282,34 @@ func TestNewBudgetInputSet(t *testing.T) {
 			DeadlineHeight: fn.Some(int32(2)),
 		},
 	}
+	input3 := SweeperInput{
+		Input: inp2,
+		params: Params{
+			Budget:         100,
+			DeadlineHeight: fn.Some(testHeight),
+		},
+	}
 
 	// Pass a slice of inputs with different deadline heights.
 	set, err = NewBudgetInputSet([]SweeperInput{input1, input2}, testHeight)
-	rt.ErrorContains(err, "inputs have different deadline heights")
+	rt.ErrorContains(err, "input deadline height not matched")
 	rt.Nil(set)
 
-	// Pass a slice of inputs that only one input has the deadline height.
+	// Pass a slice of inputs that only one input has the deadline height,
+	// but it has a different value than the specified testHeight.
 	set, err = NewBudgetInputSet([]SweeperInput{input0, input2}, testHeight)
-	rt.NoError(err)
-	rt.NotNil(set)
+	rt.ErrorContains(err, "input deadline height not matched")
+	rt.Nil(set)
 
 	// Pass a slice of inputs that are duplicates.
-	set, err = NewBudgetInputSet([]SweeperInput{input1, input1}, testHeight)
+	set, err = NewBudgetInputSet([]SweeperInput{input3, input3}, testHeight)
 	rt.ErrorContains(err, "duplicate inputs")
 	rt.Nil(set)
+
+	// Pass a slice of inputs that only one input has the deadline height,
+	set, err = NewBudgetInputSet([]SweeperInput{input0, input3}, testHeight)
+	rt.NoError(err)
+	rt.NotNil(set)
 }
 
 // TestBudgetInputSetAddInput checks that `addInput` correctly updates the

--- a/sweep/tx_input_set_test.go
+++ b/sweep/tx_input_set_test.go
@@ -253,7 +253,7 @@ func TestNewBudgetInputSet(t *testing.T) {
 	rt := require.New(t)
 
 	// Pass an empty slice and expect an error.
-	set, err := NewBudgetInputSet([]SweeperInput{})
+	set, err := NewBudgetInputSet([]SweeperInput{}, testHeight)
 	rt.ErrorContains(err, "inputs slice is empty")
 	rt.Nil(set)
 
@@ -284,17 +284,17 @@ func TestNewBudgetInputSet(t *testing.T) {
 	}
 
 	// Pass a slice of inputs with different deadline heights.
-	set, err = NewBudgetInputSet([]SweeperInput{input1, input2})
+	set, err = NewBudgetInputSet([]SweeperInput{input1, input2}, testHeight)
 	rt.ErrorContains(err, "inputs have different deadline heights")
 	rt.Nil(set)
 
 	// Pass a slice of inputs that only one input has the deadline height.
-	set, err = NewBudgetInputSet([]SweeperInput{input0, input2})
+	set, err = NewBudgetInputSet([]SweeperInput{input0, input2}, testHeight)
 	rt.NoError(err)
 	rt.NotNil(set)
 
 	// Pass a slice of inputs that are duplicates.
-	set, err = NewBudgetInputSet([]SweeperInput{input1, input1})
+	set, err = NewBudgetInputSet([]SweeperInput{input1, input1}, testHeight)
 	rt.ErrorContains(err, "duplicate inputs")
 	rt.Nil(set)
 }
@@ -314,7 +314,7 @@ func TestBudgetInputSetAddInput(t *testing.T) {
 	}
 
 	// Initialize an input set, which adds the above input.
-	set, err := NewBudgetInputSet([]SweeperInput{*pi})
+	set, err := NewBudgetInputSet([]SweeperInput{*pi}, testHeight)
 	require.NoError(t, err)
 
 	// Add the input to the set again.
@@ -646,7 +646,7 @@ func TestAddWalletInputSuccess(t *testing.T) {
 		min, max).Return([]*lnwallet.Utxo{utxo, utxo}, nil).Once()
 
 	// Initialize an input set with the pending input.
-	set, err := NewBudgetInputSet([]SweeperInput{*pi})
+	set, err := NewBudgetInputSet([]SweeperInput{*pi}, deadline)
 	require.NoError(t, err)
 
 	// Add wallet inputs to the input set, which should give us an error as
@@ -669,7 +669,7 @@ func TestAddWalletInputSuccess(t *testing.T) {
 
 	// Finally, check the interface methods.
 	require.EqualValues(t, budget, set.Budget())
-	require.Equal(t, deadline, set.DeadlineHeight().UnsafeFromSome())
+	require.Equal(t, deadline, set.DeadlineHeight())
 	// Weak check, a strong check is to open the slice and check each item.
 	require.Len(t, set.inputs, 3)
 }

--- a/sweep/txgenerator.go
+++ b/sweep/txgenerator.go
@@ -44,7 +44,7 @@ func createSweepTx(inputs []input.Input, outputs []*wire.TxOut,
 		return nil, 0, err
 	}
 
-	txFee := estimator.fee()
+	txFee := estimator.feeWithParent()
 
 	var (
 		// Create the sweep transaction that we will be building. We

--- a/sweep/txgenerator.go
+++ b/sweep/txgenerator.go
@@ -273,7 +273,11 @@ func getWeightEstimate(inputs []input.Input, outputs []*wire.TxOut,
 
 		err := weightEstimate.add(inp)
 		if err != nil {
-			log.Warn(err)
+			// TODO(yy): check if this is even possible? If so, we
+			// should return the error here instead of filtering!
+			log.Errorf("Failed to get weight estimate for "+
+				"input=%v, witnessType=%v: %v ", inp.OutPoint(),
+				inp.WitnessType(), err)
 
 			// Skip inputs for which no weight estimate can be
 			// given.

--- a/sweep/txgenerator.go
+++ b/sweep/txgenerator.go
@@ -74,7 +74,7 @@ func createSweepTx(inputs []input.Input, outputs []*wire.TxOut,
 
 		idxs = append(idxs, o)
 		sweepTx.AddTxIn(&wire.TxIn{
-			PreviousOutPoint: *o.OutPoint(),
+			PreviousOutPoint: o.OutPoint(),
 			Sequence:         o.BlocksToMaturity(),
 		})
 		sweepTx.AddTxOut(o.RequiredTxOut())
@@ -102,7 +102,7 @@ func createSweepTx(inputs []input.Input, outputs []*wire.TxOut,
 
 		idxs = append(idxs, o)
 		sweepTx.AddTxIn(&wire.TxIn{
-			PreviousOutPoint: *o.OutPoint(),
+			PreviousOutPoint: o.OutPoint(),
 			Sequence:         o.BlocksToMaturity(),
 		})
 
@@ -309,9 +309,7 @@ func inputTypeSummary(inputs []input.Input) string {
 
 	var parts []string
 	for _, i := range sortedInputs {
-		part := fmt.Sprintf("%v (%v)",
-			*i.OutPoint(), i.WitnessType())
-
+		part := fmt.Sprintf("%v (%v)", i.OutPoint(), i.WitnessType())
 		parts = append(parts, part)
 	}
 	return strings.Join(parts, ", ")

--- a/sweep/weight_estimator.go
+++ b/sweep/weight_estimator.go
@@ -106,6 +106,19 @@ func (w *weightEstimator) weight() int {
 	return w.estimator.Weight()
 }
 
+// fee returns the tx fee to use for the aggregated inputs and outputs, which
+// is different from feeWithParent as it doesn't take into account unconfirmed
+// parent transactions.
+func (w *weightEstimator) fee() btcutil.Amount {
+	// Calculate the weight of the transaction.
+	weight := int64(w.estimator.Weight())
+
+	// Calculate the fee.
+	fee := w.feeRate.FeeForWeight(weight)
+
+	return fee
+}
+
 // feeWithParent returns the tx fee to use for the aggregated inputs and
 // outputs, taking into account unconfirmed parent transactions (cpfp).
 func (w *weightEstimator) feeWithParent() btcutil.Amount {

--- a/sweep/weight_estimator.go
+++ b/sweep/weight_estimator.go
@@ -106,9 +106,9 @@ func (w *weightEstimator) weight() int {
 	return w.estimator.Weight()
 }
 
-// fee returns the tx fee to use for the aggregated inputs and outputs, taking
-// into account unconfirmed parent transactions (cpfp).
-func (w *weightEstimator) fee() btcutil.Amount {
+// feeWithParent returns the tx fee to use for the aggregated inputs and
+// outputs, taking into account unconfirmed parent transactions (cpfp).
+func (w *weightEstimator) feeWithParent() btcutil.Amount {
 	// Calculate fee and weight for just this tx.
 	childWeight := int64(w.estimator.Weight())
 

--- a/sweep/weight_estimator_test.go
+++ b/sweep/weight_estimator_test.go
@@ -30,7 +30,8 @@ func TestWeightEstimator(t *testing.T) {
 	// The expectations is that this input is added.
 	const expectedWeight1 = 322
 	require.Equal(t, expectedWeight1, w.weight())
-	require.Equal(t, testFeeRate.FeeForWeight(expectedWeight1), w.fee())
+	require.Equal(t, testFeeRate.FeeForWeight(expectedWeight1),
+		w.feeWithParent())
 
 	// Define a parent transaction that pays a fee of 30000 sat/kw.
 	parentTxHighFee := &input.TxInfo{
@@ -51,7 +52,8 @@ func TestWeightEstimator(t *testing.T) {
 	// rate than the child. We expect no additional fee on the child.
 	const expectedWeight2 = expectedWeight1 + 280
 	require.Equal(t, expectedWeight2, w.weight())
-	require.Equal(t, testFeeRate.FeeForWeight(expectedWeight2), w.fee())
+	require.Equal(t, testFeeRate.FeeForWeight(expectedWeight2),
+		w.feeWithParent())
 
 	// Define a parent transaction that pays a fee of 10000 sat/kw.
 	parentTxLowFee := &input.TxInfo{
@@ -78,7 +80,7 @@ func TestWeightEstimator(t *testing.T) {
 		expectedWeight3+parentTxLowFee.Weight,
 	) - parentTxLowFee.Fee
 
-	require.Equal(t, expectedFee, w.fee())
+	require.Equal(t, expectedFee, w.feeWithParent())
 }
 
 // TestWeightEstimatorMaxFee tests that the weight estimator correctly caps the
@@ -118,7 +120,7 @@ func TestWeightEstimatorMaxFee(t *testing.T) {
 	//
 	// Thus we cap at the maxFee.
 	expectedFee := maxFeeRate.FeeForWeight(childWeight)
-	require.Equal(t, expectedFee, w.fee())
+	require.Equal(t, expectedFee, w.feeWithParent())
 }
 
 // TestWeightEstimatorAddOutput tests that adding the raw P2WKH output to the

--- a/watchtower/wtclient/backup_task.go
+++ b/watchtower/wtclient/backup_task.go
@@ -67,10 +67,10 @@ func newBackupTask(id wtdb.BackupID, sweepPkScript []byte) *backupTask {
 func (t *backupTask) inputs() map[wire.OutPoint]input.Input {
 	inputs := make(map[wire.OutPoint]input.Input)
 	if t.toLocalInput != nil {
-		inputs[*t.toLocalInput.OutPoint()] = t.toLocalInput
+		inputs[t.toLocalInput.OutPoint()] = t.toLocalInput
 	}
 	if t.toRemoteInput != nil {
-		inputs[*t.toRemoteInput.OutPoint()] = t.toRemoteInput
+		inputs[t.toRemoteInput.OutPoint()] = t.toRemoteInput
 	}
 
 	return inputs
@@ -297,7 +297,7 @@ func (t *backupTask) craftSessionPayload(
 	commitType := t.commitmentType
 	for _, inp := range inputs {
 		// Lookup the input's new post-sort position.
-		i := inputIndex[*inp.OutPoint()]
+		i := inputIndex[inp.OutPoint()]
 
 		// Construct the full witness required to spend this input.
 		inputScript, err := inp.CraftInputScript(

--- a/watchtower/wtclient/backup_task_internal_test.go
+++ b/watchtower/wtclient/backup_task_internal_test.go
@@ -580,10 +580,10 @@ func testBackupTask(t *testing.T, test backupTaskTest) {
 	// task's inputs() method.
 	expInputs := make(map[wire.OutPoint]input.Input)
 	if task.toLocalInput != nil {
-		expInputs[*task.toLocalInput.OutPoint()] = task.toLocalInput
+		expInputs[task.toLocalInput.OutPoint()] = task.toLocalInput
 	}
 	if task.toRemoteInput != nil {
-		expInputs[*task.toRemoteInput.OutPoint()] = task.toRemoteInput
+		expInputs[task.toRemoteInput.OutPoint()] = task.toRemoteInput
 	}
 
 	// Assert that the inputs method returns the correct slice of


### PR DESCRIPTION
This PR addresses the comments collected from previous sweeper PRs to avoid too many rebase conflicts there,
- [x] Don't prefix with State we already have hover information to determine what the type is, [link](https://github.com/lightningnetwork/lnd/pull/8423/files#r1483677771)
- [x] offer the input to the sweeper in `htlcSuccessResolver`, [link](https://github.com/lightningnetwork/lnd/pull/8147#discussion_r1501921252)
- [x] make sure `UtxoAggregator` return public types, [link](https://github.com/lightningnetwork/lnd/pull/8422/files#r1484920305)
- [x] If we can't get spend notifications, then we don't know when anything is confirmed, which would impact the sweeper's ability to know when [it should stop trying to increase the fee](https://github.com/lightningnetwork/lnd/pull/8423/files#r1540282757).
- [x] the OutPoint method here needs to actually return a pointer, instead can just be wire.OutPoint.

In addition, it also makes some changes based on the final PR #8514 so edgy cases are now caught so the sweeper can be ready to be used in all the contract resolvers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lightningnetwork/lnd/8581)
<!-- Reviewable:end -->
