### PR TITLE
make: add cache directory for linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ DOCKER_TOOLS = docker run \
   --rm \
   -v $(shell bash -c "go env GOCACHE || (mkdir -p /tmp/go-cache; echo /tmp/go-cache)"):/tmp/build/.cache \
   -v $(shell bash -c "go env GOMODCACHE || (mkdir -p /tmp/go-modcache; echo /tmp/go-modcache)"):/tmp/build/.modcache \
+  -v $(shell bash -c "mkdir -p /tmp/go-lint-cache; echo /tmp/go-lint-cache"):/root/.cache/golangci-lint \
   -v $$(pwd):/build lnd-tools
 
 GREEN := "\\033[0;32m"


### PR DESCRIPTION
Mounts a local temporary folder to the linter docker container in order to persist the linter cache across runs.

This may speed up linting, depending on which files are modified, some sample:

* `Execution took 1m9s`: no cache
* `Execution took 55s`: modified `channeldb` package
* `Execution took 24s`: modified `routing` package
* `Execution took 13s`: modified `server.go`
* `Execution took 2s`: no changes

Not sure if the `mkdir` command will interfere with windows setups, or how to circumvent that best?