### PR TITLE
trivial: fix linter errors and return verbose errors

### DIFF
--- a/contractcourt/breach_arbitrator_test.go
+++ b/contractcourt/breach_arbitrator_test.go
@@ -958,7 +958,7 @@ func initBreachedState(t *testing.T) (*BreachArbitrator,
 	// Create a pair of channels using a notifier that allows us to signal
 	// a spend of the funding transaction. Alice's channel will be the on
 	// observing a breach.
-	alice, bob, err := createInitChannels(t, 1)
+	alice, bob, err := createInitChannels(t)
 	require.NoError(t, err, "unable to create test channels")
 
 	// Instantiate a breach arbiter to handle the breach of alice's channel.
@@ -2150,7 +2150,7 @@ func createTestArbiter(t *testing.T, contractBreaches chan *ContractBreachEvent,
 // createInitChannels creates two initialized test channels funded with 10 BTC,
 // with 5 BTC allocated to each side. Within the channel, Alice is the
 // initiator.
-func createInitChannels(t *testing.T, revocationWindow int) (
+func createInitChannels(t *testing.T) (
 	*lnwallet.LightningChannel, *lnwallet.LightningChannel, error) {
 
 	aliceKeyPriv, aliceKeyPub := btcec.PrivKeyFromBytes(
@@ -2395,7 +2395,7 @@ func createInitChannels(t *testing.T, revocationWindow int) (
 
 	// Now that the channel are open, simulate the start of a session by
 	// having Alice and Bob extend their revocation windows to each other.
-	err = initRevocationWindows(channelAlice, channelBob, revocationWindow)
+	err = initRevocationWindows(channelAlice, channelBob)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2408,7 +2408,7 @@ func createInitChannels(t *testing.T, revocationWindow int) (
 // commitment state machines.
 //
 // TODO(conner) remove code duplication
-func initRevocationWindows(chanA, chanB *lnwallet.LightningChannel, windowSize int) error {
+func initRevocationWindows(chanA, chanB *lnwallet.LightningChannel) error {
 	aliceNextRevoke, err := chanA.NextRevocationKey()
 	if err != nil {
 		return err

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -1188,7 +1188,7 @@ func (f *Manager) stateStep(channel *channeldb.OpenChannel,
 			// If this is a zero-conf channel, then we will wait
 			// for it to be confirmed before announcing it to the
 			// greater network.
-			err := f.waitForZeroConfChannel(channel, pendingChanID)
+			err := f.waitForZeroConfChannel(channel)
 			if err != nil {
 				return fmt.Errorf("failed waiting for zero "+
 					"channel: %v", err)
@@ -3605,9 +3605,7 @@ func (f *Manager) annAfterSixConfs(completeChan *channeldb.OpenChannel,
 // waitForZeroConfChannel is called when the state is addedToRouterGraph with
 // a zero-conf channel. This will wait for the real confirmation, add the
 // confirmed SCID to the router graph, and then announce after six confs.
-func (f *Manager) waitForZeroConfChannel(c *channeldb.OpenChannel,
-	pendingID [32]byte) error {
-
+func (f *Manager) waitForZeroConfChannel(c *channeldb.OpenChannel) error {
 	// First we'll check whether the channel is confirmed on-chain. If it
 	// is already confirmed, the chainntnfs subsystem will return with the
 	// confirmed tx. Otherwise, we'll wait here until confirmation occurs.

--- a/netann/chan_status_manager.go
+++ b/netann/chan_status_manager.go
@@ -195,7 +195,7 @@ func (m *ChanStatusManager) start() error {
 		// have been pruned from the channel graph but not yet from our
 		// set of channels. We'll skip it as we can't determine its
 		// initial state.
-		case err == channeldb.ErrEdgeNotFound:
+		case errors.Is(err, channeldb.ErrEdgeNotFound):
 			log.Warnf("Unable to find channel policies for %v, "+
 				"skipping. This is typical if the channel is "+
 				"in the process of closing.", c.FundingOutpoint)
@@ -580,7 +580,7 @@ func (m *ChanStatusManager) disableInactiveChannels() {
 			// that the channel has been closed. Thus we remove the
 			// outpoint from the set of tracked outpoints to prevent
 			// further attempts.
-			if err == channeldb.ErrEdgeNotFound {
+			if errors.Is(err, channeldb.ErrEdgeNotFound) {
 				log.Debugf("Removing channel(%v) from "+
 					"consideration for passive disabling",
 					outpoint)

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -974,7 +974,7 @@ func (p *Brontide) loadActiveChannels(chans []*channeldb.OpenChannel) (
 		info, p1, p2, err := graph.FetchChannelEdgesByOutpoint(
 			&chanPoint,
 		)
-		if err != nil && err != channeldb.ErrEdgeNotFound {
+		if err != nil && !errors.Is(err, channeldb.ErrEdgeNotFound) {
 			return nil, err
 		}
 

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -1089,7 +1089,7 @@ func (p *Brontide) loadActiveChannels(chans []*channeldb.OpenChannel) (
 				return
 			}
 
-			shutdownMsg = fn.Some[lnwire.Shutdown](*shutdown)
+			shutdownMsg = fn.Some(*shutdown)
 		})
 		if shutdownInfoErr != nil {
 			return nil, shutdownInfoErr
@@ -2938,7 +2938,7 @@ func (p *Brontide) restartCoopClose(lnChan *lnwallet.LightningChannel) (
 		})
 
 	// An error other than ErrNoShutdownInfo was returned
-	case err != nil && !errors.Is(err, channeldb.ErrNoShutdownInfo):
+	case !errors.Is(err, channeldb.ErrNoShutdownInfo):
 		return nil, err
 
 	case errors.Is(err, channeldb.ErrNoShutdownInfo):

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -5677,7 +5677,7 @@ sendLoop:
 func (r *rpcServer) SendPaymentSync(ctx context.Context,
 	nextPayment *lnrpc.SendRequest) (*lnrpc.SendResponse, error) {
 
-	return r.sendPaymentSync(ctx, &rpcPaymentRequest{
+	return r.sendPaymentSync(&rpcPaymentRequest{
 		SendRequest: nextPayment,
 	})
 }
@@ -5698,12 +5698,12 @@ func (r *rpcServer) SendToRouteSync(ctx context.Context,
 		return nil, err
 	}
 
-	return r.sendPaymentSync(ctx, paymentRequest)
+	return r.sendPaymentSync(paymentRequest)
 }
 
 // sendPaymentSync is the synchronous variant of sendPayment. It will block and
 // wait until the payment has been fully completed.
-func (r *rpcServer) sendPaymentSync(ctx context.Context,
+func (r *rpcServer) sendPaymentSync(
 	nextPayment *rpcPaymentRequest) (*lnrpc.SendResponse, error) {
 
 	// We don't allow payments to be sent while the daemon itself is still

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2891,7 +2891,7 @@ func abandonChanFromGraph(chanGraph *channeldb.ChannelGraph,
 	// the graph, so we'll return a nil error.
 	chanID, err := chanGraph.ChannelID(chanPoint)
 	switch {
-	case err == channeldb.ErrEdgeNotFound:
+	case errors.Is(err, channeldb.ErrEdgeNotFound):
 		return nil
 	case err != nil:
 		return err

--- a/server.go
+++ b/server.go
@@ -1266,7 +1266,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		info, e1, e2, err := s.graphDB.FetchChannelEdgesByID(
 			scid.ToUint64(),
 		)
-		if err == channeldb.ErrEdgeNotFound {
+		if errors.Is(err, channeldb.ErrEdgeNotFound) {
 			// This is unlikely but there is a slim chance of this
 			// being hit if lnd was killed via SIGKILL and the
 			// funding manager was stepping through the delete


### PR DESCRIPTION
Fixed complaints from IDE and linters, and improved returned errors when creating this [analysis](https://github.com/lightningnetwork/lnd/issues/7261#issuecomment-2153008660).