### PR TITLE
Beat [1/4]: handle sweeper's broadcast error

### DIFF
--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -65,7 +65,7 @@ type Bumper interface {
 	// and monitors its confirmation status for potential fee bumping. It
 	// returns a chan that the caller can use to receive updates about the
 	// broadcast result and potential RBF attempts.
-	Broadcast(req *BumpRequest) (<-chan *BumpResult, error)
+	Broadcast(req *BumpRequest) <-chan *BumpResult
 }
 
 // BumpEvent represents the event of a fee bumping attempt.
@@ -382,9 +382,9 @@ func (t *TxPublisher) isNeutrinoBackend() bool {
 // RBF-compliant unless the budget specified cannot cover the fee.
 //
 // NOTE: part of the Bumper interface.
-func (t *TxPublisher) Broadcast(req *BumpRequest) (<-chan *BumpResult, error) {
-	log.Tracef("Received broadcast request: %s", lnutils.SpewLogClosure(
-		req))
+func (t *TxPublisher) Broadcast(req *BumpRequest) <-chan *BumpResult {
+	log.Tracef("Received broadcast request: %s",
+		lnutils.SpewLogClosure(req))
 
 	// Store the request.
 	requestID, record := t.storeInitialRecord(req)
@@ -398,7 +398,7 @@ func (t *TxPublisher) Broadcast(req *BumpRequest) (<-chan *BumpResult, error) {
 		t.handleInitialBroadcast(record, requestID)
 	}
 
-	return subscriber, nil
+	return subscriber
 }
 
 // storeInitialRecord initializes a monitor record and saves it in the map.

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -143,6 +143,10 @@ type BumpRequest struct {
 	// ExtraTxOut tracks if this bump request has an optional set of extra
 	// outputs to add to the transaction.
 	ExtraTxOut fn.Option[SweepOutput]
+
+	// Immediate is used to specify that the tx should be broadcast
+	// immediately.
+	Immediate bool
 }
 
 // MaxFeeRateAllowed returns the maximum fee rate allowed for the given

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -84,6 +84,11 @@ const (
 	// TxConfirmed is sent when the tx is confirmed.
 	TxConfirmed
 
+	// TxFatal is sent when the inputs in this tx cannot be retried. Txns
+	// will end up in this state if they have encountered a non-fee related
+	// error, which means they cannot be retried with increased budget.
+	TxFatal
+
 	// sentinalEvent is used to check if an event is unknown.
 	sentinalEvent
 )
@@ -99,6 +104,8 @@ func (e BumpEvent) String() string {
 		return "Replaced"
 	case TxConfirmed:
 		return "Confirmed"
+	case TxFatal:
+		return "Fatal"
 	default:
 		return "Unknown"
 	}
@@ -246,10 +253,20 @@ type BumpResult struct {
 	requestID uint64
 }
 
+// String returns a human-readable string for the result.
+func (b *BumpResult) String() string {
+	desc := fmt.Sprintf("Event=%v", b.Event)
+	if b.Tx != nil {
+		desc += fmt.Sprintf(", Tx=%v", b.Tx.TxHash())
+	}
+
+	return fmt.Sprintf("[%s]", desc)
+}
+
 // Validate validates the BumpResult so it's safe to use.
 func (b *BumpResult) Validate() error {
-	// Every result must have a tx.
-	if b.Tx == nil {
+	// Every result must have a tx except the fatal or failed case.
+	if b.Tx == nil && b.Event != TxFatal {
 		return fmt.Errorf("%w: nil tx", ErrInvalidBumpResult)
 	}
 
@@ -263,9 +280,11 @@ func (b *BumpResult) Validate() error {
 		return fmt.Errorf("%w: nil replacing tx", ErrInvalidBumpResult)
 	}
 
-	// If it's a failed event, it must have an error.
-	if b.Event == TxFailed && b.Err == nil {
-		return fmt.Errorf("%w: nil error", ErrInvalidBumpResult)
+	// If it's a failed or fatal event, it must have an error.
+	if b.Event == TxFatal || b.Event == TxFailed {
+		if b.Err == nil {
+			return fmt.Errorf("%w: nil error", ErrInvalidBumpResult)
+		}
 	}
 
 	// If it's a confirmed event, it must have a fee rate and fee.
@@ -654,8 +673,7 @@ func (t *TxPublisher) notifyResult(result *BumpResult) {
 		return
 	}
 
-	log.Debugf("Sending result for requestID=%v, tx=%v", id,
-		result.Tx.TxHash())
+	log.Debugf("Sending result %v for requestID=%v", result, id)
 
 	select {
 	// Send the result to the subscriber.
@@ -673,20 +691,31 @@ func (t *TxPublisher) notifyResult(result *BumpResult) {
 func (t *TxPublisher) removeResult(result *BumpResult) {
 	id := result.requestID
 
-	// Remove the record from the maps if there's an error. This means this
-	// tx has failed its broadcast and cannot be retried. There are two
-	// cases,
-	// - when the budget cannot cover the fee.
-	// - when a non-RBF related error occurs.
+	var txid chainhash.Hash
+	if result.Tx != nil {
+		txid = result.Tx.TxHash()
+	}
+
+	// Remove the record from the maps if there's an error or the tx is
+	// confirmed. When there's an error, it means this tx has failed its
+	// broadcast and cannot be retried. There are two cases it may fail,
+	// - when the budget cannot cover the increased fee calculated by the
+	//   fee function, hence the budget is used up.
+	// - when a non-fee related error returned from PublishTransaction.
 	switch result.Event {
 	case TxFailed:
 		log.Errorf("Removing monitor record=%v, tx=%v, due to err: %v",
-			id, result.Tx.TxHash(), result.Err)
+			id, txid, result.Err)
 
 	case TxConfirmed:
-		// Remove the record is the tx is confirmed.
+		// Remove the record if the tx is confirmed.
 		log.Debugf("Removing confirmed monitor record=%v, tx=%v", id,
-			result.Tx.TxHash())
+			txid)
+
+	case TxFatal:
+		// Remove the record if there's an error.
+		log.Debugf("Removing monitor record=%v due to fatal err: %v",
+			id, result.Err)
 
 	// Do nothing if it's neither failed or confirmed.
 	default:

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -417,31 +417,23 @@ func (t *TxPublisher) storeInitialRecord(req *BumpRequest) (
 	return requestID, record
 }
 
-// initialBroadcast initializes a fee function, creates an RBF-compliant tx and
-// broadcasts it.
-func (t *TxPublisher) initialBroadcast(requestID uint64,
-	req *BumpRequest) (*BumpResult, error) {
-
+// initializeTx initializes a fee function and creates an RBF-compliant tx. If
+// succeeded, the initial tx is stored in the records map.
+func (t *TxPublisher) initializeTx(requestID uint64, req *BumpRequest) error {
 	// Create a fee bumping algorithm to be used for future RBF.
 	feeAlgo, err := t.initializeFeeFunction(req)
 	if err != nil {
-		return nil, fmt.Errorf("init fee function: %w", err)
+		return fmt.Errorf("init fee function: %w", err)
 	}
 
 	// Create the initial tx to be broadcasted. This tx is guaranteed to
 	// comply with the RBF restrictions.
 	err = t.createRBFCompliantTx(requestID, req, feeAlgo)
 	if err != nil {
-		return nil, fmt.Errorf("create RBF-compliant tx: %w", err)
+		return fmt.Errorf("create RBF-compliant tx: %w", err)
 	}
 
-	// Broadcast the tx and return the monitored record.
-	result, err := t.broadcast(requestID)
-	if err != nil {
-		return nil, fmt.Errorf("broadcast sweep tx: %w", err)
-	}
-
-	return result, nil
+	return nil
 }
 
 // initializeFeeFunction initializes a fee function to be used for this request
@@ -954,6 +946,50 @@ func (t *TxPublisher) handleTxConfirmed(r *monitorRecord, requestID uint64) {
 	t.handleResult(result)
 }
 
+// handleInitialTxError takes the error from `initializeTx` and decides the
+// bump event. It will construct a BumpResult and handles it.
+func (t *TxPublisher) handleInitialTxError(requestID uint64, err error) {
+	// We now decide what type of event to send.
+	var event BumpEvent
+
+	switch {
+	// When the error is due to a dust output, we'll send a TxFailed so
+	// these inputs can be retried with a different group in the next
+	// block.
+	case errors.Is(err, ErrTxNoOutput):
+		event = TxFailed
+
+	// When the error is due to budget being used up, we'll send a TxFailed
+	// so these inputs can be retried with a different group in the next
+	// block.
+	case errors.Is(err, ErrMaxPosition):
+		event = TxFailed
+
+	// When the error is due to zero fee rate delta, we'll send a TxFailed
+	// so these inputs can be retried in the next block.
+	case errors.Is(err, ErrZeroFeeRateDelta):
+		event = TxFailed
+
+	// Otherwise this is not a fee-related error and the tx cannot be
+	// retried. In that case we will fail ALL the inputs in this tx, which
+	// means they will be removed from the sweeper and never be tried
+	// again.
+	//
+	// TODO(yy): Find out which input is causing the failure and fail that
+	// one only.
+	default:
+		event = TxFatal
+	}
+
+	result := &BumpResult{
+		Event:     event,
+		Err:       err,
+		requestID: requestID,
+	}
+
+	t.handleResult(result)
+}
+
 // handleInitialBroadcast is called when a new request is received. It will
 // handle the initial tx creation and broadcast. In details,
 // 1. init a fee function based on the given strategy.
@@ -971,44 +1007,27 @@ func (t *TxPublisher) handleInitialBroadcast(r *monitorRecord,
 
 	// Attempt an initial broadcast which is guaranteed to comply with the
 	// RBF rules.
-	result, err = t.initialBroadcast(requestID, r.req)
+	//
+	// Create the initial tx to be broadcasted.
+	err = t.initializeTx(requestID, r.req)
 	if err != nil {
 		log.Errorf("Initial broadcast failed: %v", err)
 
-		// We now decide what type of event to send.
-		var event BumpEvent
+		// We now handle the initialization error and exit.
+		t.handleInitialTxError(requestID, err)
 
-		switch {
-		// When the error is due to a dust output, we'll send a
-		// TxFailed so these inputs can be retried with a different
-		// group in the next block.
-		case errors.Is(err, ErrTxNoOutput):
-			event = TxFailed
+		return
+	}
 
-		// When the error is due to budget being used up, we'll send a
-		// TxFailed so these inputs can be retried with a different
-		// group in the next block.
-		case errors.Is(err, ErrMaxPosition):
-			event = TxFailed
-
-		// When the error is due to zero fee rate delta, we'll send a
-		// TxFailed so these inputs can be retried in the next block.
-		case errors.Is(err, ErrZeroFeeRateDelta):
-			event = TxFailed
-
-		// Otherwise this is not a fee-related error and the tx cannot
-		// be retried. In that case we will fail ALL the inputs in this
-		// tx, which means they will be removed from the sweeper and
-		// never be tried again.
-		//
-		// TODO(yy): Find out which input is causing the failure and
-		// fail that one only.
-		default:
-			event = TxFatal
-		}
-
+	// Successfully created the first tx, now broadcast it.
+	result, err = t.broadcast(requestID)
+	if err != nil {
+		// The broadcast failed, which can only happen if the tx record
+		// cannot be found or the aux sweeper returns an error. In
+		// either case, we will send back a TxFail event so these
+		// inputs can be retried.
 		result = &BumpResult{
-			Event:     event,
+			Event:     TxFailed,
 			Err:       err,
 			requestID: requestID,
 		}

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -908,11 +908,9 @@ func (t *TxPublisher) processRecords() {
 	// For records that are confirmed, we'll notify the caller about this
 	// result.
 	for requestID, r := range confirmedRecords {
-		rec := r
-
 		log.Debugf("Tx=%v is confirmed", r.tx.TxHash())
 		t.wg.Add(1)
-		go t.handleTxConfirmed(rec, requestID)
+		go t.handleTxConfirmed(r, requestID)
 	}
 
 	// Get the current height to be used in the following goroutines.
@@ -920,22 +918,18 @@ func (t *TxPublisher) processRecords() {
 
 	// For records that are not confirmed, we perform a fee bump if needed.
 	for requestID, r := range feeBumpRecords {
-		rec := r
-
 		log.Debugf("Attempting to fee bump Tx=%v", r.tx.TxHash())
 		t.wg.Add(1)
-		go t.handleFeeBumpTx(requestID, rec, currentHeight)
+		go t.handleFeeBumpTx(requestID, r, currentHeight)
 	}
 
 	// For records that are failed, we'll notify the caller about this
 	// result.
 	for requestID, r := range failedRecords {
-		rec := r
-
 		log.Debugf("Tx=%v has inputs been spent by a third party, "+
 			"failing it now", r.tx.TxHash())
 		t.wg.Add(1)
-		go t.handleThirdPartySpent(rec, requestID)
+		go t.handleThirdPartySpent(r, requestID)
 	}
 }
 

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -376,40 +376,52 @@ func (t *TxPublisher) isNeutrinoBackend() bool {
 	return t.cfg.Wallet.BackEnd() == "neutrino"
 }
 
-// Broadcast is used to publish the tx created from the given inputs. It will,
-// 1. init a fee function based on the given strategy.
-// 2. create an RBF-compliant tx and monitor it for confirmation.
-// 3. notify the initial broadcast result back to the caller.
-// The initial broadcast is guaranteed to be RBF-compliant unless the budget
-// specified cannot cover the fee.
+// Broadcast is used to publish the tx created from the given inputs. It will
+// register the broadcast request and return a chan to the caller to subscribe
+// the broadcast result. The initial broadcast is guaranteed to be
+// RBF-compliant unless the budget specified cannot cover the fee.
 //
 // NOTE: part of the Bumper interface.
 func (t *TxPublisher) Broadcast(req *BumpRequest) (<-chan *BumpResult, error) {
 	log.Tracef("Received broadcast request: %s", lnutils.SpewLogClosure(
 		req))
 
-	// Attempt an initial broadcast which is guaranteed to comply with the
-	// RBF rules.
-	result, err := t.initialBroadcast(req)
-	if err != nil {
-		log.Errorf("Initial broadcast failed: %v", err)
-
-		return nil, err
-	}
+	// Store the request.
+	requestID, record := t.storeInitialRecord(req)
 
 	// Create a chan to send the result to the caller.
 	subscriber := make(chan *BumpResult, 1)
-	t.subscriberChans.Store(result.requestID, subscriber)
+	t.subscriberChans.Store(requestID, subscriber)
 
-	// Send the initial broadcast result to the caller.
-	t.handleResult(result)
+	// Publish the tx immediately if specified.
+	if req.Immediate {
+		t.handleInitialBroadcast(record, requestID)
+	}
 
 	return subscriber, nil
 }
 
+// storeInitialRecord initializes a monitor record and saves it in the map.
+func (t *TxPublisher) storeInitialRecord(req *BumpRequest) (
+	uint64, *monitorRecord) {
+
+	// Increase the request counter.
+	//
+	// NOTE: this is the only place where we increase the counter.
+	requestID := t.requestCounter.Add(1)
+
+	// Register the record.
+	record := &monitorRecord{req: req}
+	t.records.Store(requestID, record)
+
+	return requestID, record
+}
+
 // initialBroadcast initializes a fee function, creates an RBF-compliant tx and
 // broadcasts it.
-func (t *TxPublisher) initialBroadcast(req *BumpRequest) (*BumpResult, error) {
+func (t *TxPublisher) initialBroadcast(requestID uint64,
+	req *BumpRequest) (*BumpResult, error) {
+
 	// Create a fee bumping algorithm to be used for future RBF.
 	feeAlgo, err := t.initializeFeeFunction(req)
 	if err != nil {
@@ -418,7 +430,7 @@ func (t *TxPublisher) initialBroadcast(req *BumpRequest) (*BumpResult, error) {
 
 	// Create the initial tx to be broadcasted. This tx is guaranteed to
 	// comply with the RBF restrictions.
-	requestID, err := t.createRBFCompliantTx(req, feeAlgo)
+	err = t.createRBFCompliantTx(requestID, req, feeAlgo)
 	if err != nil {
 		return nil, fmt.Errorf("create RBF-compliant tx: %w", err)
 	}
@@ -465,8 +477,8 @@ func (t *TxPublisher) initializeFeeFunction(
 // so by creating a tx, validate it using `TestMempoolAccept`, and bump its fee
 // and redo the process until the tx is valid, or return an error when non-RBF
 // related errors occur or the budget has been used up.
-func (t *TxPublisher) createRBFCompliantTx(req *BumpRequest,
-	f FeeFunction) (uint64, error) {
+func (t *TxPublisher) createRBFCompliantTx(requestID uint64, req *BumpRequest,
+	f FeeFunction) error {
 
 	for {
 		// Create a new tx with the given fee rate and check its
@@ -475,17 +487,18 @@ func (t *TxPublisher) createRBFCompliantTx(req *BumpRequest,
 
 		switch {
 		case err == nil:
-			// The tx is valid, return the request ID.
-			requestID := t.storeRecord(
-				sweepCtx.tx, req, f, sweepCtx.fee,
+			// The tx is valid, store it.
+			t.storeRecord(
+				requestID, sweepCtx.tx, req, f, sweepCtx.fee,
 			)
 
-			log.Infof("Created tx %v for %v inputs: feerate=%v, "+
-				"fee=%v, inputs=%v", sweepCtx.tx.TxHash(),
-				len(req.Inputs), f.FeeRate(), sweepCtx.fee,
+			log.Infof("Created initial sweep tx=%v for %v inputs: "+
+				"feerate=%v, fee=%v, inputs:\n%v",
+				sweepCtx.tx.TxHash(), len(req.Inputs),
+				f.FeeRate(), sweepCtx.fee,
 				inputTypeSummary(req.Inputs))
 
-			return requestID, nil
+			return nil
 
 		// If the error indicates the fees paid is not enough, we will
 		// ask the fee function to increase the fee rate and retry.
@@ -516,7 +529,7 @@ func (t *TxPublisher) createRBFCompliantTx(req *BumpRequest,
 				// cluster these inputs differetly.
 				increased, err = f.Increment()
 				if err != nil {
-					return 0, err
+					return err
 				}
 			}
 
@@ -526,20 +539,14 @@ func (t *TxPublisher) createRBFCompliantTx(req *BumpRequest,
 		// mempool acceptance.
 		default:
 			log.Debugf("Failed to create RBF-compliant tx: %v", err)
-			return 0, err
+			return err
 		}
 	}
 }
 
 // storeRecord stores the given record in the records map.
-func (t *TxPublisher) storeRecord(tx *wire.MsgTx, req *BumpRequest,
-	f FeeFunction, fee btcutil.Amount) uint64 {
-
-	// Increase the request counter.
-	//
-	// NOTE: this is the only place where we increase the
-	// counter.
-	requestID := t.requestCounter.Add(1)
+func (t *TxPublisher) storeRecord(requestID uint64, tx *wire.MsgTx,
+	req *BumpRequest, f FeeFunction, fee btcutil.Amount) {
 
 	// Register the record.
 	t.records.Store(requestID, &monitorRecord{
@@ -548,8 +555,6 @@ func (t *TxPublisher) storeRecord(tx *wire.MsgTx, req *BumpRequest,
 		feeFunction: f,
 		fee:         fee,
 	})
-
-	return requestID
 }
 
 // createAndCheckTx creates a tx based on the given inputs, change output
@@ -844,18 +849,27 @@ func (t *TxPublisher) processRecords() {
 	// confirmed.
 	confirmedRecords := make(map[uint64]*monitorRecord)
 
-	// feeBumpRecords stores a map of the records which need to be bumped.
+	// feeBumpRecords stores a map of records which need to be bumped.
 	feeBumpRecords := make(map[uint64]*monitorRecord)
 
-	// failedRecords stores a map of the records which has inputs being
-	// spent by a third party.
+	// failedRecords stores a map of records which has inputs being spent
+	// by a third party.
 	//
 	// NOTE: this is only used for neutrino backend.
 	failedRecords := make(map[uint64]*monitorRecord)
 
+	// initialRecords stores a map of records which are being created and
+	// published for the first time.
+	initialRecords := make(map[uint64]*monitorRecord)
+
 	// visitor is a helper closure that visits each record and divides them
 	// into two groups.
 	visitor := func(requestID uint64, r *monitorRecord) error {
+		if r.tx == nil {
+			initialRecords[requestID] = r
+			return nil
+		}
+
 		log.Tracef("Checking monitor recordID=%v for tx=%v", requestID,
 			r.tx.TxHash())
 
@@ -883,8 +897,13 @@ func (t *TxPublisher) processRecords() {
 		return nil
 	}
 
-	// Iterate through all the records and divide them into two groups.
+	// Iterate through all the records and divide them into four groups.
 	t.records.ForEach(visitor)
+
+	// Handle the initial broadcast.
+	for requestID, r := range initialRecords {
+		t.handleInitialBroadcast(r, requestID)
+	}
 
 	// For records that are confirmed, we'll notify the caller about this
 	// result.
@@ -938,6 +957,69 @@ func (t *TxPublisher) handleTxConfirmed(r *monitorRecord, requestID uint64) {
 	}
 
 	// Notify that this tx is confirmed and remove the record from the map.
+	t.handleResult(result)
+}
+
+// handleInitialBroadcast is called when a new request is received. It will
+// handle the initial tx creation and broadcast. In details,
+// 1. init a fee function based on the given strategy.
+// 2. create an RBF-compliant tx and monitor it for confirmation.
+// 3. notify the initial broadcast result back to the caller.
+func (t *TxPublisher) handleInitialBroadcast(r *monitorRecord,
+	requestID uint64) {
+
+	log.Debugf("Initial broadcast for requestID=%v", requestID)
+
+	var (
+		result *BumpResult
+		err    error
+	)
+
+	// Attempt an initial broadcast which is guaranteed to comply with the
+	// RBF rules.
+	result, err = t.initialBroadcast(requestID, r.req)
+	if err != nil {
+		log.Errorf("Initial broadcast failed: %v", err)
+
+		// We now decide what type of event to send.
+		var event BumpEvent
+
+		switch {
+		// When the error is due to a dust output, we'll send a
+		// TxFailed so these inputs can be retried with a different
+		// group in the next block.
+		case errors.Is(err, ErrTxNoOutput):
+			event = TxFailed
+
+		// When the error is due to budget being used up, we'll send a
+		// TxFailed so these inputs can be retried with a different
+		// group in the next block.
+		case errors.Is(err, ErrMaxPosition):
+			event = TxFailed
+
+		// When the error is due to zero fee rate delta, we'll send a
+		// TxFailed so these inputs can be retried in the next block.
+		case errors.Is(err, ErrZeroFeeRateDelta):
+			event = TxFailed
+
+		// Otherwise this is not a fee-related error and the tx cannot
+		// be retried. In that case we will fail ALL the inputs in this
+		// tx, which means they will be removed from the sweeper and
+		// never be tried again.
+		//
+		// TODO(yy): Find out which input is causing the failure and
+		// fail that one only.
+		default:
+			event = TxFatal
+		}
+
+		result = &BumpResult{
+			Event:     event,
+			Err:       err,
+			requestID: requestID,
+		}
+	}
+
 	t.handleResult(result)
 }
 

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -91,6 +91,19 @@ func TestBumpResultValidate(t *testing.T) {
 	}
 	require.ErrorIs(t, b.Validate(), ErrInvalidBumpResult)
 
+	// A failed event without a tx will give an error.
+	b = BumpResult{
+		Event: TxFailed,
+		Err:   errDummy,
+	}
+	require.ErrorIs(t, b.Validate(), ErrInvalidBumpResult)
+
+	// A fatal event without a failure reason will give an error.
+	b = BumpResult{
+		Event: TxFailed,
+	}
+	require.ErrorIs(t, b.Validate(), ErrInvalidBumpResult)
+
 	// A confirmed event without fee info will give an error.
 	b = BumpResult{
 		Tx:    &wire.MsgTx{},
@@ -102,6 +115,13 @@ func TestBumpResultValidate(t *testing.T) {
 	b = BumpResult{
 		Tx:    &wire.MsgTx{},
 		Event: TxPublished,
+	}
+	require.NoError(t, b.Validate())
+
+	// Tx is allowed to be nil in a TxFatal event.
+	b = BumpResult{
+		Event: TxFatal,
+		Err:   errDummy,
 	}
 	require.NoError(t, b.Validate())
 }

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -91,13 +91,6 @@ func TestBumpResultValidate(t *testing.T) {
 	}
 	require.ErrorIs(t, b.Validate(), ErrInvalidBumpResult)
 
-	// A failed event without a tx will give an error.
-	b = BumpResult{
-		Event: TxFailed,
-		Err:   errDummy,
-	}
-	require.ErrorIs(t, b.Validate(), ErrInvalidBumpResult)
-
 	// A fatal event without a failure reason will give an error.
 	b = BumpResult{
 		Event: TxFailed,
@@ -115,6 +108,13 @@ func TestBumpResultValidate(t *testing.T) {
 	b = BumpResult{
 		Tx:    &wire.MsgTx{},
 		Event: TxPublished,
+	}
+	require.NoError(t, b.Validate())
+
+	// Tx is allowed to be nil in a TxFailed event.
+	b = BumpResult{
+		Event: TxFailed,
+		Err:   errDummy,
 	}
 	require.NoError(t, b.Validate())
 

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -939,8 +939,7 @@ func TestBroadcast(t *testing.T) {
 	}
 
 	// Send the req and expect no error.
-	resultChan, err := tp.Broadcast(req)
-	require.NoError(t, err)
+	resultChan := tp.Broadcast(req)
 	require.NotNil(t, resultChan)
 
 	// Validate the record was stored.
@@ -990,8 +989,7 @@ func TestBroadcastImmediate(t *testing.T) {
 		chainfee.SatPerKWeight(0), errDummy).Once()
 
 	// Send the req and expect no error.
-	resultChan, err := tp.Broadcast(req)
-	require.NoError(t, err)
+	resultChan := tp.Broadcast(req)
 	require.NotNil(t, resultChan)
 
 	// Validate the record was removed due to an error returned in initial
@@ -1486,8 +1484,7 @@ func TestHandleInitialBroadcastSuccess(t *testing.T) {
 	}
 
 	// Register the testing record use `Broadcast`.
-	resultChan, err := tp.Broadcast(req)
-	require.NoError(t, err)
+	resultChan := tp.Broadcast(req)
 
 	// Grab the monitor record from the map.
 	rid := tp.requestCounter.Load()
@@ -1558,8 +1555,7 @@ func TestHandleInitialBroadcastFail(t *testing.T) {
 		mock.Anything).Return(errDummy).Once()
 
 	// Register the testing record use `Broadcast`.
-	resultChan, err := tp.Broadcast(req)
-	require.NoError(t, err)
+	resultChan := tp.Broadcast(req)
 
 	// Grab the monitor record from the map.
 	rid := tp.requestCounter.Load()
@@ -1592,8 +1588,7 @@ func TestHandleInitialBroadcastFail(t *testing.T) {
 		mock.Anything, mock.Anything).Return(errDummy).Once()
 
 	// Register the testing record use `Broadcast`.
-	resultChan, err = tp.Broadcast(req)
-	require.NoError(t, err)
+	resultChan = tp.Broadcast(req)
 
 	// Grab the monitor record from the map.
 	rid = tp.requestCounter.Load()

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -344,13 +344,10 @@ func TestStoreRecord(t *testing.T) {
 	initialCounter := tp.requestCounter.Load()
 
 	// Call the method under test.
-	requestID := tp.storeRecord(tx, req, feeFunc, fee)
-
-	// Check the request ID is as expected.
-	require.Equal(t, initialCounter+1, requestID)
+	tp.storeRecord(initialCounter, tx, req, feeFunc, fee)
 
 	// Read the saved record and compare.
-	record, ok := tp.records.Load(requestID)
+	record, ok := tp.records.Load(initialCounter)
 	require.True(t, ok)
 	require.Equal(t, tx, record.tx)
 	require.Equal(t, feeFunc, record.feeFunction)
@@ -646,23 +643,19 @@ func TestCreateRBFCompliantTx(t *testing.T) {
 		},
 	}
 
+	var requestCounter atomic.Uint64
 	for _, tc := range testCases {
 		tc := tc
 
+		rid := requestCounter.Add(1)
 		t.Run(tc.name, func(t *testing.T) {
 			tc.setupMock()
 
 			// Call the method under test.
-			id, err := tp.createRBFCompliantTx(req, m.feeFunc)
+			err := tp.createRBFCompliantTx(rid, req, m.feeFunc)
 
 			// Check the result is as expected.
 			require.ErrorIs(t, err, tc.expectedErr)
-
-			// If there's an error, expect the requestID to be
-			// empty.
-			if tc.expectedErr != nil {
-				require.Zero(t, id)
-			}
 		})
 	}
 }
@@ -687,7 +680,8 @@ func TestTxPublisherBroadcast(t *testing.T) {
 
 	// Create a testing record and put it in the map.
 	fee := btcutil.Amount(1000)
-	requestID := tp.storeRecord(tx, req, m.feeFunc, fee)
+	requestID := uint64(1)
+	tp.storeRecord(requestID, tx, req, m.feeFunc, fee)
 
 	// Quickly check when the requestID cannot be found, an error is
 	// returned.
@@ -774,6 +768,9 @@ func TestRemoveResult(t *testing.T) {
 	// Create a testing record and put it in the map.
 	fee := btcutil.Amount(1000)
 
+	// Create a test request ID counter.
+	requestCounter := atomic.Uint64{}
+
 	testCases := []struct {
 		name        string
 		setupRecord func() uint64
@@ -785,10 +782,11 @@ func TestRemoveResult(t *testing.T) {
 			// removed.
 			name: "remove on TxConfirmed",
 			setupRecord: func() uint64 {
-				id := tp.storeRecord(tx, req, m.feeFunc, fee)
-				tp.subscriberChans.Store(id, nil)
+				rid := requestCounter.Add(1)
+				tp.storeRecord(rid, tx, req, m.feeFunc, fee)
+				tp.subscriberChans.Store(rid, nil)
 
-				return id
+				return rid
 			},
 			result: &BumpResult{
 				Event: TxConfirmed,
@@ -800,10 +798,11 @@ func TestRemoveResult(t *testing.T) {
 			// When the tx is failed, the records will be removed.
 			name: "remove on TxFailed",
 			setupRecord: func() uint64 {
-				id := tp.storeRecord(tx, req, m.feeFunc, fee)
-				tp.subscriberChans.Store(id, nil)
+				rid := requestCounter.Add(1)
+				tp.storeRecord(rid, tx, req, m.feeFunc, fee)
+				tp.subscriberChans.Store(rid, nil)
 
-				return id
+				return rid
 			},
 			result: &BumpResult{
 				Event: TxFailed,
@@ -816,10 +815,11 @@ func TestRemoveResult(t *testing.T) {
 			// Noop when the tx is neither confirmed or failed.
 			name: "noop when tx is not confirmed or failed",
 			setupRecord: func() uint64 {
-				id := tp.storeRecord(tx, req, m.feeFunc, fee)
-				tp.subscriberChans.Store(id, nil)
+				rid := requestCounter.Add(1)
+				tp.storeRecord(rid, tx, req, m.feeFunc, fee)
+				tp.subscriberChans.Store(rid, nil)
 
-				return id
+				return rid
 			},
 			result: &BumpResult{
 				Event: TxPublished,
@@ -866,7 +866,8 @@ func TestNotifyResult(t *testing.T) {
 
 	// Create a testing record and put it in the map.
 	fee := btcutil.Amount(1000)
-	requestID := tp.storeRecord(tx, req, m.feeFunc, fee)
+	requestID := uint64(1)
+	tp.storeRecord(requestID, tx, req, m.feeFunc, fee)
 
 	// Create a subscription to the event.
 	subscriber := make(chan *BumpResult, 1)
@@ -914,40 +915,16 @@ func TestNotifyResult(t *testing.T) {
 	}
 }
 
-// TestBroadcastSuccess checks the public `Broadcast` method can successfully
-// broadcast a tx based on the request.
-func TestBroadcastSuccess(t *testing.T) {
+// TestBroadcast checks the public `Broadcast` method can successfully register
+// a broadcast request.
+func TestBroadcast(t *testing.T) {
 	t.Parallel()
 
 	// Create a publisher using the mocks.
-	tp, m := createTestPublisher(t)
+	tp, _ := createTestPublisher(t)
 
 	// Create a test feerate.
 	feerate := chainfee.SatPerKWeight(1000)
-
-	// Mock the fee estimator to return the testing fee rate.
-	//
-	// We are not testing `NewLinearFeeFunction` here, so the actual params
-	// used are irrelevant.
-	m.estimator.On("EstimateFeePerKW", mock.Anything).Return(
-		feerate, nil).Once()
-	m.estimator.On("RelayFeePerKW").Return(chainfee.FeePerKwFloor).Once()
-
-	// Mock the signer to always return a valid script.
-	//
-	// NOTE: we are not testing the utility of creating valid txes here, so
-	// this is fine to be mocked. This behaves essentially as skipping the
-	// Signer check and alaways assume the tx has a valid sig.
-	script := &input.Script{}
-	m.signer.On("ComputeInputScript", mock.Anything,
-		mock.Anything).Return(script, nil)
-
-	// Mock the testmempoolaccept to pass.
-	m.wallet.On("CheckMempoolAcceptance", mock.Anything).Return(nil).Once()
-
-	// Mock the wallet to publish successfully.
-	m.wallet.On("PublishTransaction",
-		mock.Anything, mock.Anything).Return(nil).Once()
 
 	// Create a test request.
 	inp := createTestInput(1000, input.WitnessKeyHash)
@@ -964,25 +941,23 @@ func TestBroadcastSuccess(t *testing.T) {
 	// Send the req and expect no error.
 	resultChan, err := tp.Broadcast(req)
 	require.NoError(t, err)
-
-	// Check the result is sent back.
-	select {
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for subscriber to receive result")
-
-	case result := <-resultChan:
-		// We expect the first result to be TxPublished.
-		require.Equal(t, TxPublished, result.Event)
-	}
+	require.NotNil(t, resultChan)
 
 	// Validate the record was stored.
 	require.Equal(t, 1, tp.records.Len())
 	require.Equal(t, 1, tp.subscriberChans.Len())
+
+	// Validate the record.
+	rid := tp.requestCounter.Load()
+	record, found := tp.records.Load(rid)
+	require.True(t, found)
+	require.Equal(t, req, record.req)
 }
 
-// TestBroadcastFail checks the public `Broadcast` returns the error or a
-// failed result when the broadcast fails.
-func TestBroadcastFail(t *testing.T) {
+// TestBroadcastImmediate checks the public `Broadcast` method can successfully
+// register a broadcast request and publish the tx when `Immediate` flag is
+// set.
+func TestBroadcastImmediate(t *testing.T) {
 	t.Parallel()
 
 	// Create a publisher using the mocks.
@@ -1001,64 +976,28 @@ func TestBroadcastFail(t *testing.T) {
 		Budget:          btcutil.Amount(1000),
 		MaxFeeRate:      feerate * 10,
 		DeadlineHeight:  10,
+		Immediate:       true,
 	}
 
-	// Mock the fee estimator to return the testing fee rate.
+	// Mock the fee estimator to return an error.
 	//
-	// We are not testing `NewLinearFeeFunction` here, so the actual params
-	// used are irrelevant.
+	// NOTE: We are not testing `handleInitialBroadcast` here, but only
+	// interested in checking that this method is indeed called when
+	// `Immediate` is true. Thus we mock the method to return an error to
+	// quickly abort. As long as this mocked method is called, we know the
+	// `Immediate` flag works.
 	m.estimator.On("EstimateFeePerKW", mock.Anything).Return(
-		feerate, nil).Twice()
-	m.estimator.On("RelayFeePerKW").Return(chainfee.FeePerKwFloor).Twice()
+		chainfee.SatPerKWeight(0), errDummy).Once()
 
-	// Mock the signer to always return a valid script.
-	//
-	// NOTE: we are not testing the utility of creating valid txes here, so
-	// this is fine to be mocked. This behaves essentially as skipping the
-	// Signer check and alaways assume the tx has a valid sig.
-	script := &input.Script{}
-	m.signer.On("ComputeInputScript", mock.Anything,
-		mock.Anything).Return(script, nil)
-
-	// Mock the testmempoolaccept to return an error.
-	m.wallet.On("CheckMempoolAcceptance",
-		mock.Anything).Return(errDummy).Once()
-
-	// Send the req and expect an error returned.
+	// Send the req and expect no error.
 	resultChan, err := tp.Broadcast(req)
-	require.ErrorIs(t, err, errDummy)
-	require.Nil(t, resultChan)
-
-	// Validate the record was NOT stored.
-	require.Equal(t, 0, tp.records.Len())
-	require.Equal(t, 0, tp.subscriberChans.Len())
-
-	// Mock the testmempoolaccept again, this time it passes.
-	m.wallet.On("CheckMempoolAcceptance", mock.Anything).Return(nil).Once()
-
-	// Mock the wallet to fail on publish.
-	m.wallet.On("PublishTransaction",
-		mock.Anything, mock.Anything).Return(errDummy).Once()
-
-	// Send the req and expect no error returned.
-	resultChan, err = tp.Broadcast(req)
 	require.NoError(t, err)
+	require.NotNil(t, resultChan)
 
-	// Check the result is sent back.
-	select {
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for subscriber to receive result")
-
-	case result := <-resultChan:
-		// We expect the result to be TxFailed and the error is set in
-		// the result.
-		require.Equal(t, TxFailed, result.Event)
-		require.ErrorIs(t, result.Err, errDummy)
-	}
-
-	// Validate the record was removed.
-	require.Equal(t, 0, tp.records.Len())
-	require.Equal(t, 0, tp.subscriberChans.Len())
+	// Validate the record was removed due to an error returned in initial
+	// broadcast.
+	require.Empty(t, tp.records.Len())
+	require.Empty(t, tp.subscriberChans.Len())
 }
 
 // TestCreateAnPublishFail checks all the error cases are handled properly in
@@ -1223,7 +1162,8 @@ func TestHandleTxConfirmed(t *testing.T) {
 
 	// Create a testing record and put it in the map.
 	fee := btcutil.Amount(1000)
-	requestID := tp.storeRecord(tx, req, m.feeFunc, fee)
+	requestID := uint64(1)
+	tp.storeRecord(requestID, tx, req, m.feeFunc, fee)
 	record, ok := tp.records.Load(requestID)
 	require.True(t, ok)
 
@@ -1295,7 +1235,8 @@ func TestHandleFeeBumpTx(t *testing.T) {
 
 	// Create a testing record and put it in the map.
 	fee := btcutil.Amount(1000)
-	requestID := tp.storeRecord(tx, req, m.feeFunc, fee)
+	requestID := uint64(1)
+	tp.storeRecord(requestID, tx, req, m.feeFunc, fee)
 
 	// Create a subscription to the event.
 	subscriber := make(chan *BumpResult, 1)
@@ -1495,4 +1436,187 @@ func TestProcessRecords(t *testing.T) {
 		require.Nil(t, result.Err)
 		require.Equal(t, requestID2, result.requestID)
 	}
+}
+
+// TestHandleInitialBroadcastSuccess checks `handleInitialBroadcast` method can
+// successfully broadcast a tx based on the request.
+func TestHandleInitialBroadcastSuccess(t *testing.T) {
+	t.Parallel()
+
+	// Create a publisher using the mocks.
+	tp, m := createTestPublisher(t)
+
+	// Create a test feerate.
+	feerate := chainfee.SatPerKWeight(1000)
+
+	// Mock the fee estimator to return the testing fee rate.
+	//
+	// We are not testing `NewLinearFeeFunction` here, so the actual params
+	// used are irrelevant.
+	m.estimator.On("EstimateFeePerKW", mock.Anything).Return(
+		feerate, nil).Once()
+	m.estimator.On("RelayFeePerKW").Return(chainfee.FeePerKwFloor).Once()
+
+	// Mock the signer to always return a valid script.
+	//
+	// NOTE: we are not testing the utility of creating valid txes here, so
+	// this is fine to be mocked. This behaves essentially as skipping the
+	// Signer check and alaways assume the tx has a valid sig.
+	script := &input.Script{}
+	m.signer.On("ComputeInputScript", mock.Anything,
+		mock.Anything).Return(script, nil)
+
+	// Mock the testmempoolaccept to pass.
+	m.wallet.On("CheckMempoolAcceptance", mock.Anything).Return(nil).Once()
+
+	// Mock the wallet to publish successfully.
+	m.wallet.On("PublishTransaction",
+		mock.Anything, mock.Anything).Return(nil).Once()
+
+	// Create a test request.
+	inp := createTestInput(1000, input.WitnessKeyHash)
+
+	// Create a testing bump request.
+	req := &BumpRequest{
+		DeliveryAddress: changePkScript,
+		Inputs:          []input.Input{&inp},
+		Budget:          btcutil.Amount(1000),
+		MaxFeeRate:      feerate * 10,
+		DeadlineHeight:  10,
+	}
+
+	// Register the testing record use `Broadcast`.
+	resultChan, err := tp.Broadcast(req)
+	require.NoError(t, err)
+
+	// Grab the monitor record from the map.
+	rid := tp.requestCounter.Load()
+	rec, ok := tp.records.Load(rid)
+	require.True(t, ok)
+
+	// Call the method under test.
+	tp.wg.Add(1)
+	tp.handleInitialBroadcast(rec, rid)
+
+	// Check the result is sent back.
+	select {
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for subscriber to receive result")
+
+	case result := <-resultChan:
+		// We expect the first result to be TxPublished.
+		require.Equal(t, TxPublished, result.Event)
+	}
+
+	// Validate the record was stored.
+	require.Equal(t, 1, tp.records.Len())
+	require.Equal(t, 1, tp.subscriberChans.Len())
+}
+
+// TestHandleInitialBroadcastFail checks `handleInitialBroadcast` returns the
+// error or a failed result when the broadcast fails.
+func TestHandleInitialBroadcastFail(t *testing.T) {
+	t.Parallel()
+
+	// Create a publisher using the mocks.
+	tp, m := createTestPublisher(t)
+
+	// Create a test feerate.
+	feerate := chainfee.SatPerKWeight(1000)
+
+	// Create a test request.
+	inp := createTestInput(1000, input.WitnessKeyHash)
+
+	// Create a testing bump request.
+	req := &BumpRequest{
+		DeliveryAddress: changePkScript,
+		Inputs:          []input.Input{&inp},
+		Budget:          btcutil.Amount(1000),
+		MaxFeeRate:      feerate * 10,
+		DeadlineHeight:  10,
+	}
+
+	// Mock the fee estimator to return the testing fee rate.
+	//
+	// We are not testing `NewLinearFeeFunction` here, so the actual params
+	// used are irrelevant.
+	m.estimator.On("EstimateFeePerKW", mock.Anything).Return(
+		feerate, nil).Twice()
+	m.estimator.On("RelayFeePerKW").Return(chainfee.FeePerKwFloor).Twice()
+
+	// Mock the signer to always return a valid script.
+	//
+	// NOTE: we are not testing the utility of creating valid txes here, so
+	// this is fine to be mocked. This behaves essentially as skipping the
+	// Signer check and alaways assume the tx has a valid sig.
+	script := &input.Script{}
+	m.signer.On("ComputeInputScript", mock.Anything,
+		mock.Anything).Return(script, nil)
+
+	// Mock the testmempoolaccept to return an error.
+	m.wallet.On("CheckMempoolAcceptance",
+		mock.Anything).Return(errDummy).Once()
+
+	// Register the testing record use `Broadcast`.
+	resultChan, err := tp.Broadcast(req)
+	require.NoError(t, err)
+
+	// Grab the monitor record from the map.
+	rid := tp.requestCounter.Load()
+	rec, ok := tp.records.Load(rid)
+	require.True(t, ok)
+
+	// Call the method under test and expect an error returned.
+	tp.wg.Add(1)
+	tp.handleInitialBroadcast(rec, rid)
+
+	// Check the result is sent back.
+	select {
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for subscriber to receive result")
+
+	case result := <-resultChan:
+		// We expect the first result to be TxFatal.
+		require.Equal(t, TxFatal, result.Event)
+	}
+
+	// Validate the record was NOT stored.
+	require.Equal(t, 0, tp.records.Len())
+	require.Equal(t, 0, tp.subscriberChans.Len())
+
+	// Mock the testmempoolaccept again, this time it passes.
+	m.wallet.On("CheckMempoolAcceptance", mock.Anything).Return(nil).Once()
+
+	// Mock the wallet to fail on publish.
+	m.wallet.On("PublishTransaction",
+		mock.Anything, mock.Anything).Return(errDummy).Once()
+
+	// Register the testing record use `Broadcast`.
+	resultChan, err = tp.Broadcast(req)
+	require.NoError(t, err)
+
+	// Grab the monitor record from the map.
+	rid = tp.requestCounter.Load()
+	rec, ok = tp.records.Load(rid)
+	require.True(t, ok)
+
+	// Call the method under test.
+	tp.wg.Add(1)
+	tp.handleInitialBroadcast(rec, rid)
+
+	// Check the result is sent back.
+	select {
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for subscriber to receive result")
+
+	case result := <-resultChan:
+		// We expect the result to be TxFailed and the error is set in
+		// the result.
+		require.Equal(t, TxFailed, result.Event)
+		require.ErrorIs(t, result.Err, errDummy)
+	}
+
+	// Validate the record was removed.
+	require.Equal(t, 0, tp.records.Len())
+	require.Equal(t, 0, tp.subscriberChans.Len())
 }

--- a/sweep/fee_function.go
+++ b/sweep/fee_function.go
@@ -14,6 +14,9 @@ var (
 	// ErrMaxPosition is returned when trying to increase the position of
 	// the fee function while it's already at its max.
 	ErrMaxPosition = errors.New("position already at max")
+
+	// ErrZeroFeeRateDelta is returned when the fee rate delta is zero.
+	ErrZeroFeeRateDelta = errors.New("fee rate delta is zero")
 )
 
 // mSatPerKWeight represents a fee rate in msat/kw.
@@ -169,7 +172,7 @@ func NewLinearFeeFunction(maxFeeRate chainfee.SatPerKWeight,
 			"endingFeeRate=%v, width=%v, delta=%v", start, end,
 			l.width, l.deltaFeeRate)
 
-		return nil, fmt.Errorf("fee rate delta is zero")
+		return nil, ErrZeroFeeRateDelta
 	}
 
 	// Attach the calculated values to the fee function.

--- a/sweep/mock_test.go
+++ b/sweep/mock_test.go
@@ -268,6 +268,13 @@ func (m *MockInputSet) StartingFeeRate() fn.Option[chainfee.SatPerKWeight] {
 	return args.Get(0).(fn.Option[chainfee.SatPerKWeight])
 }
 
+// Immediate returns whether the inputs should be swept immediately.
+func (m *MockInputSet) Immediate() bool {
+	args := m.Called()
+
+	return args.Bool(0)
+}
+
 // MockBumper is a mock implementation of the interface Bumper.
 type MockBumper struct {
 	mock.Mock

--- a/sweep/mock_test.go
+++ b/sweep/mock_test.go
@@ -284,14 +284,14 @@ type MockBumper struct {
 var _ Bumper = (*MockBumper)(nil)
 
 // Broadcast broadcasts the transaction to the network.
-func (m *MockBumper) Broadcast(req *BumpRequest) (<-chan *BumpResult, error) {
+func (m *MockBumper) Broadcast(req *BumpRequest) <-chan *BumpResult {
 	args := m.Called(req)
 
 	if args.Get(0) == nil {
-		return nil, args.Error(1)
+		return nil
 	}
 
-	return args.Get(0).(chan *BumpResult), args.Error(1)
+	return args.Get(0).(chan *BumpResult)
 }
 
 // MockFeeFunction is a mock implementation of the FeeFunction interface.

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -827,6 +827,7 @@ func (s *UtxoSweeper) sweep(set InputSet) error {
 		DeliveryAddress: sweepAddr,
 		MaxFeeRate:      s.cfg.MaxFeeRate.FeePerKWeight(),
 		StartingFeeRate: set.StartingFeeRate(),
+		Immediate:       set.Immediate(),
 		// TODO(yy): pass the strategy here.
 	}
 

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1669,6 +1669,14 @@ func (s *UtxoSweeper) monitorFeeBumpResult(set InputSet,
 			// in sweeper and rely solely on this event to mark
 			// inputs as Swept?
 			if r.Event == TxConfirmed || r.Event == TxFailed {
+				// Exit if the tx is failed to be created.
+				if r.Tx == nil {
+					log.Debugf("Received %v for nil tx, "+
+						"exit monitor", r.Event)
+
+					return
+				}
+
 				log.Debugf("Received %v for sweep tx %v, exit "+
 					"fee bump monitor", r.Event,
 					r.Tx.TxHash())
@@ -1694,7 +1702,10 @@ func (s *UtxoSweeper) handleBumpEventTxFailed(resp *bumpResp) {
 	r := resp.result
 	tx, err := r.Tx, r.Err
 
-	log.Warnf("Fee bump attempt failed for tx=%v: %v", tx.TxHash(), err)
+	if tx != nil {
+		log.Warnf("Fee bump attempt failed for tx=%v: %v", tx.TxHash(),
+			err)
+	}
 
 	// NOTE: When marking the inputs as failed, we are using the input set
 	// instead of the inputs found in the tx. This is fine for current

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1441,11 +1441,6 @@ func (s *UtxoSweeper) markInputFailed(pi *SweeperInput, err error) {
 
 	pi.state = Failed
 
-	// Remove all other inputs in this exclusive group.
-	if pi.params.ExclusiveGroup != nil {
-		s.removeExclusiveGroup(*pi.params.ExclusiveGroup)
-	}
-
 	s.signalResult(pi, Result{Err: err})
 }
 
@@ -1728,6 +1723,62 @@ func (s *UtxoSweeper) handleBumpEventTxPublished(resp *bumpResp) error {
 	return nil
 }
 
+// handleBumpEventTxFatal handles the case where there's an unexpected error
+// when creating or publishing the sweeping tx. In this case, the tx will be
+// removed from the sweeper store and the inputs will be marked as `Failed`,
+// which means they will not be retried.
+func (s *UtxoSweeper) handleBumpEventTxFatal(resp *bumpResp) error {
+	r := resp.result
+
+	// Remove the tx from the sweeper store if there is one. Since this is
+	// a broadcast error, it's likely there isn't a tx here.
+	if r.Tx != nil {
+		txid := r.Tx.TxHash()
+		log.Infof("Tx=%v failed with unexpected error: %v", txid, r.Err)
+
+		// Remove the tx from the sweeper db if it exists.
+		if err := s.cfg.Store.DeleteTx(txid); err != nil {
+			return fmt.Errorf("delete tx record for %v: %w", txid,
+				err)
+		}
+	}
+
+	// Mark the inputs as failed.
+	s.markInputsFailed(resp.set, r.Err)
+
+	return nil
+}
+
+// markInputsFailed marks all inputs found in the tx as failed. It will also
+// notify all the subscribers of these inputs.
+func (s *UtxoSweeper) markInputsFailed(set InputSet, err error) {
+	for _, inp := range set.Inputs() {
+		outpoint := inp.OutPoint()
+
+		input, ok := s.inputs[outpoint]
+		if !ok {
+			// It's very likely that a spending tx contains inputs
+			// that we don't know.
+			log.Tracef("Skipped marking input as failed: %v not "+
+				"found in pending inputs", outpoint)
+
+			continue
+		}
+
+		// If the input is already in a terminal state, we don't want
+		// to rewrite it, which also indicates an error as we only get
+		// an error event during the initial broadcast.
+		if input.terminated() {
+			log.Errorf("Skipped marking input=%v as failed due to "+
+				"unexpected state=%v", outpoint, input.state)
+
+			continue
+		}
+
+		s.markInputFailed(input, err)
+	}
+}
+
 // handleBumpEvent handles the result sent from the bumper based on its event
 // type.
 //
@@ -1752,8 +1803,10 @@ func (s *UtxoSweeper) handleBumpEvent(r *bumpResp) error {
 	case TxReplaced:
 		return s.handleBumpEventTxReplaced(r)
 
+	// There's a fatal error in creating the tx, we will remove the tx from
+	// the sweeper db and mark the inputs as failed.
 	case TxFatal:
-		// TODO(yy): create a method to remove this input.
+		return s.handleBumpEventTxFatal(r)
 	}
 
 	return nil

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -838,16 +838,7 @@ func (s *UtxoSweeper) sweep(set InputSet) error {
 
 	// Broadcast will return a read-only chan that we will listen to for
 	// this publish result and future RBF attempt.
-	resp, err := s.cfg.Publisher.Broadcast(req)
-	if err != nil {
-		log.Errorf("Initial broadcast failed: %v, inputs=\n%v", err,
-			inputTypeSummary(set.Inputs()))
-
-		// TODO(yy): find out which input is causing the failure.
-		s.markInputsPublishFailed(set)
-
-		return err
-	}
+	resp := s.cfg.Publisher.Broadcast(req)
 
 	// Successfully sent the broadcast attempt, we now handle the result by
 	// subscribing to the result chan and listen for future updates about

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1729,7 +1729,7 @@ func (s *UtxoSweeper) handleBumpEventTxPublished(r *BumpResult) error {
 // NOTE: TxConfirmed event is not handled, since we already subscribe to the
 // input's spending event, we don't need to do anything here.
 func (s *UtxoSweeper) handleBumpEvent(r *BumpResult) error {
-	log.Debugf("Received bump event [%v] for tx %v", r.Event, r.Tx.TxHash())
+	log.Debugf("Received bump result %v", r)
 
 	switch r.Event {
 	// The tx has been published, we update the inputs' state and create a
@@ -1745,6 +1745,9 @@ func (s *UtxoSweeper) handleBumpEvent(r *BumpResult) error {
 	// with the new one.
 	case TxReplaced:
 		return s.handleBumpEventTxReplaced(r)
+
+	case TxFatal:
+		// TODO(yy): create a method to remove this input.
 	}
 
 	return nil

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -443,6 +443,7 @@ func TestUpdateSweeperInputs(t *testing.T) {
 	// returned.
 	inp2.On("RequiredLockTime").Return(
 		uint32(s.currentHeight+1), true).Once()
+	inp2.On("OutPoint").Return(wire.OutPoint{Index: 2}).Maybe()
 	input7 := &SweeperInput{state: Init, Input: inp2}
 
 	// Mock the input to have a CSV expiry in the future so it will NOT be
@@ -451,6 +452,7 @@ func TestUpdateSweeperInputs(t *testing.T) {
 		uint32(s.currentHeight), false).Once()
 	inp3.On("BlocksToMaturity").Return(uint32(2)).Once()
 	inp3.On("HeightHint").Return(uint32(s.currentHeight)).Once()
+	inp3.On("OutPoint").Return(wire.OutPoint{Index: 3}).Maybe()
 	input8 := &SweeperInput{state: Init, Input: inp3}
 
 	// Add the inputs to the sweeper. After the update, we should see the

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -739,7 +739,7 @@ func TestHandleBumpEventTxFailed(t *testing.T) {
 
 	// Call the method under test.
 	err := s.handleBumpEvent(resp)
-	require.ErrorIs(t, err, errDummy)
+	require.NoError(t, err)
 
 	// Assert the states of the first two inputs are updated.
 	require.Equal(t, PublishFailed, s.inputs[op1].state)

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -673,13 +673,8 @@ func TestSweepPendingInputs(t *testing.T) {
 		setNeedWallet, normalSet,
 	})
 
-	// Mock `Broadcast` to return an error. This should cause the
-	// `createSweepTx` inside `sweep` to fail. This is done so we can
-	// terminate the method early as we are only interested in testing the
-	// workflow in `sweepPendingInputs`. We don't need to test `sweep` here
-	// as it should be tested in its own unit test.
-	dummyErr := errors.New("dummy error")
-	publisher.On("Broadcast", mock.Anything).Return(nil, dummyErr).Twice()
+	// Mock `Broadcast` to return a result.
+	publisher.On("Broadcast", mock.Anything).Return(nil).Twice()
 
 	// Call the method under test.
 	s.sweepPendingInputs(pis)

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -704,11 +704,13 @@ func TestSweepPendingInputs(t *testing.T) {
 	setNeedWallet.On("Budget").Return(btcutil.Amount(1)).Once()
 	setNeedWallet.On("StartingFeeRate").Return(
 		fn.None[chainfee.SatPerKWeight]()).Once()
+	setNeedWallet.On("Immediate").Return(false).Once()
 	normalSet.On("Inputs").Return(nil).Maybe()
 	normalSet.On("DeadlineHeight").Return(testHeight).Once()
 	normalSet.On("Budget").Return(btcutil.Amount(1)).Once()
 	normalSet.On("StartingFeeRate").Return(
 		fn.None[chainfee.SatPerKWeight]()).Once()
+	normalSet.On("Immediate").Return(false).Once()
 
 	// Make pending inputs for testing. We don't need real values here as
 	// the returned clusters are mocked.

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -1,6 +1,7 @@
 package sweep
 
 import (
+	"crypto/rand"
 	"errors"
 	"testing"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/stretchr/testify/mock"
@@ -33,6 +35,41 @@ var (
 	})
 )
 
+// createMockInput creates a mock input and saves it to the sweeper's inputs
+// map. The created input has the specified state and a random outpoint. It
+// will assert the method `OutPoint` is called at least once.
+func createMockInput(t *testing.T, s *UtxoSweeper,
+	state SweepState) *input.MockInput {
+
+	inp := &input.MockInput{}
+	t.Cleanup(func() {
+		inp.AssertExpectations(t)
+	})
+
+	randBuf := make([]byte, lntypes.HashSize)
+	_, err := rand.Read(randBuf)
+	require.NoError(t, err, "internal error, cannot generate random bytes")
+
+	randHash, err := chainhash.NewHash(randBuf)
+	require.NoError(t, err)
+
+	inp.On("OutPoint").Return(wire.OutPoint{
+		Hash:  *randHash,
+		Index: 0,
+	})
+
+	// We don't do branch switches based on the witness type here so we
+	// just mock it.
+	inp.On("WitnessType").Return(input.CommitmentTimeLock).Maybe()
+
+	s.inputs[inp.OutPoint()] = &SweeperInput{
+		Input: inp,
+		state: state,
+	}
+
+	return inp
+}
+
 // TestMarkInputsPendingPublish checks that given a list of inputs with
 // different states, only the non-terminal state will be marked as `Published`.
 func TestMarkInputsPendingPublish(t *testing.T) {
@@ -47,50 +84,21 @@ func TestMarkInputsPendingPublish(t *testing.T) {
 	set := &MockInputSet{}
 	defer set.AssertExpectations(t)
 
-	// Create three testing inputs.
-	//
-	// inputNotExist specifies an input that's not found in the sweeper's
-	// `pendingInputs` map.
-	inputNotExist := &input.MockInput{}
-	defer inputNotExist.AssertExpectations(t)
-
-	inputNotExist.On("OutPoint").Return(wire.OutPoint{Index: 0})
-
-	// inputInit specifies a newly created input.
-	inputInit := &input.MockInput{}
-	defer inputInit.AssertExpectations(t)
-
-	inputInit.On("OutPoint").Return(wire.OutPoint{Index: 1})
-
-	s.inputs[inputInit.OutPoint()] = &SweeperInput{
-		state: Init,
-	}
-
-	// inputPendingPublish specifies an input that's about to be published.
-	inputPendingPublish := &input.MockInput{}
-	defer inputPendingPublish.AssertExpectations(t)
-
-	inputPendingPublish.On("OutPoint").Return(wire.OutPoint{Index: 2})
-
-	s.inputs[inputPendingPublish.OutPoint()] = &SweeperInput{
-		state: PendingPublish,
-	}
-
-	// inputTerminated specifies an input that's terminated.
-	inputTerminated := &input.MockInput{}
-	defer inputTerminated.AssertExpectations(t)
-
-	inputTerminated.On("OutPoint").Return(wire.OutPoint{Index: 3})
-
-	s.inputs[inputTerminated.OutPoint()] = &SweeperInput{
-		state: Excluded,
-	}
+	// Create three inputs with different states.
+	// - inputInit specifies a newly created input.
+	// - inputPendingPublish specifies an input about to be published.
+	// - inputTerminated specifies an input that's terminated.
+	var (
+		inputInit           = createMockInput(t, s, Init)
+		inputPendingPublish = createMockInput(t, s, PendingPublish)
+		inputTerminated     = createMockInput(t, s, Excluded)
+	)
 
 	// Mark the test inputs. We expect the non-exist input and the
 	// inputTerminated to be skipped, and the rest to be marked as pending
 	// publish.
 	set.On("Inputs").Return([]input.Input{
-		inputNotExist, inputInit, inputPendingPublish, inputTerminated,
+		inputInit, inputPendingPublish, inputTerminated,
 	})
 	s.markInputsPendingPublish(set)
 
@@ -122,36 +130,22 @@ func TestMarkInputsPublished(t *testing.T) {
 	dummyTR := &TxRecord{}
 	dummyErr := errors.New("dummy error")
 
+	// Create a mock input set.
+	set := &MockInputSet{}
+	defer set.AssertExpectations(t)
+
 	// Create a test sweeper.
 	s := New(&UtxoSweeperConfig{
 		Store: mockStore,
 	})
 
-	// Create three testing inputs.
-	//
-	// inputNotExist specifies an input that's not found in the sweeper's
-	// `inputs` map.
-	inputNotExist := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 1},
-	}
-
-	// inputInit specifies a newly created input. When marking this as
-	// published, we should see an error log as this input hasn't been
-	// published yet.
-	inputInit := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 2},
-	}
-	s.inputs[inputInit.PreviousOutPoint] = &SweeperInput{
-		state: Init,
-	}
-
-	// inputPendingPublish specifies an input that's about to be published.
-	inputPendingPublish := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 3},
-	}
-	s.inputs[inputPendingPublish.PreviousOutPoint] = &SweeperInput{
-		state: PendingPublish,
-	}
+	// Create two inputs with different states.
+	// - inputInit specifies a newly created input.
+	// - inputPendingPublish specifies an input about to be published.
+	var (
+		inputInit           = createMockInput(t, s, Init)
+		inputPendingPublish = createMockInput(t, s, PendingPublish)
+	)
 
 	// First, check that when an error is returned from db, it's properly
 	// returned here.
@@ -171,9 +165,9 @@ func TestMarkInputsPublished(t *testing.T) {
 	// Mark the test inputs. We expect the non-exist input and the
 	// inputInit to be skipped, and the final input to be marked as
 	// published.
-	err = s.markInputsPublished(dummyTR, []*wire.TxIn{
-		inputNotExist, inputInit, inputPendingPublish,
-	})
+	set.On("Inputs").Return([]input.Input{inputInit, inputPendingPublish})
+
+	err = s.markInputsPublished(dummyTR, set)
 	require.NoError(err)
 
 	// We expect unchanged number of pending inputs.
@@ -181,11 +175,11 @@ func TestMarkInputsPublished(t *testing.T) {
 
 	// We expect the init input's state to stay unchanged.
 	require.Equal(Init,
-		s.inputs[inputInit.PreviousOutPoint].state)
+		s.inputs[inputInit.OutPoint()].state)
 
 	// We expect the pending-publish input's is now marked as published.
 	require.Equal(Published,
-		s.inputs[inputPendingPublish.PreviousOutPoint].state)
+		s.inputs[inputPendingPublish.OutPoint()].state)
 
 	// Assert mocked statements are executed as expected.
 	mockStore.AssertExpectations(t)
@@ -202,117 +196,75 @@ func TestMarkInputsPublishFailed(t *testing.T) {
 	// Create a mock sweeper store.
 	mockStore := NewMockSweeperStore()
 
+	// Create a mock input set.
+	set := &MockInputSet{}
+	defer set.AssertExpectations(t)
+
 	// Create a test sweeper.
 	s := New(&UtxoSweeperConfig{
 		Store: mockStore,
 	})
 
-	// Create testing inputs for each state.
-	//
-	// inputNotExist specifies an input that's not found in the sweeper's
-	// `inputs` map.
-	inputNotExist := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 1},
-	}
+	// Create inputs with different states.
+	// - inputInit specifies a newly created input. When marking this as
+	//   published, we should see an error log as this input hasn't been
+	//   published yet.
+	// - inputPendingPublish specifies an input about to be published.
+	// - inputPublished specifies an input that's published.
+	// - inputPublishFailed specifies an input that's failed to be
+	//   published.
+	// - inputSwept specifies an input that's swept.
+	// - inputExcluded specifies an input that's excluded.
+	// - inputFailed specifies an input that's failed.
+	var (
+		inputInit           = createMockInput(t, s, Init)
+		inputPendingPublish = createMockInput(t, s, PendingPublish)
+		inputPublished      = createMockInput(t, s, Published)
+		inputPublishFailed  = createMockInput(t, s, PublishFailed)
+		inputSwept          = createMockInput(t, s, Swept)
+		inputExcluded       = createMockInput(t, s, Excluded)
+		inputFailed         = createMockInput(t, s, Failed)
+	)
 
-	// inputInit specifies a newly created input. When marking this as
-	// published, we should see an error log as this input hasn't been
-	// published yet.
-	inputInit := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 2},
-	}
-	s.inputs[inputInit.PreviousOutPoint] = &SweeperInput{
-		state: Init,
-	}
-
-	// inputPendingPublish specifies an input that's about to be published.
-	inputPendingPublish := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 3},
-	}
-	s.inputs[inputPendingPublish.PreviousOutPoint] = &SweeperInput{
-		state: PendingPublish,
-	}
-
-	// inputPublished specifies an input that's published.
-	inputPublished := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 4},
-	}
-	s.inputs[inputPublished.PreviousOutPoint] = &SweeperInput{
-		state: Published,
-	}
-
-	// inputPublishFailed specifies an input that's failed to be published.
-	inputPublishFailed := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 5},
-	}
-	s.inputs[inputPublishFailed.PreviousOutPoint] = &SweeperInput{
-		state: PublishFailed,
-	}
-
-	// inputSwept specifies an input that's swept.
-	inputSwept := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 6},
-	}
-	s.inputs[inputSwept.PreviousOutPoint] = &SweeperInput{
-		state: Swept,
-	}
-
-	// inputExcluded specifies an input that's excluded.
-	inputExcluded := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 7},
-	}
-	s.inputs[inputExcluded.PreviousOutPoint] = &SweeperInput{
-		state: Excluded,
-	}
-
-	// inputFailed specifies an input that's failed.
-	inputFailed := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 8},
-	}
-	s.inputs[inputFailed.PreviousOutPoint] = &SweeperInput{
-		state: Failed,
-	}
-
-	// Gather all inputs' outpoints.
-	pendingOps := make([]wire.OutPoint, 0, len(s.inputs)+1)
-	for op := range s.inputs {
-		pendingOps = append(pendingOps, op)
-	}
-	pendingOps = append(pendingOps, inputNotExist.PreviousOutPoint)
+	// Gather all inputs.
+	set.On("Inputs").Return([]input.Input{
+		inputInit, inputPendingPublish, inputPublished,
+		inputPublishFailed, inputSwept, inputExcluded, inputFailed,
+	})
 
 	// Mark the test inputs. We expect the non-exist input and the
 	// inputInit to be skipped, and the final input to be marked as
 	// published.
-	s.markInputsPublishFailed(pendingOps)
+	s.markInputsPublishFailed(set)
 
 	// We expect unchanged number of pending inputs.
 	require.Len(s.inputs, 7)
 
 	// We expect the init input's state to stay unchanged.
 	require.Equal(Init,
-		s.inputs[inputInit.PreviousOutPoint].state)
+		s.inputs[inputInit.OutPoint()].state)
 
 	// We expect the pending-publish input's is now marked as publish
 	// failed.
 	require.Equal(PublishFailed,
-		s.inputs[inputPendingPublish.PreviousOutPoint].state)
+		s.inputs[inputPendingPublish.OutPoint()].state)
 
 	// We expect the published input's is now marked as publish failed.
 	require.Equal(PublishFailed,
-		s.inputs[inputPublished.PreviousOutPoint].state)
+		s.inputs[inputPublished.OutPoint()].state)
 
 	// We expect the publish failed input to stay unchanged.
 	require.Equal(PublishFailed,
-		s.inputs[inputPublishFailed.PreviousOutPoint].state)
+		s.inputs[inputPublishFailed.OutPoint()].state)
 
 	// We expect the swept input to stay unchanged.
-	require.Equal(Swept, s.inputs[inputSwept.PreviousOutPoint].state)
+	require.Equal(Swept, s.inputs[inputSwept.OutPoint()].state)
 
 	// We expect the excluded input to stay unchanged.
-	require.Equal(Excluded, s.inputs[inputExcluded.PreviousOutPoint].state)
+	require.Equal(Excluded, s.inputs[inputExcluded.OutPoint()].state)
 
 	// We expect the failed input to stay unchanged.
-	require.Equal(Failed, s.inputs[inputFailed.PreviousOutPoint].state)
+	require.Equal(Failed, s.inputs[inputFailed.OutPoint()].state)
 
 	// Assert mocked statements are executed as expected.
 	mockStore.AssertExpectations(t)
@@ -738,33 +690,33 @@ func TestSweepPendingInputs(t *testing.T) {
 func TestHandleBumpEventTxFailed(t *testing.T) {
 	t.Parallel()
 
+	// Create a mock input set.
+	set := &MockInputSet{}
+	defer set.AssertExpectations(t)
+
 	// Create a test sweeper.
 	s := New(&UtxoSweeperConfig{})
 
-	var (
-		// Create four testing outpoints.
-		op1        = wire.OutPoint{Hash: chainhash.Hash{1}}
-		op2        = wire.OutPoint{Hash: chainhash.Hash{2}}
-		op3        = wire.OutPoint{Hash: chainhash.Hash{3}}
-		opNotExist = wire.OutPoint{Hash: chainhash.Hash{4}}
-	)
+	// inputNotExist specifies an input that's not found in the sweeper's
+	// `pendingInputs` map.
+	inputNotExist := &input.MockInput{}
+	defer inputNotExist.AssertExpectations(t)
+	inputNotExist.On("OutPoint").Return(wire.OutPoint{Index: 0})
+	opNotExist := inputNotExist.OutPoint()
 
 	// Create three mock inputs.
-	input1 := &input.MockInput{}
-	defer input1.AssertExpectations(t)
+	var (
+		input1 = createMockInput(t, s, PendingPublish)
+		input2 = createMockInput(t, s, PendingPublish)
+		input3 = createMockInput(t, s, PendingPublish)
+	)
 
-	input2 := &input.MockInput{}
-	defer input2.AssertExpectations(t)
-
-	input3 := &input.MockInput{}
-	defer input3.AssertExpectations(t)
+	op1 := input1.OutPoint()
+	op2 := input2.OutPoint()
+	op3 := input3.OutPoint()
 
 	// Construct the initial state for the sweeper.
-	s.inputs = InputsMap{
-		op1: &SweeperInput{Input: input1, state: PendingPublish},
-		op2: &SweeperInput{Input: input2, state: PendingPublish},
-		op3: &SweeperInput{Input: input3, state: PendingPublish},
-	}
+	set.On("Inputs").Return([]input.Input{input1, input2, input3})
 
 	// Create a testing tx that spends the first two inputs.
 	tx := &wire.MsgTx{
@@ -782,16 +734,26 @@ func TestHandleBumpEventTxFailed(t *testing.T) {
 		Err:   errDummy,
 	}
 
+	// Create a testing bump response.
+	resp := &bumpResp{
+		result: br,
+		set:    set,
+	}
+
 	// Call the method under test.
-	err := s.handleBumpEvent(br)
+	err := s.handleBumpEvent(resp)
 	require.ErrorIs(t, err, errDummy)
 
 	// Assert the states of the first two inputs are updated.
 	require.Equal(t, PublishFailed, s.inputs[op1].state)
 	require.Equal(t, PublishFailed, s.inputs[op2].state)
 
-	// Assert the state of the third input is not updated.
-	require.Equal(t, PendingPublish, s.inputs[op3].state)
+	// Assert the state of the third input.
+	//
+	// NOTE: Although the tx doesn't spend it, we still mark this input as
+	// failed as we are treating the input set as the single source of
+	// truth.
+	require.Equal(t, PublishFailed, s.inputs[op3].state)
 
 	// Assert the non-existing input is not added to the pending inputs.
 	require.NotContains(t, s.inputs, opNotExist)
@@ -810,23 +772,21 @@ func TestHandleBumpEventTxReplaced(t *testing.T) {
 	wallet := &MockWallet{}
 	defer wallet.AssertExpectations(t)
 
+	// Create a mock input set.
+	set := &MockInputSet{}
+	defer set.AssertExpectations(t)
+
 	// Create a test sweeper.
 	s := New(&UtxoSweeperConfig{
 		Store:  store,
 		Wallet: wallet,
 	})
 
-	// Create a testing outpoint.
-	op := wire.OutPoint{Hash: chainhash.Hash{1}}
-
 	// Create a mock input.
-	inp := &input.MockInput{}
-	defer inp.AssertExpectations(t)
+	inp := createMockInput(t, s, PendingPublish)
+	set.On("Inputs").Return([]input.Input{inp})
 
-	// Construct the initial state for the sweeper.
-	s.inputs = InputsMap{
-		op: &SweeperInput{Input: inp, state: PendingPublish},
-	}
+	op := inp.OutPoint()
 
 	// Create a testing tx that spends the input.
 	tx := &wire.MsgTx{
@@ -851,12 +811,18 @@ func TestHandleBumpEventTxReplaced(t *testing.T) {
 		Event:      TxReplaced,
 	}
 
+	// Create a testing bump response.
+	resp := &bumpResp{
+		result: br,
+		set:    set,
+	}
+
 	// Mock the store to return an error.
 	dummyErr := errors.New("dummy error")
 	store.On("GetTx", tx.TxHash()).Return(nil, dummyErr).Once()
 
 	// Call the method under test and assert the error is returned.
-	err := s.handleBumpEventTxReplaced(br)
+	err := s.handleBumpEventTxReplaced(resp)
 	require.ErrorIs(t, err, dummyErr)
 
 	// Mock the store to return the old tx record.
@@ -871,7 +837,7 @@ func TestHandleBumpEventTxReplaced(t *testing.T) {
 	store.On("DeleteTx", tx.TxHash()).Return(dummyErr).Once()
 
 	// Call the method under test and assert the error is returned.
-	err = s.handleBumpEventTxReplaced(br)
+	err = s.handleBumpEventTxReplaced(resp)
 	require.ErrorIs(t, err, dummyErr)
 
 	// Mock the store to return the old tx record and delete it without
@@ -891,7 +857,7 @@ func TestHandleBumpEventTxReplaced(t *testing.T) {
 	wallet.On("CancelRebroadcast", tx.TxHash()).Once()
 
 	// Call the method under test.
-	err = s.handleBumpEventTxReplaced(br)
+	err = s.handleBumpEventTxReplaced(resp)
 	require.NoError(t, err)
 
 	// Assert the state of the input is updated.
@@ -907,22 +873,20 @@ func TestHandleBumpEventTxPublished(t *testing.T) {
 	store := &MockSweeperStore{}
 	defer store.AssertExpectations(t)
 
+	// Create a mock input set.
+	set := &MockInputSet{}
+	defer set.AssertExpectations(t)
+
 	// Create a test sweeper.
 	s := New(&UtxoSweeperConfig{
 		Store: store,
 	})
 
-	// Create a testing outpoint.
-	op := wire.OutPoint{Hash: chainhash.Hash{1}}
-
 	// Create a mock input.
-	inp := &input.MockInput{}
-	defer inp.AssertExpectations(t)
+	inp := createMockInput(t, s, PendingPublish)
+	set.On("Inputs").Return([]input.Input{inp})
 
-	// Construct the initial state for the sweeper.
-	s.inputs = InputsMap{
-		op: &SweeperInput{Input: inp, state: PendingPublish},
-	}
+	op := inp.OutPoint()
 
 	// Create a testing tx that spends the input.
 	tx := &wire.MsgTx{
@@ -938,6 +902,12 @@ func TestHandleBumpEventTxPublished(t *testing.T) {
 		Event: TxPublished,
 	}
 
+	// Create a testing bump response.
+	resp := &bumpResp{
+		result: br,
+		set:    set,
+	}
+
 	// Mock the store to save the new tx record.
 	store.On("StoreTx", &TxRecord{
 		Txid:      tx.TxHash(),
@@ -945,7 +915,7 @@ func TestHandleBumpEventTxPublished(t *testing.T) {
 	}).Return(nil).Once()
 
 	// Call the method under test.
-	err := s.handleBumpEventTxPublished(br)
+	err := s.handleBumpEventTxPublished(resp)
 	require.NoError(t, err)
 
 	// Assert the state of the input is updated.
@@ -963,25 +933,21 @@ func TestMonitorFeeBumpResult(t *testing.T) {
 	wallet := &MockWallet{}
 	defer wallet.AssertExpectations(t)
 
+	// Create a mock input set.
+	set := &MockInputSet{}
+	defer set.AssertExpectations(t)
+
 	// Create a test sweeper.
 	s := New(&UtxoSweeperConfig{
 		Store:  store,
 		Wallet: wallet,
 	})
 
-	// Create a testing outpoint.
-	op := wire.OutPoint{Hash: chainhash.Hash{1}}
-
 	// Create a mock input.
-	inp := &input.MockInput{}
-	defer inp.AssertExpectations(t)
-
-	// Construct the initial state for the sweeper.
-	s.inputs = InputsMap{
-		op: &SweeperInput{Input: inp, state: PendingPublish},
-	}
+	inp := createMockInput(t, s, PendingPublish)
 
 	// Create a testing tx that spends the input.
+	op := inp.OutPoint()
 	tx := &wire.MsgTx{
 		LockTime: 1,
 		TxIn: []*wire.TxIn{
@@ -1060,7 +1026,8 @@ func TestMonitorFeeBumpResult(t *testing.T) {
 				return resultChan
 			},
 			shouldExit: false,
-		}, {
+		},
+		{
 			// When the sweeper is shutting down, the monitor loop
 			// should exit.
 			name: "exit on sweeper shutdown",
@@ -1087,7 +1054,7 @@ func TestMonitorFeeBumpResult(t *testing.T) {
 
 			s.wg.Add(1)
 			go func() {
-				s.monitorFeeBumpResult(resultChan)
+				s.monitorFeeBumpResult(set, resultChan)
 				close(done)
 			}()
 

--- a/sweep/tx_input_set.go
+++ b/sweep/tx_input_set.go
@@ -64,6 +64,13 @@ type InputSet interface {
 	// StartingFeeRate returns the max starting fee rate found in the
 	// inputs.
 	StartingFeeRate() fn.Option[chainfee.SatPerKWeight]
+
+	// Immediate returns a boolean to indicate whether the tx made from
+	// this input set should be published immediately.
+	//
+	// TODO(yy): create a new method `Params` to combine the informational
+	// methods DeadlineHeight, Budget, StartingFeeRate and Immediate.
+	Immediate() bool
 }
 
 // createWalletTxInput converts a wallet utxo into an object that can be added
@@ -411,4 +418,19 @@ func (b *BudgetInputSet) StartingFeeRate() fn.Option[chainfee.SatPerKWeight] {
 	}
 
 	return startingFeeRate
+}
+
+// Immediate returns whether the inputs should be swept immediately.
+//
+// NOTE: part of the InputSet interface.
+func (b *BudgetInputSet) Immediate() bool {
+	for _, inp := range b.inputs {
+		// As long as one of the inputs is immediate, the whole set is
+		// immediate.
+		if inp.params.Immediate {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
NOTE: itest is fixed in the final PR #9227.

Depends on
- #8892
- #9237
- #9221

This PR prepares the incoming blockbeat PRs, the changes are,
- `BlockEpoch` now has the block data instead of the block header. This block data is used in the incoming blockbeat PR to query spending transactions.
- Added a new sweeping state, `TxError`. Inputs resulting in this state will be removed from the sweeper.
- check input's CSV and CLTV in the sweeper, and skip sweeping them if not matured.
- When calculating the deadline, make sure it's derived from mature height, not current height.