### PR TITLE
lnwallet: respect local dust limit in cooperative close

### DIFF
--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -8616,7 +8616,7 @@ func CreateCooperativeCloseTx(fundingTxIn wire.TxIn,
 			Value:    int64(ourBalance),
 		})
 	}
-	if theirBalance >= remoteDust {
+	if theirBalance >= remoteDust && theirBalance >= localDust {
 		closeTx.AddTxOut(&wire.TxOut{
 			PkScript: theirDeliveryScript,
 			Value:    int64(theirBalance),


### PR DESCRIPTION
## Change Description
When the remote dustlimit is lower than the local one, a cooperative closure could create an output that doesn't respect the local dustlimit. By comparing the remote balance to the local dustlimit we're protected against creating invalid cooperative close transactions according to the local standards.

This requirement is part of the BOLTs: https://github.com/lightning/bolts/blob/5f8fea8dc3c8c612167dd9645c4a21fe9de2f147/03-transactions.md?plain=1#L373

Unfortunately this now leads to failure to close the channel. But that's better than crafting invalid transactions in my opinion.

Next steps will be
- allowing the remote peer to eliminate its own output ([spec](https://github.com/lightning/bolts/blob/5f8fea8dc3c8c612167dd9645c4a21fe9de2f147/03-transactions.md?plain=1#L374)).  
- potentially having a ruleset to in some circumstances eliminate the local output if it's small enough.

## Steps to Test
- Create a channel with Alice and Bob
- Alice has dustlimit 10000
- Bob has dustlimit 2000
- Bob's balance is 2500
- Alice should not include Bob's output in the closing transaction

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
