### PR TITLE
lnrpc: rejects positive inbound fees by default

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -2376,14 +2376,14 @@ func updateChannelPolicy(ctx *cli.Context) error {
 
 	inboundBaseFeeMsat := ctx.Int64("inbound_base_fee_msat")
 	if inboundBaseFeeMsat < math.MinInt32 ||
-		inboundBaseFeeMsat > 0 {
+		inboundBaseFeeMsat > math.MaxInt32 {
 
 		return errors.New("inbound_base_fee_msat out of range")
 	}
 
 	inboundFeeRatePpm := ctx.Int64("inbound_fee_rate_ppm")
 	if inboundFeeRatePpm < math.MinInt32 ||
-		inboundFeeRatePpm > 0 {
+		inboundFeeRatePpm > math.MaxInt32 {
 
 		return errors.New("inbound_fee_rate_ppm out of range")
 	}

--- a/config.go
+++ b/config.go
@@ -411,6 +411,8 @@ type Config struct {
 
 	RejectHTLC bool `long:"rejecthtlc" description:"If true, lnd will not forward any HTLCs that are meant as onward payments. This option will still allow lnd to send HTLCs and receive HTLCs but lnd won't be used as a hop."`
 
+	AcceptPositiveInboundFees bool `long:"accept-positive-inbound-fees" description:"If true, lnd will also allow setting positive inbound fees. By default, lnd only allows to set negative inbound fees (an inbound \"discount\") to remain backwards compatible with senders whose implementations do not yet support inbound fees."`
+
 	// RequireInterceptor determines whether the HTLC interceptor is
 	// registered regardless of whether the RPC is called or not.
 	RequireInterceptor bool `long:"requireinterceptor" description:"Whether to always intercept HTLCs, even if no stream is attached"`

--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -120,8 +120,13 @@ call where arguments were swapped.
   node operators to require senders to pay an inbound fee for forwards and
   payments. It is recommended to only use negative fees (an inbound "discount")
   initially to keep the channels open for senders that do not recognize inbound
-  fees. [Send support](https://github.com/lightningnetwork/lnd/pull/6934) is
+  fees.
+
+  [Send support](https://github.com/lightningnetwork/lnd/pull/6934) is
   implemented as well.
+
+  [Positive inbound fees](https://github.com/lightningnetwork/lnd/pull/8627) 
+  can be enabled with the option `accept-positive-inbound-fees`.
 
 * A new config value,
   [sweeper.maxfeerate](https://github.com/lightningnetwork/lnd/pull/7823), is
@@ -448,6 +453,7 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
 * Carla Kirk-Cohen
 * Elle Mouton
 * ErikEk
+* Feelancer21
 * Jesse de Wit
 * Joost Jager
 * Keagan McClelland

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -7109,6 +7109,20 @@ func (r *rpcServer) UpdateChannelPolicy(ctx context.Context,
 			MaxTimeLockDelta)
 	}
 
+	// By default, positive inbound fees are rejected.
+	if !r.cfg.AcceptPositiveInboundFees {
+		if req.InboundBaseFeeMsat > 0 {
+			return nil, fmt.Errorf("positive values for inbound "+
+				"base fee msat are not supported: %v",
+				req.InboundBaseFeeMsat)
+		}
+		if req.InboundFeeRatePpm > 0 {
+			return nil, fmt.Errorf("positive values for inbound "+
+				"fee rate ppm are not supported: %v",
+				req.InboundFeeRatePpm)
+		}
+	}
+
 	baseFeeMsat := lnwire.MilliSatoshi(req.BaseFeeMsat)
 	feeSchema := routing.FeeSchema{
 		BaseFee: baseFeeMsat,

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -438,6 +438,13 @@
 ; If true, all HTLCs will be held until they are handled by an interceptor
 ; requireinterceptor=false
 
+; If true, lnd will also allow setting positive inbound fees. By default, lnd
+; only allows to set negative inbound fees (an inbound "discount") to remain
+; backwards compatible with senders whose implementations do not yet support
+; inbound fees. Therefore, you should ONLY set this setting if you know what you
+; are doing. [experimental]
+; accept-positive-inbound-fees=false
+
 ; If true, will apply a randomized staggering between 0s and 30s when
 ; reconnecting to persistent peers on startup. The first 10 reconnections will be
 ; attempted instantly, regardless of the flag's value


### PR DESCRIPTION
Positive inbound are now rejected by default. The user can enable positive inbound fees with the option 'no-reject-positive-inbound-fees'.

## Change Description
Description of change / link to associated issue.

## Steps to Test
Tested with `lncli updatechanpolicy` with positive and negative inbound fees and with enabled and disabled option

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
