### PR TITLE
lntest: add test node name to tmp directory name

### DIFF
--- a/lntest/node/harness_node.go
+++ b/lntest/node/harness_node.go
@@ -97,7 +97,12 @@ type HarnessNode struct {
 func NewHarnessNode(t *testing.T, cfg *BaseNodeConfig) (*HarnessNode, error) {
 	if cfg.BaseDir == "" {
 		var err error
-		cfg.BaseDir, err = ioutil.TempDir("", "lndtest-node")
+
+		// Create a temporary directory for the node's data and logs.
+		// Use dash suffix as a separator between base name and random
+		// suffix.
+		dirBaseName := fmt.Sprintf("lndtest-node-%s-", cfg.Name)
+		cfg.BaseDir, err = os.MkdirTemp("", dirBaseName)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Change Description

In this commit we add the LND node name to the temporary directory's name. This change makes it easier to identify a particular test node's temporary directory.

This commit also replaces the depreciated `ioutil.TempDir` function call with `os.MkdirTemp`.

## Steps to Test
1. Create a new test harness node with a unique name.
2. Observe the node's directory in the system tmp directory.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
