### PR TITLE
[1/4] Route Blinding Receives: Groundwork

### DIFF
--- a/cmd/lncli/cmd_payments.go
+++ b/cmd/lncli/cmd_payments.go
@@ -1099,8 +1099,13 @@ var queryRoutesCommand = cli.Command{
 		},
 		cli.Int64Flag{
 			Name: "final_cltv_delta",
-			Usage: "(optional) number of blocks the last hop has to reveal " +
-				"the preimage",
+			Usage: "(optional) number of blocks the last hop has " +
+				"to reveal the preimage. Note that this " +
+				"should not be set in the case where the " +
+				"path includes a blinded path since in " +
+				"that case, the receiver will already have " +
+				"accounted for this value in the " +
+				"blinded_cltv value",
 		},
 		cli.BoolFlag{
 			Name:  "use_mc",
@@ -1236,6 +1241,13 @@ func parseBlindedPaymentParameters(ctx *cli.Context) (
 	// blinded path.
 	if !ctx.IsSet(blindingPointFlag.Name) {
 		return nil, nil
+	}
+
+	// If a blinded path has been provided, then the final_cltv_delta flag
+	// should not be provided since this value will be ignored.
+	if ctx.IsSet("final_cltv_delta") {
+		return nil, fmt.Errorf("`final_cltv_delta` should not be " +
+			"provided if a blinded path is provided")
 	}
 
 	// If any one of our blinding related flags is set, we expect the

--- a/docs/release-notes/release-notes-0.18.3.md
+++ b/docs/release-notes/release-notes-0.18.3.md
@@ -89,6 +89,9 @@
   channel. We will still wait for the channel to have at least one confirmation
   and so the main change here is that we don't error out for such a case.
 
+* [Groundwork](https://github.com/lightningnetwork/lnd/pull/8752) in preparation
+  for implementing route blinding receives.
+
 ## Testing
 ## Database
 

--- a/htlcswitch/hop/iterator_test.go
+++ b/htlcswitch/hop/iterator_test.go
@@ -186,7 +186,7 @@ func TestDecryptAndValidateFwdInfo(t *testing.T) {
 
 	// Encode valid blinding data that we'll fake decrypting for our test.
 	maxCltv := 1000
-	blindedData := record.NewBlindedRouteData(
+	blindedData := record.NewNonFinalBlindedRouteData(
 		lnwire.NewShortChanIDFromInt(1500), nil,
 		record.PaymentRelayInfo{
 			CltvExpiryDelta: 10,

--- a/htlcswitch/hop/payload_test.go
+++ b/htlcswitch/hop/payload_test.go
@@ -646,7 +646,7 @@ func TestValidateBlindedRouteData(t *testing.T) {
 	}{
 		{
 			name: "max cltv expired",
-			data: record.NewBlindedRouteData(
+			data: record.NewNonFinalBlindedRouteData(
 				scid,
 				nil,
 				record.PaymentRelayInfo{},
@@ -663,7 +663,7 @@ func TestValidateBlindedRouteData(t *testing.T) {
 		},
 		{
 			name: "zero max cltv",
-			data: record.NewBlindedRouteData(
+			data: record.NewNonFinalBlindedRouteData(
 				scid,
 				nil,
 				record.PaymentRelayInfo{},
@@ -682,7 +682,7 @@ func TestValidateBlindedRouteData(t *testing.T) {
 		},
 		{
 			name: "amount below minimum",
-			data: record.NewBlindedRouteData(
+			data: record.NewNonFinalBlindedRouteData(
 				scid,
 				nil,
 				record.PaymentRelayInfo{},
@@ -699,7 +699,7 @@ func TestValidateBlindedRouteData(t *testing.T) {
 		},
 		{
 			name: "valid, no features",
-			data: record.NewBlindedRouteData(
+			data: record.NewNonFinalBlindedRouteData(
 				scid,
 				nil,
 				record.PaymentRelayInfo{},
@@ -714,7 +714,7 @@ func TestValidateBlindedRouteData(t *testing.T) {
 		},
 		{
 			name: "unknown features",
-			data: record.NewBlindedRouteData(
+			data: record.NewNonFinalBlindedRouteData(
 				scid,
 				nil,
 				record.PaymentRelayInfo{},
@@ -738,7 +738,7 @@ func TestValidateBlindedRouteData(t *testing.T) {
 		},
 		{
 			name: "valid data",
-			data: record.NewBlindedRouteData(
+			data: record.NewNonFinalBlindedRouteData(
 				scid,
 				nil,
 				record.PaymentRelayInfo{

--- a/itest/lnd_route_blinding_test.go
+++ b/itest/lnd_route_blinding_test.go
@@ -676,7 +676,7 @@ func (b *blindedForwardTest) createBlindedRoute(hops []*forwardingEdge,
 
 		// Encode the route's blinded data and include it in the
 		// blinded hop.
-		payload := record.NewBlindedRouteData(
+		payload := record.NewNonFinalBlindedRouteData(
 			scid, nil, *relayInfo, constraints, nil,
 		)
 		payloadBytes, err := record.EncodeBlindedRouteData(payload)
@@ -739,7 +739,7 @@ func (b *blindedForwardTest) createBlindedRoute(hops []*forwardingEdge,
 		// node ID here so that it _looks like_ a valid
 		// forwarding hop (though in reality it's the last
 		// hop).
-		record.NewBlindedRouteData(
+		record.NewNonFinalBlindedRouteData(
 			lnwire.NewShortChanIDFromInt(100), nil,
 			record.PaymentRelayInfo{}, nil, nil,
 		),

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -14304,19 +14304,20 @@ type PayReq struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Destination     string              `protobuf:"bytes,1,opt,name=destination,proto3" json:"destination,omitempty"`
-	PaymentHash     string              `protobuf:"bytes,2,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
-	NumSatoshis     int64               `protobuf:"varint,3,opt,name=num_satoshis,json=numSatoshis,proto3" json:"num_satoshis,omitempty"`
-	Timestamp       int64               `protobuf:"varint,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
-	Expiry          int64               `protobuf:"varint,5,opt,name=expiry,proto3" json:"expiry,omitempty"`
-	Description     string              `protobuf:"bytes,6,opt,name=description,proto3" json:"description,omitempty"`
-	DescriptionHash string              `protobuf:"bytes,7,opt,name=description_hash,json=descriptionHash,proto3" json:"description_hash,omitempty"`
-	FallbackAddr    string              `protobuf:"bytes,8,opt,name=fallback_addr,json=fallbackAddr,proto3" json:"fallback_addr,omitempty"`
-	CltvExpiry      int64               `protobuf:"varint,9,opt,name=cltv_expiry,json=cltvExpiry,proto3" json:"cltv_expiry,omitempty"`
-	RouteHints      []*RouteHint        `protobuf:"bytes,10,rep,name=route_hints,json=routeHints,proto3" json:"route_hints,omitempty"`
-	PaymentAddr     []byte              `protobuf:"bytes,11,opt,name=payment_addr,json=paymentAddr,proto3" json:"payment_addr,omitempty"`
-	NumMsat         int64               `protobuf:"varint,12,opt,name=num_msat,json=numMsat,proto3" json:"num_msat,omitempty"`
-	Features        map[uint32]*Feature `protobuf:"bytes,13,rep,name=features,proto3" json:"features,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	Destination     string                `protobuf:"bytes,1,opt,name=destination,proto3" json:"destination,omitempty"`
+	PaymentHash     string                `protobuf:"bytes,2,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
+	NumSatoshis     int64                 `protobuf:"varint,3,opt,name=num_satoshis,json=numSatoshis,proto3" json:"num_satoshis,omitempty"`
+	Timestamp       int64                 `protobuf:"varint,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	Expiry          int64                 `protobuf:"varint,5,opt,name=expiry,proto3" json:"expiry,omitempty"`
+	Description     string                `protobuf:"bytes,6,opt,name=description,proto3" json:"description,omitempty"`
+	DescriptionHash string                `protobuf:"bytes,7,opt,name=description_hash,json=descriptionHash,proto3" json:"description_hash,omitempty"`
+	FallbackAddr    string                `protobuf:"bytes,8,opt,name=fallback_addr,json=fallbackAddr,proto3" json:"fallback_addr,omitempty"`
+	CltvExpiry      int64                 `protobuf:"varint,9,opt,name=cltv_expiry,json=cltvExpiry,proto3" json:"cltv_expiry,omitempty"`
+	RouteHints      []*RouteHint          `protobuf:"bytes,10,rep,name=route_hints,json=routeHints,proto3" json:"route_hints,omitempty"`
+	PaymentAddr     []byte                `protobuf:"bytes,11,opt,name=payment_addr,json=paymentAddr,proto3" json:"payment_addr,omitempty"`
+	NumMsat         int64                 `protobuf:"varint,12,opt,name=num_msat,json=numMsat,proto3" json:"num_msat,omitempty"`
+	Features        map[uint32]*Feature   `protobuf:"bytes,13,rep,name=features,proto3" json:"features,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	BlindedPaths    []*BlindedPaymentPath `protobuf:"bytes,14,rep,name=blinded_paths,json=blindedPaths,proto3" json:"blinded_paths,omitempty"`
 }
 
 func (x *PayReq) Reset() {
@@ -14438,6 +14439,13 @@ func (x *PayReq) GetNumMsat() int64 {
 func (x *PayReq) GetFeatures() map[uint32]*Feature {
 	if x != nil {
 		return x.Features
+	}
+	return nil
+}
+
+func (x *PayReq) GetBlindedPaths() []*BlindedPaymentPath {
+	if x != nil {
+		return x.BlindedPaths
 	}
 	return nil
 }
@@ -20202,7 +20210,7 @@ var file_lightning_proto_rawDesc = []byte{
 	0x75, 0x62, 0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x73, 0x22, 0x27, 0x0a, 0x0c, 0x50, 0x61, 0x79,
 	0x52, 0x65, 0x71, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x12, 0x17, 0x0a, 0x07, 0x70, 0x61, 0x79,
 	0x5f, 0x72, 0x65, 0x71, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x06, 0x70, 0x61, 0x79, 0x52,
-	0x65, 0x71, 0x22, 0xb0, 0x04, 0x0a, 0x06, 0x50, 0x61, 0x79, 0x52, 0x65, 0x71, 0x12, 0x20, 0x0a,
+	0x65, 0x71, 0x22, 0xf0, 0x04, 0x0a, 0x06, 0x50, 0x61, 0x79, 0x52, 0x65, 0x71, 0x12, 0x20, 0x0a,
 	0x0b, 0x64, 0x65, 0x73, 0x74, 0x69, 0x6e, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20, 0x01,
 	0x28, 0x09, 0x52, 0x0b, 0x64, 0x65, 0x73, 0x74, 0x69, 0x6e, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12,
 	0x21, 0x0a, 0x0c, 0x70, 0x61, 0x79, 0x6d, 0x65, 0x6e, 0x74, 0x5f, 0x68, 0x61, 0x73, 0x68, 0x18,
@@ -20232,7 +20240,11 @@ var file_lightning_proto_rawDesc = []byte{
 	0x37, 0x0a, 0x08, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x18, 0x0d, 0x20, 0x03, 0x28,
 	0x0b, 0x32, 0x1b, 0x2e, 0x6c, 0x6e, 0x72, 0x70, 0x63, 0x2e, 0x50, 0x61, 0x79, 0x52, 0x65, 0x71,
 	0x2e, 0x46, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x45, 0x6e, 0x74, 0x72, 0x79, 0x52, 0x08,
-	0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x1a, 0x4b, 0x0a, 0x0d, 0x46, 0x65, 0x61, 0x74,
+	0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0x12, 0x3e, 0x0a, 0x0d, 0x62, 0x6c, 0x69, 0x6e,
+	0x64, 0x65, 0x64, 0x5f, 0x70, 0x61, 0x74, 0x68, 0x73, 0x18, 0x0e, 0x20, 0x03, 0x28, 0x0b, 0x32,
+	0x19, 0x2e, 0x6c, 0x6e, 0x72, 0x70, 0x63, 0x2e, 0x42, 0x6c, 0x69, 0x6e, 0x64, 0x65, 0x64, 0x50,
+	0x61, 0x79, 0x6d, 0x65, 0x6e, 0x74, 0x50, 0x61, 0x74, 0x68, 0x52, 0x0c, 0x62, 0x6c, 0x69, 0x6e,
+	0x64, 0x65, 0x64, 0x50, 0x61, 0x74, 0x68, 0x73, 0x1a, 0x4b, 0x0a, 0x0d, 0x46, 0x65, 0x61, 0x74,
 	0x75, 0x72, 0x65, 0x73, 0x45, 0x6e, 0x74, 0x72, 0x79, 0x12, 0x10, 0x0a, 0x03, 0x6b, 0x65, 0x79,
 	0x18, 0x01, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x03, 0x6b, 0x65, 0x79, 0x12, 0x24, 0x0a, 0x05, 0x76,
 	0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x0e, 0x2e, 0x6c, 0x6e, 0x72,
@@ -21520,192 +21532,193 @@ var file_lightning_proto_depIdxs = []int32{
 	38,  // 138: lnrpc.AbandonChannelRequest.channel_point:type_name -> lnrpc.ChannelPoint
 	150, // 139: lnrpc.PayReq.route_hints:type_name -> lnrpc.RouteHint
 	244, // 140: lnrpc.PayReq.features:type_name -> lnrpc.PayReq.FeaturesEntry
-	179, // 141: lnrpc.FeeReportResponse.channel_fees:type_name -> lnrpc.ChannelFeeReport
-	38,  // 142: lnrpc.PolicyUpdateRequest.chan_point:type_name -> lnrpc.ChannelPoint
-	181, // 143: lnrpc.PolicyUpdateRequest.inbound_fee:type_name -> lnrpc.InboundFee
-	39,  // 144: lnrpc.FailedUpdate.outpoint:type_name -> lnrpc.OutPoint
-	11,  // 145: lnrpc.FailedUpdate.reason:type_name -> lnrpc.UpdateFailure
-	183, // 146: lnrpc.PolicyUpdateResponse.failed_updates:type_name -> lnrpc.FailedUpdate
-	186, // 147: lnrpc.ForwardingHistoryResponse.forwarding_events:type_name -> lnrpc.ForwardingEvent
-	38,  // 148: lnrpc.ExportChannelBackupRequest.chan_point:type_name -> lnrpc.ChannelPoint
-	38,  // 149: lnrpc.ChannelBackup.chan_point:type_name -> lnrpc.ChannelPoint
-	38,  // 150: lnrpc.MultiChanBackup.chan_points:type_name -> lnrpc.ChannelPoint
-	193, // 151: lnrpc.ChanBackupSnapshot.single_chan_backups:type_name -> lnrpc.ChannelBackups
-	190, // 152: lnrpc.ChanBackupSnapshot.multi_chan_backup:type_name -> lnrpc.MultiChanBackup
-	189, // 153: lnrpc.ChannelBackups.chan_backups:type_name -> lnrpc.ChannelBackup
-	193, // 154: lnrpc.RestoreChanBackupRequest.chan_backups:type_name -> lnrpc.ChannelBackups
-	198, // 155: lnrpc.BakeMacaroonRequest.permissions:type_name -> lnrpc.MacaroonPermission
-	198, // 156: lnrpc.MacaroonPermissionList.permissions:type_name -> lnrpc.MacaroonPermission
-	245, // 157: lnrpc.ListPermissionsResponse.method_permissions:type_name -> lnrpc.ListPermissionsResponse.MethodPermissionsEntry
-	20,  // 158: lnrpc.Failure.code:type_name -> lnrpc.Failure.FailureCode
-	209, // 159: lnrpc.Failure.channel_update:type_name -> lnrpc.ChannelUpdate
-	211, // 160: lnrpc.MacaroonId.ops:type_name -> lnrpc.Op
-	198, // 161: lnrpc.CheckMacPermRequest.permissions:type_name -> lnrpc.MacaroonPermission
-	215, // 162: lnrpc.RPCMiddlewareRequest.stream_auth:type_name -> lnrpc.StreamAuth
-	216, // 163: lnrpc.RPCMiddlewareRequest.request:type_name -> lnrpc.RPCMessage
-	216, // 164: lnrpc.RPCMiddlewareRequest.response:type_name -> lnrpc.RPCMessage
-	218, // 165: lnrpc.RPCMiddlewareResponse.register:type_name -> lnrpc.MiddlewareRegistration
-	219, // 166: lnrpc.RPCMiddlewareResponse.feedback:type_name -> lnrpc.InterceptFeedback
-	177, // 167: lnrpc.Peer.FeaturesEntry.value:type_name -> lnrpc.Feature
-	177, // 168: lnrpc.GetInfoResponse.FeaturesEntry.value:type_name -> lnrpc.Feature
-	4,   // 169: lnrpc.PendingChannelsResponse.PendingChannel.initiator:type_name -> lnrpc.Initiator
-	3,   // 170: lnrpc.PendingChannelsResponse.PendingChannel.commitment_type:type_name -> lnrpc.CommitmentType
-	226, // 171: lnrpc.PendingChannelsResponse.PendingOpenChannel.channel:type_name -> lnrpc.PendingChannelsResponse.PendingChannel
-	226, // 172: lnrpc.PendingChannelsResponse.WaitingCloseChannel.channel:type_name -> lnrpc.PendingChannelsResponse.PendingChannel
-	229, // 173: lnrpc.PendingChannelsResponse.WaitingCloseChannel.commitments:type_name -> lnrpc.PendingChannelsResponse.Commitments
-	226, // 174: lnrpc.PendingChannelsResponse.ClosedChannel.channel:type_name -> lnrpc.PendingChannelsResponse.PendingChannel
-	226, // 175: lnrpc.PendingChannelsResponse.ForceClosedChannel.channel:type_name -> lnrpc.PendingChannelsResponse.PendingChannel
-	108, // 176: lnrpc.PendingChannelsResponse.ForceClosedChannel.pending_htlcs:type_name -> lnrpc.PendingHTLC
-	15,  // 177: lnrpc.PendingChannelsResponse.ForceClosedChannel.anchor:type_name -> lnrpc.PendingChannelsResponse.ForceClosedChannel.AnchorState
-	113, // 178: lnrpc.WalletBalanceResponse.AccountBalanceEntry.value:type_name -> lnrpc.WalletAccountBalance
-	177, // 179: lnrpc.LightningNode.FeaturesEntry.value:type_name -> lnrpc.Feature
-	137, // 180: lnrpc.NodeMetricsResponse.BetweennessCentralityEntry.value:type_name -> lnrpc.FloatMetric
-	177, // 181: lnrpc.NodeUpdate.FeaturesEntry.value:type_name -> lnrpc.Feature
-	177, // 182: lnrpc.Invoice.FeaturesEntry.value:type_name -> lnrpc.Feature
-	154, // 183: lnrpc.Invoice.AmpInvoiceStateEntry.value:type_name -> lnrpc.AMPInvoiceState
-	177, // 184: lnrpc.PayReq.FeaturesEntry.value:type_name -> lnrpc.Feature
-	205, // 185: lnrpc.ListPermissionsResponse.MethodPermissionsEntry.value:type_name -> lnrpc.MacaroonPermissionList
-	114, // 186: lnrpc.Lightning.WalletBalance:input_type -> lnrpc.WalletBalanceRequest
-	117, // 187: lnrpc.Lightning.ChannelBalance:input_type -> lnrpc.ChannelBalanceRequest
-	30,  // 188: lnrpc.Lightning.GetTransactions:input_type -> lnrpc.GetTransactionsRequest
-	42,  // 189: lnrpc.Lightning.EstimateFee:input_type -> lnrpc.EstimateFeeRequest
-	46,  // 190: lnrpc.Lightning.SendCoins:input_type -> lnrpc.SendCoinsRequest
-	48,  // 191: lnrpc.Lightning.ListUnspent:input_type -> lnrpc.ListUnspentRequest
-	30,  // 192: lnrpc.Lightning.SubscribeTransactions:input_type -> lnrpc.GetTransactionsRequest
-	44,  // 193: lnrpc.Lightning.SendMany:input_type -> lnrpc.SendManyRequest
-	50,  // 194: lnrpc.Lightning.NewAddress:input_type -> lnrpc.NewAddressRequest
-	52,  // 195: lnrpc.Lightning.SignMessage:input_type -> lnrpc.SignMessageRequest
-	54,  // 196: lnrpc.Lightning.VerifyMessage:input_type -> lnrpc.VerifyMessageRequest
-	56,  // 197: lnrpc.Lightning.ConnectPeer:input_type -> lnrpc.ConnectPeerRequest
-	58,  // 198: lnrpc.Lightning.DisconnectPeer:input_type -> lnrpc.DisconnectPeerRequest
-	74,  // 199: lnrpc.Lightning.ListPeers:input_type -> lnrpc.ListPeersRequest
-	76,  // 200: lnrpc.Lightning.SubscribePeerEvents:input_type -> lnrpc.PeerEventSubscription
-	78,  // 201: lnrpc.Lightning.GetInfo:input_type -> lnrpc.GetInfoRequest
-	80,  // 202: lnrpc.Lightning.GetDebugInfo:input_type -> lnrpc.GetDebugInfoRequest
-	82,  // 203: lnrpc.Lightning.GetRecoveryInfo:input_type -> lnrpc.GetRecoveryInfoRequest
-	109, // 204: lnrpc.Lightning.PendingChannels:input_type -> lnrpc.PendingChannelsRequest
-	63,  // 205: lnrpc.Lightning.ListChannels:input_type -> lnrpc.ListChannelsRequest
-	111, // 206: lnrpc.Lightning.SubscribeChannelEvents:input_type -> lnrpc.ChannelEventSubscription
-	70,  // 207: lnrpc.Lightning.ClosedChannels:input_type -> lnrpc.ClosedChannelsRequest
-	96,  // 208: lnrpc.Lightning.OpenChannelSync:input_type -> lnrpc.OpenChannelRequest
-	96,  // 209: lnrpc.Lightning.OpenChannel:input_type -> lnrpc.OpenChannelRequest
-	93,  // 210: lnrpc.Lightning.BatchOpenChannel:input_type -> lnrpc.BatchOpenChannelRequest
-	106, // 211: lnrpc.Lightning.FundingStateStep:input_type -> lnrpc.FundingTransitionMsg
-	37,  // 212: lnrpc.Lightning.ChannelAcceptor:input_type -> lnrpc.ChannelAcceptResponse
-	88,  // 213: lnrpc.Lightning.CloseChannel:input_type -> lnrpc.CloseChannelRequest
-	171, // 214: lnrpc.Lightning.AbandonChannel:input_type -> lnrpc.AbandonChannelRequest
-	33,  // 215: lnrpc.Lightning.SendPayment:input_type -> lnrpc.SendRequest
-	33,  // 216: lnrpc.Lightning.SendPaymentSync:input_type -> lnrpc.SendRequest
-	35,  // 217: lnrpc.Lightning.SendToRoute:input_type -> lnrpc.SendToRouteRequest
-	35,  // 218: lnrpc.Lightning.SendToRouteSync:input_type -> lnrpc.SendToRouteRequest
-	155, // 219: lnrpc.Lightning.AddInvoice:input_type -> lnrpc.Invoice
-	160, // 220: lnrpc.Lightning.ListInvoices:input_type -> lnrpc.ListInvoiceRequest
-	159, // 221: lnrpc.Lightning.LookupInvoice:input_type -> lnrpc.PaymentHash
-	162, // 222: lnrpc.Lightning.SubscribeInvoices:input_type -> lnrpc.InvoiceSubscription
-	175, // 223: lnrpc.Lightning.DecodePayReq:input_type -> lnrpc.PayReqString
-	165, // 224: lnrpc.Lightning.ListPayments:input_type -> lnrpc.ListPaymentsRequest
-	167, // 225: lnrpc.Lightning.DeletePayment:input_type -> lnrpc.DeletePaymentRequest
-	168, // 226: lnrpc.Lightning.DeleteAllPayments:input_type -> lnrpc.DeleteAllPaymentsRequest
-	133, // 227: lnrpc.Lightning.DescribeGraph:input_type -> lnrpc.ChannelGraphRequest
-	135, // 228: lnrpc.Lightning.GetNodeMetrics:input_type -> lnrpc.NodeMetricsRequest
-	138, // 229: lnrpc.Lightning.GetChanInfo:input_type -> lnrpc.ChanInfoRequest
-	127, // 230: lnrpc.Lightning.GetNodeInfo:input_type -> lnrpc.NodeInfoRequest
-	119, // 231: lnrpc.Lightning.QueryRoutes:input_type -> lnrpc.QueryRoutesRequest
-	139, // 232: lnrpc.Lightning.GetNetworkInfo:input_type -> lnrpc.NetworkInfoRequest
-	141, // 233: lnrpc.Lightning.StopDaemon:input_type -> lnrpc.StopRequest
-	143, // 234: lnrpc.Lightning.SubscribeChannelGraph:input_type -> lnrpc.GraphTopologySubscription
-	173, // 235: lnrpc.Lightning.DebugLevel:input_type -> lnrpc.DebugLevelRequest
-	178, // 236: lnrpc.Lightning.FeeReport:input_type -> lnrpc.FeeReportRequest
-	182, // 237: lnrpc.Lightning.UpdateChannelPolicy:input_type -> lnrpc.PolicyUpdateRequest
-	185, // 238: lnrpc.Lightning.ForwardingHistory:input_type -> lnrpc.ForwardingHistoryRequest
-	188, // 239: lnrpc.Lightning.ExportChannelBackup:input_type -> lnrpc.ExportChannelBackupRequest
-	191, // 240: lnrpc.Lightning.ExportAllChannelBackups:input_type -> lnrpc.ChanBackupExportRequest
-	192, // 241: lnrpc.Lightning.VerifyChanBackup:input_type -> lnrpc.ChanBackupSnapshot
-	194, // 242: lnrpc.Lightning.RestoreChannelBackups:input_type -> lnrpc.RestoreChanBackupRequest
-	196, // 243: lnrpc.Lightning.SubscribeChannelBackups:input_type -> lnrpc.ChannelBackupSubscription
-	199, // 244: lnrpc.Lightning.BakeMacaroon:input_type -> lnrpc.BakeMacaroonRequest
-	201, // 245: lnrpc.Lightning.ListMacaroonIDs:input_type -> lnrpc.ListMacaroonIDsRequest
-	203, // 246: lnrpc.Lightning.DeleteMacaroonID:input_type -> lnrpc.DeleteMacaroonIDRequest
-	206, // 247: lnrpc.Lightning.ListPermissions:input_type -> lnrpc.ListPermissionsRequest
-	212, // 248: lnrpc.Lightning.CheckMacaroonPermissions:input_type -> lnrpc.CheckMacPermRequest
-	217, // 249: lnrpc.Lightning.RegisterRPCMiddleware:input_type -> lnrpc.RPCMiddlewareResponse
-	25,  // 250: lnrpc.Lightning.SendCustomMessage:input_type -> lnrpc.SendCustomMessageRequest
-	23,  // 251: lnrpc.Lightning.SubscribeCustomMessages:input_type -> lnrpc.SubscribeCustomMessagesRequest
-	66,  // 252: lnrpc.Lightning.ListAliases:input_type -> lnrpc.ListAliasesRequest
-	21,  // 253: lnrpc.Lightning.LookupHtlcResolution:input_type -> lnrpc.LookupHtlcResolutionRequest
-	115, // 254: lnrpc.Lightning.WalletBalance:output_type -> lnrpc.WalletBalanceResponse
-	118, // 255: lnrpc.Lightning.ChannelBalance:output_type -> lnrpc.ChannelBalanceResponse
-	31,  // 256: lnrpc.Lightning.GetTransactions:output_type -> lnrpc.TransactionDetails
-	43,  // 257: lnrpc.Lightning.EstimateFee:output_type -> lnrpc.EstimateFeeResponse
-	47,  // 258: lnrpc.Lightning.SendCoins:output_type -> lnrpc.SendCoinsResponse
-	49,  // 259: lnrpc.Lightning.ListUnspent:output_type -> lnrpc.ListUnspentResponse
-	29,  // 260: lnrpc.Lightning.SubscribeTransactions:output_type -> lnrpc.Transaction
-	45,  // 261: lnrpc.Lightning.SendMany:output_type -> lnrpc.SendManyResponse
-	51,  // 262: lnrpc.Lightning.NewAddress:output_type -> lnrpc.NewAddressResponse
-	53,  // 263: lnrpc.Lightning.SignMessage:output_type -> lnrpc.SignMessageResponse
-	55,  // 264: lnrpc.Lightning.VerifyMessage:output_type -> lnrpc.VerifyMessageResponse
-	57,  // 265: lnrpc.Lightning.ConnectPeer:output_type -> lnrpc.ConnectPeerResponse
-	59,  // 266: lnrpc.Lightning.DisconnectPeer:output_type -> lnrpc.DisconnectPeerResponse
-	75,  // 267: lnrpc.Lightning.ListPeers:output_type -> lnrpc.ListPeersResponse
-	77,  // 268: lnrpc.Lightning.SubscribePeerEvents:output_type -> lnrpc.PeerEvent
-	79,  // 269: lnrpc.Lightning.GetInfo:output_type -> lnrpc.GetInfoResponse
-	81,  // 270: lnrpc.Lightning.GetDebugInfo:output_type -> lnrpc.GetDebugInfoResponse
-	83,  // 271: lnrpc.Lightning.GetRecoveryInfo:output_type -> lnrpc.GetRecoveryInfoResponse
-	110, // 272: lnrpc.Lightning.PendingChannels:output_type -> lnrpc.PendingChannelsResponse
-	64,  // 273: lnrpc.Lightning.ListChannels:output_type -> lnrpc.ListChannelsResponse
-	112, // 274: lnrpc.Lightning.SubscribeChannelEvents:output_type -> lnrpc.ChannelEventUpdate
-	71,  // 275: lnrpc.Lightning.ClosedChannels:output_type -> lnrpc.ClosedChannelsResponse
-	38,  // 276: lnrpc.Lightning.OpenChannelSync:output_type -> lnrpc.ChannelPoint
-	97,  // 277: lnrpc.Lightning.OpenChannel:output_type -> lnrpc.OpenStatusUpdate
-	95,  // 278: lnrpc.Lightning.BatchOpenChannel:output_type -> lnrpc.BatchOpenChannelResponse
-	107, // 279: lnrpc.Lightning.FundingStateStep:output_type -> lnrpc.FundingStateStepResp
-	36,  // 280: lnrpc.Lightning.ChannelAcceptor:output_type -> lnrpc.ChannelAcceptRequest
-	89,  // 281: lnrpc.Lightning.CloseChannel:output_type -> lnrpc.CloseStatusUpdate
-	172, // 282: lnrpc.Lightning.AbandonChannel:output_type -> lnrpc.AbandonChannelResponse
-	34,  // 283: lnrpc.Lightning.SendPayment:output_type -> lnrpc.SendResponse
-	34,  // 284: lnrpc.Lightning.SendPaymentSync:output_type -> lnrpc.SendResponse
-	34,  // 285: lnrpc.Lightning.SendToRoute:output_type -> lnrpc.SendResponse
-	34,  // 286: lnrpc.Lightning.SendToRouteSync:output_type -> lnrpc.SendResponse
-	158, // 287: lnrpc.Lightning.AddInvoice:output_type -> lnrpc.AddInvoiceResponse
-	161, // 288: lnrpc.Lightning.ListInvoices:output_type -> lnrpc.ListInvoiceResponse
-	155, // 289: lnrpc.Lightning.LookupInvoice:output_type -> lnrpc.Invoice
-	155, // 290: lnrpc.Lightning.SubscribeInvoices:output_type -> lnrpc.Invoice
-	176, // 291: lnrpc.Lightning.DecodePayReq:output_type -> lnrpc.PayReq
-	166, // 292: lnrpc.Lightning.ListPayments:output_type -> lnrpc.ListPaymentsResponse
-	169, // 293: lnrpc.Lightning.DeletePayment:output_type -> lnrpc.DeletePaymentResponse
-	170, // 294: lnrpc.Lightning.DeleteAllPayments:output_type -> lnrpc.DeleteAllPaymentsResponse
-	134, // 295: lnrpc.Lightning.DescribeGraph:output_type -> lnrpc.ChannelGraph
-	136, // 296: lnrpc.Lightning.GetNodeMetrics:output_type -> lnrpc.NodeMetricsResponse
-	132, // 297: lnrpc.Lightning.GetChanInfo:output_type -> lnrpc.ChannelEdge
-	128, // 298: lnrpc.Lightning.GetNodeInfo:output_type -> lnrpc.NodeInfo
-	122, // 299: lnrpc.Lightning.QueryRoutes:output_type -> lnrpc.QueryRoutesResponse
-	140, // 300: lnrpc.Lightning.GetNetworkInfo:output_type -> lnrpc.NetworkInfo
-	142, // 301: lnrpc.Lightning.StopDaemon:output_type -> lnrpc.StopResponse
-	144, // 302: lnrpc.Lightning.SubscribeChannelGraph:output_type -> lnrpc.GraphTopologyUpdate
-	174, // 303: lnrpc.Lightning.DebugLevel:output_type -> lnrpc.DebugLevelResponse
-	180, // 304: lnrpc.Lightning.FeeReport:output_type -> lnrpc.FeeReportResponse
-	184, // 305: lnrpc.Lightning.UpdateChannelPolicy:output_type -> lnrpc.PolicyUpdateResponse
-	187, // 306: lnrpc.Lightning.ForwardingHistory:output_type -> lnrpc.ForwardingHistoryResponse
-	189, // 307: lnrpc.Lightning.ExportChannelBackup:output_type -> lnrpc.ChannelBackup
-	192, // 308: lnrpc.Lightning.ExportAllChannelBackups:output_type -> lnrpc.ChanBackupSnapshot
-	197, // 309: lnrpc.Lightning.VerifyChanBackup:output_type -> lnrpc.VerifyChanBackupResponse
-	195, // 310: lnrpc.Lightning.RestoreChannelBackups:output_type -> lnrpc.RestoreBackupResponse
-	192, // 311: lnrpc.Lightning.SubscribeChannelBackups:output_type -> lnrpc.ChanBackupSnapshot
-	200, // 312: lnrpc.Lightning.BakeMacaroon:output_type -> lnrpc.BakeMacaroonResponse
-	202, // 313: lnrpc.Lightning.ListMacaroonIDs:output_type -> lnrpc.ListMacaroonIDsResponse
-	204, // 314: lnrpc.Lightning.DeleteMacaroonID:output_type -> lnrpc.DeleteMacaroonIDResponse
-	207, // 315: lnrpc.Lightning.ListPermissions:output_type -> lnrpc.ListPermissionsResponse
-	213, // 316: lnrpc.Lightning.CheckMacaroonPermissions:output_type -> lnrpc.CheckMacPermResponse
-	214, // 317: lnrpc.Lightning.RegisterRPCMiddleware:output_type -> lnrpc.RPCMiddlewareRequest
-	26,  // 318: lnrpc.Lightning.SendCustomMessage:output_type -> lnrpc.SendCustomMessageResponse
-	24,  // 319: lnrpc.Lightning.SubscribeCustomMessages:output_type -> lnrpc.CustomMessage
-	67,  // 320: lnrpc.Lightning.ListAliases:output_type -> lnrpc.ListAliasesResponse
-	22,  // 321: lnrpc.Lightning.LookupHtlcResolution:output_type -> lnrpc.LookupHtlcResolutionResponse
-	254, // [254:322] is the sub-list for method output_type
-	186, // [186:254] is the sub-list for method input_type
-	186, // [186:186] is the sub-list for extension type_name
-	186, // [186:186] is the sub-list for extension extendee
-	0,   // [0:186] is the sub-list for field type_name
+	151, // 141: lnrpc.PayReq.blinded_paths:type_name -> lnrpc.BlindedPaymentPath
+	179, // 142: lnrpc.FeeReportResponse.channel_fees:type_name -> lnrpc.ChannelFeeReport
+	38,  // 143: lnrpc.PolicyUpdateRequest.chan_point:type_name -> lnrpc.ChannelPoint
+	181, // 144: lnrpc.PolicyUpdateRequest.inbound_fee:type_name -> lnrpc.InboundFee
+	39,  // 145: lnrpc.FailedUpdate.outpoint:type_name -> lnrpc.OutPoint
+	11,  // 146: lnrpc.FailedUpdate.reason:type_name -> lnrpc.UpdateFailure
+	183, // 147: lnrpc.PolicyUpdateResponse.failed_updates:type_name -> lnrpc.FailedUpdate
+	186, // 148: lnrpc.ForwardingHistoryResponse.forwarding_events:type_name -> lnrpc.ForwardingEvent
+	38,  // 149: lnrpc.ExportChannelBackupRequest.chan_point:type_name -> lnrpc.ChannelPoint
+	38,  // 150: lnrpc.ChannelBackup.chan_point:type_name -> lnrpc.ChannelPoint
+	38,  // 151: lnrpc.MultiChanBackup.chan_points:type_name -> lnrpc.ChannelPoint
+	193, // 152: lnrpc.ChanBackupSnapshot.single_chan_backups:type_name -> lnrpc.ChannelBackups
+	190, // 153: lnrpc.ChanBackupSnapshot.multi_chan_backup:type_name -> lnrpc.MultiChanBackup
+	189, // 154: lnrpc.ChannelBackups.chan_backups:type_name -> lnrpc.ChannelBackup
+	193, // 155: lnrpc.RestoreChanBackupRequest.chan_backups:type_name -> lnrpc.ChannelBackups
+	198, // 156: lnrpc.BakeMacaroonRequest.permissions:type_name -> lnrpc.MacaroonPermission
+	198, // 157: lnrpc.MacaroonPermissionList.permissions:type_name -> lnrpc.MacaroonPermission
+	245, // 158: lnrpc.ListPermissionsResponse.method_permissions:type_name -> lnrpc.ListPermissionsResponse.MethodPermissionsEntry
+	20,  // 159: lnrpc.Failure.code:type_name -> lnrpc.Failure.FailureCode
+	209, // 160: lnrpc.Failure.channel_update:type_name -> lnrpc.ChannelUpdate
+	211, // 161: lnrpc.MacaroonId.ops:type_name -> lnrpc.Op
+	198, // 162: lnrpc.CheckMacPermRequest.permissions:type_name -> lnrpc.MacaroonPermission
+	215, // 163: lnrpc.RPCMiddlewareRequest.stream_auth:type_name -> lnrpc.StreamAuth
+	216, // 164: lnrpc.RPCMiddlewareRequest.request:type_name -> lnrpc.RPCMessage
+	216, // 165: lnrpc.RPCMiddlewareRequest.response:type_name -> lnrpc.RPCMessage
+	218, // 166: lnrpc.RPCMiddlewareResponse.register:type_name -> lnrpc.MiddlewareRegistration
+	219, // 167: lnrpc.RPCMiddlewareResponse.feedback:type_name -> lnrpc.InterceptFeedback
+	177, // 168: lnrpc.Peer.FeaturesEntry.value:type_name -> lnrpc.Feature
+	177, // 169: lnrpc.GetInfoResponse.FeaturesEntry.value:type_name -> lnrpc.Feature
+	4,   // 170: lnrpc.PendingChannelsResponse.PendingChannel.initiator:type_name -> lnrpc.Initiator
+	3,   // 171: lnrpc.PendingChannelsResponse.PendingChannel.commitment_type:type_name -> lnrpc.CommitmentType
+	226, // 172: lnrpc.PendingChannelsResponse.PendingOpenChannel.channel:type_name -> lnrpc.PendingChannelsResponse.PendingChannel
+	226, // 173: lnrpc.PendingChannelsResponse.WaitingCloseChannel.channel:type_name -> lnrpc.PendingChannelsResponse.PendingChannel
+	229, // 174: lnrpc.PendingChannelsResponse.WaitingCloseChannel.commitments:type_name -> lnrpc.PendingChannelsResponse.Commitments
+	226, // 175: lnrpc.PendingChannelsResponse.ClosedChannel.channel:type_name -> lnrpc.PendingChannelsResponse.PendingChannel
+	226, // 176: lnrpc.PendingChannelsResponse.ForceClosedChannel.channel:type_name -> lnrpc.PendingChannelsResponse.PendingChannel
+	108, // 177: lnrpc.PendingChannelsResponse.ForceClosedChannel.pending_htlcs:type_name -> lnrpc.PendingHTLC
+	15,  // 178: lnrpc.PendingChannelsResponse.ForceClosedChannel.anchor:type_name -> lnrpc.PendingChannelsResponse.ForceClosedChannel.AnchorState
+	113, // 179: lnrpc.WalletBalanceResponse.AccountBalanceEntry.value:type_name -> lnrpc.WalletAccountBalance
+	177, // 180: lnrpc.LightningNode.FeaturesEntry.value:type_name -> lnrpc.Feature
+	137, // 181: lnrpc.NodeMetricsResponse.BetweennessCentralityEntry.value:type_name -> lnrpc.FloatMetric
+	177, // 182: lnrpc.NodeUpdate.FeaturesEntry.value:type_name -> lnrpc.Feature
+	177, // 183: lnrpc.Invoice.FeaturesEntry.value:type_name -> lnrpc.Feature
+	154, // 184: lnrpc.Invoice.AmpInvoiceStateEntry.value:type_name -> lnrpc.AMPInvoiceState
+	177, // 185: lnrpc.PayReq.FeaturesEntry.value:type_name -> lnrpc.Feature
+	205, // 186: lnrpc.ListPermissionsResponse.MethodPermissionsEntry.value:type_name -> lnrpc.MacaroonPermissionList
+	114, // 187: lnrpc.Lightning.WalletBalance:input_type -> lnrpc.WalletBalanceRequest
+	117, // 188: lnrpc.Lightning.ChannelBalance:input_type -> lnrpc.ChannelBalanceRequest
+	30,  // 189: lnrpc.Lightning.GetTransactions:input_type -> lnrpc.GetTransactionsRequest
+	42,  // 190: lnrpc.Lightning.EstimateFee:input_type -> lnrpc.EstimateFeeRequest
+	46,  // 191: lnrpc.Lightning.SendCoins:input_type -> lnrpc.SendCoinsRequest
+	48,  // 192: lnrpc.Lightning.ListUnspent:input_type -> lnrpc.ListUnspentRequest
+	30,  // 193: lnrpc.Lightning.SubscribeTransactions:input_type -> lnrpc.GetTransactionsRequest
+	44,  // 194: lnrpc.Lightning.SendMany:input_type -> lnrpc.SendManyRequest
+	50,  // 195: lnrpc.Lightning.NewAddress:input_type -> lnrpc.NewAddressRequest
+	52,  // 196: lnrpc.Lightning.SignMessage:input_type -> lnrpc.SignMessageRequest
+	54,  // 197: lnrpc.Lightning.VerifyMessage:input_type -> lnrpc.VerifyMessageRequest
+	56,  // 198: lnrpc.Lightning.ConnectPeer:input_type -> lnrpc.ConnectPeerRequest
+	58,  // 199: lnrpc.Lightning.DisconnectPeer:input_type -> lnrpc.DisconnectPeerRequest
+	74,  // 200: lnrpc.Lightning.ListPeers:input_type -> lnrpc.ListPeersRequest
+	76,  // 201: lnrpc.Lightning.SubscribePeerEvents:input_type -> lnrpc.PeerEventSubscription
+	78,  // 202: lnrpc.Lightning.GetInfo:input_type -> lnrpc.GetInfoRequest
+	80,  // 203: lnrpc.Lightning.GetDebugInfo:input_type -> lnrpc.GetDebugInfoRequest
+	82,  // 204: lnrpc.Lightning.GetRecoveryInfo:input_type -> lnrpc.GetRecoveryInfoRequest
+	109, // 205: lnrpc.Lightning.PendingChannels:input_type -> lnrpc.PendingChannelsRequest
+	63,  // 206: lnrpc.Lightning.ListChannels:input_type -> lnrpc.ListChannelsRequest
+	111, // 207: lnrpc.Lightning.SubscribeChannelEvents:input_type -> lnrpc.ChannelEventSubscription
+	70,  // 208: lnrpc.Lightning.ClosedChannels:input_type -> lnrpc.ClosedChannelsRequest
+	96,  // 209: lnrpc.Lightning.OpenChannelSync:input_type -> lnrpc.OpenChannelRequest
+	96,  // 210: lnrpc.Lightning.OpenChannel:input_type -> lnrpc.OpenChannelRequest
+	93,  // 211: lnrpc.Lightning.BatchOpenChannel:input_type -> lnrpc.BatchOpenChannelRequest
+	106, // 212: lnrpc.Lightning.FundingStateStep:input_type -> lnrpc.FundingTransitionMsg
+	37,  // 213: lnrpc.Lightning.ChannelAcceptor:input_type -> lnrpc.ChannelAcceptResponse
+	88,  // 214: lnrpc.Lightning.CloseChannel:input_type -> lnrpc.CloseChannelRequest
+	171, // 215: lnrpc.Lightning.AbandonChannel:input_type -> lnrpc.AbandonChannelRequest
+	33,  // 216: lnrpc.Lightning.SendPayment:input_type -> lnrpc.SendRequest
+	33,  // 217: lnrpc.Lightning.SendPaymentSync:input_type -> lnrpc.SendRequest
+	35,  // 218: lnrpc.Lightning.SendToRoute:input_type -> lnrpc.SendToRouteRequest
+	35,  // 219: lnrpc.Lightning.SendToRouteSync:input_type -> lnrpc.SendToRouteRequest
+	155, // 220: lnrpc.Lightning.AddInvoice:input_type -> lnrpc.Invoice
+	160, // 221: lnrpc.Lightning.ListInvoices:input_type -> lnrpc.ListInvoiceRequest
+	159, // 222: lnrpc.Lightning.LookupInvoice:input_type -> lnrpc.PaymentHash
+	162, // 223: lnrpc.Lightning.SubscribeInvoices:input_type -> lnrpc.InvoiceSubscription
+	175, // 224: lnrpc.Lightning.DecodePayReq:input_type -> lnrpc.PayReqString
+	165, // 225: lnrpc.Lightning.ListPayments:input_type -> lnrpc.ListPaymentsRequest
+	167, // 226: lnrpc.Lightning.DeletePayment:input_type -> lnrpc.DeletePaymentRequest
+	168, // 227: lnrpc.Lightning.DeleteAllPayments:input_type -> lnrpc.DeleteAllPaymentsRequest
+	133, // 228: lnrpc.Lightning.DescribeGraph:input_type -> lnrpc.ChannelGraphRequest
+	135, // 229: lnrpc.Lightning.GetNodeMetrics:input_type -> lnrpc.NodeMetricsRequest
+	138, // 230: lnrpc.Lightning.GetChanInfo:input_type -> lnrpc.ChanInfoRequest
+	127, // 231: lnrpc.Lightning.GetNodeInfo:input_type -> lnrpc.NodeInfoRequest
+	119, // 232: lnrpc.Lightning.QueryRoutes:input_type -> lnrpc.QueryRoutesRequest
+	139, // 233: lnrpc.Lightning.GetNetworkInfo:input_type -> lnrpc.NetworkInfoRequest
+	141, // 234: lnrpc.Lightning.StopDaemon:input_type -> lnrpc.StopRequest
+	143, // 235: lnrpc.Lightning.SubscribeChannelGraph:input_type -> lnrpc.GraphTopologySubscription
+	173, // 236: lnrpc.Lightning.DebugLevel:input_type -> lnrpc.DebugLevelRequest
+	178, // 237: lnrpc.Lightning.FeeReport:input_type -> lnrpc.FeeReportRequest
+	182, // 238: lnrpc.Lightning.UpdateChannelPolicy:input_type -> lnrpc.PolicyUpdateRequest
+	185, // 239: lnrpc.Lightning.ForwardingHistory:input_type -> lnrpc.ForwardingHistoryRequest
+	188, // 240: lnrpc.Lightning.ExportChannelBackup:input_type -> lnrpc.ExportChannelBackupRequest
+	191, // 241: lnrpc.Lightning.ExportAllChannelBackups:input_type -> lnrpc.ChanBackupExportRequest
+	192, // 242: lnrpc.Lightning.VerifyChanBackup:input_type -> lnrpc.ChanBackupSnapshot
+	194, // 243: lnrpc.Lightning.RestoreChannelBackups:input_type -> lnrpc.RestoreChanBackupRequest
+	196, // 244: lnrpc.Lightning.SubscribeChannelBackups:input_type -> lnrpc.ChannelBackupSubscription
+	199, // 245: lnrpc.Lightning.BakeMacaroon:input_type -> lnrpc.BakeMacaroonRequest
+	201, // 246: lnrpc.Lightning.ListMacaroonIDs:input_type -> lnrpc.ListMacaroonIDsRequest
+	203, // 247: lnrpc.Lightning.DeleteMacaroonID:input_type -> lnrpc.DeleteMacaroonIDRequest
+	206, // 248: lnrpc.Lightning.ListPermissions:input_type -> lnrpc.ListPermissionsRequest
+	212, // 249: lnrpc.Lightning.CheckMacaroonPermissions:input_type -> lnrpc.CheckMacPermRequest
+	217, // 250: lnrpc.Lightning.RegisterRPCMiddleware:input_type -> lnrpc.RPCMiddlewareResponse
+	25,  // 251: lnrpc.Lightning.SendCustomMessage:input_type -> lnrpc.SendCustomMessageRequest
+	23,  // 252: lnrpc.Lightning.SubscribeCustomMessages:input_type -> lnrpc.SubscribeCustomMessagesRequest
+	66,  // 253: lnrpc.Lightning.ListAliases:input_type -> lnrpc.ListAliasesRequest
+	21,  // 254: lnrpc.Lightning.LookupHtlcResolution:input_type -> lnrpc.LookupHtlcResolutionRequest
+	115, // 255: lnrpc.Lightning.WalletBalance:output_type -> lnrpc.WalletBalanceResponse
+	118, // 256: lnrpc.Lightning.ChannelBalance:output_type -> lnrpc.ChannelBalanceResponse
+	31,  // 257: lnrpc.Lightning.GetTransactions:output_type -> lnrpc.TransactionDetails
+	43,  // 258: lnrpc.Lightning.EstimateFee:output_type -> lnrpc.EstimateFeeResponse
+	47,  // 259: lnrpc.Lightning.SendCoins:output_type -> lnrpc.SendCoinsResponse
+	49,  // 260: lnrpc.Lightning.ListUnspent:output_type -> lnrpc.ListUnspentResponse
+	29,  // 261: lnrpc.Lightning.SubscribeTransactions:output_type -> lnrpc.Transaction
+	45,  // 262: lnrpc.Lightning.SendMany:output_type -> lnrpc.SendManyResponse
+	51,  // 263: lnrpc.Lightning.NewAddress:output_type -> lnrpc.NewAddressResponse
+	53,  // 264: lnrpc.Lightning.SignMessage:output_type -> lnrpc.SignMessageResponse
+	55,  // 265: lnrpc.Lightning.VerifyMessage:output_type -> lnrpc.VerifyMessageResponse
+	57,  // 266: lnrpc.Lightning.ConnectPeer:output_type -> lnrpc.ConnectPeerResponse
+	59,  // 267: lnrpc.Lightning.DisconnectPeer:output_type -> lnrpc.DisconnectPeerResponse
+	75,  // 268: lnrpc.Lightning.ListPeers:output_type -> lnrpc.ListPeersResponse
+	77,  // 269: lnrpc.Lightning.SubscribePeerEvents:output_type -> lnrpc.PeerEvent
+	79,  // 270: lnrpc.Lightning.GetInfo:output_type -> lnrpc.GetInfoResponse
+	81,  // 271: lnrpc.Lightning.GetDebugInfo:output_type -> lnrpc.GetDebugInfoResponse
+	83,  // 272: lnrpc.Lightning.GetRecoveryInfo:output_type -> lnrpc.GetRecoveryInfoResponse
+	110, // 273: lnrpc.Lightning.PendingChannels:output_type -> lnrpc.PendingChannelsResponse
+	64,  // 274: lnrpc.Lightning.ListChannels:output_type -> lnrpc.ListChannelsResponse
+	112, // 275: lnrpc.Lightning.SubscribeChannelEvents:output_type -> lnrpc.ChannelEventUpdate
+	71,  // 276: lnrpc.Lightning.ClosedChannels:output_type -> lnrpc.ClosedChannelsResponse
+	38,  // 277: lnrpc.Lightning.OpenChannelSync:output_type -> lnrpc.ChannelPoint
+	97,  // 278: lnrpc.Lightning.OpenChannel:output_type -> lnrpc.OpenStatusUpdate
+	95,  // 279: lnrpc.Lightning.BatchOpenChannel:output_type -> lnrpc.BatchOpenChannelResponse
+	107, // 280: lnrpc.Lightning.FundingStateStep:output_type -> lnrpc.FundingStateStepResp
+	36,  // 281: lnrpc.Lightning.ChannelAcceptor:output_type -> lnrpc.ChannelAcceptRequest
+	89,  // 282: lnrpc.Lightning.CloseChannel:output_type -> lnrpc.CloseStatusUpdate
+	172, // 283: lnrpc.Lightning.AbandonChannel:output_type -> lnrpc.AbandonChannelResponse
+	34,  // 284: lnrpc.Lightning.SendPayment:output_type -> lnrpc.SendResponse
+	34,  // 285: lnrpc.Lightning.SendPaymentSync:output_type -> lnrpc.SendResponse
+	34,  // 286: lnrpc.Lightning.SendToRoute:output_type -> lnrpc.SendResponse
+	34,  // 287: lnrpc.Lightning.SendToRouteSync:output_type -> lnrpc.SendResponse
+	158, // 288: lnrpc.Lightning.AddInvoice:output_type -> lnrpc.AddInvoiceResponse
+	161, // 289: lnrpc.Lightning.ListInvoices:output_type -> lnrpc.ListInvoiceResponse
+	155, // 290: lnrpc.Lightning.LookupInvoice:output_type -> lnrpc.Invoice
+	155, // 291: lnrpc.Lightning.SubscribeInvoices:output_type -> lnrpc.Invoice
+	176, // 292: lnrpc.Lightning.DecodePayReq:output_type -> lnrpc.PayReq
+	166, // 293: lnrpc.Lightning.ListPayments:output_type -> lnrpc.ListPaymentsResponse
+	169, // 294: lnrpc.Lightning.DeletePayment:output_type -> lnrpc.DeletePaymentResponse
+	170, // 295: lnrpc.Lightning.DeleteAllPayments:output_type -> lnrpc.DeleteAllPaymentsResponse
+	134, // 296: lnrpc.Lightning.DescribeGraph:output_type -> lnrpc.ChannelGraph
+	136, // 297: lnrpc.Lightning.GetNodeMetrics:output_type -> lnrpc.NodeMetricsResponse
+	132, // 298: lnrpc.Lightning.GetChanInfo:output_type -> lnrpc.ChannelEdge
+	128, // 299: lnrpc.Lightning.GetNodeInfo:output_type -> lnrpc.NodeInfo
+	122, // 300: lnrpc.Lightning.QueryRoutes:output_type -> lnrpc.QueryRoutesResponse
+	140, // 301: lnrpc.Lightning.GetNetworkInfo:output_type -> lnrpc.NetworkInfo
+	142, // 302: lnrpc.Lightning.StopDaemon:output_type -> lnrpc.StopResponse
+	144, // 303: lnrpc.Lightning.SubscribeChannelGraph:output_type -> lnrpc.GraphTopologyUpdate
+	174, // 304: lnrpc.Lightning.DebugLevel:output_type -> lnrpc.DebugLevelResponse
+	180, // 305: lnrpc.Lightning.FeeReport:output_type -> lnrpc.FeeReportResponse
+	184, // 306: lnrpc.Lightning.UpdateChannelPolicy:output_type -> lnrpc.PolicyUpdateResponse
+	187, // 307: lnrpc.Lightning.ForwardingHistory:output_type -> lnrpc.ForwardingHistoryResponse
+	189, // 308: lnrpc.Lightning.ExportChannelBackup:output_type -> lnrpc.ChannelBackup
+	192, // 309: lnrpc.Lightning.ExportAllChannelBackups:output_type -> lnrpc.ChanBackupSnapshot
+	197, // 310: lnrpc.Lightning.VerifyChanBackup:output_type -> lnrpc.VerifyChanBackupResponse
+	195, // 311: lnrpc.Lightning.RestoreChannelBackups:output_type -> lnrpc.RestoreBackupResponse
+	192, // 312: lnrpc.Lightning.SubscribeChannelBackups:output_type -> lnrpc.ChanBackupSnapshot
+	200, // 313: lnrpc.Lightning.BakeMacaroon:output_type -> lnrpc.BakeMacaroonResponse
+	202, // 314: lnrpc.Lightning.ListMacaroonIDs:output_type -> lnrpc.ListMacaroonIDsResponse
+	204, // 315: lnrpc.Lightning.DeleteMacaroonID:output_type -> lnrpc.DeleteMacaroonIDResponse
+	207, // 316: lnrpc.Lightning.ListPermissions:output_type -> lnrpc.ListPermissionsResponse
+	213, // 317: lnrpc.Lightning.CheckMacaroonPermissions:output_type -> lnrpc.CheckMacPermResponse
+	214, // 318: lnrpc.Lightning.RegisterRPCMiddleware:output_type -> lnrpc.RPCMiddlewareRequest
+	26,  // 319: lnrpc.Lightning.SendCustomMessage:output_type -> lnrpc.SendCustomMessageResponse
+	24,  // 320: lnrpc.Lightning.SubscribeCustomMessages:output_type -> lnrpc.CustomMessage
+	67,  // 321: lnrpc.Lightning.ListAliases:output_type -> lnrpc.ListAliasesResponse
+	22,  // 322: lnrpc.Lightning.LookupHtlcResolution:output_type -> lnrpc.LookupHtlcResolutionResponse
+	255, // [255:323] is the sub-list for method output_type
+	187, // [187:255] is the sub-list for method input_type
+	187, // [187:187] is the sub-list for extension type_name
+	187, // [187:187] is the sub-list for extension extendee
+	0,   // [0:187] is the sub-list for field type_name
 }
 
 func init() { file_lightning_proto_init() }

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -4289,6 +4289,7 @@ message PayReq {
     bytes payment_addr = 11;
     int64 num_msat = 12;
     map<uint32, Feature> features = 13;
+    repeated BlindedPaymentPath blinded_paths = 14;
 }
 
 enum FeatureBit {

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -6299,6 +6299,12 @@
           "additionalProperties": {
             "$ref": "#/definitions/lnrpcFeature"
           }
+        },
+        "blinded_paths": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/lnrpcBlindedPaymentPath"
+          }
         }
       }
     },

--- a/record/blinded_data_test.go
+++ b/record/blinded_data_test.go
@@ -101,7 +101,7 @@ func TestBlindedDataEncoding(t *testing.T) {
 				}
 			}
 
-			encodedData := NewBlindedRouteData(
+			encodedData := NewNonFinalBlindedRouteData(
 				channelID, pubkey(t), info, constraints,
 				testCase.features,
 			)
@@ -134,7 +134,7 @@ func TestBlindingSpecTestVectors(t *testing.T) {
 	}{
 		{
 			encoded: "011a0000000000000000000000000000000000000000000000000000020800000000000006c10a0800240000009627100c06000b69e505dc0e00fd023103123456",
-			expectedPaymentData: NewBlindedRouteData(
+			expectedPaymentData: NewNonFinalBlindedRouteData(
 				lnwire.ShortChannelID{
 					BlockHeight: 0,
 					TxIndex:     0,
@@ -158,7 +158,7 @@ func TestBlindingSpecTestVectors(t *testing.T) {
 		},
 		{
 			encoded: "020800000000000004510821031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f0a0800300000006401f40c06000b69c105dc0e00",
-			expectedPaymentData: NewBlindedRouteData(
+			expectedPaymentData: NewNonFinalBlindedRouteData(
 				lnwire.ShortChannelID{
 					TxPosition: 1105,
 				},

--- a/routing/additional_edge.go
+++ b/routing/additional_edge.go
@@ -2,8 +2,8 @@ package routing
 
 import (
 	"errors"
+	"fmt"
 
-	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
@@ -61,11 +61,42 @@ func (p *PrivateEdge) IntermediatePayloadSize(amount lnwire.MilliSatoshi,
 }
 
 // BlindedEdge implements the AdditionalEdge interface. Blinded hops are viewed
-// as additional edges because they are appened at the end of a normal route.
+// as additional edges because they are appended at the end of a normal route.
 type BlindedEdge struct {
-	policy        *models.CachedEdgePolicy
-	cipherText    []byte
-	blindingPoint *btcec.PublicKey
+	policy *models.CachedEdgePolicy
+
+	// blindedPayment is the BlindedPayment that this blinded edge was
+	// derived from.
+	blindedPayment *BlindedPayment
+
+	// hopIndex is the index of the hop in the blinded payment path that
+	// this edge is associated with.
+	hopIndex int
+}
+
+// NewBlindedEdge constructs a new BlindedEdge which packages the policy info
+// for a specific hop within the given blinded payment path. The hop index
+// should correspond to the hop within the blinded payment that this edge is
+// associated with.
+func NewBlindedEdge(policy *models.CachedEdgePolicy, payment *BlindedPayment,
+	hopIndex int) (*BlindedEdge, error) {
+
+	if payment == nil {
+		return nil, fmt.Errorf("blinded payment cannot be nil for " +
+			"blinded edge")
+	}
+
+	if hopIndex < 0 || hopIndex >= len(payment.BlindedPath.BlindedHops) {
+		return nil, fmt.Errorf("the hop index %d is outside the "+
+			"valid range between 0 and %d", hopIndex,
+			len(payment.BlindedPath.BlindedHops)-1)
+	}
+
+	return &BlindedEdge{
+		policy:         policy,
+		hopIndex:       hopIndex,
+		blindedPayment: payment,
+	}, nil
 }
 
 // EdgePolicy return the policy of the BlindedEdge.
@@ -78,9 +109,11 @@ func (b *BlindedEdge) EdgePolicy() *models.CachedEdgePolicy {
 func (b *BlindedEdge) IntermediatePayloadSize(_ lnwire.MilliSatoshi, _ uint32,
 	_ uint64) uint64 {
 
+	blindedPath := b.blindedPayment.BlindedPath
+
 	hop := route.Hop{
-		BlindingPoint: b.blindingPoint,
-		EncryptedData: b.cipherText,
+		BlindingPoint: blindedPath.BlindingPoint,
+		EncryptedData: blindedPath.BlindedHops[b.hopIndex].CipherText,
 	}
 
 	// For blinded paths the next chanID is in the encrypted data tlv.

--- a/routing/additional_edge.go
+++ b/routing/additional_edge.go
@@ -29,6 +29,11 @@ type AdditionalEdge interface {
 
 	// EdgePolicy returns the policy of the additional edge.
 	EdgePolicy() *models.CachedEdgePolicy
+
+	// BlindedPayment returns the BlindedPayment that this additional edge
+	// info was derived from. It will return nil if this edge was not
+	// derived from a blinded route.
+	BlindedPayment() *BlindedPayment
 }
 
 // PayloadSizeFunc defines the interface for the payload size function.
@@ -58,6 +63,12 @@ func (p *PrivateEdge) IntermediatePayloadSize(amount lnwire.MilliSatoshi,
 	}
 
 	return hop.PayloadSize(channelID)
+}
+
+// BlindedPayment is a no-op for a PrivateEdge since it is not associated with
+// a blinded payment. This will thus return nil.
+func (p *PrivateEdge) BlindedPayment() *BlindedPayment {
+	return nil
 }
 
 // BlindedEdge implements the AdditionalEdge interface. Blinded hops are viewed
@@ -118,6 +129,12 @@ func (b *BlindedEdge) IntermediatePayloadSize(_ lnwire.MilliSatoshi, _ uint32,
 
 	// For blinded paths the next chanID is in the encrypted data tlv.
 	return hop.PayloadSize(0)
+}
+
+// BlindedPayment returns the blinded payment that this edge is associated
+// with.
+func (b *BlindedEdge) BlindedPayment() *BlindedPayment {
+	return b.blindedPayment
 }
 
 // Compile-time constraints to ensure the PrivateEdge and the BlindedEdge

--- a/routing/additional_edge_test.go
+++ b/routing/additional_edge_test.go
@@ -42,9 +42,13 @@ func TestIntermediatePayloadSize(t *testing.T) {
 			hop: route.Hop{
 				EncryptedData: []byte{12, 13},
 			},
-			edge: &BlindedEdge{
-				cipherText: []byte{12, 13},
-			},
+			edge: &BlindedEdge{blindedPayment: &BlindedPayment{
+				BlindedPath: &sphinx.BlindedPath{
+					BlindedHops: []*sphinx.BlindedHopInfo{
+						{CipherText: []byte{12, 13}},
+					},
+				},
+			}},
 		},
 		{
 			name: "Blinded edge - introduction point",
@@ -52,10 +56,14 @@ func TestIntermediatePayloadSize(t *testing.T) {
 				EncryptedData: []byte{12, 13},
 				BlindingPoint: blindedPoint,
 			},
-			edge: &BlindedEdge{
-				cipherText:    []byte{12, 13},
-				blindingPoint: blindedPoint,
-			},
+			edge: &BlindedEdge{blindedPayment: &BlindedPayment{
+				BlindedPath: &sphinx.BlindedPath{
+					BlindingPoint: blindedPoint,
+					BlindedHops: []*sphinx.BlindedHopInfo{
+						{CipherText: []byte{12, 13}},
+					},
+				},
+			}},
 		},
 	}
 

--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -96,9 +96,17 @@ type edgePolicyWithSource struct {
 // such as amounts and cltvs, as well as more complex features like destination
 // custom records and payment address.
 type finalHopParams struct {
-	amt         lnwire.MilliSatoshi
-	totalAmt    lnwire.MilliSatoshi
-	cltvDelta   uint16
+	amt      lnwire.MilliSatoshi
+	totalAmt lnwire.MilliSatoshi
+
+	// cltvDelta is the final hop's minimum CLTV expiry delta.
+	//
+	// NOTE that in the case of paying to a blinded path, this value will
+	// be set to a duplicate of the blinded path's accumulated CLTV value.
+	// We would then only need to use this value in the case where the
+	// introduction node of the path is also the destination node.
+	cltvDelta uint16
+
 	records     record.CustomSet
 	paymentAddr *[32]byte
 
@@ -190,10 +198,21 @@ func newRoute(sourceVertex route.Vertex,
 			// reporting through RPC. Set to zero for the final hop.
 			fee = 0
 
-			// As this is the last hop, we'll use the specified
-			// final CLTV delta value instead of the value from the
-			// last link in the route.
-			totalTimeLock += uint32(finalHop.cltvDelta)
+			// Only include the final hop CLTV delta in the total
+			// time lock value if this is not a route to a blinded
+			// path. For blinded paths, the total time-lock from the
+			// whole path will be deduced from the introduction
+			// node's CLTV delta. The exception is for the case
+			// where the final hop is the blinded path introduction
+			// node.
+			if blindedPath == nil ||
+				len(blindedPath.BlindedHops) == 1 {
+
+				// As this is the last hop, we'll use the
+				// specified final CLTV delta value instead of
+				// the value from the last link in the route.
+				totalTimeLock += uint32(finalHop.cltvDelta)
+			}
 			outgoingTimeLock = totalTimeLock
 
 			// Attach any custom records to the final hop.

--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -968,6 +968,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 				inboundFee,
 				fakeHopHintCapacity,
 				reverseEdge.edge.IntermediatePayloadSize,
+				reverseEdge.edge.BlindedPayment(),
 			)
 		}
 

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -3322,16 +3322,19 @@ func TestBlindedRouteConstruction(t *testing.T) {
 			ToNodeFeatures: tlvFeatures,
 		}
 
-		// Create final hop parameters for payment amount = 110. Note
-		// that final cltv delta is not set because blinded paths
-		// include this final delta in their aggregate delta. A
-		// sender-set delta may be added to account for block arrival
-		// during payment, but we do not set it in this test.
+		// Create final hop parameters for payment amount = 110.
 		totalAmt       lnwire.MilliSatoshi = 110
 		finalHopParams                     = finalHopParams{
 			amt:      totalAmt,
 			totalAmt: totalAmt,
 			metadata: metadata,
+
+			// We set a CLTV delta here just to test that this will
+			// be ignored by newRoute since this is a blinded path
+			// where the accumulated CLTV delta for the route
+			// communicated in the blinded path should be assumed to
+			// include the CLTV delta of the final hop.
+			cltvDelta: MaxCLTVDelta,
 		}
 	)
 

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -3341,7 +3341,9 @@ func TestBlindedRouteConstruction(t *testing.T) {
 	// that make up the graph we'll give to route construction. The hints
 	// map is keyed by source node, so we can retrieve our blinded edges
 	// accordingly.
-	blindedEdges := blindedPayment.toRouteHints()
+	blindedEdges, err := blindedPayment.toRouteHints()
+	require.NoError(t, err)
+
 	carolDaveEdge := blindedEdges[carolVertex][0]
 	daveEveEdge := blindedEdges[daveBlindedVertex][0]
 

--- a/routing/router.go
+++ b/routing/router.go
@@ -2001,6 +2001,7 @@ func NewRouteRequest(source route.Vertex, target *route.Vertex,
 		// Assume that we're starting off with a regular payment.
 		requestHints  = routeHints
 		requestExpiry = finalExpiry
+		err           error
 	)
 
 	if blindedPayment != nil {
@@ -2038,7 +2039,10 @@ func NewRouteRequest(source route.Vertex, target *route.Vertex,
 			requestExpiry = blindedPayment.CltvExpiryDelta
 		}
 
-		requestHints = blindedPayment.toRouteHints()
+		requestHints, err = blindedPayment.toRouteHints()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	requestTarget, err := getTargetNode(target, blindedPayment)

--- a/routing/unified_edges_test.go
+++ b/routing/unified_edges_test.go
@@ -59,37 +59,37 @@ func TestNodeEdgeUnifier(t *testing.T) {
 	unifierFilled := newNodeEdgeUnifier(source, toNode, false, nil)
 
 	unifierFilled.addPolicy(
-		fromNode, &p1, inboundFee1, c1, defaultHopPayloadSize,
+		fromNode, &p1, inboundFee1, c1, defaultHopPayloadSize, nil,
 	)
 	unifierFilled.addPolicy(
-		fromNode, &p2, inboundFee2, c2, defaultHopPayloadSize,
+		fromNode, &p2, inboundFee2, c2, defaultHopPayloadSize, nil,
 	)
 
 	unifierNoCapacity := newNodeEdgeUnifier(source, toNode, false, nil)
 	unifierNoCapacity.addPolicy(
-		fromNode, &p1, inboundFee1, 0, defaultHopPayloadSize,
+		fromNode, &p1, inboundFee1, 0, defaultHopPayloadSize, nil,
 	)
 	unifierNoCapacity.addPolicy(
-		fromNode, &p2, inboundFee2, 0, defaultHopPayloadSize,
+		fromNode, &p2, inboundFee2, 0, defaultHopPayloadSize, nil,
 	)
 
 	unifierNoInfo := newNodeEdgeUnifier(source, toNode, false, nil)
 	unifierNoInfo.addPolicy(
 		fromNode, &models.CachedEdgePolicy{}, models.InboundFee{},
-		0, defaultHopPayloadSize,
+		0, defaultHopPayloadSize, nil,
 	)
 
 	unifierInboundFee := newNodeEdgeUnifier(source, toNode, true, nil)
 	unifierInboundFee.addPolicy(
-		fromNode, &p1, inboundFee1, c1, defaultHopPayloadSize,
+		fromNode, &p1, inboundFee1, c1, defaultHopPayloadSize, nil,
 	)
 	unifierInboundFee.addPolicy(
-		fromNode, &p2, inboundFee2, c2, defaultHopPayloadSize,
+		fromNode, &p2, inboundFee2, c2, defaultHopPayloadSize, nil,
 	)
 
 	unifierLocal := newNodeEdgeUnifier(fromNode, toNode, true, nil)
 	unifierLocal.addPolicy(
-		fromNode, &p1, inboundFee1, c1, defaultHopPayloadSize,
+		fromNode, &p1, inboundFee1, c1, defaultHopPayloadSize, nil,
 	)
 
 	inboundFeeZero := models.InboundFee{}
@@ -98,10 +98,11 @@ func TestNodeEdgeUnifier(t *testing.T) {
 	}
 	unifierNegInboundFee := newNodeEdgeUnifier(source, toNode, true, nil)
 	unifierNegInboundFee.addPolicy(
-		fromNode, &p1, inboundFeeZero, c1, defaultHopPayloadSize,
+		fromNode, &p1, inboundFeeZero, c1, defaultHopPayloadSize, nil,
 	)
 	unifierNegInboundFee.addPolicy(
 		fromNode, &p2, inboundFeeNegative, c2, defaultHopPayloadSize,
+		nil,
 	)
 
 	tests := []struct {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -6971,6 +6971,13 @@ func (r *rpcServer) DecodePayReq(ctx context.Context,
 	// Convert between the `lnrpc` and `routing` types.
 	routeHints := invoicesrpc.CreateRPCRouteHints(payReq.RouteHints)
 
+	blindedPaymentPaths, err := invoicesrpc.CreateRPCBlindedPayments(
+		payReq.BlindedPaymentPaths,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	var amtSat, amtMsat int64
 	if payReq.MilliSat != nil {
 		amtSat = int64(payReq.MilliSat.ToSatoshis())
@@ -6996,6 +7003,7 @@ func (r *rpcServer) DecodePayReq(ctx context.Context,
 		Expiry:          expiry,
 		CltvExpiry:      int64(payReq.MinFinalCLTVExpiry()),
 		RouteHints:      routeHints,
+		BlindedPaths:    blindedPaymentPaths,
 		PaymentAddr:     paymentAddr,
 		Features:        invoicesrpc.CreateRPCFeatures(payReq.Features),
 	}, nil

--- a/zpay32/blinded_path.go
+++ b/zpay32/blinded_path.go
@@ -1,0 +1,246 @@
+package zpay32
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	sphinx "github.com/lightningnetwork/lightning-onion"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+const (
+	// relayInfoSize is the number of bytes that the relay info of a blinded
+	// payment will occupy.
+	// 	base fee: 4 bytes
+	//	prop fee: 4 bytes
+	//	cltv delta: 2 bytes
+	//	min htlc: 8 bytes
+	//	max htlc: 8 bytes
+	relayInfoSize = 26
+
+	// maxNumHopsPerPath is the maximum number of blinded path hops that can
+	// be included in a single encoded blinded path. This is calculated
+	// based on the `data_length` limit of 638 bytes for any tagged field in
+	// a BOLT 11 invoice along with the estimated number of bytes required
+	// for encoding the most minimal blinded path hop. See the [bLIP
+	// proposal](https://github.com/lightning/blips/pull/39) for a detailed
+	// calculation.
+	maxNumHopsPerPath = 7
+)
+
+// BlindedPaymentPath holds all the information a payer needs to know about a
+// blinded path to a receiver of a payment.
+type BlindedPaymentPath struct {
+	// FeeBaseMsat is the total base fee for the path in milli-satoshis.
+	FeeBaseMsat uint32
+
+	// FeeRate is the total fee rate for the path in parts per million.
+	FeeRate uint32
+
+	// CltvExpiryDelta is the total CLTV delta to apply to the path.
+	CltvExpiryDelta uint16
+
+	// HTLCMinMsat is the minimum number of milli-satoshis that any hop in
+	// the path will route.
+	HTLCMinMsat uint64
+
+	// HTLCMaxMsat is the maximum number of milli-satoshis that a hop in the
+	// path will route.
+	HTLCMaxMsat uint64
+
+	// Features is the feature bit vector for the path.
+	Features *lnwire.FeatureVector
+
+	// FirstEphemeralBlindingPoint is the blinding point to send to the
+	// introduction node. It will be used by the introduction node to derive
+	// a shared secret with the receiver which can then be used to decode
+	// the encrypted payload from the receiver.
+	FirstEphemeralBlindingPoint *btcec.PublicKey
+
+	// Hops is the blinded path. The first hop is the introduction node and
+	// so the BlindedNodeID of this hop will be the real node ID.
+	Hops []*sphinx.BlindedHopInfo
+}
+
+// DecodeBlindedPayment attempts to parse a BlindedPaymentPath from the passed
+// reader.
+func DecodeBlindedPayment(r io.Reader) (*BlindedPaymentPath, error) {
+	var relayInfo [relayInfoSize]byte
+	n, err := r.Read(relayInfo[:])
+	if err != nil {
+		return nil, err
+	}
+	if n != relayInfoSize {
+		return nil, fmt.Errorf("unable to read %d relay info bytes "+
+			"off of the given stream: %w", relayInfoSize, err)
+	}
+
+	var payment BlindedPaymentPath
+
+	// Parse the relay info fields.
+	payment.FeeBaseMsat = binary.BigEndian.Uint32(relayInfo[:4])
+	payment.FeeRate = binary.BigEndian.Uint32(relayInfo[4:8])
+	payment.CltvExpiryDelta = binary.BigEndian.Uint16(relayInfo[8:10])
+	payment.HTLCMinMsat = binary.BigEndian.Uint64(relayInfo[10:18])
+	payment.HTLCMaxMsat = binary.BigEndian.Uint64(relayInfo[18:])
+
+	// Parse the feature bit vector.
+	f := lnwire.EmptyFeatureVector()
+	err = f.Decode(r)
+	if err != nil {
+		return nil, err
+	}
+	payment.Features = f
+
+	// Parse the first ephemeral blinding point.
+	var blindingPointBytes [btcec.PubKeyBytesLenCompressed]byte
+	_, err = r.Read(blindingPointBytes[:])
+	if err != nil {
+		return nil, err
+	}
+
+	blinding, err := btcec.ParsePubKey(blindingPointBytes[:])
+	if err != nil {
+		return nil, err
+	}
+	payment.FirstEphemeralBlindingPoint = blinding
+
+	// Read the one byte hop number.
+	var numHops [1]byte
+	_, err = r.Read(numHops[:])
+	if err != nil {
+		return nil, err
+	}
+
+	payment.Hops = make([]*sphinx.BlindedHopInfo, int(numHops[0]))
+
+	// Parse each hop.
+	for i := 0; i < len(payment.Hops); i++ {
+		hop, err := DecodeBlindedHop(r)
+		if err != nil {
+			return nil, err
+		}
+
+		payment.Hops[i] = hop
+	}
+
+	return &payment, nil
+}
+
+// Encode serialises the BlindedPaymentPath and writes the bytes to the passed
+// writer.
+// 1) The first 26 bytes contain the relay info:
+//   - Base Fee in msat: uint32 (4 bytes).
+//   - Proportional Fee in PPM: uint32 (4 bytes).
+//   - CLTV expiry delta: uint16 (2 bytes).
+//   - HTLC min msat: uint64 (8 bytes).
+//   - HTLC max msat: uint64 (8 bytes).
+//
+// 2) Feature bit vector length (2 bytes).
+// 3) Feature bit vector (can be zero length).
+// 4) First blinding point: 33 bytes.
+// 5) Number of hops: 1 byte.
+// 6) Encoded BlindedHops.
+func (p *BlindedPaymentPath) Encode(w io.Writer) error {
+	var relayInfo [26]byte
+	binary.BigEndian.PutUint32(relayInfo[:4], p.FeeBaseMsat)
+	binary.BigEndian.PutUint32(relayInfo[4:8], p.FeeRate)
+	binary.BigEndian.PutUint16(relayInfo[8:10], p.CltvExpiryDelta)
+	binary.BigEndian.PutUint64(relayInfo[10:18], p.HTLCMinMsat)
+	binary.BigEndian.PutUint64(relayInfo[18:], p.HTLCMaxMsat)
+
+	_, err := w.Write(relayInfo[:])
+	if err != nil {
+		return err
+	}
+
+	err = p.Features.Encode(w)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(p.FirstEphemeralBlindingPoint.SerializeCompressed())
+	if err != nil {
+		return err
+	}
+
+	numHops := len(p.Hops)
+	if numHops > maxNumHopsPerPath {
+		return fmt.Errorf("the number of hops, %d, exceeds the "+
+			"maximum of %d", numHops, maxNumHopsPerPath)
+	}
+
+	_, err = w.Write([]byte{byte(numHops)})
+	if err != nil {
+		return err
+	}
+
+	for _, hop := range p.Hops {
+		err = EncodeBlindedHop(w, hop)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// DecodeBlindedHop reads a sphinx.BlindedHopInfo from the passed reader.
+func DecodeBlindedHop(r io.Reader) (*sphinx.BlindedHopInfo, error) {
+	var nodeIDBytes [btcec.PubKeyBytesLenCompressed]byte
+	_, err := r.Read(nodeIDBytes[:])
+	if err != nil {
+		return nil, err
+	}
+
+	nodeID, err := btcec.ParsePubKey(nodeIDBytes[:])
+	if err != nil {
+		return nil, err
+	}
+
+	dataLen, err := tlv.ReadVarInt(r, &[8]byte{})
+	if err != nil {
+		return nil, err
+	}
+
+	encryptedData := make([]byte, dataLen)
+	_, err = r.Read(encryptedData)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sphinx.BlindedHopInfo{
+		BlindedNodePub: nodeID,
+		CipherText:     encryptedData,
+	}, nil
+}
+
+// EncodeBlindedHop writes the passed BlindedHopInfo to the given writer.
+//
+// 1) Blinded node pub key: 33 bytes
+// 2) Cipher text length: BigSize
+// 3) Cipher text.
+func EncodeBlindedHop(w io.Writer, hop *sphinx.BlindedHopInfo) error {
+	_, err := w.Write(hop.BlindedNodePub.SerializeCompressed())
+	if err != nil {
+		return err
+	}
+
+	if len(hop.CipherText) > math.MaxUint16 {
+		return fmt.Errorf("encrypted recipient data can not exceed a "+
+			"length of %d bytes", math.MaxUint16)
+	}
+
+	err = tlv.WriteVarInt(w, uint64(len(hop.CipherText)), &[8]byte{})
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(hop.CipherText)
+
+	return err
+}

--- a/zpay32/encode.go
+++ b/zpay32/encode.go
@@ -260,6 +260,29 @@ func writeTaggedFields(bufferBase32 *bytes.Buffer, invoice *Invoice) error {
 		}
 	}
 
+	for _, path := range invoice.BlindedPaymentPaths {
+		var buf bytes.Buffer
+
+		err := path.Encode(&buf)
+		if err != nil {
+			return err
+		}
+
+		blindedPathBase32, err := bech32.ConvertBits(
+			buf.Bytes(), 8, 5, true,
+		)
+		if err != nil {
+			return err
+		}
+
+		err = writeTaggedField(
+			bufferBase32, fieldTypeB, blindedPathBase32,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
 	if invoice.Destination != nil {
 		// Convert 33 byte pubkey to 53 5-bit groups.
 		pubKeyBase32, err := bech32.ConvertBits(

--- a/zpay32/invoice.go
+++ b/zpay32/invoice.go
@@ -156,6 +156,10 @@ type Invoice struct {
 	// This field is un-exported and can only be read by the
 	// MinFinalCLTVExpiry() method. By forcing callers to read via this
 	// method, we can easily enforce the default if not specified.
+	//
+	// NOTE: this field is ignored in the case that the invoice contains
+	// blinded paths since then the final minimum cltv expiry delta is
+	// expected to be included in the route's accumulated CLTV delta value.
 	minFinalCLTVExpiry *uint64
 
 	// Description is a short description of the purpose of this invoice.

--- a/zpay32/invoice.go
+++ b/zpay32/invoice.go
@@ -76,6 +76,10 @@ const (
 	// probing the recipient.
 	fieldTypeS = 16
 
+	// fieldTypeB contains blinded payment path information. This field may
+	// be repeated to include multiple blinded payment paths in the invoice.
+	fieldTypeB = 20
+
 	// maxInvoiceLength is the maximum total length an invoice can have.
 	// This is chosen to be the maximum number of bytes that can fit into a
 	// single QR code: https://en.wikipedia.org/wiki/QR_code#Storage
@@ -180,8 +184,16 @@ type Invoice struct {
 	// hint can be individually used to reach the destination. These usually
 	// represent private routes.
 	//
-	// NOTE: This is optional.
+	// NOTE: This is optional and should not be set at the same time as
+	// BlindedPaymentPaths.
 	RouteHints [][]HopHint
+
+	// BlindedPaymentPaths is a set of blinded payment paths that can be
+	// used to find the payment receiver.
+	//
+	// NOTE: This is optional and should not be set at the same time as
+	// RouteHints.
+	BlindedPaymentPaths []*BlindedPaymentPath
 
 	// Features represents an optional field used to signal optional or
 	// required support for features by the receiver.
@@ -260,6 +272,15 @@ func FallbackAddr(fallbackAddr btcutil.Address) func(*Invoice) {
 func RouteHint(routeHint []HopHint) func(*Invoice) {
 	return func(i *Invoice) {
 		i.RouteHints = append(i.RouteHints, routeHint)
+	}
+}
+
+// WithBlindedPaymentPath is a functional option that allows a caller of
+// NewInvoice to attach a blinded payment path to the invoice. The option can
+// be used multiple times to attach multiple paths.
+func WithBlindedPaymentPath(p *BlindedPaymentPath) func(*Invoice) {
+	return func(i *Invoice) {
+		i.BlindedPaymentPaths = append(i.BlindedPaymentPaths, p)
 	}
 }
 
@@ -353,6 +374,13 @@ func validateInvoice(invoice *Invoice) error {
 	// The invoice must contain a payment hash.
 	if invoice.PaymentHash == nil {
 		return fmt.Errorf("no payment hash found")
+	}
+
+	if len(invoice.RouteHints) != 0 &&
+		len(invoice.BlindedPaymentPaths) != 0 {
+
+		return fmt.Errorf("cannot have both route hints and blinded " +
+			"payment paths")
 	}
 
 	// Either Description or DescriptionHash must be set, not both.


### PR DESCRIPTION
To make review a bit more manageable, I've split out some of the groundwork needed for 
the main route blinding receives PR. This PR thus has no functional changes. 

Tracking Issue: https://github.com/lightningnetwork/lnd/issues/6690

## PR Overview: 

1) a couple of refactors & interface expansions so that we have easy access to the `BlindedPayment` associated with an edge in path finding later on. 
2) Remove the need to communicate the "TLV Option" in a blinded path feature bit vector. This bit can be assumed for any nodes in a blinded path. 
3) Add fields to `BlindedRouteData` that will be required for receives. Namely, PathID and Padding. 
4) Bolt11 blinded payment path encoding


EDIT:  bLIP proposal here: https://github.com/lightning/blips/pull/39