### PR TITLE
Adjust ping parameters to improve tor stability

### DIFF
--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -76,6 +76,12 @@ const (
 
 	// ErrorBufferSize is the number of historic peer errors that we store.
 	ErrorBufferSize = 10
+
+	// pongSizeCeiling is the upper bound on a uniformly distributed random
+	// variable that we use for requesting pong responses. We don't use the
+	// MaxPongBytes (upper bound accepted by the protocol) because it is
+	// needlessly wasteful of precious Tor bandwidth for little to no gain.
+	pongSizeCeiling = 4096
 )
 
 var (
@@ -558,17 +564,16 @@ func NewBrontide(cfg Config) *Brontide {
 		return lastSerializedBlockHeader[:]
 	}
 
-	// TODO(roasbeef): make dynamic in order to
-	// create fake cover traffic
-	// NOTE(proofofkeags): this was changed to be
-	// dynamic to allow better pong identification,
-	// however, more thought is needed to make this
-	// actually usable as a traffic decoy
+	// TODO(roasbeef): make dynamic in order to create fake cover traffic.
+	//
+	// NOTE(proofofkeags): this was changed to be dynamic to allow better
+	// pong identification, however, more thought is needed to make this
+	// actually usable as a traffic decoy.
 	randPongSize := func() uint16 {
 		return uint16(
 			// We don't need cryptographic randomness here.
 			/* #nosec */
-			rand.Intn(lnwire.MaxPongBytes + 1),
+			rand.Intn(pongSizeCeiling) + 1,
 		)
 	}
 

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -1257,15 +1257,13 @@ func (p *Brontide) Disconnect(reason error) {
 
 	p.log.Infof(err.Error())
 
+	// Stop PingManager before closing TCP connection.
+	p.pingManager.Stop()
+
 	// Ensure that the TCP connection is properly closed before continuing.
 	p.cfg.Conn.Close()
 
 	close(p.quit)
-
-	if err := p.pingManager.Stop(); err != nil {
-		p.log.Errorf("couldn't stop pingManager during disconnect: %v",
-			err)
-	}
 }
 
 // String returns the string representation of this peer.

--- a/peer/ping_manager.go
+++ b/peer/ping_manager.go
@@ -196,12 +196,10 @@ func (m *PingManager) pingHandler() {
 	}
 }
 
-// Stop interrupts the goroutines that the PingManager owns. Can only be called
-// when the PingManager is running.
-func (m *PingManager) Stop() error {
+// Stop interrupts the goroutines that the PingManager owns.
+func (m *PingManager) Stop() {
 	if m.pingTicker == nil {
-		return errors.New("PingManager cannot be stopped because it " +
-			"isn't running")
+		return
 	}
 
 	m.stopped.Do(func() {
@@ -211,8 +209,6 @@ func (m *PingManager) Stop() error {
 		m.pingTicker.Stop()
 		m.pingTimeout.Stop()
 	})
-
-	return nil
 }
 
 // setPingState is a private method to keep track of all of the fields we need

--- a/peer/ping_manager_test.go
+++ b/peer/ping_manager_test.go
@@ -83,6 +83,6 @@ func TestPingManager(t *testing.T) {
 			require.False(t, test.result)
 		}
 
-		require.NoError(t, mgr.Stop(), "Could not stop pingManager")
+		mgr.Stop()
 	}
 }


### PR DESCRIPTION
## Change Description
Here we do the following things to increase stability with tor peers:
1. Reduce maximum pong payload size to ease bandwidth consumption
2. Make PingManager.Stop infallible so that it doesn't pollute the logs with false errors in the case where we fail to send or receive the `init` message.
3. If we detect that the connection with our peer is over tor (heuristic), then we will triple the timeout parameters to give them more time to respond.

## Steps to Test
Run this patch with a bunch of tor peers and see if it improves the long term stability of those peers.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
