### PR TITLE
cfg: fail startup on flags.Error parsing error

### DIFF
--- a/config.go
+++ b/config.go
@@ -38,6 +38,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc/peersrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/signrpc"
+	"github.com/lightningnetwork/lnd/lnutils"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing"
@@ -771,7 +772,9 @@ func LoadConfig(interceptor signal.Interceptor) (*Config, error) {
 		// If it's a parsing related error, then we'll return
 		// immediately, otherwise we can proceed as possibly the config
 		// file doesn't exist which is OK.
-		if _, ok := err.(*flags.IniError); ok {
+		if lnutils.ErrorAs[*flags.IniError](err) ||
+			lnutils.ErrorAs[*flags.Error](err) {
+
 			return nil, err
 		}
 

--- a/docs/release-notes/release-notes-0.18.1.md
+++ b/docs/release-notes/release-notes-0.18.1.md
@@ -22,9 +22,12 @@
 * `closedchannels` now [successfully reports](https://github.com/lightningnetwork/lnd/pull/8800)
   settled balances even if the delivery address is set to an address that
   LND does not control.
- 
+
 * [SendPaymentV2](https://github.com/lightningnetwork/lnd/pull/8734) now cancels
   the background payment loop if the user cancels the stream context.
+
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/8822) that caused
+  LND to read the config only partially and continued with the startup.
 
 # New Features
 ## Functional Enhancements


### PR DESCRIPTION
## Change Description
Fixes the issue of @theborakompanioni when updating to LND v0.18.0-beta: https://github.com/lightningnetwork/lnd/pull/7867#issuecomment-2158279005

Having removed option groups in the config caused the config file parser to throw an error, but that error is `flags.Error` which only printed a warning but did not prevent starting the node.

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
