### PR TITLE
Fixes the total num of payments returned by QueryPayments when there are dates restrictions

### DIFF
--- a/channeldb/payments.go
+++ b/channeldb/payments.go
@@ -529,6 +529,22 @@ func (d *DB) QueryPayments(query PaymentsQuery) (PaymentsResponse, error) {
 			return fmt.Errorf("index bucket does not exist")
 		}
 
+		// Helper function to check if a payment meets the creation time
+		// criteria.
+		paymentInRange := func(payment *MPPayment) bool {
+			createTime := payment.Info.CreationTime.Unix()
+			if createTime < query.CreationDateStart {
+				return false
+			}
+			if query.CreationDateEnd != 0 &&
+				createTime > query.CreationDateEnd {
+
+				return false
+			}
+
+			return true
+		}
+
 		// accumulatePayments gets payments with the sequence number
 		// and hash provided and adds them to our list of payments if
 		// they meet the criteria of our query. It returns the number
@@ -557,21 +573,8 @@ func (d *DB) QueryPayments(query PaymentsQuery) (PaymentsResponse, error) {
 				return false, err
 			}
 
-			// Get the creation time in Unix seconds, this always
-			// rounds down the nanoseconds to full seconds.
-			createTime := payment.Info.CreationTime.Unix()
-
-			// Skip any payments that were created before the
-			// specified time.
-			if createTime < query.CreationDateStart {
-				return false, nil
-			}
-
-			// Skip any payments that were created after the
-			// specified time.
-			if query.CreationDateEnd != 0 &&
-				createTime > query.CreationDateEnd {
-
+			// Check if the payment is within the time range.
+			if !paymentInRange(payment) {
 				return false, nil
 			}
 
@@ -601,19 +604,32 @@ func (d *DB) QueryPayments(query PaymentsQuery) (PaymentsResponse, error) {
 				totalPayments uint64
 				err           error
 			)
-			countFn := func(_, _ []byte) error {
-				totalPayments++
 
+			countFn := func(sequenceKey, hash []byte) error {
+				r := bytes.NewReader(hash)
+				paymentHash, err := deserializePaymentIndex(r)
+				if err != nil {
+					return err
+				}
+
+				payment, err := fetchPaymentWithSequenceNumber(
+					tx, paymentHash, sequenceKey,
+				)
+
+				if err != nil {
+					return err
+				}
+				// Check if the payment is within the time
+				// range.
+				if !paymentInRange(payment) {
+					return nil
+				}
+
+				totalPayments++
 				return nil
 			}
-
-			// In non-boltdb database backends, there's a faster
-			// ForAll query that allows for batch fetching items.
-			if fastBucket, ok := indexes.(kvdb.ExtendedRBucket); ok {
-				err = fastBucket.ForAll(countFn)
-			} else {
-				err = indexes.ForEach(countFn)
-			}
+			// TODO Waiting a better way to do it on SQL databases
+			err = indexes.ForEach(countFn)
 			if err != nil {
 				return fmt.Errorf("error counting payments: %w",
 					err)

--- a/docs/release-notes/release-notes-0.18.3.md
+++ b/docs/release-notes/release-notes-0.18.3.md
@@ -33,6 +33,10 @@
   created](https://github.com/lightningnetwork/lnd/pull/8921) when multiple RPC
   calls are made concurrently.
 
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/8883) when RPC call
+  is made to list payments with the counting total number of payments enabled.
+
+
 # New Features
 ## Functional Enhancements
 ## RPC Additions
@@ -128,5 +132,6 @@
 * Elle Mouton
 * Matheus Degiovani
 * Oliver Gugger
+* Pins
 * Slyghtning
 * Yong Yu

--- a/itest/lnd_payment_test.go
+++ b/itest/lnd_payment_test.go
@@ -256,6 +256,14 @@ func testListPayments(ht *lntest.HarnessTest) {
 				endDate:  createTimeSeconds - 1,
 				expected: false,
 			},
+			{
+				// Use an earlier both start date and end date
+				// should return us nothing.
+				name:      "earlier start and end date",
+				startDate: createTimeSeconds - 2,
+				endDate:   createTimeSeconds - 1,
+				expected:  false,
+			},
 		}
 	}
 
@@ -271,15 +279,21 @@ func testListPayments(ht *lntest.HarnessTest) {
 	for _, tc := range testCases {
 		ht.Run("payment_"+tc.name, func(t *testing.T) {
 			req := &lnrpc.ListPaymentsRequest{
-				CreationDateStart: tc.startDate,
-				CreationDateEnd:   tc.endDate,
+				CreationDateStart:  tc.startDate,
+				CreationDateEnd:    tc.endDate,
+				CountTotalPayments: true,
 			}
 			resp := alice.RPC.ListPayments(req)
 
 			if tc.expected {
 				require.Lenf(t, resp.Payments, 1, "req=%v", req)
+				require.Equal(t, resp.TotalNumPayments,
+					uint64(1),
+					"TNP=%v", resp.TotalNumPayments)
 			} else {
 				require.Emptyf(t, resp.Payments, "req=%v", req)
+				require.Zero(t, resp.TotalNumPayments,
+					"TNP=%v", resp.TotalNumPayments)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #8530

## Change Description
The function QueryPayments was not considering the dates restriction when counting the total num of payments.

## Steps to Test
`lncli listpayments --creation_date_start 1650000000 --count_total_payments --creation_date_end 1650000001 | grep total_num_payments`

This command should return 0 as there are no payments between the date start and the date end.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
