### PR TITLE
sqldb: reset out of scope containers on potential ExecTx retry

### DIFF
--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -401,6 +401,9 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
   start](https://github.com/lightningnetwork/lnd/pull/8568) if native SQL is
   enabled but the channeldb already has any KV invoices stored.
 
+* [Fix a bug](https://github.com/lightningnetwork/lnd/pull/8595) when retrying
+  SQL InvoiceDB transactions due to database errors.
+
 ## Code Health
 
 * [Remove database pointers](https://github.com/lightningnetwork/lnd/pull/8117) 

--- a/sqldb/invoices.go
+++ b/sqldb/invoices.go
@@ -611,10 +611,11 @@ func (i *InvoiceStore) LookupInvoice(ctx context.Context,
 func (i *InvoiceStore) FetchPendingInvoices(ctx context.Context) (
 	map[lntypes.Hash]invpkg.Invoice, error) {
 
-	invoices := make(map[lntypes.Hash]invpkg.Invoice)
+	var invoices map[lntypes.Hash]invpkg.Invoice
 
 	readTxOpt := NewInvoiceQueryReadTx()
 	err := i.db.ExecTx(ctx, &readTxOpt, func(db InvoiceQueries) error {
+		invoices = make(map[lntypes.Hash]invpkg.Invoice)
 		limit := queryPaginationLimit
 
 		return queryWithLimit(func(offset int) (int, error) {
@@ -671,6 +672,7 @@ func (i *InvoiceStore) InvoicesSettledSince(ctx context.Context, idx uint64) (
 
 	readTxOpt := NewInvoiceQueryReadTx()
 	err := i.db.ExecTx(ctx, &readTxOpt, func(db InvoiceQueries) error {
+		invoices = nil
 		settleIdx := idx
 		limit := queryPaginationLimit
 
@@ -784,6 +786,7 @@ func (i *InvoiceStore) InvoicesAddedSince(ctx context.Context, idx uint64) (
 
 	readTxOpt := NewInvoiceQueryReadTx()
 	err := i.db.ExecTx(ctx, &readTxOpt, func(db InvoiceQueries) error {
+		result = nil
 		addIdx := idx
 		limit := queryPaginationLimit
 
@@ -840,6 +843,7 @@ func (i *InvoiceStore) QueryInvoices(ctx context.Context,
 
 	readTxOpt := NewInvoiceQueryReadTx()
 	err := i.db.ExecTx(ctx, &readTxOpt, func(db InvoiceQueries) error {
+		invoices = nil
 		limit := queryPaginationLimit
 
 		return queryWithLimit(func(offset int) (int, error) {


### PR DESCRIPTION
As SQL serializaton errors can lead to transaction retries we need to ensure that we reset any out of scope containers where we accumulate results. Otherwise partial data from a previously executed transacton retry may be returned along with the latest result.

This is a potential fix for the flake reported in https://github.com/lightningnetwork/lnd/issues/8583