### PR TITLE
channeldb: add persist nodeannounment config in db

### DIFF
--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -447,6 +447,7 @@ var dbTopLevelBuckets = [][]byte{
 	outpointBucket,
 	chanIDBucket,
 	historicalChannelBucket,
+	nodeAnnouncementBucket,
 }
 
 // Wipe completely deletes all saved state within all used buckets within the
@@ -519,6 +520,9 @@ type ChannelStateDB struct {
 	// linkNodeDB separates all DB operations on LinkNodes.
 	linkNodeDB *LinkNodeDB
 
+	// nodeAnnouncementDB seperates all DB operations on NodeAnnouncements.
+	nodeAnnouncementDb *NodeAnnouncementDB
+
 	// parent holds a pointer to the "main" channeldb.DB object. This is
 	// only used for testing and should never be used in production code.
 	// For testing use the ChannelStateDB.GetParentDB() function to retrieve
@@ -540,6 +544,11 @@ func (c *ChannelStateDB) GetParentDB() *DB {
 // LinkNodeDB returns the current instance of the link node database.
 func (c *ChannelStateDB) LinkNodeDB() *LinkNodeDB {
 	return c.linkNodeDB
+}
+
+// nodeAnnouncementDB returns the current instance of the nodeannouncement database.
+func (c *ChannelStateDB) NodeAnnouncemenDB() *NodeAnnouncementDB {
+	return c.nodeAnnouncementDb
 }
 
 // FetchOpenChannels starts a new database transaction and returns all stored

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -286,12 +286,6 @@ var (
 			number:    31,
 			migration: migration31.DeleteLastPublishedTxTLB,
 		},
-		{
-			// Create a top level bucket which holds information
-			// about our node announcement.
-			number:    32,
-			migration: mig.CreateTLB(nodeAnnouncementBucket),
-		},
 	}
 
 	// optionalVersions stores all optional migrations that are applied

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -286,6 +286,12 @@ var (
 			number:    31,
 			migration: migration31.DeleteLastPublishedTxTLB,
 		},
+		{
+			// Create a top level bucket which holds information
+			// about our node announcement.
+			number:    32,
+			migration: mig.CreateTLB(nodeAnnouncementBucket),
+		},
 	}
 
 	// optionalVersions stores all optional migrations that are applied
@@ -520,9 +526,6 @@ type ChannelStateDB struct {
 	// linkNodeDB separates all DB operations on LinkNodes.
 	linkNodeDB *LinkNodeDB
 
-	// nodeAnnouncementDB seperates all DB operations on NodeAnnouncements.
-	nodeAnnouncementDb *NodeAnnouncementDB
-
 	// parent holds a pointer to the "main" channeldb.DB object. This is
 	// only used for testing and should never be used in production code.
 	// For testing use the ChannelStateDB.GetParentDB() function to retrieve
@@ -544,11 +547,6 @@ func (c *ChannelStateDB) GetParentDB() *DB {
 // LinkNodeDB returns the current instance of the link node database.
 func (c *ChannelStateDB) LinkNodeDB() *LinkNodeDB {
 	return c.linkNodeDB
-}
-
-// nodeAnnouncementDB returns the current instance of the nodeannouncement database.
-func (c *ChannelStateDB) NodeAnnouncemenDB() *NodeAnnouncementDB {
-	return c.nodeAnnouncementDb
 }
 
 // FetchOpenChannels starts a new database transaction and returns all stored

--- a/channeldb/error.go
+++ b/channeldb/error.go
@@ -108,6 +108,16 @@ var (
 	// channel with a channel point that is already present in the
 	// database.
 	ErrChanAlreadyExists = fmt.Errorf("channel already exists")
+
+	// ErrNodeAnnBucketNotFound is returned when the nodeannouncement
+	// bucket hasn't been created yet.
+	ErrNodeAnnBucketNotFound = fmt.Errorf("no node announcement bucket " +
+		"exist")
+
+	// ErrNodeAnnNotFound is returned when we're unable to find the target
+	// node announcement.
+	ErrNodeAnnNotFound = fmt.Errorf("node announcement with target " +
+		"identity not found")
 )
 
 // ErrTooManyExtraOpaqueBytes creates an error which should be returned if the

--- a/channeldb/node.go
+++ b/channeldb/node.go
@@ -1,0 +1,175 @@
+package channeldb
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightningnetwork/lnd/kvdb"
+)
+
+var (
+	// nodeAnnouncementBucket stores announcement config pertaining to node.
+	// This bucket allows one to query for persisted node announcement
+	// config and use it when starting orrestarting a node
+	nodeAnnouncementBucket = []byte("nab")
+)
+
+type NodeAnnouncement struct {
+	// Alias indicate the human readable name that a node operator can
+	// assign to their node for better readability and easier identification
+	Alias string
+
+	// Color represent the hexadecimal value that node operators can assign
+	// to their nodes. It's represented as a hex string.
+	Color string
+
+	// IdentityPub is the node's current identity public key. Any
+	// channel/topology related information received by this node MUST be
+	// signed by this public key.
+	IdentityPub *btcec.PublicKey
+
+	db *NodeAnnouncementDB
+}
+
+type NodeAnnouncementDB struct {
+	backend kvdb.Backend
+}
+
+func NewNodeAnnouncement(db *NodeAnnouncementDB, identityPub *btcec.PublicKey, alias, color string) *NodeAnnouncement {
+
+	return &NodeAnnouncement{
+		Alias:       alias,
+		IdentityPub: identityPub,
+		Color:       color,
+		db:          db,
+	}
+}
+
+// FetchNodeAnnouncement attempts to lookup the data for NodeAnnouncement based
+// on a target identity public key. If a particular NodeAnnouncement for the
+// passed identity public key cannot be found, then returns ErrNodeAnnNotFound
+func (l *NodeAnnouncementDB) FetchNodeAnnouncement(identity *btcec.PublicKey) (*NodeAnnouncement, error) {
+	var nodeAnnouncement *NodeAnnouncement
+	err := kvdb.View(l.backend, func(tx kvdb.RTx) error {
+		nodeAnn, err := fetchNodeAnnouncement(tx, identity)
+		if err != nil {
+			return err
+		}
+
+		nodeAnnouncement = nodeAnn
+		return nil
+	}, func() {
+		nodeAnnouncement = nil
+	})
+
+	return nodeAnnouncement, err
+}
+
+func fetchNodeAnnouncement(tx kvdb.RTx, targetPub *btcec.PublicKey) (*NodeAnnouncement, error) {
+	// First fetch the bucket for storing node announcement, bailing out
+	// early if it hasn't been created yet.
+	nodeAnnBucket := tx.ReadBucket(nodeAnnouncementBucket)
+	if nodeAnnBucket == nil {
+		return nil, ErrNodeAnnBucketNotFound
+	}
+
+	// If a node announcement for that particular public key cannot be
+	// located, then exit early with ErrNodeAnnNotFound
+	pubkey := targetPub.SerializeCompressed()
+	nodeAnnBytes := nodeAnnBucket.Get(pubkey)
+	if nodeAnnBytes == nil {
+		return nil, ErrNodeAnnNotFound
+	}
+
+	// FInally, decode and allocate a fresh NodeAnnouncement object to be
+	// returned to the caller
+	nodeAnnReader := bytes.NewReader(nodeAnnBytes)
+	return deserializeNodeAnnouncement(nodeAnnReader)
+
+}
+
+func (n *NodeAnnouncement) PutNodeAnnouncement(pubkey *btcec.PublicKey, alias, color string) error {
+	nodeAnn := NewNodeAnnouncement(n.db, pubkey, alias, color)
+
+	return kvdb.Update(n.db.backend, func(tx kvdb.RwTx) error {
+		nodeAnnBucket := tx.ReadWriteBucket(nodeAnnouncementBucket)
+		if nodeAnnBucket == nil {
+			_, err := tx.CreateTopLevelBucket(nodeAnnouncementBucket)
+			if err != nil {
+				return err
+			}
+
+			nodeAnnBucket = tx.ReadWriteBucket(nodeAnnouncementBucket)
+			if nodeAnnBucket == nil {
+				return ErrNodeAnnBucketNotFound
+			}
+		}
+
+		return putNodeAnnouncement(nodeAnnBucket, nodeAnn)
+	}, func() {})
+}
+
+func putNodeAnnouncement(nodeAnnBucket kvdb.RwBucket, n *NodeAnnouncement) error {
+	// First serialize the NodeAnnouncement into raw-bytes encoding.
+	var b bytes.Buffer
+	if err := serializeNodeAnnouncement(&b, n); err != nil {
+		return err
+	}
+
+	// Finally insert the link-node into the node metadata bucket keyed
+	// according to the its pubkey serialized in compressed form.
+	nodePub := n.IdentityPub.SerializeCompressed()
+	return nodeAnnBucket.Put(nodePub, b.Bytes())
+}
+
+func serializeNodeAnnouncement(w io.Writer, n *NodeAnnouncement) error {
+	// Serialize Alias
+	if _, err := w.Write([]byte(n.Alias + "\x00")); err != nil {
+		return err
+	}
+
+	// Serialize Color
+	if _, err := w.Write([]byte(n.Color + "\x00")); err != nil {
+		return err
+	}
+
+	// Serialize IdentityPub
+	serializedID := n.IdentityPub.SerializeCompressed()
+	if _, err := w.Write(serializedID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func deserializeNodeAnnouncement(r io.Reader) (*NodeAnnouncement, error) {
+	var err error
+	nodeAnn := &NodeAnnouncement{}
+
+	// Read Alias
+	aliasBuf := make([]byte, 32)
+	if _, err := io.ReadFull(r, aliasBuf); err != nil {
+		return nil, err
+	}
+	nodeAnn.Alias = string(bytes.TrimRight(aliasBuf, "\x00"))
+
+	// Read Color
+	colorBuf := make([]byte, 8)
+	if _, err := io.ReadFull(r, colorBuf); err != nil {
+		return nil, err
+	}
+	nodeAnn.Color = string(bytes.TrimRight(colorBuf, "\x00"))
+
+	var pub [33]byte
+	if _, err := io.ReadFull(r, pub[:]); err != nil {
+		return nil, err
+	}
+	nodeAnn.IdentityPub, err = btcec.ParsePubKey(pub[:])
+	if err != nil {
+		return nil, err
+	}
+
+	return nodeAnn, err
+
+}

--- a/channeldb/node.go
+++ b/channeldb/node.go
@@ -40,6 +40,19 @@ type NodeAnnouncement struct {
 	NodeID [33]byte
 }
 
+// Sync performs a full database sync which writes the current up-to-date data
+// within the struct to the database.
+func (n *NodeAnnouncement) Sync(db *DB) error {
+	return kvdb.Update(db, func(tx kvdb.RwTx) error {
+		nodeAnnBucket := tx.ReadWriteBucket(nodeAnnouncementBucket)
+		if nodeAnnBucket == nil {
+			return ErrNodeAnnBucketNotFound
+		}
+
+		return putNodeAnnouncement(nodeAnnBucket, n)
+	}, func() {})
+}
+
 // FetchNodeAnnouncement attempts to lookup the data for NodeAnnouncement based
 // on a target identity public key. If a particular NodeAnnouncement for the
 // passed identity public key cannot be found, then returns ErrNodeAnnNotFound

--- a/channeldb/node_test.go
+++ b/channeldb/node_test.go
@@ -1,0 +1,52 @@
+package channeldb
+
+import (
+	"image/color"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeAnnouncementEncodeDecode(t *testing.T) {
+	t.Parallel()
+
+	fullDB, err := MakeTestDB(t)
+	require.NoError(t, err, "unable to make test database")
+
+	// We'll start by creating initial data to use for populating our test
+	// node announcement instance
+	var alias [32]byte
+	copy(alias[:], []byte("alice"))
+	color := color.RGBA{255, 255, 255, 0}
+	_, pub := btcec.PrivKeyFromBytes(key[:])
+
+	nodeAnn := &NodeAnnouncement{
+		Alias:  alias,
+		Color:  color,
+		NodeID: [33]byte(pub.SerializeCompressed()),
+	}
+	if err := nodeAnn.Sync(fullDB); err != nil {
+		t.Fatalf("unable to sync node announcement: %v", err)
+	}
+
+	// Fetch the current node announcement from the database, it should
+	// match the one we just persisted
+	persistedNodeAnn, err := fullDB.FetchNodeAnnouncement(pub)
+	require.NoError(t, err, "unable to fetch node announcement")
+	if nodeAnn.Alias != persistedNodeAnn.Alias {
+		t.Fatalf("node aliases don't match: expected %v, got %v",
+			nodeAnn.Alias.String(), persistedNodeAnn.Alias.String())
+	}
+
+	if nodeAnn.Color != persistedNodeAnn.Color {
+		t.Fatalf("node colors don't match: expected %v, got %v",
+			nodeAnn.Color, persistedNodeAnn.Color)
+	}
+
+	if nodeAnn.NodeID != persistedNodeAnn.NodeID {
+		t.Fatalf("node nodeIds don't match: expected %v, got %v",
+			nodeAnn.NodeID, persistedNodeAnn.NodeID)
+	}
+
+}

--- a/lnrpc/peersrpc/config_active.go
+++ b/lnrpc/peersrpc/config_active.go
@@ -6,6 +6,7 @@ package peersrpc
 import (
 	"net"
 
+	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/netann"
 )
@@ -29,4 +30,6 @@ type Config struct {
 	// vector should be provided.
 	UpdateNodeAnnouncement func(features *lnwire.RawFeatureVector,
 		mods ...netann.NodeAnnModifier) error
+
+	ChanStateDB *channeldb.ChannelStateDB
 }

--- a/lnrpc/peersrpc/peers_server.go
+++ b/lnrpc/peersrpc/peers_server.go
@@ -401,7 +401,7 @@ func (s *Server) UpdateNodeAnnouncement(_ context.Context,
 	nodeAnnouncement := s.cfg.GetNodeAnnouncement()
 	s.cfg.ChanStateDB.GetParentDB().PutNodeAnnouncement(
 		nodeAnnouncement.NodeID, nodeAnnouncement.Alias,
-		nodeAnnouncement.RGBColor)
+		nodeAnnouncement.RGBColor, nodeAnnouncement.Addresses, nodeAnnouncement.Features)
 
 	return resp, nil
 }

--- a/lnrpc/peersrpc/peers_server.go
+++ b/lnrpc/peersrpc/peers_server.go
@@ -398,5 +398,10 @@ func (s *Server) UpdateNodeAnnouncement(_ context.Context,
 		return nil, err
 	}
 
+	nodeAnnouncement := s.cfg.GetNodeAnnouncement()
+	s.cfg.ChanStateDB.GetParentDB().PutNodeAnnouncement(
+		nodeAnnouncement.NodeID, nodeAnnouncement.Alias,
+		nodeAnnouncement.RGBColor)
+
 	return resp, nil
 }

--- a/server.go
+++ b/server.go
@@ -817,6 +817,13 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 	// key.
 	alias := cfg.Alias
 	if alias == "" {
+		pubkey := nodeKeyDesc.PubKey
+		persistedAlias, err := s.miscDB.ChannelStateDB().NodeAnnouncemenDB().FetchNodeAnnouncement(pubkey)
+		if err == nil && persistedAlias.Alias != "" {
+			alias = persistedAlias.Alias
+		}
+	}
+	if alias == "" {
 		alias = hex.EncodeToString(serializedPubKey[:10])
 	}
 	nodeAlias, err := lnwire.NewNodeAlias(alias)

--- a/subrpcserver_config.go
+++ b/subrpcserver_config.go
@@ -332,6 +332,10 @@ func (s *subRPCServerConfigs) PopulateDependencies(cfg *Config,
 				reflect.ValueOf(updateNodeAnnouncement),
 			)
 
+			subCfgValue.FieldByName("ChanStateDB").Set(
+				reflect.ValueOf(chanStateDB),
+			)
+
 		default:
 			return fmt.Errorf("unknown field: %v, %T", fieldName,
 				cfg)


### PR DESCRIPTION
In this commit, we save the node announcement config in the database so that we can retrieve the config later and use it when a node restarts.

closes #7123 

## Change Description
Description of change / link to associated issue.
We start by checking the configuration from the configuration file `lnd.conf` or arguments when the node starts. If the configuration is absent, we check for the ones persisted on disk and use them; otherwise, we resolve to the default settings.

## Steps to Test
Steps for reviewers to follow to test the change.
- Make sure no alias is not set in your `lnd.conf`
- Use the `updatenodeannouncement` RPC call and set something as your alias
- Verify the alias is set using `lncli getinfo`
- Now stop and start the node again and run `lncli getinfo` again
- You'll see that the alias is set to the first 10 characters of the node's pubkey

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
