### PR TITLE
invoices: ensure synchronous access to NewTestSqliteDB

### DIFF
--- a/invoices/invoiceregistry_test.go
+++ b/invoices/invoiceregistry_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"fmt"
 	"math"
+	"sync"
 	"testing"
 	"testing/quick"
 	"time"
@@ -22,6 +23,12 @@ import (
 	"github.com/lightningnetwork/lnd/sqldb"
 	"github.com/stretchr/testify/require"
 )
+
+// sqliteConstructorMu is used to ensure that only one thread can call the
+// sqldb.NewTestSqliteDB constructor at a time. This is a temporary workaround
+// that can be removed once this race condition in the sqlite repo is resolved:
+// https://gitlab.com/cznic/sqlite/-/issues/180
+var sqliteConstructorMu sync.Mutex
 
 // TestInvoiceRegistry is a master test which encompasses all tests using an
 // InvoiceDB instance. The purpose of this test is to be able to run all tests
@@ -130,7 +137,9 @@ func TestInvoiceRegistry(t *testing.T) {
 
 		var db *sqldb.BaseDB
 		if sqlite {
+			sqliteConstructorMu.Lock()
 			db = sqldb.NewTestSqliteDB(t).BaseDB
+			sqliteConstructorMu.Unlock()
 		} else {
 			db = sqldb.NewTestPostgresDB(t, pgFixture).BaseDB
 		}

--- a/invoices/invoices_test.go
+++ b/invoices/invoices_test.go
@@ -234,7 +234,9 @@ func TestInvoices(t *testing.T) {
 	makeSQLDB := func(t *testing.T, sqlite bool) invpkg.InvoiceDB {
 		var db *sqldb.BaseDB
 		if sqlite {
+			sqliteConstructorMu.Lock()
 			db = sqldb.NewTestSqliteDB(t).BaseDB
+			sqliteConstructorMu.Unlock()
 		} else {
 			db = sqldb.NewTestPostgresDB(t, pgFixture).BaseDB
 		}


### PR DESCRIPTION
Add a temporary mutex around the call to sqldb.NewTestSqliteDB in the TestInvoiceRegistry test to ensure that only a single thread can access it at a time. This is a temporary work around that can be removed once this race condition in the sqlite repo has been resolved: https://gitlab.com/cznic/sqlite/-/issues/180

