### PR TITLE
contractcourt: Taproot Channel Bugfixes

### DIFF
--- a/contractcourt/chain_watcher.go
+++ b/contractcourt/chain_watcher.go
@@ -12,6 +12,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/mempool"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
@@ -689,7 +690,10 @@ func (c *chainWatcher) closeObserver(spendNtfn *chainntnfs.SpendEvent) {
 		// sequence number that's finalized. This won't happen with
 		// regular commitment transactions due to the state hint
 		// encoding scheme.
-		if commitTxBroadcast.TxIn[0].Sequence == wire.MaxTxInSequenceNum {
+		switch commitTxBroadcast.TxIn[0].Sequence {
+		case wire.MaxTxInSequenceNum:
+			fallthrough
+		case mempool.MaxRBFSequence:
 			// TODO(roasbeef): rare but possible, need itest case
 			// for
 			err := c.dispatchCooperativeClose(commitSpend)


### PR DESCRIPTION
## Change Description
This PR fixes two bugs with Taproot Channel closures. These bugs never had corresponding issue documentation so they will be described here:

---

1. The first bug is an issue wherein we only identified a coop close transaction as one that had the finalized squence number. Since taproot channels use the new RBF coop close process, they will have the max RBF-able sequence number instead. Right now we do not correctly identify this RBF coop close transaction for taproot channels.
 
SOLUTION: include the max RBF sequence number in the heuristic for identifying coop close transactions.

---

2. The second bug is an issue wherein we fail to properly identify whether the commitment transaction was broadcast by the local or remote party because we use a broken heuristic when analyzing the output script. Right now we check if the final byte of the script is an OP_DROP. However both the local and remote outputs of the commitment transaction will end with an OP_DROP.

SOLUTION: check the signing key of the resolver and compare it to the channel config to see if we are using the delay key or the non-delay key.

---

## Steps to Test
I'm unsure what our testing strategy should be here. Open to suggestions.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
