### PR TITLE
sweep: add more descriptive log message

### DIFF
--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -129,6 +129,11 @@
 
 * [Fixed](https://github.com/lightningnetwork/lnd/pull/8685) lncli "bumpfee"
   parsing of the immediate/force flag.
+  
+* [Added](https://github.com/lightningnetwork/lnd/pull/8686) more descriptive
+  log message in case the initial broadcast of a sweep transaction fails because
+  its budget is too small and the transaction is unlikely to confirm at the
+  current absolute deadline target.
 
 # New Features
 ## Functional Enhancements

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -342,6 +342,13 @@ func (t *TxPublisher) initialBroadcast(req *BumpRequest) (*BumpResult, error) {
 	// Create a fee bumping algorithm to be used for future RBF.
 	feeAlgo, err := t.initializeFeeFunction(req)
 	if err != nil {
+		log.Infof("Registering a sweep bump request with the current "+
+			"budget(%v) having still a large enough absolute "+
+			"deadline(%v) is not economical and unlikely to "+
+			"confirm, it will be broadcasted regardless once the "+
+			"relative deadline approaches 1 block given the same "+
+			"inputs.", req.Budget, req.DeadlineHeight)
+
 		return nil, fmt.Errorf("init fee function: %w", err)
 	}
 


### PR DESCRIPTION
The fee function works as expected, this PR just adds a more descriptive log message. The behaviour observed in  https://github.com/lightningnetwork/lnd/pull/8485#issuecomment-2075431990 is normal.

As soon as inputs and their allocated budget cannot pay for the current starting feerate (based on a conftarget >1) it makes no sense to create a sweep transaction because the chances of it confirming are really low especially considering the conftarget of 1 (assuming the fee estimation is kinda accurate). This gives the sweeper subsystem the possibility to add other inputs to this set and finally if the conf-target (relative deadline) reaches 1 block, the transaction is broadcasted anyways. So I think this is what we want.