### PR TITLE
routing: repopulate missing edges in graph for local channels

### DIFF
--- a/config.go
+++ b/config.go
@@ -502,6 +502,11 @@ type Config struct {
 	// HTTPHeaderTimeout is the maximum duration that the server will wait
 	// before timing out reading the headers of an HTTP request.
 	HTTPHeaderTimeout time.Duration `long:"http-header-timeout" description:"The maximum duration that the server will wait before timing out reading the headers of an HTTP request."`
+
+	// RepopulateMissingEdges is a value indicating whether missing edges of
+	// local channels should be re-added to the local view of the graph on
+	// startup.
+	RepopulateMissingEdges bool `long:"repopulate-missing-edges" description:"Repopulates any missing edges of local channels in the node's local view of the graph. This can help with 'edge not found' issues where LND will always select the default routing policy. Should be set to false after successful execution to avoid repopulating on every restart of lnd."`
 }
 
 // GRPCConfig holds the configuration options for the gRPC server.

--- a/lnd.go
+++ b/lnd.go
@@ -585,6 +585,16 @@ func Main(cfg *Config, lisCfg ListenerCfg, implCfg *ImplementationCfg,
 		return mkErr("unable to create server: %v", err)
 	}
 
+	// Ensure all local channels have corresponding edges and channel
+	// policies in the graph db before starting.
+	if cfg.RepopulateMissingEdges {
+		err = server.edgeRepopulator.RepopulateMissingEdges()
+		if err != nil {
+			return mkErr(
+				"unable to repopulate missing edges: %v", err)
+		}
+	}
+
 	// Set up an autopilot manager from the current config. This will be
 	// used to manage the underlying autopilot agent, starting and stopping
 	// it at will.

--- a/routing/repopulate.go
+++ b/routing/repopulate.go
@@ -1,0 +1,155 @@
+package routing
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+// EdgeRepopulator's only job is to ensure every local channel has a
+// corresponding edge and policy in the graph database.
+type EdgeRepopulator struct {
+	LocalPubkey          btcec.PublicKey
+	DefaultRoutingPolicy models.ForwardingPolicy
+	ChanStateDB          *channeldb.ChannelStateDB
+	GraphDB              *channeldb.ChannelGraph
+}
+
+// RepopulateMissingEdges iterates all open channels and checks whether a local
+// channel policy is stored for that channel. If the policy is missing, it is
+// populated with the default channel policy.
+func (e *EdgeRepopulator) RepopulateMissingEdges() error {
+	log.Debug("RepopulateMissingEdges started")
+
+	// First fetch all current open channels.
+	channels, err := e.ChanStateDB.FetchAllOpenChannels()
+	if err != nil {
+		return fmt.Errorf("failed to fetch open channels: %w", err)
+	}
+
+	for _, c := range channels {
+		// For every channel, check the graph whether there is a
+		// corresponding edge.
+		edge1Timestamp, edge2Timestamp, exists, _, err :=
+			e.GraphDB.HasChannelEdge(c.ShortChanID().ToUint64())
+		if err != nil {
+			log.Warnf("Failed to populate edge for channel %s: %v",
+				c.FundingOutpoint.String(), err)
+			continue
+		}
+
+		// Initialize some fields with relatively long lines here.
+		localBytes := e.LocalPubkey.SerializeCompressed()
+		remoteBytes := c.IdentityPub.SerializeCompressed()
+		localBitcoin := c.LocalChanCfg.MultiSigKey.PubKey.
+			SerializeCompressed()
+		remoteBitcoin := c.RemoteChanCfg.MultiSigKey.PubKey.
+			SerializeCompressed()
+
+		// local1 is a value indicating whether the local node is node 1
+		// in the channel edge. If true, the local node is node 1, if
+		// false the local node is node 2.
+		local1 := bytes.Compare(localBytes, remoteBytes) < 0
+
+		// If the channel edge belonging to the current channel doesn't
+		// exist in the graph, it is added here.
+		if !exists {
+			var (
+				nodeKey1Bytes, nodeKey2Bytes,
+				bitcoinKey1Bytes, bitcoinKey2Bytes []byte
+				featureBuf bytes.Buffer
+			)
+
+			if local1 {
+				nodeKey1Bytes = localBytes
+				nodeKey2Bytes = remoteBytes
+				bitcoinKey1Bytes = localBitcoin
+				bitcoinKey2Bytes = remoteBitcoin
+			} else {
+				nodeKey1Bytes = remoteBytes
+				nodeKey2Bytes = localBytes
+				bitcoinKey1Bytes = remoteBitcoin
+				bitcoinKey2Bytes = localBitcoin
+			}
+
+			err = lnwire.NewRawFeatureVector().Encode(&featureBuf)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to encode features: %v", err)
+			}
+
+			edge := &models.ChannelEdgeInfo{
+				ChannelID:    c.ShortChanID().ToUint64(),
+				ChainHash:    c.ChainHash,
+				Features:     featureBuf.Bytes(),
+				Capacity:     c.Capacity,
+				ChannelPoint: c.FundingOutpoint,
+			}
+
+			copy(edge.NodeKey1Bytes[:], nodeKey1Bytes)
+			copy(edge.NodeKey2Bytes[:], nodeKey2Bytes)
+			copy(edge.BitcoinKey1Bytes[:], bitcoinKey1Bytes)
+			copy(edge.BitcoinKey2Bytes[:], bitcoinKey2Bytes)
+
+			// Add the newly created, missing edge to the graph.
+			err := e.GraphDB.AddChannelEdge(edge)
+			if err != nil {
+				log.Errorf("Failed to fix missing edge for "+
+					"local channel %s: %w",
+					c.FundingOutpoint.String(), err)
+				continue
+			}
+
+			log.Infof("Fixed missing edge for local channel %s",
+				c.FundingOutpoint.String())
+		}
+
+		var localTimestamp time.Time
+		var chanFlags lnwire.ChanUpdateChanFlags
+		if local1 {
+			localTimestamp = edge1Timestamp
+			chanFlags = 0
+		} else {
+			localTimestamp = edge2Timestamp
+			chanFlags = 1
+		}
+
+		policy := e.DefaultRoutingPolicy
+		msgFlags := lnwire.ChanUpdateRequiredMaxHtlc
+		localPolicy := &models.ChannelEdgePolicy{
+			ChannelID:                 c.ShortChanID().ToUint64(),
+			LastUpdate:                time.Now(),
+			MessageFlags:              msgFlags,
+			ChannelFlags:              chanFlags,
+			TimeLockDelta:             uint16(policy.TimeLockDelta),
+			MinHTLC:                   policy.MinHTLCOut,
+			MaxHTLC:                   policy.MaxHTLC,
+			FeeBaseMSat:               policy.BaseFee,
+			FeeProportionalMillionths: policy.FeeRate,
+		}
+
+		// If the update timestamp of the local edge policy is zero,
+		// that means the local channel policy is missing. It is added
+		// here.
+		if localTimestamp.IsZero() {
+			err := e.GraphDB.UpdateEdgePolicy(localPolicy)
+			if err != nil {
+				log.Errorf("Failed to fix missing policy for "+
+					"local channel %s: %w",
+					c.FundingOutpoint.String(), err)
+				continue
+			}
+
+			log.Infof("Fixed missing policy for local channel %s",
+				c.FundingOutpoint.String())
+		}
+	}
+
+	log.Debug("RepopulateMissingEdges completed")
+	return nil
+}

--- a/server.go
+++ b/server.go
@@ -278,6 +278,8 @@ type server struct {
 
 	localChanMgr *localchans.Manager
 
+	edgeRepopulator *routing.EdgeRepopulator
+
 	utxoNursery *contractcourt.UtxoNursery
 
 	sweeper *sweep.UtxoSweeper
@@ -1047,6 +1049,13 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		PropagateChanPolicyUpdate: s.authGossiper.PropagateChanPolicyUpdate,
 		UpdateForwardingPolicies:  s.htlcSwitch.UpdateForwardingPolicies,
 		FetchChannel:              s.chanStateDB.FetchChannel,
+	}
+
+	s.edgeRepopulator = &routing.EdgeRepopulator{
+		LocalPubkey:          *nodeKeyDesc.PubKey,
+		DefaultRoutingPolicy: cc.RoutingPolicy,
+		ChanStateDB:          s.chanStateDB,
+		GraphDB:              s.graphDB,
 	}
 
 	utxnStore, err := contractcourt.NewNurseryStore(


### PR DESCRIPTION
## Change Description
Some channels missed corresponding edges in the graph database. This had a few implications:
- `lncli getchaninfo` would return "edge not found"
- forwarding htlcs over a channel with a missing edge would use the default channel policy
- `lncli updatechanpolicy` would fail to the edge missing

This commit adds a flag to LND startup: `repopulate-missing-edges`. When LND is started with this flag, any missing edges will be prefilled in the database with the default routing policy. This allows the user to later update the channel policy of these channels.

Note that 784dc8d530713d9209ba92f3ec7477ed0bfc27f2 partly addresses the issue for new channels, but old channels were still affected by this issue.

Fixes https://github.com/lightningnetwork/lnd/issues/7261

## Steps to Test
I'm not entirely sure how to test this properly yet. Have a database where the channel edge is missing. `lncli getchaninfo` should fail. Then run LND with the `repopulate-missing-edges` flag. It should fix the issue. 

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
