### PR TITLE
[code-health]: reduce duplication in brontide test.

### DIFF
--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -48,10 +48,13 @@ func TestPeerChannelClosureShutdownResponseLinkRemoved(t *testing.T) {
 
 	mockSwitch := &mockMessageSwitch{}
 
-	alicePeer, bobChan, err := createTestPeerWithChannel(
+	harness, err := createTestPeerWithChannel(
 		t, notifier, broadcastTxChan, noUpdate, mockSwitch,
 	)
 	require.NoError(t, err, "unable to create test channels")
+
+	alicePeer := harness.peer
+	bobChan := harness.channel
 
 	chanPoint := bobChan.ChannelPoint()
 	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
@@ -96,10 +99,13 @@ func TestPeerChannelClosureAcceptFeeResponder(t *testing.T) {
 
 	mockSwitch := &mockMessageSwitch{}
 
-	alicePeer, bobChan, err := createTestPeerWithChannel(
+	harness, err := createTestPeerWithChannel(
 		t, notifier, broadcastTxChan, noUpdate, mockSwitch,
 	)
 	require.NoError(t, err, "unable to create test channels")
+
+	alicePeer := harness.peer
+	bobChan := harness.channel
 
 	chanPoint := bobChan.ChannelPoint()
 	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
@@ -201,10 +207,13 @@ func TestPeerChannelClosureAcceptFeeInitiator(t *testing.T) {
 
 	mockSwitch := &mockMessageSwitch{}
 
-	alicePeer, bobChan, err := createTestPeerWithChannel(
+	harness, err := createTestPeerWithChannel(
 		t, notifier, broadcastTxChan, noUpdate, mockSwitch,
 	)
 	require.NoError(t, err, "unable to create test channels")
+
+	bobChan := harness.channel
+	alicePeer := harness.peer
 
 	chanPoint := bobChan.ChannelPoint()
 	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
@@ -325,10 +334,13 @@ func TestPeerChannelClosureFeeNegotiationsResponder(t *testing.T) {
 
 	mockSwitch := &mockMessageSwitch{}
 
-	alicePeer, bobChan, err := createTestPeerWithChannel(
+	harness, err := createTestPeerWithChannel(
 		t, notifier, broadcastTxChan, noUpdate, mockSwitch,
 	)
 	require.NoError(t, err, "unable to create test channels")
+
+	bobChan := harness.channel
+	alicePeer := harness.peer
 
 	chanPoint := bobChan.ChannelPoint()
 	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
@@ -512,10 +524,13 @@ func TestPeerChannelClosureFeeNegotiationsInitiator(t *testing.T) {
 
 	mockSwitch := &mockMessageSwitch{}
 
-	alicePeer, bobChan, err := createTestPeerWithChannel(
+	harness, err := createTestPeerWithChannel(
 		t, notifier, broadcastTxChan, noUpdate, mockSwitch,
 	)
 	require.NoError(t, err, "unable to create test channels")
+
+	alicePeer := harness.peer
+	bobChan := harness.channel
 
 	chanPoint := bobChan.ChannelPoint()
 	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
@@ -840,7 +855,7 @@ func TestCustomShutdownScript(t *testing.T) {
 			mockSwitch := &mockMessageSwitch{}
 
 			// Open a channel.
-			alicePeer, bobChan, err := createTestPeerWithChannel(
+			harness, err := createTestPeerWithChannel(
 				t, notifier, broadcastTxChan, test.update,
 				mockSwitch,
 			)
@@ -848,13 +863,16 @@ func TestCustomShutdownScript(t *testing.T) {
 				t.Fatalf("unable to create test channels: %v", err)
 			}
 
+			alicePeer := harness.peer
+			bobChan := harness.channel
+
 			chanPoint := bobChan.ChannelPoint()
 			chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
 			mockLink := newMockUpdateHandler(chanID)
 			mockSwitch.links = append(mockSwitch.links, mockLink)
 
-			// Request initiator to cooperatively close the channel, with
-			// a specified delivery address.
+			// Request initiator to cooperatively close the channel,
+			// with a specified delivery address.
 			updateChan := make(chan interface{}, 1)
 			errChan := make(chan error, 1)
 			closeCommand := htlcswitch.ChanClose{
@@ -1195,10 +1213,13 @@ func TestUpdateNextRevocation(t *testing.T) {
 	broadcastTxChan := make(chan *wire.MsgTx)
 	mockSwitch := &mockMessageSwitch{}
 
-	alicePeer, bobChan, err := createTestPeerWithChannel(
+	harness, err := createTestPeerWithChannel(
 		t, notifier, broadcastTxChan, noUpdate, mockSwitch,
 	)
 	require.NoError(err, "unable to create test channels")
+
+	bobChan := harness.channel
+	alicePeer := harness.peer
 
 	// testChannel is used to test the updateNextRevocation function.
 	testChannel := bobChan.State()
@@ -1432,10 +1453,12 @@ func TestStartupWriteMessageRace(t *testing.T) {
 
 	// createTestPeerWithChannel creates a peer and a channel with that
 	// peer.
-	peer, _, err := createTestPeerWithChannel(
+	harness, err := createTestPeerWithChannel(
 		t, notifier, broadcastTxChan, getChannels, mockSwitch,
 	)
 	require.NoError(t, err, "unable to create test channel")
+
+	peer := harness.peer
 
 	// Avoid the need to mock the channel graph by marking the channel
 	// borked. Borked channels still get a reestablish message sent on
@@ -1528,10 +1551,12 @@ func TestRemovePendingChannel(t *testing.T) {
 
 	// createTestPeerWithChannel creates a peer and a channel with that
 	// peer.
-	peer, _, err := createTestPeerWithChannel(
+	harness, err := createTestPeerWithChannel(
 		t, notifier, broadcastTxChan, noUpdate, mockSwitch,
 	)
 	require.NoError(t, err, "unable to create test channel")
+
+	peer := harness.peer
 
 	// Add a pending channel to the peer Alice.
 	errChan := make(chan error, 1)

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -39,18 +39,7 @@ var (
 func TestPeerChannelClosureShutdownResponseLinkRemoved(t *testing.T) {
 	t.Parallel()
 
-	notifier := &mock.ChainNotifier{
-		SpendChan: make(chan *chainntnfs.SpendDetail),
-		EpochChan: make(chan *chainntnfs.BlockEpoch),
-		ConfChan:  make(chan *chainntnfs.TxConfirmation),
-	}
-	broadcastTxChan := make(chan *wire.MsgTx)
-
-	mockSwitch := &mockMessageSwitch{}
-
-	harness, err := createTestPeerWithChannel(
-		t, notifier, broadcastTxChan, noUpdate, mockSwitch,
-	)
+	harness, err := createTestPeerWithChannel(t, noUpdate)
 	require.NoError(t, err, "unable to create test channels")
 
 	alicePeer := harness.peer
@@ -90,22 +79,14 @@ func TestPeerChannelClosureShutdownResponseLinkRemoved(t *testing.T) {
 func TestPeerChannelClosureAcceptFeeResponder(t *testing.T) {
 	t.Parallel()
 
-	notifier := &mock.ChainNotifier{
-		SpendChan: make(chan *chainntnfs.SpendDetail),
-		EpochChan: make(chan *chainntnfs.BlockEpoch),
-		ConfChan:  make(chan *chainntnfs.TxConfirmation),
-	}
-	broadcastTxChan := make(chan *wire.MsgTx)
-
-	mockSwitch := &mockMessageSwitch{}
-
-	harness, err := createTestPeerWithChannel(
-		t, notifier, broadcastTxChan, noUpdate, mockSwitch,
-	)
+	harness, err := createTestPeerWithChannel(t, noUpdate)
 	require.NoError(t, err, "unable to create test channels")
 
 	alicePeer := harness.peer
 	bobChan := harness.channel
+	mockSwitch := harness.mockSwitch
+	broadcastTxChan := harness.publishTx
+	notifier := harness.notifier
 
 	chanPoint := bobChan.ChannelPoint()
 	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
@@ -198,22 +179,14 @@ func TestPeerChannelClosureAcceptFeeResponder(t *testing.T) {
 func TestPeerChannelClosureAcceptFeeInitiator(t *testing.T) {
 	t.Parallel()
 
-	notifier := &mock.ChainNotifier{
-		SpendChan: make(chan *chainntnfs.SpendDetail),
-		EpochChan: make(chan *chainntnfs.BlockEpoch),
-		ConfChan:  make(chan *chainntnfs.TxConfirmation),
-	}
-	broadcastTxChan := make(chan *wire.MsgTx)
-
-	mockSwitch := &mockMessageSwitch{}
-
-	harness, err := createTestPeerWithChannel(
-		t, notifier, broadcastTxChan, noUpdate, mockSwitch,
-	)
+	harness, err := createTestPeerWithChannel(t, noUpdate)
 	require.NoError(t, err, "unable to create test channels")
 
 	bobChan := harness.channel
 	alicePeer := harness.peer
+	mockSwitch := harness.mockSwitch
+	broadcastTxChan := harness.publishTx
+	notifier := harness.notifier
 
 	chanPoint := bobChan.ChannelPoint()
 	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
@@ -325,22 +298,14 @@ func TestPeerChannelClosureAcceptFeeInitiator(t *testing.T) {
 func TestPeerChannelClosureFeeNegotiationsResponder(t *testing.T) {
 	t.Parallel()
 
-	notifier := &mock.ChainNotifier{
-		SpendChan: make(chan *chainntnfs.SpendDetail),
-		EpochChan: make(chan *chainntnfs.BlockEpoch),
-		ConfChan:  make(chan *chainntnfs.TxConfirmation),
-	}
-	broadcastTxChan := make(chan *wire.MsgTx)
-
-	mockSwitch := &mockMessageSwitch{}
-
-	harness, err := createTestPeerWithChannel(
-		t, notifier, broadcastTxChan, noUpdate, mockSwitch,
-	)
+	harness, err := createTestPeerWithChannel(t, noUpdate)
 	require.NoError(t, err, "unable to create test channels")
 
 	bobChan := harness.channel
 	alicePeer := harness.peer
+	mockSwitch := harness.mockSwitch
+	broadcastTxChan := harness.publishTx
+	notifier := harness.notifier
 
 	chanPoint := bobChan.ChannelPoint()
 	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
@@ -515,22 +480,14 @@ func TestPeerChannelClosureFeeNegotiationsResponder(t *testing.T) {
 func TestPeerChannelClosureFeeNegotiationsInitiator(t *testing.T) {
 	t.Parallel()
 
-	notifier := &mock.ChainNotifier{
-		SpendChan: make(chan *chainntnfs.SpendDetail),
-		EpochChan: make(chan *chainntnfs.BlockEpoch),
-		ConfChan:  make(chan *chainntnfs.TxConfirmation),
-	}
-	broadcastTxChan := make(chan *wire.MsgTx)
-
-	mockSwitch := &mockMessageSwitch{}
-
-	harness, err := createTestPeerWithChannel(
-		t, notifier, broadcastTxChan, noUpdate, mockSwitch,
-	)
+	harness, err := createTestPeerWithChannel(t, noUpdate)
 	require.NoError(t, err, "unable to create test channels")
 
 	alicePeer := harness.peer
 	bobChan := harness.channel
+	mockSwitch := harness.mockSwitch
+	broadcastTxChan := harness.publishTx
+	notifier := harness.notifier
 
 	chanPoint := bobChan.ChannelPoint()
 	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
@@ -845,19 +802,9 @@ func TestCustomShutdownScript(t *testing.T) {
 		test := test
 
 		t.Run(test.name, func(t *testing.T) {
-			notifier := &mock.ChainNotifier{
-				SpendChan: make(chan *chainntnfs.SpendDetail),
-				EpochChan: make(chan *chainntnfs.BlockEpoch),
-				ConfChan:  make(chan *chainntnfs.TxConfirmation),
-			}
-			broadcastTxChan := make(chan *wire.MsgTx)
-
-			mockSwitch := &mockMessageSwitch{}
-
 			// Open a channel.
 			harness, err := createTestPeerWithChannel(
-				t, notifier, broadcastTxChan, test.update,
-				mockSwitch,
+				t, test.update,
 			)
 			if err != nil {
 				t.Fatalf("unable to create test channels: %v", err)
@@ -865,6 +812,7 @@ func TestCustomShutdownScript(t *testing.T) {
 
 			alicePeer := harness.peer
 			bobChan := harness.channel
+			mockSwitch := harness.mockSwitch
 
 			chanPoint := bobChan.ChannelPoint()
 			chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
@@ -1203,19 +1151,7 @@ func TestUpdateNextRevocation(t *testing.T) {
 
 	require := require.New(t)
 
-	// TODO(yy): create interface for lnwallet.LightningChannel so we can
-	// easily mock it without the following setups.
-	notifier := &mock.ChainNotifier{
-		SpendChan: make(chan *chainntnfs.SpendDetail),
-		EpochChan: make(chan *chainntnfs.BlockEpoch),
-		ConfChan:  make(chan *chainntnfs.TxConfirmation),
-	}
-	broadcastTxChan := make(chan *wire.MsgTx)
-	mockSwitch := &mockMessageSwitch{}
-
-	harness, err := createTestPeerWithChannel(
-		t, notifier, broadcastTxChan, noUpdate, mockSwitch,
-	)
+	harness, err := createTestPeerWithChannel(t, noUpdate)
 	require.NoError(err, "unable to create test channels")
 
 	bobChan := harness.channel
@@ -1433,15 +1369,6 @@ func TestHandleRemovePendingChannel(t *testing.T) {
 func TestStartupWriteMessageRace(t *testing.T) {
 	t.Parallel()
 
-	// Set up parameters for createTestPeerWithChannel.
-	notifier := &mock.ChainNotifier{
-		SpendChan: make(chan *chainntnfs.SpendDetail),
-		EpochChan: make(chan *chainntnfs.BlockEpoch),
-		ConfChan:  make(chan *chainntnfs.TxConfirmation),
-	}
-	broadcastTxChan := make(chan *wire.MsgTx)
-	mockSwitch := &mockMessageSwitch{}
-
 	// Use a callback to extract the channel created by
 	// createTestPeerWithChannel, so we can mark it borked below.
 	// We can't mark it borked within the callback, since the channel hasn't
@@ -1453,9 +1380,7 @@ func TestStartupWriteMessageRace(t *testing.T) {
 
 	// createTestPeerWithChannel creates a peer and a channel with that
 	// peer.
-	harness, err := createTestPeerWithChannel(
-		t, notifier, broadcastTxChan, getChannels, mockSwitch,
-	)
+	harness, err := createTestPeerWithChannel(t, getChannels)
 	require.NoError(t, err, "unable to create test channel")
 
 	peer := harness.peer
@@ -1540,20 +1465,8 @@ func TestStartupWriteMessageRace(t *testing.T) {
 func TestRemovePendingChannel(t *testing.T) {
 	t.Parallel()
 
-	// Set up parameters for createTestPeerWithChannel.
-	notifier := &mock.ChainNotifier{
-		SpendChan: make(chan *chainntnfs.SpendDetail),
-		EpochChan: make(chan *chainntnfs.BlockEpoch),
-		ConfChan:  make(chan *chainntnfs.TxConfirmation),
-	}
-	broadcastTxChan := make(chan *wire.MsgTx)
-	mockSwitch := &mockMessageSwitch{}
-
-	// createTestPeerWithChannel creates a peer and a channel with that
-	// peer.
-	harness, err := createTestPeerWithChannel(
-		t, notifier, broadcastTxChan, noUpdate, mockSwitch,
-	)
+	// createTestPeerWithChannel creates a peer and a channel.
+	harness, err := createTestPeerWithChannel(t, noUpdate)
 	require.NoError(t, err, "unable to create test channel")
 
 	peer := harness.peer

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -48,7 +48,7 @@ func TestPeerChannelClosureShutdownResponseLinkRemoved(t *testing.T) {
 
 	mockSwitch := &mockMessageSwitch{}
 
-	alicePeer, bobChan, err := createTestPeer(
+	alicePeer, bobChan, err := createTestPeerWithChannel(
 		t, notifier, broadcastTxChan, noUpdate, mockSwitch,
 	)
 	require.NoError(t, err, "unable to create test channels")
@@ -96,7 +96,7 @@ func TestPeerChannelClosureAcceptFeeResponder(t *testing.T) {
 
 	mockSwitch := &mockMessageSwitch{}
 
-	alicePeer, bobChan, err := createTestPeer(
+	alicePeer, bobChan, err := createTestPeerWithChannel(
 		t, notifier, broadcastTxChan, noUpdate, mockSwitch,
 	)
 	require.NoError(t, err, "unable to create test channels")
@@ -201,7 +201,7 @@ func TestPeerChannelClosureAcceptFeeInitiator(t *testing.T) {
 
 	mockSwitch := &mockMessageSwitch{}
 
-	alicePeer, bobChan, err := createTestPeer(
+	alicePeer, bobChan, err := createTestPeerWithChannel(
 		t, notifier, broadcastTxChan, noUpdate, mockSwitch,
 	)
 	require.NoError(t, err, "unable to create test channels")
@@ -325,7 +325,7 @@ func TestPeerChannelClosureFeeNegotiationsResponder(t *testing.T) {
 
 	mockSwitch := &mockMessageSwitch{}
 
-	alicePeer, bobChan, err := createTestPeer(
+	alicePeer, bobChan, err := createTestPeerWithChannel(
 		t, notifier, broadcastTxChan, noUpdate, mockSwitch,
 	)
 	require.NoError(t, err, "unable to create test channels")
@@ -512,7 +512,7 @@ func TestPeerChannelClosureFeeNegotiationsInitiator(t *testing.T) {
 
 	mockSwitch := &mockMessageSwitch{}
 
-	alicePeer, bobChan, err := createTestPeer(
+	alicePeer, bobChan, err := createTestPeerWithChannel(
 		t, notifier, broadcastTxChan, noUpdate, mockSwitch,
 	)
 	require.NoError(t, err, "unable to create test channels")
@@ -840,7 +840,7 @@ func TestCustomShutdownScript(t *testing.T) {
 			mockSwitch := &mockMessageSwitch{}
 
 			// Open a channel.
-			alicePeer, bobChan, err := createTestPeer(
+			alicePeer, bobChan, err := createTestPeerWithChannel(
 				t, notifier, broadcastTxChan, test.update,
 				mockSwitch,
 			)
@@ -1195,7 +1195,7 @@ func TestUpdateNextRevocation(t *testing.T) {
 	broadcastTxChan := make(chan *wire.MsgTx)
 	mockSwitch := &mockMessageSwitch{}
 
-	alicePeer, bobChan, err := createTestPeer(
+	alicePeer, bobChan, err := createTestPeerWithChannel(
 		t, notifier, broadcastTxChan, noUpdate, mockSwitch,
 	)
 	require.NoError(err, "unable to create test channels")
@@ -1412,7 +1412,7 @@ func TestHandleRemovePendingChannel(t *testing.T) {
 func TestStartupWriteMessageRace(t *testing.T) {
 	t.Parallel()
 
-	// Set up parameters for createTestPeer.
+	// Set up parameters for createTestPeerWithChannel.
 	notifier := &mock.ChainNotifier{
 		SpendChan: make(chan *chainntnfs.SpendDetail),
 		EpochChan: make(chan *chainntnfs.BlockEpoch),
@@ -1421,17 +1421,18 @@ func TestStartupWriteMessageRace(t *testing.T) {
 	broadcastTxChan := make(chan *wire.MsgTx)
 	mockSwitch := &mockMessageSwitch{}
 
-	// Use a callback to extract the channel created by createTestPeer, so
-	// we can mark it borked below. We can't mark it borked within the
-	// callback, since the channel hasn't been saved to the DB yet when the
-	// callback executes.
+	// Use a callback to extract the channel created by
+	// createTestPeerWithChannel, so we can mark it borked below.
+	// We can't mark it borked within the callback, since the channel hasn't
+	// been saved to the DB yet when the callback executes.
 	var channel *channeldb.OpenChannel
 	getChannels := func(a, b *channeldb.OpenChannel) {
 		channel = a
 	}
 
-	// createTestPeer creates a peer and a channel with that peer.
-	peer, _, err := createTestPeer(
+	// createTestPeerWithChannel creates a peer and a channel with that
+	// peer.
+	peer, _, err := createTestPeerWithChannel(
 		t, notifier, broadcastTxChan, getChannels, mockSwitch,
 	)
 	require.NoError(t, err, "unable to create test channel")
@@ -1516,7 +1517,7 @@ func TestStartupWriteMessageRace(t *testing.T) {
 func TestRemovePendingChannel(t *testing.T) {
 	t.Parallel()
 
-	// Set up parameters for createTestPeer.
+	// Set up parameters for createTestPeerWithChannel.
 	notifier := &mock.ChainNotifier{
 		SpendChan: make(chan *chainntnfs.SpendDetail),
 		EpochChan: make(chan *chainntnfs.BlockEpoch),
@@ -1525,8 +1526,9 @@ func TestRemovePendingChannel(t *testing.T) {
 	broadcastTxChan := make(chan *wire.MsgTx)
 	mockSwitch := &mockMessageSwitch{}
 
-	// createTestPeer creates a peer and a channel with that peer.
-	peer, _, err := createTestPeer(
+	// createTestPeerWithChannel creates a peer and a channel with that
+	// peer.
+	peer, _, err := createTestPeerWithChannel(
 		t, notifier, broadcastTxChan, noUpdate, mockSwitch,
 	)
 	require.NoError(t, err, "unable to create test channel")

--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -48,15 +48,16 @@ var (
 	testKeyLoc = keychain.KeyLocator{Family: keychain.KeyFamilyNodeKey}
 )
 
-// noUpdate is a function which can be used as a parameter in createTestPeer to
-// call the setup code with no custom values on the channels set up.
+// noUpdate is a function which can be used as a parameter in
+// createTestPeerWithChannel to call the setup code with no custom values on
+// the channels set up.
 var noUpdate = func(a, b *channeldb.OpenChannel) {}
 
-// createTestPeer creates a channel between two nodes, and returns a peer for
-// one of the nodes, together with the channel seen from both nodes. It takes
-// an updateChan function which can be used to modify the default values on
-// the channel states for each peer.
-func createTestPeer(t *testing.T, notifier chainntnfs.ChainNotifier,
+// createTestPeerWithChannel creates a channel between two nodes, and returns a
+// peer for one of the nodes, together with the channel seen from both nodes.
+// It takes an updateChan function which can be used to modify the default
+// values on the channel states for each peer.
+func createTestPeerWithChannel(t *testing.T, notifier chainntnfs.ChainNotifier,
 	publTx chan *wire.MsgTx, updateChan func(a, b *channeldb.OpenChannel),
 	mockSwitch *mockMessageSwitch) (
 	*Brontide, *lnwallet.LightningChannel, error) {


### PR DESCRIPTION
## Change Description
This pull request is an off shoot of the peer backup PR (currently halted): https://github.com/lightningnetwork/lnd/pull/8490

It removes the duplicity in creating a peer instance and starting a peer in brontide tests.

It does not require a change log.

