### PR TITLE
invoices: if there are no invoices make gc noop

### DIFF
--- a/channeldb/invoices.go
+++ b/channeldb/invoices.go
@@ -2139,14 +2139,14 @@ func (d *DB) DeleteCanceledInvoices(_ context.Context) error {
 			invoiceIndexBucket,
 		)
 		if invoiceIndex == nil {
-			return invpkg.ErrNoInvoicesCreated
+			return nil
 		}
 
 		invoiceAddIndex := invoices.NestedReadWriteBucket(
 			addIndexBucket,
 		)
 		if invoiceAddIndex == nil {
-			return invpkg.ErrNoInvoicesCreated
+			return nil
 		}
 
 		payAddrIndex := tx.ReadWriteBucket(payAddrIndexBucket)

--- a/invoices/invoices_test.go
+++ b/invoices/invoices_test.go
@@ -2681,8 +2681,11 @@ func testDeleteCanceledInvoices(t *testing.T,
 		}, nil
 	}
 
-	// Add some invoices to the test db.
+	// Test deletion of canceled invoices when there are none.
 	ctxb := context.Background()
+	require.NoError(t, db.DeleteCanceledInvoices(ctxb))
+
+	// Add some invoices to the test db.
 	var invoices []invpkg.Invoice
 	for i := 0; i < 10; i++ {
 		invoice, err := randInvoice(lnwire.MilliSatoshi(i + 1))


### PR DESCRIPTION
## Change Description
In 0.18 we no longer check the pending invoices for deletion count. This will cause a failure to start in LND. This fixes it by making a noop in the `DeleteCanceledInvoices` func.

## Steps to Test
1. Startup lnd node with no invoices and `gc-canceled-invoices-on-startup=true`

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
