### PR TITLE
lnwallet: fix off-by-one error in dust detection for co-op closes

### DIFF
--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -8612,13 +8612,13 @@ func CreateCooperativeCloseTx(fundingTxIn wire.TxIn,
 
 	// Create both cooperative closure outputs, properly respecting the
 	// dust limits of both parties.
-	if ourBalance >= localDust {
+	if ourBalance > localDust {
 		closeTx.AddTxOut(&wire.TxOut{
 			PkScript: ourDeliveryScript,
 			Value:    int64(ourBalance),
 		})
 	}
-	if theirBalance >= remoteDust {
+	if theirBalance > remoteDust {
 		closeTx.AddTxOut(&wire.TxOut{
 			PkScript: theirDeliveryScript,
 			Value:    int64(theirBalance),


### PR DESCRIPTION
## Change Description
This PR changes `CreateCooperativeCloseTx` to only include a balance output if the output is strictly *greater than* the dust limit. This matches the behavior of `LocalBalanceDust` and `RemoteBalanceDust`, which mark a balance output as dust if it's *less than or equal to* the dust limit.

Without this change, `CreateCooperativeCloseTx` includes the balance output when it's *greater than or equal to* the dust limit. When the balance of the channel responder is exactly the dust limit in a tweakless channel, the transaction includes the output but not the fee for the output, determined by the channel closer in `initFeeBaseline` [here](https://github.com/lightningnetwork/lnd/blob/5c33465a13deb4f614a9512ad7d6a4e035130a35/lnwallet/chancloser/chancloser.go#L295).

When deciding whether to change `CreateCooperativeCloseTx` or `(Local|Remote)BalanceDust`, I checked [how LDK implements this](https://github.com/lightningdevkit/rust-lightning/blob/d43218ab8bc36d4cb773f21340ceccaebf6c8fc1/lightning/src/ln/channel.rs#L3790-L3796) because this caused a force-close when attempting a co-op close from LND of a channel with LDK. LDK omits the output when it's *less than or equal to* the dust limit, similar to `(Local|Remote)BalanceDust`, and does not accept a co-op close transaction with the output included.

## Steps to Test
There are a couple of ways I can add a test. The easier way is to directly test for inclusion/exclusion of an output that's exactly the dust amount when calling this function.

A more interesting way would be to create a channel, set the balance on one side to dust, use a `ChanCloser` to create a close TX, and ensure that the fee rate, total fee, and weight of the transaction match, though it's more involved in terms of setup to provide access to both `lnwallet` internals *and* `ChanCloser` without import cycles.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
