### PR TITLE
Allow multiple etcd host

### DIFF
--- a/docs/release-notes/release-notes-0.18.3.md
+++ b/docs/release-notes/release-notes-0.18.3.md
@@ -87,6 +87,9 @@ commitment when the channel was force closed.
 * Commitment fees are now taken into account when [calculating the fee
   exposure threshold](https://github.com/lightningnetwork/lnd/pull/8824).
 
+* [Allow](https://github.com/lightningnetwork/lnd/pull/8845) multiple etcd hosts
+  to be specified in db.etcd.host.
+
 ## RPC Updates
 
 * [`xImportMissionControl`](https://github.com/lightningnetwork/lnd/pull/8779) 

--- a/kvdb/etcd/config.go
+++ b/kvdb/etcd/config.go
@@ -14,7 +14,7 @@ type Config struct {
 
 	EmbeddedLogFile string `long:"embedded_log_file" description:"Optional log file to use for embedded instance logs. note: use for testing only."`
 
-	Host string `long:"host" description:"Etcd database host."`
+	Host string `long:"host" description:"Etcd database host. Supports multiple hosts separated by a comma."`
 
 	User string `long:"user" description:"Etcd database user."`
 

--- a/kvdb/etcd/db.go
+++ b/kvdb/etcd/db.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -138,7 +139,7 @@ func NewEtcdClient(ctx context.Context, cfg Config) (*clientv3.Client,
 	context.Context, func(), error) {
 
 	clientCfg := clientv3.Config{
-		Endpoints:          []string{cfg.Host},
+		Endpoints:          strings.Split(cfg.Host, ","),
 		DialTimeout:        etcdConnectionTimeout,
 		Username:           cfg.User,
 		Password:           cfg.Pass,

--- a/kvdb/etcd/fixture.go
+++ b/kvdb/etcd/fixture.go
@@ -5,6 +5,7 @@ package etcd
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -49,7 +50,7 @@ func NewEtcdTestFixture(t *testing.T) *EtcdTestFixture {
 	t.Cleanup(etcdCleanup)
 
 	cli, err := clientv3.New(clientv3.Config{
-		Endpoints: []string{config.Host},
+		Endpoints: strings.Split(config.Host, ","),
 		Username:  config.User,
 		Password:  config.Pass,
 	})

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1374,7 +1374,7 @@
 
 [etcd]
 
-; Etcd database host.
+; Etcd database host. Supports multiple hosts separated by a comma.
 ; Default:
 ;   db.etcd.host=
 ; Example:


### PR DESCRIPTION
## Change Description
This patch allow set multiple etcd servers. like an etcd cluster in docker swarm/kubernetes.

## Steps to Test
    ./lnd-debug \
       --db.backend=etcd \
       --db.etcd.host=etcd1:2379,etcd2:2379 \

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
