### PR TITLE
contractcourt: consider delivery addresses when evaluating toSelfAmount

### DIFF
--- a/docs/release-notes/release-notes-0.18.1.md
+++ b/docs/release-notes/release-notes-0.18.1.md
@@ -19,6 +19,10 @@
 
 # Bug Fixes
 
+* `closedchannels` now [successfully reports](https://github.com/lightningnetwork/lnd/pull/8800)
+  settled balances even if the delivery address is set to an address that
+  LND does not control.
+
 # New Features
 ## Functional Enhancements
 ## RPC Additions

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/clock v1.1.1
-	github.com/lightningnetwork/lnd/fn v1.0.5
+	github.com/lightningnetwork/lnd/fn v1.0.9
 	github.com/lightningnetwork/lnd/healthcheck v1.2.4
 	github.com/lightningnetwork/lnd/kvdb v1.4.8
 	github.com/lightningnetwork/lnd/queue v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -448,8 +448,8 @@ github.com/lightningnetwork/lnd/cert v1.2.2 h1:71YK6hogeJtxSxw2teq3eGeuy4rHGKcFf
 github.com/lightningnetwork/lnd/cert v1.2.2/go.mod h1:jQmFn/Ez4zhDgq2hnYSw8r35bqGVxViXhX6Cd7HXM6U=
 github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsDIBjgjWdZgA0=
 github.com/lightningnetwork/lnd/clock v1.1.1/go.mod h1:mGnAhPyjYZQJmebS7aevElXKTFDuO+uNFFfMXK1W8xQ=
-github.com/lightningnetwork/lnd/fn v1.0.5 h1:ffDgMSn83avw6rNzxhbt6w5/2oIrwQKTPGfyaLupZtE=
-github.com/lightningnetwork/lnd/fn v1.0.5/go.mod h1:P027+0CyELd92H9gnReUkGGAqbFA1HwjHWdfaDFD51U=
+github.com/lightningnetwork/lnd/fn v1.0.9 h1:VPljrzHGh0Wfs2NZe/ugUfH0hl6/L2eXW0LLXMUEy3s=
+github.com/lightningnetwork/lnd/fn v1.0.9/go.mod h1:P027+0CyELd92H9gnReUkGGAqbFA1HwjHWdfaDFD51U=
 github.com/lightningnetwork/lnd/healthcheck v1.2.4 h1:lLPLac+p/TllByxGSlkCwkJlkddqMP5UCoawCj3mgFQ=
 github.com/lightningnetwork/lnd/healthcheck v1.2.4/go.mod h1:G7Tst2tVvWo7cx6mSBEToQC5L1XOGxzZTPB29g9Rv2I=
 github.com/lightningnetwork/lnd/kvdb v1.4.8 h1:xH0a5Vi1yrcZ5BEeF2ba3vlKBRxrL9uYXlWTjOjbNTY=

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -626,4 +626,8 @@ var allTestCases = []*lntest.TestCase{
 		Name:     "sweep commit output and anchor",
 		TestFunc: testSweepCommitOutputAndAnchor,
 	},
+	{
+		Name:     "coop close with external delivery",
+		TestFunc: testCoopCloseWithExternalDelivery,
+	},
 }

--- a/itest/lnd_coop_close_external_delivery_test.go
+++ b/itest/lnd_coop_close_external_delivery_test.go
@@ -1,0 +1,92 @@
+package itest
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lntest"
+	"github.com/stretchr/testify/require"
+)
+
+func testCoopCloseWithExternalDelivery(ht *lntest.HarnessTest) {
+	ht.Run("set delivery address at open", func(t *testing.T) {
+		tt := ht.Subtest(t)
+		testCoopCloseWithExternalDeliveryImpl(tt, true)
+	})
+	ht.Run("set delivery address at close", func(t *testing.T) {
+		tt := ht.Subtest(t)
+		testCoopCloseWithExternalDeliveryImpl(tt, false)
+	})
+}
+
+// testCoopCloseWithExternalDeliveryImpl ensures that we have a valid settled
+// balance irrespective of whether the delivery address is in LND's wallet or
+// not. Some users set this value to be an address in a different wallet and
+// this should not affect our ability to accurately report the settled balance.
+func testCoopCloseWithExternalDeliveryImpl(ht *lntest.HarnessTest,
+	upfrontShutdown bool) {
+
+	alice, bob := ht.Alice, ht.Bob
+	ht.ConnectNodes(alice, bob)
+
+	// Here we generate a final delivery address in bob's wallet but set by
+	// alice. We do this to ensure that the address is not in alice's LND
+	// wallet. We already correctly track settled balances when the address
+	// is in the LND wallet.
+	addr := bob.RPC.NewAddress(&lnrpc.NewAddressRequest{
+		Type: lnrpc.AddressType_UNUSED_WITNESS_PUBKEY_HASH,
+	})
+
+	// Prepare for channel open.
+	openParams := lntest.OpenChannelParams{
+		Amt: btcutil.Amount(1000000),
+	}
+
+	// If we are testing the case where we set it on open then we'll set the
+	// upfront shutdown script in the channel open parameters.
+	if upfrontShutdown {
+		openParams.CloseAddress = addr.Address
+	}
+
+	// Open the channel!
+	chanPoint := ht.OpenChannel(alice, bob, openParams)
+
+	// Prepare for channel close.
+	closeParams := lnrpc.CloseChannelRequest{
+		ChannelPoint: chanPoint,
+		TargetConf:   6,
+	}
+
+	// If we are testing the case where we set the delivery address on
+	// channel close then we will set it in the channel close parameters.
+	if !upfrontShutdown {
+		closeParams.DeliveryAddress = addr.Address
+	}
+
+	// Close the channel!
+	closeClient := alice.RPC.CloseChannel(&closeParams)
+
+	// Assert that we got a channel update when we get a closing txid.
+	_, err := closeClient.Recv()
+	require.NoError(ht, err)
+
+	// Mine the closing transaction.
+	ht.MineClosingTx(chanPoint)
+
+	// Assert that we got a channel update when the closing tx was mined.
+	_, err = closeClient.Recv()
+	require.NoError(ht, err)
+
+	// Here we query our closed channels to conduct the final test
+	// assertion. We want to ensure that even though alice's delivery
+	// address is set to an address in bob's wallet, we should still show
+	// the balance as settled.
+	closed := alice.RPC.ClosedChannels(&lnrpc.ClosedChannelsRequest{
+		Cooperative: true,
+	})
+
+	// The settled balance should never be zero at this point.
+	require.NotZero(ht, len(closed.Channels))
+	require.NotZero(ht, closed.Channels[0].SettledBalance)
+}

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -1007,6 +1007,10 @@ type OpenChannelParams struct {
 	// FundMax flag is specified the entirety of selected funds is
 	// allocated towards channel funding.
 	Outpoints []*lnrpc.OutPoint
+
+	// CloseAddress sets the upfront_shutdown_script parameter during
+	// channel open. It is expected to be encoded as a bitcoin address.
+	CloseAddress string
 }
 
 // prepareOpenChannel waits for both nodes to be synced to chain and returns an
@@ -1059,6 +1063,7 @@ func (h *HarnessTest) prepareOpenChannel(srcNode, destNode *node.HarnessNode,
 		FundMax:            p.FundMax,
 		Memo:               p.Memo,
 		Outpoints:          p.Outpoints,
+		CloseAddress:       p.CloseAddress,
 	}
 }
 


### PR DESCRIPTION
## Change Description
This commit fixes https://github.com/lightningnetwork/lnd/issues/8535 by changing how we assess toSelfAmount inside
the chainWatcher.

In certain cases users may wish to close out channel funds to external
delivery addresses set either during open or close.

Prior to this change we only consider addresses that our wallet is
aware of and permitted the possibility of multiple to_self outputs,
which is impossible according to the protocol.

This change now identifies to_self outputs based off of matching
delivery scripts, and if no delivery script is set, fall back to
the first output that our wallet can recognize.

NOTE FOR REVIEWERS: The itest commit is ordered first to confirm that the test fails prior to the change. After the fix commit, the test passes. If you want to confirm that the test is correctly designed you can run the test prior to the fix commit.

## Steps to Test
`make itest icase=coop_close_with_external_delivery`

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
