### PR TITLE
routing: inbound fees support for BuildRoute

### DIFF
--- a/channeldb/graph_test.go
+++ b/channeldb/graph_test.go
@@ -3688,7 +3688,7 @@ func TestLightningNodeSigVerification(t *testing.T) {
 	}
 }
 
-// TestComputeFee tests fee calculation based on both in- and outgoing amt.
+// TestComputeFee tests fee calculation based on the outgoing amt.
 func TestComputeFee(t *testing.T) {
 	var (
 		policy = models.ChannelEdgePolicy{
@@ -3702,11 +3702,6 @@ func TestComputeFee(t *testing.T) {
 	fee := policy.ComputeFee(outgoingAmt)
 	if fee != expectedFee {
 		t.Fatalf("expected fee %v, got %v", expectedFee, fee)
-	}
-
-	fwdFee := policy.ComputeFeeFromIncoming(outgoingAmt + fee)
-	if fwdFee != expectedFee {
-		t.Fatalf("expected fee %v, but got %v", fee, fwdFee)
 	}
 }
 

--- a/channeldb/models/cached_edge_policy.go
+++ b/channeldb/models/cached_edge_policy.go
@@ -71,17 +71,6 @@ func (c *CachedEdgePolicy) ComputeFee(
 	return c.FeeBaseMSat + (amt*c.FeeProportionalMillionths)/feeRateParts
 }
 
-// ComputeFeeFromIncoming computes the fee to forward an HTLC given the incoming
-// amount.
-func (c *CachedEdgePolicy) ComputeFeeFromIncoming(
-	incomingAmt lnwire.MilliSatoshi) lnwire.MilliSatoshi {
-
-	return incomingAmt - divideCeil(
-		feeRateParts*(incomingAmt-c.FeeBaseMSat),
-		feeRateParts+c.FeeProportionalMillionths,
-	)
-}
-
 // NewCachedPolicy turns a full policy into a minimal one that can be cached.
 func NewCachedPolicy(policy *ChannelEdgePolicy) *CachedEdgePolicy {
 	return &CachedEdgePolicy{

--- a/channeldb/models/channel_edge_policy.go
+++ b/channeldb/models/channel_edge_policy.go
@@ -113,19 +113,3 @@ func (c *ChannelEdgePolicy) ComputeFee(
 
 	return c.FeeBaseMSat + (amt*c.FeeProportionalMillionths)/feeRateParts
 }
-
-// divideCeil divides dividend by factor and rounds the result up.
-func divideCeil(dividend, factor lnwire.MilliSatoshi) lnwire.MilliSatoshi {
-	return (dividend + factor - 1) / factor
-}
-
-// ComputeFeeFromIncoming computes the fee to forward an HTLC given the incoming
-// amount.
-func (c *ChannelEdgePolicy) ComputeFeeFromIncoming(
-	incomingAmt lnwire.MilliSatoshi) lnwire.MilliSatoshi {
-
-	return incomingAmt - divideCeil(
-		feeRateParts*(incomingAmt-c.FeeBaseMSat),
-		feeRateParts+c.FeeProportionalMillionths,
-	)
-}

--- a/docs/release-notes/release-notes-0.18.3.md
+++ b/docs/release-notes/release-notes-0.18.3.md
@@ -84,6 +84,9 @@
 * [`ChanInfoRequest`](https://github.com/lightningnetwork/lnd/pull/8813)
   adds support for channel points.
 
+* [BuildRoute](https://github.com/lightningnetwork/lnd/pull/8886) now supports
+  inbound fees.
+
 ## lncli Updates
 
 * [`importmc`](https://github.com/lightningnetwork/lnd/pull/8779) now accepts

--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -1411,10 +1412,10 @@ func (s *Server) BuildRoute(_ context.Context,
 	}
 
 	// Prepare BuildRoute call parameters from rpc request.
-	var amt *lnwire.MilliSatoshi
+	var amt fn.Option[lnwire.MilliSatoshi]
 	if req.AmtMsat != 0 {
 		rpcAmt := lnwire.MilliSatoshi(req.AmtMsat)
-		amt = &rpcAmt
+		amt = fn.Some(rpcAmt)
 	}
 
 	var outgoingChan *uint64

--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -1401,6 +1401,10 @@ func (s *Server) trackPaymentStream(context context.Context,
 func (s *Server) BuildRoute(_ context.Context,
 	req *BuildRouteRequest) (*BuildRouteResponse, error) {
 
+	if len(req.HopPubkeys) == 0 {
+		return nil, errors.New("no hops specified")
+	}
+
 	// Unmarshall hop list.
 	hops := make([]route.Vertex, len(req.HopPubkeys))
 	for i, pubkeyBytes := range req.HopPubkeys {

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -1619,6 +1619,11 @@ func TestBuildRoute(t *testing.T) {
 	_, err = rand.Read(payAddr[:])
 	require.NoError(t, err)
 
+	// Test that we can't build a route when no hops are given.
+	hops = []route.Vertex{}
+	_, err = ctx.router.BuildRoute(nil, hops, nil, 40, nil)
+	require.Error(t, err)
+
 	// Create hop list for an unknown destination.
 	hops := []route.Vertex{ctx.aliases["b"], ctx.aliases["y"]}
 	_, err = ctx.router.BuildRoute(nil, hops, nil, 40, &payAddr)
@@ -1698,7 +1703,8 @@ func TestReceiverAmtForwardPass(t *testing.T) {
 		expectedErr string
 	}{
 		{
-			name: "empty",
+			name:        "empty",
+			expectedErr: "no edges to forward through",
 		},
 		{
 			name: "single edge, no valid policy",


### PR DESCRIPTION
This PR attempts to add support for inbound fees to `BuildRoute`. The three passes `BuildRoute` goes through (see https://github.com/lightningnetwork/lnd/issues/8814#issuecomment-2160012218 for an explanation) are altered to determine the edges in the backward pass (from receiver to sender) as opposed to the previous approach where this is done in the forward pass (sender to receiver). This way we get fixed edges that can be used to determine the minimal sender/maximal receiver amount with inbound fees, doing a reverse amount calculation (thanks to @feelancer21 for the analysis https://github.com/lightningnetwork/lnd/issues/8814#issuecomment-2168351570). The computation for the outgoing amount based on the incoming amount is done using `big.Int` arithmetic.

Previous work on this: https://github.com/lightningnetwork/lnd/pull/7060