### PR TITLE
Persist nodeannouncement

### DIFF
--- a/cert/selfsigned.go
+++ b/cert/selfsigned.go
@@ -9,7 +9,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"os"
@@ -295,14 +294,14 @@ func GenCertPair(org string, tlsExtraIPs, tlsExtraDomains []string,
 func WriteCertPair(certFile, keyFile string, certBytes, keyBytes []byte) error {
 	// Write cert and key files.
 	if certFile != "" {
-		err := ioutil.WriteFile(certFile, certBytes, 0644)
+		err := os.WriteFile(certFile, certBytes, 0644)
 		if err != nil {
 			return err
 		}
 	}
 
 	if keyFile != "" {
-		err := ioutil.WriteFile(keyFile, keyBytes, 0600)
+		err := os.WriteFile(keyFile, keyBytes, 0600)
 		if err != nil {
 			os.Remove(certFile)
 			return err

--- a/cert/selfsigned_test.go
+++ b/cert/selfsigned_test.go
@@ -1,7 +1,7 @@
 package cert_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -42,10 +42,10 @@ func TestIsOutdatedCert(t *testing.T) {
 	// number of IPs and domains.
 	for numIPs := 1; numIPs <= len(extraIPs); numIPs++ {
 		for numDomains := 1; numDomains <= len(extraDomains); numDomains++ {
-			certBytes, err := ioutil.ReadFile(certPath)
+			certBytes, err := os.ReadFile(certPath)
 			require.NoError(t, err)
 
-			keyBytes, err := ioutil.ReadFile(keyPath)
+			keyBytes, err := os.ReadFile(keyPath)
 			require.NoError(t, err)
 
 			_, parsedCert, err := cert.LoadCertFromBytes(
@@ -98,10 +98,10 @@ func TestIsOutdatedPermutation(t *testing.T) {
 	err = cert.WriteCertPair(certPath, keyPath, certBytes, keyBytes)
 	require.NoError(t, err)
 
-	certBytes, err = ioutil.ReadFile(certPath)
+	certBytes, err = os.ReadFile(certPath)
 	require.NoError(t, err)
 
-	keyBytes, err = ioutil.ReadFile(keyPath)
+	keyBytes, err = os.ReadFile(keyPath)
 	require.NoError(t, err)
 
 	_, parsedCert, err := cert.LoadCertFromBytes(certBytes, keyBytes)
@@ -171,10 +171,10 @@ func TestTLSDisableAutofill(t *testing.T) {
 	require.NoError(t, err)
 
 	// Read certs from disk.
-	certBytes, err = ioutil.ReadFile(certPath)
+	certBytes, err = os.ReadFile(certPath)
 	require.NoError(t, err)
 
-	keyBytes, err = ioutil.ReadFile(keyPath)
+	keyBytes, err = os.ReadFile(keyPath)
 	require.NoError(t, err)
 
 	// Load the certificate.
@@ -230,10 +230,10 @@ func TestTLSConfig(t *testing.T) {
 	err = cert.WriteCertPair(certPath, keyPath, certBytes, keyBytes)
 	require.NoError(t, err)
 
-	certBytes, err = ioutil.ReadFile(certPath)
+	certBytes, err = os.ReadFile(certPath)
 	require.NoError(t, err)
 
-	keyBytes, err = ioutil.ReadFile(keyPath)
+	keyBytes, err = os.ReadFile(keyPath)
 	require.NoError(t, err)
 
 	// Load the certificate.

--- a/cert/tls.go
+++ b/cert/tls.go
@@ -3,7 +3,7 @@ package cert
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 	"sync"
 )
 
@@ -31,11 +31,11 @@ var (
 func GetCertBytesFromPath(certPath, keyPath string) (certBytes,
 	keyBytes []byte, err error) {
 
-	certBytes, err = ioutil.ReadFile(certPath)
+	certBytes, err = os.ReadFile(certPath)
 	if err != nil {
 		return nil, nil, err
 	}
-	keyBytes, err = ioutil.ReadFile(keyPath)
+	keyBytes, err = os.ReadFile(keyPath)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/chainreg/chainregistry.go
+++ b/chainreg/chainregistry.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/url"
 	"os"
@@ -547,7 +547,7 @@ func NewPartialChainControl(cfg *Config) (*PartialChainControl, func(), error) {
 			if err != nil {
 				return nil, nil, err
 			}
-			rpcCert, err = ioutil.ReadAll(certFile)
+			rpcCert, err = io.ReadAll(certFile)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/chanbackup/backupfile.go
+++ b/chanbackup/backupfile.go
@@ -2,7 +2,6 @@ package chanbackup
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -138,7 +137,7 @@ func (b *MultiFile) ExtractMulti(keyChain keychain.KeyRing) (*Multi, error) {
 	// Now that we've confirmed the target file is populated, we'll read
 	// all the contents of the file. This function ensures that file is
 	// always closed, even if we can't read the contents.
-	multiBytes, err := ioutil.ReadFile(b.fileName)
+	multiBytes, err := os.ReadFile(b.fileName)
 	if err != nil {
 		return nil, err
 	}

--- a/chanbackup/backupfile_test.go
+++ b/chanbackup/backupfile_test.go
@@ -3,7 +3,6 @@ package chanbackup
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -27,7 +26,7 @@ func assertBackupMatches(t *testing.T, filePath string,
 
 	t.Helper()
 
-	packedBackup, err := ioutil.ReadFile(filePath)
+	packedBackup, err := os.ReadFile(filePath)
 	require.NoError(t, err, "unable to test file")
 
 	if !bytes.Equal(packedBackup, currentBackup) {

--- a/channeldb/error.go
+++ b/channeldb/error.go
@@ -108,6 +108,12 @@ var (
 	// channel with a channel point that is already present in the
 	// database.
 	ErrChanAlreadyExists = fmt.Errorf("channel already exists")
+
+	ErrNodeAnnBucketNotFound = fmt.Errorf("no node announcement bucket " +
+		"exist")
+
+	ErrNodeAnnNotFound = fmt.Errorf("node announcement with target " + 
+		"identity not found")
 )
 
 // ErrTooManyExtraOpaqueBytes creates an error which should be returned if the

--- a/channeldb/migration/lnwire21/announcement_signatures.go
+++ b/channeldb/migration/lnwire21/announcement_signatures.go
@@ -2,7 +2,6 @@ package lnwire
 
 import (
 	"io"
-	"io/ioutil"
 )
 
 // AnnounceSignatures is a direct message between two endpoints of a
@@ -66,7 +65,7 @@ func (a *AnnounceSignatures) Decode(r io.Reader, pver uint32) error {
 	// we'll collect the remainder into the ExtraOpaqueData field. If there
 	// aren't any bytes, then we'll snip off the slice to avoid carrying
 	// around excess capacity.
-	a.ExtraOpaqueData, err = ioutil.ReadAll(r)
+	a.ExtraOpaqueData, err = io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/channeldb/migration/lnwire21/channel_announcement.go
+++ b/channeldb/migration/lnwire21/channel_announcement.go
@@ -3,7 +3,6 @@ package lnwire
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 )
@@ -89,7 +88,7 @@ func (a *ChannelAnnouncement) Decode(r io.Reader, pver uint32) error {
 	// we'll collect the remainder into the ExtraOpaqueData field. If there
 	// aren't any bytes, then we'll snip off the slice to avoid carrying
 	// around excess capacity.
-	a.ExtraOpaqueData, err = ioutil.ReadAll(r)
+	a.ExtraOpaqueData, err = io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/channeldb/migration/lnwire21/channel_update.go
+++ b/channeldb/migration/lnwire21/channel_update.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 )
@@ -160,7 +159,7 @@ func (a *ChannelUpdate) Decode(r io.Reader, pver uint32) error {
 	// we'll collect the remainder into the ExtraOpaqueData field. If there
 	// aren't any bytes, then we'll snip off the slice to avoid carrying
 	// around excess capacity.
-	a.ExtraOpaqueData, err = ioutil.ReadAll(r)
+	a.ExtraOpaqueData, err = io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/channeldb/migration/lnwire21/node_announcement.go
+++ b/channeldb/migration/lnwire21/node_announcement.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"image/color"
 	"io"
-	"io/ioutil"
 	"net"
 	"unicode/utf8"
 )
@@ -127,7 +126,7 @@ func (a *NodeAnnouncement) Decode(r io.Reader, pver uint32) error {
 	// we'll collect the remainder into the ExtraOpaqueData field. If there
 	// aren't any bytes, then we'll snip off the slice to avoid carrying
 	// around excess capacity.
-	a.ExtraOpaqueData, err = ioutil.ReadAll(r)
+	a.ExtraOpaqueData, err = io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/channeldb/node.go
+++ b/channeldb/node.go
@@ -1,0 +1,175 @@
+package channeldb
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightningnetwork/lnd/kvdb"
+)
+
+var (
+	// nodeAnnouncementBucket stores announcement config pertaining to node.
+	// This bucket allows one to query for persisted node announcement
+	// config and use it when starting orrestarting a node
+	nodeAnnouncementBucket = []byte("nab")
+)
+
+type NodeAnnouncement struct {
+	// Alias indicate the human readable name that a node operator can
+	// assign to their node for better readability and easier identification
+	Alias string
+
+	// Color represent the hexadecimal value that node operators can assign
+	// to their nodes. It's represented as a hex string.
+	Color string
+
+	// IdentityPub is the node's current identity public key. Any
+	// channel/topology related information received by this node MUST be
+	// signed by this public key.
+	IdentityPub *btcec.PublicKey
+
+	db *NodeAnnouncementDB
+}
+
+type NodeAnnouncementDB struct {
+	backend kvdb.Backend
+}
+
+func NewNodeAnnouncement(db *NodeAnnouncementDB, identityPub *btcec.PublicKey, alias, color string) *NodeAnnouncement {
+
+	return &NodeAnnouncement{
+		Alias:       alias,
+		IdentityPub: identityPub,
+		Color:       color,
+		db:          db,
+	}
+}
+
+// FetchNodeAnnouncement attempts to lookup the data for NodeAnnouncement based
+// on a target identity public key. If a particular NodeAnnouncement for the
+// passed identity public key cannot be found, then returns ErrNodeAnnNotFound
+func (l *NodeAnnouncementDB) FetchNodeAnnouncement(identity *btcec.PublicKey) (*NodeAnnouncement, error) {
+	var nodeAnnouncement *NodeAnnouncement
+	err := kvdb.View(l.backend, func(tx kvdb.RTx) error {
+		nodeAnn, err := fetchNodeAnnouncement(tx, identity)
+		if err != nil {
+			return err
+		}
+
+		nodeAnnouncement = nodeAnn
+		return nil
+	}, func() {
+		nodeAnnouncement = nil
+	})
+
+	return nodeAnnouncement, err
+}
+
+func fetchNodeAnnouncement(tx kvdb.RTx, targetPub *btcec.PublicKey) (*NodeAnnouncement, error) {
+	// First fetch the bucket for storing node announcement, bailing out
+	// early if it hasn't been created yet.
+	nodeAnnBucket := tx.ReadBucket(nodeAnnouncementBucket)
+	if nodeAnnBucket == nil {
+		return nil, ErrNodeAnnBucketNotFound
+	}
+
+	// If a node announcement for that particular public key cannot be
+	// located, then exit early with ErrNodeAnnNotFound
+	pubkey := targetPub.SerializeCompressed()
+	nodeAnnBytes := nodeAnnBucket.Get(pubkey)
+	if nodeAnnBytes == nil {
+		return nil, ErrNodeAnnNotFound
+	}
+
+	// FInally, decode and allocate a fresh NodeAnnouncement object to be
+	// returned to the caller
+	nodeAnnReader := bytes.NewReader(nodeAnnBytes)
+	return deserializeNodeAnnouncement(nodeAnnReader)
+
+}
+
+func (n *NodeAnnouncement) PutNodeAnnouncement(pubkey *btcec.PublicKey, alias, color string) error {
+	nodeAnn := NewNodeAnnouncement(n.db, pubkey, alias, color)
+
+	return kvdb.Update(n.db.backend, func(tx kvdb.RwTx) error {
+		nodeAnnBucket := tx.ReadWriteBucket(nodeAnnouncementBucket)
+		if nodeAnnBucket == nil {
+			_, err := tx.CreateTopLevelBucket(nodeAnnouncementBucket)
+			if err != nil {
+				return err
+			}
+
+			nodeAnnBucket = tx.ReadWriteBucket(nodeAnnouncementBucket)
+			if nodeAnnBucket == nil {
+				return ErrNodeAnnBucketNotFound
+			}
+		}
+
+		return putNodeAnnouncement(nodeAnnBucket, nodeAnn)
+	}, func() {})
+}
+
+func putNodeAnnouncement(nodeAnnBucket kvdb.RwBucket, n *NodeAnnouncement) error {
+	// First serialize the NodeAnnouncement into raw-bytes encoding.
+	var b bytes.Buffer
+	if err := serializeNodeAnnouncement(&b, n); err != nil {
+		return err
+	}
+
+	// Finally insert the link-node into the node metadata bucket keyed
+	// according to the its pubkey serialized in compressed form.
+	nodePub := n.IdentityPub.SerializeCompressed()
+	return nodeAnnBucket.Put(nodePub, b.Bytes())
+}
+
+func serializeNodeAnnouncement(w io.Writer, n *NodeAnnouncement) error {
+	// Serialize Alias
+	if _, err := w.Write([]byte(n.Alias + "\x00")); err != nil {
+		return err
+	}
+
+	// Serialize Color
+	if _, err := w.Write([]byte(n.Color + "\x00")); err != nil {
+		return err
+	}
+
+	// Serialize IdentityPub
+	serializedID := n.IdentityPub.SerializeCompressed()
+	if _, err := w.Write(serializedID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func deserializeNodeAnnouncement(r io.Reader) (*NodeAnnouncement, error) {
+	var err error
+	nodeAnn := &NodeAnnouncement{}
+
+	// Read Alias
+	aliasBuf := make([]byte, 32)
+	if _, err := io.ReadFull(r, aliasBuf); err != nil {
+		return nil, err
+	}
+	nodeAnn.Alias = string(bytes.TrimRight(aliasBuf, "\x00"))
+
+	// Read Color
+	colorBuf := make([]byte, 8)
+	if _, err := io.ReadFull(r, colorBuf); err != nil {
+		return nil, err
+	}
+	nodeAnn.Color = string(bytes.TrimRight(colorBuf, "\x00"))
+
+	var pub [33]byte
+	if _, err := io.ReadFull(r, pub[:]); err != nil {
+		return nil, err
+	}
+	nodeAnn.IdentityPub, err = btcec.ParsePubKey(pub[:])
+	if err != nil {
+		return nil, err
+	}
+
+	return nodeAnn, err
+
+}

--- a/cmd/lncli/cmd_macaroon.go
+++ b/cmd/lncli/cmd_macaroon.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strconv"
@@ -193,7 +192,7 @@ func bakeMacaroon(ctx *cli.Context) error {
 	// a file or write to the standard output using hex encoding.
 	switch {
 	case savePath != "":
-		err = ioutil.WriteFile(savePath, macBytes, 0644)
+		err = os.WriteFile(savePath, macBytes, 0644)
 		if err != nil {
 			return err
 		}
@@ -472,7 +471,7 @@ func constrainMacaroon(ctx *cli.Context) error {
 	}
 
 	// Now we can output the result.
-	err = ioutil.WriteFile(destMacFile, destMacBytes, 0644)
+	err = os.WriteFile(destMacFile, destMacBytes, 0644)
 	if err != nil {
 		return fmt.Errorf("error writing destination macaroon file "+
 			"%s: %v", destMacFile, err)

--- a/cmd/lncli/cmd_macaroon.go
+++ b/cmd/lncli/cmd_macaroon.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"unicode"
@@ -352,7 +353,7 @@ func printMacaroon(ctx *cli.Context) error {
 		macPath := lncfg.CleanAndExpandPath(ctx.String("macaroon_file"))
 
 		// Load the specified macaroon file.
-		macBytes, err = ioutil.ReadFile(macPath)
+		macBytes, err = os.ReadFile(macPath)
 		if err != nil {
 			return fmt.Errorf("unable to read macaroon path %v: %v",
 				macPath, err)
@@ -441,7 +442,7 @@ func constrainMacaroon(ctx *cli.Context) error {
 	sourceMacFile := lncfg.CleanAndExpandPath(args.First())
 	args = args.Tail()
 
-	sourceMacBytes, err := ioutil.ReadFile(sourceMacFile)
+	sourceMacBytes, err := os.ReadFile(sourceMacFile)
 	if err != nil {
 		return fmt.Errorf("error trying to read source macaroon file "+
 			"%s: %v", sourceMacFile, err)

--- a/cmd/lncli/cmd_open_channel.go
+++ b/cmd/lncli/cmd_open_channel.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -1016,7 +1015,7 @@ func readTerminalOrFile(quit chan struct{}) (string, error) {
 
 	// If it's a path to an existing file and it's small enough, let's try
 	// to read its content now.
-	content, err := ioutil.ReadFile(maybeFile)
+	content, err := os.ReadFile(maybeFile)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/lncli/cmd_payments.go
+++ b/cmd/lncli/cmd_payments.go
@@ -7,7 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"runtime"
 	"strconv"
@@ -987,7 +987,7 @@ func sendToRoute(ctx *cli.Context) error {
 	// The user is signalling that we should read stdin in order to parse
 	// the set of target routes.
 	case args.Present() && args.First() == "-":
-		b, err := ioutil.ReadAll(os.Stdin)
+		b, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/cmd/lncli/cmd_profile.go
+++ b/cmd/lncli/cmd_profile.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -423,7 +422,7 @@ func profileAddMacaroon(ctx *cli.Context) error {
 
 	// Now load and possibly encrypt the macaroon file.
 	macPath := lncfg.CleanAndExpandPath(ctx.GlobalString("macaroonpath"))
-	macBytes, err := ioutil.ReadFile(macPath)
+	macBytes, err := os.ReadFile(macPath)
 	if err != nil {
 		return fmt.Errorf("unable to read macaroon path: %w", err)
 	}

--- a/cmd/lncli/cmd_walletunlocker.go
+++ b/cmd/lncli/cmd_walletunlocker.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -712,7 +711,7 @@ func createWatchOnly(ctx *cli.Context) error {
 	}
 
 	jsonFile := lncfg.CleanAndExpandPath(ctx.Args().First())
-	jsonBytes, err := ioutil.ReadFile(jsonFile)
+	jsonBytes, err := os.ReadFile(jsonFile)
 	if err != nil {
 		return fmt.Errorf("error reading JSON from file %v: %v",
 			jsonFile, err)

--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"strconv"
@@ -2833,7 +2832,7 @@ func parseChanBackups(ctx *cli.Context) (*lnrpc.RestoreChanBackupRequest, error)
 		}, nil
 
 	case ctx.IsSet("multi_file"):
-		packedMulti, err := ioutil.ReadFile(ctx.String("multi_file"))
+		packedMulti, err := os.ReadFile(ctx.String("multi_file"))
 		if err != nil {
 			return nil, fmt.Errorf("unable to decode multi packed "+
 				"backup: %v", err)

--- a/cmd/lncli/profile.go
+++ b/cmd/lncli/profile.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 
@@ -129,7 +130,7 @@ func profileFromContext(ctx *cli.Context, store, skipMacaroons bool) (
 	var tlsCert []byte
 	if tlsCertPath != "" && !insecure {
 		var err error
-		tlsCert, err = ioutil.ReadFile(tlsCertPath)
+		tlsCert, err = os.ReadFile(tlsCertPath)
 		if err != nil {
 			return nil, fmt.Errorf("could not load TLS cert "+
 				"file: %v", err)
@@ -167,7 +168,7 @@ func profileFromContext(ctx *cli.Context, store, skipMacaroons bool) (
 	}
 
 	// Now load and possibly encrypt the macaroon file.
-	macBytes, err := ioutil.ReadFile(macPath)
+	macBytes, err := os.ReadFile(macPath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read macaroon path (check "+
 			"the network setting!): %v", err)
@@ -222,7 +223,7 @@ func loadProfileFile(file string) (*profileFile, error) {
 		return nil, errNoProfileFile
 	}
 
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("could not load profile file %s: %w",
 			file, err)

--- a/cmd/lncli/profile.go
+++ b/cmd/lncli/profile.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -244,7 +243,7 @@ func saveProfileFile(file string, f *profileFile) error {
 	if err != nil {
 		return fmt.Errorf("could not marshal profile: %w", err)
 	}
-	return ioutil.WriteFile(file, content, 0644)
+	return os.WriteFile(file, content, 0644)
 }
 
 // profileFile is a struct that represents the whole content of a profile file.

--- a/config.go
+++ b/config.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/user"
@@ -1848,7 +1847,7 @@ func parseRPCParams(cConfig *lncfg.Chain, nodeConfig interface{},
 
 		// We convert the cookie into a user name and password.
 		if conf.RPCCookie != "" {
-			cookie, err := ioutil.ReadFile(conf.RPCCookie)
+			cookie, err := os.ReadFile(conf.RPCCookie)
 			if err != nil {
 				return fmt.Errorf("cannot read cookie file: %w",
 					err)
@@ -2121,7 +2120,7 @@ func extractBitcoindRPCParams(networkName, bitcoindDataDir, bitcoindConfigPath,
 	if rpcCookiePath != "" {
 		cookiePath = rpcCookiePath
 	}
-	cookie, err := ioutil.ReadFile(cookiePath)
+	cookie, err := os.ReadFile(cookiePath)
 	if err == nil {
 		splitCookie := strings.Split(string(cookie), ":")
 		if len(splitCookie) == 2 {

--- a/config.go
+++ b/config.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"os"
@@ -2008,7 +2009,7 @@ func extractBtcdRPCParams(btcdConfigPath string) (string, string, error) {
 
 	// With the file open extract the contents of the configuration file so
 	// we can attempt to locate the RPC credentials.
-	configContents, err := ioutil.ReadAll(btcdConfigFile)
+	configContents, err := io.ReadAll(btcdConfigFile)
 	if err != nil {
 		return "", "", err
 	}
@@ -2058,7 +2059,7 @@ func extractBitcoindRPCParams(networkName, bitcoindDataDir, bitcoindConfigPath,
 
 	// With the file open extract the contents of the configuration file so
 	// we can attempt to locate the RPC credentials.
-	configContents, err := ioutil.ReadAll(bitcoindConfigFile)
+	configContents, err := io.ReadAll(bitcoindConfigFile)
 	if err != nil {
 		return "", "", "", "", err
 	}

--- a/config_builder.go
+++ b/config_builder.go
@@ -6,7 +6,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -329,7 +328,7 @@ func (d *DefaultWalletImpl) BuildWalletConfig(ctx context.Context,
 	case d.cfg.WalletUnlockPasswordFile != "" && walletExists:
 		d.logger.Infof("Attempting automatic wallet unlock with " +
 			"password provided in file")
-		pwBytes, err := ioutil.ReadFile(d.cfg.WalletUnlockPasswordFile)
+		pwBytes, err := os.ReadFile(d.cfg.WalletUnlockPasswordFile)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("error reading "+
 				"password from file %s: %v",

--- a/contractcourt/htlc_incoming_contest_resolver_test.go
+++ b/contractcourt/htlc_incoming_contest_resolver_test.go
@@ -3,7 +3,6 @@ package contractcourt
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	sphinx "github.com/lightningnetwork/lightning-onion"
@@ -291,7 +290,7 @@ type mockOnionProcessor struct {
 func (o *mockOnionProcessor) ReconstructHopIterator(r io.Reader, rHash []byte,
 	_ hop.ReconstructBlindingInfo) (hop.Iterator, error) {
 
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -7,7 +7,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -946,7 +945,7 @@ var _ ChannelLink = (*mockChannelLink)(nil)
 func newDB() (*channeldb.DB, func(), error) {
 	// First, create a temporary directory to be used for the duration of
 	// this test.
-	tempDirName, err := ioutil.TempDir("", "channeldb")
+	tempDirName, err := os.MkdirTemp("", "channeldb")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/musig2v040/musig2_test.go
+++ b/internal/musig2v040/musig2_test.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sync"
 	"testing"
 
@@ -256,7 +256,7 @@ func TestMuSig2KeyAggTestVectors(t *testing.T) {
 
 		var formattedJson bytes.Buffer
 		json.Indent(&formattedJson, jsonBytes, "", "\t")
-		err = ioutil.WriteFile(
+		err = os.WriteFile(
 			keyAggTestVectorName, formattedJson.Bytes(), 0644,
 		)
 		if err != nil {
@@ -656,7 +656,7 @@ func TestMuSig2SigningTestVectors(t *testing.T) {
 
 		var formattedJson bytes.Buffer
 		json.Indent(&formattedJson, jsonBytes, "", "\t")
-		err = ioutil.WriteFile(
+		err = os.WriteFile(
 			signTestVectorName, formattedJson.Bytes(), 0644,
 		)
 		if err != nil {
@@ -1540,7 +1540,7 @@ func TestMusig2AggregateNoncesTestVectors(t *testing.T) {
 
 		var formattedJson bytes.Buffer
 		json.Indent(&formattedJson, jsonBytes, "", "\t")
-		err = ioutil.WriteFile(
+		err = os.WriteFile(
 			nonceAggTestVectorName, formattedJson.Bytes(), 0644,
 		)
 		if err != nil {

--- a/itest/lnd_channel_backup_test.go
+++ b/itest/lnd_channel_backup_test.go
@@ -3,7 +3,6 @@ package itest
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -285,7 +284,7 @@ func testChannelBackupRestoreBasic(ht *lntest.HarnessTest) {
 
 				// Read the entire Multi backup stored within
 				// this node's channel.backup file.
-				multi, err := ioutil.ReadFile(backupFilePath)
+				multi, err := os.ReadFile(backupFilePath)
 				require.NoError(st, err)
 
 				// Now that we have Dave's backup file, we'll
@@ -376,7 +375,7 @@ func testChannelBackupRestoreBasic(ht *lntest.HarnessTest) {
 
 				// Read the entire Multi backup stored within
 				// this node's channel.backup file.
-				multi, err := ioutil.ReadFile(backupFilePath)
+				multi, err := os.ReadFile(backupFilePath)
 				require.NoError(st, err)
 
 				// Now that we have Dave's backup file, we'll
@@ -501,7 +500,7 @@ func runChanRestoreScenarioUnConfirmed(ht *lntest.HarnessTest, useFile bool) {
 		backupFilePath := dave.Cfg.ChanBackupPath()
 		// Read the entire Multi backup stored within this node's
 		// channel.backup file.
-		multi, err = ioutil.ReadFile(backupFilePath)
+		multi, err = os.ReadFile(backupFilePath)
 		require.NoError(ht, err)
 	} else {
 		// For this restoration method, we'll grab the current
@@ -646,7 +645,7 @@ func runChanRestoreScenarioCommitTypes(ht *lntest.HarnessTest,
 
 	// Read the entire Multi backup stored within this node's
 	// channels.backup file.
-	multi, err := ioutil.ReadFile(backupFilePath)
+	multi, err := os.ReadFile(backupFilePath)
 	require.NoError(ht, err)
 
 	// If this was a zero conf taproot channel, then since it's private,
@@ -774,7 +773,7 @@ func runChanRestoreScenarioForceClose(ht *lntest.HarnessTest, zeroConf bool) {
 
 	// Read the entire Multi backup stored within this node's
 	// channel.backup file.
-	multi, err := ioutil.ReadFile(backupFilePath)
+	multi, err := os.ReadFile(backupFilePath)
 	require.NoError(ht, err)
 
 	// Now that we have Dave's backup file, we'll create a new nodeRestorer
@@ -907,7 +906,7 @@ func testChannelBackupUpdates(ht *lntest.HarnessTest) {
 	// the on disk back up file to our currentBackup pointer above.
 	assertBackupFileState := func() {
 		err := wait.NoError(func() error {
-			packedBackup, err := ioutil.ReadFile(backupFilePath)
+			packedBackup, err := os.ReadFile(backupFilePath)
 			if err != nil {
 				return fmt.Errorf("unable to read backup "+
 					"file: %v", err)

--- a/itest/lnd_misc_test.go
+++ b/itest/lnd_misc_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/txscript"
@@ -708,7 +708,7 @@ func testAbandonChannel(ht *lntest.HarnessTest) {
 	// To make sure the channel is removed from the backup file as well
 	// when being abandoned, grab a backup snapshot so we can compare it
 	// with the later state.
-	bkupBefore, err := ioutil.ReadFile(alice.Cfg.ChanBackupPath())
+	bkupBefore, err := os.ReadFile(alice.Cfg.ChanBackupPath())
 	require.NoError(ht, err, "channel backup before abandoning channel")
 
 	// Send request to abandon channel.
@@ -733,7 +733,7 @@ func testAbandonChannel(ht *lntest.HarnessTest) {
 
 	// Make sure the channel is no longer in the channel backup list.
 	err = wait.NoError(func() error {
-		bkupAfter, err := ioutil.ReadFile(alice.Cfg.ChanBackupPath())
+		bkupAfter, err := os.ReadFile(alice.Cfg.ChanBackupPath())
 		if err != nil {
 			return fmt.Errorf("could not get channel backup "+
 				"before abandoning channel: %v", err)

--- a/kvdb/backend.go
+++ b/kvdb/backend.go
@@ -218,7 +218,7 @@ func lastCompactionDate(dbFile string) (time.Time, error) {
 		return zeroTime, nil
 	}
 
-	tsBytes, err := ioutil.ReadFile(tsFile)
+	tsBytes, err := os.ReadFile(tsFile)
 	if err != nil {
 		return zeroTime, err
 	}

--- a/kvdb/backend.go
+++ b/kvdb/backend.go
@@ -9,7 +9,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -235,7 +234,7 @@ func updateLastCompactionDate(dbFile string) error {
 	byteOrder.PutUint64(tsBytes[:], uint64(time.Now().UnixNano()))
 
 	tsFile := fmt.Sprintf("%s%s", dbFile, LastCompactionFileNameSuffix)
-	return ioutil.WriteFile(tsFile, tsBytes[:], 0600)
+	return os.WriteFile(tsFile, tsBytes[:], 0600)
 }
 
 // GetTestBackend opens (or creates if doesn't exist) a bbolt or etcd

--- a/lnd.go
+++ b/lnd.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -83,7 +82,7 @@ func AdminAuthOptions(cfg *Config, skipMacaroons bool) ([]grpc.DialOption,
 	// Get the admin macaroon if macaroons are active.
 	if !skipMacaroons && !cfg.NoMacaroons {
 		// Load the admin macaroon file.
-		macBytes, err := ioutil.ReadFile(cfg.AdminMacPath)
+		macBytes, err := os.ReadFile(cfg.AdminMacPath)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read macaroon "+
 				"path (check the network setting!): %v", err)

--- a/lnrpc/chainrpc/chain_server.go
+++ b/lnrpc/chainrpc/chain_server.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -153,7 +152,7 @@ func New(cfg *Config) (*Server, lnrpc.MacaroonPerms, error) {
 		if err != nil {
 			return nil, nil, err
 		}
-		err = ioutil.WriteFile(macFilePath, chainNotifierMacBytes, 0644)
+		err = os.WriteFile(macFilePath, chainNotifierMacBytes, 0644)
 		if err != nil {
 			_ = os.Remove(macFilePath)
 			return nil, nil, err

--- a/lnrpc/invoicesrpc/invoices_server.go
+++ b/lnrpc/invoicesrpc/invoices_server.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -132,7 +131,7 @@ func New(cfg *Config) (*Server, lnrpc.MacaroonPerms, error) {
 		if err != nil {
 			return nil, nil, err
 		}
-		err = ioutil.WriteFile(macFilePath, invoicesMacBytes, 0644)
+		err = os.WriteFile(macFilePath, invoicesMacBytes, 0644)
 		if err != nil {
 			_ = os.Remove(macFilePath)
 			return nil, nil, err

--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -6,7 +6,6 @@ import (
 	crand "crypto/rand"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -216,7 +215,7 @@ func New(cfg *Config) (*Server, lnrpc.MacaroonPerms, error) {
 		if err != nil {
 			return nil, nil, err
 		}
-		err = ioutil.WriteFile(macFilePath, routerMacBytes, 0644)
+		err = os.WriteFile(macFilePath, routerMacBytes, 0644)
 		if err != nil {
 			_ = os.Remove(macFilePath)
 			return nil, nil, err

--- a/lnrpc/signrpc/signer_server.go
+++ b/lnrpc/signrpc/signer_server.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -167,7 +166,7 @@ func New(cfg *Config) (*Server, lnrpc.MacaroonPerms, error) {
 		if err != nil {
 			return nil, nil, err
 		}
-		err = ioutil.WriteFile(macFilePath, signerMacBytes, 0644)
+		err = os.WriteFile(macFilePath, signerMacBytes, 0644)
 		if err != nil {
 			_ = os.Remove(macFilePath)
 			return nil, nil, err

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -10,7 +10,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -287,7 +286,7 @@ func New(cfg *Config) (*WalletKit, lnrpc.MacaroonPerms, error) {
 		if err != nil {
 			return nil, nil, err
 		}
-		err = ioutil.WriteFile(macFilePath, walletKitMacBytes, 0644)
+		err = os.WriteFile(macFilePath, walletKitMacBytes, 0644)
 		if err != nil {
 			_ = os.Remove(macFilePath)
 			return nil, nil, err

--- a/lntest/bitcoind_common.go
+++ b/lntest/bitcoind_common.go
@@ -6,7 +6,6 @@ package lntest
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -105,7 +104,7 @@ func newBackend(miner string, netParams *chaincfg.Params, extraArgs []string,
 		return nil, nil, err
 	}
 
-	tempBitcoindDir, err := ioutil.TempDir("", "bitcoind")
+	tempBitcoindDir, err := os.MkdirTemp("", "bitcoind")
 	if err != nil {
 		return nil, nil,
 			fmt.Errorf("unable to create temp directory: %w", err)

--- a/lntest/btcd.go
+++ b/lntest/btcd.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -135,7 +134,7 @@ func NewBackend(miner string, netParams *chaincfg.Params) (
 		// the log files, including any compressed log files from
 		// logrorate, before deleting the temporary log dir.
 		logDir := fmt.Sprintf("%s/%s", baseLogDir, netParams.Name)
-		files, err := ioutil.ReadDir(logDir)
+		files, err := os.ReadDir(logDir)
 		if err != nil {
 			errStr += fmt.Sprintf(
 				"unable to read log directory: %v\n", err,

--- a/lntest/harness_miner.go
+++ b/lntest/harness_miner.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -121,7 +120,7 @@ func (h *HarnessMiner) saveLogs() {
 	// After shutting down the miner, we'll make a copy of the log files
 	// before deleting the temporary log dir.
 	path := fmt.Sprintf("%s/%s", h.logPath, harnessNetParams.Name)
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	require.NoError(h, err, "unable to read log directory")
 
 	for _, file := range files {

--- a/lntest/node/harness_node.go
+++ b/lntest/node/harness_node.go
@@ -1027,7 +1027,7 @@ func addLogFile(hn *HarnessNode) error {
 // copyAll copies all files and directories from srcDir to dstDir recursively.
 // Note that this function does not support links.
 func copyAll(dstDir, srcDir string) error {
-	entries, err := ioutil.ReadDir(srcDir)
+	entries, err := os.ReadDir(srcDir)
 	if err != nil {
 		return err
 	}

--- a/lntest/node/harness_node.go
+++ b/lntest/node/harness_node.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -97,7 +96,7 @@ type HarnessNode struct {
 func NewHarnessNode(t *testing.T, cfg *BaseNodeConfig) (*HarnessNode, error) {
 	if cfg.BaseDir == "" {
 		var err error
-		cfg.BaseDir, err = ioutil.TempDir("", "lndtest-node")
+		cfg.BaseDir, err = os.MkdirTemp("", "lndtest-node")
 		if err != nil {
 			return nil, err
 		}
@@ -819,7 +818,7 @@ func (hn *HarnessNode) BackupDB() error {
 		}
 	} else {
 		// Backup files.
-		tempDir, err := ioutil.TempDir("", "past-state")
+		tempDir, err := os.MkdirTemp("", "past-state")
 		if err != nil {
 			return fmt.Errorf("unable to create temp db folder: %w",
 				err)

--- a/lntest/node/harness_node.go
+++ b/lntest/node/harness_node.go
@@ -292,7 +292,7 @@ func (hn *HarnessNode) ReadMacaroon(macPath string, timeout time.Duration) (
 	// using it.
 	var mac *macaroon.Macaroon
 	err := wait.NoError(func() error {
-		macBytes, err := ioutil.ReadFile(macPath)
+		macBytes, err := os.ReadFile(macPath)
 		if err != nil {
 			return fmt.Errorf("error reading macaroon file: %w",
 				err)

--- a/lnwallet/rpcwallet/rpcwallet.go
+++ b/lnwallet/rpcwallet/rpcwallet.go
@@ -7,7 +7,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -1259,7 +1259,7 @@ func extractSignature(in *psbt.PInput,
 func connectRPC(hostPort, tlsCertPath, macaroonPath string,
 	timeout time.Duration) (*grpc.ClientConn, error) {
 
-	certBytes, err := ioutil.ReadFile(tlsCertPath)
+	certBytes, err := os.ReadFile(tlsCertPath)
 	if err != nil {
 		return nil, fmt.Errorf("error reading TLS cert file %v: %w",
 			tlsCertPath, err)
@@ -1271,7 +1271,7 @@ func connectRPC(hostPort, tlsCertPath, macaroonPath string,
 			"certificate")
 	}
 
-	macBytes, err := ioutil.ReadFile(macaroonPath)
+	macBytes, err := os.ReadFile(macaroonPath)
 	if err != nil {
 		return nil, fmt.Errorf("error reading macaroon file %v: %w",
 			macaroonPath, err)

--- a/lnwallet/transactions_test.go
+++ b/lnwallet/transactions_test.go
@@ -8,8 +8,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
+	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -229,7 +229,7 @@ func TestCommitmentAndHTLCTransactions(t *testing.T) {
 
 		var testCases []testCase
 
-		jsonText, err := ioutil.ReadFile(set.jsonFile)
+		jsonText, err := os.ReadFile(set.jsonFile)
 		require.NoError(t, err)
 
 		err = json.Unmarshal(jsonText, &testCases)

--- a/lnwire/onion_error.go
+++ b/lnwire/onion_error.go
@@ -7,7 +7,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/go-errors/errors"
@@ -1304,7 +1303,7 @@ func DecodeFailure(r io.Reader, pver uint32) (FailureMessage, error) {
 		return nil, fmt.Errorf("unable to read pad len: %w", err)
 	}
 
-	if _, err := io.CopyN(ioutil.Discard, r, int64(padLength)); err != nil {
+	if _, err := io.CopyN(io.Discard, r, int64(padLength)); err != nil {
 		return nil, fmt.Errorf("unable to read padding %w", err)
 	}
 

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -8,9 +8,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"net"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -183,7 +183,7 @@ func makeTestGraph(t *testing.T, useCache bool) (*channeldb.ChannelGraph,
 func parseTestGraph(t *testing.T, useCache bool, path string) (
 	*testGraphInstance, error) {
 
-	graphJSON, err := ioutil.ReadFile(path)
+	graphJSON, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/tls_manager.go
+++ b/tls_manager.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -279,7 +278,7 @@ func (t *TLSManager) ensureEncryption(keyRing keychain.SecretKeyRing) error {
 		if err != nil {
 			return err
 		}
-		err = ioutil.WriteFile(
+		err = os.WriteFile(
 			t.cfg.TLSKeyPath, b.Bytes(), modifyFilePermissions,
 		)
 		if err != nil {

--- a/tls_manager_test.go
+++ b/tls_manager_test.go
@@ -9,7 +9,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"os"
@@ -351,9 +350,9 @@ func writeTestCertFiles(t *testing.T, expiredCert, encryptTLSKey bool,
 		require.NoError(t, err, "failed to encrypt private key")
 	}
 
-	err = ioutil.WriteFile(tempDir+"/tls.cert", certBuf.Bytes(), 0644)
+	err = os.WriteFile(tempDir+"/tls.cert", certBuf.Bytes(), 0644)
 	require.NoError(t, err, "failed to write cert file")
-	err = ioutil.WriteFile(tempDir+"/tls.key", keyBuf.Bytes(), 0600)
+	err = os.WriteFile(tempDir+"/tls.key", keyBuf.Bytes(), 0600)
 	require.NoError(t, err, "failed to write key file")
 
 	return certPath, keyPath, parsedCert

--- a/tls_manager_test.go
+++ b/tls_manager_test.go
@@ -12,6 +12,7 @@ import (
 	"io/ioutil"
 	"math/big"
 	"net"
+	"os"
 	"testing"
 	"time"
 
@@ -199,7 +200,7 @@ func TestGenerateEphemeralCert(t *testing.T) {
 	keyBytes, err := tlsManager.loadEphemeralCertificate()
 	require.NoError(t, err, "failed to generate new certificate")
 
-	certBytes, err := ioutil.ReadFile(tmpCertPath)
+	certBytes, err := os.ReadFile(tmpCertPath)
 	require.NoError(t, err)
 
 	tlsr, err := cert.NewTLSReloader(certBytes, keyBytes)
@@ -207,15 +208,15 @@ func TestGenerateEphemeralCert(t *testing.T) {
 	tlsManager.tlsReloader = tlsr
 
 	// Make sure .tmp file is created at the tmp cert path.
-	_, err = ioutil.ReadFile(tmpCertPath)
+	_, err = os.ReadFile(tmpCertPath)
 	require.NoError(t, err, "couldn't find temp cert file")
 
 	// But no key should be stored.
-	_, err = ioutil.ReadFile(cfg.TLSKeyPath)
+	_, err = os.ReadFile(cfg.TLSKeyPath)
 	require.Error(t, err, "shouldn't have found file")
 
 	// And no permanent cert file should be stored.
-	_, err = ioutil.ReadFile(cfg.TLSCertPath)
+	_, err = os.ReadFile(cfg.TLSCertPath)
 	require.Error(t, err, "shouldn't have found a permanent cert file")
 
 	// Now test that when we reload the certificate it generates the new

--- a/tlv/stream.go
+++ b/tlv/stream.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"math"
 )
 
@@ -262,7 +261,7 @@ func (s *Stream) decode(r io.Reader, parsedTypes TypeMap, p2p bool) (TypeMap,
 			// If the caller provided an initialized TypeMap, record
 			// the encoded bytes.
 			var b *bytes.Buffer
-			writer := ioutil.Discard
+			writer := io.Discard
 			if parsedTypes != nil {
 				b = bytes.NewBuffer(make([]byte, 0, length))
 				writer = b

--- a/tor/cmd_onion.go
+++ b/tor/cmd_onion.go
@@ -124,7 +124,7 @@ func (f *OnionFile) PrivateKey() ([]byte, error) {
 	}
 
 	// Try to read the Tor private key to pass into the AddOnion call.
-	privateKeyContent, err := ioutil.ReadFile(f.privateKeyPath)
+	privateKeyContent, err := os.ReadFile(f.privateKeyPath)
 	if err != nil {
 		return nil, err
 	}

--- a/tor/cmd_onion.go
+++ b/tor/cmd_onion.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -105,7 +104,7 @@ func (f *OnionFile) StorePrivateKey(privateKey []byte) error {
 		privateKeyContent = b.Bytes()
 	}
 
-	err := ioutil.WriteFile(
+	err := os.WriteFile(
 		f.privateKeyPath, privateKeyContent, f.privateKeyPerm,
 	)
 	if err != nil {

--- a/tor/controller.go
+++ b/tor/controller.go
@@ -8,8 +8,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/textproto"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -597,7 +597,7 @@ func (c *Controller) getAuthCookie(info protocolInfo) ([]byte, error) {
 	cookieFilePath = strings.Trim(cookieFilePath, "\"")
 
 	// Read the cookie from the file and ensure it has the correct length.
-	cookie, err := ioutil.ReadFile(cookieFilePath)
+	cookie, err := os.ReadFile(cookieFilePath)
 	if err != nil {
 		return nil, err
 	}

--- a/watchtower/tlv_bench_test.go
+++ b/watchtower/tlv_bench_test.go
@@ -3,7 +3,6 @@ package watchtower_test
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
@@ -104,7 +103,7 @@ func BenchmarkEncodeCreateSession(t *testing.B) {
 
 	var err error
 	for i := 0; i < t.N; i++ {
-		err = m.Encode(ioutil.Discard, 0)
+		err = m.Encode(io.Discard, 0)
 	}
 	require.NoError(t, err)
 }
@@ -118,7 +117,7 @@ func BenchmarkEncodeCreateSessionTLV(t *testing.B) {
 
 	var err error
 	for i := 0; i < t.N; i++ {
-		err = m.Encode(ioutil.Discard)
+		err = m.Encode(io.Discard)
 	}
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Change Description
Description of change / link to associated issue.

Allow node runners to persist `nodeannouncement` configurations in the db to be used when a node restarts.
Closes #

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
