### PR TITLE
itest: fix ascii

### DIFF
--- a/itest/lnd_mpp_test.go
+++ b/itest/lnd_mpp_test.go
@@ -248,8 +248,8 @@ type mppOpenChannelRequest struct {
 // openChannels is a helper to open channels that sets up a network topology
 // with three different paths Alice <-> Bob as following,
 //
-//		 _ Eve _
-//		/       \
+//		      _ Eve _
+//		     /       \
 //	 Alice -- Carol ---- Bob
 //		\              /
 //		 \__ Dave ____/


### PR DESCRIPTION
This PR fixes the ascii so that it's the same as the one [here](https://github.com/lightningnetwork/lnd/blob/b76f733a9edc452385ad8e5a3ed8fe391d827182/itest/lnd_mpp_test.go#L177).