### PR TITLE
lnrpc: ensure parsing of the Amp flag for payments is consistent

### DIFF
--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -368,6 +368,10 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
   whether through gRPC or the REST API, due to the destructive nature of the
   operation.
 
+* When paying an AMP payment request, [the `--amp` flag is now
+  required](https://github.com/lightningnetwork/lnd/pull/8681) to be consistent
+  w/ the flow when a payment request isn't used. 
+
 ## lncli Updates
 
 * [Documented all available `lncli`
@@ -532,6 +536,7 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
 * Marcos Fernandez Perez
 * Matt Morehouse
 * Mohamed Awnallah
+* Olaoluwa Osuntokun
 * Ononiwu Maureen Chiamaka
 * Slyghtning
 * Tee8z

--- a/itest/lnd_amp_test.go
+++ b/itest/lnd_amp_test.go
@@ -129,6 +129,7 @@ func testSendPaymentAMPInvoiceCase(ht *lntest.HarnessTest,
 		PaymentAddr:    externalPayAddr,
 		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
+		Amp:            true,
 	}
 	payment := ht.SendPaymentAssertSettled(mts.alice, sendReq)
 
@@ -252,6 +253,7 @@ func testSendPaymentAMPInvoiceRepeat(ht *lntest.HarnessTest) {
 	// Now we'll use Carol to pay the invoice that Dave created.
 	ht.CompletePaymentRequests(
 		carol, []string{addInvoiceResp.PaymentRequest},
+		lntest.WithAMP(),
 	)
 
 	// Dave should get a notification that the invoice has been settled.
@@ -274,6 +276,7 @@ func testSendPaymentAMPInvoiceRepeat(ht *lntest.HarnessTest) {
 	// has received another payment.
 	ht.CompletePaymentRequests(
 		carol, []string{addInvoiceResp.PaymentRequest},
+		lntest.WithAMP(),
 	)
 
 	// Dave should get another notification.

--- a/lnrpc/routerrpc/router_backend.go
+++ b/lnrpc/routerrpc/router_backend.go
@@ -940,6 +940,14 @@ func (r *RouterBackend) extractIntentFromSendRequest(
 
 		payAddr := payReq.PaymentAddr
 		if payReq.Features.HasFeature(lnwire.AMPOptional) {
+			// The opt-in AMP flag is required to pay an AMP
+			// invoice.
+			if !rpcPayReq.Amp {
+				return nil, fmt.Errorf("the AMP flag (--amp " +
+					"or SendPaymentRequest.Amp) must be " +
+					"set to pay an AMP invoice")
+			}
+
 			// Generate random SetID and root share.
 			var setID [32]byte
 			_, err = rand.Read(setID[:])


### PR DESCRIPTION
In this commit, we fix an inconsistent in the API related to AMP payments. When a payment request isn't specified, we require the `--amp` flag on the CLI to make an AMP payment. However, for payment requests, we don't require this flag. To fix this inconsistency, we now require the `--amp` flag to _also_ be set for payment requests.

