### PR TITLE
rpc: add default conf target back

### DIFF
--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -342,14 +342,6 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
   add coin selection strategy option to the following on-chain RPC calls
   `EstimateFee`, `SendMany`, `SendCoins`, `BatchOpenChannel`, `SendOutputs`, and `FundPsbt`.
 
-* Previously when callng `SendCoins`, `SendMany`, `OpenChannel` and
-  `CloseChannel` for coop close, it is allowed to specify both an empty
-  `SatPerVbyte` and `TargetConf`, and a default conf target of 6 will be used.
-  This is [no longer allowed](
-  https://github.com/lightningnetwork/lnd/pull/8422) and the caller must
-  specify either `SatPerVbyte` or `TargetConf` so the fee estimator can do a
-  proper fee estimation.
-
 * `BumpFee` has been updated to take advantage of the [new budget-based
   sweeper](https://github.com/lightningnetwork/lnd/pull/8667). The param
   `force` has been deprecated and replaced with a new param `immediate`, and a
@@ -421,6 +413,18 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
   manage the lifecycle of the inputs.
 
 ## Breaking Changes
+
+* Previously when callng `SendCoins`, `SendMany`, `OpenChannel` and
+  `CloseChannel` for coop close, it is allowed to specify both an empty
+  `SatPerVbyte` and `TargetConf`, and a default conf target of 6 will be used.
+  This will [no longer be
+  allowed](https://github.com/lightningnetwork/lnd/pull/8422) in the next
+  release (v0.19.0) and the caller must specify either `SatPerVbyte` or
+  `TargetConf` so the fee estimator can do a proper fee estimation. For current
+  release, [an error will be
+  logged](https://github.com/lightningnetwork/lnd/pull/8693) when no values are
+  specified.
+
 ## Performance Improvements
 
 * Watchtower client DB migration to massively [improve the start-up 

--- a/itest/lnd_misc_test.go
+++ b/itest/lnd_misc_test.go
@@ -815,13 +815,18 @@ func testSweepAllCoins(ht *lntest.HarnessTest) {
 		TargetConf: 6,
 	})
 
+	// TODO(yy): we still allow default values to be used when neither conf
+	// target or fee rate is set in 0.18.0. When future release forbidden
+	// this behavior, we should revive the test below, which asserts either
+	// conf target or fee rate is set.
+	//
 	// Send coins to a compatible address without specifying fee rate or
 	// conf target.
-	ainz.RPC.SendCoinsAssertErr(&lnrpc.SendCoinsRequest{
-		Addr:    ht.Miner.NewMinerAddress().String(),
-		SendAll: true,
-		Label:   sendCoinsLabel,
-	})
+	// ainz.RPC.SendCoinsAssertErr(&lnrpc.SendCoinsRequest{
+	// 	Addr:    ht.Miner.NewMinerAddress().String(),
+	// 	SendAll: true,
+	// 	Label:   sendCoinsLabel,
+	// })
 
 	// Send coins to a compatible address.
 	ainz.RPC.SendCoins(&lnrpc.SendCoinsRequest{

--- a/sweep/walletsweep.go
+++ b/sweep/walletsweep.go
@@ -16,13 +16,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet/chanfunding"
 )
 
-const (
-	// defaultNumBlocksEstimate is the number of blocks that we fall back
-	// to issuing an estimate for if a fee pre fence doesn't specify an
-	// explicit conf target or fee rate.
-	defaultNumBlocksEstimate = 6
-)
-
 var (
 	// ErrNoFeePreference is returned when we attempt to satisfy a sweep
 	// request from a client whom did not specify a fee preference.


### PR DESCRIPTION
The itest has been reverted to test the default behavior.