### PR TITLE
Fixing newline on "Shutdown complete" log message	modified:   lnd.go

### DIFF
--- a/lnd.go
+++ b/lnd.go
@@ -139,7 +139,12 @@ func Main(cfg *Config, lisCfg ListenerCfg, implCfg *ImplementationCfg,
 	interceptor signal.Interceptor) error {
 
 	defer func() {
-		ltndLog.Info("Shutdown complete\n")
+		// Create a blank line after the final log message to ensure
+		// that after the final log message is printed a new line.
+		// This was done because the '\n' character was not working
+		// properly.
+		ltndLog.Info("Shutdown complete")
+		ltndLog.Info(" ")
 		err := cfg.LogWriter.Close()
 		if err != nil {
 			ltndLog.Errorf("Could not close log rotator: %v", err)


### PR DESCRIPTION
Fixes #8713 

## Change Description
Insert a blank line log message after the "Shutdown complete" log message to ensure that a new line is printed.
		
This is actually a workaround as the '\n' character was not working properly in some situations. See the tests I did at #8713. 

You can reproduce the bug starting and stopping the LND using the "systemctl start lnd" and "systemctl stop lnd".

## Steps to Test
The bug fix was tested on Ubuntu using systemctl start/stop lnd, as the bug only manifested this way. 

## Original Flaw

2024-05-20 14:04:17.705 [WRN] LTND: Config 'bitcoin.active' is deprecated, please remove it
2024-05-20 14:04:17.705 [INF] LTND: Version: 0.18.0-beta.rc2 commit=v0.18.0-beta.rc1-48-g2a8ca878f, build=development, logging=default, debuglevel=info
.
.
.
2024-05-20 14:05:01.948 [INF] LTND: **Shutdown complete2024-05-20** 14:05:19.906 [WRN] LTND: Config 'bitcoin.active' is deprecated, please remove it
2024-05-20 14:05:19.907 [INF] LTND: Version: 0.18.0-beta.rc2 commit=v0.18.0-beta.rc1-48-g2a8ca878f, build=development, logging=default, debuglevel=info

## Test After the PR

2024-05-20 15:59:47.298 [WRN] LTND: Config 'bitcoin.active' is deprecated, please remove it
2024-05-20 15:59:47.298 [INF] LTND: Version: 0.18.0-beta.rc2 commit=v0.18.0-beta.rc1-48-g2a8ca878f-dirty, build=development, logging=default, debuglevel=info
.
.
.
**2024-05-20 16:00:29.366 [INF] LTND: Shutdown complete
2024-05-20 16:00:29.366 [INF] LTND:**
2024-05-20 16:00:47.594 [WRN] LTND: Config 'bitcoin.active' is deprecated, please remove it
2024-05-20 16:00:47.594 [INF] LTND: Version: 0.18.0-beta.rc2 commit=v0.18.0-beta.rc1-48-g2a8ca878f-dirty, build=development, logging=default, debuglevel=info

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
