### PR TITLE
lnd: fix sweepall argument call.

### DIFF
--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -109,6 +109,9 @@
 
 * [Removed](https://github.com/lightningnetwork/lnd/pull/8577) some unreachable code
 
+[Fixed](https://github.com/lightningnetwork/lnd/pull/8609) fixed a function
+call where arguments were swapped.
+
 # New Features
 ## Functional Enhancements
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1310,7 +1310,7 @@ func (r *rpcServer) SendCoins(ctx context.Context,
 		// pay to the change address created above if we needed to
 		// reserve any value, the rest will go to targetAddr.
 		sweepTxPkg, err := sweep.CraftSweepAllTx(
-			maxFeeRate, feePerKw, uint32(bestHeight), nil,
+			feePerKw, maxFeeRate, uint32(bestHeight), nil,
 			targetAddr, wallet, wallet, wallet.WalletController,
 			r.server.cc.Signer, minConfs,
 		)
@@ -1363,7 +1363,7 @@ func (r *rpcServer) SendCoins(ctx context.Context,
 			}
 
 			sweepTxPkg, err = sweep.CraftSweepAllTx(
-				maxFeeRate, feePerKw, uint32(bestHeight),
+				feePerKw, maxFeeRate, uint32(bestHeight),
 				outputs, targetAddr, wallet, wallet,
 				wallet.WalletController,
 				r.server.cc.Signer, minConfs,


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/8608

I think no more itests or unit tests are needed because this behavior could not have resulted in a bug because we catch the 0 sat/vbyte behaviour in your fee-estimation code.