### PR TITLE
multi: make reassignment of alias channel edge atomic

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -1804,7 +1804,7 @@ func (c *OpenChannel) ChanSyncMsg() (*lnwire.ChannelReestablish, error) {
 		currentCommitSecret[0] ^= 1
 
 		// If this is a tweakless channel, then we'll purposefully send
-		// a next local height taht's invalid to trigger a force close
+		// a next local height that's invalid to trigger a force close
 		// on their end. We do this as tweakless channels don't require
 		// that the commitment point is valid, only that it's present.
 		if c.ChanType.IsTweakless() {

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -63,6 +63,11 @@
 * [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/9322) that caused
     estimateroutefee to ignore the default payment timeout.
 
+* [Make reassignment of alias channel edges atomic](
+  https://github.com/lightningnetwork/lnd/pull/8777). This fixes an edge case
+  where we might rate limit a peer because he already sent us a channel update
+  with the confirmed channel ID but the graph was still not updated.
+
 # New Features
 
 * [Support](https://github.com/lightningnetwork/lnd/pull/8390) for 

--- a/graph/builder.go
+++ b/graph/builder.go
@@ -1724,7 +1724,7 @@ func (b *Builder) IsStaleNode(node route.Vertex,
 	// then we know that this is actually a stale announcement.
 	err := b.assertNodeAnnFreshness(node, timestamp)
 	if err != nil {
-		log.Debugf("Checking stale node %x got %v", node, err)
+		log.Debugf("Checking stale node %v got %v", node, err)
 		return true
 	}
 

--- a/lnwire/channel_ready.go
+++ b/lnwire/channel_ready.go
@@ -2,6 +2,7 @@ package lnwire
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -169,4 +170,19 @@ func (c *ChannelReady) Encode(w *bytes.Buffer, _ uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *ChannelReady) MsgType() MessageType {
 	return MsgChannelReady
+}
+
+// String returns a human-readable description of the ChannelReady msg.
+func (c *ChannelReady) String() string {
+	// Handle the case where the AliasScid is nil.
+	aliasStr := "nil"
+	if c.AliasScid != nil {
+		aliasStr = fmt.Sprintf("%v(uint=%d)",
+			c.AliasScid, c.AliasScid.ToUint64())
+	}
+
+	return fmt.Sprintf("chan_id=%v, next_point=%x, aliasSCID=%s",
+		c.ChanID, c.NextPerCommitmentPoint.SerializeCompressed(),
+		aliasStr,
+	)
 }

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -2268,8 +2268,7 @@ func messageSummary(msg lnwire.Message) string {
 		return fmt.Sprintf("chan_id=%v", msg.ChanID)
 
 	case *lnwire.ChannelReady:
-		return fmt.Sprintf("chan_id=%v, next_point=%x",
-			msg.ChanID, msg.NextPerCommitmentPoint.SerializeCompressed())
+		return msg.String()
 
 	case *lnwire.Shutdown:
 		return fmt.Sprintf("chan_id=%v, script=%x", msg.ChannelID,


### PR DESCRIPTION
When the option SCID is used we need to make sure we update the
channel data in an atomic way so that we don't miss any updates
by our peer because we rate limit ChanUpdate msg which can cause some side effects revealed in  https://github.com/lightningnetwork/lnd/pull/8582

Prerequisite for: https://github.com/lightningnetwork/lnd/pull/8582

EDIT:

So the main rational behind this change is, that we need to make sure that in case a channel is an alias channel (zero-conf or non-zeroconf) that we "ReAdd" the edge info atomically. This guarantees that we delete all data which might still have the alias channel as a channel id and moreover we need to do it atomically so that we do not receive updates in the meantime and therefore rate-limit the gossip-messages.
