### PR TITLE
Fix an error string match between different `btcd` versions

### DIFF
--- a/docs/release-notes/release-notes-0.18.1.md
+++ b/docs/release-notes/release-notes-0.18.1.md
@@ -19,70 +19,25 @@
 
 # Bug Fixes
 
-* `closedchannels` now [successfully reports](https://github.com/lightningnetwork/lnd/pull/8800)
-  settled balances even if the delivery address is set to an address that
-  LND does not control.
-
-* [SendPaymentV2](https://github.com/lightningnetwork/lnd/pull/8734) now cancels
-  the background payment loop if the user cancels the stream context.
-
-* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/8822) that caused
-  LND to read the config only partially and continued with the startup.
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/8862) in error
+  matching from publishing transactions that can cause the broadcast process to
+  fail if `btcd` with an older version (pre-`v0.24.2`) is used.
 
 # New Features
 ## Functional Enhancements
 ## RPC Additions
-
-* The [SendPaymentRequest](https://github.com/lightningnetwork/lnd/pull/8734) 
-  message receives a new flag `cancelable` which indicates if the payment loop 
-  is cancelable. The cancellation can either occur manually by cancelling the 
-  send payment stream context, or automatically at the end of the timeout period 
-  if the user provided `timeout_seconds`.
-
 ## lncli Additions
-
-* [Added](https://github.com/lightningnetwork/lnd/pull/8491) the `cltv_expiry`
-  argument to `addinvoice` and `addholdinvoice`, allowing users to set the
-  `min_final_cltv_expiry_delta`.
-
-* The [`lncli wallet estimatefeerate`](https://github.com/lightningnetwork/lnd/pull/8730)
-  command returns the fee rate estimate for on-chain transactions in sat/kw and
-  sat/vb to achieve a given confirmation target.
 
 # Improvements
 ## Functional Updates
 ## RPC Updates
-
-* [`xImportMissionControl`](https://github.com/lightningnetwork/lnd/pull/8779) 
-  now accepts `0` failure amounts.
-
-* [`ChanInfoRequest`](https://github.com/lightningnetwork/lnd/pull/8813)
-  adds support for channel points.
-
 ## lncli Updates
-
-* [`importmc`](https://github.com/lightningnetwork/lnd/pull/8779) now accepts
-  `0` failure amounts.
- 
-* [`getchaninfo`](https://github.com/lightningnetwork/lnd/pull/8813) now accepts
-  a channel outpoint besides a channel id.
-
-* [Fixed](https://github.com/lightningnetwork/lnd/pull/8823) how we parse the
-  `--amp` flag when sending a payment specifying the payment request.
-
 ## Code Health
 ## Breaking Changes
 ## Performance Improvements
 
-* Mission Control Store [improved performance during DB
-  flushing](https://github.com/lightningnetwork/lnd/pull/8549) stage.
-
 # Technical and Architectural Updates
 ## BOLT Spec Updates
-
-* Start assuming that all hops used during path-finding and route construction
-  [support the TLV onion 
-  format](https://github.com/lightningnetwork/lnd/pull/8791).
 
 ## Testing
 ## Database
@@ -91,8 +46,4 @@
 
 # Contributors (Alphabetical Order)
 
-* Andras Banki-Horvath
-* Bufo
-* Elle Mouton
-* Matheus Degiovani
-* Slyghtning
+* Yyforyongyu

--- a/docs/release-notes/release-notes-0.18.2.md
+++ b/docs/release-notes/release-notes-0.18.2.md
@@ -1,0 +1,98 @@
+# Release Notes
+- [Bug Fixes](#bug-fixes)
+- [New Features](#new-features)
+    - [Functional Enhancements](#functional-enhancements)
+    - [RPC Additions](#rpc-additions)
+    - [lncli Additions](#lncli-additions)
+- [Improvements](#improvements)
+    - [Functional Updates](#functional-updates)
+    - [RPC Updates](#rpc-updates)
+    - [lncli Updates](#lncli-updates)
+    - [Breaking Changes](#breaking-changes)
+    - [Performance Improvements](#performance-improvements)
+- [Technical and Architectural Updates](#technical-and-architectural-updates)
+    - [BOLT Spec Updates](#bolt-spec-updates)
+    - [Testing](#testing)
+    - [Database](#database)
+    - [Code Health](#code-health)
+    - [Tooling and Documentation](#tooling-and-documentation)
+
+# Bug Fixes
+
+* `closedchannels` now [successfully reports](https://github.com/lightningnetwork/lnd/pull/8800)
+  settled balances even if the delivery address is set to an address that
+  LND does not control.
+
+* [SendPaymentV2](https://github.com/lightningnetwork/lnd/pull/8734) now cancels
+  the background payment loop if the user cancels the stream context.
+
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/8822) that caused
+  LND to read the config only partially and continued with the startup.
+
+# New Features
+## Functional Enhancements
+## RPC Additions
+
+* The [SendPaymentRequest](https://github.com/lightningnetwork/lnd/pull/8734) 
+  message receives a new flag `cancelable` which indicates if the payment loop 
+  is cancelable. The cancellation can either occur manually by cancelling the 
+  send payment stream context, or automatically at the end of the timeout period 
+  if the user provided `timeout_seconds`.
+
+## lncli Additions
+
+* [Added](https://github.com/lightningnetwork/lnd/pull/8491) the `cltv_expiry`
+  argument to `addinvoice` and `addholdinvoice`, allowing users to set the
+  `min_final_cltv_expiry_delta`.
+
+* The [`lncli wallet estimatefeerate`](https://github.com/lightningnetwork/lnd/pull/8730)
+  command returns the fee rate estimate for on-chain transactions in sat/kw and
+  sat/vb to achieve a given confirmation target.
+
+# Improvements
+## Functional Updates
+## RPC Updates
+
+* [`xImportMissionControl`](https://github.com/lightningnetwork/lnd/pull/8779) 
+  now accepts `0` failure amounts.
+
+* [`ChanInfoRequest`](https://github.com/lightningnetwork/lnd/pull/8813)
+  adds support for channel points.
+
+## lncli Updates
+
+* [`importmc`](https://github.com/lightningnetwork/lnd/pull/8779) now accepts
+  `0` failure amounts.
+ 
+* [`getchaninfo`](https://github.com/lightningnetwork/lnd/pull/8813) now accepts
+  a channel outpoint besides a channel id.
+
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/8823) how we parse the
+  `--amp` flag when sending a payment specifying the payment request.
+
+## Code Health
+## Breaking Changes
+## Performance Improvements
+
+* Mission Control Store [improved performance during DB
+  flushing](https://github.com/lightningnetwork/lnd/pull/8549) stage.
+
+# Technical and Architectural Updates
+## BOLT Spec Updates
+
+* Start assuming that all hops used during path-finding and route construction
+  [support the TLV onion 
+  format](https://github.com/lightningnetwork/lnd/pull/8791).
+
+## Testing
+## Database
+## Code Health
+## Tooling and Documentation
+
+# Contributors (Alphabetical Order)
+
+* Andras Banki-Horvath
+* Bufo
+* Elle Mouton
+* Matheus Degiovani
+* Slyghtning

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ require (
 	github.com/NebulousLabs/go-upnp v0.0.0-20180202185039-29b680b06c82
 	github.com/Yawning/aez v0.0.0-20211027044916-e49e68abd344
 	github.com/andybalholm/brotli v1.0.4
-	github.com/btcsuite/btcd v0.24.2-beta.rc1.0.20240403021926-ae5533602c46
+	github.com/btcsuite/btcd v0.24.2-beta.rc1.0.20240625142744-cc26860b4026
 	github.com/btcsuite/btcd/btcec/v2 v2.3.3
 	github.com/btcsuite/btcd/btcutil v1.1.5
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.8
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
-	github.com/btcsuite/btcwallet v0.16.10-0.20240404104514-b2f31f9045fb
+	github.com/btcsuite/btcwallet v0.16.10-0.20240625163855-b42ed59f0528
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.3.4
 	github.com/btcsuite/btcwallet/wallet/txrules v1.2.1
 	github.com/btcsuite/btcwallet/walletdb v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=
-github.com/btcsuite/btcd v0.24.2-beta.rc1.0.20240403021926-ae5533602c46 h1:tjpNTdZNQqE14menwDGAxWfzN0DFHVTXFEyEL8yvA/4=
-github.com/btcsuite/btcd v0.24.2-beta.rc1.0.20240403021926-ae5533602c46/go.mod h1:5C8ChTkl5ejr3WHj8tkQSCmydiMEPB0ZhQhehpq7Dgg=
+github.com/btcsuite/btcd v0.24.2-beta.rc1.0.20240625142744-cc26860b4026 h1:s8/96vQSj05bqLl9RyM/eMX8gLtiayEj520TVE4YGy0=
+github.com/btcsuite/btcd v0.24.2-beta.rc1.0.20240625142744-cc26860b4026/go.mod h1:5C8ChTkl5ejr3WHj8tkQSCmydiMEPB0ZhQhehpq7Dgg=
 github.com/btcsuite/btcd/btcec/v2 v2.1.0/go.mod h1:2VzYrv4Gm4apmbVVsSq5bqf1Ec8v56E48Vt0Y/umPgA=
 github.com/btcsuite/btcd/btcec/v2 v2.1.3/go.mod h1:ctjw4H1kknNJmRN4iP1R7bTQ+v3GJkZBd6mui8ZsAZE=
 github.com/btcsuite/btcd/btcec/v2 v2.3.3 h1:6+iXlDKE8RMtKsvK0gshlXIuPbyWM/h84Ensb7o3sC0=
@@ -92,8 +92,8 @@ github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0/go.mod h1:7SFka0XMvUgj3hfZtyd
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
-github.com/btcsuite/btcwallet v0.16.10-0.20240404104514-b2f31f9045fb h1:qoIOlBPRZWtfpcbQlNFf67Wz8ZlXo+mxQc9Pnbm/iqU=
-github.com/btcsuite/btcwallet v0.16.10-0.20240404104514-b2f31f9045fb/go.mod h1:2C3Q/MhYAKmk7F+Tey6LfKtKRTdQsrCf8AAAzzDPmH4=
+github.com/btcsuite/btcwallet v0.16.10-0.20240625163855-b42ed59f0528 h1:DZRmr47CdPnNglwEVACPnJnGrfb/GBGyoGs5oqvLFg4=
+github.com/btcsuite/btcwallet v0.16.10-0.20240625163855-b42ed59f0528/go.mod h1:SLFUSQbP8ON/wxholYMfVLvGPJyk7boczOW/ob+nww4=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.4 h1:poyHFf7+5+RdxNp5r2T6IBRD7RyraUsYARYbp/7t4D8=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.4/go.mod h1:GETGDQuyq+VFfH1S/+/7slLM/9aNa4l7P4ejX6dJfb0=
 github.com/btcsuite/btcwallet/wallet/txrules v1.2.1 h1:UZo7YRzdHbwhK7Rhv3PO9bXgTxiOH45edK5qdsdiatk=


### PR DESCRIPTION
Here's what happened,
1.  `lnd` asks `btcwallet` to publish a tx -> calls `btcd` RPC
2. an old `btcd` is running, and gives an error back: `already have transaction ...`
3. `btcwallet` tries to map the error, using a method imported from new `btcd/rpcclient`, which matches against `already have transaction in mempool ...`, which is an error string returned from this new `btcd`
4. the match failed

Diving deeper about how to avoid this from a design perspective,
- remove the broadcaster, which is designed for `neutrino` backend, and replace it with a mempool rebroadcaster - today we always broadcast twice for each tx, and rebroadcast it in every new block - this is unnecessary or not enough as the tx may fall out of the mempool during the 10min. I think a better approach is to poll the mempool for this published tx, and rebroadcast it only if it falls out of the mempool.

- move the multi-chain rpc handling from `btcd` to `btcwallet`, in specific, the `btcd/rpcclient` package is more suitable to be placed in `btcwallet`, which imo is the root cause of this bug, `btcwallet` imports a newer version of `btcd` to use the `btcd/rpcclient` package, while the running `btcd` is in an older version. The RPC related to handling different chain backends should be moved into the `btcwallet` for clarity.

Haven't decided whether this should be a backport suggested by @Crypt-iQ  or create a 0.18.1 release?