### PR TITLE
tlv: add axiomatic RecordProducer implementation for Record

### DIFF
--- a/tlv/record.go
+++ b/tlv/record.go
@@ -63,6 +63,15 @@ type Record struct {
 	decoder    Decoder
 }
 
+// Record (the function) is the trivial implementation of RecordProducer for
+// Record (the type). This makes it seamless to mix primitive and dynamic
+// records together in the same collections.
+//
+// NOTE: Part of the RecordProducer interface.
+func (f *Record) Record() Record {
+	return *f
+}
+
 // Size returns the size of the Record's value. If no static size is known, the
 // dynamic size will be evaluated.
 func (f *Record) Size() uint64 {


### PR DESCRIPTION
This commit introduces a RecordProducer implementation for Record that serves as the identity function. This makes it easier for us to mix Primitive and Dynamic records in the same RecordProducer collections.

## Change Description
Description of change / link to associated issue.

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
