### PR TITLE
Allow 0 failure amt on importmc

### DIFF
--- a/cmd/lncli/cmd_import_mission_control.go
+++ b/cmd/lncli/cmd_import_mission_control.go
@@ -66,8 +66,9 @@ func importMissionControl(ctx *cli.Context) error {
 		return fmt.Errorf("please provide amount in msat: %w", err)
 	}
 
-	if amt <= 0 {
-		return errors.New("amount must be >0")
+	// Allow 0 value as failure amount.
+	if !ctx.IsSet("failure") && amt <= 0 {
+		return errors.New("success amount must be >0")
 	}
 
 	client := routerrpc.NewRouterClient(conn)

--- a/docs/release-notes/release-notes-0.18.1.md
+++ b/docs/release-notes/release-notes-0.18.1.md
@@ -27,7 +27,15 @@
 # Improvements
 ## Functional Updates
 ## RPC Updates
+
+* [`xImportMissionControl`](https://github.com/lightningnetwork/lnd/pull/8779) 
+  now accepts `0` failure amounts.
+
 ## lncli Updates
+
+* [`importmc`](https://github.com/lightningnetwork/lnd/pull/8779) now accepts
+  `0` failure amounts.
+
 ## Code Health
 ## Breaking Changes
 ## Performance Improvements
@@ -40,3 +48,5 @@
 ## Tooling and Documentation
 
 # Contributors (Alphabetical Order)
+
+* Bufo


### PR DESCRIPTION
## Change Description
Aims to fix #8778 

Do not throw an error when importing a `HistoryPair` with a zero failure amount. A zero failure amount can happen, since the amount won't be saved on a node failure, like [here](https://github.com/lightningnetwork/lnd/blob/22f4724260f74619799ca8a7774e10f5c581000e/routing/missioncontrol_state.go#L148-L149)

## Steps to Test
You can import a history pair with a 0 failure amount

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
