### PR TITLE
refactor: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/aezeed/errors.go
+++ b/aezeed/errors.go
@@ -1,20 +1,23 @@
 package aezeed
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 var (
 	// ErrIncorrectVersion is returned if a seed bares a mismatched
 	// external version to that of the package executing the aezeed scheme.
-	ErrIncorrectVersion = fmt.Errorf("wrong seed version")
+	ErrIncorrectVersion = errors.New("wrong seed version")
 
 	// ErrInvalidPass is returned if the user enters an invalid passphrase
 	// for a particular enciphered mnemonic.
-	ErrInvalidPass = fmt.Errorf("invalid passphrase")
+	ErrInvalidPass = errors.New("invalid passphrase")
 
 	// ErrIncorrectMnemonic is returned if we detect that the checksum of
 	// the specified mnemonic doesn't match. This indicates the user input
 	// the wrong mnemonic.
-	ErrIncorrectMnemonic = fmt.Errorf("mnemonic phrase checksum doesn't " +
+	ErrIncorrectMnemonic = errors.New("mnemonic phrase checksum doesn't " +
 		"match")
 )
 

--- a/aliasmgr/aliasmgr.go
+++ b/aliasmgr/aliasmgr.go
@@ -2,7 +2,7 @@ package aliasmgr
 
 import (
 	"encoding/binary"
-	"fmt"
+	"errors"
 	"sync"
 
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
@@ -63,11 +63,11 @@ var (
 	}
 
 	// errNoBase is returned when a base SCID isn't found.
-	errNoBase = fmt.Errorf("no base found")
+	errNoBase = errors.New("no base found")
 
 	// errNoPeerAlias is returned when the peer's alias for a given
 	// channel is not found.
-	errNoPeerAlias = fmt.Errorf("no peer alias found")
+	errNoPeerAlias = errors.New("no peer alias found")
 )
 
 // Manager is a struct that handles aliases for LND. It has an underlying

--- a/amp/shard_tracker.go
+++ b/amp/shard_tracker.go
@@ -3,6 +3,7 @@ package amp
 import (
 	"crypto/rand"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -139,7 +140,7 @@ func (s *ShardTracker) CancelShard(pid uint64) error {
 
 	c, ok := s.shards[pid]
 	if !ok {
-		return fmt.Errorf("pid not found")
+		return errors.New("pid not found")
 	}
 	delete(s.shards, pid)
 

--- a/pilot.go
+++ b/pilot.go
@@ -66,7 +66,7 @@ func validateAtplCfg(cfg *lncfg.AutoPilot) ([]*autopilot.WeightedHeuristic,
 	}
 
 	if sum != 1.0 {
-		return nil, fmt.Errorf("heuristic weights must sum to 1.0")
+		return nil, errors.New("heuristic weights must sum to 1.0")
 	}
 	return heuristics, nil
 }

--- a/sqldb/no_sqlite.go
+++ b/sqldb/no_sqlite.go
@@ -2,7 +2,7 @@
 
 package sqldb
 
-import "fmt"
+import "errors"
 
 // SqliteStore is a database store implementation that uses a sqlite backend.
 type SqliteStore struct {
@@ -14,5 +14,5 @@ type SqliteStore struct {
 // NewSqliteStore attempts to open a new sqlite database based on the passed
 // config.
 func NewSqliteStore(cfg *SqliteConfig, dbPath string) (*SqliteStore, error) {
-	return nil, fmt.Errorf("SQLite backend not supported in WebAssembly")
+	return nil, errors.New("SQLite backend not supported in WebAssembly")
 }


### PR DESCRIPTION
Standardized error handling across multiple components by replacing `fmt.Errorf` with `errors.New`.