### PR TITLE
multi: allow min-depth of zero for non-zero conf channels

### DIFF
--- a/docs/release-notes/release-notes-0.18.2.md
+++ b/docs/release-notes/release-notes-0.18.2.md
@@ -84,6 +84,11 @@
   [support the TLV onion 
   format](https://github.com/lightningnetwork/lnd/pull/8791).
 
+* Allow channel fundee to send a [minimum confirmation depth of
+  0](https://github.com/lightningnetwork/lnd/pull/8796) for a non-zero-conf
+  channel. We will still wait for the channel to have at least one confirmation
+  and so the main change here is that we don't error out for such a case.
+
 ## Testing
 ## Database
 ## Code Health


### PR DESCRIPTION
~If our peer indicates to us that they are OK with a zero conf channel (ie, they trust us) by setting min-depth to 0 in accept_channel, then as long as they support SCID aliases, we should just upgrade the channel to ZeroConf and continue the funding flow.~

EDIT: updated to just allow the peer to set min-depth to 0. We dont upgrade the channel type.

Fixes #8783 

NOTE: we already allow ourselves to do this when our peer sends us an OpenChannel without a zero-conf channel type: https://github.com/lightningnetwork/lnd/blob/fed760913ff98a89c73414acde6cf29f8728321a/funding/manager.go#L1570-L1583

So all this PR does is allow our peer to do this too :) 
