### PR TITLE
Revert "feature: make gossip queries compulsory"

### DIFF
--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -390,6 +390,11 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
   and makes TLV Onions, Static Remote Keys, Gossip Queries, compulsory features
   for LND's peers. Data Loss Protection has been compulsory for years.
 
+* [Don't Require Gossip Queries](https://github.com/lightningnetwork/lnd/pull/8615)
+  This change undoes a portion of what was introduced in #8275 due to a subsequent
+  [spec change](https://github.com/lightning/bolts/pull/1092/commits/e0ee59f3c92b7c98be8dfc47b7db358b45baf9de)
+  that meant we shouldn't require it.
+
 ## Testing
 
 * Added fuzz tests for [onion

--- a/feature/default_sets.go
+++ b/feature/default_sets.go
@@ -14,7 +14,7 @@ var defaultSetDesc = setDesc{
 		SetInit:    {}, // I
 		SetNodeAnn: {}, // N
 	},
-	lnwire.GossipQueriesRequired: {
+	lnwire.GossipQueriesOptional: {
 		SetInit:    {}, // I
 		SetNodeAnn: {}, // N
 	},

--- a/feature/manager_internal_test.go
+++ b/feature/manager_internal_test.go
@@ -151,7 +151,7 @@ func TestUpdateFeatureSets(t *testing.T) {
 			SetInit:    {}, // I
 			SetNodeAnn: {}, // N
 		},
-		lnwire.GossipQueriesRequired: {
+		lnwire.GossipQueriesOptional: {
 			SetNodeAnn: {}, // N
 		},
 	}
@@ -201,7 +201,7 @@ func TestUpdateFeatureSets(t *testing.T) {
 				),
 				SetNodeAnn: lnwire.NewRawFeatureVector(
 					lnwire.DataLossProtectRequired,
-					lnwire.GossipQueriesRequired,
+					lnwire.GossipQueriesOptional,
 					lnwire.FeatureBit(1000),
 				),
 			},
@@ -222,7 +222,7 @@ func TestUpdateFeatureSets(t *testing.T) {
 				),
 				SetNodeAnn: lnwire.NewRawFeatureVector(
 					lnwire.DataLossProtectRequired,
-					lnwire.GossipQueriesRequired,
+					lnwire.GossipQueriesOptional,
 				),
 			},
 			config: Config{
@@ -242,7 +242,7 @@ func TestUpdateFeatureSets(t *testing.T) {
 				),
 				SetNodeAnn: lnwire.NewRawFeatureVector(
 					lnwire.DataLossProtectRequired,
-					lnwire.GossipQueriesRequired,
+					lnwire.GossipQueriesOptional,
 					lnwire.FeatureBit(500),
 				),
 				SetInvoice: lnwire.NewRawFeatureVector(

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -757,6 +757,13 @@ func (p *Brontide) initGossipSync() {
 	if p.remoteFeatures.HasFeature(lnwire.GossipQueriesOptional) {
 		p.log.Info("Negotiated chan series queries")
 
+		if p.cfg.AuthGossiper == nil {
+			// This should only ever be hit in the unit tests.
+			p.log.Warn("No AuthGossiper configured. Abandoning " +
+				"gossip sync.")
+			return
+		}
+
 		// Register the peer's gossip syncer with the gossiper.
 		// This blocks synchronously to ensure the gossip syncer is
 		// registered with the gossiper before attempting to read

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -757,13 +757,6 @@ func (p *Brontide) initGossipSync() {
 	if p.remoteFeatures.HasFeature(lnwire.GossipQueriesOptional) {
 		p.log.Info("Negotiated chan series queries")
 
-		if p.cfg.AuthGossiper == nil {
-			// This should only ever be hit in the unit tests.
-			p.log.Warn("No AuthGossiper configured. Abandoning " +
-				"gossip sync.")
-			return
-		}
-
 		// Register the peer's gossip syncer with the gossiper.
 		// This blocks synchronously to ensure the gossip syncer is
 		// registered with the gossiper before attempting to read

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -1138,7 +1138,6 @@ func TestPeerCustomMessage(t *testing.T) {
 		initReplyMsg := lnwire.NewInitMessage(
 			lnwire.NewRawFeatureVector(
 				lnwire.DataLossProtectRequired,
-				lnwire.GossipQueriesOptional,
 			),
 			lnwire.NewRawFeatureVector(),
 		)


### PR DESCRIPTION
This reverts commit 717facc2020315652f66988cdab15bc75c313357.

It turns out that we can't do this since it would result in incompatibility with LDK. The spec has been updated to reallow optional gossip queries so we revert this commit.

The spec change commit that subsequently relaxed this restriction it originally introduced can be found [here](https://github.com/lightning/bolts/pull/1092/commits/e0ee59f3c92b7c98be8dfc47b7db358b45baf9de)

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
