### PR TITLE
Makefile: add GOCC variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ ESCPKG := github.com\/lightningnetwork\/lnd
 MOBILE_PKG := $(PKG)/mobile
 TOOLS_DIR := tools
 
+GOCC ?= go
 PREFIX ?= /usr/local
 
 BTCD_PKG := github.com/btcsuite/btcd
@@ -24,7 +25,7 @@ ANDROID_BUILD := $(ANDROID_BUILD_DIR)/Lndmobile.aar
 COMMIT := $(shell git describe --tags --dirty)
 
 # Determine the minor version of the active Go installation.
-ACTIVE_GO_VERSION := $(shell go version | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p')
+ACTIVE_GO_VERSION := $(shell $(GOCC) version | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p')
 ACTIVE_GO_VERSION_MINOR := $(shell echo $(ACTIVE_GO_VERSION) | cut -d. -f2)
 
 LOOPVARFIX :=
@@ -37,9 +38,9 @@ endif
 # versions are checked against this version.
 GO_VERSION = 1.23.6
 
-GOBUILD := $(LOOPVARFIX) go build -v
-GOINSTALL := $(LOOPVARFIX) go install -v
-GOTEST := $(LOOPVARFIX) go test
+GOBUILD := $(LOOPVARFIX) $(GOCC) build -v
+GOINSTALL := $(LOOPVARFIX) $(GOCC) install -v
+GOTEST := $(LOOPVARFIX) $(GOCC) test
 
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -name "*pb.go" -not -name "*pb.gw.go" -not -name "*.pb.json.go")
 
@@ -73,8 +74,8 @@ endif
 
 DOCKER_TOOLS = docker run \
   --rm \
-  -v $(shell bash -c "go env GOCACHE || (mkdir -p /tmp/go-cache; echo /tmp/go-cache)"):/tmp/build/.cache \
-  -v $(shell bash -c "go env GOMODCACHE || (mkdir -p /tmp/go-modcache; echo /tmp/go-modcache)"):/tmp/build/.modcache \
+  -v $(shell bash -c "$(GOCC) env GOCACHE || (mkdir -p /tmp/go-cache; echo /tmp/go-cache)"):/tmp/build/.cache \
+  -v $(shell bash -c "$(GOCC) env GOMODCACHE || (mkdir -p /tmp/go-modcache; echo /tmp/go-modcache)"):/tmp/build/.modcache \
   -v $(shell bash -c "mkdir -p /tmp/go-lint-cache; echo /tmp/go-lint-cache"):/root/.cache/golangci-lint \
   -v $$(pwd):/build lnd-tools
 
@@ -93,15 +94,15 @@ all: scratch check install
 # ============
 $(GOACC_BIN):
 	@$(call print, "Installing go-acc.")
-	cd $(TOOLS_DIR); go install -trimpath -tags=tools $(GOACC_PKG)
+	cd $(TOOLS_DIR); $(GOCC) install -trimpath -tags=tools $(GOACC_PKG)
 
 $(BTCD_BIN):
 	@$(call print, "Installing btcd.")
-	cd $(TOOLS_DIR); go install -trimpath $(BTCD_PKG)
+	cd $(TOOLS_DIR); $(GOCC) install -trimpath $(BTCD_PKG)
 
 $(GOIMPORTS_BIN):
 	@$(call print, "Installing goimports.")
-	cd $(TOOLS_DIR); go install -trimpath $(GOIMPORTS_PKG)
+	cd $(TOOLS_DIR); $(GOCC) install -trimpath $(GOIMPORTS_PKG)
 
 # ============
 # INSTALLATION
@@ -407,7 +408,7 @@ mobile-rpc:
 #? vendor: Create a vendor directory with all dependencies
 vendor:
 	@$(call print, "Re-creating vendor directory.")
-	rm -r vendor/; go mod vendor
+	rm -r vendor/; $(GOCC) mod vendor
 
 #? apple: Build mobile RPC stubs and project template for iOS and macOS
 apple: mobile-rpc

--- a/make/release_flags.mk
+++ b/make/release_flags.mk
@@ -6,8 +6,8 @@ DOCKER_RELEASE_HELPER = docker run \
   --rm \
   --user $(shell id -u):$(shell id -g) \
   -v $(shell pwd):/tmp/build/lnd \
-  -v $(shell bash -c "go env GOCACHE || (mkdir -p /tmp/go-cache; echo /tmp/go-cache)"):/tmp/build/.cache \
-  -v $(shell bash -c "go env GOMODCACHE || (mkdir -p /tmp/go-modcache; echo /tmp/go-modcache)"):/tmp/build/.modcache \
+  -v $(shell bash -c "$(GOCC) env GOCACHE || (mkdir -p /tmp/go-cache; echo /tmp/go-cache)"):/tmp/build/.cache \
+  -v $(shell bash -c "$(GOCC) env GOMODCACHE || (mkdir -p /tmp/go-modcache; echo /tmp/go-modcache)"):/tmp/build/.modcache \
   -e SKIP_VERSION_CHECK \
   lnd-release-helper
 

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -6,7 +6,7 @@ ITEST_FLAGS =
 ITEST_COVERAGE =
 COLLECT_ITEST_COVERAGE =
 EXEC_SUFFIX =
-COVER_PKG = $$(go list -deps -tags="$(DEV_TAGS)" ./... | grep '$(PKG)' | grep -v lnrpc)
+COVER_PKG = $$($(GOCC) list -deps -tags="$(DEV_TAGS)" ./... | grep '$(PKG)' | grep -v lnrpc)
 NUM_ITEST_TRANCHES = 4
 ITEST_PARALLELISM = $(NUM_ITEST_TRANCHES)
 POSTGRES_START_DELAY = 5
@@ -88,7 +88,7 @@ endif
 # Enable integration test coverage (requires Go >= 1.20.0).
 ifneq ($(cover),)
 ITEST_COVERAGE = -cover
-COLLECT_ITEST_COVERAGE = go tool covdata textfmt -i=itest/cover -o coverage.txt
+COLLECT_ITEST_COVERAGE = $(GOCC) tool covdata textfmt -i=itest/cover -o coverage.txt
 endif
 
 # Define the log tags that will be applied only when running unit tests. If none
@@ -115,8 +115,8 @@ ifneq ($(nocache),)
 TEST_FLAGS += -test.count=1
 endif
 
-GOLIST := go list -tags="$(DEV_TAGS)" -deps $(PKG)/... | grep '$(PKG)'| grep -v '/vendor/'
-GOLISTCOVER := $(shell go list -tags="$(DEV_TAGS)" -deps -f '{{.ImportPath}}' ./... | grep '$(PKG)' | sed -e 's/^$(ESCPKG)/./')
+GOLIST := $(GOCC) list -tags="$(DEV_TAGS)" -deps $(PKG)/... | grep '$(PKG)'| grep -v '/vendor/'
+GOLISTCOVER := $(shell $(GOCC) list -tags="$(DEV_TAGS)" -deps -f '{{.ImportPath}}' ./... | grep '$(PKG)' | sed -e 's/^$(ESCPKG)/./')
 
 # UNIT_TARGTED is undefined iff a specific package and/or unit test case is
 # not being targeted.


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/6489.

Allows me to build with a different Golang version than is currently in `$PATH`:

```
make install GOCC=/usr/lib/go-1.21.9/bin/go GOROOT=/usr/lib/go-1.21.9
```

Depending on the setup, the `GOROOT=...` argument also needs to be specified to avoid an error like `compile: version "go1.21.0" does not match go tool version "go1.21.9"`.
