### PR TITLE
[1/?]: multi: add ability to fund+use musig2 channels that commit to a tapscript root

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -247,6 +247,10 @@ type chanAuxData struct {
 	// memo is an optional text field that gives context to the user about
 	// the channel.
 	memo tlv.OptionalRecordT[tlv.TlvType5, []byte]
+
+	// tapscriptRoot is the optional Tapscript root the channel funding
+	// output commits to.
+	tapscriptRoot tlv.OptionalRecordT[tlv.TlvType6, [32]byte]
 }
 
 // encode serializes the chanAuxData to the given io.Writer.
@@ -260,6 +264,11 @@ func (c *chanAuxData) encode(w io.Writer) error {
 	c.memo.WhenSome(func(memo tlv.RecordT[tlv.TlvType5, []byte]) {
 		tlvRecords = append(tlvRecords, memo.Record())
 	})
+	c.tapscriptRoot.WhenSome(
+		func(root tlv.RecordT[tlv.TlvType6, [32]byte]) {
+			tlvRecords = append(tlvRecords, root.Record())
+		},
+	)
 
 	// Create the tlv stream.
 	tlvStream, err := tlv.NewStream(tlvRecords...)
@@ -273,6 +282,7 @@ func (c *chanAuxData) encode(w io.Writer) error {
 // decode deserializes the chanAuxData from the given io.Reader.
 func (c *chanAuxData) decode(r io.Reader) error {
 	memo := c.memo.Zero()
+	tapscriptRoot := c.tapscriptRoot.Zero()
 
 	// Create the tlv stream.
 	tlvStream, err := tlv.NewStream(
@@ -281,6 +291,7 @@ func (c *chanAuxData) decode(r io.Reader) error {
 		c.initialRemoteBalance.Record(),
 		c.realScid.Record(),
 		memo.Record(),
+		tapscriptRoot.Record(),
 	)
 	if err != nil {
 		return err
@@ -293,6 +304,9 @@ func (c *chanAuxData) decode(r io.Reader) error {
 
 	if _, ok := tlvs[memo.TlvType()]; ok {
 		c.memo = tlv.SomeRecordT(memo)
+	}
+	if _, ok := tlvs[tapscriptRoot.TlvType()]; ok {
+		c.tapscriptRoot = tlv.SomeRecordT(tapscriptRoot)
 	}
 
 	return nil
@@ -307,6 +321,9 @@ func (c *chanAuxData) toOpenChan(o *OpenChannel) {
 	o.confirmedScid = c.realScid.Val
 	c.memo.WhenSomeV(func(memo []byte) {
 		o.Memo = memo
+	})
+	c.tapscriptRoot.WhenSomeV(func(h [32]byte) {
+		o.TapscriptRoot = fn.Some[chainhash.Hash](h)
 	})
 }
 
@@ -332,6 +349,11 @@ func newChanAuxDataFromChan(openChan *OpenChannel) *chanAuxData {
 			tlv.NewPrimitiveRecord[tlv.TlvType5](openChan.Memo),
 		)
 	}
+	openChan.TapscriptRoot.WhenSome(func(h chainhash.Hash) {
+		c.tapscriptRoot = tlv.SomeRecordT(
+			tlv.NewPrimitiveRecord[tlv.TlvType6, [32]byte](h),
+		)
+	})
 
 	return c
 }
@@ -413,6 +435,11 @@ const (
 	// SimpleTaprootFeatureBit indicates that the simple-taproot-chans
 	// feature bit was negotiated during the lifetime of the channel.
 	SimpleTaprootFeatureBit ChannelType = 1 << 10
+
+	// TapscriptRootBit indicates that this is a MuSig2 channel with a top
+	// level tapscript commitment. This MUST be set along with the
+	// SimpleTaprootFeatureBit.
+	TapscriptRootBit ChannelType = 1 << 11
 )
 
 // IsSingleFunder returns true if the channel type if one of the known single
@@ -481,6 +508,12 @@ func (c ChannelType) HasScidAliasFeature() bool {
 // IsTaproot returns true if the channel is using taproot features.
 func (c ChannelType) IsTaproot() bool {
 	return c&SimpleTaprootFeatureBit == SimpleTaprootFeatureBit
+}
+
+// HasTapscriptRoot returns true if the channel is using a top level tapscript
+// root commitment.
+func (c ChannelType) HasTapscriptRoot() bool {
+	return c&TapscriptRootBit == TapscriptRootBit
 }
 
 // ChannelConstraints represents a set of constraints meant to allow a node to

--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/clock"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnmock"
@@ -172,7 +173,7 @@ func fundingPointOption(chanPoint wire.OutPoint) testChannelOption {
 }
 
 // channelIDOption is an option which sets the short channel ID of the channel.
-var channelIDOption = func(chanID lnwire.ShortChannelID) testChannelOption {
+func channelIDOption(chanID lnwire.ShortChannelID) testChannelOption {
 	return func(params *testChannelParams) {
 		params.channel.ShortChannelID = chanID
 	}
@@ -312,6 +313,9 @@ func createTestChannelState(t *testing.T, cdb *ChannelStateDB) *OpenChannel {
 	uniqueOutputIndex.Add(1)
 	op := wire.OutPoint{Hash: key, Index: uniqueOutputIndex.Load()}
 
+	var tapscriptRoot chainhash.Hash
+	copy(tapscriptRoot[:], bytes.Repeat([]byte{1}, 32))
+
 	return &OpenChannel{
 		ChanType:          SingleFunderBit | FrozenBit,
 		ChainHash:         key,
@@ -354,6 +358,8 @@ func createTestChannelState(t *testing.T, cdb *ChannelStateDB) *OpenChannel {
 		ThawHeight:              uint32(defaultPendingHeight),
 		InitialLocalBalance:     lnwire.MilliSatoshi(9000),
 		InitialRemoteBalance:    lnwire.MilliSatoshi(3000),
+		Memo:                    []byte("test"),
+		TapscriptRoot:           fn.Some(tapscriptRoot),
 	}
 }
 

--- a/contractcourt/chain_watcher.go
+++ b/contractcourt/chain_watcher.go
@@ -16,6 +16,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lnwallet"
 )
@@ -301,8 +302,11 @@ func (c *chainWatcher) Start() error {
 		err error
 	)
 	if chanState.ChanType.IsTaproot() {
+		fundingOpts := fn.MapOptionZ(
+			chanState.TapscriptRoot, lnwallet.TapscriptRootToOpt,
+		)
 		c.fundingPkScript, _, err = input.GenTaprootFundingScript(
-			localKey, remoteKey, 0,
+			localKey, remoteKey, 0, fundingOpts...,
 		)
 		if err != nil {
 			return err

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/discovery"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/labels"
@@ -2853,8 +2854,12 @@ func makeFundingScript(channel *channeldb.OpenChannel) ([]byte, error) {
 	remoteKey := channel.RemoteChanCfg.MultiSigKey.PubKey
 
 	if channel.ChanType.IsTaproot() {
+		fundingOpts := fn.MapOptionZ(
+			channel.TapscriptRoot, lnwallet.TapscriptRootToOpt,
+		)
 		pkScript, _, err := input.GenTaprootFundingScript(
 			localKey, remoteKey, int64(channel.Capacity),
+			fundingOpts...,
 		)
 		if err != nil {
 			return nil, err

--- a/input/script_utils.go
+++ b/input/script_utils.go
@@ -11,8 +11,10 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/lnutils"
 	"golang.org/x/crypto/ripemd160"
 )
@@ -197,27 +199,59 @@ func GenFundingPkScript(aPub, bPub []byte, amt int64) ([]byte, *wire.TxOut, erro
 	return witnessScript, wire.NewTxOut(amt, pkScript), nil
 }
 
+// fundingScriptOpts is a functional option that can be used to modify the way
+// the funding pkScript is created.
+type fundingScriptOpts struct {
+	tapscriptRoot fn.Option[chainhash.Hash]
+}
+
+// FundingScriptOpt is a functional option that can be used to modify the way
+// the funding script is created.
+type FundingScriptOpt func(*fundingScriptOpts)
+
+// defaultFundingScriptOpts returns a new instance of the default
+// fundingScriptOpts.
+func defaultFundingScriptOpts() *fundingScriptOpts {
+	return &fundingScriptOpts{}
+}
+
+// WithTapscriptRoot is a functional option that can be used to specify the
+// tapscript root for a MuSig2 funding output.
+func WithTapscriptRoot(root chainhash.Hash) FundingScriptOpt {
+	return func(o *fundingScriptOpts) {
+		o.tapscriptRoot = fn.Some(root)
+	}
+}
+
 // GenTaprootFundingScript constructs the taproot-native funding output that
-// uses musig2 to create a single aggregated key to anchor the channel.
+// uses MuSig2 to create a single aggregated key to anchor the channel.
 func GenTaprootFundingScript(aPub, bPub *btcec.PublicKey,
-	amt int64) ([]byte, *wire.TxOut, error) {
+	amt int64, opts ...FundingScriptOpt) ([]byte, *wire.TxOut, error) {
+
+	options := defaultFundingScriptOpts()
+	for _, optFunc := range opts {
+		optFunc(options)
+	}
+
+	muSig2Opt := musig2.WithBIP86KeyTweak()
+	options.tapscriptRoot.WhenSome(func(scriptRoot chainhash.Hash) {
+		muSig2Opt = musig2.WithTaprootKeyTweak(scriptRoot[:])
+	})
 
 	// Similar to the existing p2wsh funding script, we'll always make sure
 	// we sort the keys before any major operations. In order to ensure
 	// that there's no other way this output can be spent, we'll use a BIP
-	// 86 tweak here during aggregation.
-	//
-	// TODO(roasbeef): revisit if BIP 86 is needed here?
+	// 86 tweak here during aggregation, unless the user has explicitly
+	// specified a tapscript root.
 	combinedKey, _, _, err := musig2.AggregateKeys(
-		[]*btcec.PublicKey{aPub, bPub}, true,
-		musig2.WithBIP86KeyTweak(),
+		[]*btcec.PublicKey{aPub, bPub}, true, muSig2Opt,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to combine keys: %w", err)
 	}
 
 	// Now that we have the combined key, we can create a taproot pkScript
-	// from this, and then make the txout given the amount.
+	// from this, and then make the txOut given the amount.
 	pkScript, err := PayToTaprootScript(combinedKey.FinalKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to make taproot "+
@@ -227,7 +261,7 @@ func GenTaprootFundingScript(aPub, bPub *btcec.PublicKey,
 	txOut := wire.NewTxOut(amt, pkScript)
 
 	// For the "witness program" we just return the raw pkScript since the
-	// output we create can _only_ be spent with a musig2 signature.
+	// output we create can _only_ be spent with a MuSig2 signature.
 	return pkScript, txOut, nil
 }
 

--- a/lnwallet/chancloser/chancloser_test.go
+++ b/lnwallet/chancloser/chancloser_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnutils"
@@ -175,8 +176,9 @@ func (m *mockChannel) RemoteUpfrontShutdownScript() lnwire.DeliveryAddress {
 }
 
 func (m *mockChannel) CreateCloseProposal(fee btcutil.Amount,
-	localScript, remoteScript []byte, _ ...lnwallet.ChanCloseOpt,
-) (input.Signature, *chainhash.Hash, btcutil.Amount, error) {
+	localScript, remoteScript []byte,
+	_ ...lnwallet.ChanCloseOpt) (input.Signature, *chainhash.Hash,
+	btcutil.Amount, error) {
 
 	if m.chanType.IsTaproot() {
 		return lnwallet.NewMusigPartialSig(
@@ -185,6 +187,7 @@ func (m *mockChannel) CreateCloseProposal(fee btcutil.Amount,
 				R: new(btcec.PublicKey),
 			},
 			lnwire.Musig2Nonce{}, lnwire.Musig2Nonce{}, nil,
+			fn.None[chainhash.Hash](),
 		), nil, 0, nil
 	}
 

--- a/lnwallet/chanfunding/canned_assembler.go
+++ b/lnwallet/chanfunding/canned_assembler.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 )
@@ -56,6 +58,14 @@ type ShimIntent struct {
 	// generate an aggregate key to use as the taproot-native multi-sig
 	// output.
 	musig2 bool
+
+	// tapscriptRoot is the root of the tapscript tree that will be used to
+	// create the funding output. This field will only be utilized if the
+	// MuSig2 flag above is set to true.
+	//
+	// TODO(roasbeef): fold above into new chan type? sum type like thing,
+	// includes the tapscript root, etc
+	tapscriptRoot fn.Option[chainhash.Hash]
 }
 
 // FundingOutput returns the witness script, and the output that creates the
@@ -73,12 +83,18 @@ func (s *ShimIntent) FundingOutput() ([]byte, *wire.TxOut, error) {
 	// If musig2 is active, then we'll return a single aggregated key
 	// rather than using the "existing" funding script.
 	if s.musig2 {
+		var scriptOpts []input.FundingScriptOpt
+		s.tapscriptRoot.WhenSome(func(root chainhash.Hash) {
+			scriptOpts = append(
+				scriptOpts, input.WithTapscriptRoot(root),
+			)
+		})
+
 		// Similar to the existing p2wsh script, we'll always ensure
 		// the keys are sorted before use.
 		return input.GenTaprootFundingScript(
-			s.localKey.PubKey,
-			s.remoteKey,
-			int64(totalAmt),
+			s.localKey.PubKey, s.remoteKey, int64(totalAmt),
+			scriptOpts...,
 		)
 	}
 

--- a/lnwallet/chanfunding/interface.go
+++ b/lnwallet/chanfunding/interface.go
@@ -4,9 +4,11 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/btcsuite/btcwallet/wtxmgr"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 )
 
@@ -119,6 +121,11 @@ type Request struct {
 	// output. By definition, this'll also use segwit v1 (taproot) for the
 	// funding output.
 	Musig2 bool
+
+	// TapscriptRoot is the root of the tapscript tree that will be used to
+	// create the funding output. This field will only be utilized if the
+	// Musig2 flag above is set to true.
+	TapscriptRoot fn.Option[chainhash.Hash]
 }
 
 // Intent is returned by an Assembler and represents the base functionality the

--- a/lnwallet/chanfunding/psbt_assembler.go
+++ b/lnwallet/chanfunding/psbt_assembler.go
@@ -534,6 +534,7 @@ func (p *PsbtAssembler) ProvisionChannel(req *Request) (Intent, error) {
 		ShimIntent: ShimIntent{
 			localFundingAmt: p.fundingAmt,
 			musig2:          req.Musig2,
+			tapscriptRoot:   req.TapscriptRoot,
 		},
 		State:         PsbtShimRegistered,
 		BasePsbt:      p.basePsbt,

--- a/lnwallet/chanfunding/wallet_assembler.go
+++ b/lnwallet/chanfunding/wallet_assembler.go
@@ -393,7 +393,6 @@ func (w *WalletAssembler) ProvisionChannel(r *Request) (Intent, error) {
 		// we will call the specialized coin selection function for
 		// that.
 		case r.FundUpToMaxAmt != 0 && r.MinFundAmt != 0:
-
 			// We need to ensure that manually selected coins, which
 			// are spent entirely on the channel funding, leave
 			// enough funds in the wallet to cover for a reserve.
@@ -538,6 +537,7 @@ func (w *WalletAssembler) ProvisionChannel(r *Request) (Intent, error) {
 				localFundingAmt:  localContributionAmt,
 				remoteFundingAmt: r.RemoteAmt,
 				musig2:           r.Musig2,
+				tapscriptRoot:    r.TapscriptRoot,
 			},
 			InputCoins: selectedCoins,
 			coinLeaser: w.cfg.CoinLeaser,

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -386,6 +386,12 @@ func TestSimpleAddSettleWorkflow(t *testing.T) {
 		)
 	})
 
+	t.Run("taproot with tapscript root", func(t *testing.T) {
+		flags := channeldb.SimpleTaprootFeatureBit |
+			channeldb.TapscriptRootBit
+		testAddSettleWorkflow(t, true, flags, false)
+	})
+
 	t.Run("storeFinalHtlcResolutions=true", func(t *testing.T) {
 		testAddSettleWorkflow(t, false, 0, true)
 	})
@@ -824,6 +830,16 @@ func TestForceClose(t *testing.T) {
 			chanType: channeldb.SingleFunderTweaklessBit |
 				channeldb.AnchorOutputsBit |
 				channeldb.SimpleTaprootFeatureBit,
+			expectedCommitWeight: input.TaprootCommitWeight,
+			anchorAmt:            anchorSize * 2,
+		})
+	})
+	t.Run("taproot with tapscript root", func(t *testing.T) {
+		testForceClose(t, &forceCloseTestCase{
+			chanType: channeldb.SingleFunderTweaklessBit |
+				channeldb.AnchorOutputsBit |
+				channeldb.SimpleTaprootFeatureBit |
+				channeldb.TapscriptRootBit,
 			expectedCommitWeight: input.TaprootCommitWeight,
 			anchorAmt:            anchorSize * 2,
 		})

--- a/lnwallet/musig_session.go
+++ b/lnwallet/musig_session.go
@@ -8,8 +8,10 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -37,6 +39,12 @@ var (
 	ErrSessionNotFinalized = fmt.Errorf("musig2 session not finalized")
 )
 
+// tapscriptRootToSignOpt is a function that takes a tapscript root and returns
+// a MuSig2 sign opt that'll apply the tweak when signing+verifying.
+func tapscriptRootToSignOpt(root chainhash.Hash) musig2.SignOption {
+	return musig2.WithTaprootSignTweak(root[:])
+}
+
 // MusigPartialSig is a wrapper around the base musig2.PartialSignature type
 // that also includes information about the set of nonces used, and also the
 // signer. This allows us to implement the input.Signature interface, as that
@@ -54,25 +62,30 @@ type MusigPartialSig struct {
 
 	// signerKeys is the set of public keys of all signers.
 	signerKeys []*btcec.PublicKey
+
+	// tapscriptRoot is an optional tweak, that if specified, will be used
+	// instead of the normal BIP 86 tweak when validating the signature.
+	tapscriptTweak fn.Option[chainhash.Hash]
 }
 
-// NewMusigPartialSig creates a new musig partial signature.
-func NewMusigPartialSig(sig *musig2.PartialSignature,
-	signerNonce, combinedNonce lnwire.Musig2Nonce,
-	signerKeys []*btcec.PublicKey) *MusigPartialSig {
+// NewMusigPartialSig creates a new MuSig2 partial signature.
+func NewMusigPartialSig(sig *musig2.PartialSignature, signerNonce,
+	combinedNonce lnwire.Musig2Nonce, signerKeys []*btcec.PublicKey,
+	tapscriptTweak fn.Option[chainhash.Hash]) *MusigPartialSig {
 
 	return &MusigPartialSig{
-		sig:           sig,
-		signerNonce:   signerNonce,
-		combinedNonce: combinedNonce,
-		signerKeys:    signerKeys,
+		sig:            sig,
+		signerNonce:    signerNonce,
+		combinedNonce:  combinedNonce,
+		signerKeys:     signerKeys,
+		tapscriptTweak: tapscriptTweak,
 	}
 }
 
 // FromWireSig maps a wire partial sig to this internal type that we'll use to
 // perform signature validation.
-func (p *MusigPartialSig) FromWireSig(sig *lnwire.PartialSigWithNonce,
-) *MusigPartialSig {
+func (p *MusigPartialSig) FromWireSig(
+	sig *lnwire.PartialSigWithNonce) *MusigPartialSig {
 
 	p.sig = &musig2.PartialSignature{
 		S: &sig.Sig,
@@ -135,9 +148,15 @@ func (p *MusigPartialSig) Verify(msg []byte, pub *btcec.PublicKey) bool {
 	var m [32]byte
 	copy(m[:], msg)
 
+	// If we have a tapscript tweak, then we'll use that as a tweak
+	// otherwise, we'll fall back to the normal BIP 86 sign tweak.
+	signOpts := fn.MapOption(tapscriptRootToSignOpt)(
+		p.tapscriptTweak,
+	).UnwrapOr(musig2.WithBip86SignTweak())
+
 	return p.sig.Verify(
 		p.signerNonce, p.combinedNonce, p.signerKeys, pub, m,
-		musig2.WithSortedKeys(), musig2.WithBip86SignTweak(),
+		musig2.WithSortedKeys(), signOpts,
 	)
 }
 
@@ -158,6 +177,14 @@ func (n *MusigNoncePair) String() string {
 	return fmt.Sprintf("NoncePair(verification_nonce=%x, "+
 		"signing_nonce=%x)", n.VerificationNonce.PubNonce[:],
 		n.SigningNonce.PubNonce[:])
+}
+
+// TapscriptRootToTweak is a function that takes a MuSig2 taproot tweak and
+// returns the root hash of the tapscript tree.
+func muSig2TweakToRoot(tweak input.MuSig2Tweaks) chainhash.Hash {
+	var root chainhash.Hash
+	copy(root[:], tweak.TaprootTweak)
+	return root
 }
 
 // MusigSession abstracts over the details of a logical musig session. A single
@@ -197,15 +224,20 @@ type MusigSession struct {
 	// commitType tracks if this is the session for the local or remote
 	// commitment.
 	commitType MusigCommitType
+
+	// tapscriptTweak is an optional tweak, that if specified, will be used
+	// instead of the normal BIP 86 tweak when creating the MuSig2
+	// aggregate key and session.
+	tapscriptTweak fn.Option[input.MuSig2Tweaks]
 }
 
 // NewPartialMusigSession creates a new musig2 session given only the
 // verification nonce (local nonce), and the other information that has already
 // been bound to the session.
 func NewPartialMusigSession(verificationNonce musig2.Nonces,
-	localKey, remoteKey keychain.KeyDescriptor,
-	signer input.MuSig2Signer, inputTxOut *wire.TxOut,
-	commitType MusigCommitType) *MusigSession {
+	localKey, remoteKey keychain.KeyDescriptor, signer input.MuSig2Signer,
+	inputTxOut *wire.TxOut, commitType MusigCommitType,
+	tapscriptTweak fn.Option[input.MuSig2Tweaks]) *MusigSession {
 
 	signerKeys := []*btcec.PublicKey{localKey.PubKey, remoteKey.PubKey}
 
@@ -214,13 +246,14 @@ func NewPartialMusigSession(verificationNonce musig2.Nonces,
 	}
 
 	return &MusigSession{
-		nonces:     nonces,
-		remoteKey:  remoteKey,
-		localKey:   localKey,
-		inputTxOut: inputTxOut,
-		signerKeys: signerKeys,
-		signer:     signer,
-		commitType: commitType,
+		nonces:         nonces,
+		remoteKey:      remoteKey,
+		localKey:       localKey,
+		inputTxOut:     inputTxOut,
+		signerKeys:     signerKeys,
+		signer:         signer,
+		commitType:     commitType,
+		tapscriptTweak: tapscriptTweak,
 	}
 }
 
@@ -254,9 +287,9 @@ func (m *MusigSession) FinalizeSession(signingNonce musig2.Nonces) error {
 		remoteNonce = m.nonces.SigningNonce
 	}
 
-	tweakDesc := input.MuSig2Tweaks{
+	tweakDesc := m.tapscriptTweak.UnwrapOr(input.MuSig2Tweaks{
 		TaprootBIP0086Tweak: true,
-	}
+	})
 	m.session, err = m.signer.MuSig2CreateSession(
 		input.MuSig2Version100RC2, m.localKey.KeyLocator, m.signerKeys,
 		&tweakDesc, [][musig2.PubNonceSize]byte{remoteNonce.PubNonce},
@@ -351,8 +384,11 @@ func (m *MusigSession) SignCommit(tx *wire.MsgTx) (*MusigPartialSig, error) {
 		return nil, err
 	}
 
+	tapscriptRoot := fn.MapOption(muSig2TweakToRoot)(m.tapscriptTweak)
+
 	return NewMusigPartialSig(
 		sig, m.session.PublicNonce, m.combinedNonce, m.signerKeys,
+		tapscriptRoot,
 	), nil
 }
 
@@ -364,7 +400,7 @@ func (m *MusigSession) Refresh(verificationNonce *musig2.Nonces,
 
 	return NewPartialMusigSession(
 		*verificationNonce, m.localKey, m.remoteKey, m.signer,
-		m.inputTxOut, m.commitType,
+		m.inputTxOut, m.commitType, m.tapscriptTweak,
 	), nil
 }
 
@@ -451,9 +487,11 @@ func (m *MusigSession) VerifyCommitSig(commitTx *wire.MsgTx,
 	// When we verify a commitment signature, we always assume that we're
 	// verifying a signature on our local commitment. Therefore, we'll use:
 	// their remote nonce, and also public key.
+	tapscriptRoot := fn.MapOption(muSig2TweakToRoot)(m.tapscriptTweak)
 	partialSig := NewMusigPartialSig(
 		&musig2.PartialSignature{S: &sig.Sig},
 		m.nonces.SigningNonce.PubNonce, m.combinedNonce, m.signerKeys,
+		tapscriptRoot,
 	)
 
 	// With the partial sig loaded with the proper context, we'll now
@@ -537,6 +575,10 @@ type MusigSessionCfg struct {
 	// InputTxOut is the output that we're signing for. This will be the
 	// funding input.
 	InputTxOut *wire.TxOut
+
+	// TapscriptRoot is an optional tweak that can be used to modify the
+	// MuSig2 public key used in the session.
+	TapscriptTweak fn.Option[chainhash.Hash]
 }
 
 // MusigPairSession houses the two musig2 sessions needed to do funding and
@@ -561,13 +603,14 @@ func NewMusigPairSession(cfg *MusigSessionCfg) *MusigPairSession {
 	//
 	// Both sessions will be created using only the verification nonce for
 	// the local+remote party.
+	tapscriptTweak := fn.MapOption(TapscriptRootToTweak)(cfg.TapscriptTweak)
 	localSession := NewPartialMusigSession(
-		cfg.LocalNonce, cfg.LocalKey, cfg.RemoteKey,
-		cfg.Signer, cfg.InputTxOut, LocalMusigCommit,
+		cfg.LocalNonce, cfg.LocalKey, cfg.RemoteKey, cfg.Signer,
+		cfg.InputTxOut, LocalMusigCommit, tapscriptTweak,
 	)
 	remoteSession := NewPartialMusigSession(
-		cfg.RemoteNonce, cfg.LocalKey, cfg.RemoteKey,
-		cfg.Signer, cfg.InputTxOut, RemoteMusigCommit,
+		cfg.RemoteNonce, cfg.LocalKey, cfg.RemoteKey, cfg.Signer,
+		cfg.InputTxOut, RemoteMusigCommit, tapscriptTweak,
 	)
 
 	return &MusigPairSession{

--- a/lnwallet/reservation.go
+++ b/lnwallet/reservation.go
@@ -412,6 +412,10 @@ func NewChannelReservation(capacity, localFundingAmt btcutil.Amount,
 		chanType |= channeldb.ScidAliasFeatureBit
 	}
 
+	if req.TapscriptRoot.IsSome() {
+		chanType |= channeldb.TapscriptRootBit
+	}
+
 	return &ChannelReservation{
 		ourContribution: &ChannelContribution{
 			FundingAmount: ourBalance.ToSatoshis(),
@@ -445,6 +449,7 @@ func NewChannelReservation(capacity, localFundingAmt btcutil.Amount,
 			InitialLocalBalance:  ourBalance,
 			InitialRemoteBalance: theirBalance,
 			Memo:                 req.Memo,
+			TapscriptRoot:        req.TapscriptRoot,
 		},
 		pushMSat:      req.PushMSat,
 		pendingChanID: req.PendingChanID,

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -14,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
@@ -341,6 +342,21 @@ func CreateTestChannels(t *testing.T, chanType channeldb.ChannelType,
 		RemoteCommitment:        bobRemoteCommit,
 		Db:                      dbBob.ChannelStateDB(),
 		Packager:                channeldb.NewChannelPackager(shortChanID),
+	}
+
+	// If the channel type has a tapscript root, then we'll also specify
+	// one here to apply to both the channels.
+	if chanType.HasTapscriptRoot() {
+		var tapscriptRoot chainhash.Hash
+		_, err := io.ReadFull(rand.Reader, tapscriptRoot[:])
+		if err != nil {
+			return nil, nil, err
+		}
+
+		someRoot := fn.Some(tapscriptRoot)
+
+		aliceChannelState.TapscriptRoot = someRoot
+		bobChannelState.TapscriptRoot = someRoot
 	}
 
 	aliceSigner := input.NewMockSigner(aliceKeys, nil)

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -2445,6 +2445,12 @@ func initStateHints(commit1, commit2 *wire.MsgTx,
 	return nil
 }
 
+// TapscriptRootToOpt is a helper function that converts a tapscript root into
+// the functional option we can use to pass into GenTaprootFundingScript.
+func TapscriptRootToOpt(root chainhash.Hash) []input.FundingScriptOpt {
+	return []input.FundingScriptOpt{input.WithTapscriptRoot(root)}
+}
+
 // ValidateChannel will attempt to fully validate a newly mined channel, given
 // its funding transaction and existing channel state. If this method returns
 // an error, then the mined channel is invalid, and shouldn't be used.

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -23,6 +23,7 @@ import (
 	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
@@ -199,6 +200,11 @@ type InitFundingReserveMsg struct {
 	// Memo is any arbitrary information we wish to store locally about the
 	// channel that will be useful to our future selves.
 	Memo []byte
+
+	// TapscriptRoot is the root of the tapscript tree that will be used to
+	// create the funding output. This is an optional field that should
+	// only be set for taproot channels.
+	TapscriptRoot fn.Option[chainhash.Hash]
 
 	// err is a channel in which all errors will be sent across. Will be
 	// nil if this initial set is successful.
@@ -2086,8 +2092,14 @@ func (l *LightningWallet) verifyCommitSig(res *ChannelReservation,
 		// already. If we're the responder in the funding flow, we may
 		// not have generated it already.
 		if res.musigSessions == nil {
+			fundingOpts := fn.MapOptionZ(
+				res.partialState.TapscriptRoot,
+				TapscriptRootToOpt,
+			)
+
 			_, fundingOutput, err := input.GenTaprootFundingScript(
 				localKey, remoteKey, channelValue,
+				fundingOpts...,
 			)
 			if err != nil {
 				return err
@@ -2327,11 +2339,18 @@ func (l *LightningWallet) handleSingleFunderSigs(req *addSingleFunderSigsMsg) {
 		fundingTxOut         *wire.TxOut
 	)
 	if chanType.IsTaproot() {
-		fundingWitnessScript, fundingTxOut, err = input.GenTaprootFundingScript( //nolint:lll
+		fundingOpts := fn.MapOptionZ(
+			pendingReservation.partialState.TapscriptRoot,
+			TapscriptRootToOpt,
+		)
+		//nolint:lll
+		fundingWitnessScript, fundingTxOut, err = input.GenTaprootFundingScript(
 			ourKey.PubKey, theirKey.PubKey, channelValue,
+			fundingOpts...,
 		)
 	} else {
-		fundingWitnessScript, fundingTxOut, err = input.GenFundingPkScript( //nolint:lll
+		//nolint:lll
+		fundingWitnessScript, fundingTxOut, err = input.GenFundingPkScript(
 			ourKey.PubKey.SerializeCompressed(),
 			theirKey.PubKey.SerializeCompressed(), channelValue,
 		)
@@ -2451,6 +2470,14 @@ func TapscriptRootToOpt(root chainhash.Hash) []input.FundingScriptOpt {
 	return []input.FundingScriptOpt{input.WithTapscriptRoot(root)}
 }
 
+// TapscriptRootToTweak is a helper function that converts a tapscript root
+// into a tweak that can be used with the MuSig2 API.
+func TapscriptRootToTweak(root chainhash.Hash) input.MuSig2Tweaks {
+	return input.MuSig2Tweaks{
+		TaprootTweak: root[:],
+	}
+}
+
 // ValidateChannel will attempt to fully validate a newly mined channel, given
 // its funding transaction and existing channel state. If this method returns
 // an error, then the mined channel is invalid, and shouldn't be used.
@@ -2472,8 +2499,13 @@ func (l *LightningWallet) ValidateChannel(channelState *channeldb.OpenChannel,
 	// funding transaction, and also commitment validity.
 	var fundingScript []byte
 	if channelState.ChanType.IsTaproot() {
+		fundingOpts := fn.MapOptionZ(
+			channelState.TapscriptRoot, TapscriptRootToOpt,
+		)
+
 		fundingScript, _, err = input.GenTaprootFundingScript(
 			localKey, remoteKey, int64(channel.Capacity),
+			fundingOpts...,
 		)
 		if err != nil {
 			return err

--- a/peer/musig_chan_closer.go
+++ b/peer/musig_chan_closer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chancloser"
@@ -43,10 +44,15 @@ func (m *MusigChanCloser) ProposalClosingOpts() (
 	}
 
 	localKey, remoteKey := m.channel.MultiSigKeys()
+
+	tapscriptTweak := fn.MapOption(lnwallet.TapscriptRootToTweak)(
+		m.channel.State().TapscriptRoot,
+	)
+
 	m.musigSession = lnwallet.NewPartialMusigSession(
 		*m.remoteNonce, localKey, remoteKey,
 		m.channel.Signer, m.channel.FundingTxOut(),
-		lnwallet.RemoteMusigCommit,
+		lnwallet.RemoteMusigCommit, tapscriptTweak,
 	)
 
 	err := m.musigSession.FinalizeSession(*m.localNonce)

--- a/routing/router.go
+++ b/routing/router.go
@@ -1557,6 +1557,8 @@ func makeFundingScript(bitcoinKey1, bitcoinKey2 []byte,
 			return nil, err
 		}
 
+		// TODO(roasbeef): add tapscript root to gossip v1.5
+
 		return fundingScript, nil
 	}
 


### PR DESCRIPTION
Replaces https://github.com/lightningnetwork/lnd/pull/8546 (with correct base branch and upstream feature branch).

In this PR, we add the initial plumbing that'll allow users to create and use musig2 channels that also commit to a tapscript root. Along the way, we start to store a new optional tapscript root in the `channeldb.OpenChannel` struct within the existing TLV stream appended to the older hard coded byte stream. The musig2 session itself will now conditionally pass in a tapscript root to the key aggregation and signing operations. We've also hooked up the lower half of the funding flow (lnwallet reservations) as well to ensure the new field gets propagated all the way down the relevant call stacks. 

Link to all PRs in the saga:
 - 1/?: https://github.com/lightningnetwork/lnd/pull/8683
 - 2/?: https://github.com/lightningnetwork/lnd/pull/8684
 - 3/?: https://github.com/lightningnetwork/lnd/pull/8622
 - 4/?: https://github.com/lightningnetwork/lnd/pull/8632
 - 5/?: https://github.com/lightningnetwork/lnd/pull/8641