### PR TITLE
funding: add absent error logs for failed inbound funding requests

### DIFF
--- a/funding/manager.go
+++ b/funding/manager.go
@@ -1550,6 +1550,8 @@ func (f *Manager) fundeeProcessOpenChannel(peer lnpeer.Peer,
 			// Fail the funding flow.
 			flowErr := fmt.Errorf("channel acceptor blocked " +
 				"zero-conf channel negotiation")
+			log.Errorf("Cancelling funding flow for %v based on "+
+				"channel acceptor response: %v", cid, flowErr)
 			f.failFundingFlow(peer, cid, flowErr)
 			return
 		}
@@ -1564,6 +1566,9 @@ func (f *Manager) fundeeProcessOpenChannel(peer lnpeer.Peer,
 				// Fail the funding flow.
 				flowErr := fmt.Errorf("scid-alias feature " +
 					"must be negotiated for zero-conf")
+				log.Errorf("Cancelling funding flow for "+
+					"zero-conf channel %v: %v", cid,
+					flowErr)
 				f.failFundingFlow(peer, cid, flowErr)
 				return
 			}
@@ -1580,7 +1585,8 @@ func (f *Manager) fundeeProcessOpenChannel(peer lnpeer.Peer,
 	case public && scid:
 		err = fmt.Errorf("option-scid-alias chantype for public " +
 			"channel")
-		log.Error(err)
+		log.Errorf("Cancelling funding flow for public channel %v "+
+			"with scid-alias: %v", cid, err)
 		f.failFundingFlow(peer, cid, err)
 
 		return
@@ -1589,7 +1595,8 @@ func (f *Manager) fundeeProcessOpenChannel(peer lnpeer.Peer,
 	// unadvertised channels for now.
 	case commitType.IsTaproot() && public:
 		err = fmt.Errorf("taproot channel type for public channel")
-		log.Error(err)
+		log.Errorf("Cancelling funding flow for public taproot "+
+			"channel %v: %v", cid, err)
 		f.failFundingFlow(peer, cid, err)
 
 		return


### PR DESCRIPTION
## Change Description

Add missing error logs when the ChannelAcceptor does not enable zero-conf in the ChannelAcceptResponse to an incoming funding request with the zero-conf feature enabled.

## Steps to Test

To test this connect a channel acceptor to the lnd node that accepts incoming channels but sets zero_conf to false.

For example a Python script that connects through gRPC:

```python
import lightning_pb2 as lnd
import lightning_pb2_grpc as lndrpc
import grpc
import os
import queue
import codecs

os.environ["GRPC_SSL_CIPHER_SUITES"] = "HIGH+ECDSA"

with open(os.path.expanduser("~/.lnd/data/chain/bitcoin/mainnet/admin.macaroon"), "rb") as macaroon_file:
    macaroon = macaroon_file.read()
    macaroon = codecs.encode(macaroon, "hex")

with open(os.path.expanduser("~/.lnd/tls.cert"), "rb") as cert_file:
    cert = cert_file.read()

def metadata_callback(context, callback):
    callback([("macaroon", macaroon)], None)

cert_creds = grpc.ssl_channel_credentials(cert)
auth_creds = grpc.metadata_call_credentials(metadata_callback)
creds = grpc.composite_channel_credentials(cert_creds, auth_creds)

connection = grpc.secure_channel("localhost:10009", creds)
client = lndrpc.LightningStub(connection)

response_queue = queue.Queue()

def responses(queue):
    while True:
        yield queue.get()

for request in client.ChannelAcceptor(responses(response_queue)):
    print("Accepting channel: " + request.pending_chan_id.hex())
    resp = lnd.ChannelAcceptResponse(accept = True, pending_chan_id = request.pending_chan_id, zero_conf = False)
    response_queue.put(resp)
```

Then use another node to try opening a zero-conf channel to the lnd node with this patch. The expected behavior is an error message in the lnd logs stating `channel acceptor blocked zero-conf channel negotiation`

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
