### PR TITLE
lnwallet: add short chan ID to AuxShutdownReq

### DIFF
--- a/lnwallet/chancloser/aux_closer.go
+++ b/lnwallet/chancloser/aux_closer.go
@@ -34,6 +34,10 @@ type AuxShutdownReq struct {
 	// down.
 	ChanPoint wire.OutPoint
 
+	// ShortChanID is the short channel ID of the channel that is being
+	// closed.
+	ShortChanID lnwire.ShortChannelID
+
 	// Initiator is true if the local node is the initiator of the channel.
 	Initiator bool
 

--- a/lnwallet/chancloser/chancloser.go
+++ b/lnwallet/chancloser/chancloser.go
@@ -375,6 +375,7 @@ func (c *ChanCloser) initChanShutdown() (*lnwire.Shutdown, error) {
 	err := fn.MapOptionZ(c.cfg.AuxCloser, func(a AuxChanCloser) error {
 		shutdownCustomRecords, err := a.ShutdownBlob(AuxShutdownReq{
 			ChanPoint:   c.chanPoint,
+			ShortChanID: c.cfg.Channel.ShortChanID(),
 			Initiator:   c.cfg.Channel.IsInitiator(),
 			InternalKey: c.localInternalKey,
 			CommitBlob:  c.cfg.Channel.LocalCommitmentBlob(),
@@ -979,6 +980,7 @@ func (c *ChanCloser) ReceiveClosingSigned( //nolint:funlen
 				channel := c.cfg.Channel
 				req := AuxShutdownReq{
 					ChanPoint:   c.chanPoint,
+					ShortChanID: c.cfg.Channel.ShortChanID(),
 					InternalKey: c.localInternalKey,
 					Initiator:   channel.IsInitiator(),
 					//nolint:lll
@@ -1059,6 +1061,7 @@ func (c *ChanCloser) auxCloseOutputs(
 	err := fn.MapOptionZ(c.cfg.AuxCloser, func(aux AuxChanCloser) error {
 		req := AuxShutdownReq{
 			ChanPoint:   c.chanPoint,
+			ShortChanID: c.cfg.Channel.ShortChanID(),
 			InternalKey: c.localInternalKey,
 			Initiator:   c.cfg.Channel.IsInitiator(),
 			CommitBlob:  c.cfg.Channel.LocalCommitmentBlob(),


### PR DESCRIPTION
This allows implementations to obtain information related where the funding transaction confirmed in the mainchain.

