### PR TITLE
mutil: introduce simple `BlockBeat` to fix itest flakes

### DIFF
--- a/chainio/blockbeat.go
+++ b/chainio/blockbeat.go
@@ -1,0 +1,262 @@
+package chainio
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/lightningnetwork/lnd/fn"
+)
+
+// DefaultProcessBlockTimeout is the timeout value used when waiting for one
+// consumer to finish processing the new block epoch.
+var DefaultProcessBlockTimeout = 30 * time.Second
+
+// Consumer defines a blockbeat consumer interface. Subsystems that need block
+// info should implement it.
+type Consumer interface {
+	// Name returns a human-readable string for this subsystem.
+	Name() string
+
+	// ProcessBlock takes a beat and processes it. A receive-only error
+	// chan must be returned.
+	//
+	// NOTE: When implementing this, it's very important to send back the
+	// error or nil to the channel immediately, otherwise BlockBeat will
+	// timeout and lnd will shutdown.
+	ProcessBlock(b Beat) <-chan error
+}
+
+// Beat contains the block epoch and a buffer error chan.
+//
+// TODO(yy): extend this to check for confirmation status - which serves as the
+// single source of truth, to avoid the potential race between receiving blocks
+// and `GetTransactionDetails/RegisterSpendNtfn/RegisterConfirmationsNtfn`.
+type Beat struct {
+	// Epoch is the current block epoch the blockbeat is aware of.
+	Epoch chainntnfs.BlockEpoch
+
+	// Err is a buffered chan that receives an error or nil from
+	// ProcessBlock.
+	Err chan error
+}
+
+// NewBeat creates a new beat with the specified block epoch and a buffered
+// error chan.
+func NewBeat(epoch chainntnfs.BlockEpoch) Beat {
+	return Beat{
+		Epoch: epoch,
+		Err:   make(chan error, 1),
+	}
+}
+
+// BlockBeat is a service that handles dispatching new blocks to `lnd`'s
+// subsystems. During startup, subsystems that are block-driven should
+// implement the `Consumer` interface and register themselves via
+// `RegisterQueue`. When two subsystems are independent of each other, they
+// should be registered in differet queues so blocks are notified concurrently.
+// Otherwise, when living in the same queue, the subsystems are notified of the
+// new blocks sequentially, which means it's critical to understand the
+// relationship of these systems to properly handle the order.
+type BlockBeat struct {
+	wg sync.WaitGroup
+
+	// notifier is used to receive new block epochs.
+	notifier chainntnfs.ChainNotifier
+
+	// blockEpoch is the latest block epoch received .
+	blockEpoch chainntnfs.BlockEpoch
+
+	// consumerQueues is a map of consumers that will receive blocks. Each
+	// queue is notified concurrently, and consumers in the same queue is
+	// notified sequentially.
+	consumerQueues map[uint32][]Consumer
+
+	// counter is used to assign a unique id to each queue.
+	counter atomic.Uint32
+
+	// quit is used to signal the BlockBeat to stop.
+	quit chan struct{}
+}
+
+// NewBlockBeat returns a new blockbeat instance.
+func NewBlockBeat(notifier chainntnfs.ChainNotifier) *BlockBeat {
+	return &BlockBeat{
+		notifier:       notifier,
+		quit:           make(chan struct{}),
+		consumerQueues: make(map[uint32][]Consumer),
+	}
+}
+
+// RegisterQueue takes a list of consumers and register them in the same queue.
+//
+// NOTE: these consumers are notified sequentially.
+func (b *BlockBeat) RegisterQueue(consumers []Consumer) {
+	qid := b.counter.Add(1)
+
+	b.consumerQueues[qid] = append(b.consumerQueues[qid], consumers...)
+	log.Infof("Registered queue=%d with %d blockbeat consumers", qid,
+		len(consumers))
+
+	for _, c := range consumers {
+		log.Debugf("Consumer [%s] registered in queue %d", c.Name(),
+			qid)
+	}
+}
+
+// Start starts the blockbeat - it registers a block notification and monitors
+// and dispatches new blocks in a goroutine. It will refuse to start if there
+// are no registered consumers.
+func (b *BlockBeat) Start() error {
+	// Make sure consumers are registered.
+	if len(b.consumerQueues) == 0 {
+		return fmt.Errorf("no consumers registered")
+	}
+
+	// Start listening to new block epochs.
+	blockEpochs, err := b.notifier.RegisterBlockEpochNtfn(nil)
+	if err != nil {
+		return fmt.Errorf("register block epoch ntfn: %w", err)
+	}
+
+	log.Infof("BlockBeat is starting with %d consumer queues",
+		len(b.consumerQueues))
+	defer log.Debug("BlockBeat started")
+
+	b.wg.Add(1)
+	go b.dispatchBlocks(blockEpochs)
+
+	return nil
+}
+
+// Stop shuts down the blockbeat.
+func (b *BlockBeat) Stop() {
+	log.Info("BlockBeat is stopping")
+	defer log.Debug("BlockBeat stopped")
+
+	// Signal the dispatchBlocks goroutine to stop.
+	close(b.quit)
+	b.wg.Wait()
+}
+
+// dispatchBlocks listens to new block epoch and dispatches it to all the
+// consumers. Each queue in BlockBeat is notified concurrently, and the
+// consumers in the same queue are notified sequentially.
+func (b *BlockBeat) dispatchBlocks(blockEpochs *chainntnfs.BlockEpochEvent) {
+	defer b.wg.Done()
+	defer blockEpochs.Cancel()
+
+	for {
+		select {
+		case blockEpoch, ok := <-blockEpochs.Epochs:
+			if !ok {
+				log.Debugf("Block epoch channel closed")
+				return
+			}
+
+			log.Infof("Received new block %v at height %d, "+
+				"notifying consumers...", blockEpoch.Hash,
+				blockEpoch.Height)
+
+			// Update the current block epoch.
+			b.blockEpoch = *blockEpoch
+
+			// Notify all consumers.
+			b.notifyQueues()
+
+			log.Infof("Notified all consumers on block %v at "+
+				"height %d", blockEpoch.Hash, blockEpoch.Height)
+
+		case <-b.quit:
+			log.Debugf("BlockBeat quit signal received")
+			return
+		}
+	}
+}
+
+// notifyQueues notifies each queue concurrently about the latest block epoch.
+func (b *BlockBeat) notifyQueues() {
+	// errChans is a map of channels that will be used to receive errors
+	// returned from notifying the consumers.
+	errChans := make(map[uint32]chan error, len(b.consumerQueues))
+
+	// Notify each queue in goroutines.
+	for qid, consumers := range b.consumerQueues {
+		log.Debugf("Notifying queue=%d on block %d", qid,
+			b.blockEpoch.Height)
+
+		// Create a signal chan.
+		errChan := make(chan error)
+		errChans[qid] = errChan
+
+		// Notify each queue concurrently.
+		b.wg.Add(1)
+		go func(qid uint32, c []Consumer,
+			epoch chainntnfs.BlockEpoch) {
+
+			defer b.wg.Done()
+
+			// Notify each consumer in this queue sequentially.
+			errChan <- b.notifyQueue(c, epoch)
+		}(qid, consumers, b.blockEpoch)
+	}
+
+	// Wait for all consumers in each queue to finish.
+	for qid, errChan := range errChans {
+		select {
+		case err := <-errChan:
+			// It's critical that the subsystems can process blocks
+			// correctly and timely, if an error returns, we'd
+			// gracefully shutdown lnd to bring attentions.
+			if err != nil {
+				log.Criticalf("Queue=%d failed to process "+
+					"block: %v", qid, err)
+
+				return
+			}
+
+			log.Debugf("Notified queue=%d on block %d", qid,
+				b.blockEpoch.Height)
+
+		case <-b.quit:
+		}
+	}
+}
+
+// notifyQueue takes a list of consumers and notify them about the new epoch
+// sequentially.
+func (b *BlockBeat) notifyQueue(queue []Consumer,
+	epoch chainntnfs.BlockEpoch) error {
+
+	for _, c := range queue {
+		log.Debugf("Notifying consumer [%s] on block %d", c.Name(),
+			epoch.Height)
+
+		// Construct a new beat with a buffered error chan.
+		beat := NewBeat(epoch)
+
+		// Record the time it takes the consumer to process this block.
+		start := time.Now()
+
+		// We expect the consumer to finish processing this block under
+		// 30s, otherwise a timeout error is returned.
+		err, timeout := fn.RecvOrTimeout(
+			c.ProcessBlock(beat), DefaultProcessBlockTimeout,
+		)
+		if err != nil {
+			return fmt.Errorf("%s: ProcessBlock got: %w", c.Name(),
+				err)
+		}
+		if timeout != nil {
+			return fmt.Errorf("%s timed out while processing block",
+				c.Name())
+		}
+
+		log.Debugf("Consumer [%s] processed block %d in %v", c.Name(),
+			epoch.Height, time.Since(start))
+	}
+
+	return nil
+}

--- a/chainio/blockbeat_test.go
+++ b/chainio/blockbeat_test.go
@@ -1,0 +1,1 @@
+package chainio

--- a/chainio/log.go
+++ b/chainio/log.go
@@ -1,0 +1,29 @@
+package chainio
+
+import (
+	"github.com/btcsuite/btclog"
+	"github.com/lightningnetwork/lnd/build"
+)
+
+// log is a logger that is initialized with no output filters.  This
+// means the package will not perform any logging by default until the caller
+// requests it.
+var log btclog.Logger
+
+// The default amount of logging is none.
+func init() {
+	UseLogger(build.NewSubLogger("CHIO", nil))
+}
+
+// DisableLog disables all library log output.  Logging output is disabled
+// by default until UseLogger is called.
+func DisableLog() {
+	UseLogger(btclog.Disabled)
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+// This should be used in preference to SetLogWriter if the caller is also
+// using btclog.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/chainntnfs/best_block_view.go
+++ b/chainntnfs/best_block_view.go
@@ -68,7 +68,7 @@ func (t *BestBlockTracker) BestBlockHeader() (*wire.BlockHeader, error) {
 		return nil, errors.New("best block header not yet known")
 	}
 
-	return epoch.BlockHeader, nil
+	return &epoch.Block.Header, nil
 }
 
 // updateLoop is a helper that subscribes to the underlying BlockEpochEvent

--- a/chainntnfs/best_block_view_test.go
+++ b/chainntnfs/best_block_view_test.go
@@ -26,14 +26,15 @@ func (blockEpoch) Generate(r *rand.Rand, size int) reflect.Value {
 	return reflect.ValueOf(blockEpoch(chainntnfs.BlockEpoch{
 		Hash:   &chainHash,
 		Height: r.Int31n(1000000),
-		BlockHeader: &wire.BlockHeader{
-			Version:    2,
-			PrevBlock:  prevBlockHash,
-			MerkleRoot: merkleRootHash,
-			Timestamp:  time.Now(),
-			Bits:       r.Uint32(),
-			Nonce:      r.Uint32(),
-		},
+		Block: wire.MsgBlock{
+			Header: wire.BlockHeader{
+				Version:    2,
+				PrevBlock:  prevBlockHash,
+				MerkleRoot: merkleRootHash,
+				Timestamp:  time.Now(),
+				Bits:       r.Uint32(),
+				Nonce:      r.Uint32(),
+			}},
 	}))
 }
 
@@ -77,7 +78,7 @@ func TestBestBlockTracker(t *testing.T) {
 		header, _ := tracker.BestBlockHeader()
 
 		return height == uint32(epoch.Height) &&
-			header == epoch.BlockHeader
+			*header == epoch.Block.Header
 	}
 	idempotence := func(epochRand blockEpoch) bool {
 		epoch := chainntnfs.BlockEpoch(epochRand)

--- a/chainntnfs/test/test_interface.go
+++ b/chainntnfs/test/test_interface.go
@@ -410,17 +410,14 @@ func testBlockEpochNotification(miner *rpctest.Harness,
 				// and that header matches the contained header
 				// hash.
 				blockEpoch := <-epochClient.Epochs
-				if blockEpoch.BlockHeader == nil {
-					t.Logf("%d", i)
-					clientErrors <- fmt.Errorf("block " +
-						"header is nil")
-					return
-				}
-				if blockEpoch.BlockHeader.BlockHash() !=
-					*blockEpoch.Hash {
+				t.Logf("%d", i)
 
-					clientErrors <- fmt.Errorf("block " +
-						"header hash mismatch")
+				got := blockEpoch.Block.Header.BlockHash()
+				want := *blockEpoch.Hash
+				if got != want {
+					clientErrors <- fmt.Errorf("block "+
+						"header hash mismatch: "+
+						"want=%v, got=%v", want, got)
 					return
 				}
 

--- a/config_builder.go
+++ b/config_builder.go
@@ -629,8 +629,7 @@ func proxyBlockEpoch(notifier chainntnfs.ChainNotifier,
 		go func() {
 			for blk := range blockEpoch.Epochs {
 				ntfn := blockntfns.NewBlockConnected(
-					*blk.BlockHeader,
-					uint32(blk.Height),
+					blk.Block.Header, uint32(blk.Height),
 				)
 
 				sub.Notifications <- ntfn

--- a/contractcourt/anchor_resolver.go
+++ b/contractcourt/anchor_resolver.go
@@ -84,9 +84,7 @@ func (c *anchorResolver) ResolverKey() []byte {
 }
 
 // Resolve offers the anchor output to the sweeper and waits for it to be swept.
-func (c *anchorResolver) Resolve(_ bool,
-	_ <-chan int32) (ContractResolver, error) {
-
+func (c *anchorResolver) Resolve(_ <-chan int32) (ContractResolver, error) {
 	// Attempt to update the sweep parameters to the post-confirmation
 	// situation. We don't want to force sweep anymore, because the anchor
 	// lost its special purpose to get the commitment confirmed. It is just

--- a/contractcourt/anchor_resolver.go
+++ b/contractcourt/anchor_resolver.go
@@ -84,7 +84,9 @@ func (c *anchorResolver) ResolverKey() []byte {
 }
 
 // Resolve offers the anchor output to the sweeper and waits for it to be swept.
-func (c *anchorResolver) Resolve(_ bool) (ContractResolver, error) {
+func (c *anchorResolver) Resolve(_ bool,
+	_ <-chan int32) (ContractResolver, error) {
+
 	// Attempt to update the sweep parameters to the post-confirmation
 	// situation. We don't want to force sweep anymore, because the anchor
 	// lost its special purpose to get the commitment confirmed. It is just

--- a/contractcourt/breach_resolver.go
+++ b/contractcourt/breach_resolver.go
@@ -47,9 +47,7 @@ func (b *breachResolver) ResolverKey() []byte {
 // been broadcast.
 //
 // TODO(yy): let sweeper handle the breach inputs.
-func (b *breachResolver) Resolve(_ bool,
-	_ <-chan int32) (ContractResolver, error) {
-
+func (b *breachResolver) Resolve(_ <-chan int32) (ContractResolver, error) {
 	if !b.subscribed {
 		complete, err := b.SubscribeBreachComplete(
 			&b.ChanPoint, b.replyChan,

--- a/contractcourt/breach_resolver.go
+++ b/contractcourt/breach_resolver.go
@@ -47,7 +47,9 @@ func (b *breachResolver) ResolverKey() []byte {
 // been broadcast.
 //
 // TODO(yy): let sweeper handle the breach inputs.
-func (b *breachResolver) Resolve(_ bool) (ContractResolver, error) {
+func (b *breachResolver) Resolve(_ bool,
+	_ <-chan int32) (ContractResolver, error) {
+
 	if !b.subscribed {
 		complete, err := b.SubscribeBreachComplete(
 			&b.ChanPoint, b.replyChan,

--- a/contractcourt/chain_arbitrator_test.go
+++ b/contractcourt/chain_arbitrator_test.go
@@ -80,7 +80,6 @@ func TestChainArbitratorRepublishCloses(t *testing.T) {
 		ChainIO: &mock.ChainIO{},
 		Notifier: &mock.ChainNotifier{
 			SpendChan: make(chan *chainntnfs.SpendDetail),
-			EpochChan: make(chan *chainntnfs.BlockEpoch),
 			ConfChan:  make(chan *chainntnfs.TxConfirmation),
 		},
 		PublishTx: func(tx *wire.MsgTx, _ string) error {
@@ -165,7 +164,6 @@ func TestResolveContract(t *testing.T) {
 		ChainIO: &mock.ChainIO{},
 		Notifier: &mock.ChainNotifier{
 			SpendChan: make(chan *chainntnfs.SpendDetail),
-			EpochChan: make(chan *chainntnfs.BlockEpoch),
 			ConfChan:  make(chan *chainntnfs.TxConfirmation),
 		},
 		PublishTx: func(tx *wire.MsgTx, _ string) error {

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -413,6 +413,9 @@ func NewChannelArbitrator(cfg ChannelArbitratorConfig,
 	}
 }
 
+// Compile-time check for the WebFeeService interface.
+var _ chainio.Consumer = (*ChannelArbitrator)(nil)
+
 // chanArbStartState contains the information from disk that we need to start
 // up a channel arbitrator.
 type chanArbStartState struct {
@@ -3194,9 +3197,11 @@ func (c *ChannelArbitrator) handleBlockbeat(beat chainio.Beat) error {
 	return nil
 }
 
-// processBlock sends the specified blockbeat to the channel arbitrator's inner
+// ProcessBlock sends the specified blockbeat to the channel arbitrator's inner
 // loop for processing.
-func (c *ChannelArbitrator) processBlock(beat chainio.Beat) <-chan error {
+//
+// NOTE: Part of chainio.Consumer interface.
+func (c *ChannelArbitrator) ProcessBlock(beat chainio.Beat) <-chan error {
 	select {
 	case c.blockBeatChan <- beat:
 		log.Debugf("Received block beat for height=%d",
@@ -3207,6 +3212,13 @@ func (c *ChannelArbitrator) processBlock(beat chainio.Beat) <-chan error {
 	}
 
 	return beat.Err
+}
+
+// Name returns a human-readable string for this subsystem.
+//
+// NOTE: Part of chainio.Consumer interface.
+func (c *ChannelArbitrator) Name() string {
+	return fmt.Sprint("ChannelArbitrator(%v)", c.cfg.ChanPoint)
 }
 
 // checkLegacyBreach returns StateFullyResolved if the channel was closed with

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1593,7 +1593,7 @@ func (c *ChannelArbitrator) launchResolvers(resolvers []ContractResolver,
 		blockChan := make(chan int32, arbitratorBlockBufferSize)
 		c.activeResolvers[contract] = blockChan
 
-		go c.resolveContract(contract, immediate)
+		go c.resolveContract(contract, blockChan, immediate)
 	}
 }
 
@@ -2607,7 +2607,7 @@ func (c *ChannelArbitrator) replaceResolver(oldResolver,
 //
 // NOTE: This MUST be run as a goroutine.
 func (c *ChannelArbitrator) resolveContract(currentContract ContractResolver,
-	immediate bool) {
+	blockChan <-chan int32, immediate bool) {
 
 	defer c.wg.Done()
 
@@ -2629,7 +2629,9 @@ func (c *ChannelArbitrator) resolveContract(currentContract ContractResolver,
 		default:
 			// Otherwise, we'll attempt to resolve the current
 			// contract.
-			nextContract, err := currentContract.Resolve(immediate)
+			nextContract, err := currentContract.Resolve(
+				immediate, blockChan,
+			)
 			if err != nil {
 				if err == errResolverShuttingDown {
 					return

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1615,8 +1615,8 @@ func (c *ChannelArbitrator) advanceState(
 	for {
 		priorState = c.state
 		log.Debugf("ChannelArbitrator(%v): attempting state step with "+
-			"trigger=%v from state=%v", c.cfg.ChanPoint, trigger,
-			priorState)
+			"trigger=%v from state=%v at height=%v",
+			c.cfg.ChanPoint, trigger, priorState, triggerHeight)
 
 		nextState, closeTx, err := c.stateStep(
 			triggerHeight, trigger, confCommitSet,
@@ -2880,15 +2880,17 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 		// We have broadcasted our commitment, and it is now confirmed
 		// on-chain.
 		case closeInfo := <-c.cfg.ChainEvents.LocalUnilateralClosure:
-			log.Infof("ChannelArbitrator(%v): local on-chain "+
-				"channel close", c.cfg.ChanPoint)
-
 			if c.state != StateCommitmentBroadcasted {
 				log.Errorf("ChannelArbitrator(%v): unexpected "+
 					"local on-chain channel close",
 					c.cfg.ChanPoint)
 			}
+
 			closeTx := closeInfo.CloseTx
+
+			log.Infof("ChannelArbitrator(%v): local force close "+
+				"tx=%v confirmed", c.cfg.ChanPoint,
+				closeTx.TxHash())
 
 			contractRes := &ContractResolutions{
 				CommitHash:       closeTx.TxHash(),

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -359,7 +359,6 @@ func createTestChannelArbitrator(t *testing.T, log ArbitratorLog,
 		OutgoingBroadcastDelta: 5,
 		IncomingBroadcastDelta: 5,
 		Notifier: &mock.ChainNotifier{
-			EpochChan: make(chan *chainntnfs.BlockEpoch),
 			SpendChan: make(chan *chainntnfs.SpendDetail),
 			ConfChan:  make(chan *chainntnfs.TxConfirmation),
 		},
@@ -1068,12 +1067,10 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 	}
 
 	// Send a notification that the expiry height has been reached.
-	oldNotifier.EpochChan <- &chainntnfs.BlockEpoch{Height: 10}
-
 	beat := chainio.NewBeat(chainntnfs.BlockEpoch{
 		Height: 10,
 	})
-	chanArbCtx.chanArb.blockBeatChan <- beat
+	chanArb.blockBeatChan <- beat
 
 	// htlcOutgoingContestResolver is now transforming into a
 	// htlcTimeoutResolver and should send the contract off for incubation.

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/chainio"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/channeldb/models"
@@ -1065,6 +1066,11 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 	// Send a notification that the expiry height has been reached.
 	oldNotifier.EpochChan <- &chainntnfs.BlockEpoch{Height: 10}
 
+	beat := chainio.NewBeat(chainntnfs.BlockEpoch{
+		Height: 10,
+	})
+	chanArbCtx.chanArb.blockBeatChan <- beat
+
 	// htlcOutgoingContestResolver is now transforming into a
 	// htlcTimeoutResolver and should send the contract off for incubation.
 	select {
@@ -1900,7 +1906,10 @@ func TestChannelArbitratorDanglingCommitForceClose(t *testing.T) {
 			// now mine a block (height 5), which is 5 blocks away
 			// (our grace delta) from the expiry of that HTLC.
 			case testCase.htlcExpired:
-				chanArbCtx.chanArb.blocks <- 5
+				beat := chainio.NewBeat(chainntnfs.BlockEpoch{
+					Height: 5,
+				})
+				chanArbCtx.chanArb.blockBeatChan <- beat
 
 			// Otherwise, we'll just trigger a regular force close
 			// request.
@@ -2004,7 +2013,10 @@ func TestChannelArbitratorDanglingCommitForceClose(t *testing.T) {
 			// so instead, we'll mine another block which'll cause
 			// it to re-examine its state and realize there're no
 			// more HTLCs.
-			chanArbCtx.chanArb.blocks <- 6
+			beat := chainio.NewBeat(chainntnfs.BlockEpoch{
+				Height: 6,
+			})
+			chanArbCtx.chanArb.blockBeatChan <- beat
 			chanArbCtx.AssertStateTransitions(StateFullyResolved)
 		})
 	}
@@ -2076,13 +2088,19 @@ func TestChannelArbitratorPendingExpiredHTLC(t *testing.T) {
 	// We will advance the uptime to 10 seconds which should be still within
 	// the grace period and should not trigger going to chain.
 	testClock.SetTime(startTime.Add(time.Second * 10))
-	chanArbCtx.chanArb.blocks <- 5
+	beat := chainio.NewBeat(chainntnfs.BlockEpoch{
+		Height: 5,
+	})
+	chanArbCtx.chanArb.blockBeatChan <- beat
 	chanArbCtx.AssertState(StateDefault)
 
 	// We will advance the uptime to 16 seconds which should trigger going
 	// to chain.
 	testClock.SetTime(startTime.Add(time.Second * 16))
-	chanArbCtx.chanArb.blocks <- 6
+	beat = chainio.NewBeat(chainntnfs.BlockEpoch{
+		Height: 6,
+	})
+	chanArbCtx.chanArb.blockBeatChan <- beat
 	chanArbCtx.AssertStateTransitions(
 		StateBroadcastCommit,
 		StateCommitmentBroadcasted,
@@ -2450,7 +2468,10 @@ func TestSweepAnchors(t *testing.T) {
 
 	// Set current block height.
 	heightHint := uint32(1000)
-	chanArbCtx.chanArb.blocks <- int32(heightHint)
+	beat := chainio.NewBeat(chainntnfs.BlockEpoch{
+		Height: int32(heightHint),
+	})
+	chanArbCtx.chanArb.blockBeatChan <- beat
 
 	htlcIndexBase := uint64(99)
 	deadlineDelta := uint32(10)
@@ -2651,7 +2672,10 @@ func TestChannelArbitratorAnchors(t *testing.T) {
 
 	// Set current block height.
 	heightHint := uint32(1000)
-	chanArbCtx.chanArb.blocks <- int32(heightHint)
+	beat := chainio.NewBeat(chainntnfs.BlockEpoch{
+		Height: int32(heightHint),
+	})
+	chanArbCtx.chanArb.blockBeatChan <- beat
 
 	htlcAmt := lnwire.MilliSatoshi(1_000_000)
 

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -809,7 +809,7 @@ func TestChannelArbitratorBreachClose(t *testing.T) {
 	require.Equal(t, 2, len(chanArb.activeResolvers))
 
 	var anchorExists, breachExists bool
-	for _, resolver := range chanArb.activeResolvers {
+	for resolver := range chanArb.activeResolvers {
 		switch resolver.(type) {
 		case *anchorResolver:
 			anchorExists = true
@@ -1040,9 +1040,13 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 			len(chanArb.activeResolvers))
 	}
 
+	var resolver ContractResolver
+	for r := range chanArb.activeResolvers {
+		resolver = r
+	}
+
 	// We'll now examine the in-memory state of the active resolvers to
 	// ensure t hey were populated properly.
-	resolver := chanArb.activeResolvers[0]
 	outgoingResolver, ok := resolver.(*htlcOutgoingContestResolver)
 	if !ok {
 		t.Fatalf("expected outgoing contest resolver, got %vT",
@@ -2801,7 +2805,11 @@ func TestChannelArbitratorAnchors(t *testing.T) {
 			len(chanArb.activeResolvers))
 	}
 
-	resolver := chanArb.activeResolvers[0]
+	var resolver ContractResolver
+	for r := range chanArb.activeResolvers {
+		resolver = r
+	}
+
 	_, ok := resolver.(*anchorResolver)
 	if !ok {
 		t.Fatalf("expected anchor resolver, got %T", resolver)

--- a/contractcourt/commit_sweep_resolver.go
+++ b/contractcourt/commit_sweep_resolver.go
@@ -182,7 +182,7 @@ func (c *commitSweepResolver) getCommitTxConfHeight() (uint32, error) {
 // NOTE: This function MUST be run as a goroutine.
 //
 //nolint:funlen
-func (c *commitSweepResolver) Resolve(_ bool,
+func (c *commitSweepResolver) Resolve(
 	blockChan <-chan int32) (ContractResolver, error) {
 
 	// If we're already resolved, then we can exit early.

--- a/contractcourt/commit_sweep_resolver_test.go
+++ b/contractcourt/commit_sweep_resolver_test.go
@@ -83,7 +83,7 @@ func (i *commitSweepResolverTestContext) resolve() {
 	// Start resolver.
 	i.resolverResultChan = make(chan resolveResult, 1)
 	go func() {
-		nextResolver, err := i.resolver.Resolve(false, i.blockChan)
+		nextResolver, err := i.resolver.Resolve(i.blockChan)
 		i.resolverResultChan <- resolveResult{
 			nextResolver: nextResolver,
 			err:          err,

--- a/contractcourt/contract_resolver.go
+++ b/contractcourt/contract_resolver.go
@@ -43,7 +43,8 @@ type ContractResolver interface {
 	// resolution, then another resolve is returned.
 	//
 	// NOTE: This function MUST be run as a goroutine.
-	Resolve(immediate bool) (ContractResolver, error)
+	Resolve(immediate bool,
+		blockChan <-chan int32) (ContractResolver, error)
 
 	// SupplementState allows the user of a ContractResolver to supplement
 	// it with state required for the proper resolution of a contract.

--- a/contractcourt/contract_resolver.go
+++ b/contractcourt/contract_resolver.go
@@ -43,8 +43,7 @@ type ContractResolver interface {
 	// resolution, then another resolve is returned.
 	//
 	// NOTE: This function MUST be run as a goroutine.
-	Resolve(immediate bool,
-		blockChan <-chan int32) (ContractResolver, error)
+	Resolve(blockChan <-chan int32) (ContractResolver, error)
 
 	// SupplementState allows the user of a ContractResolver to supplement
 	// it with state required for the proper resolution of a contract.

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -90,7 +90,7 @@ func (h *htlcIncomingContestResolver) processFinalHtlcFail() error {
 //     as we have no remaining actions left at our disposal.
 //
 // NOTE: Part of the ContractResolver interface.
-func (h *htlcIncomingContestResolver) Resolve(_ bool,
+func (h *htlcIncomingContestResolver) Resolve(
 	blockChan <-chan int32) (ContractResolver, error) {
 
 	// If we're already full resolved, then we don't have anything further

--- a/contractcourt/htlc_incoming_contest_resolver_test.go
+++ b/contractcourt/htlc_incoming_contest_resolver_test.go
@@ -396,7 +396,7 @@ func (i *incomingResolverTestContext) resolve() {
 	i.resolveErr = make(chan error, 1)
 	go func() {
 		var err error
-		i.nextResolver, err = i.resolver.Resolve(false, i.blockChan)
+		i.nextResolver, err = i.resolver.Resolve(i.blockChan)
 		i.resolveErr <- err
 	}()
 

--- a/contractcourt/htlc_outgoing_contest_resolver.go
+++ b/contractcourt/htlc_outgoing_contest_resolver.go
@@ -49,7 +49,7 @@ func newOutgoingContestResolver(res lnwallet.OutgoingHtlcResolution,
 // When either of these two things happens, we'll create a new resolver which
 // is able to handle the final resolution of the contract. We're only the pivot
 // point.
-func (h *htlcOutgoingContestResolver) Resolve(_ bool,
+func (h *htlcOutgoingContestResolver) Resolve(
 	blockChan <-chan int32) (ContractResolver, error) {
 
 	// If we're already full resolved, then we don't have anything further

--- a/contractcourt/htlc_outgoing_contest_resolver_test.go
+++ b/contractcourt/htlc_outgoing_contest_resolver_test.go
@@ -210,7 +210,7 @@ func (i *outgoingResolverTestContext) resolve() {
 	// Start resolver.
 	i.resolverResultChan = make(chan resolveResult, 1)
 	go func() {
-		nextResolver, err := i.resolver.Resolve(false, i.blockChan)
+		nextResolver, err := i.resolver.Resolve(i.blockChan)
 		i.resolverResultChan <- resolveResult{
 			nextResolver: nextResolver,
 			err:          err,

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -115,7 +115,7 @@ func (h *htlcSuccessResolver) ResolverKey() []byte {
 // TODO(roasbeef): create multi to batch
 //
 // NOTE: Part of the ContractResolver interface.
-func (h *htlcSuccessResolver) Resolve(immediate bool,
+func (h *htlcSuccessResolver) Resolve(
 	blockChan <-chan int32) (ContractResolver, error) {
 
 	// If we're already resolved, then we can exit early.
@@ -126,12 +126,12 @@ func (h *htlcSuccessResolver) Resolve(immediate bool,
 	// If we don't have a success transaction, then this means that this is
 	// an output on the remote party's commitment transaction.
 	if h.htlcResolution.SignedSuccessTx == nil {
-		return h.resolveRemoteCommitOutput(immediate)
+		return h.resolveRemoteCommitOutput()
 	}
 
 	// Otherwise this an output on our own commitment, and we must start by
 	// broadcasting the second-level success transaction.
-	secondLevelOutpoint, err := h.broadcastSuccessTx(immediate, blockChan)
+	secondLevelOutpoint, err := h.broadcastSuccessTx(blockChan)
 	if err != nil {
 		return nil, err
 	}
@@ -165,8 +165,8 @@ func (h *htlcSuccessResolver) Resolve(immediate bool,
 // broadcasting the second-level success transaction. It returns the ultimate
 // outpoint of the second-level tx, that we must wait to be spent for the
 // resolver to be fully resolved.
-func (h *htlcSuccessResolver) broadcastSuccessTx(immediate bool,
-	blockChan <-chan int32) (*wire.OutPoint, error) {
+func (h *htlcSuccessResolver) broadcastSuccessTx(blockChan <-chan int32) (
+	*wire.OutPoint, error) {
 
 	// If we have non-nil SignDetails, this means that have a 2nd level
 	// HTLC transaction that is signed using sighash SINGLE|ANYONECANPAY
@@ -175,7 +175,7 @@ func (h *htlcSuccessResolver) broadcastSuccessTx(immediate bool,
 	// the checkpointed outputIncubating field to determine if we already
 	// swept the HTLC output into the second level transaction.
 	if h.htlcResolution.SignDetails != nil {
-		return h.broadcastReSignedSuccessTx(immediate, blockChan)
+		return h.broadcastReSignedSuccessTx(blockChan)
 	}
 
 	// Otherwise we'll publish the second-level transaction directly and
@@ -227,7 +227,7 @@ func (h *htlcSuccessResolver) broadcastSuccessTx(immediate bool,
 // will re-sign it and attach fees at will.
 //
 //nolint:funlen
-func (h *htlcSuccessResolver) broadcastReSignedSuccessTx(immediate bool,
+func (h *htlcSuccessResolver) broadcastReSignedSuccessTx(
 	blockChan <-chan int32) (*wire.OutPoint, error) {
 
 	// Keep track of the tx spending the HTLC output on the commitment, as
@@ -284,7 +284,6 @@ func (h *htlcSuccessResolver) broadcastReSignedSuccessTx(immediate bool,
 			sweep.Params{
 				Budget:         budget,
 				DeadlineHeight: deadline,
-				Immediate:      immediate,
 			},
 		)
 		if err != nil {
@@ -440,7 +439,7 @@ func (h *htlcSuccessResolver) broadcastReSignedSuccessTx(immediate bool,
 // resolveRemoteCommitOutput handles sweeping an HTLC output on the remote
 // commitment with the preimage. In this case we can sweep the output directly,
 // and don't have to broadcast a second-level transaction.
-func (h *htlcSuccessResolver) resolveRemoteCommitOutput(immediate bool) (
+func (h *htlcSuccessResolver) resolveRemoteCommitOutput() (
 	ContractResolver, error) {
 
 	isTaproot := txscript.IsPayToTaproot(
@@ -489,7 +488,6 @@ func (h *htlcSuccessResolver) resolveRemoteCommitOutput(immediate bool) (
 		sweep.Params{
 			Budget:         budget,
 			DeadlineHeight: deadline,
-			Immediate:      immediate,
 		},
 	)
 	if err != nil {

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -136,7 +136,7 @@ func (i *htlcResolverTestContext) resolve() {
 	// Start resolver.
 	i.resolverResultChan = make(chan resolveResult, 1)
 	go func() {
-		nextResolver, err := i.resolver.Resolve(false, i.blockChan)
+		nextResolver, err := i.resolver.Resolve(i.blockChan)
 		i.resolverResultChan <- resolveResult{
 			nextResolver: nextResolver,
 			err:          err,

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -418,8 +418,8 @@ func checkSizeAndIndex(witness wire.TxWitness, size, index int) bool {
 // see a direct sweep via the timeout clause.
 //
 // NOTE: Part of the ContractResolver interface.
-func (h *htlcTimeoutResolver) Resolve(
-	immediate bool) (ContractResolver, error) {
+func (h *htlcTimeoutResolver) Resolve(immediate bool,
+	blockChan <-chan int32) (ContractResolver, error) {
 
 	// If we're already resolved, then we can exit early.
 	if h.resolved {
@@ -468,7 +468,7 @@ func (h *htlcTimeoutResolver) Resolve(
 
 	// Depending on whether this was a local or remote commit, we must
 	// handle the spending transaction accordingly.
-	return h.handleCommitSpend(commitSpend)
+	return h.handleCommitSpend(blockChan, commitSpend)
 }
 
 // sweepSecondLevelTx sends a second level timeout transaction to the sweeper.
@@ -668,7 +668,7 @@ func (h *htlcTimeoutResolver) checkPointSecondLevelTx() error {
 // confirmed second-level timeout transaction, and we'll sweep that into our
 // wallet. If the was a remote commitment, the resolver will resolve
 // immetiately.
-func (h *htlcTimeoutResolver) handleCommitSpend(
+func (h *htlcTimeoutResolver) handleCommitSpend(blockChan <-chan int32,
 	commitSpend *chainntnfs.SpendDetail) (ContractResolver, error) {
 
 	var (
@@ -731,7 +731,7 @@ func (h *htlcTimeoutResolver) handleCommitSpend(
 		waitHeight--
 
 		// TODO(yy): let sweeper handles the wait?
-		err := waitForHeight(waitHeight, h.Notifier, h.quit)
+		err := waitForHeight(waitHeight, blockChan, h.quit)
 		if err != nil {
 			return nil, err
 		}

--- a/contractcourt/htlc_timeout_resolver_test.go
+++ b/contractcourt/htlc_timeout_resolver_test.go
@@ -373,9 +373,7 @@ func TestHtlcTimeoutResolver(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-
-			// TODO(yy): fix.
-			_, err := resolver.Resolve(false, nil)
+			_, err := resolver.Resolve(nil)
 			if err != nil {
 				resolveErr <- err
 			}

--- a/contractcourt/htlc_timeout_resolver_test.go
+++ b/contractcourt/htlc_timeout_resolver_test.go
@@ -267,7 +267,6 @@ func TestHtlcTimeoutResolver(t *testing.T) {
 	}
 
 	notifier := &mock.ChainNotifier{
-		EpochChan: make(chan *chainntnfs.BlockEpoch),
 		SpendChan: make(chan *chainntnfs.SpendDetail),
 		ConfChan:  make(chan *chainntnfs.TxConfirmation),
 	}
@@ -375,7 +374,8 @@ func TestHtlcTimeoutResolver(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			_, err := resolver.Resolve(false)
+			// TODO(yy): fix.
+			_, err := resolver.Resolve(false, nil)
 			if err != nil {
 				resolveErr <- err
 			}
@@ -1089,9 +1089,7 @@ func TestHtlcTimeoutSecondStageSweeper(t *testing.T) {
 				}
 
 				// Mimic CSV lock expiring.
-				ctx.notifier.EpochChan <- &chainntnfs.BlockEpoch{
-					Height: 13,
-				}
+				ctx.notifyEpoch(13)
 
 				// The timeout tx output should now be given to
 				// the sweeper.

--- a/lntest/harness_assertion.go
+++ b/lntest/harness_assertion.go
@@ -2633,3 +2633,36 @@ func (h *HarnessTest) FindSweepingTxns(txns []*wire.MsgTx,
 
 	return sweepTxns
 }
+
+// AssertForceCloseAndAnchorTxnsInMempool asserts that the force close and
+// anchor sweep txns are found in the mempool and returns the force close tx
+// and the anchor sweep tx.
+func (h *HarnessTest) AssertForceCloseAndAnchorTxnsInMempool() (*wire.MsgTx,
+	*wire.MsgTx) {
+
+	// Assert there are two txns in the mempool.
+	txns := h.Miner.GetNumTxsFromMempool(2)
+
+	// Assume the first is the force close tx.
+	forceCloseTx, anchorSweepTx := txns[0], txns[1]
+
+	// Get the txid.
+	closeTxid := forceCloseTx.TxHash()
+
+	// We now check whether there is an anchor input used in the assumed
+	// anchorSweepTx by checking every input's previous outpoint against
+	// the assumed closingTxid. If we fail to find one, it means the first
+	// item from the above txns is the anchor sweeping tx.
+	for _, inp := range anchorSweepTx.TxIn {
+		if inp.PreviousOutPoint.Hash == closeTxid {
+			// Found a match, this is indeed the anchor sweeping tx
+			// so we return it here.
+			return forceCloseTx, anchorSweepTx
+		}
+	}
+
+	// The assumed order is incorrect so we swap and return.
+	forceCloseTx, anchorSweepTx = anchorSweepTx, forceCloseTx
+
+	return forceCloseTx, anchorSweepTx
+}

--- a/log.go
+++ b/log.go
@@ -7,6 +7,7 @@ import (
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/autopilot"
 	"github.com/lightningnetwork/lnd/build"
+	"github.com/lightningnetwork/lnd/chainio"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/chainreg"
 	"github.com/lightningnetwork/lnd/chanacceptor"
@@ -164,6 +165,7 @@ func SetupLoggers(root *build.RotatingLogWriter, interceptor signal.Interceptor)
 	AddSubLogger(root, "CHFD", interceptor, chanfunding.UseLogger)
 	AddSubLogger(root, "PEER", interceptor, peer.UseLogger)
 	AddSubLogger(root, "CHCL", interceptor, chancloser.UseLogger)
+	AddSubLogger(root, "CHIO", interceptor, chainio.UseLogger)
 
 	AddSubLogger(root, routing.Subsystem, interceptor, routing.UseLogger)
 	AddSubLogger(root, routerrpc.Subsystem, interceptor, routerrpc.UseLogger)

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -52,7 +52,7 @@ type Bumper interface {
 	// and monitors its confirmation status for potential fee bumping. It
 	// returns a chan that the caller can use to receive updates about the
 	// broadcast result and potential RBF attempts.
-	Broadcast(req *BumpRequest) (<-chan *BumpResult, error)
+	Broadcast(req *BumpRequest) <-chan *BumpResult
 }
 
 // BumpEvent represents the event of a fee bumping attempt.
@@ -325,7 +325,7 @@ func (t *TxPublisher) isNeutrinoBackend() bool {
 // RBF-compliant unless the budget specified cannot cover the fee.
 //
 // NOTE: part of the Bumper interface.
-func (t *TxPublisher) Broadcast(req *BumpRequest) (<-chan *BumpResult, error) {
+func (t *TxPublisher) Broadcast(req *BumpRequest) <-chan *BumpResult {
 	log.Tracef("Received broadcast request: %s", newLogClosure(
 		func() string {
 			return spew.Sdump(req)
@@ -343,7 +343,7 @@ func (t *TxPublisher) Broadcast(req *BumpRequest) (<-chan *BumpResult, error) {
 	subscriber := make(chan *BumpResult, 1)
 	t.subscriberChans.Store(requestID, subscriber)
 
-	return subscriber, nil
+	return subscriber
 }
 
 // initialBroadcast initializes a fee function, creates an RBF-compliant tx and

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -13,6 +13,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/lightningnetwork/lnd/chainio"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
@@ -297,6 +298,11 @@ type TxPublisher struct {
 	// the chan that the publisher sends the fee bump result to.
 	subscriberChans lnutils.SyncMap[uint64, chan *BumpResult]
 
+	// blockBeatChan is a channel to receive blocks from BlockBeat. The
+	// received block contains the best known height and the transactions
+	// confirmed in this block.
+	blockBeatChan chan chainio.Beat
+
 	// quit is used to signal the publisher to stop.
 	quit chan struct{}
 }
@@ -311,6 +317,7 @@ func NewTxPublisher(cfg TxPublisherConfig) *TxPublisher {
 		records:         lnutils.SyncMap[uint64, *monitorRecord]{},
 		subscriberChans: lnutils.SyncMap[uint64, chan *BumpResult]{},
 		quit:            make(chan struct{}),
+		blockBeatChan:   make(chan chainio.Beat),
 	}
 }
 
@@ -344,6 +351,25 @@ func (t *TxPublisher) Broadcast(req *BumpRequest) <-chan *BumpResult {
 	t.subscriberChans.Store(requestID, subscriber)
 
 	return subscriber
+}
+
+// NOTE: part of the `chainio.Consumer` interface.
+func (t *TxPublisher) ProcessBlock(beat chainio.Beat) <-chan error {
+	select {
+	case t.blockBeatChan <- beat:
+		log.Tracef("TxPublisher received block beat for height=%d",
+			beat.Epoch.Height)
+
+	case <-t.quit:
+		return nil
+	}
+
+	return beat.Err
+}
+
+// NOTE: part of the `chainio.Consumer` interface.
+func (t *TxPublisher) Name() string {
+	return "tx publisher"
 }
 
 // initialBroadcast initializes a fee function, creates an RBF-compliant tx and
@@ -677,13 +703,8 @@ func (t *TxPublisher) Start() error {
 	log.Info("TxPublisher starting...")
 	defer log.Debugf("TxPublisher started")
 
-	blockEvent, err := t.cfg.Notifier.RegisterBlockEpochNtfn(nil)
-	if err != nil {
-		return fmt.Errorf("register block epoch ntfn: %w", err)
-	}
-
 	t.wg.Add(1)
-	go t.monitor(blockEvent)
+	go t.monitor()
 
 	return nil
 }
@@ -703,13 +724,12 @@ func (t *TxPublisher) Stop() {
 // to be bumped. If so, it will attempt to bump the fee of the tx.
 //
 // NOTE: Must be run as a goroutine.
-func (t *TxPublisher) monitor(blockEvent *chainntnfs.BlockEpochEvent) {
-	defer blockEvent.Cancel()
+func (t *TxPublisher) monitor() {
 	defer t.wg.Done()
 
 	for {
 		select {
-		case epoch, ok := <-blockEvent.Epochs:
+		case beat, ok := <-t.blockBeatChan:
 			if !ok {
 				// We should stop the publisher before stopping
 				// the chain service. Otherwise it indicates an
@@ -720,6 +740,7 @@ func (t *TxPublisher) monitor(blockEvent *chainntnfs.BlockEpochEvent) {
 				return
 			}
 
+			epoch := beat.Epoch
 			log.Debugf("TxPublisher received new block: %v",
 				epoch.Height)
 
@@ -729,6 +750,9 @@ func (t *TxPublisher) monitor(blockEvent *chainntnfs.BlockEpochEvent) {
 			// Check all monitored txns to see if any of them needs
 			// to be bumped.
 			t.processRecords()
+
+			// Notify we've processed the block.
+			fn.SendOrQuit(beat.Err, nil, t.quit)
 
 		case <-t.quit:
 			log.Debug("Fee bumper stopped, exit monitor")

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -905,8 +905,7 @@ func TestBroadcast(t *testing.T) {
 	}
 
 	// Send the req and expect no error.
-	resultChan, err := tp.Broadcast(req)
-	require.NoError(t, err)
+	resultChan := tp.Broadcast(req)
 	require.NotNil(t, resultChan)
 
 	// Validate the record was stored.
@@ -1406,8 +1405,7 @@ func TestHandleInitialBroadcastSuccess(t *testing.T) {
 	}
 
 	// Register the testing record use `Broadcast`.
-	resultChan, err := tp.Broadcast(req)
-	require.NoError(t, err)
+	resultChan := tp.Broadcast(req)
 
 	// Grab the monitor record from the map.
 	rid := tp.requestCounter.Load()
@@ -1478,8 +1476,7 @@ func TestHandleInitialBroadcastFail(t *testing.T) {
 		mock.Anything).Return(errDummy).Once()
 
 	// Register the testing record use `Broadcast`.
-	resultChan, err := tp.Broadcast(req)
-	require.NoError(t, err)
+	resultChan := tp.Broadcast(req)
 
 	// Grab the monitor record from the map.
 	rid := tp.requestCounter.Load()
@@ -1512,8 +1509,7 @@ func TestHandleInitialBroadcastFail(t *testing.T) {
 		mock.Anything, mock.Anything).Return(errDummy).Once()
 
 	// Register the testing record use `Broadcast`.
-	resultChan, err = tp.Broadcast(req)
-	require.NoError(t, err)
+	resultChan = tp.Broadcast(req)
 
 	// Grab the monitor record from the map.
 	rid = tp.requestCounter.Load()

--- a/sweep/fee_function.go
+++ b/sweep/fee_function.go
@@ -14,6 +14,9 @@ var (
 	// ErrMaxPosition is returned when trying to increase the position of
 	// the fee function while it's already at its max.
 	ErrMaxPosition = errors.New("position already at max")
+
+	// ErrZeroFeeRateDelta is returned when the fee rate delta is zero.
+	ErrZeroFeeRateDelta = errors.New("fee rate delta is zero")
 )
 
 // mSatPerKWeight represents a fee rate in msat/kw.
@@ -169,7 +172,7 @@ func NewLinearFeeFunction(maxFeeRate chainfee.SatPerKWeight,
 			"endingFeeRate=%v, width=%v, delta=%v", start, end,
 			l.width, l.deltaFeeRate)
 
-		return nil, fmt.Errorf("fee rate delta is zero")
+		return nil, ErrZeroFeeRateDelta
 	}
 
 	// Attach the calculated values to the fee function.

--- a/sweep/mock_test.go
+++ b/sweep/mock_test.go
@@ -276,14 +276,14 @@ type MockBumper struct {
 var _ Bumper = (*MockBumper)(nil)
 
 // Broadcast broadcasts the transaction to the network.
-func (m *MockBumper) Broadcast(req *BumpRequest) (<-chan *BumpResult, error) {
+func (m *MockBumper) Broadcast(req *BumpRequest) <-chan *BumpResult {
 	args := m.Called(req)
 
 	if args.Get(0) == nil {
-		return nil, args.Error(1)
+		return nil
 	}
 
-	return args.Get(0).(chan *BumpResult), args.Error(1)
+	return args.Get(0).(chan *BumpResult)
 }
 
 // MockFeeFunction is a mock implementation of the FeeFunction interface.

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -221,6 +221,30 @@ func (p *SweeperInput) terminated() bool {
 	}
 }
 
+// isMature returns a boolean indicating whether the input has a timelock that
+// has been reached or not. The locktime found is also returned.
+func (p *SweeperInput) isMature(currentHeight uint32) (bool, uint32) {
+	locktime, _ := p.RequiredLockTime()
+	if currentHeight < locktime {
+		log.Debugf("Input %v has locktime=%v, current height is %v",
+			p.OutPoint(), locktime, currentHeight)
+
+		return false, locktime
+	}
+
+	// If the input has a CSV that's not yet reached, we will skip
+	// this input and wait for the expiry.
+	locktime = p.BlocksToMaturity() + p.HeightHint()
+	if currentHeight+1 < locktime {
+		log.Debugf("Input %v has CSV expiry=%v, current height is %v",
+			p.OutPoint(), locktime, currentHeight)
+
+		return false, locktime
+	}
+
+	return true, locktime
+}
+
 // InputsMap is a type alias for a set of pending inputs.
 type InputsMap = map[wire.OutPoint]*SweeperInput
 
@@ -1026,6 +1050,12 @@ func (s *UtxoSweeper) handlePendingSweepsReq(
 
 	resps := make(map[wire.OutPoint]*PendingInputResponse, len(s.inputs))
 	for _, inp := range s.inputs {
+		// Skip immature inputs for compatibility.
+		mature, _ := inp.isMature(uint32(s.currentHeight))
+		if !mature {
+			continue
+		}
+
 		// Only the exported fields are set, as we expect the response
 		// to only be consumed externally.
 		op := inp.OutPoint()
@@ -1476,20 +1506,9 @@ func (s *UtxoSweeper) updateSweeperInputs() InputsMap {
 
 		// If the input has a locktime that's not yet reached, we will
 		// skip this input and wait for the locktime to be reached.
-		locktime, _ := input.RequiredLockTime()
-		if uint32(s.currentHeight) < locktime {
-			log.Warnf("Skipping input %v due to locktime=%v not "+
-				"reached, current height is %v", op, locktime,
-				s.currentHeight)
-
-			continue
-		}
-
-		// If the input has a CSV that's not yet reached, we will skip
-		// this input and wait for the expiry.
-		locktime = input.BlocksToMaturity() + input.HeightHint()
-		if s.currentHeight < int32(locktime)-1 {
-			log.Infof("Skipping input %v due to CSV expiry=%v not "+
+		mature, locktime := input.isMature(uint32(s.currentHeight))
+		if !mature {
+			log.Infof("Skipping input %v due to locktime=%v not "+
 				"reached, current height is %v", op, locktime,
 				s.currentHeight)
 

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1718,7 +1718,7 @@ func (s *UtxoSweeper) handleBumpEventTxPublished(r *BumpResult) error {
 // NOTE: TxConfirmed event is not handled, since we already subscribe to the
 // input's spending event, we don't need to do anything here.
 func (s *UtxoSweeper) handleBumpEvent(r *BumpResult) error {
-	log.Debugf("Received bump event [%v] for tx %v", r.Event, r.Tx.TxHash())
+	log.Debugf("Received bump result %v", r)
 
 	switch r.Event {
 	// The tx has been published, we update the inputs' state and create a
@@ -1734,6 +1734,9 @@ func (s *UtxoSweeper) handleBumpEvent(r *BumpResult) error {
 	// with the new one.
 	case TxReplaced:
 		return s.handleBumpEventTxReplaced(r)
+
+	case TxError:
+		// TODO(yy): create a method to remove this input.
 	}
 
 	return nil

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -525,7 +525,7 @@ func (s *UtxoSweeper) SweepInput(inp input.Input,
 	}
 
 	absoluteTimeLock, _ := inp.RequiredLockTime()
-	log.Infof("Sweep request received: out_point=%v, witness_type=%v, "+
+	log.Debugf("Sweep request received: out_point=%v, witness_type=%v, "+
 		"relative_time_lock=%v, absolute_time_lock=%v, amount=%v, "+
 		"parent=(%v), params=(%v)", inp.OutPoint(), inp.WitnessType(),
 		inp.BlocksToMaturity(), absoluteTimeLock,
@@ -725,7 +725,17 @@ func (s *UtxoSweeper) collector(blockEpochs <-chan *chainntnfs.BlockEpoch) {
 			inputs := s.updateSweeperInputs()
 
 			log.Debugf("Received new block: height=%v, attempt "+
-				"sweeping %d inputs", epoch.Height, len(inputs))
+				"sweeping %d inputs:\n%s", epoch.Height,
+				len(inputs), newLogClosure(func() string {
+					inps := make(
+						[]input.Input, 0, len(inputs),
+					)
+					for _, in := range inputs {
+						inps = append(inps, in)
+					}
+
+					return inputTypeSummary(inps)
+				})())
 
 			// Attempt to sweep any pending inputs.
 			s.sweepPendingInputs(inputs)
@@ -1191,13 +1201,29 @@ func (s *UtxoSweeper) mempoolLookup(op wire.OutPoint) fn.Option[wire.MsgTx] {
 	return s.cfg.Mempool.LookupInputMempoolSpend(op)
 }
 
-// handleNewInput processes a new input by registering spend notification and
-// scheduling sweeping for it.
-func (s *UtxoSweeper) handleNewInput(input *sweepInputMessage) error {
+// calculateDefaultDeadline calculates the default deadline height for a sweep
+// request that has no deadline height specified.
+func (s *UtxoSweeper) calculateDefaultDeadline(pi *SweeperInput) int32 {
 	// Create a default deadline height, which will be used when there's no
 	// DeadlineHeight specified for a given input.
 	defaultDeadline := s.currentHeight + int32(s.cfg.NoDeadlineConfTarget)
 
+	// If the input is immature and has a locktime, we'll use the locktime
+	// height as the starting height.
+	matured, locktime := pi.isMature(uint32(s.currentHeight))
+	if !matured {
+		defaultDeadline = int32(locktime + s.cfg.NoDeadlineConfTarget)
+		log.Debugf("Input %v is immature, using locktime=%v instead "+
+			"of current height=%d", pi.OutPoint(), locktime,
+			s.currentHeight)
+	}
+
+	return defaultDeadline
+}
+
+// handleNewInput processes a new input by registering spend notification and
+// scheduling sweeping for it.
+func (s *UtxoSweeper) handleNewInput(input *sweepInputMessage) error {
 	outpoint := input.input.OutPoint()
 	pi, pending := s.inputs[outpoint]
 	if pending {
@@ -1222,14 +1248,21 @@ func (s *UtxoSweeper) handleNewInput(input *sweepInputMessage) error {
 		Input:     input.input,
 		params:    input.params,
 		rbf:       rbfInfo,
-		// Set the acutal deadline height.
-		DeadlineHeight: input.params.DeadlineHeight.UnwrapOr(
-			defaultDeadline,
-		),
 	}
+
+	// Set the acutal deadline height.
+	pi.DeadlineHeight = input.params.DeadlineHeight.UnwrapOr(
+		s.calculateDefaultDeadline(pi),
+	)
 
 	s.inputs[outpoint] = pi
 	log.Tracef("input %v, state=%v, added to inputs", outpoint, pi.state)
+
+	log.Infof("Registered sweep request at block %d: out_point=%v, "+
+		"witness_type=%v, amount=%v, deadline=%d, params=(%v)",
+		s.currentHeight, pi.OutPoint(), pi.WitnessType(),
+		btcutil.Amount(pi.SignDesc().Output.Value), pi.DeadlineHeight,
+		pi.params)
 
 	// Start watching for spend of this input, either by us or the remote
 	// party.
@@ -1626,7 +1659,7 @@ func (s *UtxoSweeper) monitorFeeBumpResult(resultChan <-chan *BumpResult) {
 func (s *UtxoSweeper) handleBumpEventTxFailed(r *BumpResult) error {
 	tx, err := r.Tx, r.Err
 
-	log.Errorf("Fee bump attempt failed for tx=%v: %v", tx.TxHash(), err)
+	log.Warnf("Fee bump attempt failed for tx=%v: %v", tx.TxHash(), err)
 
 	outpoints := make([]wire.OutPoint, 0, len(tx.TxIn))
 	for _, inp := range tx.TxIn {
@@ -1636,7 +1669,7 @@ func (s *UtxoSweeper) handleBumpEventTxFailed(r *BumpResult) error {
 	// TODO(yy): should we also remove the failed tx from db?
 	s.markInputsPublishFailed(outpoints)
 
-	return err
+	return nil
 }
 
 // handleBumpEventTxReplaced handles the case where the sweeping tx has been

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -823,21 +823,7 @@ func (s *UtxoSweeper) sweep(set InputSet) error {
 
 	// Broadcast will return a read-only chan that we will listen to for
 	// this publish result and future RBF attempt.
-	resp, err := s.cfg.Publisher.Broadcast(req)
-	if err != nil {
-		outpoints := make([]wire.OutPoint, len(set.Inputs()))
-		for i, inp := range set.Inputs() {
-			outpoints[i] = inp.OutPoint()
-		}
-
-		log.Errorf("Initial broadcast failed: %v, inputs=\n%v", err,
-			inputTypeSummary(set.Inputs()))
-
-		// TODO(yy): find out which input is causing the failure.
-		s.markInputsPublishFailed(outpoints)
-
-		return err
-	}
+	resp := s.cfg.Publisher.Broadcast(req)
 
 	// Successfully sent the broadcast attempt, we now handle the result by
 	// subscribing to the result chan and listen for future updates about

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/lightningnetwork/lnd/chainio"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
@@ -335,6 +336,11 @@ type UtxoSweeper struct {
 	// bumpResultChan is a channel that receives broadcast results from the
 	// TxPublisher.
 	bumpResultChan chan *BumpResult
+
+	// blockBeatChan is a channel to receive blocks from BlockBeat. The
+	// received block contains the best known height and the transactions
+	// confirmed in this block.
+	blockBeatChan chan chainio.Beat
 }
 
 // UtxoSweeperConfig contains dependencies of UtxoSweeper.
@@ -419,6 +425,7 @@ func New(cfg *UtxoSweeperConfig) *UtxoSweeper {
 		quit:              make(chan struct{}),
 		inputs:            make(InputsMap),
 		bumpResultChan:    make(chan *BumpResult, 100),
+		blockBeatChan:     make(chan chainio.Beat),
 	}
 }
 
@@ -434,21 +441,12 @@ func (s *UtxoSweeper) Start() error {
 	// not change from here on.
 	s.relayFeeRate = s.cfg.FeeEstimator.RelayFeePerKW()
 
-	// We need to register for block epochs and retry sweeping every block.
-	// We should get a notification with the current best block immediately
-	// if we don't provide any epoch. We'll wait for that in the collector.
-	blockEpochs, err := s.cfg.Notifier.RegisterBlockEpochNtfn(nil)
-	if err != nil {
-		return fmt.Errorf("register block epoch ntfn: %w", err)
-	}
-
 	// Start sweeper main loop.
 	s.wg.Add(1)
 	go func() {
-		defer blockEpochs.Cancel()
 		defer s.wg.Done()
 
-		s.collector(blockEpochs.Epochs)
+		s.collector()
 
 		// The collector exited and won't longer handle incoming
 		// requests. This can happen on shutdown, when the block
@@ -501,6 +499,25 @@ func (s *UtxoSweeper) Stop() error {
 	s.wg.Wait()
 
 	return nil
+}
+
+// NOTE: part of the `chainio.Consumer` interface.
+func (s *UtxoSweeper) ProcessBlock(beat chainio.Beat) <-chan error {
+	select {
+	case s.blockBeatChan <- beat:
+		log.Debugf("Received block beat for height=%d",
+			beat.Epoch.Height)
+
+	case <-s.quit:
+		return nil
+	}
+
+	return beat.Err
+}
+
+// NOTE: part of the `chainio.Consumer` interface.
+func (s *UtxoSweeper) Name() string {
+	return "sweeper"
 }
 
 // SweepInput sweeps inputs back into the wallet. The inputs will be batched and
@@ -634,18 +651,7 @@ func (s *UtxoSweeper) removeConflictSweepDescendants(
 
 // collector is the sweeper main loop. It processes new inputs, spend
 // notifications and counts down to publication of the sweep tx.
-func (s *UtxoSweeper) collector(blockEpochs <-chan *chainntnfs.BlockEpoch) {
-	// We registered for the block epochs with a nil request. The notifier
-	// should send us the current best block immediately. So we need to wait
-	// for it here because we need to know the current best height.
-	select {
-	case bestBlock := <-blockEpochs:
-		s.currentHeight = bestBlock.Height
-
-	case <-s.quit:
-		return
-	}
-
+func (s *UtxoSweeper) collector() {
 	for {
 		// Clean inputs, which will remove inputs that are swept,
 		// failed, or excluded from the sweeper and return inputs that
@@ -708,7 +714,7 @@ func (s *UtxoSweeper) collector(blockEpochs <-chan *chainntnfs.BlockEpoch) {
 
 		// A new block comes in, update the bestHeight, perform a check
 		// over all pending inputs and publish sweeping txns if needed.
-		case epoch, ok := <-blockEpochs:
+		case beat, ok := <-s.blockBeatChan:
 			if !ok {
 				// We should stop the sweeper before stopping
 				// the chain service. Otherwise it indicates an
@@ -717,6 +723,8 @@ func (s *UtxoSweeper) collector(blockEpochs <-chan *chainntnfs.BlockEpoch) {
 
 				return
 			}
+
+			epoch := beat.Epoch
 
 			// Update the sweeper to the best height.
 			s.currentHeight = epoch.Height
@@ -739,6 +747,9 @@ func (s *UtxoSweeper) collector(blockEpochs <-chan *chainntnfs.BlockEpoch) {
 
 			// Attempt to sweep any pending inputs.
 			s.sweepPendingInputs(inputs)
+
+			// Notify we've processed the block.
+			fn.SendOrQuit(beat.Err, nil, s.quit)
 
 		case <-s.quit:
 			return

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -775,7 +775,7 @@ func TestHandleBumpEventTxFailed(t *testing.T) {
 
 	// Call the method under test.
 	err := s.handleBumpEvent(br)
-	require.ErrorIs(t, err, errDummy)
+	require.NoError(t, err)
 
 	// Assert the states of the first two inputs are updated.
 	require.Equal(t, PublishFailed, s.inputs[op1].state)

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -715,13 +715,8 @@ func TestSweepPendingInputs(t *testing.T) {
 		setNeedWallet, normalSet,
 	})
 
-	// Mock `Broadcast` to return an error. This should cause the
-	// `createSweepTx` inside `sweep` to fail. This is done so we can
-	// terminate the method early as we are only interested in testing the
-	// workflow in `sweepPendingInputs`. We don't need to test `sweep` here
-	// as it should be tested in its own unit test.
-	dummyErr := errors.New("dummy error")
-	publisher.On("Broadcast", mock.Anything).Return(nil, dummyErr).Twice()
+	// Mock `Broadcast` to return a result.
+	publisher.On("Broadcast", mock.Anything).Return(nil).Twice()
 
 	// Call the method under test.
 	s.sweepPendingInputs(pis)

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -490,6 +490,7 @@ func TestUpdateSweeperInputs(t *testing.T) {
 	// returned.
 	inp2.On("RequiredLockTime").Return(
 		uint32(s.currentHeight+1), true).Once()
+	inp2.On("OutPoint").Return(wire.OutPoint{Index: 2}).Maybe()
 	input7 := &SweeperInput{state: Init, Input: inp2}
 
 	// Mock the input to have a CSV expiry in the future so it will NOT be
@@ -498,6 +499,7 @@ func TestUpdateSweeperInputs(t *testing.T) {
 		uint32(s.currentHeight), false).Once()
 	inp3.On("BlocksToMaturity").Return(uint32(2)).Once()
 	inp3.On("HeightHint").Return(uint32(s.currentHeight)).Once()
+	inp3.On("OutPoint").Return(wire.OutPoint{Index: 3}).Maybe()
 	input8 := &SweeperInput{state: Init, Input: inp3}
 
 	// Add the inputs to the sweeper. After the update, we should see the


### PR DESCRIPTION
In an attempt to fix the itest flakes found in the sweeper/multi-hop tests, I realized there's no easy way to get around the block sync issue. In fact, I think these flakes already mean block sync may cause issues outside of the test context. Thus, a minimal version of `BlockBeat` is implemented.

Atm, when a new block is received, it's sent to the subsystems concurrently,
```mermaid
flowchart
    block((block))
    
    block ---> c[ChainArb]
    block ---> ca1[ChannelArb1]
    block ---> ca2[ChannelArb2]
		block ---> us[UtxoSweeper]
		block ---> b[Bumper]
    block ---> ar[AnchorResolver]
    block ---> cr[CommitResolver]
    block ---> hr[HtlcResolver...]
```

One system may process the block faster than another, causing a block sync issue. `Blockbeat` will make sure the blocks are sent in the following order,

```mermaid
flowchart
    block((block))
    
    block --> c[ChainArb]
    c --> ca1[ChannelArb1]
		c --> ca2[ChannelArb2]
		c --> ca3[ChannelArb...]
    ca1 ---> ar[AnchorResolver]
    ca1 ---> cr[CommitResolver]
    ca1 ---> hr[HtlcResolver...]
    ca2 ---> rs2[Resolvers...]
    ca3 ---> rs3[Resolvers...]
		ar ---> us[UtxoSweeper]
		cr ---> us[UtxoSweeper]
	  hr ---> us[UtxoSweeper]
	  rs2 ---> us[UtxoSweeper]
	  rs3 ---> us[UtxoSweeper]
		us ---> b[Bumper]
```

which means the following new behavior in the sweeper:
1. no more waiting for the next block to trigger the sweep - when an input is sent to the sweeper at height X, the sweeping won't happen until block X+1, which is no longer the case.
2. no need to immediately sweep inputs during restart - this hack can be removed now.
3. no more different views of block heights among these subsystems - the fee func can now accurately calculate its width.

TODOs:
- [ ] fix unit tests
- [ ] add unit tests
- [ ] fix itests -> new pr to limit the scope