### PR TITLE
fix lncli bumpfee flag parsing

### DIFF
--- a/cmd/lncli/walletrpc_active.go
+++ b/cmd/lncli/walletrpc_active.go
@@ -272,10 +272,24 @@ func bumpFee(ctx *cli.Context) error {
 	client, cleanUp := getWalletClient(ctx)
 	defer cleanUp()
 
+	// Parse immediate flag (force flag was deprecated).
+	immediate := false
+	switch {
+	case ctx.IsSet("immediate") && ctx.IsSet("force"):
+		return fmt.Errorf("cannot set immediate and force flag at " +
+			"the same time")
+
+	case ctx.Bool("immediate"):
+		immediate = true
+
+	case ctx.Bool("force"):
+		immediate = true
+	}
+
 	resp, err := client.BumpFee(ctxc, &walletrpc.BumpFeeRequest{
 		Outpoint:   protoOutPoint,
 		TargetConf: uint32(ctx.Uint64("conf_target")),
-		Immediate:  ctx.Bool("force"),
+		Immediate:  immediate,
 		Budget:     ctx.Uint64("budget"),
 	})
 	if err != nil {

--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -127,6 +127,9 @@
   utxos which are unconfirmed and originated from the sweeper subsystem are not
   selected because they bear the risk of being replaced (BIP 125 RBF).
 
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/8685) lncli "bumpfee"
+  parsing of the immediate/force flag.
+
 # New Features
 ## Functional Enhancements
 


### PR DESCRIPTION
Simple fix of the `lncli wallet bumpfee` parsing of the immediate/force flag.
