### PR TITLE
Fix batchopen fee calculation

### DIFF
--- a/docs/release-notes/release-notes-0.18.3.md
+++ b/docs/release-notes/release-notes-0.18.3.md
@@ -32,6 +32,9 @@
 * [Avoids duplicate wallet addresses being
   created](https://github.com/lightningnetwork/lnd/pull/8921) when multiple RPC
   calls are made concurrently.
+  
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/8896) that caused
+  LND to use a default fee rate for the batch channel opening flow.
 
 # New Features
 ## Functional Enhancements
@@ -130,3 +133,4 @@
 * Oliver Gugger
 * Slyghtning
 * Yong Yu
+* Ziggie

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2158,29 +2158,23 @@ func (r *rpcServer) parseOpenChannelReq(in *lnrpc.OpenChannelRequest,
 		return nil, fmt.Errorf("cannot open channel to self")
 	}
 
-	var feeRate chainfee.SatPerKWeight
+	// NOTE: We also need to do the fee rate calculation for the psbt
+	// funding flow because the `batchfund` depends on it.
+	targetConf := maybeUseDefaultConf(
+		in.SatPerByte, in.SatPerVbyte, uint32(in.TargetConf),
+	)
 
-	// Skip estimating fee rate for PSBT funding.
-	if in.FundingShim == nil || in.FundingShim.GetPsbtShim() == nil {
-		// Keep the old behavior prior to 0.18.0 - when the user
-		// doesn't set fee rate or conf target, the default conf target
-		// of 6 is used.
-		targetConf := maybeUseDefaultConf(
-			in.SatPerByte, in.SatPerVbyte, uint32(in.TargetConf),
-		)
-
-		// Calculate an appropriate fee rate for this transaction.
-		feeRate, err = lnrpc.CalculateFeeRate(
-			uint64(in.SatPerByte), in.SatPerVbyte,
-			targetConf, r.server.cc.FeeEstimator,
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		rpcsLog.Debugf("[openchannel]: using fee of %v sat/kw for "+
-			"funding tx", int64(feeRate))
+	// Calculate an appropriate fee rate for this transaction.
+	feeRate, err := lnrpc.CalculateFeeRate(
+		uint64(in.SatPerByte), in.SatPerVbyte,
+		targetConf, r.server.cc.FeeEstimator,
+	)
+	if err != nil {
+		return nil, err
 	}
+
+	rpcsLog.Debugf("[openchannel]: using fee of %v sat/kw for "+
+		"funding tx", int64(feeRate))
 
 	script, err := chancloser.ParseUpfrontShutdownAddress(
 		in.CloseAddress, r.cfg.ActiveNetParams.Params,

--- a/server.go
+++ b/server.go
@@ -4578,16 +4578,15 @@ func (s *server) OpenChannel(
 		return req.Updates, req.Err
 	}
 
-	// If the fee rate wasn't specified, then we'll use a default
-	// confirmation target.
+	// If the fee rate wasn't specified at this point we fail the funding
+	// because of the missing fee rate information. The caller of the
+	// `OpenChannel` method needs to make sure that default values for the
+	// fee rate are set beforehand.
 	if req.FundingFeePerKw == 0 {
-		estimator := s.cc.FeeEstimator
-		feeRate, err := estimator.EstimateFeePerKW(6)
-		if err != nil {
-			req.Err <- err
-			return req.Updates, req.Err
-		}
-		req.FundingFeePerKw = feeRate
+		req.Err <- fmt.Errorf("no FundingFeePerKw specified for " +
+			"the channel opening transaction")
+
+		return req.Updates, req.Err
 	}
 
 	// Spawn a goroutine to send the funding workflow request to the funding


### PR DESCRIPTION
Simple fix, though the underlying design probably needs some refactor because even for the batchopen flow we don't really need to do the fee-calculation for every channel but rather for the whole request.

Fixes https://github.com/lightningnetwork/lnd/issues/8895

Will add release-notes as soon as we decided in which release this will be included.
