### PR TITLE
lncli: Use EOF as a terminator instead of the newline in `lncli unlock --stdin` command

### DIFF
--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -274,6 +274,10 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
   maintain a healthy connection to the network by checking the number of
   outbound peers if they are below 6.
 
+* [Use EOF as a terminator](https://github.com/lightningnetwork/lnd/pull/8657)
+  is added to `lncli unlock --stdin` command to use EOF as a terminator instead
+  of newline.
+
 ### Logging
 * [Add the htlc amount](https://github.com/lightningnetwork/lnd/pull/8156) to
   contract court logs in case of timed-out HTLCs in order to easily spot dust


### PR DESCRIPTION
## Change Description

Replaces #5638
Closes #5584 

## Steps to Test

1. Password with new lines at the end: Warning Printed since `echo` prints a new line by default at the end of the echoed string.
```bash
ubuntu@carol:~/lnd$ echo "test" | lncli unlock --stdin
WARNING: Password contains leading ortrailing newline characters and they will not be trimmed.
[lncli] rpc error: code = Unknown desc = invalid passphrase for master public key
```

2. Password with new lines at the beginning: Warning Printed.
```bash
ubuntu@carol:~/lnd$ echo "\ntest" | lncli unlock --stdin
WARNING: Password contains leading ortrailing newline characters and they will not be trimmed.
[lncli] rpc error: code = Unknown desc = invalid passphrase for master public key
```

3. Valid Password with no new lines at the beginning/end: No Warning Printed.
```bash
ubuntu@carol:~/lnd$ echo -n "test" | lncli unlock --stdin
lnd successfully unlocked!
```

## Approach

```mermaid
graph TD;
    A[Is password given from stdin?] -->|true| B[Copy password from stdin];
    B --> C[Create buffer];
    C --> D[Copy stdin to buffer];
    D --> E{Error during copy?};
    E -->|yes| F[Return error];
    E -->|no| G{EOF encountered?};
    G -->|yes| I[Trim buffer from carriage returns];
    I --> J[Check for leading or trailing newline];
    J -->|yes| K[Issue warning];
    J -->|no| L[Continue];
    K --> L;
    L --> M[Finish];
```

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
