### PR TITLE
chainntnfs: fix race in `TestInterfaces`

### DIFF
--- a/chainntnfs/test/test_interface.go
+++ b/chainntnfs/test/test_interface.go
@@ -1893,7 +1893,6 @@ func TestInterfaces(t *testing.T, targetBackEnd string) {
 	// play around with.
 	miner := unittest.NewMiner(t, unittest.NetParams, nil, true, 25)
 
-	rpcConfig := miner.RPCConfig()
 	p2pAddr := miner.P2PAddress()
 
 	log.Printf("Running %v ChainNotifier interface tests",
@@ -1953,10 +1952,10 @@ func TestInterfaces(t *testing.T, targetBackEnd string) {
 			}
 
 		case "btcd":
-			configCopy := rpcConfig
+			rpcConfig := miner.RPCConfig()
 			newNotifier = func() (chainntnfs.TestChainNotifier, error) {
 				return btcdnotify.New(
-					&configCopy, unittest.NetParams,
+					&rpcConfig, unittest.NetParams,
 					hintCache, hintCache, blockCache,
 				)
 			}


### PR DESCRIPTION
Found this race in this sweeper PR [build](https://github.com/lightningnetwork/lnd/actions/runs/8430170345/job/23085602197?pr=8423),
```
==================
WARNING: DATA RACE
Write at 0x00c00054a110 by goroutine 11:
  github.com/lightningnetwork/lnd/chainntnfs/btcdnotify.New()
      /home/runner/work/lnd/lnd/chainntnfs/btcdnotify/btcd.go:135 +0xa2d
  github.com/lightningnetwork/lnd/chainntnfs/test.TestInterfaces.func3()
      /home/runner/work/lnd/lnd/chainntnfs/test/test_interface.go:1958 +0x70
  github.com/lightningnetwork/lnd/chainntnfs/test.TestInterfaces()
      /home/runner/work/lnd/lnd/chainntnfs/test/test_interface.go:2025 +0x1444
  github.com/lightningnetwork/lnd/chainntnfs/test/btcd_test.TestInterfaces()
      /home/runner/work/lnd/lnd/chainntnfs/test/btcd/btcd_test.go:15 +0x32
  testing.tRunner()
      /opt/hostedtoolcache/go/1.21.0/x64/src/testing/testing.go:1595 +0x238
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.21.0/x64/src/testing/testing.go:1648 +0x44

Previous read at 0x00c00054a110 by goroutine 150:
  github.com/btcsuite/btcd/rpcclient.(*Client).Disconnect()
      /home/runner/go/pkg/mod/github.com/btcsuite/btcd@v0.24.1-0.20240301210420-1a2b599bf1af/rpcclient/infrastructure.go:1115 +0xe9
  github.com/btcsuite/btcd/rpcclient.(*Client).wsInHandler()
      /home/runner/go/pkg/mod/github.com/btcsuite/btcd@v0.24.1-0.20240301210420-1a2b599bf1af/rpcclient/infrastructure.go:481 +0x1fe
  github.com/btcsuite/btcd/rpcclient.(*Client).start.func3()
      /home/runner/go/pkg/mod/github.com/btcsuite/btcd@v0.24.1-0.20240301210420-1a2b599bf1af/rpcclient/infrastructure.go:1176 +0x33

Goroutine 11 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.21.0/x64/src/testing/testing.go:1648 +0x82a
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.21.0/x64/src/testing/testing.go:2054 +0x84
  testing.tRunner()
      /opt/hostedtoolcache/go/1.21.0/x64/src/testing/testing.go:1595 +0x238
  testing.runTests()
      /opt/hostedtoolcache/go/1.21.0/x64/src/testing/testing.go:2052 +0x896
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.21.0/x64/src/testing/testing.go:1925 +0xb57
  main.main()
      _testmain.go:47 +0x2bd

Goroutine 150 (finished) created at:
  github.com/btcsuite/btcd/rpcclient.(*Client).start()
      /home/runner/go/pkg/mod/github.com/btcsuite/btcd@v0.24.1-0.20240301210420-1a2b599bf1af/rpcclient/infrastructure.go:1176 +0x2c7
  github.com/btcsuite/btcd/rpcclient.(*Client).Connect()
      /home/runner/go/pkg/mod/github.com/btcsuite/btcd@v0.24.1-0.20240301210420-1a2b599bf1af/rpcclient/infrastructure.go:1561 +0x429
  github.com/lightningnetwork/lnd/chainntnfs/btcdnotify.(*BtcdNotifier).startNotifier()
      /home/runner/work/lnd/lnd/chainntnfs/btcdnotify/btcd.go:221 +0x129
  github.com/lightningnetwork/lnd/chainntnfs/btcdnotify.(*BtcdNotifier).Start.func1()
      /home/runner/work/lnd/lnd/chainntnfs/btcdnotify/btcd.go:165 +0x37
  sync.(*Once).doSlow()
      /opt/hostedtoolcache/go/1.21.0/x64/src/sync/once.go:74 +0xf0
  sync.(*Once).Do()
      /opt/hostedtoolcache/go/1.21.0/x64/src/sync/once.go:65 +0x44
  github.com/lightningnetwork/lnd/chainntnfs/btcdnotify.(*BtcdNotifier).Start()
      /home/runner/work/lnd/lnd/chainntnfs/btcdnotify/btcd.go:164 +0x6c
  github.com/lightningnetwork/lnd/chainntnfs/test.TestInterfaces()
      /home/runner/work/lnd/lnd/chainntnfs/test/test_interface.go:1985 +0xeaf
  github.com/lightningnetwork/lnd/chainntnfs/test/btcd_test.TestInterfaces()
      /home/runner/work/lnd/lnd/chainntnfs/test/btcd/btcd_test.go:15 +0x32
  testing.tRunner()
      /opt/hostedtoolcache/go/1.21.0/x64/src/testing/testing.go:1595 +0x238
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.21.0/x64/src/testing/testing.go:1648 +0x44
==================
```
