### PR TITLE
fix dbtest backend

### DIFF
--- a/autopilot/prefattach_test.go
+++ b/autopilot/prefattach_test.go
@@ -25,7 +25,7 @@ type testGraph interface {
 
 func newDiskChanGraph(t *testing.T) (testGraph, error) {
 	// Next, create channeldb for the first time.
-	cdb, err := channeldb.Open(t.TempDir())
+	cdb, err := channeldb.OpenTestDB(t.TempDir())
 	if err != nil {
 		return nil, err
 	}

--- a/chainntnfs/bitcoindnotify/bitcoind_test.go
+++ b/chainntnfs/bitcoindnotify/bitcoind_test.go
@@ -37,7 +37,7 @@ var (
 func initHintCache(t *testing.T) *channeldb.HeightHintCache {
 	t.Helper()
 
-	db, err := channeldb.Open(t.TempDir())
+	db, err := channeldb.OpenTestDB(t.TempDir())
 	require.NoError(t, err, "unable to create db")
 	t.Cleanup(func() {
 		require.NoError(t, db.Close())

--- a/chainntnfs/btcdnotify/btcd_test.go
+++ b/chainntnfs/btcdnotify/btcd_test.go
@@ -33,7 +33,7 @@ var (
 func initHintCache(t *testing.T) *channeldb.HeightHintCache {
 	t.Helper()
 
-	db, err := channeldb.Open(t.TempDir())
+	db, err := channeldb.OpenTestDB(t.TempDir())
 	require.NoError(t, err, "unable to create db")
 	t.Cleanup(func() {
 		require.NoError(t, db.Close())

--- a/chainntnfs/test/test_interface.go
+++ b/chainntnfs/test/test_interface.go
@@ -1906,7 +1906,7 @@ func TestInterfaces(t *testing.T, targetBackEnd string) {
 
 		// Initialize a height hint cache for each notifier.
 		tempDir := t.TempDir()
-		db, err := channeldb.Open(tempDir)
+		db, err := channeldb.OpenTestDB(tempDir)
 		if err != nil {
 			t.Fatalf("unable to create db: %v", err)
 		}

--- a/channeldb/db_test.go
+++ b/channeldb/db_test.go
@@ -33,7 +33,7 @@ func TestOpenWithCreate(t *testing.T) {
 
 	// Next, open thereby creating channeldb for the first time.
 	dbPath := filepath.Join(tempDirName, "cdb")
-	backend, cleanup, err := kvdb.GetTestBackend(dbPath, "cdb")
+	backend, cleanup, err := kvdb.GetTestBackend(dbPath, dbName)
 	require.NoError(t, err, "unable to get test db backend")
 	t.Cleanup(cleanup)
 
@@ -50,7 +50,7 @@ func TestOpenWithCreate(t *testing.T) {
 
 	// Now, reopen the same db in dry run migration mode. Since we have not
 	// applied any migrations, this should ignore the flag and not fail.
-	cdb, err = Open(dbPath, OptionDryRunMigration(true))
+	cdb, err = OpenTestDB(dbPath, OptionDryRunMigration(true))
 	require.NoError(t, err, "unable to create channeldb")
 	if err := cdb.Close(); err != nil {
 		t.Fatalf("unable to close channeldb: %v", err)
@@ -69,7 +69,7 @@ func TestWipe(t *testing.T) {
 
 	// Next, open thereby creating channeldb for the first time.
 	dbPath := filepath.Join(tempDirName, "cdb")
-	backend, cleanup, err := kvdb.GetTestBackend(dbPath, "cdb")
+	backend, cleanup, err := kvdb.GetTestBackend(dbPath, dbName)
 	require.NoError(t, err, "unable to get test db backend")
 	t.Cleanup(cleanup)
 

--- a/channeldb/height_hint_test.go
+++ b/channeldb/height_hint_test.go
@@ -23,7 +23,7 @@ func initHintCache(t *testing.T) *HeightHintCache {
 func initHintCacheWithConfig(t *testing.T, cfg CacheConfig) *HeightHintCache {
 	t.Helper()
 
-	db, err := Open(t.TempDir())
+	db, err := OpenTestDB(t.TempDir())
 	require.NoError(t, err, "unable to create db")
 	hintCache, err := NewHeightHintCache(cfg, db.Backend)
 	require.NoError(t, err, "unable to create hint cache")

--- a/channeldb/meta_test.go
+++ b/channeldb/meta_test.go
@@ -421,7 +421,7 @@ func TestMigrationReversion(t *testing.T) {
 
 	tempDirName := t.TempDir()
 
-	backend, cleanup, err := kvdb.GetTestBackend(tempDirName, "cdb")
+	backend, cleanup, err := kvdb.GetTestBackend(tempDirName, dbName)
 	require.NoError(t, err, "unable to get test db backend")
 
 	cdb, err := CreateWithBackend(backend)
@@ -446,7 +446,7 @@ func TestMigrationReversion(t *testing.T) {
 
 	require.NoError(t, err, "unable to increase db version")
 
-	backend, cleanup, err = kvdb.GetTestBackend(tempDirName, "cdb")
+	backend, cleanup, err = kvdb.GetTestBackend(tempDirName, dbName)
 	require.NoError(t, err, "unable to get test db backend")
 	t.Cleanup(cleanup)
 

--- a/contractcourt/breach_arbitrator_test.go
+++ b/contractcourt/breach_arbitrator_test.go
@@ -635,7 +635,7 @@ func TestMockRetributionStore(t *testing.T) {
 }
 
 func makeTestChannelDB(t *testing.T) (*channeldb.DB, error) {
-	db, err := channeldb.Open(t.TempDir())
+	db, err := channeldb.OpenTestDB(t.TempDir())
 	if err != nil {
 		return nil, err
 	}
@@ -667,7 +667,9 @@ func TestChannelDBRetributionStore(t *testing.T) {
 							"restart: %v",
 							err)
 					}
-					db, err = channeldb.Open(db.Path())
+					db, err = channeldb.OpenTestDB(
+						db.Path(),
+					)
 					if err != nil {
 						t.Fatalf("unable to open "+
 							"channeldb: %v", err)
@@ -2259,7 +2261,7 @@ func createInitChannels(t *testing.T, revocationWindow int) (
 		return nil, nil, err
 	}
 
-	dbAlice, err := channeldb.Open(t.TempDir())
+	dbAlice, err := channeldb.OpenTestDB(t.TempDir())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2267,7 +2269,7 @@ func createInitChannels(t *testing.T, revocationWindow int) (
 		require.NoError(t, dbAlice.Close())
 	})
 
-	dbBob, err := channeldb.Open(t.TempDir())
+	dbBob, err := channeldb.OpenTestDB(t.TempDir())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/contractcourt/breach_arbitrator_test.go
+++ b/contractcourt/breach_arbitrator_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lntest/channels"
 	"github.com/lightningnetwork/lnd/lntest/mock"
 	"github.com/lightningnetwork/lnd/lntest/wait"
@@ -647,6 +648,11 @@ func makeTestChannelDB(t *testing.T) (*channeldb.DB, error) {
 // channeldb.DB, and tests its behavior using the general RetributionStore test
 // suite.
 func TestChannelDBRetributionStore(t *testing.T) {
+	// TODO(ziggie): Analyse why restart of the etcd database is not
+	// working.
+	if kvdb.EtcdBackend {
+		t.Skip()
+	}
 	// Finally, instantiate retribution store and execute RetributionStore
 	// test suite.
 	for _, test := range retributionStoreTestSuite {

--- a/contractcourt/chain_arbitrator_test.go
+++ b/contractcourt/chain_arbitrator_test.go
@@ -21,7 +21,7 @@ import (
 func TestChainArbitratorRepublishCloses(t *testing.T) {
 	t.Parallel()
 
-	db, err := channeldb.Open(t.TempDir())
+	db, err := channeldb.OpenTestDB(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,7 +136,7 @@ func TestChainArbitratorRepublishCloses(t *testing.T) {
 func TestResolveContract(t *testing.T) {
 	t.Parallel()
 
-	db, err := channeldb.Open(t.TempDir())
+	db, err := channeldb.OpenTestDB(t.TempDir())
 	require.NoError(t, err, "unable to open db")
 	t.Cleanup(func() {
 		require.NoError(t, db.Close())

--- a/contractcourt/chain_watcher_test.go
+++ b/contractcourt/chain_watcher_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lntest/mock"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -205,7 +206,7 @@ func executeStateTransitions(t *testing.T, htlcAmount lnwire.MilliSatoshi,
 		chanStates []*channeldb.OpenChannel
 	)
 
-	state, err := copyChannelState(t, aliceChannel.State())
+	state, err := copyChannelStateBoltDB(t, aliceChannel.State())
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +223,7 @@ func executeStateTransitions(t *testing.T, htlcAmount lnwire.MilliSatoshi,
 			return nil, err
 		}
 
-		state, err := copyChannelState(t, aliceChannel.State())
+		state, err := copyChannelStateBoltDB(t, aliceChannel.State())
 		if err != nil {
 			return nil, err
 		}
@@ -238,6 +239,10 @@ func executeStateTransitions(t *testing.T, htlcAmount lnwire.MilliSatoshi,
 // remote force close using the obtained data loss commitment point.
 func TestChainWatcherDataLossProtect(t *testing.T) {
 	t.Parallel()
+
+	if !kvdb.IsBoltDB() {
+		t.Skip()
+	}
 
 	// dlpScenario is our primary quick check testing function for this
 	// test as whole. It ensures that if the remote party broadcasts a
@@ -417,6 +422,10 @@ func TestChainWatcherDataLossProtect(t *testing.T) {
 // commitment output based on only the outputs present on the transaction.
 func TestChainWatcherLocalForceCloseDetect(t *testing.T) {
 	t.Parallel()
+
+	if !kvdb.IsBoltDB() {
+		t.Skip()
+	}
 
 	// localForceCloseScenario is the primary test we'll use to execute our
 	// table driven tests. We'll assert that for any number of state

--- a/contractcourt/utils_test.go
+++ b/contractcourt/utils_test.go
@@ -65,12 +65,12 @@ func copyChannelState(t *testing.T, state *channeldb.OpenChannel) (
 		return nil, err
 	}
 
-	newDb, err := channeldb.Open(tempDbPath)
+	newDB, err := channeldb.OpenTestDB(tempDbPath)
 	if err != nil {
 		return nil, err
 	}
 
-	chans, err := newDb.ChannelStateDB().FetchAllChannels()
+	chans, err := newDB.ChannelStateDB().FetchAllChannels()
 	if err != nil {
 		return nil, err
 	}

--- a/contractcourt/utils_test.go
+++ b/contractcourt/utils_test.go
@@ -52,7 +52,7 @@ func copyFile(dest, src string) error {
 
 // copyChannelState copies the OpenChannel state by copying the database and
 // creating a new struct from it. The copied state is returned.
-func copyChannelState(t *testing.T, state *channeldb.OpenChannel) (
+func copyChannelStateBoltDB(t *testing.T, state *channeldb.OpenChannel) (
 	*channeldb.OpenChannel, error) {
 
 	// Make a copy of the DB.

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -75,7 +75,7 @@ var (
 // makeTestDB creates a new instance of the ChannelDB for testing purposes.
 func makeTestDB(t *testing.T) (*channeldb.DB, error) {
 	// Create channeldb for the first time.
-	cdb, err := channeldb.Open(t.TempDir())
+	cdb, err := channeldb.OpenTestDB(t.TempDir())
 	if err != nil {
 		return nil, err
 	}

--- a/discovery/message_store_test.go
+++ b/discovery/message_store_test.go
@@ -17,7 +17,7 @@ import (
 func createTestMessageStore(t *testing.T) *MessageStore {
 	t.Helper()
 
-	db, err := channeldb.Open(t.TempDir())
+	db, err := channeldb.OpenTestDB(t.TempDir())
 	if err != nil {
 		t.Fatalf("unable to open db: %v", err)
 	}

--- a/docs/release-notes/release-notes-0.18.1.md
+++ b/docs/release-notes/release-notes-0.18.1.md
@@ -1,0 +1,49 @@
+# Release Notes
+- [Bug Fixes](#bug-fixes)
+- [New Features](#new-features)
+    - [Functional Enhancements](#functional-enhancements)
+    - [RPC Additions](#rpc-additions)
+    - [lncli Additions](#lncli-additions)
+- [Improvements](#improvements)
+    - [Functional Updates](#functional-updates)
+    - [RPC Updates](#rpc-updates)
+    - [lncli Updates](#lncli-updates)
+    - [Breaking Changes](#breaking-changes)
+    - [Performance Improvements](#performance-improvements)
+- [Technical and Architectural Updates](#technical-and-architectural-updates)
+    - [BOLT Spec Updates](#bolt-spec-updates)
+    - [Testing](#testing)
+    - [Database](#database)
+    - [Code Health](#code-health)
+    - [Tooling and Documentation](#tooling-and-documentation)
+
+# Bug Fixes
+
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/8745) unit testcases 
+  where only the bolt db backend would be used instead of the specified golang
+  tagged kvdb backend.
+
+
+# New Features
+## Functional Enhancements
+## RPC Additions
+## lncli Additions
+
+# Improvements
+## Functional Updates
+## RPC Updates
+## lncli Updates
+## Code Health
+## Breaking Changes
+## Performance Improvements
+
+# Technical and Architectural Updates
+## BOLT Spec Updates
+## Testing
+## Database
+## Code Health
+## Tooling and Documentation
+
+# Contributors (Alphabetical Order)
+
+* ziggie1984

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -424,7 +424,7 @@ func createTestFundingManager(t *testing.T, privKey *btcec.PrivateKey,
 	}
 
 	dbDir := filepath.Join(tempTestDir, "cdb")
-	fullDB, err := channeldb.Open(dbDir)
+	fullDB, err := channeldb.OpenTestDB(dbDir)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -208,3 +208,5 @@ replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-d
 go 1.21.4
 
 retract v0.0.2
+
+replace github.com/lightningnetwork/lnd/kvdb v1.4.8 => github.com/ziggie1984/lnd/kvdb v1.4.5-0.20240514092815-f6491b6ba90c

--- a/go.sum
+++ b/go.sum
@@ -452,8 +452,6 @@ github.com/lightningnetwork/lnd/fn v1.0.5 h1:ffDgMSn83avw6rNzxhbt6w5/2oIrwQKTPGf
 github.com/lightningnetwork/lnd/fn v1.0.5/go.mod h1:P027+0CyELd92H9gnReUkGGAqbFA1HwjHWdfaDFD51U=
 github.com/lightningnetwork/lnd/healthcheck v1.2.4 h1:lLPLac+p/TllByxGSlkCwkJlkddqMP5UCoawCj3mgFQ=
 github.com/lightningnetwork/lnd/healthcheck v1.2.4/go.mod h1:G7Tst2tVvWo7cx6mSBEToQC5L1XOGxzZTPB29g9Rv2I=
-github.com/lightningnetwork/lnd/kvdb v1.4.8 h1:xH0a5Vi1yrcZ5BEeF2ba3vlKBRxrL9uYXlWTjOjbNTY=
-github.com/lightningnetwork/lnd/kvdb v1.4.8/go.mod h1:J2diNABOoII9UrMnxXS5w7vZwP7CA1CStrl8MnIrb3A=
 github.com/lightningnetwork/lnd/queue v1.1.1 h1:99ovBlpM9B0FRCGYJo6RSFDlt8/vOkQQZznVb18iNMI=
 github.com/lightningnetwork/lnd/queue v1.1.1/go.mod h1:7A6nC1Qrm32FHuhx/mi1cieAiBZo5O6l8IBIoQxvkz4=
 github.com/lightningnetwork/lnd/sqldb v1.0.2 h1:PfuYzScYMD9/QonKo/QvgsbXfTnH5DfldIimkfdW4Bk=
@@ -618,6 +616,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
+github.com/ziggie1984/lnd/kvdb v1.4.5-0.20240514092815-f6491b6ba90c h1:Q3ZtDBN5+46q172SsBXRs4tCc1of33GajCq/jcdZIQc=
+github.com/ziggie1984/lnd/kvdb v1.4.5-0.20240514092815-f6491b6ba90c/go.mod h1:J2diNABOoII9UrMnxXS5w7vZwP7CA1CStrl8MnIrb3A=
 gitlab.com/yawning/bsaes.git v0.0.0-20190805113838-0a714cd429ec h1:FpfFs4EhNehiVfzQttTuxanPIT43FtkkCFypIod8LHo=
 gitlab.com/yawning/bsaes.git v0.0.0-20190805113838-0a714cd429ec/go.mod h1:BZ1RAoRPbCxum9Grlv5aeksu2H8BiKehBYooU2LFiOQ=
 go.etcd.io/bbolt v1.3.7 h1:j+zJOnnEjF/kyHlDDgGnVL/AIqIJPq8UoB2GSNfkUfQ=

--- a/htlcswitch/circuit_test.go
+++ b/htlcswitch/circuit_test.go
@@ -626,7 +626,7 @@ func makeCircuitDB(t *testing.T, path string) *channeldb.DB {
 		path = t.TempDir()
 	}
 
-	db, err := channeldb.Open(path)
+	db, err := channeldb.OpenTestDB(path)
 	require.NoError(t, err, "unable to open channel db")
 	t.Cleanup(func() { db.Close() })
 

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -212,7 +212,7 @@ func initSwitchWithTempDB(t testing.TB, startingHeight uint32) (*Switch,
 	error) {
 
 	tempPath := filepath.Join(t.TempDir(), "switchdb")
-	db, err := channeldb.Open(tempPath)
+	db, err := channeldb.OpenTestDB(tempPath)
 	if err != nil {
 		return nil, err
 	}
@@ -952,7 +952,7 @@ func newDB() (*channeldb.DB, func(), error) {
 	}
 
 	// Next, create channeldb for the first time.
-	cdb, err := channeldb.Open(tempDirName)
+	cdb, err := channeldb.OpenTestDB(tempDirName)
 	if err != nil {
 		os.RemoveAll(tempDirName)
 		return nil, nil, err

--- a/htlcswitch/payment_result_test.go
+++ b/htlcswitch/payment_result_test.go
@@ -102,7 +102,7 @@ func TestNetworkResultStore(t *testing.T) {
 
 	const numResults = 4
 
-	db, err := channeldb.Open(t.TempDir())
+	db, err := channeldb.OpenTestDB(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -999,7 +999,7 @@ func TestSwitchForwardFailAfterFullAdd(t *testing.T) {
 
 	tempPath := t.TempDir()
 
-	cdb, err := channeldb.Open(tempPath)
+	cdb, err := channeldb.OpenTestDB(tempPath)
 	require.NoError(t, err, "unable to open channeldb")
 	t.Cleanup(func() { cdb.Close() })
 
@@ -1093,7 +1093,7 @@ func TestSwitchForwardFailAfterFullAdd(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
-	cdb2, err := channeldb.Open(tempPath)
+	cdb2, err := channeldb.OpenTestDB(tempPath)
 	require.NoError(t, err, "unable to reopen channeldb")
 	t.Cleanup(func() { cdb2.Close() })
 
@@ -1189,7 +1189,7 @@ func TestSwitchForwardSettleAfterFullAdd(t *testing.T) {
 
 	tempPath := t.TempDir()
 
-	cdb, err := channeldb.Open(tempPath)
+	cdb, err := channeldb.OpenTestDB(tempPath)
 	require.NoError(t, err, "unable to open channeldb")
 	t.Cleanup(func() { cdb.Close() })
 
@@ -1283,7 +1283,7 @@ func TestSwitchForwardSettleAfterFullAdd(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
-	cdb2, err := channeldb.Open(tempPath)
+	cdb2, err := channeldb.OpenTestDB(tempPath)
 	require.NoError(t, err, "unable to reopen channeldb")
 	t.Cleanup(func() { cdb2.Close() })
 
@@ -1382,7 +1382,7 @@ func TestSwitchForwardDropAfterFullAdd(t *testing.T) {
 
 	tempPath := t.TempDir()
 
-	cdb, err := channeldb.Open(tempPath)
+	cdb, err := channeldb.OpenTestDB(tempPath)
 	require.NoError(t, err, "unable to open channeldb")
 	t.Cleanup(func() { cdb.Close() })
 
@@ -1468,7 +1468,7 @@ func TestSwitchForwardDropAfterFullAdd(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
-	cdb2, err := channeldb.Open(tempPath)
+	cdb2, err := channeldb.OpenTestDB(tempPath)
 	require.NoError(t, err, "unable to reopen channeldb")
 	t.Cleanup(func() { cdb2.Close() })
 
@@ -1538,7 +1538,7 @@ func TestSwitchForwardFailAfterHalfAdd(t *testing.T) {
 
 	tempPath := t.TempDir()
 
-	cdb, err := channeldb.Open(tempPath)
+	cdb, err := channeldb.OpenTestDB(tempPath)
 	require.NoError(t, err, "unable to open channeldb")
 	t.Cleanup(func() { cdb.Close() })
 
@@ -1619,7 +1619,7 @@ func TestSwitchForwardFailAfterHalfAdd(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
-	cdb2, err := channeldb.Open(tempPath)
+	cdb2, err := channeldb.OpenTestDB(tempPath)
 	require.NoError(t, err, "unable to reopen channeldb")
 	t.Cleanup(func() { cdb2.Close() })
 
@@ -1695,7 +1695,7 @@ func TestSwitchForwardCircuitPersistence(t *testing.T) {
 
 	tempPath := t.TempDir()
 
-	cdb, err := channeldb.Open(tempPath)
+	cdb, err := channeldb.OpenTestDB(tempPath)
 	require.NoError(t, err, "unable to open channeldb")
 	t.Cleanup(func() { cdb.Close() })
 
@@ -1775,7 +1775,7 @@ func TestSwitchForwardCircuitPersistence(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
-	cdb2, err := channeldb.Open(tempPath)
+	cdb2, err := channeldb.OpenTestDB(tempPath)
 	require.NoError(t, err, "unable to reopen channeldb")
 	t.Cleanup(func() { cdb2.Close() })
 
@@ -1867,7 +1867,7 @@ func TestSwitchForwardCircuitPersistence(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
-	cdb3, err := channeldb.Open(tempPath)
+	cdb3, err := channeldb.OpenTestDB(tempPath)
 	require.NoError(t, err, "unable to reopen channeldb")
 	t.Cleanup(func() { cdb3.Close() })
 
@@ -3824,7 +3824,7 @@ func newInterceptableSwitchTestContext(
 
 	tempPath := t.TempDir()
 
-	cdb, err := channeldb.Open(tempPath)
+	cdb, err := channeldb.OpenTestDB(tempPath)
 	require.NoError(t, err, "unable to open channeldb")
 	t.Cleanup(func() { cdb.Close() })
 
@@ -4866,7 +4866,7 @@ func testSwitchForwardFailAlias(t *testing.T, zeroConf bool) {
 
 	tempPath := t.TempDir()
 
-	cdb, err := channeldb.Open(tempPath)
+	cdb, err := channeldb.OpenTestDB(tempPath)
 	require.NoError(t, err)
 	t.Cleanup(func() { cdb.Close() })
 
@@ -4942,7 +4942,7 @@ func testSwitchForwardFailAlias(t *testing.T, zeroConf bool) {
 	err = cdb.Close()
 	require.NoError(t, err)
 
-	cdb2, err := channeldb.Open(tempPath)
+	cdb2, err := channeldb.OpenTestDB(tempPath)
 	require.NoError(t, err)
 	t.Cleanup(func() { cdb2.Close() })
 
@@ -5082,7 +5082,7 @@ func testSwitchAliasFailAdd(t *testing.T, zeroConf, private, useAlias bool) {
 
 	tempPath := t.TempDir()
 
-	cdb, err := channeldb.Open(tempPath)
+	cdb, err := channeldb.OpenTestDB(tempPath)
 	require.NoError(t, err)
 	defer cdb.Close()
 
@@ -5423,7 +5423,7 @@ func testSwitchAliasInterceptFail(t *testing.T, zeroConf bool) {
 
 	tempPath := t.TempDir()
 
-	cdb, err := channeldb.Open(tempPath)
+	cdb, err := channeldb.OpenTestDB(tempPath)
 	require.NoError(t, err)
 	t.Cleanup(func() { cdb.Close() })
 

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -239,7 +239,7 @@ func createTestChannel(t *testing.T, alicePrivKey, bobPrivKey []byte,
 		return nil, nil, err
 	}
 
-	dbAlice, err := channeldb.Open(t.TempDir())
+	dbAlice, err := channeldb.OpenTestDB(t.TempDir())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -247,7 +247,7 @@ func createTestChannel(t *testing.T, alicePrivKey, bobPrivKey []byte,
 		require.NoError(t, dbAlice.Close())
 	})
 
-	dbBob, err := channeldb.Open(t.TempDir())
+	dbBob, err := channeldb.OpenTestDB(t.TempDir())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -386,7 +386,7 @@ func createTestChannel(t *testing.T, alicePrivKey, bobPrivKey []byte,
 		switch err {
 		case nil:
 		case kvdb.ErrDatabaseNotOpen:
-			dbAlice, err = channeldb.Open(dbAlice.Path())
+			dbAlice, err = channeldb.OpenTestDB(dbAlice.Path())
 			if err != nil {
 				return nil, errors.Errorf("unable to reopen alice "+
 					"db: %v", err)
@@ -432,7 +432,7 @@ func createTestChannel(t *testing.T, alicePrivKey, bobPrivKey []byte,
 		switch err {
 		case nil:
 		case kvdb.ErrDatabaseNotOpen:
-			dbBob, err = channeldb.Open(dbBob.Path())
+			dbBob, err = channeldb.OpenTestDB(dbBob.Path())
 			if err != nil {
 				return nil, errors.Errorf("unable to reopen bob "+
 					"db: %v", err)

--- a/kvdb/backend.go
+++ b/kvdb/backend.go
@@ -32,6 +32,11 @@ var (
 	byteOrder = binary.BigEndian
 )
 
+// IsBoltDB returns whether the backend runs on bolt db.
+func IsBoltDB() bool {
+	return !PostgresBackend && !SqliteBackend && !EtcdBackend
+}
+
 // fileExists returns true if the file exists, and false otherwise.
 func fileExists(path string) bool {
 	if _, err := os.Stat(path); err != nil {

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -314,7 +314,7 @@ func createTestWallet(tempTestDir string, miningNode *rpctest.Harness,
 	signer input.Signer, bio lnwallet.BlockChainIO) (*lnwallet.LightningWallet, error) {
 
 	dbDir := filepath.Join(tempTestDir, "cdb")
-	fullDB, err := channeldb.Open(dbDir)
+	fullDB, err := channeldb.OpenTestDB(dbDir)
 	if err != nil {
 		return nil, err
 	}
@@ -3099,7 +3099,7 @@ func TestLightningWallet(t *testing.T, targetBackEnd string) {
 	rpcConfig := miningNode.RPCConfig()
 
 	tempDir := t.TempDir()
-	db, err := channeldb.Open(tempDir)
+	db, err := channeldb.OpenTestDB(tempDir)
 	require.NoError(t, err, "unable to create db")
 	testCfg := channeldb.CacheConfig{
 		QueryDisable: false,

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -229,7 +229,7 @@ func CreateTestChannels(t *testing.T, chanType channeldb.ChannelType,
 		return nil, nil, err
 	}
 
-	dbAlice, err := channeldb.Open(t.TempDir(), dbModifiers...)
+	dbAlice, err := channeldb.OpenTestDB(t.TempDir(), dbModifiers...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -237,7 +237,7 @@ func CreateTestChannels(t *testing.T, chanType channeldb.ChannelType,
 		require.NoError(t, dbAlice.Close())
 	})
 
-	dbBob, err := channeldb.Open(t.TempDir(), dbModifiers...)
+	dbBob, err := channeldb.OpenTestDB(t.TempDir(), dbModifiers...)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/lnwallet/transactions_test.go
+++ b/lnwallet/transactions_test.go
@@ -905,10 +905,10 @@ func createTestChannelsForVectors(tc *testContext, chanType channeldb.ChannelTyp
 	)
 
 	// Create temporary databases.
-	dbRemote, err := channeldb.Open(t.TempDir())
+	dbRemote, err := channeldb.OpenTestDB(t.TempDir())
 	require.NoError(t, err)
 
-	dbLocal, err := channeldb.Open(t.TempDir())
+	dbLocal, err := channeldb.OpenTestDB(t.TempDir())
 	require.NoError(t, err)
 
 	// Create the initial commitment transactions for the channel.

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -1057,7 +1057,7 @@ func TestPeerCustomMessage(t *testing.T) {
 	t.Parallel()
 
 	// Set up node Alice.
-	dbAlice, err := channeldb.Open(t.TempDir())
+	dbAlice, err := channeldb.OpenTestDB(t.TempDir())
 	require.NoError(t, err)
 
 	aliceKey, err := btcec.NewPrivateKey()

--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -170,7 +170,7 @@ func createTestPeer(t *testing.T, notifier chainntnfs.ChainNotifier,
 		return nil, nil, err
 	}
 
-	dbAlice, err := channeldb.Open(t.TempDir())
+	dbAlice, err := channeldb.OpenTestDB(t.TempDir())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -178,7 +178,7 @@ func createTestPeer(t *testing.T, notifier chainntnfs.ChainNotifier,
 		require.NoError(t, dbAlice.Close())
 	})
 
-	dbBob, err := channeldb.Open(t.TempDir())
+	dbBob, err := channeldb.OpenTestDB(t.TempDir())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/routing/control_tower_test.go
+++ b/routing/control_tower_test.go
@@ -526,7 +526,7 @@ func testPaymentControlSubscribeFail(t *testing.T, registerAttempt,
 }
 
 func initDB(t *testing.T, keepFailedPaymentAttempts bool) (*channeldb.DB, error) {
-	db, err := channeldb.Open(
+	db, err := channeldb.OpenTestDB(
 		t.TempDir(), channeldb.OptionKeepFailedPaymentAttempts(
 			keepFailedPaymentAttempts,
 		),


### PR DESCRIPTION
Replaces #8462

1. This PR fixes a testcase where we would basically test not what the testcase was suppose to test (reopening the same database).

2. Moreover it enhances a lot of unit-tests which would initially only test the bolt db backend and makes those tests compatible with the global kvdb backend, so those tests are now executed depending on the selected golang kv tag.
