### PR TITLE
lncli: fix parsing of --amp when sending a payment

### DIFF
--- a/cmd/lncli/cmd_payments.go
+++ b/cmd/lncli/cmd_payments.go
@@ -328,14 +328,15 @@ func sendPayment(ctx *cli.Context) error {
 			PaymentRequest:    stripPrefix(ctx.String("pay_req")),
 			Amt:               ctx.Int64("amt"),
 			DestCustomRecords: make(map[uint64][]byte),
+			Amp:               ctx.Bool(ampFlag.Name),
 		}
 
 		// We'll attempt to parse a payment address as well, given that
 		// if the user is using an AMP invoice, then they may be trying
 		// to specify that value manually.
 		//
-		// Don't parse unnamed arguments to prevent confusion with the main
-		// unnamed argument format for non-AMP payments.
+		// Don't parse unnamed arguments to prevent confusion with the
+		// main unnamed argument format for non-AMP payments.
 		payAddr, err := parsePayAddr(ctx, nil)
 		if err != nil {
 			return err

--- a/docs/release-notes/release-notes-0.18.1.md
+++ b/docs/release-notes/release-notes-0.18.1.md
@@ -46,6 +46,9 @@
 * [`getchaninfo`](https://github.com/lightningnetwork/lnd/pull/8813) now accepts
   a channel outpoint besides a channel id.
 
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/8823) how we parse the
+  `--amp` flag when sending a payment specifying the payment request.
+
 ## Code Health
 ## Breaking Changes
 ## Performance Improvements
@@ -59,4 +62,5 @@
 
 # Contributors (Alphabetical Order)
 
+* Andras Banki-Horvath
 * Bufo


### PR DESCRIPTION
## Change Description

Previously when sending an AMP payment specifying the payment request and the `--amp` flag together the `Amp` field of the `SendPaymentRequest` was not filled properly. This PR attempts to fix this.
