### PR TITLE
Fixing the current state update when lncli debuglevel and lncli setmccfg are called

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -19,6 +19,10 @@
 
 # Bug Fixes
 
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/8857) to correctly 
+  propagate mission control and debug level config values to the main LND config
+  struct so that the GetDebugInfo response is accurate.
+
 # New Features
 ## Functional Enhancements
 ## RPC Additions
@@ -53,4 +57,5 @@
 
 # Contributors (Alphabetical Order)
 
+* Pins
 * Ziggie

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -7061,6 +7061,9 @@ func (r *rpcServer) DebugLevel(ctx context.Context,
 		return nil, err
 	}
 
+	// Propagate the new config level to the main config struct.
+	r.cfg.DebugLevel = req.LevelSpec
+
 	return &lnrpc.DebugLevelResponse{}, nil
 }
 


### PR DESCRIPTION
Fixes #8793	

modified:   rpcserver.go
modified:   server.go
 modified:   routing/missioncontrol.go

## Change Description
Changed the DebugLevel function to start updating the main cfg DebugLevel variable.

Created the function UpdateRoutingConfig to just update the main cfg  values, this function is a callback function propagated by NewMissionControl function called when creating a new server on server.go. And finally, call the callback function on SetConfig on routing/missioncontrol.go

## Steps to Test
After running LND with the wallet unlocked, send the lncli commands to change the debuglevel and estimator and check if they are updated unsing 'getdebuginfo'.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
