### PR TITLE
itest/flake: add more comprehensive assertions before HTLC cleared check

### DIFF
--- a/itest/lnd_route_blinding_test.go
+++ b/itest/lnd_route_blinding_test.go
@@ -1018,10 +1018,14 @@ func testErrorHandlingOnChainFailure(ht *lntest.HarnessTest) {
 	// suspended Carol we don't need to account for her commitment output
 	// claim.
 	ht.Miner.MineBlocksAndAssertNumTxes(1, 1)
+	ht.AssertNumPendingSweeps(ht.Bob, 0)
 
 	// Assert that the HTLC has cleared.
-	ht.AssertHTLCNotActive(ht.Alice, testCase.channels[0], hash[:])
+	ht.WaitForBlockchainSync(ht.Bob)
+	ht.WaitForBlockchainSync(ht.Alice)
+
 	ht.AssertHTLCNotActive(ht.Bob, testCase.channels[0], hash[:])
+	ht.AssertHTLCNotActive(ht.Alice, testCase.channels[0], hash[:])
 
 	// Wait for the HTLC to reflect as failed for Alice.
 	paymentStream := ht.Alice.RPC.TrackPaymentV2(hash[:])


### PR DESCRIPTION
In [build](https://github.com/lightningnetwork/lnd/actions/runs/8856782353/job/24323472072), we're failing because we need to wait for an on chain resolution of a htlc timeout to complete _then_ assert that it's been removed from the sender's channels. which takes pretty long. 

This PR adds more checks in between mining the timeout tx and asserting that the htlc is cleared out so that slower machines won't time out. 

```
 === RUN   TestLightningNetworkDaemon/tranche03/145-of-154/neutrino/on_chain_to_blinded
    harness.go:437: finished test: multi_hop_local_force_close_on-chain_htlc_timeout, start height=1716, end height=1759, mined blocks=43
=== RUN   TestLightningNetworkDaemon/tranche00/37-of-154/neutrino/multi_hop_local_force_close_on-chain_htlc_timeout/zeroconf=false/committype=SCRIPT_ENFORCED_LEASE
    harness_assertion.go:1407: 
        	Error Trace:	/home/runner/work/lnd/lnd/lntest/harness_assertion.go:1407
        	            				/home/runner/work/lnd/lnd/itest/lnd_route_blinding_test.go:1023
        	            				/home/runner/work/lnd/lnd/lntest/harness.go:384
        	            				/home/runner/work/lnd/lnd/itest/lnd_test.go:139
        	Error:      	Received unexpected error:
        	            	node [Alice:03c7d66ecb481533a18fba3d10d2a31ac96c6ed834e4f17bdd68f53ebc3f8d5dd1] still has: the payHash 1ac2f192702849e03dfe5c31ec66a4f6408b5eb16cc02f1583ce713b22be92ed
        	Test:       	TestLightningNetworkDaemon/tranche03/145-of-154/neutrino/on_chain_to_blinded
        	Messages:   	timeout checking pending HTLC
    harness.go:437: finished test: on_chain_to_blinded, start height=1607, end height=1695, mined blocks=88
    harness.go:443: test failed, skipped cleanup
```