### PR TITLE
cli: update `pendingsweeps` response

### DIFF
--- a/cmd/lncli/walletrpc_types.go
+++ b/cmd/lncli/walletrpc_types.go
@@ -5,16 +5,19 @@ import "github.com/lightningnetwork/lnd/lnrpc/walletrpc"
 // PendingSweep is a CLI-friendly type of the walletrpc.PendingSweep proto. We
 // use this to show more useful string versions of byte slices and enums.
 type PendingSweep struct {
-	OutPoint          OutPoint `json:"outpoint"`
-	WitnessType       string   `json:"witness_type"`
-	AmountSat         uint32   `json:"amount_sat"`
-	SatPerVByte       uint32   `json:"sat_per_vbyte"`
-	BroadcastAttempts uint32   `json:"broadcast_attempts"`
-	// TODO(yy): deprecate.
-	NextBroadcastHeight  uint32 `json:"next_broadcast_height"`
-	RequestedSatPerVByte uint32 `json:"requested_sat_per_vbyte"`
-	RequestedConfTarget  uint32 `json:"requested_conf_target"`
-	Force                bool   `json:"force"`
+	OutPoint             OutPoint `json:"outpoint"`
+	WitnessType          string   `json:"witness_type"`
+	AmountSat            uint32   `json:"amount_sat"`
+	SatPerVByte          uint32   `json:"sat_per_vbyte"`
+	BroadcastAttempts    uint32   `json:"broadcast_attempts"`
+	RequestedSatPerVByte uint32   `json:"requested_sat_per_vbyte"`
+	Immediate            bool     `json:"immediate"`
+	Budget               uint64   `json:"budget"`
+	DeadlineHeight       uint32   `json:"deadline_height"`
+
+	NextBroadcastHeight uint32 `json:"next_broadcast_height"`
+	RequestedConfTarget uint32 `json:"requested_conf_target"`
+	Force               bool   `json:"force"`
 }
 
 // NewPendingSweepFromProto converts the walletrpc.PendingSweep proto type into
@@ -26,9 +29,14 @@ func NewPendingSweepFromProto(pendingSweep *walletrpc.PendingSweep) *PendingSwee
 		AmountSat:            pendingSweep.AmountSat,
 		SatPerVByte:          uint32(pendingSweep.SatPerVbyte),
 		BroadcastAttempts:    pendingSweep.BroadcastAttempts,
-		NextBroadcastHeight:  pendingSweep.NextBroadcastHeight,
 		RequestedSatPerVByte: uint32(pendingSweep.RequestedSatPerVbyte),
-		RequestedConfTarget:  pendingSweep.RequestedConfTarget,
-		Force:                pendingSweep.Force,
+		Immediate:            pendingSweep.Immediate,
+		Budget:               pendingSweep.Budget,
+		DeadlineHeight:       pendingSweep.DeadlineHeight,
+
+		// Deprecated fields.
+		NextBroadcastHeight: pendingSweep.NextBroadcastHeight,
+		RequestedConfTarget: pendingSweep.RequestedConfTarget,
+		Force:               pendingSweep.Force,
 	}
 }


### PR DESCRIPTION
Turns out the `pendingsweeps` cli doesn't use the proto directly so we need to update the returned response to reflect the new fields.