### PR TITLE
cfg: move experimental options to main protocol cfg

### DIFF
--- a/config.go
+++ b/config.go
@@ -1667,8 +1667,7 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 
 	// If the experimental protocol options specify any protocol messages
 	// that we want to handle as custom messages, set them now.
-	//nolint:lll
-	customMsg := cfg.ProtocolOptions.ExperimentalProtocol.CustomMessageOverrides()
+	customMsg := cfg.ProtocolOptions.CustomMessageOverrides()
 
 	// We can safely set our custom override values during startup because
 	// startup is blocked on config parsing.

--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -317,6 +317,10 @@
 * [Add inbound fees](https://github.com/lightningnetwork/lnd/pull/8723) to 
   `subscribeChannelGraph`.
 
+* [Moved](https://github.com/lightningnetwork/lnd/pull/8744) the experimental
+  "custom" options to the main protocol config so that they can be used without
+  the dev build flag set.
+
 ### Logging
 * [Add the htlc amount](https://github.com/lightningnetwork/lnd/pull/8156) to
   contract court logs in case of timed-out HTLCs in order to easily spot dust

--- a/lncfg/protocol.go
+++ b/lncfg/protocol.go
@@ -2,6 +2,11 @@
 
 package lncfg
 
+import (
+	"github.com/lightningnetwork/lnd/feature"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
 // ProtocolOptions is a struct that we use to be able to test backwards
 // compatibility of protocol additions, while defaulting to the latest within
 // lnd, or to enable experimental protocol changes.
@@ -57,6 +62,23 @@ type ProtocolOptions struct {
 
 	// NoRouteBlindingOption disables forwarding of payments in blinded routes.
 	NoRouteBlindingOption bool `long:"no-route-blinding" description:"do not forward payments that are a part of a blinded route"`
+
+	// CustomMessage allows the custom message APIs to handle messages with
+	// the provided protocol numbers, which fall outside the custom message
+	// number range.
+	CustomMessage []uint16 `long:"custom-message" description:"allows the custom message apis to send and report messages with the protocol number provided that fall outside of the custom message number range."`
+
+	// CustomInit specifies feature bits to advertise in the node's init
+	// message.
+	CustomInit []uint16 `long:"custom-init" description:"custom feature bits — numbers defined in BOLT 9 — to advertise in the node's init message"`
+
+	// CustomNodeAnn specifies custom feature bits to advertise in the
+	// node's announcement message.
+	CustomNodeAnn []uint16 `long:"custom-nodeann" description:"custom feature bits — numbers defined in BOLT 9 — to advertise in the node's announcement message"`
+
+	// CustomInvoice specifies custom feature bits to advertise in the
+	// node's invoices.
+	CustomInvoice []uint16 `long:"custom-invoice" description:"custom feature bits — numbers defined in BOLT 9 — to advertise in the node's invoices"`
 }
 
 // Wumbo returns true if lnd should permit the creation and acceptance of wumbo
@@ -104,4 +126,30 @@ func (l *ProtocolOptions) NoTimestampsQuery() bool {
 // NoRouteBlinding returns true if forwarding of blinded payments is disabled.
 func (l *ProtocolOptions) NoRouteBlinding() bool {
 	return l.NoRouteBlindingOption
+}
+
+// CustomMessageOverrides returns the set of protocol messages that we override
+// to allow custom handling.
+func (p ProtocolOptions) CustomMessageOverrides() []uint16 {
+	return p.CustomMessage
+}
+
+// CustomFeatures returns a custom set of feature bits to advertise.
+func (p ProtocolOptions) CustomFeatures() map[feature.Set][]lnwire.FeatureBit {
+	customFeatures := make(map[feature.Set][]lnwire.FeatureBit)
+
+	setFeatures := func(set feature.Set, bits []uint16) {
+		for _, customFeature := range bits {
+			customFeatures[set] = append(
+				customFeatures[set],
+				lnwire.FeatureBit(customFeature),
+			)
+		}
+	}
+
+	setFeatures(feature.SetInit, p.CustomInit)
+	setFeatures(feature.SetNodeAnn, p.CustomNodeAnn)
+	setFeatures(feature.SetInvoice, p.CustomInvoice)
+
+	return customFeatures
 }

--- a/lncfg/protocol_experimental_off.go
+++ b/lncfg/protocol_experimental_off.go
@@ -3,23 +3,7 @@
 
 package lncfg
 
-import (
-	"github.com/lightningnetwork/lnd/feature"
-	"github.com/lightningnetwork/lnd/lnwire"
-)
-
 // ExperimentalProtocol is a sub-config that houses any experimental protocol
 // features that also require a build-tag to activate.
 type ExperimentalProtocol struct {
-}
-
-// CustomMessageOverrides returns the set of protocol messages that we override
-// to allow custom handling.
-func (p ExperimentalProtocol) CustomMessageOverrides() []uint16 {
-	return nil
-}
-
-// CustomFeatures returns a custom set of feature bits to advertise.
-func (p ExperimentalProtocol) CustomFeatures() map[feature.Set][]lnwire.FeatureBit {
-	return map[feature.Set][]lnwire.FeatureBit{}
 }

--- a/lncfg/protocol_experimental_on.go
+++ b/lncfg/protocol_experimental_on.go
@@ -3,49 +3,7 @@
 
 package lncfg
 
-import (
-	"github.com/lightningnetwork/lnd/feature"
-	"github.com/lightningnetwork/lnd/lnwire"
-)
-
 // ExperimentalProtocol is a sub-config that houses any experimental protocol
 // features that also require a build-tag to activate.
-//
-//nolint:lll
 type ExperimentalProtocol struct {
-	CustomMessage []uint16 `long:"custom-message" description:"allows the custom message apis to send and report messages with the protocol number provided that fall outside of the custom message number range."`
-
-	CustomInit []uint16 `long:"custom-init" description:"custom feature bits to advertise in the node's init message"`
-
-	CustomNodeAnn []uint16 `long:"custom-nodeann" description:"custom feature bits to advertise in the node's announcement message"`
-
-	CustomInvoice []uint16 `long:"custom-invoice" description:"custom feature bits to advertise in the node's invoices"`
-}
-
-// CustomMessageOverrides returns the set of protocol messages that we override
-// to allow custom handling.
-func (p ExperimentalProtocol) CustomMessageOverrides() []uint16 {
-	return p.CustomMessage
-}
-
-// CustomFeatures returns a custom set of feature bits to advertise.
-//
-//nolint:lll
-func (p ExperimentalProtocol) CustomFeatures() map[feature.Set][]lnwire.FeatureBit {
-	customFeatures := make(map[feature.Set][]lnwire.FeatureBit)
-
-	setFeatures := func(set feature.Set, bits []uint16) {
-		for _, customFeature := range bits {
-			customFeatures[set] = append(
-				customFeatures[set],
-				lnwire.FeatureBit(customFeature),
-			)
-		}
-	}
-
-	setFeatures(feature.SetInit, p.CustomInit)
-	setFeatures(feature.SetNodeAnn, p.CustomNodeAnn)
-	setFeatures(feature.SetInvoice, p.CustomInvoice)
-
-	return customFeatures
 }

--- a/lncfg/protocol_integration.go
+++ b/lncfg/protocol_integration.go
@@ -2,6 +2,11 @@
 
 package lncfg
 
+import (
+	"github.com/lightningnetwork/lnd/feature"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
 // ProtocolOptions is a struct that we use to be able to test backwards
 // compatibility of protocol additions, while defaulting to the latest within
 // lnd, or to enable experimental protocol changes.
@@ -60,6 +65,23 @@ type ProtocolOptions struct {
 
 	// NoRouteBlindingOption disables forwarding of payments in blinded routes.
 	NoRouteBlindingOption bool `long:"no-route-blinding" description:"do not forward payments that are a part of a blinded route"`
+
+	// CustomMessage allows the custom message APIs to handle messages with
+	// the provided protocol numbers, which fall outside the custom message
+	// number range.
+	CustomMessage []uint16 `long:"custom-message" description:"allows the custom message apis to send and report messages with the protocol number provided that fall outside of the custom message number range."`
+
+	// CustomInit specifies feature bits to advertise in the node's init
+	// message.
+	CustomInit []uint16 `long:"custom-init" description:"custom feature bits to advertise in the node's init message"`
+
+	// CustomNodeAnn specifies custom feature bits to advertise in the
+	// node's announcement message.
+	CustomNodeAnn []uint16 `long:"custom-nodeann" description:"custom feature bits to advertise in the node's announcement message"`
+
+	// CustomInvoice specifies custom feature bits to advertise in the
+	// node's invoices.
+	CustomInvoice []uint16 `long:"custom-invoice" description:"custom feature bits to advertise in the node's invoices"`
 }
 
 // Wumbo returns true if lnd should permit the creation and acceptance of wumbo
@@ -99,4 +121,30 @@ func (l *ProtocolOptions) NoAnySegwit() bool {
 // NoRouteBlinding returns true if forwarding of blinded payments is disabled.
 func (l *ProtocolOptions) NoRouteBlinding() bool {
 	return l.NoRouteBlindingOption
+}
+
+// CustomMessageOverrides returns the set of protocol messages that we override
+// to allow custom handling.
+func (l ProtocolOptions) CustomMessageOverrides() []uint16 {
+	return l.CustomMessage
+}
+
+// CustomFeatures returns a custom set of feature bits to advertise.
+func (l ProtocolOptions) CustomFeatures() map[feature.Set][]lnwire.FeatureBit {
+	customFeatures := make(map[feature.Set][]lnwire.FeatureBit)
+
+	setFeatures := func(set feature.Set, bits []uint16) {
+		for _, customFeature := range bits {
+			customFeatures[set] = append(
+				customFeatures[set],
+				lnwire.FeatureBit(customFeature),
+			)
+		}
+	}
+
+	setFeatures(feature.SetInit, l.CustomInit)
+	setFeatures(feature.SetNodeAnn, l.CustomNodeAnn)
+	setFeatures(feature.SetInvoice, l.CustomInvoice)
+
+	return customFeatures
 }

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1306,6 +1306,39 @@
 ; Set to disable blinded route forwarding.
 ; protocol.no-route-blinding=false
 
+; Set to handle messages of a particular type that falls outside of the
+; custom message number range (i.e. 513 is onion messages). Note that you can
+; set this option as many times as you want to support more than one custom
+; message type.
+; Default:
+;   protocol.custom-message=
+; Example:
+;   protocol.custom-message=513
+
+; Specifies feature bits — numbers defined in BOLT 9 — to advertise in the
+; node's init message. Note that you can set this option as many times as you
+; want to support more than one feature bit.
+; Default:
+;   protocol.custom-init=
+; Example:
+;   protocol.custom-init=39
+
+; Specifies custom feature bits — numbers defined in BOLT 9 — to advertise in
+; the node's announcement message. Note that you can set this option as many
+; times as you want to support more than one feature bit.
+; Default:
+;   protocol.custom-nodeann=
+; Example:
+;   protocol.custom-nodeann=39
+
+; Specifies custom feature bits — numbers defined in BOLT 9 — to advertise in
+; the node's invoices. Note that you can set this option as many times as you
+; want to support more than one feature bit.
+; Default:
+;   protocol.custom-invoice=
+; Example:
+;   protocol.custom-invoice=39
+
 [db]
 
 ; The selected database backend. The current default backend is "bolt". lnd

--- a/server.go
+++ b/server.go
@@ -547,7 +547,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		NoOptionScidAlias:        !cfg.ProtocolOptions.ScidAlias(),
 		NoZeroConf:               !cfg.ProtocolOptions.ZeroConf(),
 		NoAnySegwit:              cfg.ProtocolOptions.NoAnySegwit(),
-		CustomFeatures:           cfg.ProtocolOptions.ExperimentalProtocol.CustomFeatures(),
+		CustomFeatures:           cfg.ProtocolOptions.CustomFeatures(),
 		NoTaprootChans:           !cfg.ProtocolOptions.TaprootChans,
 		NoRouteBlinding:          cfg.ProtocolOptions.NoRouteBlinding(),
 	})


### PR DESCRIPTION
## Change Description

This PR simply moves the experimental custom message config options to the main protocol config, so that the dev build flag doesn't need to be set to use them. Closes issue #8536.

We've gotten multiple requests for this at LNDK -- people don't want to be running LND in dev mode in production. There hasn't been any discussion on the #8536 issue, so hoping to at least spur discussion on what needs to happen to make this change feasible. :)

Tested this with LNDK to confirm it works properly.

## Steps to Test
The config options set in `sample-lnd.conf` should be possible to set without the dev flag.