### PR TITLE
itest+lntest: let abandoned channel be either not found or in zombie

### DIFF
--- a/itest/lnd_misc_test.go
+++ b/itest/lnd_misc_test.go
@@ -729,7 +729,7 @@ func testAbandonChannel(ht *lntest.HarnessTest) {
 	require.Len(ht, aliceClosedList.Channels, 1, "alice closed channels")
 
 	// Ensure that the channel can no longer be found in the channel graph.
-	ht.AssertZombieChannel(alice, chanID)
+	ht.AssertNotInGraph(alice, chanID)
 
 	// Make sure the channel is no longer in the channel backup list.
 	err = wait.NoError(func() error {


### PR DESCRIPTION
Fixes itest flake found in [this build](https://github.com/lightningnetwork/lnd/actions/runs/9499362448/job/26180102404) in the `abandonchannel` test. 

When abandoning a channel, we remove it from the graph and then add it to the zombie channel index. However, if we then process a ChannelUpdate for this channel it will result in us calling `processZombieUpdate` which will delete the edge from the zombie index. The abandon channel itest currently asserts that a channel is no longer in the graph by asserting that when querying for the channel we get a "marked as zombie" error but to account for the above series of operations, we now also allow it to just not be found at all ("edge not found").


## More in-depth step by step explanation and some logs:

1. AbandonChannel: 
    1. remove from open channel bucket & add close channel entry 
    2. remove from graph AND add to zombie index

What can happen is that now we actually process an old ChannelUpdate for the channel

Logs from the failing test:
```
2024-06-13 12:19:01.459 [DBG] DISC: Removed edge with chan_id=443:1:0 from zombie index
```

The `Remove edge with chan from zombie index` line is called from `processZombieUpdate` which is called from the gossiper’s `handleChanUpdate` method IF it attempts to fetch a channel that we currently see as a zombie. `processZombieUpdate` will then call `MarkEdgeLive` and all that that does is remove the channel from the zombie index completely. 

This is fine and valid imo. So I think the thing to do here is: update the test so that it accounts for this order of operations. 
