### PR TITLE
fn: add predicate combinators for && and ||

### DIFF
--- a/fn/predicate.go
+++ b/fn/predicate.go
@@ -1,0 +1,20 @@
+package fn
+
+// Pred[A] is a type alias for a predicate operating over type A.
+type Pred[A any] func(A) bool
+
+// PredAnd is a lifted version of the && operation that operates over functions
+// producing a boolean value from some type A.
+func PredAnd[A any](p0 Pred[A], p1 Pred[A]) Pred[A] {
+	return func(a A) bool {
+		return p0(a) && p1(a)
+	}
+}
+
+// PredOr is a lifted version of the || operation that operates over functions
+// producing a boolean value from some type A.
+func PredOr[A any](p0 Pred[A], p1 Pred[A]) Pred[A] {
+	return func(a A) bool {
+		return p0(a) || p1(a)
+	}
+}


### PR DESCRIPTION
## Change Description
This is a commit needed for #8800. I'm peeling it off into a separate PR to allow CI to pass there since we need to push tags for CI to recognize the new functions in the `fn` package.

## Steps to Test
n/a

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
