### PR TITLE
makefile+dev.Dockerfile: add install-all command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,8 +136,13 @@ manpages:
 	@$(call print, "Generating man pages lncli.1 and lnd.1.")
 	./scripts/gen_man_pages.sh $(DESTDIR) $(PREFIX)
 
-#? install: Build and install lnd and lncli binaries, place them in $GOPATH/bin, generate and install man pages
-install: install-binaries manpages
+#? install: Build and install lnd and lncli binaries and place them in $GOPATH/bin.
+install: install-binaries
+
+#? install-all: Performs all the same tasks as the install command along with generating and
+# installing the man pages for the lnd and lncli binaries. This command is useful in an
+# environment where a user has root access and so has write access to the man page directory.
+install-all: install manpages
 
 #? release-install: Build and install lnd and lncli release binaries, place them in $GOPATH/bin
 release-install:

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -24,7 +24,7 @@ COPY . /go/src/github.com/lightningnetwork/lnd
 #  Install/build lnd.
 RUN cd /go/src/github.com/lightningnetwork/lnd \
 &&  make \
-&&  make install tags="signrpc walletrpc chainrpc invoicesrpc peersrpc"
+&&  make install-all tags="signrpc walletrpc chainrpc invoicesrpc peersrpc"
 
 # Start a new, final image to reduce size.
 FROM alpine as final

--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -284,7 +284,9 @@
 
 * [Man pages](https://github.com/lightningnetwork/lnd/pull/8525) Generate man
   pages automatically using `lncli generatemanpage` command for both `lncli`
-  and `lnd` commands when running `make install` in the Makefile.
+  and `lnd` commands when running 
+  [`make install-all`](https://github.com/lightningnetwork/lnd/pull/8739) in 
+  the Makefile.
 
 # Improvements
 ## Functional Updates


### PR DESCRIPTION
Add a new `make install-all` command that will perform all `make install` actions along with generating the manpages. The `manpages` command is then removed from the existing `make install` command. The docker build is then updated to use the new `make install-all` command. This is done because some users running `make install` may be doing so in environments where they do not have write access to the directory where the man pages need to be written to.

