### PR TITLE
multi: don't ignore node announcement of channel peer

### DIFF
--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -24,6 +24,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/ticker"
 )
 
@@ -2591,6 +2592,21 @@ func (s *Switch) HasActiveLink(chanID lnwire.ChannelID) bool {
 
 	if link, ok := s.linkIndex[chanID]; ok {
 		return link.EligibleToForward()
+	}
+
+	return false
+}
+
+// HaveLinkWith returns true if there is at least one link with the given peer.
+func (s *Switch) HaveLinkWith(peer route.Vertex) bool {
+	s.indexMtx.RLock()
+	defer s.indexMtx.RUnlock()
+
+	for chanID := range s.linkIndex {
+		l := s.linkIndex[chanID]
+		if l.PeerPubKey() == peer {
+			return true
+		}
 	}
 
 	return false

--- a/server.go
+++ b/server.go
@@ -1011,6 +1011,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		Clock:               clock.NewDefaultClock(),
 		StrictZombiePruning: strictPruning,
 		IsAlias:             aliasmgr.IsAlias,
+		HaveChannelWith:     s.htlcSwitch.HaveLinkWith,
 		TrafficShaper:       implCfg.TrafficShaper,
 	})
 	if err != nil {


### PR DESCRIPTION
Fixes #8870.

Due to unfortunate timing, it's possible for a node announcement of the peer we just opened an unannounced channel with to come in before we've added them to our graph.
But because the link is already present, we can just ask the switch if we know the peer, making sure this still isn't a DoS vector (in-memory lookup instead of channel database query).
