### PR TITLE
Beat [3/4]: Implement `Consumer` on `chainWatcher` and resolvers

### DIFF
--- a/chainio/blockbeat.go
+++ b/chainio/blockbeat.go
@@ -1,9 +1,12 @@
 package chainio
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/chainntnfs"
@@ -158,4 +161,123 @@ func (b Beat) notifyAndWait(c Consumer) error {
 		time.Since(start))
 
 	return nil
+}
+
+// HasOutpointSpent queries the block to find a spending tx that spends the
+// given outpoint. Returns the spend details if found, otherwise nil.
+//
+// NOTE: Part of the Blockbeat interface.
+func (b Beat) HasOutpointSpent(outpoint wire.OutPoint) *chainntnfs.SpendDetail {
+	b.log.Tracef("Querying spending tx for outpoint=%v", outpoint)
+
+	// Iterate all the txns in this block.
+	for _, tx := range b.epoch.Block.Transactions {
+		txHash := tx.TxHash()
+
+		// Iterate all the inputs in this tx.
+		for i, txIn := range tx.TxIn {
+			// Skip if the input doesn't spend the outpoint.
+			if txIn.PreviousOutPoint != outpoint {
+				continue
+			}
+
+			// Found a match, return the spend details.
+			details := &chainntnfs.SpendDetail{
+				SpentOutPoint:     &outpoint,
+				SpenderTxHash:     &txHash,
+				SpendingTx:        tx,
+				SpenderInputIndex: uint32(i),
+				SpendingHeight:    b.epoch.Height,
+			}
+
+			return details
+		}
+	}
+
+	return nil
+}
+
+// ErrPkScriptMismatch is returned when the expected pkScript doesn't match the
+// actual pkScript.
+var ErrPkScriptMismatch = errors.New("pkscript mismatch")
+
+// HasOutpointSpentByScript queries the block to find a spending tx that spends
+// the given outpoint using the pkScript.
+//
+// NOTE: Part of the Blockbeat interface.
+func (b Beat) HasOutpointSpentByScript(outpoint wire.OutPoint,
+	pkScript txscript.PkScript) (*chainntnfs.SpendDetail, error) {
+
+	b.log.Tracef("Querying spending tx for outpoint=%v, pkScript=%v",
+		outpoint, pkScript)
+
+	// For taproot outputs, we will skip matching the pkScript as we cannot
+	// derive the spent pkScript directly from the witness.
+	isTaproot := pkScript.Class() == txscript.WitnessV1TaprootTy
+
+	// matchTxIn is a helper closure that checks if the txIn spends the
+	// given outpoint using the specified pkScript. Returns an error if the
+	// outpoint is found but the pkScript doesn't match.
+	matchTxIn := func(txIn *wire.TxIn) (bool, error) {
+		prevOut := txIn.PreviousOutPoint
+
+		// Exit early if the input doesn't spend the outpoint.
+		if prevOut != outpoint {
+			return false, nil
+		}
+
+		// If this is a taproot output, we skip matching the pkScript.
+		if isTaproot {
+			return true, nil
+		}
+
+		// Compute the script and matches it with the pkScript.
+		script, err := txscript.ComputePkScript(
+			txIn.SignatureScript, txIn.Witness,
+		)
+		if err != nil {
+			b.log.Errorf("Failed to compute pkscript: %v", err)
+			return false, err
+		}
+
+		// Check if the scripts match.
+		if script != pkScript {
+			return false, fmt.Errorf("%w: want %v, got %v",
+				ErrPkScriptMismatch, pkScript, script)
+		}
+
+		return true, nil
+	}
+
+	// Iterate all the txns in this block.
+	for _, tx := range b.epoch.Block.Transactions {
+		txHash := tx.TxHash()
+
+		// Iterate all the inputs in this tx.
+		for i, txIn := range tx.TxIn {
+			// Check if the input spends the outpoint.
+			found, err := matchTxIn(txIn)
+			if err != nil {
+				return nil, err
+			}
+
+			// Skip if the input cannot be matched.
+			if !found {
+				continue
+			}
+
+			// Found a match, return the spend details.
+			details := &chainntnfs.SpendDetail{
+				SpentOutPoint:     &outpoint,
+				SpenderTxHash:     &txHash,
+				SpendingTx:        tx,
+				SpenderInputIndex: uint32(i),
+				SpendingHeight:    b.epoch.Height,
+			}
+
+			return details, nil
+		}
+	}
+
+	return nil, nil
 }

--- a/chainio/interface.go
+++ b/chainio/interface.go
@@ -1,5 +1,11 @@
 package chainio
 
+import (
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/chainntnfs"
+)
+
 // Blockbeat defines an interface that can be used by subsystems to retrieve
 // block data. It is sent by the BlockbeatDispatcher whenever a new block is
 // received. Once the subsystem finishes processing the block, it must signal
@@ -32,6 +38,17 @@ type Blockbeat interface {
 	// DispatchConcurrent sends the blockbeat to the specified consumers
 	// sequentially.
 	DispatchSequential(consumers []Consumer) error
+
+	// HasOutpointSpentByScript queries the block to find a spending tx
+	// that spends the given outpoint using the pkScript. Return an error
+	// is the outpoint is spent but using a different pkScript.
+	HasOutpointSpentByScript(outpoint wire.OutPoint,
+		pkScript txscript.PkScript) (*chainntnfs.SpendDetail, error)
+
+	// HasOutpointSpent queries the block to find a spending tx that spends
+	// the given outpoint. Returns the spend details if found, otherwise
+	// nil.
+	HasOutpointSpent(outpoint wire.OutPoint) *chainntnfs.SpendDetail
 }
 
 // Consumer defines a blockbeat consumer interface. Subsystems that need block

--- a/chainio/mocks.go
+++ b/chainio/mocks.go
@@ -1,0 +1,70 @@
+package chainio
+
+import (
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockBeat is a mock implementation of the Beat interface.
+type MockBeat struct {
+	mock.Mock
+}
+
+// Compile-time check to ensure MockBeat satisfies the Blockbeat interface.
+var _ Blockbeat = (*MockBeat)(nil)
+
+// Height returns the height of the block epoch.
+func (m *MockBeat) Height() int32 {
+	args := m.Called()
+
+	return args.Get(0).(int32)
+}
+
+func (m *MockBeat) NotifyBlockProcessed(err error, quitChan chan struct{}) {
+	m.Called(err, quitChan)
+}
+
+// DispatchSequential takes a list of consumers and notify them about the new
+// epoch sequentially.
+func (m *MockBeat) DispatchSequential(consumers []Consumer) error {
+	args := m.Called(consumers)
+
+	return args.Error(0)
+}
+
+// DispatchConcurrent notifies each consumer concurrently about the blockbeat.
+func (m *MockBeat) DispatchConcurrent(consumers []Consumer) error {
+	args := m.Called(consumers)
+
+	return args.Error(0)
+}
+
+// HasOutpointSpentByScript queries the block to find a spending tx that spends
+// the given outpoint using the pkScript.
+func (m *MockBeat) HasOutpointSpentByScript(outpoint wire.OutPoint,
+	pkScript txscript.PkScript) (*chainntnfs.SpendDetail, error) {
+
+	args := m.Called(outpoint, pkScript)
+
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*chainntnfs.SpendDetail), args.Error(1)
+}
+
+// HasOutpointSpent queries the block to find a spending tx that spends the
+// given outpoint. Returns the spend details if found, otherwise nil.
+func (m *MockBeat) HasOutpointSpent(
+	outpoint wire.OutPoint) *chainntnfs.SpendDetail {
+
+	args := m.Called(outpoint)
+
+	if args.Get(0) == nil {
+		return nil
+	}
+
+	return args.Get(0).(*chainntnfs.SpendDetail)
+}

--- a/chanrestore.go
+++ b/chanrestore.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/chanbackup"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/contractcourt"
@@ -279,6 +280,9 @@ func (c *chanDBRestorer) RestoreChansFromSingles(backups ...chanbackup.Single) e
 
 	ltndLog.Infof("Informing chain watchers of new restored channels")
 
+	// Create a slice of channel points.
+	chanPoints := make([]wire.OutPoint, 0, len(channelShells))
+
 	// Finally, we'll need to inform the chain arbitrator of these new
 	// channels so we'll properly watch for their ultimate closure on chain
 	// and sweep them via the DLP.
@@ -287,7 +291,14 @@ func (c *chanDBRestorer) RestoreChansFromSingles(backups ...chanbackup.Single) e
 		if err != nil {
 			return err
 		}
+
+		chanPoints = append(
+			chanPoints, restoredChannel.Chan.FundingOutpoint,
+		)
 	}
+
+	// With all the channels restored, we'll now re-send the blockbeat.
+	c.chainArb.RedispatchBlockbeat(chanPoints)
 
 	return nil
 }
@@ -307,7 +318,7 @@ func (s *server) ConnectPeer(nodePub *btcec.PublicKey, addrs []net.Addr) error {
 	// to ensure the new connection is created after this new link/channel
 	// is known.
 	if err := s.DisconnectPeer(nodePub); err != nil {
-		ltndLog.Infof("Peer(%v) is already connected, proceeding "+
+		ltndLog.Infof("Peer(%x) is already connected, proceeding "+
 			"with chan restore", nodePub.SerializeCompressed())
 	}
 

--- a/contractcourt/anchor_resolver.go
+++ b/contractcourt/anchor_resolver.go
@@ -176,13 +176,13 @@ var _ ContractResolver = (*anchorResolver)(nil)
 
 // Launch offers the anchor output to the sweeper.
 func (c *anchorResolver) Launch() error {
-	if c.launched {
+	if c.launched.Load() {
 		c.log.Tracef("already launched")
 		return nil
 	}
 
 	c.log.Debugf("launching resolver...")
-	c.launched = true
+	c.launched.Store(true)
 
 	// If we're already resolved, then we can exit early.
 	if c.IsResolved() {

--- a/contractcourt/anchor_resolver.go
+++ b/contractcourt/anchor_resolver.go
@@ -2,6 +2,7 @@ package contractcourt
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"sync"
 
@@ -71,7 +72,7 @@ func newAnchorResolver(anchorSignDescriptor input.SignDescriptor,
 		currentReport:        report,
 	}
 
-	r.initLogger(r)
+	r.initLogger(fmt.Sprintf("%T(%v)", r, r.anchor))
 
 	return r
 }

--- a/contractcourt/anchor_resolver.go
+++ b/contractcourt/anchor_resolver.go
@@ -84,8 +84,123 @@ func (c *anchorResolver) ResolverKey() []byte {
 	return nil
 }
 
-// Resolve offers the anchor output to the sweeper and waits for it to be swept.
+// Resolve waits for the output to be swept.
 func (c *anchorResolver) Resolve() (ContractResolver, error) {
+	// If we're already resolved, then we can exit early.
+	if c.resolved {
+		c.log.Errorf("already resolved")
+		return nil, nil
+	}
+
+	var (
+		outcome channeldb.ResolverOutcome
+		spendTx *chainhash.Hash
+	)
+
+	select {
+	case sweepRes := <-c.sweepResultChan:
+		switch sweepRes.Err {
+		// Anchor was swept successfully.
+		case nil:
+			sweepTxID := sweepRes.Tx.TxHash()
+
+			spendTx = &sweepTxID
+			outcome = channeldb.ResolverOutcomeClaimed
+
+		// Anchor was swept by someone else. This is possible after the
+		// 16 block csv lock.
+		case sweep.ErrRemoteSpend:
+			c.log.Warnf("our anchor spent by someone else")
+			outcome = channeldb.ResolverOutcomeUnclaimed
+
+		// An unexpected error occurred.
+		default:
+			c.log.Errorf("unable to sweep anchor: %v", sweepRes.Err)
+
+			return nil, sweepRes.Err
+		}
+
+	case <-c.quit:
+		return nil, errResolverShuttingDown
+	}
+
+	c.log.Infof("resolved in tx %v", spendTx)
+
+	// Update report to reflect that funds are no longer in limbo.
+	c.reportLock.Lock()
+	if outcome == channeldb.ResolverOutcomeClaimed {
+		c.currentReport.RecoveredBalance = c.currentReport.LimboBalance
+	}
+	c.currentReport.LimboBalance = 0
+	report := c.currentReport.resolverReport(
+		spendTx, channeldb.ResolverTypeAnchor, outcome,
+	)
+	c.reportLock.Unlock()
+
+	c.resolved = true
+	return nil, c.PutResolverReport(nil, report)
+}
+
+// Stop signals the resolver to cancel any current resolution processes, and
+// suspend.
+//
+// NOTE: Part of the ContractResolver interface.
+func (c *anchorResolver) Stop() {
+	c.log.Debugf("stopping...")
+	defer c.log.Debugf("stopped")
+
+	close(c.quit)
+}
+
+// IsResolved returns true if the stored state in the resolve is fully
+// resolved. In this case the target output can be forgotten.
+//
+// NOTE: Part of the ContractResolver interface.
+func (c *anchorResolver) IsResolved() bool {
+	return c.resolved
+}
+
+// SupplementState allows the user of a ContractResolver to supplement it with
+// state required for the proper resolution of a contract.
+//
+// NOTE: Part of the ContractResolver interface.
+func (c *anchorResolver) SupplementState(state *channeldb.OpenChannel) {
+	c.chanType = state.ChanType
+}
+
+// report returns a report on the resolution state of the contract.
+func (c *anchorResolver) report() *ContractReport {
+	c.reportLock.Lock()
+	defer c.reportLock.Unlock()
+
+	reportCopy := c.currentReport
+	return &reportCopy
+}
+
+func (c *anchorResolver) Encode(w io.Writer) error {
+	return errors.New("serialization not supported")
+}
+
+// A compile time assertion to ensure anchorResolver meets the
+// ContractResolver interface.
+var _ ContractResolver = (*anchorResolver)(nil)
+
+// Launch offers the anchor output to the sweeper.
+func (c *anchorResolver) Launch() error {
+	if c.launched {
+		c.log.Tracef("already launched")
+		return nil
+	}
+
+	c.log.Debugf("launching resolver...")
+	c.launched = true
+
+	// If we're already resolved, then we can exit early.
+	if c.resolved {
+		c.log.Errorf("already resolved")
+		return nil
+	}
+
 	// Attempt to update the sweep parameters to the post-confirmation
 	// situation. We don't want to force sweep anymore, because the anchor
 	// lost its special purpose to get the commitment confirmed. It is just
@@ -125,94 +240,12 @@ func (c *anchorResolver) Resolve() (ContractResolver, error) {
 			DeadlineHeight: fn.None[int32](),
 		},
 	)
+
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	var (
-		outcome channeldb.ResolverOutcome
-		spendTx *chainhash.Hash
-	)
+	c.sweepResultChan = resultChan
 
-	select {
-	case sweepRes := <-resultChan:
-		switch sweepRes.Err {
-		// Anchor was swept successfully.
-		case nil:
-			sweepTxID := sweepRes.Tx.TxHash()
-
-			spendTx = &sweepTxID
-			outcome = channeldb.ResolverOutcomeClaimed
-
-		// Anchor was swept by someone else. This is possible after the
-		// 16 block csv lock.
-		case sweep.ErrRemoteSpend:
-			c.log.Warnf("our anchor spent by someone else")
-			outcome = channeldb.ResolverOutcomeUnclaimed
-
-		// An unexpected error occurred.
-		default:
-			c.log.Errorf("unable to sweep anchor: %v", sweepRes.Err)
-
-			return nil, sweepRes.Err
-		}
-
-	case <-c.quit:
-		return nil, errResolverShuttingDown
-	}
-
-	// Update report to reflect that funds are no longer in limbo.
-	c.reportLock.Lock()
-	if outcome == channeldb.ResolverOutcomeClaimed {
-		c.currentReport.RecoveredBalance = c.currentReport.LimboBalance
-	}
-	c.currentReport.LimboBalance = 0
-	report := c.currentReport.resolverReport(
-		spendTx, channeldb.ResolverTypeAnchor, outcome,
-	)
-	c.reportLock.Unlock()
-
-	c.resolved = true
-	return nil, c.PutResolverReport(nil, report)
+	return nil
 }
-
-// Stop signals the resolver to cancel any current resolution processes, and
-// suspend.
-//
-// NOTE: Part of the ContractResolver interface.
-func (c *anchorResolver) Stop() {
-	close(c.quit)
-}
-
-// IsResolved returns true if the stored state in the resolve is fully
-// resolved. In this case the target output can be forgotten.
-//
-// NOTE: Part of the ContractResolver interface.
-func (c *anchorResolver) IsResolved() bool {
-	return c.resolved
-}
-
-// SupplementState allows the user of a ContractResolver to supplement it with
-// state required for the proper resolution of a contract.
-//
-// NOTE: Part of the ContractResolver interface.
-func (c *anchorResolver) SupplementState(state *channeldb.OpenChannel) {
-	c.chanType = state.ChanType
-}
-
-// report returns a report on the resolution state of the contract.
-func (c *anchorResolver) report() *ContractReport {
-	c.reportLock.Lock()
-	defer c.reportLock.Unlock()
-
-	reportCopy := c.currentReport
-	return &reportCopy
-}
-
-func (c *anchorResolver) Encode(w io.Writer) error {
-	return errors.New("serialization not supported")
-}
-
-// A compile time assertion to ensure anchorResolver meets the
-// ContractResolver interface.
-var _ ContractResolver = (*anchorResolver)(nil)

--- a/contractcourt/anchor_resolver.go
+++ b/contractcourt/anchor_resolver.go
@@ -24,9 +24,6 @@ type anchorResolver struct {
 	// anchor is the outpoint on the commitment transaction.
 	anchor wire.OutPoint
 
-	// resolved reflects if the contract has been fully resolved or not.
-	resolved bool
-
 	// broadcastHeight is the height that the original contract was
 	// broadcast to the main-chain at. We'll use this value to bound any
 	// historical queries to the chain for spends/confirmations.
@@ -87,7 +84,7 @@ func (c *anchorResolver) ResolverKey() []byte {
 // Resolve waits for the output to be swept.
 func (c *anchorResolver) Resolve() (ContractResolver, error) {
 	// If we're already resolved, then we can exit early.
-	if c.resolved {
+	if c.IsResolved() {
 		c.log.Errorf("already resolved")
 		return nil, nil
 	}
@@ -137,7 +134,7 @@ func (c *anchorResolver) Resolve() (ContractResolver, error) {
 	)
 	c.reportLock.Unlock()
 
-	c.resolved = true
+	c.resolved.Store(true)
 	return nil, c.PutResolverReport(nil, report)
 }
 
@@ -150,14 +147,6 @@ func (c *anchorResolver) Stop() {
 	defer c.log.Debugf("stopped")
 
 	close(c.quit)
-}
-
-// IsResolved returns true if the stored state in the resolve is fully
-// resolved. In this case the target output can be forgotten.
-//
-// NOTE: Part of the ContractResolver interface.
-func (c *anchorResolver) IsResolved() bool {
-	return c.resolved
 }
 
 // SupplementState allows the user of a ContractResolver to supplement it with
@@ -196,7 +185,7 @@ func (c *anchorResolver) Launch() error {
 	c.launched = true
 
 	// If we're already resolved, then we can exit early.
-	if c.resolved {
+	if c.IsResolved() {
 		c.log.Errorf("already resolved")
 		return nil
 	}

--- a/contractcourt/breach_resolver.go
+++ b/contractcourt/breach_resolver.go
@@ -83,6 +83,7 @@ func (b *breachResolver) Resolve() (ContractResolver, error) {
 
 // Stop signals the breachResolver to stop.
 func (b *breachResolver) Stop() {
+	b.log.Debugf("stopping...")
 	close(b.quit)
 }
 
@@ -123,3 +124,16 @@ func newBreachResolverFromReader(r io.Reader, resCfg ResolverConfig) (
 // A compile time assertion to ensure breachResolver meets the ContractResolver
 // interface.
 var _ ContractResolver = (*breachResolver)(nil)
+
+// TODO(yy): implement it once the outputs are offered to the sweeper.
+func (b *breachResolver) Launch() error {
+	if b.launched {
+		b.log.Tracef("already launched")
+		return nil
+	}
+
+	b.log.Debugf("launching resolver...")
+	b.launched = true
+
+	return nil
+}

--- a/contractcourt/breach_resolver.go
+++ b/contractcourt/breach_resolver.go
@@ -2,6 +2,7 @@ package contractcourt
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 
 	"github.com/lightningnetwork/lnd/channeldb"
@@ -32,7 +33,7 @@ func newBreachResolver(resCfg ResolverConfig) *breachResolver {
 		replyChan:           make(chan struct{}),
 	}
 
-	r.initLogger(r)
+	r.initLogger(fmt.Sprintf("%T(%v)", r, r.ChanPoint))
 
 	return r
 }
@@ -114,7 +115,7 @@ func newBreachResolverFromReader(r io.Reader, resCfg ResolverConfig) (
 		return nil, err
 	}
 
-	b.initLogger(b)
+	b.initLogger(fmt.Sprintf("%T(%v)", b, b.ChanPoint))
 
 	return b, nil
 }

--- a/contractcourt/breach_resolver.go
+++ b/contractcourt/breach_resolver.go
@@ -126,13 +126,13 @@ var _ ContractResolver = (*breachResolver)(nil)
 
 // TODO(yy): implement it once the outputs are offered to the sweeper.
 func (b *breachResolver) Launch() error {
-	if b.launched {
+	if b.launched.Load() {
 		b.log.Tracef("already launched")
 		return nil
 	}
 
 	b.log.Debugf("launching resolver...")
-	b.launched = true
+	b.launched.Store(true)
 
 	return nil
 }

--- a/contractcourt/briefcase_test.go
+++ b/contractcourt/briefcase_test.go
@@ -205,8 +205,8 @@ func assertResolversEqual(t *testing.T, originalResolver ContractResolver,
 				ogRes.outputIncubating, diskRes.outputIncubating)
 		}
 		if ogRes.resolved != diskRes.resolved {
-			t.Fatalf("expected %v, got %v", ogRes.resolved,
-				diskRes.resolved)
+			t.Fatalf("expected %v, got %v", ogRes.resolved.Load(),
+				diskRes.resolved.Load())
 		}
 		if ogRes.broadcastHeight != diskRes.broadcastHeight {
 			t.Fatalf("expected %v, got %v",
@@ -228,8 +228,8 @@ func assertResolversEqual(t *testing.T, originalResolver ContractResolver,
 				ogRes.outputIncubating, diskRes.outputIncubating)
 		}
 		if ogRes.resolved != diskRes.resolved {
-			t.Fatalf("expected %v, got %v", ogRes.resolved,
-				diskRes.resolved)
+			t.Fatalf("expected %v, got %v", ogRes.resolved.Load(),
+				diskRes.resolved.Load())
 		}
 		if ogRes.broadcastHeight != diskRes.broadcastHeight {
 			t.Fatalf("expected %v, got %v",
@@ -274,8 +274,8 @@ func assertResolversEqual(t *testing.T, originalResolver ContractResolver,
 				ogRes.commitResolution, diskRes.commitResolution)
 		}
 		if ogRes.resolved != diskRes.resolved {
-			t.Fatalf("expected %v, got %v", ogRes.resolved,
-				diskRes.resolved)
+			t.Fatalf("expected %v, got %v", ogRes.resolved.Load(),
+				diskRes.resolved.Load())
 		}
 		if ogRes.broadcastHeight != diskRes.broadcastHeight {
 			t.Fatalf("expected %v, got %v",
@@ -311,13 +311,14 @@ func TestContractInsertionRetrieval(t *testing.T) {
 			SweepSignDesc:   testSignDesc,
 		},
 		outputIncubating: true,
-		resolved:         true,
 		broadcastHeight:  102,
 		htlc: channeldb.HTLC{
 			HtlcIndex: 12,
 		},
 	}
-	successResolver := htlcSuccessResolver{
+	timeoutResolver.resolved.Store(true)
+
+	successResolver := &htlcSuccessResolver{
 		htlcResolution: lnwallet.IncomingHtlcResolution{
 			Preimage:        testPreimage,
 			SignedSuccessTx: nil,
@@ -326,40 +327,49 @@ func TestContractInsertionRetrieval(t *testing.T) {
 			SweepSignDesc:   testSignDesc,
 		},
 		outputIncubating: true,
-		resolved:         true,
 		broadcastHeight:  109,
 		htlc: channeldb.HTLC{
 			RHash: testPreimage,
 		},
 	}
-	resolvers := []ContractResolver{
-		&timeoutResolver,
-		&successResolver,
-		&commitSweepResolver{
-			commitResolution: lnwallet.CommitOutputResolution{
-				SelfOutPoint:       testChanPoint2,
-				SelfOutputSignDesc: testSignDesc,
-				MaturityDelay:      99,
-			},
-			resolved:        false,
-			broadcastHeight: 109,
-			chanPoint:       testChanPoint1,
+	successResolver.resolved.Store(true)
+
+	commitResolver := &commitSweepResolver{
+		commitResolution: lnwallet.CommitOutputResolution{
+			SelfOutPoint:       testChanPoint2,
+			SelfOutputSignDesc: testSignDesc,
+			MaturityDelay:      99,
 		},
+		broadcastHeight: 109,
+		chanPoint:       testChanPoint1,
+	}
+	commitResolver.resolved.Store(false)
+
+	resolvers := []ContractResolver{
+		&timeoutResolver, successResolver, commitResolver,
 	}
 
 	// All resolvers require a unique ResolverKey() output. To achieve this
 	// for the composite resolvers, we'll mutate the underlying resolver
 	// with a new outpoint.
-	contestTimeout := timeoutResolver
-	contestTimeout.htlcResolution.ClaimOutpoint = randOutPoint()
+	contestTimeout := htlcTimeoutResolver{
+		htlcResolution: lnwallet.OutgoingHtlcResolution{
+			ClaimOutpoint: randOutPoint(),
+			SweepSignDesc: testSignDesc,
+		},
+	}
 	resolvers = append(resolvers, &htlcOutgoingContestResolver{
 		htlcTimeoutResolver: &contestTimeout,
 	})
-	contestSuccess := successResolver
-	contestSuccess.htlcResolution.ClaimOutpoint = randOutPoint()
+	contestSuccess := &htlcSuccessResolver{
+		htlcResolution: lnwallet.IncomingHtlcResolution{
+			ClaimOutpoint: randOutPoint(),
+			SweepSignDesc: testSignDesc,
+		},
+	}
 	resolvers = append(resolvers, &htlcIncomingContestResolver{
 		htlcExpiry:          100,
-		htlcSuccessResolver: &contestSuccess,
+		htlcSuccessResolver: contestSuccess,
 	})
 
 	// For quick lookup during the test, we'll create this map which allow
@@ -437,12 +447,12 @@ func TestContractResolution(t *testing.T) {
 			SweepSignDesc:   testSignDesc,
 		},
 		outputIncubating: true,
-		resolved:         true,
 		broadcastHeight:  192,
 		htlc: channeldb.HTLC{
 			HtlcIndex: 9912,
 		},
 	}
+	timeoutResolver.resolved.Store(true)
 
 	// First, we'll insert the resolver into the database and ensure that
 	// we get the same resolver out the other side. We do not need to apply
@@ -490,12 +500,13 @@ func TestContractSwapping(t *testing.T) {
 			SweepSignDesc:   testSignDesc,
 		},
 		outputIncubating: true,
-		resolved:         true,
 		broadcastHeight:  102,
 		htlc: channeldb.HTLC{
 			HtlcIndex: 12,
 		},
 	}
+	timeoutResolver.resolved.Store(true)
+
 	contestResolver := &htlcOutgoingContestResolver{
 		htlcTimeoutResolver: timeoutResolver,
 	}

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -503,7 +503,7 @@ func (c *ChainArbitrator) ResolveContract(chanPoint wire.OutPoint) error {
 
 		if err := chainArb.Stop(); err != nil {
 			log.Warnf("unable to stop ChannelArbitrator(%v): %v",
-				chanPoint, err)
+				chainArb.id(), err)
 		}
 	}
 	if chainWatcher != nil {
@@ -961,7 +961,7 @@ func (c *ChainArbitrator) Stop() error {
 	}
 	for chanPoint, arbitrator := range activeChannels {
 		log.Tracef("Attempting to stop ChannelArbitrator(%v)",
-			chanPoint)
+			arbitrator.id())
 
 		if err := arbitrator.Stop(); err != nil {
 			log.Errorf("unable to stop arbitrator for "+
@@ -1136,7 +1136,7 @@ func (c *ChainArbitrator) WatchNewChannel(newChan *channeldb.OpenChannel) error 
 	chanPoint := newChan.FundingOutpoint
 
 	log.Infof("Creating new ChannelArbitrator for ChannelPoint(%v)",
-		chanPoint)
+		newChan.FundingOutpoint)
 
 	// If we're already watching this channel, then we'll ignore this
 	// request.
@@ -1276,8 +1276,9 @@ func (c *ChainArbitrator) FindOutgoingHTLCDeadline(scid lnwire.ShortChannelID,
 
 				log.Debugf("ChannelArbitrator(%v): found "+
 					"incoming HTLC in channel=%v using "+
-					"rHash=%x, refundTimeout=%v", scid,
-					cp, rHash, htlc.RefundTimeout)
+					"rHash=%x, refundTimeout=%v",
+					channelArb.id(), cp, rHash,
+					htlc.RefundTimeout)
 
 				return fn.Some(int32(htlc.RefundTimeout))
 			}

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -1300,3 +1300,42 @@ func (c *ChainArbitrator) FindOutgoingHTLCDeadline(scid lnwire.ShortChannelID,
 func (c *ChainArbitrator) Name() string {
 	return "ChainArbitrator"
 }
+
+// RedispatchBlockbeat resends the current blockbeat to the channels specified
+// by the chanPoints. It is used when a channel is added to the chain
+// arbitrator after it has been started, e.g., during the channel restore
+// process.
+func (c *ChainArbitrator) RedispatchBlockbeat(chanPoints []wire.OutPoint) {
+	// Get the current blockbeat.
+	beat := c.CurrentBeat()
+
+	// Prepare two sets of consumers.
+	channels := make([]chainio.Consumer, 0, len(chanPoints))
+	watchers := make([]chainio.Consumer, 0, len(chanPoints))
+
+	// Read the active channels in a lock.
+	c.Lock()
+	for _, op := range chanPoints {
+		if channel, ok := c.activeChannels[op]; ok {
+			channels = append(channels, channel)
+		}
+
+		if watcher, ok := c.activeWatchers[op]; ok {
+			watchers = append(watchers, watcher)
+		}
+	}
+	c.Unlock()
+
+	// Iterate all the copied watchers and send the blockbeat to them.
+	err := beat.DispatchConcurrent(watchers)
+	if err != nil {
+		log.Errorf("Notify blockbeat failed: %v", err)
+	}
+
+	// Iterate all the copied channels and send the blockbeat to them.
+	err = beat.DispatchConcurrent(channels)
+	if err != nil {
+		// Shutdown lnd if there's an error processing the block.
+		log.Errorf("Notify blockbeat failed: %v", err)
+	}
+}

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -806,16 +806,28 @@ func (c *ChainArbitrator) handleBlockbeat(beat chainio.Blockbeat) {
 
 	// Create a slice to record active channel arbitrator.
 	channels := make([]chainio.Consumer, 0, len(c.activeChannels))
+	watchers := make([]chainio.Consumer, 0, len(c.activeWatchers))
 
 	// Copy the active channels to the slice.
 	for _, channel := range c.activeChannels {
 		channels = append(channels, channel)
 	}
 
+	for _, watcher := range c.activeWatchers {
+		watchers = append(watchers, watcher)
+	}
+
 	c.Unlock()
 
+	// Iterate all the copied watchers and send the blockbeat to them.
+	err := beat.DispatchConcurrent(watchers)
+	if err != nil {
+		// Shutdown lnd if there's an error processing the block.
+		log.Criticalf("Notify blockbeat failed: %v", err)
+	}
+
 	// Iterate all the copied channels and send the blockbeat to them.
-	err := beat.DispatchConcurrent(channels)
+	err = beat.DispatchConcurrent(channels)
 	if err != nil {
 		// Shutdown lnd if there's an error processing the block.
 		log.Criticalf("Notify blockbeat failed: %v", err)

--- a/contractcourt/chain_watcher.go
+++ b/contractcourt/chain_watcher.go
@@ -15,6 +15,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/lightningnetwork/lnd/chainio"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/fn"
@@ -201,6 +202,8 @@ type chainWatcher struct {
 	started int32 // To be used atomically.
 	stopped int32 // To be used atomically.
 
+	chainio.BeatConsumer
+
 	quit chan struct{}
 	wg   sync.WaitGroup
 
@@ -251,12 +254,27 @@ func newChainWatcher(cfg chainWatcherConfig) (*chainWatcher, error) {
 		)
 	}
 
-	return &chainWatcher{
+	c := &chainWatcher{
 		cfg:                 cfg,
 		stateHintObfuscator: stateHint,
 		quit:                make(chan struct{}),
 		clientSubscriptions: make(map[uint64]*ChainEventSubscription),
-	}, nil
+	}
+
+	// Mount the block consumer.
+	c.BeatConsumer = chainio.NewBeatConsumer(c.quit, c.Name())
+
+	return c, nil
+}
+
+// Compile-time check for the chainio.Consumer interface.
+var _ chainio.Consumer = (*chainWatcher)(nil)
+
+// Name returns the name of the watcher.
+//
+// NOTE: part of the `chainio.Consumer` interface.
+func (c *chainWatcher) Name() string {
+	return fmt.Sprintf("ChainWatcher(%v)", c.cfg.chanState.FundingOutpoint)
 }
 
 // Start starts all goroutines that the chainWatcher needs to perform its

--- a/contractcourt/chain_watcher.go
+++ b/contractcourt/chain_watcher.go
@@ -536,7 +536,7 @@ func newChainSet(chanState *channeldb.OpenChannel) (*chainSet, error) {
 	localCommit, remoteCommit, err := chanState.LatestCommitments()
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch channel state for "+
-			"chan_point=%v", chanState.FundingOutpoint)
+			"chan_point=%v: %v", chanState.FundingOutpoint, err)
 	}
 
 	log.Tracef("ChannelPoint(%v): local_commit_type=%v, local_commit=%v",
@@ -605,162 +605,118 @@ func newChainSet(chanState *channeldb.OpenChannel) (*chainSet, error) {
 // notifications to all subscribers.
 func (c *chainWatcher) closeObserver(spendNtfn *chainntnfs.SpendEvent) {
 	defer c.wg.Done()
+	defer spendNtfn.Cancel()
+
+	fundingOutpoint := c.cfg.chanState.FundingOutpoint
+	pkScript, err := txscript.ParsePkScript(c.fundingPkScript)
+	if err != nil {
+		log.Errorf("Unable to parse pkScript: %v", err)
+	}
 
 	log.Infof("Close observer for ChannelPoint(%v) active",
 		c.cfg.chanState.FundingOutpoint)
 
-	// If this is a taproot channel, before we proceed, we want to ensure
-	// that the expected funding output has confirmed on chain.
-	if c.cfg.chanState.ChanType.IsTaproot() {
-		fundingPoint := c.cfg.chanState.FundingOutpoint
-
-		confNtfn, err := c.cfg.notifier.RegisterConfirmationsNtfn(
-			&fundingPoint.Hash, c.fundingPkScript, 1, c.heightHint,
-		)
-		if err != nil {
-			log.Warnf("unable to register for conf: %v", err)
-		}
-
-		log.Infof("Waiting for taproot ChannelPoint(%v) to confirm...",
-			c.cfg.chanState.FundingOutpoint)
-
+	for {
 		select {
-		case _, ok := <-confNtfn.Confirmed:
-			// If the channel was closed, then this means that the
-			// notifier exited, so we will as well.
-			if !ok {
-				return
-			}
+		// A new block is received, we will check whether this block
+		// contains a spending tx that we are interested in.
+		case beat := <-c.BlockbeatChan:
+			log.Tracef("ChainWatcher(%v) received blockbeat %v",
+				c.cfg.chanState.FundingOutpoint, beat.Height())
+
+			// Process the block.
+			c.handleBlockbeat(
+				beat, fundingOutpoint, pkScript, spendNtfn,
+			)
+
+		// The chainWatcher has been signalled to exit, so we'll do so
+		// now.
 		case <-c.quit:
 			return
 		}
 	}
+}
+
+// handleBlockbeat takes a blockbeat and queries for a spending tx for the
+// funding output. If the spending tx is found, it will be handled based on the
+// closure type.
+func (c *chainWatcher) handleBlockbeat(beat chainio.Blockbeat,
+	fundingOutpoint wire.OutPoint, pkScript txscript.PkScript,
+	spendNtfn *chainntnfs.SpendEvent) {
+
+	// Notify the chain arbitrator has processed the block.
+	defer beat.NotifyBlockProcessed(nil, c.quit)
+
+	// If this is a taproot channel, before we proceed, we want to ensure
+	// that the expected funding output has confirmed on chain.
+	if c.cfg.chanState.IsPending && c.cfg.chanState.ChanType.IsTaproot() {
+		// If the funding output hasn't confirmed in this block, we
+		// will check it again in the next block.
+		if !c.chanPointConfirmed(fundingOutpoint) {
+			return
+		}
+	}
+
+	// Check if the block contains a spending tx for the funding output.
+	spend, err := beat.HasOutpointSpentByScript(fundingOutpoint, pkScript)
+	if err != nil {
+		log.Errorf("Query spend failed for %v", fundingOutpoint, err)
+
+		return
+	}
+
+	// Found a spending tx of the funding outpoint and handle it now.
+	if spend != nil {
+		log.Debugf("Found spend details for funding output: %v",
+			spend.SpenderTxHash)
+
+		err = c.handleCommitSpend(spend)
+		if err != nil {
+			log.Errorf("Failed to handle commit spend: %v", err)
+		}
+
+		return
+	}
+
+	log.Tracef("No spend found for ChannelPoint(%v) in block %v",
+		c.cfg.chanState.FundingOutpoint, beat.Height())
+
+	// If this block doesn't contain a spending tx, we still need to check
+	// past blocks to see if the channel is already closed. Atm the
+	// `blockbeat` is not able to do rescan, so we perform a non-blocking
+	// read on the spending notification to see if it's already spent.
+	c.handleRestart(spendNtfn)
+}
+
+// chanPointConfirmed checks whether the given channel point has confirmed.
+// This is used to ensure that the funding output has confirmed on chain before
+// we proceed with the rest of the close observer logic for taproot channels.
+func (c *chainWatcher) chanPointConfirmed(op wire.OutPoint) bool {
+	confNtfn, err := c.cfg.notifier.RegisterConfirmationsNtfn(
+		&op.Hash, c.fundingPkScript, 1, c.heightHint,
+	)
+	if err != nil {
+		log.Errorf("Unable to register for conf: %v", err)
+
+		return false
+	}
 
 	select {
-	// We've detected a spend of the channel onchain! Depending on the type
-	// of spend, we'll act accordingly, so we'll examine the spending
-	// transaction to determine what we should do.
-	//
-	// TODO(Roasbeef): need to be able to ensure this only triggers
-	// on confirmation, to ensure if multiple txns are broadcast, we
-	// act on the one that's timestamped
-	case commitSpend, ok := <-spendNtfn.Spend:
+	case _, ok := <-confNtfn.Confirmed:
 		// If the channel was closed, then this means that the notifier
 		// exited, so we will as well.
 		if !ok {
-			return
+			return false
 		}
 
-		// Otherwise, the remote party might have broadcast a prior
-		// revoked state...!!!
-		commitTxBroadcast := commitSpend.SpendingTx
+		log.Debugf("Taproot ChannelPoint(%v) confirmed", op)
 
-		// First, we'll construct the chainset which includes all the
-		// data we need to dispatch an event to our subscribers about
-		// this possible channel close event.
-		chainSet, err := newChainSet(c.cfg.chanState)
-		if err != nil {
-			log.Errorf("unable to create commit set: %v", err)
-			return
-		}
+		return true
 
-		// Decode the state hint encoded within the commitment
-		// transaction to determine if this is a revoked state or not.
-		obfuscator := c.stateHintObfuscator
-		broadcastStateNum := c.cfg.extractStateNumHint(
-			commitTxBroadcast, obfuscator,
-		)
+	default:
+		log.Infof("Taproot ChannelPoint(%v) not confirmed yet", op)
 
-		// We'll go on to check whether it could be our own commitment
-		// that was published and know is confirmed.
-		ok, err = c.handleKnownLocalState(
-			commitSpend, broadcastStateNum, chainSet,
-		)
-		if err != nil {
-			log.Errorf("Unable to handle known local state: %v",
-				err)
-			return
-		}
-
-		if ok {
-			return
-		}
-
-		// Now that we know it is neither a non-cooperative closure nor
-		// a local close with the latest state, we check if it is the
-		// remote that closed with any prior or current state.
-		ok, err = c.handleKnownRemoteState(
-			commitSpend, broadcastStateNum, chainSet,
-		)
-		if err != nil {
-			log.Errorf("Unable to handle known remote state: %v",
-				err)
-			return
-		}
-
-		if ok {
-			return
-		}
-
-		// Next, we'll check to see if this is a cooperative channel
-		// closure or not. This is characterized by having an input
-		// sequence number that's finalized. This won't happen with
-		// regular commitment transactions due to the state hint
-		// encoding scheme.
-		if commitTxBroadcast.TxIn[0].Sequence == wire.MaxTxInSequenceNum {
-			// TODO(roasbeef): rare but possible, need itest case
-			// for
-			err := c.dispatchCooperativeClose(commitSpend)
-			if err != nil {
-				log.Errorf("unable to handle co op close: %v", err)
-			}
-			return
-		}
-
-		log.Warnf("Unknown commitment broadcast for "+
-			"ChannelPoint(%v) ", c.cfg.chanState.FundingOutpoint)
-
-		// We'll try to recover as best as possible from losing state.
-		// We first check if this was a local unknown state. This could
-		// happen if we force close, then lose state or attempt
-		// recovery before the commitment confirms.
-		ok, err = c.handleUnknownLocalState(
-			commitSpend, broadcastStateNum, chainSet,
-		)
-		if err != nil {
-			log.Errorf("Unable to handle known local state: %v",
-				err)
-			return
-		}
-
-		if ok {
-			return
-		}
-
-		// Since it was neither a known remote state, nor a local state
-		// that was published, it most likely mean we lost state and
-		// the remote node closed. In this case we must start the DLP
-		// protocol in hope of getting our money back.
-		ok, err = c.handleUnknownRemoteState(
-			commitSpend, broadcastStateNum, chainSet,
-		)
-		if err != nil {
-			log.Errorf("Unable to handle unknown remote state: %v",
-				err)
-			return
-		}
-
-		if ok {
-			return
-		}
-
-		log.Warnf("Unable to handle spending tx %v of channel point %v",
-			commitTxBroadcast.TxHash(), c.cfg.chanState.FundingOutpoint)
-		return
-
-	// The chainWatcher has been signalled to exit, so we'll do so now.
-	case <-c.quit:
-		return
+		return false
 	}
 }
 
@@ -1375,5 +1331,137 @@ func (c *chainWatcher) waitForCommitmentPoint() *btcec.PublicKey {
 		case <-c.quit:
 			return nil
 		}
+	}
+}
+
+// handleCommitSpend takes a spending tx of the funding output and handles the
+// channel close based on the closure type.
+func (c *chainWatcher) handleCommitSpend(
+	commitSpend *chainntnfs.SpendDetail) error {
+
+	commitTxBroadcast := commitSpend.SpendingTx
+
+	// First, we'll construct the chainset which includes all the data we
+	// need to dispatch an event to our subscribers about this possible
+	// channel close event.
+	chainSet, err := newChainSet(c.cfg.chanState)
+	if err != nil {
+		return fmt.Errorf("create commit set: %w", err)
+	}
+
+	// Decode the state hint encoded within the commitment transaction to
+	// determine if this is a revoked state or not.
+	obfuscator := c.stateHintObfuscator
+	broadcastStateNum := c.cfg.extractStateNumHint(
+		commitTxBroadcast, obfuscator,
+	)
+
+	// We'll go on to check whether it could be our own commitment that was
+	// published and know is confirmed.
+	ok, err := c.handleKnownLocalState(
+		commitSpend, broadcastStateNum, chainSet,
+	)
+	if err != nil {
+		return fmt.Errorf("handle known local state: %w", err)
+	}
+	if ok {
+		return nil
+	}
+
+	// Now that we know it is neither a non-cooperative closure nor a local
+	// close with the latest state, we check if it is the remote that
+	// closed with any prior or current state.
+	ok, err = c.handleKnownRemoteState(
+		commitSpend, broadcastStateNum, chainSet,
+	)
+	if err != nil {
+		return fmt.Errorf("handle known remote state: %w", err)
+	}
+	if ok {
+		return nil
+	}
+
+	// Next, we'll check to see if this is a cooperative channel closure or
+	// not. This is characterized by having an input sequence number that's
+	// finalized. This won't happen with regular commitment transactions
+	// due to the state hint encoding scheme.
+	if commitTxBroadcast.TxIn[0].Sequence == wire.MaxTxInSequenceNum {
+		// TODO(roasbeef): rare but possible, need itest case for
+		err := c.dispatchCooperativeClose(commitSpend)
+		if err != nil {
+			return fmt.Errorf("handle coop close: %w", err)
+		}
+
+		return nil
+	}
+
+	log.Warnf("Unknown commitment broadcast for ChannelPoint(%v) ",
+		c.cfg.chanState.FundingOutpoint)
+
+	// We'll try to recover as best as possible from losing state.  We
+	// first check if this was a local unknown state. This could happen if
+	// we force close, then lose state or attempt recovery before the
+	// commitment confirms.
+	ok, err = c.handleUnknownLocalState(
+		commitSpend, broadcastStateNum, chainSet,
+	)
+	if err != nil {
+		return fmt.Errorf("handle known local state: %w", err)
+	}
+	if ok {
+		return nil
+	}
+
+	// Since it was neither a known remote state, nor a local state that
+	// was published, it most likely mean we lost state and the remote node
+	// closed. In this case we must start the DLP protocol in hope of
+	// getting our money back.
+	ok, err = c.handleUnknownRemoteState(
+		commitSpend, broadcastStateNum, chainSet,
+	)
+	if err != nil {
+		return fmt.Errorf("handle unknown remote state: %w", err)
+	}
+	if ok {
+		return nil
+	}
+
+	log.Errorf("Unable to handle spending tx %v of channel point %v",
+		commitTxBroadcast.TxHash(), c.cfg.chanState.FundingOutpoint)
+
+	return nil
+}
+
+// handleRestart performs a non-blocking read on the spendNtfn channel to check
+// whether there's a commit spend already. Returns a bool to indicate whether
+// the spend was found and handled.
+//
+// TODO(yy): remove this step once `blockbeat` is able to handle rescanning.
+func (c *chainWatcher) handleRestart(spendNtfn *chainntnfs.SpendEvent) {
+	select {
+	// We've detected a spend of the channel onchain! Depending on the type
+	// of spend, we'll act accordingly, so we'll examine the spending
+	// transaction to determine what we should do.
+	//
+	// TODO(Roasbeef): need to be able to ensure this only triggers
+	// on confirmation, to ensure if multiple txns are broadcast, we
+	// act on the one that's timestamped
+	case commitSpend, ok := <-spendNtfn.Spend:
+		// If the channel was closed, then this means that the notifier
+		// exited, so we will as well.
+		if !ok {
+			return
+		}
+
+		log.Debugf("Found spending tx %v during restart for "+
+			"ChannelPoint(%v)", commitSpend.SpenderTxHash,
+			c.cfg.chanState.FundingOutpoint)
+
+		err := c.handleCommitSpend(commitSpend)
+		if err != nil {
+			log.Errorf("Failed to handle commit spend: %v", err)
+		}
+
+	default:
 	}
 }

--- a/contractcourt/chain_watcher_test.go
+++ b/contractcourt/chain_watcher_test.go
@@ -8,12 +8,14 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/chainio"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/input"
-	"github.com/lightningnetwork/lnd/lntest/mock"
+	lnmock "github.com/lightningnetwork/lnd/lntest/mock"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,8 +34,8 @@ func TestChainWatcherRemoteUnilateralClose(t *testing.T) {
 
 	// With the channels created, we'll now create a chain watcher instance
 	// which will be watching for any closes of Alice's channel.
-	aliceNotifier := &mock.ChainNotifier{
-		SpendChan: make(chan *chainntnfs.SpendDetail),
+	aliceNotifier := &lnmock.ChainNotifier{
+		SpendChan: make(chan *chainntnfs.SpendDetail, 1),
 		EpochChan: make(chan *chainntnfs.BlockEpoch),
 		ConfChan:  make(chan *chainntnfs.TxConfirmation),
 	}
@@ -48,6 +50,20 @@ func TestChainWatcherRemoteUnilateralClose(t *testing.T) {
 	require.NoError(t, err, "unable to start chain watcher")
 	defer aliceChainWatcher.Stop()
 
+	// Create a mock blockbeat and send it to Alice's BlockbeatChan.
+	mockBeat := &chainio.MockBeat{}
+
+	// Mock a fake block height - this is called based on the debuglevel.
+	mockBeat.On("Height").Return(int32(1)).Maybe()
+
+	// Mock `HasOutpointSpentByScript` to return nil.
+	mockBeat.On("HasOutpointSpentByScript",
+		mock.Anything, mock.Anything).Return(nil, nil).Once()
+
+	// Mock `NotifyBlockProcessed` to be call once.
+	mockBeat.On("NotifyBlockProcessed",
+		nil, aliceChainWatcher.quit).Return().Once()
+
 	// We'll request a new channel event subscription from Alice's chain
 	// watcher.
 	chanEvents := aliceChainWatcher.SubscribeChannelEvents()
@@ -60,7 +76,23 @@ func TestChainWatcherRemoteUnilateralClose(t *testing.T) {
 		SpenderTxHash: &bobTxHash,
 		SpendingTx:    bobCommit,
 	}
-	aliceNotifier.SpendChan <- bobSpend
+
+	// Here we mock the behavior of a restart. Notice the current block
+	// doen;t contain the spending tx for this funding outpoint, as mocked
+	// in `HasOutpointSpentByScript`. Instead, this spending tx will be
+	// returned from the spending notification, indicating it's a spent
+	// happened in the past.
+	select {
+	case aliceNotifier.SpendChan <- bobSpend:
+	case <-time.After(1 * time.Second):
+		t.Fatalf("unable to send spend details")
+	}
+
+	select {
+	case aliceChainWatcher.BlockbeatChan <- mockBeat:
+	case <-time.After(time.Second * 1):
+		t.Fatalf("unable to send blockbeat")
+	}
 
 	// We should get a new spend event over the remote unilateral close
 	// event channel.
@@ -116,7 +148,7 @@ func TestChainWatcherRemoteUnilateralClosePendingCommit(t *testing.T) {
 
 	// With the channels created, we'll now create a chain watcher instance
 	// which will be watching for any closes of Alice's channel.
-	aliceNotifier := &mock.ChainNotifier{
+	aliceNotifier := &lnmock.ChainNotifier{
 		SpendChan: make(chan *chainntnfs.SpendDetail),
 		EpochChan: make(chan *chainntnfs.BlockEpoch),
 		ConfChan:  make(chan *chainntnfs.TxConfirmation),
@@ -166,7 +198,26 @@ func TestChainWatcherRemoteUnilateralClosePendingCommit(t *testing.T) {
 		SpenderTxHash: &bobTxHash,
 		SpendingTx:    bobCommit,
 	}
-	aliceNotifier.SpendChan <- bobSpend
+
+	// Create a mock blockbeat and send it to Alice's BlockbeatChan.
+	mockBeat := &chainio.MockBeat{}
+
+	// Mock a fake block height - this is called based on the debuglevel.
+	mockBeat.On("Height").Return(int32(1)).Maybe()
+
+	// Mock `HasOutpointSpentByScript` to return Bob's spending tx.
+	mockBeat.On("HasOutpointSpentByScript",
+		mock.Anything, mock.Anything).Return(bobSpend, nil).Once()
+
+	// Mock `NotifyBlockProcessed` to be call once.
+	mockBeat.On("NotifyBlockProcessed",
+		nil, aliceChainWatcher.quit).Return().Once()
+
+	select {
+	case aliceChainWatcher.BlockbeatChan <- mockBeat:
+	case <-time.After(time.Second * 1):
+		t.Fatalf("unable to send blockbeat")
+	}
 
 	// We should get a new spend event over the remote unilateral close
 	// event channel.
@@ -280,7 +331,7 @@ func TestChainWatcherDataLossProtect(t *testing.T) {
 		// With the channels created, we'll now create a chain watcher
 		// instance which will be watching for any closes of Alice's
 		// channel.
-		aliceNotifier := &mock.ChainNotifier{
+		aliceNotifier := &lnmock.ChainNotifier{
 			SpendChan: make(chan *chainntnfs.SpendDetail),
 			EpochChan: make(chan *chainntnfs.BlockEpoch),
 			ConfChan:  make(chan *chainntnfs.TxConfirmation),
@@ -327,7 +378,29 @@ func TestChainWatcherDataLossProtect(t *testing.T) {
 			SpenderTxHash: &bobTxHash,
 			SpendingTx:    bobCommit,
 		}
-		aliceNotifier.SpendChan <- bobSpend
+
+		// Create a mock blockbeat and send it to Alice's
+		// BlockbeatChan.
+		mockBeat := &chainio.MockBeat{}
+
+		// Mock a fake block height - this is called based on the
+		// debuglevel.
+		mockBeat.On("Height").Return(int32(1)).Maybe()
+
+		// Mock `HasOutpointSpentByScript` to return Bob's spending tx.
+		mockBeat.On("HasOutpointSpentByScript",
+			mock.Anything, mock.Anything).Return(
+			bobSpend, nil).Once()
+
+		// Mock `NotifyBlockProcessed` to be call once.
+		mockBeat.On("NotifyBlockProcessed",
+			nil, aliceChainWatcher.quit).Return().Once()
+
+		select {
+		case aliceChainWatcher.BlockbeatChan <- mockBeat:
+		case <-time.After(time.Second * 1):
+			t.Fatalf("unable to send blockbeat")
+		}
 
 		// We should get a new uni close resolution that indicates we
 		// processed the DLP scenario.
@@ -454,7 +527,7 @@ func TestChainWatcherLocalForceCloseDetect(t *testing.T) {
 		// With the channels created, we'll now create a chain watcher
 		// instance which will be watching for any closes of Alice's
 		// channel.
-		aliceNotifier := &mock.ChainNotifier{
+		aliceNotifier := &lnmock.ChainNotifier{
 			SpendChan: make(chan *chainntnfs.SpendDetail),
 			EpochChan: make(chan *chainntnfs.BlockEpoch),
 			ConfChan:  make(chan *chainntnfs.TxConfirmation),
@@ -498,7 +571,29 @@ func TestChainWatcherLocalForceCloseDetect(t *testing.T) {
 			SpenderTxHash: &aliceTxHash,
 			SpendingTx:    aliceCommit,
 		}
-		aliceNotifier.SpendChan <- aliceSpend
+		// Create a mock blockbeat and send it to Alice's
+		// BlockbeatChan.
+		mockBeat := &chainio.MockBeat{}
+
+		// Mock a fake block height - this is called based on the
+		// debuglevel.
+		mockBeat.On("Height").Return(int32(1)).Maybe()
+
+		// Mock `HasOutpointSpentByScript` to return Alice's spending
+		// tx.
+		mockBeat.On("HasOutpointSpentByScript",
+			mock.Anything, mock.Anything).Return(
+			aliceSpend, nil).Once()
+
+		// Mock `NotifyBlockProcessed` to be call once.
+		mockBeat.On("NotifyBlockProcessed",
+			nil, aliceChainWatcher.quit).Return().Once()
+
+		select {
+		case aliceChainWatcher.BlockbeatChan <- mockBeat:
+		case <-time.After(time.Second * 1):
+			t.Fatalf("unable to send blockbeat")
+		}
 
 		// We should get a local force close event from Alice as she
 		// should be able to detect the close based on the commitment

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -469,8 +469,8 @@ func (c *ChannelArbitrator) Start(state *chanArbStartState) error {
 		}
 	}
 
-	log.Debugf("Starting ChannelArbitrator(%v), htlc_set=%v, state=%v",
-		c.cfg.ChanPoint, newLogClosure(func() string {
+	log.Tracef("Starting ChannelArbitrator(%v), htlc_set=%v, state=%v",
+		c.id(), newLogClosure(func() string {
 			return spew.Sdump(c.activeHTLCs)
 		}), state.currentState,
 	)
@@ -510,16 +510,14 @@ func (c *ChannelArbitrator) Start(state *chanArbStartState) error {
 			}
 
 			log.Warnf("ChannelArbitrator(%v): detected stalled "+
-				"state=%v for closed channel",
-				c.cfg.ChanPoint, c.state)
+				"state=%v for closed channel", c.id(), c.state)
 		}
 
 		triggerHeight = c.cfg.ClosingHeight
 	}
 
 	log.Infof("ChannelArbitrator(%v): starting state=%v, trigger=%v, "+
-		"triggerHeight=%v", c.cfg.ChanPoint, c.state, trigger,
-		triggerHeight)
+		"triggerHeight=%v", c.id(), c.state, trigger, triggerHeight)
 
 	// We'll now attempt to advance our state forward based on the current
 	// on-chain state, and our set of active contracts.
@@ -538,8 +536,8 @@ func (c *ChannelArbitrator) Start(state *chanArbStartState) error {
 			fallthrough
 		case errNoResolutions:
 			log.Warnf("ChannelArbitrator(%v): detected closed"+
-				"channel with no contract resolutions written.",
-				c.cfg.ChanPoint)
+				"channel with no contract resolutions written",
+				c.id())
 
 		default:
 			return err
@@ -722,14 +720,14 @@ func (c *ChannelArbitrator) relaunchResolvers(commitSet *CommitSet,
 		fallthrough
 	case err == channeldb.ErrChannelNotFound:
 		log.Warnf("ChannelArbitrator(%v): unable to fetch historical "+
-			"state", c.cfg.ChanPoint)
+			"state", c.id())
 
 	case err != nil:
 		return err
 	}
 
 	log.Infof("ChannelArbitrator(%v): relaunching %v contract "+
-		"resolvers", c.cfg.ChanPoint, len(unresolvedContracts))
+		"resolvers", c.id(), len(unresolvedContracts))
 
 	for i := range unresolvedContracts {
 		resolver := unresolvedContracts[i]
@@ -823,7 +821,7 @@ func (c *ChannelArbitrator) Stop() error {
 		return nil
 	}
 
-	log.Debugf("Stopping ChannelArbitrator(%v)", c.cfg.ChanPoint)
+	log.Debugf("Stopping ChannelArbitrator(%v)", c.id())
 
 	if c.cfg.ChainEvents.Cancel != nil {
 		go c.cfg.ChainEvents.Cancel()
@@ -921,8 +919,7 @@ func (c *ChannelArbitrator) stateStep(
 	// to see if while we were down, conditions have changed.
 	case StateDefault:
 		log.Debugf("ChannelArbitrator(%v): new block (height=%v) "+
-			"examining active HTLC's", c.cfg.ChanPoint,
-			triggerHeight)
+			"examining active HTLC's", c.id(), triggerHeight)
 
 		// As a new block has been connected to the end of the main
 		// chain, we'll check to see if we need to make any on-chain
@@ -952,7 +949,7 @@ func (c *ChannelArbitrator) stateStep(
 		// checking due to a chain update), then we'll exit now.
 		if len(chainActions) == 0 && trigger == chainTrigger {
 			log.Debugf("ChannelArbitrator(%v): no actions for "+
-				"chain trigger, terminating", c.cfg.ChanPoint)
+				"chain trigger, terminating", c.id())
 
 			return StateDefault, closeTx, nil
 		}
@@ -960,8 +957,7 @@ func (c *ChannelArbitrator) stateStep(
 		// Otherwise, we'll log that we checked the HTLC actions as the
 		// commitment transaction has already been broadcast.
 		log.Tracef("ChannelArbitrator(%v): logging chain_actions=%v",
-			c.cfg.ChanPoint,
-			newLogClosure(func() string {
+			c.id(), newLogClosure(func() string {
 				return spew.Sdump(chainActions)
 			}))
 
@@ -991,7 +987,7 @@ func (c *ChannelArbitrator) stateStep(
 		case localCloseTrigger:
 			log.Errorf("ChannelArbitrator(%v): unexpected local "+
 				"commitment confirmed while in StateDefault",
-				c.cfg.ChanPoint)
+				c.id())
 			fallthrough
 		case remoteCloseTrigger:
 			nextState = StateContractClosed
@@ -1022,7 +1018,8 @@ func (c *ChannelArbitrator) stateStep(
 			log.Infof("ChannelArbitrator(%v): detected %s "+
 				"close after closing channel, fast-forwarding "+
 				"to %s to resolve contract",
-				c.cfg.ChanPoint, trigger, StateContractClosed)
+				c.id(), trigger, StateContractClosed)
+
 			return StateContractClosed, closeTx, nil
 
 		case breachCloseTrigger:
@@ -1030,13 +1027,13 @@ func (c *ChannelArbitrator) stateStep(
 			if nextContractState == StateError {
 				log.Infof("ChannelArbitrator(%v): unable to "+
 					"advance breach close resolution: %v",
-					c.cfg.ChanPoint, nextContractState)
+					c.id(), nextContractState)
 				return StateError, closeTx, err
 			}
 
 			log.Infof("ChannelArbitrator(%v): detected %s close "+
 				"after closing channel, fast-forwarding to %s"+
-				" to resolve contract", c.cfg.ChanPoint,
+				" to resolve contract", c.id(),
 				trigger, nextContractState)
 
 			return nextContractState, closeTx, nil
@@ -1045,12 +1042,13 @@ func (c *ChannelArbitrator) stateStep(
 			log.Infof("ChannelArbitrator(%v): detected %s "+
 				"close after closing channel, fast-forwarding "+
 				"to %s to resolve contract",
-				c.cfg.ChanPoint, trigger, StateFullyResolved)
+				c.id(), trigger, StateFullyResolved)
+
 			return StateFullyResolved, closeTx, nil
 		}
 
 		log.Infof("ChannelArbitrator(%v): force closing "+
-			"chan", c.cfg.ChanPoint)
+			"chan", c.id())
 
 		// Now that we have all the actions decided for the set of
 		// HTLC's, we'll broadcast the commitment transaction, and
@@ -1062,7 +1060,7 @@ func (c *ChannelArbitrator) stateStep(
 		closeSummary, err := c.cfg.Channel.ForceCloseChan()
 		if err != nil {
 			log.Errorf("ChannelArbitrator(%v): unable to "+
-				"force close: %v", c.cfg.ChanPoint, err)
+				"force close: %v", c.id(), err)
 
 			// We tried to force close (HTLC may be expiring from
 			// our PoV, etc), but we think we've lost data. In this
@@ -1072,7 +1070,7 @@ func (c *ChannelArbitrator) stateStep(
 				log.Error("ChannelArbitrator(%v): broadcast "+
 					"failed due to local data loss, "+
 					"waiting for on chain confimation...",
-					c.cfg.ChanPoint)
+					c.id())
 
 				return StateBroadcastCommit, nil, nil
 			}
@@ -1088,8 +1086,8 @@ func (c *ChannelArbitrator) stateStep(
 		err = c.cfg.MarkCommitmentBroadcasted(closeTx, true)
 		if err != nil {
 			log.Errorf("ChannelArbitrator(%v): unable to "+
-				"mark commitment broadcasted: %v",
-				c.cfg.ChanPoint, err)
+				"mark commitment broadcasted: %v", c.id(), err)
+
 			return StateError, closeTx, err
 		}
 
@@ -1110,7 +1108,7 @@ func (c *ChannelArbitrator) stateStep(
 		)
 		if err := c.cfg.PublishTx(closeTx, label); err != nil {
 			log.Errorf("ChannelArbitrator(%v): unable to broadcast "+
-				"close tx: %v", c.cfg.ChanPoint, err)
+				"close tx: %v", c.id(), err)
 
 			// This makes sure we don't fail at startup if the
 			// commitment transaction has too low fees to make it
@@ -1181,7 +1179,7 @@ func (c *ChannelArbitrator) stateStep(
 		}
 
 		log.Infof("ChannelArbitrator(%v): trigger %v moving from "+
-			"state %v to %v", c.cfg.ChanPoint, trigger, c.state,
+			"state %v to %v", c.id(), trigger, c.state,
 			nextState)
 
 	// If we're in this state, then the contract has been fully closed to
@@ -1202,8 +1200,8 @@ func (c *ChannelArbitrator) stateStep(
 		// resolvers, and can go straight to our final state.
 		if contractResolutions.IsEmpty() && confCommitSet.IsEmpty() {
 			log.Infof("ChannelArbitrator(%v): contract "+
-				"resolutions empty, marking channel as fully resolved!",
-				c.cfg.ChanPoint)
+				"resolutions empty, marking channel as fully "+
+				"resolved!", c.id())
 			nextState = StateFullyResolved
 			break
 		}
@@ -1217,7 +1215,8 @@ func (c *ChannelArbitrator) stateStep(
 		)
 		if err != nil {
 			log.Errorf("ChannelArbitrator(%v): unable to "+
-				"resolve contracts: %v", c.cfg.ChanPoint, err)
+				"resolve contracts: %v", c.id(), err)
+
 			return StateError, closeTx, err
 		}
 
@@ -1225,7 +1224,7 @@ func (c *ChannelArbitrator) stateStep(
 		// messages we can send immediately.
 		if len(pktsToSend) != 0 {
 			log.Debugf("ChannelArbitrator(%v): sending "+
-				"resolution message=%v", c.cfg.ChanPoint,
+				"resolution message=%v", c.id(),
 				newLogClosure(func() string {
 					return spew.Sdump(pktsToSend)
 				}))
@@ -1238,7 +1237,7 @@ func (c *ChannelArbitrator) stateStep(
 		}
 
 		log.Debugf("ChannelArbitrator(%v): inserting %v contract "+
-			"resolvers", c.cfg.ChanPoint, len(resolvers))
+			"resolvers", c.id(), len(resolvers))
 
 		err = c.log.InsertUnresolvedContracts(nil, resolvers...)
 		if err != nil {
@@ -1255,7 +1254,7 @@ func (c *ChannelArbitrator) stateStep(
 	// all contracts are fully resolved.
 	case StateWaitingFullResolution:
 		log.Infof("ChannelArbitrator(%v): still awaiting contract "+
-			"resolution", c.cfg.ChanPoint)
+			"resolution", c.id())
 
 		unresolved, err := c.log.FetchUnresolvedContracts()
 		if err != nil {
@@ -1276,7 +1275,7 @@ func (c *ChannelArbitrator) stateStep(
 		// Add debug logs.
 		for _, r := range unresolved {
 			log.Debugf("ChannelArbitrator(%v): still have "+
-				"unresolved contract: %T", c.cfg.ChanPoint, r)
+				"unresolved contract: %T", c.id(), r)
 		}
 
 	// If we start as fully resolved, then we'll end as fully resolved.
@@ -1295,8 +1294,7 @@ func (c *ChannelArbitrator) stateStep(
 		}
 	}
 
-	log.Tracef("ChannelArbitrator(%v): next_state=%v", c.cfg.ChanPoint,
-		nextState)
+	log.Tracef("ChannelArbitrator(%v): next_state=%v", c.id(), nextState)
 
 	return nextState, closeTx, nil
 }
@@ -1329,7 +1327,7 @@ func (c *ChannelArbitrator) sweepAnchors(anchors *lnwallet.AnchorResolutions,
 		// don't have any time sensitive outputs to sweep.
 		if deadline.IsNone() {
 			log.Infof("ChannelArbitrator(%v): no HTLCs at stake, "+
-				"skipped anchor CPFP", c.cfg.ChanPoint)
+				"skipped anchor CPFP", c.id())
 
 			return nil
 		}
@@ -1376,8 +1374,8 @@ func (c *ChannelArbitrator) sweepAnchors(anchors *lnwallet.AnchorResolutions,
 
 		log.Infof("ChannelArbitrator(%v): offering anchor from %s "+
 			"commitment %v to sweeper with deadline=%v, budget=%v",
-			c.cfg.ChanPoint, anchorPath, anchor.CommitAnchor,
-			deadlineDesc, budget)
+			c.id(), anchorPath, anchor.CommitAnchor, deadlineDesc,
+			budget)
 
 		// Sweep anchor output with a confirmation target fee
 		// preference. Because this is a cpfp-operation, the anchor
@@ -1467,8 +1465,7 @@ func (c *ChannelArbitrator) findCommitmentDeadlineAndValue(heightHint uint32,
 		// Skip if the HTLC is dust.
 		if htlc.OutputIndex < 0 {
 			log.Debugf("ChannelArbitrator(%v): skipped deadline "+
-				"for dust htlc=%x",
-				c.cfg.ChanPoint, htlc.RHash[:])
+				"for dust htlc=%x", c.id(), htlc.RHash[:])
 
 			continue
 		}
@@ -1494,7 +1491,7 @@ func (c *ChannelArbitrator) findCommitmentDeadlineAndValue(heightHint uint32,
 			deadlineMinHeight = deadline
 
 			log.Tracef("ChannelArbitrator(%v): outgoing HTLC has "+
-				"deadline=%v, value=%v", c.cfg.ChanPoint,
+				"deadline=%v, value=%v", c.id(),
 				deadlineMinHeight, value)
 		}
 	}
@@ -1505,8 +1502,7 @@ func (c *ChannelArbitrator) findCommitmentDeadlineAndValue(heightHint uint32,
 		// Skip if the HTLC is dust.
 		if htlc.OutputIndex < 0 {
 			log.Debugf("ChannelArbitrator(%v): skipped deadline "+
-				"for dust htlc=%x",
-				c.cfg.ChanPoint, htlc.RHash[:])
+				"for dust htlc=%x", c.id(), htlc.RHash[:])
 
 			continue
 		}
@@ -1529,7 +1525,7 @@ func (c *ChannelArbitrator) findCommitmentDeadlineAndValue(heightHint uint32,
 			deadlineMinHeight = htlc.RefundTimeout
 
 			log.Tracef("ChannelArbitrator(%v): incoming HTLC has "+
-				"deadline=%v, amt=%v", c.cfg.ChanPoint,
+				"deadline=%v, amt=%v", c.id(),
 				deadlineMinHeight, value)
 		}
 	}
@@ -1553,7 +1549,7 @@ func (c *ChannelArbitrator) findCommitmentDeadlineAndValue(heightHint uint32,
 	case deadlineMinHeight <= heightHint:
 		log.Warnf("ChannelArbitrator(%v): deadline is passed with "+
 			"deadlineMinHeight=%d, heightHint=%d",
-			c.cfg.ChanPoint, deadlineMinHeight, heightHint)
+			c.id(), deadlineMinHeight, heightHint)
 		deadline = 1
 
 	// Use half of the deadline delta, and leave the other half to be used
@@ -1571,8 +1567,7 @@ func (c *ChannelArbitrator) findCommitmentDeadlineAndValue(heightHint uint32,
 
 	log.Debugf("ChannelArbitrator(%v): calculated valueLeft=%v, "+
 		"deadline=%d, using deadlineMinHeight=%d, heightHint=%d",
-		c.cfg.ChanPoint, valueLeft, deadline, deadlineMinHeight,
-		heightHint)
+		c.id(), valueLeft, deadline, deadlineMinHeight, heightHint)
 
 	return fn.Some(int32(deadline)), valueLeft, nil
 }
@@ -1604,15 +1599,14 @@ func (c *ChannelArbitrator) launchResolvers() {
 		// launch it again.
 		if contract.IsResolved() {
 			log.Debugf("ChannelArbitrator(%v): skipping resolver "+
-				"%T as it's already resolved", c.cfg.ChanPoint,
-				contract)
+				"%T as it's already resolved", c.id(), contract)
 
 			continue
 		}
 
 		if err := contract.Launch(); err != nil {
 			log.Errorf("ChannelArbitrator(%v): unable to launch "+
-				"contract resolver(%T): %v", c.cfg.ChanPoint,
+				"contract resolver(%T): %v", c.id(),
 				contract, err)
 		}
 	}
@@ -1639,14 +1633,15 @@ func (c *ChannelArbitrator) advanceState(
 		priorState = c.state
 		log.Debugf("ChannelArbitrator(%v): attempting state step with "+
 			"trigger=%v from state=%v at height=%v",
-			c.cfg.ChanPoint, trigger, priorState, triggerHeight)
+			c.id(), trigger, priorState, triggerHeight)
 
 		nextState, closeTx, err := c.stateStep(
 			triggerHeight, trigger, confCommitSet,
 		)
 		if err != nil {
 			log.Errorf("ChannelArbitrator(%v): unable to advance "+
-				"state: %v", c.cfg.ChanPoint, err)
+				"state: %v", c.id(), err)
+
 			return priorState, nil, err
 		}
 
@@ -1659,7 +1654,8 @@ func (c *ChannelArbitrator) advanceState(
 		// terminate.
 		if nextState == priorState {
 			log.Debugf("ChannelArbitrator(%v): terminating at "+
-				"state=%v", c.cfg.ChanPoint, nextState)
+				"state=%v", c.id(), nextState)
+
 			return nextState, forceCloseTx, nil
 		}
 
@@ -1668,8 +1664,8 @@ func (c *ChannelArbitrator) advanceState(
 		// the prior state if anything fails.
 		if err := c.log.CommitState(nextState); err != nil {
 			log.Errorf("ChannelArbitrator(%v): unable to commit "+
-				"next state(%v): %v", c.cfg.ChanPoint,
-				nextState, err)
+				"next state(%v): %v", c.id(), nextState, err)
+
 			return priorState, nil, err
 		}
 		c.state = nextState
@@ -1772,8 +1768,8 @@ func (c *ChannelArbitrator) shouldGoOnChain(htlc channeldb.HTLC,
 	broadcastCutOff := htlc.RefundTimeout - broadcastDelta
 
 	log.Tracef("ChannelArbitrator(%v): examining outgoing contract: "+
-		"expiry=%v, cutoff=%v, height=%v", c.cfg.ChanPoint, htlc.RefundTimeout,
-		broadcastCutOff, currentHeight)
+		"expiry=%v, cutoff=%v, height=%v", c.id(),
+		htlc.RefundTimeout, broadcastCutOff, currentHeight)
 
 	// TODO(roasbeef): take into account default HTLC delta, don't need to
 	// broadcast immediately
@@ -1822,8 +1818,8 @@ func (c *ChannelArbitrator) checkCommitChainActions(height uint32,
 
 	log.Debugf("ChannelArbitrator(%v): checking commit chain actions at "+
 		"height=%v, in_htlc_count=%v, out_htlc_count=%v",
-		c.cfg.ChanPoint, height,
-		len(htlcs.incomingHTLCs), len(htlcs.outgoingHTLCs))
+		c.id(), height, len(htlcs.incomingHTLCs),
+		len(htlcs.outgoingHTLCs))
 
 	actionMap := make(ChainActionMap)
 
@@ -1852,7 +1848,7 @@ func (c *ChannelArbitrator) checkCommitChainActions(height uint32,
 			log.Infof("ChannelArbitrator(%v): go to chain for "+
 				"outgoing htlc %x: timeout=%v, amount=%v, "+
 				"blocks_until_expiry=%v, broadcast_delta=%v",
-				c.cfg.ChanPoint, htlc.RHash[:],
+				c.id(), htlc.RHash[:],
 				htlc.RefundTimeout, htlc.Amt, remainingBlocks,
 				c.cfg.OutgoingBroadcastDelta,
 			)
@@ -1887,7 +1883,7 @@ func (c *ChannelArbitrator) checkCommitChainActions(height uint32,
 			log.Infof("ChannelArbitrator(%v): go to chain for "+
 				"incoming htlc %x: timeout=%v, amount=%v, "+
 				"blocks_until_expiry=%v, broadcast_delta=%v",
-				c.cfg.ChanPoint, htlc.RHash[:],
+				c.id(), htlc.RHash[:],
 				htlc.RefundTimeout, htlc.Amt, remainingBlocks,
 				c.cfg.IncomingBroadcastDelta,
 			)
@@ -1902,7 +1898,7 @@ func (c *ChannelArbitrator) checkCommitChainActions(height uint32,
 	// we're *forced* to act on each HTLC.
 	if !haveChainActions && trigger == chainTrigger {
 		log.Tracef("ChannelArbitrator(%v): no actions to take at "+
-			"height=%v", c.cfg.ChanPoint, height)
+			"height=%v", c.id(), height)
 		return actionMap, nil
 	}
 
@@ -1918,8 +1914,7 @@ func (c *ChannelArbitrator) checkCommitChainActions(height uint32,
 		// negative.
 		case htlc.OutputIndex < 0:
 			log.Tracef("ChannelArbitrator(%v): immediately "+
-				"failing dust htlc=%x", c.cfg.ChanPoint,
-				htlc.RHash[:])
+				"failing dust htlc=%x", c.id(), htlc.RHash[:])
 
 			actionMap[HtlcFailNowAction] = append(
 				actionMap[HtlcFailNowAction], htlc,
@@ -1941,7 +1936,7 @@ func (c *ChannelArbitrator) checkCommitChainActions(height uint32,
 
 			log.Tracef("ChannelArbitrator(%v): watching chain to "+
 				"decide action for outgoing htlc=%x",
-				c.cfg.ChanPoint, htlc.RHash[:])
+				c.id(), htlc.RHash[:])
 
 			actionMap[HtlcOutgoingWatchAction] = append(
 				actionMap[HtlcOutgoingWatchAction], htlc,
@@ -1951,7 +1946,7 @@ func (c *ChannelArbitrator) checkCommitChainActions(height uint32,
 		// to sweep this HTLC on-chain
 		default:
 			log.Tracef("ChannelArbitrator(%v): going on-chain to "+
-				"timeout htlc=%x", c.cfg.ChanPoint, htlc.RHash[:])
+				"timeout htlc=%x", c.id(), htlc.RHash[:])
 
 			actionMap[HtlcTimeoutAction] = append(
 				actionMap[HtlcTimeoutAction], htlc,
@@ -1969,7 +1964,7 @@ func (c *ChannelArbitrator) checkCommitChainActions(height uint32,
 		if htlc.OutputIndex < 0 {
 			log.Debugf("ChannelArbitrator(%v): no resolution "+
 				"needed for incoming dust htlc=%x",
-				c.cfg.ChanPoint, htlc.RHash[:])
+				c.id(), htlc.RHash[:])
 
 			actionMap[HtlcIncomingDustFinalAction] = append(
 				actionMap[HtlcIncomingDustFinalAction], htlc,
@@ -1979,8 +1974,7 @@ func (c *ChannelArbitrator) checkCommitChainActions(height uint32,
 		}
 
 		log.Tracef("ChannelArbitrator(%v): watching chain to decide "+
-			"action for incoming htlc=%x", c.cfg.ChanPoint,
-			htlc.RHash[:])
+			"action for incoming htlc=%x", c.id(), htlc.RHash[:])
 
 		actionMap[HtlcIncomingWatchAction] = append(
 			actionMap[HtlcIncomingWatchAction], htlc,
@@ -2114,8 +2108,7 @@ func (c *ChannelArbitrator) checkRemoteDanglingActions(
 		}
 
 		log.Infof("ChannelArbitrator(%v): fail dangling htlc=%x from "+
-			"local/remote commitments diff",
-			c.cfg.ChanPoint, htlc.RHash[:])
+			"local/remote commitments diff", c.id(), htlc.RHash[:])
 
 		actionMap[HtlcFailNowAction] = append(
 			actionMap[HtlcFailNowAction], htlc,
@@ -2197,8 +2190,7 @@ func (c *ChannelArbitrator) checkRemoteDiffActions(
 		if err != nil {
 			log.Errorf("ChannelArbitrator(%v): failed to query "+
 				"preimage for dangling htlc=%x from remote "+
-				"commitments diff", c.cfg.ChanPoint,
-				htlc.RHash[:])
+				"commitments diff", c.id(), htlc.RHash[:])
 
 			continue
 		}
@@ -2212,8 +2204,7 @@ func (c *ChannelArbitrator) checkRemoteDiffActions(
 		)
 
 		log.Infof("ChannelArbitrator(%v): fail dangling htlc=%x from "+
-			"remote commitments diff",
-			c.cfg.ChanPoint, htlc.RHash[:])
+			"remote commitments diff", c.id(), htlc.RHash[:])
 	}
 
 	return actionMap
@@ -2299,7 +2290,7 @@ func (c *ChannelArbitrator) prepContractResolutions(
 		fallthrough
 	case err == channeldb.ErrChannelNotFound:
 		log.Warnf("ChannelArbitrator(%v): unable to fetch historical "+
-			"state", c.cfg.ChanPoint)
+			"state", c.id())
 
 	case err != nil:
 		return nil, nil, err
@@ -2432,7 +2423,7 @@ func (c *ChannelArbitrator) prepContractResolutions(
 					// TODO(roasbeef): panic?
 					log.Errorf("ChannelArbitrator(%v) unable to find "+
 						"incoming resolution: %v",
-						c.cfg.ChanPoint, htlcOp)
+						c.id(), htlcOp)
 					continue
 				}
 
@@ -2459,8 +2450,10 @@ func (c *ChannelArbitrator) prepContractResolutions(
 
 				resolution, ok := outResolutionMap[htlcOp]
 				if !ok {
-					log.Errorf("ChannelArbitrator(%v) unable to find "+
-						"outgoing resolution: %v", c.cfg.ChanPoint, htlcOp)
+					log.Errorf("ChannelArbitrator(%v) "+
+						"unable to find outgoing "+
+						"resolution: %v",
+						c.id(), htlcOp)
 					continue
 				}
 
@@ -2500,7 +2493,7 @@ func (c *ChannelArbitrator) prepContractResolutions(
 				if !ok {
 					log.Errorf("ChannelArbitrator(%v) unable to find "+
 						"incoming resolution: %v",
-						c.cfg.ChanPoint, htlcOp)
+						c.id(), htlcOp)
 					continue
 				}
 
@@ -2560,7 +2553,7 @@ func (c *ChannelArbitrator) prepContractResolutions(
 				if !ok {
 					log.Errorf("ChannelArbitrator(%v) unable to find "+
 						"outgoing resolution: %v",
-						c.cfg.ChanPoint, htlcOp)
+						c.id(), htlcOp)
 					continue
 				}
 
@@ -2631,13 +2624,13 @@ func (c *ChannelArbitrator) resolveContract(currentContract ContractResolver) {
 	defer c.wg.Done()
 
 	log.Debugf("ChannelArbitrator(%v): attempting to resolve %T",
-		c.cfg.ChanPoint, currentContract)
+		c.id(), currentContract)
 
 	// Until the contract is fully resolved, we'll continue to iteratively
 	// resolve the contract one step at a time.
 	for !currentContract.IsResolved() {
-		log.Debugf("ChannelArbitrator(%v): contract %T not yet resolved",
-			c.cfg.ChanPoint, currentContract)
+		log.Debugf("ChannelArbitrator(%v): contract %T not yet "+
+			"resolved", c.id(), currentContract)
 
 		select {
 
@@ -2656,7 +2649,7 @@ func (c *ChannelArbitrator) resolveContract(currentContract ContractResolver) {
 
 				log.Errorf("ChannelArbitrator(%v): unable to "+
 					"progress %T: %v",
-					c.cfg.ChanPoint, currentContract, err)
+					c.id(), currentContract, err)
 				return
 			}
 
@@ -2669,7 +2662,7 @@ func (c *ChannelArbitrator) resolveContract(currentContract ContractResolver) {
 			case nextContract != nil:
 				log.Debugf("ChannelArbitrator(%v): swapping "+
 					"out contract %T for %T ",
-					c.cfg.ChanPoint, currentContract,
+					c.id(), currentContract,
 					nextContract)
 
 				// Swap contract in log.
@@ -2709,7 +2702,7 @@ func (c *ChannelArbitrator) resolveContract(currentContract ContractResolver) {
 			case currentContract.IsResolved():
 				log.Debugf("ChannelArbitrator(%v): marking "+
 					"contract %T fully resolved",
-					c.cfg.ChanPoint, currentContract)
+					c.id(), currentContract)
 
 				err := c.log.ResolveContract(currentContract)
 				if err != nil {
@@ -2775,8 +2768,7 @@ func (c *ChannelArbitrator) notifyContractUpdate(upd *ContractUpdate) {
 	c.unmergedSet[upd.HtlcKey] = newHtlcSet(upd.Htlcs)
 
 	log.Tracef("ChannelArbitrator(%v): fresh set of htlcs=%v",
-		c.cfg.ChanPoint,
-		newLogClosure(func() string {
+		c.id(), newLogClosure(func() string {
 			return spew.Sdump(upd)
 		}),
 	)
@@ -2828,7 +2820,7 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 			bestHeight = beat.Height()
 
 			log.Debugf("ChannelArbitrator(%v): new block height=%v",
-				c.cfg.ChanPoint, bestHeight)
+				c.id(), bestHeight)
 
 			err := c.handleBlockbeat(beat)
 			if err != nil {
@@ -2848,7 +2840,7 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 		// properly do our job.
 		case signalUpdate := <-c.signalUpdates:
 			log.Tracef("ChannelArbitrator(%v): got new signal "+
-				"update!", c.cfg.ChanPoint)
+				"update!", c.id())
 
 			// We'll update the ShortChannelID.
 			c.cfg.ShortChanID = signalUpdate.newSignals.ShortChanID
@@ -2862,7 +2854,9 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 		// needed. We'll mark the channel as resolved and exit.
 		case closeInfo := <-c.cfg.ChainEvents.CooperativeClosure:
 			log.Infof("ChannelArbitrator(%v) marking channel "+
-				"cooperatively closed", c.cfg.ChanPoint)
+				"cooperatively closed at height %v", c.id(),
+				closeInfo.CloseHeight,
+			)
 
 			err := c.cfg.MarkChannelClosed(
 				closeInfo.ChannelCloseSummary,
@@ -2889,15 +2883,13 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 		case closeInfo := <-c.cfg.ChainEvents.LocalUnilateralClosure:
 			if c.state != StateCommitmentBroadcasted {
 				log.Errorf("ChannelArbitrator(%v): unexpected "+
-					"local on-chain channel close",
-					c.cfg.ChanPoint)
+					"local on-chain channel close", c.id())
 			}
 
 			closeTx := closeInfo.CloseTx
 
 			log.Infof("ChannelArbitrator(%v): local force close "+
-				"tx=%v confirmed", c.cfg.ChanPoint,
-				closeTx.TxHash())
+				"tx=%v confirmed", c.id(), closeTx.TxHash())
 
 			contractRes := &ContractResolutions{
 				CommitHash:       closeTx.TxHash(),
@@ -2962,7 +2954,9 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 		// all.
 		case uniClosure := <-c.cfg.ChainEvents.RemoteUnilateralClosure:
 			log.Infof("ChannelArbitrator(%v): remote party has "+
-				"closed channel out on-chain", c.cfg.ChanPoint)
+				"force closed channel at height %v", c.id(),
+				uniClosure.SpendingHeight,
+			)
 
 			// If we don't have a self output, and there are no
 			// active HTLC's, then we can immediately mark the
@@ -3031,8 +3025,11 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 		// anything in particular, so just advance our state and
 		// gracefully exit.
 		case breachInfo := <-c.cfg.ChainEvents.ContractBreach:
+			closeSummary := &breachInfo.CloseSummary
+
 			log.Infof("ChannelArbitrator(%v): remote party has "+
-				"breached channel!", c.cfg.ChanPoint)
+				"breached channel at height %v!", c.id(),
+				closeSummary.CloseHeight)
 
 			// In the breach case, we'll only have anchor and
 			// breach resolutions.
@@ -3064,7 +3061,6 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 			// The channel is finally marked pending closed here as
 			// the BreachArbitrator and channel arbitrator have
 			// persisted the relevant states.
-			closeSummary := &breachInfo.CloseSummary
 			err = c.cfg.MarkChannelClosed(
 				closeSummary,
 				channeldb.ChanStatusRemoteCloseInitiator,
@@ -3081,8 +3077,8 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 			// We'll advance our state machine until it reaches a
 			// terminal state.
 			_, _, err = c.advanceState(
-				uint32(bestHeight), breachCloseTrigger,
-				&breachInfo.CommitSet,
+				closeSummary.CloseHeight,
+				breachCloseTrigger, &breachInfo.CommitSet,
 			)
 			if err != nil {
 				log.Errorf("Unable to advance state: %v", err)
@@ -3093,7 +3089,7 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 		// we can exit as the contract is fully resolved.
 		case <-c.resolutionSignal:
 			log.Infof("ChannelArbitrator(%v): a contract has been "+
-				"fully resolved!", c.cfg.ChanPoint)
+				"fully resolved!", c.id())
 
 			nextState, _, err := c.advanceState(
 				uint32(bestHeight), chainTrigger, nil,
@@ -3107,7 +3103,7 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 			if nextState == StateFullyResolved {
 				log.Infof("ChannelArbitrator(%v): all "+
 					"contracts fully resolved, exiting",
-					c.cfg.ChanPoint)
+					c.id())
 
 				return
 			}
@@ -3116,7 +3112,7 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 		// channel. We'll
 		case closeReq := <-c.forceCloseReqs:
 			log.Infof("ChannelArbitrator(%v): received force "+
-				"close request", c.cfg.ChanPoint)
+				"close request", c.id())
 
 			if c.state != StateDefault {
 				select {
@@ -3155,8 +3151,7 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 			// advancing our state, then we'll exit.
 			if nextState == StateFullyResolved {
 				log.Infof("ChannelArbitrator(%v): all "+
-					"contracts resolved, exiting",
-					c.cfg.ChanPoint)
+					"contracts resolved, exiting", c.id())
 				return
 			}
 
@@ -3194,7 +3189,7 @@ func (c *ChannelArbitrator) handleBlockbeat(beat chainio.Blockbeat) error {
 //
 // NOTE: Part of chainio.Consumer interface.
 func (c *ChannelArbitrator) Name() string {
-	return fmt.Sprintf("ChannelArbitrator(%v)", c.cfg.ChanPoint)
+	return fmt.Sprintf("ChannelArbitrator(%v)", c.id())
 }
 
 // checkLegacyBreach returns StateFullyResolved if the channel was closed with
@@ -3217,4 +3212,17 @@ func (c *ChannelArbitrator) checkLegacyBreach() (ArbitratorState, error) {
 
 	// This is a modern breach close with resolvers.
 	return StateContractClosed, nil
+}
+
+// id returns an identifier for the channel arbitrator to be used in logging.
+// It uses the ShortChanID as the id when it's not zero, otherwise ChanPoint is
+// used.
+func (c *ChannelArbitrator) id() string {
+	id := c.cfg.ShortChanID.String()
+
+	if c.cfg.ShortChanID.IsDefault() {
+		id = c.cfg.ChanPoint.String()
+	}
+
+	return id
 }

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -789,7 +789,7 @@ func (c *ChannelArbitrator) relaunchResolvers(commitSet *CommitSet,
 		// TODO(roasbeef): this isn't re-launched?
 	}
 
-	c.launchResolvers(unresolvedContracts)
+	c.resolveContracts(unresolvedContracts)
 
 	return nil
 }
@@ -1247,7 +1247,7 @@ func (c *ChannelArbitrator) stateStep(
 
 		// Finally, we'll launch all the required contract resolvers.
 		// Once they're all resolved, we're no longer needed.
-		c.launchResolvers(resolvers)
+		c.resolveContracts(resolvers)
 
 		nextState = StateWaitingFullResolution
 
@@ -1577,15 +1577,44 @@ func (c *ChannelArbitrator) findCommitmentDeadlineAndValue(heightHint uint32,
 	return fn.Some(int32(deadline)), valueLeft, nil
 }
 
-// launchResolvers updates the activeResolvers list and starts the resolvers.
-func (c *ChannelArbitrator) launchResolvers(resolvers []ContractResolver) {
+// resolveContracts updates the activeResolvers list and starts to resolve each
+// contract concurrently, and launches them.
+func (c *ChannelArbitrator) resolveContracts(resolvers []ContractResolver) {
 	c.activeResolversLock.Lock()
 	c.activeResolvers = resolvers
 	c.activeResolversLock.Unlock()
 
+	// Launch all resolvers.
+	c.launchResolvers()
+
 	for _, contract := range resolvers {
 		c.wg.Add(1)
 		go c.resolveContract(contract)
+	}
+}
+
+// launchResolvers launches all the active resolvers.
+func (c *ChannelArbitrator) launchResolvers() {
+	c.activeResolversLock.Lock()
+	resolvers := c.activeResolvers
+	c.activeResolversLock.Unlock()
+
+	for _, contract := range resolvers {
+		// If the contract is already resolved, there's no need to
+		// launch it again.
+		if contract.IsResolved() {
+			log.Debugf("ChannelArbitrator(%v): skipping resolver "+
+				"%T as it's already resolved", c.cfg.ChanPoint,
+				contract)
+
+			continue
+		}
+
+		if err := contract.Launch(); err != nil {
+			log.Errorf("ChannelArbitrator(%v): unable to launch "+
+				"contract resolver(%T): %v", c.cfg.ChanPoint,
+				contract, err)
+		}
 	}
 }
 
@@ -2668,6 +2697,13 @@ func (c *ChannelArbitrator) resolveContract(currentContract ContractResolver) {
 				// loop.
 				currentContract = nextContract
 
+				// Launch the new contract.
+				err = currentContract.Launch()
+				if err != nil {
+					log.Errorf("Failed to launch %T: %v",
+						currentContract, err)
+				}
+
 			// If this contract is actually fully resolved, then
 			// we'll mark it as such within the database.
 			case currentContract.IsResolved():
@@ -3147,6 +3183,9 @@ func (c *ChannelArbitrator) handleBlockbeat(beat chainio.Blockbeat) error {
 			return fmt.Errorf("unable to advance state: %w", err)
 		}
 	}
+
+	// Launch all active resolvers when a new blockbeat is received.
+	c.launchResolvers()
 
 	return nil
 }

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -794,11 +794,8 @@ func (c *ChannelArbitrator) relaunchResolvers(commitSet *CommitSet,
 
 // Report returns htlc reports for the active resolvers.
 func (c *ChannelArbitrator) Report() []*ContractReport {
-	c.activeResolversLock.RLock()
-	defer c.activeResolversLock.RUnlock()
-
 	var reports []*ContractReport
-	for _, resolver := range c.activeResolvers {
+	for _, resolver := range c.resolvers() {
 		r, ok := resolver.(reportingContractResolver)
 		if !ok {
 			continue
@@ -1575,6 +1572,7 @@ func (c *ChannelArbitrator) findCommitmentDeadlineAndValue(heightHint uint32,
 // resolveContracts updates the activeResolvers list and starts to resolve each
 // contract concurrently, and launches them.
 func (c *ChannelArbitrator) resolveContracts(resolvers []ContractResolver) {
+	// Update the active contract resolvers.
 	c.activeResolversLock.Lock()
 	c.activeResolvers = resolvers
 	c.activeResolversLock.Unlock()
@@ -1582,7 +1580,7 @@ func (c *ChannelArbitrator) resolveContracts(resolvers []ContractResolver) {
 	// Launch all resolvers.
 	c.launchResolvers()
 
-	for _, contract := range resolvers {
+	for _, contract := range c.resolvers() {
 		c.wg.Add(1)
 		go c.resolveContract(contract)
 	}
@@ -1590,11 +1588,7 @@ func (c *ChannelArbitrator) resolveContracts(resolvers []ContractResolver) {
 
 // launchResolvers launches all the active resolvers.
 func (c *ChannelArbitrator) launchResolvers() {
-	c.activeResolversLock.Lock()
-	resolvers := c.activeResolvers
-	c.activeResolversLock.Unlock()
-
-	for _, contract := range resolvers {
+	for _, contract := range c.resolvers() {
 		// If the contract is already resolved, there's no need to
 		// launch it again.
 		if contract.IsResolved() {
@@ -3225,4 +3219,15 @@ func (c *ChannelArbitrator) id() string {
 	}
 
 	return id
+}
+
+// resolvers returns a copy of the active resolvers.
+func (c *ChannelArbitrator) resolvers() []ContractResolver {
+	c.activeResolversLock.Lock()
+	defer c.activeResolversLock.Unlock()
+
+	resolvers := make([]ContractResolver, 0, len(c.activeResolvers))
+	resolvers = append(resolvers, c.activeResolvers...)
+
+	return resolvers
 }

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -7,13 +7,13 @@ import (
 	"reflect"
 	"sort"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/chainio"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
@@ -332,9 +332,6 @@ func withForceCloseErr(err error) testChanArbOption {
 	}
 }
 
-// blockCounter is the block height used in the test.
-var blockCounter atomic.Uint32
-
 // createTestChannelArbitrator returns a channel arbitrator test context which
 // contains a channel arbitrator with default values. These values can be
 // changed by providing options which overwrite the default config.
@@ -511,8 +508,7 @@ func createTestChannelArbitrator(t *testing.T, log ArbitratorLog,
 
 	// Mock the behavior of BlockbeatDispatcher - during the startup, a new
 	// blockbeat will always be sent.
-	height := blockCounter.Add(1)
-	chanArbCtx.receiveBlockbeat(int(height))
+	chanArbCtx.receiveBlockbeat(1)
 
 	return chanArbCtx, nil
 }
@@ -960,6 +956,7 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 			},
 		},
 	}
+	closeTxid := closeTx.TxHash()
 
 	htlcOp := wire.OutPoint{
 		Hash:  closeTx.TxHash(),
@@ -1082,12 +1079,7 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 	}
 
 	// Send a notification that the expiry height has been reached.
-	//
-	// TODO(yy): remove the EpochChan and use the blockbeat below once
-	// resolvers are hooked with the blockbeat.
 	oldNotifier.EpochChan <- &chainntnfs.BlockEpoch{Height: 10}
-	// beat := chainio.NewBlockbeatFromHeight(10)
-	// chanArb.BlockbeatChan <- beat
 
 	// htlcOutgoingContestResolver is now transforming into a
 	// htlcTimeoutResolver and should send the contract off for incubation.
@@ -1099,7 +1091,19 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 
 	// Notify resolver that the HTLC output of the commitment has been
 	// spent.
-	oldNotifier.SpendChan <- &chainntnfs.SpendDetail{SpendingTx: closeTx}
+	oldNotifier.SpendChan <- &chainntnfs.SpendDetail{
+		SpendingTx:    closeTx,
+		SpentOutPoint: &wire.OutPoint{},
+		SpenderTxHash: &closeTxid,
+	}
+
+	// Notify resolver that the HTLC output of the commitment has been
+	// spent.
+	oldNotifier.SpendChan <- &chainntnfs.SpendDetail{
+		SpendingTx:    closeTx,
+		SpentOutPoint: &wire.OutPoint{},
+		SpenderTxHash: &closeTxid,
+	}
 
 	// Finally, we should also receive a resolution message instructing the
 	// switch to cancel back the HTLC.
@@ -1126,8 +1130,12 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 	default:
 	}
 
-	// Notify resolver that the second level transaction is spent.
-	oldNotifier.SpendChan <- &chainntnfs.SpendDetail{SpendingTx: closeTx}
+	// Notify resolver that the output of the timeout tx has been spent.
+	oldNotifier.SpendChan <- &chainntnfs.SpendDetail{
+		SpendingTx:    closeTx,
+		SpentOutPoint: &wire.OutPoint{},
+		SpenderTxHash: &closeTxid,
+	}
 
 	// At this point channel should be marked as resolved.
 	chanArbCtxNew.AssertStateTransitions(StateFullyResolved)
@@ -2675,28 +2683,28 @@ func TestChannelArbitratorAnchors(t *testing.T) {
 	}
 	chanArb.UpdateContractSignals(signals)
 
-	// Set current block height.
-	heightHint := uint32(1000)
-	beat := chainio.NewBeatFromHeight(int32(heightHint))
-	chanArbCtx.chanArb.BlockbeatChan <- beat
-
 	htlcAmt := lnwire.MilliSatoshi(1_000_000)
 
 	// Create testing HTLCs.
-	deadlineDelta := uint32(10)
-	deadlinePreimageDelta := deadlineDelta + 2
+	spendingHeight := uint32(chanArb.CurrentBeat().Height())
+	deadlineDelta := uint32(100)
+
+	deadlinePreimageDelta := deadlineDelta
 	htlcWithPreimage := channeldb.HTLC{
-		HtlcIndex:     99,
-		RefundTimeout: heightHint + deadlinePreimageDelta,
+		HtlcIndex: 99,
+		// RefundTimeout is 101.
+		RefundTimeout: spendingHeight + deadlinePreimageDelta,
 		RHash:         rHash,
 		Incoming:      true,
 		Amt:           htlcAmt,
 	}
+	expectedDeadline := deadlineDelta/2 + spendingHeight
 
-	deadlineHTLCdelta := deadlineDelta + 3
+	deadlineHTLCdelta := deadlineDelta + 40
 	htlc := channeldb.HTLC{
-		HtlcIndex:     100,
-		RefundTimeout: heightHint + deadlineHTLCdelta,
+		HtlcIndex: 100,
+		// RefundTimeout is 141.
+		RefundTimeout: spendingHeight + deadlineHTLCdelta,
 		Amt:           htlcAmt,
 	}
 
@@ -2780,7 +2788,9 @@ func TestChannelArbitratorAnchors(t *testing.T) {
 	}
 
 	chanArb.cfg.ChainEvents.LocalUnilateralClosure <- &LocalUnilateralCloseInfo{
-		SpendDetail: &chainntnfs.SpendDetail{},
+		SpendDetail: &chainntnfs.SpendDetail{
+			SpendingHeight: int32(spendingHeight),
+		},
 		LocalForceCloseSummary: &lnwallet.LocalForceCloseSummary{
 			CloseTx:          closeTx,
 			HtlcResolutions:  &lnwallet.HtlcResolutions{},
@@ -2842,16 +2852,14 @@ func TestChannelArbitratorAnchors(t *testing.T) {
 	// to htlcWithPreimage's CLTV.
 	require.Equal(t, 2, len(chanArbCtx.sweeper.deadlines))
 	require.EqualValues(t,
-		heightHint+deadlinePreimageDelta/2,
+		expectedDeadline,
 		chanArbCtx.sweeper.deadlines[0], "want %d, got %d",
-		heightHint+deadlinePreimageDelta/2,
-		chanArbCtx.sweeper.deadlines[0],
+		expectedDeadline, chanArbCtx.sweeper.deadlines[0],
 	)
 	require.EqualValues(t,
-		heightHint+deadlinePreimageDelta/2,
+		expectedDeadline,
 		chanArbCtx.sweeper.deadlines[1], "want %d, got %d",
-		heightHint+deadlinePreimageDelta/2,
-		chanArbCtx.sweeper.deadlines[1],
+		expectedDeadline, chanArbCtx.sweeper.deadlines[1],
 	)
 }
 
@@ -2998,7 +3006,8 @@ func assertResolverReport(t *testing.T, reports chan *channeldb.ResolverReport,
 	select {
 	case report := <-reports:
 		if !reflect.DeepEqual(report, expected) {
-			t.Fatalf("expected: %v, got: %v", expected, report)
+			t.Fatalf("expected: %v, got: %v", spew.Sdump(expected),
+				spew.Sdump(report))
 		}
 
 	case <-time.After(defaultTimeout):

--- a/contractcourt/commit_sweep_resolver.go
+++ b/contractcourt/commit_sweep_resolver.go
@@ -157,149 +157,8 @@ func (c *commitSweepResolver) getCommitTxConfHeight() (uint32, error) {
 func (c *commitSweepResolver) Resolve() (ContractResolver, error) {
 	// If we're already resolved, then we can exit early.
 	if c.resolved {
+		c.log.Errorf("already resolved")
 		return nil, nil
-	}
-
-	confHeight, err := c.getCommitTxConfHeight()
-	if err != nil {
-		return nil, err
-	}
-
-	// Wait up until the CSV expires, unless we also have a CLTV that
-	// expires after.
-	unlockHeight := confHeight + c.commitResolution.MaturityDelay
-	if c.hasCLTV() {
-		unlockHeight = uint32(math.Max(
-			float64(unlockHeight), float64(c.leaseExpiry),
-		))
-	}
-
-	c.log.Debugf("commit conf_height=%v, unlock_height=%v",
-		confHeight, unlockHeight)
-
-	// Update report now that we learned the confirmation height.
-	c.reportLock.Lock()
-	c.currentReport.MaturityHeight = unlockHeight
-	c.reportLock.Unlock()
-
-	var (
-		isLocalCommitTx bool
-
-		signDesc = c.commitResolution.SelfOutputSignDesc
-	)
-	switch {
-	// For taproot channels, we'll know if this is the local commit based
-	// on the witness script. For local channels, the witness script has an
-	// OP_DROP value.
-	//
-	// TODO(roasbeef): revisit this after the script changes
-	//  * otherwise need to base off the key in script or the CSV value
-	//  (script num encode)
-	case c.chanType.IsTaproot():
-		scriptLen := len(signDesc.WitnessScript)
-		isLocalCommitTx = signDesc.WitnessScript[scriptLen-1] ==
-			txscript.OP_DROP
-
-	// The output is on our local commitment if the script starts with
-	// OP_IF for the revocation clause. On the remote commitment it will
-	// either be a regular P2WKH or a simple sig spend with a CSV delay.
-	default:
-		isLocalCommitTx = signDesc.WitnessScript[0] == txscript.OP_IF
-	}
-	isDelayedOutput := c.commitResolution.MaturityDelay != 0
-
-	c.log.Debugf("isDelayedOutput=%v, isLocalCommitTx=%v", isDelayedOutput,
-		isLocalCommitTx)
-
-	// There're three types of commitments, those that have tweaks for the
-	// remote key (us in this case), those that don't, and a third where
-	// there is no tweak and the output is delayed. On the local commitment
-	// our output will always be delayed. We'll rely on the presence of the
-	// commitment tweak to discern which type of commitment this is.
-	var witnessType input.WitnessType
-	switch {
-	// The local delayed output for a taproot channel.
-	case isLocalCommitTx && c.chanType.IsTaproot():
-		witnessType = input.TaprootLocalCommitSpend
-
-	// The CSV 1 delayed output for a taproot channel.
-	case !isLocalCommitTx && c.chanType.IsTaproot():
-		witnessType = input.TaprootRemoteCommitSpend
-
-	// Delayed output to us on our local commitment for a channel lease in
-	// which we are the initiator.
-	case isLocalCommitTx && c.hasCLTV():
-		witnessType = input.LeaseCommitmentTimeLock
-
-	// Delayed output to us on our local commitment.
-	case isLocalCommitTx:
-		witnessType = input.CommitmentTimeLock
-
-	// A confirmed output to us on the remote commitment for a channel lease
-	// in which we are the initiator.
-	case isDelayedOutput && c.hasCLTV():
-		witnessType = input.LeaseCommitmentToRemoteConfirmed
-
-	// A confirmed output to us on the remote commitment.
-	case isDelayedOutput:
-		witnessType = input.CommitmentToRemoteConfirmed
-
-	// A non-delayed output on the remote commitment where the key is
-	// tweakless.
-	case c.commitResolution.SelfOutputSignDesc.SingleTweak == nil:
-		witnessType = input.CommitSpendNoDelayTweakless
-
-	// A non-delayed output on the remote commitment where the key is
-	// tweaked.
-	default:
-		witnessType = input.CommitmentNoDelay
-	}
-
-	c.log.Infof("Sweeping with witness type: %v", witnessType)
-
-	// We'll craft an input with all the information required for the
-	// sweeper to create a fully valid sweeping transaction to recover
-	// these coins.
-	var inp *input.BaseInput
-	if c.hasCLTV() {
-		inp = input.NewCsvInputWithCltv(
-			&c.commitResolution.SelfOutPoint, witnessType,
-			&c.commitResolution.SelfOutputSignDesc,
-			c.broadcastHeight, c.commitResolution.MaturityDelay,
-			c.leaseExpiry,
-		)
-	} else {
-		inp = input.NewCsvInput(
-			&c.commitResolution.SelfOutPoint, witnessType,
-			&c.commitResolution.SelfOutputSignDesc,
-			c.broadcastHeight, c.commitResolution.MaturityDelay,
-		)
-	}
-
-	// TODO(roasbeef): instead of ading ctrl block to the sign desc, make
-	// new input type, have sweeper set it?
-
-	// Calculate the budget for the sweeping this input.
-	budget := calculateBudget(
-		btcutil.Amount(inp.SignDesc().Output.Value),
-		c.Budget.ToLocalRatio, c.Budget.ToLocal,
-	)
-	c.log.Infof("Sweeping commit output using budget=%v", budget)
-
-	// With our input constructed, we'll now offer it to the sweeper.
-	resultChan, err := c.Sweeper.SweepInput(
-		inp, sweep.Params{
-			Budget: budget,
-
-			// Specify a nil deadline here as there's no time
-			// pressure.
-			DeadlineHeight: fn.None[int32](),
-		},
-	)
-	if err != nil {
-		c.log.Errorf("unable to sweep input: %v", err)
-
-		return nil, err
 	}
 
 	var sweepTxID chainhash.Hash
@@ -310,7 +169,7 @@ func (c *commitSweepResolver) Resolve() (ContractResolver, error) {
 	// happen.
 	outcome := channeldb.ResolverOutcomeClaimed
 	select {
-	case sweepResult := <-resultChan:
+	case sweepResult := <-c.sweepResultChan:
 		switch sweepResult.Err {
 		// If the remote party was able to sweep this output it's
 		// likely what we sent was actually a revoked commitment.
@@ -362,6 +221,7 @@ func (c *commitSweepResolver) Resolve() (ContractResolver, error) {
 //
 // NOTE: Part of the ContractResolver interface.
 func (c *commitSweepResolver) Stop() {
+	c.log.Debugf("stopping...")
 	close(c.quit)
 }
 
@@ -494,3 +354,163 @@ func (c *commitSweepResolver) initReport() {
 // A compile time assertion to ensure commitSweepResolver meets the
 // ContractResolver interface.
 var _ reportingContractResolver = (*commitSweepResolver)(nil)
+
+// Launch constructs a commit input and offers it to the sweeper.
+func (c *commitSweepResolver) Launch() error {
+	if c.launched {
+		c.log.Tracef("already launched")
+		return nil
+	}
+
+	c.log.Debugf("launching resolver...")
+	c.launched = true
+
+	// If we're already resolved, then we can exit early.
+	if c.resolved {
+		c.log.Errorf("already resolved")
+		return nil
+	}
+
+	confHeight, err := c.getCommitTxConfHeight()
+	if err != nil {
+		return err
+	}
+
+	// Wait up until the CSV expires, unless we also have a CLTV that
+	// expires after.
+	unlockHeight := confHeight + c.commitResolution.MaturityDelay
+	if c.hasCLTV() {
+		unlockHeight = uint32(math.Max(
+			float64(unlockHeight), float64(c.leaseExpiry),
+		))
+	}
+
+	// Update report now that we learned the confirmation height.
+	c.reportLock.Lock()
+	c.currentReport.MaturityHeight = unlockHeight
+	c.reportLock.Unlock()
+
+	var (
+		isLocalCommitTx bool
+
+		signDesc = c.commitResolution.SelfOutputSignDesc
+	)
+	switch {
+	// For taproot channels, we'll know if this is the local commit based
+	// on the witness script. For local channels, the witness script has an
+	// OP_DROP value.
+	//
+	// TODO(roasbeef): revisit this after the script changes
+	//  * otherwise need to base off the key in script or the CSV value
+	//  (script num encode)
+	case c.chanType.IsTaproot():
+		scriptLen := len(signDesc.WitnessScript)
+		isLocalCommitTx = signDesc.WitnessScript[scriptLen-1] ==
+			txscript.OP_DROP
+
+	// The output is on our local commitment if the script starts with
+	// OP_IF for the revocation clause. On the remote commitment it will
+	// either be a regular P2WKH or a simple sig spend with a CSV delay.
+	default:
+		isLocalCommitTx = signDesc.WitnessScript[0] == txscript.OP_IF
+	}
+	isDelayedOutput := c.commitResolution.MaturityDelay != 0
+
+	c.log.Debugf("commit conf_height=%v, unlock_height=%v, "+
+		"isDelayedOutput=%v, isLocalCommitTx=%v", confHeight,
+		unlockHeight, isDelayedOutput, isLocalCommitTx)
+
+	// There're three types of commitments, those that have tweaks for the
+	// remote key (us in this case), those that don't, and a third where
+	// there is no tweak and the output is delayed. On the local commitment
+	// our output will always be delayed. We'll rely on the presence of the
+	// commitment tweak to discern which type of commitment this is.
+	var witnessType input.WitnessType
+	switch {
+	// The local delayed output for a taproot channel.
+	case isLocalCommitTx && c.chanType.IsTaproot():
+		witnessType = input.TaprootLocalCommitSpend
+
+	// The CSV 1 delayed output for a taproot channel.
+	case !isLocalCommitTx && c.chanType.IsTaproot():
+		witnessType = input.TaprootRemoteCommitSpend
+
+	// Delayed output to us on our local commitment for a channel lease in
+	// which we are the initiator.
+	case isLocalCommitTx && c.hasCLTV():
+		witnessType = input.LeaseCommitmentTimeLock
+
+	// Delayed output to us on our local commitment.
+	case isLocalCommitTx:
+		witnessType = input.CommitmentTimeLock
+
+	// A confirmed output to us on the remote commitment for a channel lease
+	// in which we are the initiator.
+	case isDelayedOutput && c.hasCLTV():
+		witnessType = input.LeaseCommitmentToRemoteConfirmed
+
+	// A confirmed output to us on the remote commitment.
+	case isDelayedOutput:
+		witnessType = input.CommitmentToRemoteConfirmed
+
+	// A non-delayed output on the remote commitment where the key is
+	// tweakless.
+	case c.commitResolution.SelfOutputSignDesc.SingleTweak == nil:
+		witnessType = input.CommitSpendNoDelayTweakless
+
+	// A non-delayed output on the remote commitment where the key is
+	// tweaked.
+	default:
+		witnessType = input.CommitmentNoDelay
+	}
+
+	// We'll craft an input with all the information required for the
+	// sweeper to create a fully valid sweeping transaction to recover
+	// these coins.
+	var inp *input.BaseInput
+	if c.hasCLTV() {
+		inp = input.NewCsvInputWithCltv(
+			&c.commitResolution.SelfOutPoint, witnessType,
+			&c.commitResolution.SelfOutputSignDesc,
+			c.broadcastHeight, c.commitResolution.MaturityDelay,
+			c.leaseExpiry,
+		)
+	} else {
+		inp = input.NewCsvInput(
+			&c.commitResolution.SelfOutPoint, witnessType,
+			&c.commitResolution.SelfOutputSignDesc,
+			c.broadcastHeight, c.commitResolution.MaturityDelay,
+		)
+	}
+
+	// TODO(roasbeef): instead of ading ctrl block to the sign desc, make
+	// new input type, have sweeper set it?
+
+	// Calculate the budget for the sweeping this input.
+	budget := calculateBudget(
+		btcutil.Amount(inp.SignDesc().Output.Value),
+		c.Budget.ToLocalRatio, c.Budget.ToLocal,
+	)
+	c.log.Infof("sweeping commit output %v using budget=%v", witnessType,
+		budget)
+
+	// With our input constructed, we'll now offer it to the sweeper.
+	resultChan, err := c.Sweeper.SweepInput(
+		inp, sweep.Params{
+			Budget: budget,
+
+			// Specify a nil deadline here as there's no time
+			// pressure.
+			DeadlineHeight: fn.None[int32](),
+		},
+	)
+	if err != nil {
+		c.log.Errorf("unable to sweep input: %v", err)
+
+		return err
+	}
+
+	c.sweepResultChan = resultChan
+
+	return nil
+}

--- a/contractcourt/commit_sweep_resolver.go
+++ b/contractcourt/commit_sweep_resolver.go
@@ -77,7 +77,7 @@ func newCommitSweepResolver(res lnwallet.CommitOutputResolution,
 		chanPoint:           chanPoint,
 	}
 
-	r.initLogger(r)
+	r.initLogger(fmt.Sprintf("%T(%v)", r, r.commitResolution.SelfOutPoint))
 	r.initReport()
 
 	return r
@@ -454,7 +454,7 @@ func newCommitSweepResolverFromReader(r io.Reader, resCfg ResolverConfig) (
 	// removed this, but keep in mind that this data may still be present in
 	// the database.
 
-	c.initLogger(c)
+	c.initLogger(fmt.Sprintf("%T(%v)", c, c.commitResolution.SelfOutPoint))
 	c.initReport()
 
 	return c, nil

--- a/contractcourt/commit_sweep_resolver.go
+++ b/contractcourt/commit_sweep_resolver.go
@@ -28,9 +28,6 @@ type commitSweepResolver struct {
 	// this HTLC on-chain.
 	commitResolution lnwallet.CommitOutputResolution
 
-	// resolved reflects if the contract has been fully resolved or not.
-	resolved bool
-
 	// broadcastHeight is the height that the original contract was
 	// broadcast to the main-chain at. We'll use this value to bound any
 	// historical queries to the chain for spends/confirmations.
@@ -156,7 +153,7 @@ func (c *commitSweepResolver) getCommitTxConfHeight() (uint32, error) {
 // NOTE: This function MUST be run as a goroutine.
 func (c *commitSweepResolver) Resolve() (ContractResolver, error) {
 	// If we're already resolved, then we can exit early.
-	if c.resolved {
+	if c.IsResolved() {
 		c.log.Errorf("already resolved")
 		return nil, nil
 	}
@@ -209,7 +206,7 @@ func (c *commitSweepResolver) Resolve() (ContractResolver, error) {
 	report := c.currentReport.resolverReport(
 		&sweepTxID, channeldb.ResolverTypeCommit, outcome,
 	)
-	c.resolved = true
+	c.resolved.Store(true)
 
 	// Checkpoint the resolver with a closure that will write the outcome
 	// of the resolver and its sweep transaction to disk.
@@ -223,14 +220,6 @@ func (c *commitSweepResolver) Resolve() (ContractResolver, error) {
 func (c *commitSweepResolver) Stop() {
 	c.log.Debugf("stopping...")
 	close(c.quit)
-}
-
-// IsResolved returns true if the stored state in the resolve is fully
-// resolved. In this case the target output can be forgotten.
-//
-// NOTE: Part of the ContractResolver interface.
-func (c *commitSweepResolver) IsResolved() bool {
-	return c.resolved
 }
 
 // SupplementState allows the user of a ContractResolver to supplement it with
@@ -260,7 +249,7 @@ func (c *commitSweepResolver) Encode(w io.Writer) error {
 		return err
 	}
 
-	if err := binary.Write(w, endian, c.resolved); err != nil {
+	if err := binary.Write(w, endian, c.IsResolved()); err != nil {
 		return err
 	}
 	if err := binary.Write(w, endian, c.broadcastHeight); err != nil {
@@ -295,9 +284,12 @@ func newCommitSweepResolverFromReader(r io.Reader, resCfg ResolverConfig) (
 		return nil, err
 	}
 
-	if err := binary.Read(r, endian, &c.resolved); err != nil {
+	var resolved bool
+	if err := binary.Read(r, endian, &resolved); err != nil {
 		return nil, err
 	}
+	c.resolved.Store(resolved)
+
 	if err := binary.Read(r, endian, &c.broadcastHeight); err != nil {
 		return nil, err
 	}
@@ -366,7 +358,7 @@ func (c *commitSweepResolver) Launch() error {
 	c.launched = true
 
 	// If we're already resolved, then we can exit early.
-	if c.resolved {
+	if c.IsResolved() {
 		c.log.Errorf("already resolved")
 		return nil
 	}

--- a/contractcourt/commit_sweep_resolver.go
+++ b/contractcourt/commit_sweep_resolver.go
@@ -349,13 +349,13 @@ var _ reportingContractResolver = (*commitSweepResolver)(nil)
 
 // Launch constructs a commit input and offers it to the sweeper.
 func (c *commitSweepResolver) Launch() error {
-	if c.launched {
+	if c.launched.Load() {
 		c.log.Tracef("already launched")
 		return nil
 	}
 
 	c.log.Debugf("launching resolver...")
-	c.launched = true
+	c.launched.Store(true)
 
 	// If we're already resolved, then we can exit early.
 	if c.IsResolved() {

--- a/contractcourt/commit_sweep_resolver_test.go
+++ b/contractcourt/commit_sweep_resolver_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/sweep"
+	"github.com/stretchr/testify/require"
 )
 
 type commitSweepResolverTestContext struct {
@@ -82,6 +83,9 @@ func (i *commitSweepResolverTestContext) resolve() {
 	// Start resolver.
 	i.resolverResultChan = make(chan resolveResult, 1)
 	go func() {
+		err := i.resolver.Launch()
+		require.NoError(i.t, err)
+
 		nextResolver, err := i.resolver.Resolve()
 		i.resolverResultChan <- resolveResult{
 			nextResolver: nextResolver,

--- a/contractcourt/contract_resolver.go
+++ b/contractcourt/contract_resolver.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/fn"
+	"github.com/lightningnetwork/lnd/sweep"
 )
 
 var (
@@ -110,6 +111,15 @@ type contractResolverKit struct {
 	log btclog.Logger
 
 	quit chan struct{}
+
+	// sweepResultChan is the result chan returned from calling
+	// `SweepInput`. It should be mounted to the specific resolver once the
+	// input has been offered to the sweeper.
+	sweepResultChan chan sweep.Result
+
+	// launched specifies whether the resolver has been launched. Calling
+	// `Launch` will be a no-op if this is true.
+	launched bool
 }
 
 // newContractResolverKit instantiates the mix-in struct.

--- a/contractcourt/contract_resolver.go
+++ b/contractcourt/contract_resolver.go
@@ -37,6 +37,17 @@ type ContractResolver interface {
 	// resides within.
 	ResolverKey() []byte
 
+	// Launch starts the resolver by constructing an input and offering it
+	// to the sweeper. Once offered, it's expected to monitor the sweeping
+	// result in a goroutine invoked by calling Resolve.
+	//
+	// NOTE: We can call `Resolve` inside a goroutine at the end of this
+	// method to avoid calling it in the ChannelArbitrator. However, there
+	// are some DB-related operations such as SwapContract/ResolveContract
+	// which need to be done inside the resolvers instead, which needs a
+	// deeper refactoring.
+	Launch() error
+
 	// Resolve instructs the contract resolver to resolve the output
 	// on-chain. Once the output has been *fully* resolved, the function
 	// should return immediately with a nil ContractResolver value for the

--- a/contractcourt/contract_resolver.go
+++ b/contractcourt/contract_resolver.go
@@ -121,8 +121,15 @@ func newContractResolverKit(cfg ResolverConfig) *contractResolverKit {
 }
 
 // initLogger initializes the resolver-specific logger.
-func (r *contractResolverKit) initLogger(resolver ContractResolver) {
-	logPrefix := fmt.Sprintf("%T(%v):", resolver, r.ChanPoint)
+func (r *contractResolverKit) initLogger(prefix string) {
+	logPrefix := fmt.Sprintf("ChannelArbitrator(%v): %s:", r.ChanPoint,
+		prefix)
+
+	if r.ShortChanID.IsDefault() {
+		logPrefix = fmt.Sprintf("ChannelArbitrator(%v): %s:",
+			r.ChanPoint, prefix)
+	}
+
 	r.log = build.NewPrefixLog(logPrefix, log)
 }
 

--- a/contractcourt/contract_resolver.go
+++ b/contractcourt/contract_resolver.go
@@ -131,7 +131,7 @@ type contractResolverKit struct {
 
 	// launched specifies whether the resolver has been launched. Calling
 	// `Launch` will be a no-op if this is true.
-	launched bool
+	launched atomic.Bool
 
 	// resolved reflects if the contract has been fully resolved or not.
 	resolved atomic.Bool

--- a/contractcourt/contract_resolver.go
+++ b/contractcourt/contract_resolver.go
@@ -143,7 +143,7 @@ func newContractResolverKit(cfg ResolverConfig) *contractResolverKit {
 
 // initLogger initializes the resolver-specific logger.
 func (r *contractResolverKit) initLogger(prefix string) {
-	logPrefix := fmt.Sprintf("ChannelArbitrator(%v): %s:", r.ChanPoint,
+	logPrefix := fmt.Sprintf("ChannelArbitrator(%v): %s:", r.ShortChanID,
 		prefix)
 
 	if r.ShortChanID.IsDefault() {

--- a/contractcourt/contract_resolver.go
+++ b/contractcourt/contract_resolver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync/atomic"
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog"
@@ -131,6 +132,9 @@ type contractResolverKit struct {
 	// launched specifies whether the resolver has been launched. Calling
 	// `Launch` will be a no-op if this is true.
 	launched bool
+
+	// resolved reflects if the contract has been fully resolved or not.
+	resolved atomic.Bool
 }
 
 // newContractResolverKit instantiates the mix-in struct.
@@ -152,6 +156,14 @@ func (r *contractResolverKit) initLogger(prefix string) {
 	}
 
 	r.log = build.NewPrefixLog(logPrefix, log)
+}
+
+// IsResolved returns true if the stored state in the resolve is fully
+// resolved. In this case the target output can be forgotten.
+//
+// NOTE: Part of the ContractResolver interface.
+func (r *contractResolverKit) IsResolved() bool {
+	return r.resolved.Load()
 }
 
 var (

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -83,7 +83,7 @@ func (h *htlcIncomingContestResolver) processFinalHtlcFail() error {
 func (h *htlcIncomingContestResolver) Launch() error {
 	// NOTE: we don't mark this resolver as launched as the inner resolver
 	// will set it when it's launched.
-	if h.launched {
+	if h.launched.Load() {
 		h.log.Tracef("already launched")
 		return nil
 	}

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -124,7 +124,7 @@ func (h *htlcIncomingContestResolver) Launch() error {
 func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 	// If we're already full resolved, then we don't have anything further
 	// to do.
-	if h.resolved {
+	if h.IsResolved() {
 		h.log.Errorf("already resolved")
 		return nil, nil
 	}
@@ -140,7 +140,7 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 		// will time it out and get their funds back. This situation
 		// can present itself when we crash before processRemoteAdds in
 		// the link has ran.
-		h.resolved = true
+		h.resolved.Store(true)
 
 		if err := h.processFinalHtlcFail(); err != nil {
 			return nil, err
@@ -193,7 +193,7 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 		log.Infof("%T(%v): HTLC has timed out (expiry=%v, height=%v), "+
 			"abandoning", h, h.htlcResolution.ClaimOutpoint,
 			h.htlcExpiry, currentHeight)
-		h.resolved = true
+		h.resolved.Store(true)
 
 		if err := h.processFinalHtlcFail(); err != nil {
 			return nil, err
@@ -234,7 +234,7 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 				h.htlcResolution.ClaimOutpoint,
 				h.htlcExpiry, currentHeight)
 
-			h.resolved = true
+			h.resolved.Store(true)
 
 			if err := h.processFinalHtlcFail(); err != nil {
 				return nil, err
@@ -392,7 +392,7 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 					"(expiry=%v, height=%v), abandoning", h,
 					h.htlcResolution.ClaimOutpoint,
 					h.htlcExpiry, currentHeight)
-				h.resolved = true
+				h.resolved.Store(true)
 
 				if err := h.processFinalHtlcFail(); err != nil {
 					return nil, err
@@ -510,14 +510,6 @@ func (h *htlcIncomingContestResolver) report() *ContractReport {
 func (h *htlcIncomingContestResolver) Stop() {
 	h.log.Debugf("stopping...")
 	close(h.quit)
-}
-
-// IsResolved returns true if the stored state in the resolve is fully
-// resolved. In this case the target output can be forgotten.
-//
-// NOTE: Part of the ContractResolver interface.
-func (h *htlcIncomingContestResolver) IsResolved() bool {
-	return h.resolved
 }
 
 // Encode writes an encoded version of the ContractResolver into the passed

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -78,6 +78,37 @@ func (h *htlcIncomingContestResolver) processFinalHtlcFail() error {
 	return nil
 }
 
+// Launch will call the inner resolver's launch method if the preimage can be
+// found, otherwise it's a no-op.
+func (h *htlcIncomingContestResolver) Launch() error {
+	// NOTE: we don't mark this resolver as launched as the inner resolver
+	// will set it when it's launched.
+	if h.launched {
+		h.log.Tracef("already launched")
+		return nil
+	}
+
+	h.log.Debugf("launching contest resolver...")
+
+	// Query to see if we already know the preimage.
+	preimage, ok := h.PreimageDB.LookupPreimage(h.htlc.RHash)
+	if !ok {
+		return nil
+	}
+
+	h.log.Debugf("found preimage for htlc=%x, launching success resolver",
+		h.htlc.RHash)
+
+	// If the preimage is known, we'll apply it.
+	if err := h.applyPreimage(preimage); err != nil {
+		return err
+	}
+
+	// Once we've applied the preimage, we'll launch the inner resolver to
+	// attempt to claim the HTLC.
+	return h.htlcSuccessResolver.Launch()
+}
+
 // Resolve attempts to resolve this contract. As we don't yet know of the
 // preimage for the contract, we'll wait for one of two things to happen:
 //
@@ -94,6 +125,7 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 	// If we're already full resolved, then we don't have anything further
 	// to do.
 	if h.resolved {
+		h.log.Errorf("already resolved")
 		return nil, nil
 	}
 
@@ -101,8 +133,7 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 	// now.
 	payload, nextHopOnionBlob, err := h.decodePayload()
 	if err != nil {
-		log.Debugf("ChannelArbitrator(%v): cannot decode payload of "+
-			"htlc %v", h.ChanPoint, h.HtlcPoint())
+		h.log.Debugf("cannot decode payload of htlc %v", h.HtlcPoint())
 
 		// If we've locked in an htlc with an invalid payload on our
 		// commitment tx, we don't need to resolve it. The other party
@@ -177,65 +208,6 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 		return nil, h.Checkpoint(h, report)
 	}
 
-	// applyPreimage is a helper function that will populate our internal
-	// resolver with the preimage we learn of. This should be called once
-	// the preimage is revealed so the inner resolver can properly complete
-	// its duties. The error return value indicates whether the preimage
-	// was properly applied.
-	applyPreimage := func(preimage lntypes.Preimage) error {
-		// Sanity check to see if this preimage matches our htlc. At
-		// this point it should never happen that it does not match.
-		if !preimage.Matches(h.htlc.RHash) {
-			return errors.New("preimage does not match hash")
-		}
-
-		// Update htlcResolution with the matching preimage.
-		h.htlcResolution.Preimage = preimage
-
-		log.Infof("%T(%v): applied preimage=%v", h,
-			h.htlcResolution.ClaimOutpoint, preimage)
-
-		isSecondLevel := h.htlcResolution.SignedSuccessTx != nil
-
-		// If we didn't have to go to the second level to claim (this
-		// is the remote commitment transaction), then we don't need to
-		// modify our canned witness.
-		if !isSecondLevel {
-			return nil
-		}
-
-		isTaproot := txscript.IsPayToTaproot(
-			h.htlcResolution.SignedSuccessTx.TxOut[0].PkScript,
-		)
-
-		// If this is our commitment transaction, then we'll need to
-		// populate the witness for the second-level HTLC transaction.
-		switch {
-		// For taproot channels, the witness for sweeping with success
-		// looks like:
-		//   - <sender sig> <receiver sig> <preimage> <success_script>
-		//     <control_block>
-		//
-		// So we'll insert it at the 3rd index of the witness.
-		case isTaproot:
-			//nolint:lll
-			h.htlcResolution.SignedSuccessTx.TxIn[0].Witness[2] = preimage[:]
-
-		// Within the witness for the success transaction, the
-		// preimage is the 4th element as it looks like:
-		//
-		//  * <0> <sender sig> <recvr sig> <preimage> <witness script>
-		//
-		// We'll populate it within the witness, as since this
-		// was a "contest" resolver, we didn't yet know of the
-		// preimage.
-		case !isTaproot:
-			h.htlcResolution.SignedSuccessTx.TxIn[0].Witness[3] = preimage[:]
-		}
-
-		return nil
-	}
-
 	// Define a closure to process htlc resolutions either directly or
 	// triggered by future notifications.
 	processHtlcResolution := func(e invoices.HtlcResolution) (
@@ -247,7 +219,7 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 		// If the htlc resolution was a settle, apply the
 		// preimage and return a success resolver.
 		case *invoices.HtlcSettleResolution:
-			err := applyPreimage(resolution.Preimage)
+			err := h.applyPreimage(resolution.Preimage)
 			if err != nil {
 				return nil, err
 			}
@@ -369,7 +341,9 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 			// However, we don't know how to ourselves, so we'll
 			// return our inner resolver which has the knowledge to
 			// do so.
-			if err := applyPreimage(preimage); err != nil {
+			h.log.Debugf("Found preimage for htlc=%x", h.htlc.RHash)
+
+			if err := h.applyPreimage(preimage); err != nil {
 				return nil, err
 			}
 
@@ -388,7 +362,10 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 				continue
 			}
 
-			if err := applyPreimage(preimage); err != nil {
+			h.log.Debugf("Received preimage for htlc=%x",
+				h.htlc.RHash)
+
+			if err := h.applyPreimage(preimage); err != nil {
 				return nil, err
 			}
 
@@ -435,6 +412,76 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 	}
 }
 
+// applyPreimage is a helper function that will populate our internal resolver
+// with the preimage we learn of. This should be called once the preimage is
+// revealed so the inner resolver can properly complete its duties. The error
+// return value indicates whether the preimage was properly applied.
+func (h *htlcIncomingContestResolver) applyPreimage(
+	preimage lntypes.Preimage) error {
+
+	// Sanity check to see if this preimage matches our htlc. At this point
+	// it should never happen that it does not match.
+	if !preimage.Matches(h.htlc.RHash) {
+		return errors.New("preimage does not match hash")
+	}
+
+	// We may already have the preimage since both the `Launch` and
+	// `Resolve` methods will look for it.
+	if h.htlcResolution.Preimage != lntypes.ZeroHash {
+		h.log.Debugf("already applied preimage for htlc=%x",
+			h.htlc.RHash)
+
+		return nil
+	}
+
+	// Update htlcResolution with the matching preimage.
+	h.htlcResolution.Preimage = preimage
+
+	log.Infof("%T(%v): applied preimage=%v", h,
+		h.htlcResolution.ClaimOutpoint, preimage)
+
+	isSecondLevel := h.htlcResolution.SignedSuccessTx != nil
+
+	// If we didn't have to go to the second level to claim (this
+	// is the remote commitment transaction), then we don't need to
+	// modify our canned witness.
+	if !isSecondLevel {
+		return nil
+	}
+
+	isTaproot := txscript.IsPayToTaproot(
+		h.htlcResolution.SignedSuccessTx.TxOut[0].PkScript,
+	)
+
+	// If this is our commitment transaction, then we'll need to
+	// populate the witness for the second-level HTLC transaction.
+	switch {
+	// For taproot channels, the witness for sweeping with success
+	// looks like:
+	//   - <sender sig> <receiver sig> <preimage> <success_script>
+	//     <control_block>
+	//
+	// So we'll insert it at the 3rd index of the witness.
+	case isTaproot:
+		//nolint:lll
+		h.htlcResolution.SignedSuccessTx.TxIn[0].Witness[2] = preimage[:]
+
+	// Within the witness for the success transaction, the
+	// preimage is the 4th element as it looks like:
+	//
+	//  * <0> <sender sig> <recvr sig> <preimage> <witness script>
+	//
+	// We'll populate it within the witness, as since this
+	// was a "contest" resolver, we didn't yet know of the
+	// preimage.
+	case !isTaproot:
+		//nolint:lll
+		h.htlcResolution.SignedSuccessTx.TxIn[0].Witness[3] = preimage[:]
+	}
+
+	return nil
+}
+
 // report returns a report on the resolution state of the contract.
 func (h *htlcIncomingContestResolver) report() *ContractReport {
 	// No locking needed as these values are read-only.
@@ -461,6 +508,7 @@ func (h *htlcIncomingContestResolver) report() *ContractReport {
 //
 // NOTE: Part of the ContractResolver interface.
 func (h *htlcIncomingContestResolver) Stop() {
+	h.log.Debugf("stopping...")
 	close(h.quit)
 }
 

--- a/contractcourt/htlc_incoming_contest_resolver_test.go
+++ b/contractcourt/htlc_incoming_contest_resolver_test.go
@@ -5,11 +5,13 @@ import (
 	"io"
 	"testing"
 
+	"github.com/btcsuite/btcd/wire"
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
+	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnmock"
@@ -356,6 +358,7 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 
 				return nil
 			},
+			Sweeper: newMockSweeper(),
 		},
 		PutResolverReport: func(_ kvdb.RwTx,
 			_ *channeldb.ResolverReport) error {
@@ -374,10 +377,16 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 		},
 	}
 
+	res := lnwallet.IncomingHtlcResolution{
+		SweepSignDesc: input.SignDescriptor{
+			Output: &wire.TxOut{},
+		},
+	}
+
 	c.resolver = &htlcIncomingContestResolver{
 		htlcSuccessResolver: &htlcSuccessResolver{
 			contractResolverKit: *newContractResolverKit(cfg),
-			htlcResolution:      lnwallet.IncomingHtlcResolution{},
+			htlcResolution:      res,
 			htlc: channeldb.HTLC{
 				Amt:       lnwire.MilliSatoshi(testHtlcAmount),
 				RHash:     testResHash,
@@ -386,6 +395,7 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 		},
 		htlcExpiry: testHtlcExpiry,
 	}
+	c.resolver.initLogger("htlcIncomingContestResolver")
 
 	return c
 }
@@ -395,6 +405,10 @@ func (i *incomingResolverTestContext) resolve() {
 	i.resolveErr = make(chan error, 1)
 	go func() {
 		var err error
+
+		err = i.resolver.Launch()
+		require.NoError(i.t, err)
+
 		i.nextResolver, err = i.resolver.Resolve()
 		i.resolveErr <- err
 	}()

--- a/contractcourt/htlc_lease_resolver.go
+++ b/contractcourt/htlc_lease_resolver.go
@@ -53,10 +53,7 @@ func (h *htlcLeaseResolver) deriveWaitHeight(csvDelay uint32,
 func (h *htlcLeaseResolver) makeSweepInput(op *wire.OutPoint,
 	wType, cltvWtype input.StandardWitnessType,
 	signDesc *input.SignDescriptor,
-	csvDelay, broadcastHeight uint32, payHash [32]byte) *input.BaseInput {
-
-	log.Infof("%T(%x): offering second-layer output to sweeper: %v", h,
-		payHash, op)
+	csvDelay, broadcastHeight uint32) *input.BaseInput {
 
 	if h.hasCLTV() {
 		return input.NewCsvInputWithCltv(

--- a/contractcourt/htlc_outgoing_contest_resolver.go
+++ b/contractcourt/htlc_outgoing_contest_resolver.go
@@ -40,7 +40,7 @@ func newOutgoingContestResolver(res lnwallet.OutgoingHtlcResolution,
 func (h *htlcOutgoingContestResolver) Launch() error {
 	// NOTE: we don't mark this resolver as launched as the inner resolver
 	// will set it when it's launched.
-	if h.launched {
+	if h.launched.Load() {
 		h.log.Tracef("already launched")
 		return nil
 	}

--- a/contractcourt/htlc_outgoing_contest_resolver.go
+++ b/contractcourt/htlc_outgoing_contest_resolver.go
@@ -87,7 +87,7 @@ func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 		}
 
 		// TODO(roasbeef): Checkpoint?
-		return h.claimCleanUp(commitSpend)
+		return nil, h.claimCleanUp(commitSpend)
 
 	// If it hasn't, then we'll watch for both the expiration, and the
 	// sweeping out this output.
@@ -144,7 +144,7 @@ func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 			// party is by revealing the preimage. So we'll perform
 			// our duties to clean up the contract once it has been
 			// claimed.
-			return h.claimCleanUp(commitSpend)
+			return nil, h.claimCleanUp(commitSpend)
 
 		case <-h.quit:
 			return nil, fmt.Errorf("resolver canceled")

--- a/contractcourt/htlc_outgoing_contest_resolver.go
+++ b/contractcourt/htlc_outgoing_contest_resolver.go
@@ -81,7 +81,7 @@ func (h *htlcOutgoingContestResolver) Launch() error {
 func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 	// If we're already full resolved, then we don't have anything further
 	// to do.
-	if h.resolved {
+	if h.IsResolved() {
 		h.log.Errorf("already resolved")
 		return nil, nil
 	}
@@ -215,14 +215,6 @@ func (h *htlcOutgoingContestResolver) report() *ContractReport {
 func (h *htlcOutgoingContestResolver) Stop() {
 	h.log.Debugf("stopping...")
 	close(h.quit)
-}
-
-// IsResolved returns true if the stored state in the resolve is fully
-// resolved. In this case the target output can be forgotten.
-//
-// NOTE: Part of the ContractResolver interface.
-func (h *htlcOutgoingContestResolver) IsResolved() bool {
-	return h.resolved
 }
 
 // Encode writes an encoded version of the ContractResolver into the passed

--- a/contractcourt/htlc_outgoing_contest_resolver.go
+++ b/contractcourt/htlc_outgoing_contest_resolver.go
@@ -1,7 +1,6 @@
 package contractcourt
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -36,6 +35,36 @@ func newOutgoingContestResolver(res lnwallet.OutgoingHtlcResolution,
 	}
 }
 
+// Launch will call the inner resolver's launch method if the expiry height has
+// been reached, otherwise it's a no-op.
+func (h *htlcOutgoingContestResolver) Launch() error {
+	// NOTE: we don't mark this resolver as launched as the inner resolver
+	// will set it when it's launched.
+	if h.launched {
+		h.log.Tracef("already launched")
+		return nil
+	}
+
+	h.log.Debugf("launching contest resolver...")
+
+	_, bestHeight, err := h.ChainIO.GetBestBlock()
+	if err != nil {
+		return err
+	}
+
+	if uint32(bestHeight) < h.htlcResolution.Expiry {
+		return nil
+	}
+
+	// If the current height is >= expiry, then a timeout path spend will
+	// be valid to be included in the next block, and we can immediately
+	// return the resolver.
+	h.log.Infof("expired (height=%v, expiry=%v), launching timeout "+
+		"resolver", bestHeight, h.htlcResolution.Expiry)
+
+	return h.htlcTimeoutResolver.Launch()
+}
+
 // Resolve commences the resolution of this contract. As this contract hasn't
 // yet timed out, we'll wait for one of two things to happen
 //
@@ -53,6 +82,7 @@ func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 	// If we're already full resolved, then we don't have anything further
 	// to do.
 	if h.resolved {
+		h.log.Errorf("already resolved")
 		return nil, nil
 	}
 
@@ -86,7 +116,6 @@ func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 			return nil, errResolverShuttingDown
 		}
 
-		// TODO(roasbeef): Checkpoint?
 		return nil, h.claimCleanUp(commitSpend)
 
 	// If it hasn't, then we'll watch for both the expiration, and the
@@ -124,12 +153,18 @@ func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 			// finalized` will be returned and the broadcast will
 			// fail.
 			newHeight := uint32(newBlock.Height)
-			if newHeight >= h.htlcResolution.Expiry {
-				log.Infof("%T(%v): HTLC has expired "+
+			expiry := h.htlcResolution.Expiry
+			if h.isZeroFeeOutput() {
+				expiry--
+			}
+
+			if newHeight >= expiry {
+				log.Infof("%T(%v): HTLC about to expire "+
 					"(height=%v, expiry=%v), transforming "+
 					"into timeout resolver", h,
 					h.htlcResolution.ClaimOutpoint,
 					newHeight, h.htlcResolution.Expiry)
+
 				return h.htlcTimeoutResolver, nil
 			}
 
@@ -147,7 +182,7 @@ func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 			return nil, h.claimCleanUp(commitSpend)
 
 		case <-h.quit:
-			return nil, fmt.Errorf("resolver canceled")
+			return nil, errResolverShuttingDown
 		}
 	}
 }
@@ -178,6 +213,7 @@ func (h *htlcOutgoingContestResolver) report() *ContractReport {
 //
 // NOTE: Part of the ContractResolver interface.
 func (h *htlcOutgoingContestResolver) Stop() {
+	h.log.Debugf("stopping...")
 	close(h.quit)
 }
 

--- a/contractcourt/htlc_outgoing_contest_resolver_test.go
+++ b/contractcourt/htlc_outgoing_contest_resolver_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -159,6 +160,7 @@ func newOutgoingResolverTestContext(t *testing.T) *outgoingResolverTestContext {
 
 				return nil
 			},
+			ChainIO: &mock.ChainIO{},
 		},
 		PutResolverReport: func(_ kvdb.RwTx,
 			_ *channeldb.ResolverReport) error {
@@ -195,6 +197,7 @@ func newOutgoingResolverTestContext(t *testing.T) *outgoingResolverTestContext {
 			},
 		},
 	}
+	resolver.initLogger("htlcOutgoingContestResolver")
 
 	return &outgoingResolverTestContext{
 		resolver:       resolver,
@@ -209,6 +212,9 @@ func (i *outgoingResolverTestContext) resolve() {
 	// Start resolver.
 	i.resolverResultChan = make(chan resolveResult, 1)
 	go func() {
+		err := i.resolver.Launch()
+		require.NoError(i.t, err)
+
 		nextResolver, err := i.resolver.Resolve()
 		i.resolverResultChan <- resolveResult{
 			nextResolver: nextResolver,

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -572,7 +572,6 @@ func (h *htlcSuccessResolver) sweepSuccessTxOutput() error {
 		input.LeaseHtlcAcceptedSuccessSecondLevel,
 		&h.htlcResolution.SweepSignDesc,
 		h.htlcResolution.CsvDelay, uint32(commitSpend.SpendingHeight),
-		h.htlc.RHash,
 	)
 
 	// Calculate the budget for this sweep.

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -187,38 +187,9 @@ func (h *htlcSuccessResolver) broadcastSuccessTx() (
 
 	// We'll now broadcast the second layer transaction so we can kick off
 	// the claiming process.
-	//
-	// TODO(roasbeef): after changing sighashes send to tx bundler
-	label := labels.MakeLabel(
-		labels.LabelTypeChannelClose, &h.ShortChanID,
-	)
-	err := h.PublishTx(h.htlcResolution.SignedSuccessTx, label)
+	err := h.resolveLegacySuccessTx()
 	if err != nil {
 		return nil, err
-	}
-
-	// Otherwise, this is an output on our commitment transaction. In this
-	// case, we'll send it to the incubator, but only if we haven't already
-	// done so.
-	if !h.outputIncubating {
-		log.Infof("%T(%x): incubating incoming htlc output",
-			h, h.htlc.RHash[:])
-
-		err := h.IncubateOutputs(
-			h.ChanPoint, fn.None[lnwallet.OutgoingHtlcResolution](),
-			fn.Some(h.htlcResolution),
-			h.broadcastHeight, fn.Some(int32(h.htlc.RefundTimeout)),
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		h.outputIncubating = true
-
-		if err := h.Checkpoint(h); err != nil {
-			log.Errorf("unable to Checkpoint: %v", err)
-			return nil, err
-		}
 	}
 
 	return &h.htlcResolution.ClaimOutpoint, nil
@@ -237,52 +208,7 @@ func (h *htlcSuccessResolver) broadcastReSignedSuccessTx() (*wire.OutPoint,
 	// We will have to let the sweeper re-sign the success tx and wait for
 	// it to confirm, if we haven't already.
 	if !h.outputIncubating {
-		var secondLevelInput input.HtlcSecondLevelAnchorInput
-		if h.isTaproot() {
-			//nolint:lll
-			secondLevelInput = input.MakeHtlcSecondLevelSuccessTaprootInput(
-				h.htlcResolution.SignedSuccessTx,
-				h.htlcResolution.SignDetails, h.htlcResolution.Preimage,
-				h.broadcastHeight,
-			)
-		} else {
-			//nolint:lll
-			secondLevelInput = input.MakeHtlcSecondLevelSuccessAnchorInput(
-				h.htlcResolution.SignedSuccessTx,
-				h.htlcResolution.SignDetails, h.htlcResolution.Preimage,
-				h.broadcastHeight,
-			)
-		}
-
-		// Calculate the budget for this sweep.
-		value := btcutil.Amount(
-			secondLevelInput.SignDesc().Output.Value,
-		)
-		budget := calculateBudget(
-			value, h.Budget.DeadlineHTLCRatio,
-			h.Budget.DeadlineHTLC,
-		)
-
-		// The deadline would be the CLTV in this HTLC output. If we
-		// are the initiator of this force close, with the default
-		// `IncomingBroadcastDelta`, it means we have 10 blocks left
-		// when going onchain. Given we need to mine one block to
-		// confirm the force close tx, and one more block to trigger
-		// the sweep, we have 8 blocks left to sweep the HTLC.
-		deadline := fn.Some(int32(h.htlc.RefundTimeout))
-
-		log.Infof("%T(%x): offering second-level HTLC success tx to "+
-			"sweeper with deadline=%v, budget=%v", h,
-			h.htlc.RHash[:], h.htlc.RefundTimeout, budget)
-
-		// We'll now offer the second-level transaction to the sweeper.
-		_, err := h.Sweeper.SweepInput(
-			&secondLevelInput,
-			sweep.Params{
-				Budget:         budget,
-				DeadlineHeight: deadline,
-			},
-		)
+		err := h.sweepSuccessTx()
 		if err != nil {
 			return nil, err
 		}
@@ -313,99 +239,18 @@ func (h *htlcSuccessResolver) broadcastReSignedSuccessTx() (*wire.OutPoint,
 			"confirmed!", h, h.htlc.RHash[:])
 	}
 
-	// If we ended up here after a restart, we must again get the
-	// spend notification.
-	if commitSpend == nil {
-		var err error
-		commitSpend, err = waitForSpend(
-			&h.htlcResolution.SignedSuccessTx.TxIn[0].PreviousOutPoint,
-			h.htlcResolution.SignDetails.SignDesc.Output.PkScript,
-			h.broadcastHeight, h.Notifier, h.quit,
-		)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// The HTLC success tx has a CSV lock that we must wait for, and if
-	// this is a lease enforced channel and we're the imitator, we may need
-	// to wait for longer.
-	waitHeight := h.deriveWaitHeight(
-		h.htlcResolution.CsvDelay, commitSpend,
-	)
-
-	// Now that the sweeper has broadcasted the second-level transaction,
-	// it has confirmed, and we have checkpointed our state, we'll sweep
-	// the second level output. We report the resolver has moved the next
-	// stage.
-	h.reportLock.Lock()
-	h.currentReport.Stage = 2
-	h.currentReport.MaturityHeight = waitHeight
-	h.reportLock.Unlock()
-
-	if h.hasCLTV() {
-		log.Infof("%T(%x): waiting for CSV and CLTV lock to "+
-			"expire at height %v", h, h.htlc.RHash[:],
-			waitHeight)
-	} else {
-		log.Infof("%T(%x): waiting for CSV lock to expire at "+
-			"height %v", h, h.htlc.RHash[:], waitHeight)
-	}
-
-	// We'll use this input index to determine the second-level output
-	// index on the transaction, as the signatures requires the indexes to
-	// be the same. We don't look for the second-level output script
-	// directly, as there might be more than one HTLC output to the same
-	// pkScript.
-	op := &wire.OutPoint{
-		Hash:  *commitSpend.SpenderTxHash,
-		Index: commitSpend.SpenderInputIndex,
-	}
-
-	// Let the sweeper sweep the second-level output now that the
-	// CSV/CLTV locks have expired.
-	var witType input.StandardWitnessType
-	if h.isTaproot() {
-		witType = input.TaprootHtlcAcceptedSuccessSecondLevel
-	} else {
-		witType = input.HtlcAcceptedSuccessSecondLevel
-	}
-	inp := h.makeSweepInput(
-		op, witType,
-		input.LeaseHtlcAcceptedSuccessSecondLevel,
-		&h.htlcResolution.SweepSignDesc,
-		h.htlcResolution.CsvDelay, uint32(commitSpend.SpendingHeight),
-		h.htlc.RHash,
-	)
-
-	// Calculate the budget for this sweep.
-	budget := calculateBudget(
-		btcutil.Amount(inp.SignDesc().Output.Value),
-		h.Budget.NoDeadlineHTLCRatio,
-		h.Budget.NoDeadlineHTLC,
-	)
-
-	log.Infof("%T(%x): offering second-level success tx output to sweeper "+
-		"with no deadline and budget=%v at height=%v", h,
-		h.htlc.RHash[:], budget, waitHeight)
-
-	// TODO(roasbeef): need to update above for leased types
-	_, err := h.Sweeper.SweepInput(
-		inp,
-		sweep.Params{
-			Budget: budget,
-
-			// For second level success tx, there's no rush to get
-			// it confirmed, so we use a nil deadline.
-			DeadlineHeight: fn.None[int32](),
-		},
-	)
+	err := h.sweepSuccessTxOutput()
 	if err != nil {
 		return nil, err
 	}
 
 	// Will return this outpoint, when this is spent the resolver is fully
 	// resolved.
+	op := &wire.OutPoint{
+		Hash:  *commitSpend.SpenderTxHash,
+		Index: commitSpend.SpenderInputIndex,
+	}
+
 	return op, nil
 }
 
@@ -415,50 +260,7 @@ func (h *htlcSuccessResolver) broadcastReSignedSuccessTx() (*wire.OutPoint,
 func (h *htlcSuccessResolver) resolveRemoteCommitOutput() (
 	ContractResolver, error) {
 
-	// Before we can craft out sweeping transaction, we need to
-	// create an input which contains all the items required to add
-	// this input to a sweeping transaction, and generate a
-	// witness.
-	var inp input.Input
-	if h.isTaproot() {
-		inp = lnutils.Ptr(input.MakeTaprootHtlcSucceedInput(
-			&h.htlcResolution.ClaimOutpoint,
-			&h.htlcResolution.SweepSignDesc,
-			h.htlcResolution.Preimage[:],
-			h.broadcastHeight,
-			h.htlcResolution.CsvDelay,
-		))
-	} else {
-		inp = lnutils.Ptr(input.MakeHtlcSucceedInput(
-			&h.htlcResolution.ClaimOutpoint,
-			&h.htlcResolution.SweepSignDesc,
-			h.htlcResolution.Preimage[:],
-			h.broadcastHeight,
-			h.htlcResolution.CsvDelay,
-		))
-	}
-
-	// Calculate the budget for this sweep.
-	budget := calculateBudget(
-		btcutil.Amount(inp.SignDesc().Output.Value),
-		h.Budget.DeadlineHTLCRatio,
-		h.Budget.DeadlineHTLC,
-	)
-
-	deadline := fn.Some(int32(h.htlc.RefundTimeout))
-
-	log.Infof("%T(%x): offering direct-preimage HTLC output to sweeper "+
-		"with deadline=%v, budget=%v", h, h.htlc.RHash[:],
-		h.htlc.RefundTimeout, budget)
-
-	// We'll now offer the direct preimage HTLC to the sweeper.
-	_, err := h.Sweeper.SweepInput(
-		inp,
-		sweep.Params{
-			Budget:         budget,
-			DeadlineHeight: deadline,
-		},
-	)
+	err := h.sweepRemoteCommitOutput()
 	if err != nil {
 		return nil, err
 	}
@@ -724,4 +526,235 @@ func (h *htlcSuccessResolver) isTaproot() bool {
 	return txscript.IsPayToTaproot(
 		h.htlcResolution.SweepSignDesc.Output.PkScript,
 	)
+}
+
+// sweepRemoteCommitOutput creates a sweep request to sweep the HTLC output on
+// the remote commitment via the direct preimage-spend.
+func (h *htlcSuccessResolver) sweepRemoteCommitOutput() error {
+	// Before we can craft out sweeping transaction, we need to create an
+	// input which contains all the items required to add this input to a
+	// sweeping transaction, and generate a witness.
+	var inp input.Input
+
+	if h.isTaproot() {
+		inp = lnutils.Ptr(input.MakeTaprootHtlcSucceedInput(
+			&h.htlcResolution.ClaimOutpoint,
+			&h.htlcResolution.SweepSignDesc,
+			h.htlcResolution.Preimage[:],
+			h.broadcastHeight,
+			h.htlcResolution.CsvDelay,
+		))
+	} else {
+		inp = lnutils.Ptr(input.MakeHtlcSucceedInput(
+			&h.htlcResolution.ClaimOutpoint,
+			&h.htlcResolution.SweepSignDesc,
+			h.htlcResolution.Preimage[:],
+			h.broadcastHeight,
+			h.htlcResolution.CsvDelay,
+		))
+	}
+
+	// Calculate the budget for this sweep.
+	budget := calculateBudget(
+		btcutil.Amount(inp.SignDesc().Output.Value),
+		h.Budget.DeadlineHTLCRatio,
+		h.Budget.DeadlineHTLC,
+	)
+
+	deadline := fn.Some(int32(h.htlc.RefundTimeout))
+
+	log.Infof("%T(%x): offering direct-preimage HTLC output to sweeper "+
+		"with deadline=%v, budget=%v", h, h.htlc.RHash[:],
+		h.htlc.RefundTimeout, budget)
+
+	// We'll now offer the direct preimage HTLC to the sweeper.
+	_, err := h.Sweeper.SweepInput(
+		inp,
+		sweep.Params{
+			Budget:         budget,
+			DeadlineHeight: deadline,
+		},
+	)
+
+	return err
+}
+
+// sweepSuccessTx attempts to sweep the second level success tx.
+func (h *htlcSuccessResolver) sweepSuccessTx() error {
+	var secondLevelInput input.HtlcSecondLevelAnchorInput
+	if h.isTaproot() {
+		secondLevelInput = input.MakeHtlcSecondLevelSuccessTaprootInput(
+			h.htlcResolution.SignedSuccessTx,
+			h.htlcResolution.SignDetails, h.htlcResolution.Preimage,
+			h.broadcastHeight,
+		)
+	} else {
+		secondLevelInput = input.MakeHtlcSecondLevelSuccessAnchorInput(
+			h.htlcResolution.SignedSuccessTx,
+			h.htlcResolution.SignDetails, h.htlcResolution.Preimage,
+			h.broadcastHeight,
+		)
+	}
+
+	// Calculate the budget for this sweep.
+	value := btcutil.Amount(secondLevelInput.SignDesc().Output.Value)
+	budget := calculateBudget(
+		value, h.Budget.DeadlineHTLCRatio, h.Budget.DeadlineHTLC,
+	)
+
+	// The deadline would be the CLTV in this HTLC output. If we are the
+	// initiator of this force close, with the default
+	// `IncomingBroadcastDelta`, it means we have 10 blocks left when going
+	// onchain.
+	deadline := fn.Some(int32(h.htlc.RefundTimeout))
+
+	h.log.Infof("offering second-level HTLC success tx to sweeper with "+
+		"deadline=%v, budget=%v", h.htlc.RefundTimeout, budget)
+
+	// We'll now offer the second-level transaction to the sweeper.
+	_, err := h.Sweeper.SweepInput(
+		&secondLevelInput,
+		sweep.Params{
+			Budget:         budget,
+			DeadlineHeight: deadline,
+		},
+	)
+
+	return err
+}
+
+// sweepSuccessTxOutput attempts to sweep the output of the second level
+// success tx.
+func (h *htlcSuccessResolver) sweepSuccessTxOutput() error {
+	h.log.Debugf("sweeping output %v from 2nd-level HTLC success tx",
+		h.htlcResolution.ClaimOutpoint)
+
+	// This should be non-blocking as we will only attempt to sweep the
+	// output when the second level tx has already been confirmed. In other
+	// words, waitForSpend will return immediately.
+	commitSpend, err := waitForSpend(
+		&h.htlcResolution.SignedSuccessTx.TxIn[0].PreviousOutPoint,
+		h.htlcResolution.SignDetails.SignDesc.Output.PkScript,
+		h.broadcastHeight, h.Notifier, h.quit,
+	)
+	if err != nil {
+		return err
+	}
+
+	// The HTLC success tx has a CSV lock that we must wait for, and if
+	// this is a lease enforced channel and we're the imitator, we may need
+	// to wait for longer.
+	waitHeight := h.deriveWaitHeight(h.htlcResolution.CsvDelay, commitSpend)
+
+	// Now that the sweeper has broadcasted the second-level transaction,
+	// it has confirmed, and we have checkpointed our state, we'll sweep
+	// the second level output. We report the resolver has moved the next
+	// stage.
+	h.reportLock.Lock()
+	h.currentReport.Stage = 2
+	h.currentReport.MaturityHeight = waitHeight
+	h.reportLock.Unlock()
+
+	if h.hasCLTV() {
+		log.Infof("%T(%x): waiting for CSV and CLTV lock to expire at "+
+			"height %v", h, h.htlc.RHash[:], waitHeight)
+	} else {
+		log.Infof("%T(%x): waiting for CSV lock to expire at height %v",
+			h, h.htlc.RHash[:], waitHeight)
+	}
+
+	// We'll use this input index to determine the second-level output
+	// index on the transaction, as the signatures requires the indexes to
+	// be the same. We don't look for the second-level output script
+	// directly, as there might be more than one HTLC output to the same
+	// pkScript.
+	op := &wire.OutPoint{
+		Hash:  *commitSpend.SpenderTxHash,
+		Index: commitSpend.SpenderInputIndex,
+	}
+
+	// Let the sweeper sweep the second-level output now that the
+	// CSV/CLTV locks have expired.
+	var witType input.StandardWitnessType
+	if h.isTaproot() {
+		witType = input.TaprootHtlcAcceptedSuccessSecondLevel
+	} else {
+		witType = input.HtlcAcceptedSuccessSecondLevel
+	}
+	inp := h.makeSweepInput(
+		op, witType,
+		input.LeaseHtlcAcceptedSuccessSecondLevel,
+		&h.htlcResolution.SweepSignDesc,
+		h.htlcResolution.CsvDelay, uint32(commitSpend.SpendingHeight),
+		h.htlc.RHash,
+	)
+
+	// Calculate the budget for this sweep.
+	budget := calculateBudget(
+		btcutil.Amount(inp.SignDesc().Output.Value),
+		h.Budget.NoDeadlineHTLCRatio,
+		h.Budget.NoDeadlineHTLC,
+	)
+
+	log.Infof("%T(%x): offering second-level success tx output to sweeper "+
+		"with no deadline and budget=%v at height=%v", h,
+		h.htlc.RHash[:], budget, waitHeight)
+
+	// TODO(yy): use the result chan returned from SweepInput.
+	_, err = h.Sweeper.SweepInput(
+		inp,
+		sweep.Params{
+			Budget: budget,
+
+			// For second level success tx, there's no rush to get
+			// it confirmed, so we use a nil deadline.
+			DeadlineHeight: fn.None[int32](),
+		},
+	)
+
+	return err
+}
+
+// resolveLegacySuccessTx handles an HTLC output from a pre-anchor type channel
+// by broadcasting the second-level success transaction.
+func (h *htlcSuccessResolver) resolveLegacySuccessTx() error {
+	// Otherwise we'll publish the second-level transaction directly and
+	// offer the resolution to the nursery to handle.
+	h.log.Infof("broadcasting second-level success transition tx: %v",
+		h.htlcResolution.SignedSuccessTx.TxHash())
+
+	// We'll now broadcast the second layer transaction so we can kick off
+	// the claiming process.
+	//
+	// TODO(yy): offer it to the sweeper instead.
+	label := labels.MakeLabel(
+		labels.LabelTypeChannelClose, &h.ShortChanID,
+	)
+	err := h.PublishTx(h.htlcResolution.SignedSuccessTx, label)
+	if err != nil {
+		return err
+	}
+
+	// Exit early if the output has already been sent to the UtxoNursery.
+	if h.outputIncubating {
+		return nil
+	}
+
+	// Otherwise, this is an output on our commitment transaction. In this
+	// case, we'll send it to the incubator, but only if we haven't already
+	// done so.
+	log.Infof("%T(%x): incubating incoming htlc output", h, h.htlc.RHash[:])
+
+	// Otherwise, we'll send it to the incubator.
+	err = h.IncubateOutputs(
+		h.ChanPoint, fn.None[lnwallet.OutgoingHtlcResolution](),
+		fn.Some(h.htlcResolution),
+		h.broadcastHeight, fn.Some(int32(h.htlc.RefundTimeout)),
+	)
+	if err != nil {
+		return err
+	}
+
+	h.outputIncubating = true
+	return h.Checkpoint(h)
 }

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -42,9 +42,6 @@ type htlcSuccessResolver struct {
 	// second-level output (true).
 	outputIncubating bool
 
-	// resolved reflects if the contract has been fully resolved or not.
-	resolved bool
-
 	// broadcastHeight is the height that the original contract was
 	// broadcast to the main-chain at. We'll use this value to bound any
 	// historical queries to the chain for spends/confirmations.
@@ -122,7 +119,7 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 
 	switch {
 	// If we're already resolved, then we can exit early.
-	case h.resolved:
+	case h.IsResolved():
 		h.log.Errorf("already resolved")
 
 	// If this is an output on the remote party's commitment transaction,
@@ -226,7 +223,7 @@ func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash) error {
 	}
 
 	// Finally, we checkpoint the resolver with our report(s).
-	h.resolved = true
+	h.resolved.Store(true)
 	return h.Checkpoint(h, reports...)
 }
 
@@ -239,14 +236,6 @@ func (h *htlcSuccessResolver) Stop() {
 	defer h.log.Debugf("stopped")
 
 	close(h.quit)
-}
-
-// IsResolved returns true if the stored state in the resolve is fully
-// resolved. In this case the target output can be forgotten.
-//
-// NOTE: Part of the ContractResolver interface.
-func (h *htlcSuccessResolver) IsResolved() bool {
-	return h.resolved
 }
 
 // report returns a report on the resolution state of the contract.
@@ -735,7 +724,7 @@ func (h *htlcSuccessResolver) Launch() error {
 
 	switch {
 	// If we're already resolved, then we can exit early.
-	case h.resolved:
+	case h.IsResolved():
 		h.log.Errorf("already resolved")
 		return nil
 

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -287,7 +287,7 @@ func (h *htlcSuccessResolver) Encode(w io.Writer) error {
 	if err := binary.Write(w, endian, h.outputIncubating); err != nil {
 		return err
 	}
-	if err := binary.Write(w, endian, h.resolved); err != nil {
+	if err := binary.Write(w, endian, h.IsResolved()); err != nil {
 		return err
 	}
 	if err := binary.Write(w, endian, h.broadcastHeight); err != nil {
@@ -326,9 +326,13 @@ func newSuccessResolverFromReader(r io.Reader, resCfg ResolverConfig) (
 	if err := binary.Read(r, endian, &h.outputIncubating); err != nil {
 		return nil, err
 	}
-	if err := binary.Read(r, endian, &h.resolved); err != nil {
+
+	var resolved bool
+	if err := binary.Read(r, endian, &resolved); err != nil {
 		return nil, err
 	}
+	h.resolved.Store(resolved)
+
 	if err := binary.Read(r, endian, &h.broadcastHeight); err != nil {
 		return nil, err
 	}
@@ -611,7 +615,7 @@ func (h *htlcSuccessResolver) resolveLegacySuccessTx() error {
 
 	// Exit early if the output has already been sent to the UtxoNursery.
 	if h.outputIncubating {
-		return nil
+		return h.resolveSuccessTxOutput(h.htlcResolution.ClaimOutpoint)
 	}
 
 	// Otherwise, this is an output on our commitment transaction. In this
@@ -630,7 +634,12 @@ func (h *htlcSuccessResolver) resolveLegacySuccessTx() error {
 	}
 
 	h.outputIncubating = true
-	return h.Checkpoint(h)
+	if err := h.Checkpoint(h); err != nil {
+		log.Errorf("unable to Checkpoint: %v", err)
+		return err
+	}
+
+	return h.resolveSuccessTxOutput(h.htlcResolution.ClaimOutpoint)
 }
 
 // resolveSuccessTx waits for the sweeping tx of the second-level success tx to

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -2,6 +2,7 @@ package contractcourt
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 	"sync"
 
@@ -81,8 +82,22 @@ func newSuccessResolver(res lnwallet.IncomingHtlcResolution,
 	}
 
 	h.initReport()
+	h.initLogger(fmt.Sprintf("%T(%v)", h, h.outpoint()))
 
 	return h
+}
+
+// outpoint returns the outpoint of the HTLC output we're attempting to sweep.
+func (h *htlcSuccessResolver) outpoint() wire.OutPoint {
+	// The primary key for this resolver will be the outpoint of the HTLC
+	// on the commitment transaction itself. If this is our commitment,
+	// then the output can be found within the signed success tx,
+	// otherwise, it's just the ClaimOutpoint.
+	if h.htlcResolution.SignedSuccessTx != nil {
+		return h.htlcResolution.SignedSuccessTx.TxIn[0].PreviousOutPoint
+	}
+
+	return h.htlcResolution.ClaimOutpoint
 }
 
 // ResolverKey returns an identifier which should be globally unique for this
@@ -90,18 +105,7 @@ func newSuccessResolver(res lnwallet.IncomingHtlcResolution,
 //
 // NOTE: Part of the ContractResolver interface.
 func (h *htlcSuccessResolver) ResolverKey() []byte {
-	// The primary key for this resolver will be the outpoint of the HTLC
-	// on the commitment transaction itself. If this is our commitment,
-	// then the output can be found within the signed success tx,
-	// otherwise, it's just the ClaimOutpoint.
-	var op wire.OutPoint
-	if h.htlcResolution.SignedSuccessTx != nil {
-		op = h.htlcResolution.SignedSuccessTx.TxIn[0].PreviousOutPoint
-	} else {
-		op = h.htlcResolution.ClaimOutpoint
-	}
-
-	key := newResolverID(op)
+	key := newResolverID(h.outpoint())
 	return key[:]
 }
 
@@ -673,6 +677,7 @@ func newSuccessResolverFromReader(r io.Reader, resCfg ResolverConfig) (
 	}
 
 	h.initReport()
+	h.initLogger(fmt.Sprintf("%T(%v)", h, h.outpoint()))
 
 	return h, nil
 }

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -140,27 +140,7 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 
 	// To wrap this up, we'll wait until the second-level transaction has
 	// been spent, then fully resolve the contract.
-	log.Infof("%T(%x): waiting for second-level HTLC output to be spent "+
-		"after csv_delay=%v", h, h.htlc.RHash[:], h.htlcResolution.CsvDelay)
-
-	spend, err := waitForSpend(
-		secondLevelOutpoint,
-		h.htlcResolution.SweepSignDesc.Output.PkScript,
-		h.broadcastHeight, h.Notifier, h.quit,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	h.reportLock.Lock()
-	h.currentReport.RecoveredBalance = h.currentReport.LimboBalance
-	h.currentReport.LimboBalance = 0
-	h.reportLock.Unlock()
-
-	h.resolved = true
-	return nil, h.checkpointClaim(
-		spend.SpenderTxHash, channeldb.ResolverOutcomeClaimed,
-	)
+	return nil, h.resolveSuccessTxOutput(*secondLevelOutpoint)
 }
 
 // broadcastSuccessTx handles an HTLC output on our local commitment by
@@ -213,33 +193,25 @@ func (h *htlcSuccessResolver) broadcastReSignedSuccessTx() (*wire.OutPoint,
 			return nil, err
 		}
 
-		log.Infof("%T(%x): waiting for second-level HTLC success "+
-			"transaction to confirm", h, h.htlc.RHash[:])
-
-		// Wait for the second level transaction to confirm.
-		commitSpend, err = waitForSpend(
-			&h.htlcResolution.SignedSuccessTx.TxIn[0].PreviousOutPoint,
-			h.htlcResolution.SignDetails.SignDesc.Output.PkScript,
-			h.broadcastHeight, h.Notifier, h.quit,
-		)
+		err = h.resolveSuccessTx()
 		if err != nil {
 			return nil, err
 		}
-
-		// Now that the second-level transaction has confirmed, we
-		// checkpoint the state so we'll go to the next stage in case
-		// of restarts.
-		h.outputIncubating = true
-		if err := h.Checkpoint(h); err != nil {
-			log.Errorf("unable to Checkpoint: %v", err)
-			return nil, err
-		}
-
-		log.Infof("%T(%x): second-level HTLC success transaction "+
-			"confirmed!", h, h.htlc.RHash[:])
 	}
 
-	err := h.sweepSuccessTxOutput()
+	// This should be non-blocking as we will only attempt to sweep the
+	// output when the second level tx has already been confirmed. In other
+	// words, waitForSpend will return immediately.
+	commitSpend, err := waitForSpend(
+		&h.htlcResolution.SignedSuccessTx.TxIn[0].PreviousOutPoint,
+		h.htlcResolution.SignDetails.SignDesc.Output.PkScript,
+		h.broadcastHeight, h.Notifier, h.quit,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	err = h.sweepSuccessTxOutput()
 	if err != nil {
 		return nil, err
 	}
@@ -275,23 +247,14 @@ func (h *htlcSuccessResolver) resolveRemoteCommitOutput() (
 		return nil, err
 	}
 
-	// Once the transaction has received a sufficient number of
-	// confirmations, we'll mark ourselves as fully resolved and exit.
-	h.resolved = true
-
 	// Checkpoint the resolver, and write the outcome to disk.
-	return nil, h.checkpointClaim(
-		sweepTxDetails.SpenderTxHash,
-		channeldb.ResolverOutcomeClaimed,
-	)
+	return nil, h.checkpointClaim(sweepTxDetails.SpenderTxHash)
 }
 
 // checkpointClaim checkpoints the success resolver with the reports it needs.
 // If this htlc was claimed two stages, it will write reports for both stages,
 // otherwise it will just write for the single htlc claim.
-func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash,
-	outcome channeldb.ResolverOutcome) error {
-
+func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash) error {
 	// Mark the htlc as final settled.
 	err := h.ChainArbitratorConfig.PutFinalHtlcOutcome(
 		h.ChannelArbitratorConfig.ShortChanID, h.htlc.HtlcIndex, true,
@@ -319,7 +282,7 @@ func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash,
 			OutPoint:        h.htlcResolution.ClaimOutpoint,
 			Amount:          amt,
 			ResolverType:    channeldb.ResolverTypeIncomingHtlc,
-			ResolverOutcome: outcome,
+			ResolverOutcome: channeldb.ResolverOutcomeClaimed,
 			SpendTxID:       spendTx,
 		},
 	}
@@ -344,6 +307,7 @@ func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash,
 	}
 
 	// Finally, we checkpoint the resolver with our report(s).
+	h.resolved = true
 	return h.Checkpoint(h, reports...)
 }
 
@@ -757,4 +721,82 @@ func (h *htlcSuccessResolver) resolveLegacySuccessTx() error {
 
 	h.outputIncubating = true
 	return h.Checkpoint(h)
+}
+
+// resolveSuccessTx waits for the sweeping tx of the second-level success tx to
+// confirm and offers the output from the success tx to the sweeper.
+func (h *htlcSuccessResolver) resolveSuccessTx() error {
+	h.log.Infof("waiting for 2nd-level HTLC success transaction to confirm")
+
+	// Create aliases to make the code more readable.
+	outpoint := h.htlcResolution.SignedSuccessTx.TxIn[0].PreviousOutPoint
+	pkScript := h.htlcResolution.SignDetails.SignDesc.Output.PkScript
+
+	// Wait for the second level transaction to confirm.
+	commitSpend, err := waitForSpend(
+		&outpoint, pkScript, h.broadcastHeight, h.Notifier, h.quit,
+	)
+	if err != nil {
+		return err
+	}
+
+	// We'll use this input index to determine the second-level output
+	// index on the transaction, as the signatures requires the indexes to
+	// be the same. We don't look for the second-level output script
+	// directly, as there might be more than one HTLC output to the same
+	// pkScript.
+	op := wire.OutPoint{
+		Hash:  *commitSpend.SpenderTxHash,
+		Index: commitSpend.SpenderInputIndex,
+	}
+
+	// If the 2nd-stage sweeping has already been started, we can
+	// fast-forward to start the resolving process for the stage two
+	// output.
+	if h.outputIncubating {
+		return h.resolveSuccessTxOutput(op)
+	}
+
+	// Now that the second-level transaction has confirmed, we checkpoint
+	// the state so we'll go to the next stage in case of restarts.
+	h.outputIncubating = true
+	if err := h.Checkpoint(h); err != nil {
+		log.Errorf("unable to Checkpoint: %v", err)
+		return err
+	}
+
+	h.log.Infof("2nd-level HTLC success tx=%v confirmed",
+		commitSpend.SpenderTxHash)
+
+	// Send the sweep request for the output from the success tx.
+	if err := h.sweepSuccessTxOutput(); err != nil {
+		return err
+	}
+
+	return h.resolveSuccessTxOutput(op)
+}
+
+// resolveSuccessTxOutput waits for the spend of the output from the 2nd-level
+// success tx.
+func (h *htlcSuccessResolver) resolveSuccessTxOutput(op wire.OutPoint) error {
+	// To wrap this up, we'll wait until the second-level transaction has
+	// been spent, then fully resolve the contract.
+	log.Infof("%T(%x): waiting for second-level HTLC output to be spent "+
+		"after csv_delay=%v", h, h.htlc.RHash[:],
+		h.htlcResolution.CsvDelay)
+
+	spend, err := waitForSpend(
+		&op, h.htlcResolution.SweepSignDesc.Output.PkScript,
+		h.broadcastHeight, h.Notifier, h.quit,
+	)
+	if err != nil {
+		return err
+	}
+
+	h.reportLock.Lock()
+	h.currentReport.RecoveredBalance = h.currentReport.LimboBalance
+	h.currentReport.LimboBalance = 0
+	h.reportLock.Unlock()
+
+	return h.checkpointClaim(spend.SpenderTxHash)
 }

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -127,7 +127,7 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 
 	// If we don't have a success transaction, then this means that this is
 	// an output on the remote party's commitment transaction.
-	if h.htlcResolution.SignedSuccessTx == nil {
+	if h.isRemoteCommitOutput() {
 		return h.resolveRemoteCommitOutput()
 	}
 
@@ -176,7 +176,7 @@ func (h *htlcSuccessResolver) broadcastSuccessTx() (
 	// and attach fees at will. We let the sweeper handle this job.  We use
 	// the checkpointed outputIncubating field to determine if we already
 	// swept the HTLC output into the second level transaction.
-	if h.htlcResolution.SignDetails != nil {
+	if h.isZeroFeeOutput() {
 		return h.broadcastReSignedSuccessTx()
 	}
 
@@ -236,12 +236,9 @@ func (h *htlcSuccessResolver) broadcastReSignedSuccessTx() (*wire.OutPoint,
 
 	// We will have to let the sweeper re-sign the success tx and wait for
 	// it to confirm, if we haven't already.
-	isTaproot := txscript.IsPayToTaproot(
-		h.htlcResolution.SweepSignDesc.Output.PkScript,
-	)
 	if !h.outputIncubating {
 		var secondLevelInput input.HtlcSecondLevelAnchorInput
-		if isTaproot {
+		if h.isTaproot() {
 			//nolint:lll
 			secondLevelInput = input.MakeHtlcSecondLevelSuccessTaprootInput(
 				h.htlcResolution.SignedSuccessTx,
@@ -368,7 +365,7 @@ func (h *htlcSuccessResolver) broadcastReSignedSuccessTx() (*wire.OutPoint,
 	// Let the sweeper sweep the second-level output now that the
 	// CSV/CLTV locks have expired.
 	var witType input.StandardWitnessType
-	if isTaproot {
+	if h.isTaproot() {
 		witType = input.TaprootHtlcAcceptedSuccessSecondLevel
 	} else {
 		witType = input.HtlcAcceptedSuccessSecondLevel
@@ -418,16 +415,12 @@ func (h *htlcSuccessResolver) broadcastReSignedSuccessTx() (*wire.OutPoint,
 func (h *htlcSuccessResolver) resolveRemoteCommitOutput() (
 	ContractResolver, error) {
 
-	isTaproot := txscript.IsPayToTaproot(
-		h.htlcResolution.SweepSignDesc.Output.PkScript,
-	)
-
 	// Before we can craft out sweeping transaction, we need to
 	// create an input which contains all the items required to add
 	// this input to a sweeping transaction, and generate a
 	// witness.
 	var inp input.Input
-	if isTaproot {
+	if h.isTaproot() {
 		inp = lnutils.Ptr(input.MakeTaprootHtlcSucceedInput(
 			&h.htlcResolution.ClaimOutpoint,
 			&h.htlcResolution.SweepSignDesc,
@@ -706,3 +699,29 @@ func (h *htlcSuccessResolver) SupplementDeadline(_ fn.Option[int32]) {
 // A compile time assertion to ensure htlcSuccessResolver meets the
 // ContractResolver interface.
 var _ htlcContractResolver = (*htlcSuccessResolver)(nil)
+
+// isRemoteCommitOutput returns a bool to indicate whether the htlc output is
+// on the remote commitment.
+func (h *htlcSuccessResolver) isRemoteCommitOutput() bool {
+	// If we don't have a success transaction, then this means that this is
+	// an output on the remote party's commitment transaction.
+	return h.htlcResolution.SignedSuccessTx == nil
+}
+
+// isZeroFeeOutput returns a boolean indicating whether the htlc output is from
+// a anchor-enabled channel, which uses the sighash SINGLE|ANYONECANPAY.
+func (h *htlcSuccessResolver) isZeroFeeOutput() bool {
+	// If we have non-nil SignDetails, this means it has a 2nd level HTLC
+	// transaction that is signed using sighash SINGLE|ANYONECANPAY (the
+	// case for anchor type channels). In this case we can re-sign it and
+	// attach fees at will.
+	return h.htlcResolution.SignedSuccessTx != nil &&
+		h.htlcResolution.SignDetails != nil
+}
+
+// isTaproot returns true if the resolver is for a taproot output.
+func (h *htlcSuccessResolver) isTaproot() bool {
+	return txscript.IsPayToTaproot(
+		h.htlcResolution.SweepSignDesc.Output.PkScript,
+	)
+}

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -714,13 +714,13 @@ func (h *htlcSuccessResolver) resolveSuccessTxOutput(op wire.OutPoint) error {
 // Launch creates an input based on the details of the incoming htlc resolution
 // and offers it to the sweeper.
 func (h *htlcSuccessResolver) Launch() error {
-	if h.launched {
+	if h.launched.Load() {
 		h.log.Tracef("already launched")
 		return nil
 	}
 
 	h.log.Debugf("launching resolver...")
-	h.launched = true
+	h.launched.Store(true)
 
 	switch {
 	// If we're already resolved, then we can exit early.

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -10,8 +10,6 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/davecgh/go-spew/spew"
-	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/fn"
@@ -116,139 +114,60 @@ func (h *htlcSuccessResolver) ResolverKey() []byte {
 // anymore. Every HTLC has already passed through the incoming contest resolver
 // and in there the invoice was already marked as settled.
 //
-// TODO(roasbeef): create multi to batch
-//
 // NOTE: Part of the ContractResolver interface.
+//
+// TODO(yy): refactor the interface method to return an error only.
 func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
+	var err error
+
+	switch {
 	// If we're already resolved, then we can exit early.
-	if h.resolved {
-		return nil, nil
-	}
+	case h.resolved:
+		h.log.Errorf("already resolved")
 
-	// If we don't have a success transaction, then this means that this is
-	// an output on the remote party's commitment transaction.
-	if h.isRemoteCommitOutput() {
-		return h.resolveRemoteCommitOutput()
-	}
+	// If this is an output on the remote party's commitment transaction,
+	// use the direct-spend path to sweep the htlc.
+	case h.isRemoteCommitOutput():
+		err = h.resolveRemoteCommitOutput()
 
-	// Otherwise this an output on our own commitment, and we must start by
-	// broadcasting the second-level success transaction.
-	secondLevelOutpoint, err := h.broadcastSuccessTx()
-	if err != nil {
-		return nil, err
-	}
-
-	// To wrap this up, we'll wait until the second-level transaction has
-	// been spent, then fully resolve the contract.
-	return nil, h.resolveSuccessTxOutput(*secondLevelOutpoint)
-}
-
-// broadcastSuccessTx handles an HTLC output on our local commitment by
-// broadcasting the second-level success transaction. It returns the ultimate
-// outpoint of the second-level tx, that we must wait to be spent for the
-// resolver to be fully resolved.
-func (h *htlcSuccessResolver) broadcastSuccessTx() (
-	*wire.OutPoint, error) {
-
-	// If we have non-nil SignDetails, this means that have a 2nd level
-	// HTLC transaction that is signed using sighash SINGLE|ANYONECANPAY
-	// (the case for anchor type channels). In this case we can re-sign it
-	// and attach fees at will. We let the sweeper handle this job.  We use
-	// the checkpointed outputIncubating field to determine if we already
-	// swept the HTLC output into the second level transaction.
-	if h.isZeroFeeOutput() {
-		return h.broadcastReSignedSuccessTx()
-	}
-
-	// Otherwise we'll publish the second-level transaction directly and
-	// offer the resolution to the nursery to handle.
-	log.Infof("%T(%x): broadcasting second-layer transition tx: %v",
-		h, h.htlc.RHash[:], spew.Sdump(h.htlcResolution.SignedSuccessTx))
-
-	// We'll now broadcast the second layer transaction so we can kick off
-	// the claiming process.
-	err := h.resolveLegacySuccessTx()
-	if err != nil {
-		return nil, err
-	}
-
-	return &h.htlcResolution.ClaimOutpoint, nil
-}
-
-// broadcastReSignedSuccessTx handles the case where we have non-nil
-// SignDetails, and offers the second level transaction to the Sweeper, that
-// will re-sign it and attach fees at will.
-func (h *htlcSuccessResolver) broadcastReSignedSuccessTx() (*wire.OutPoint,
-	error) {
-
-	// Keep track of the tx spending the HTLC output on the commitment, as
-	// this will be the confirmed second-level tx we'll ultimately sweep.
-	var commitSpend *chainntnfs.SpendDetail
-
-	// We will have to let the sweeper re-sign the success tx and wait for
-	// it to confirm, if we haven't already.
-	if !h.outputIncubating {
-		err := h.sweepSuccessTx()
-		if err != nil {
-			return nil, err
-		}
-
+	// If this is an output on our commitment transaction using post-anchor
+	// channel type, it will be handled by the sweeper.
+	case h.isZeroFeeOutput():
 		err = h.resolveSuccessTx()
-		if err != nil {
-			return nil, err
-		}
+
+	// If this is an output on our own commitment using pre-anchor channel
+	// type, we will publish the success tx and offer the output to the
+	// nursery.
+	default:
+		err = h.resolveLegacySuccessTx()
 	}
 
-	// This should be non-blocking as we will only attempt to sweep the
-	// output when the second level tx has already been confirmed. In other
-	// words, waitForSpend will return immediately.
-	commitSpend, err := waitForSpend(
-		&h.htlcResolution.SignedSuccessTx.TxIn[0].PreviousOutPoint,
-		h.htlcResolution.SignDetails.SignDesc.Output.PkScript,
-		h.broadcastHeight, h.Notifier, h.quit,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	err = h.sweepSuccessTxOutput()
-	if err != nil {
-		return nil, err
-	}
-
-	// Will return this outpoint, when this is spent the resolver is fully
-	// resolved.
-	op := &wire.OutPoint{
-		Hash:  *commitSpend.SpenderTxHash,
-		Index: commitSpend.SpenderInputIndex,
-	}
-
-	return op, nil
+	return nil, err
 }
 
 // resolveRemoteCommitOutput handles sweeping an HTLC output on the remote
 // commitment with the preimage. In this case we can sweep the output directly,
 // and don't have to broadcast a second-level transaction.
-func (h *htlcSuccessResolver) resolveRemoteCommitOutput() (
-	ContractResolver, error) {
-
-	err := h.sweepRemoteCommitOutput()
-	if err != nil {
-		return nil, err
-	}
+func (h *htlcSuccessResolver) resolveRemoteCommitOutput() error {
+	h.log.Info("waiting for direct-preimage spend of the htlc to confirm")
 
 	// Wait for the direct-preimage HTLC sweep tx to confirm.
+	//
+	// TODO(yy): use the result chan returned from `SweepInput`.
 	sweepTxDetails, err := waitForSpend(
 		&h.htlcResolution.ClaimOutpoint,
 		h.htlcResolution.SweepSignDesc.Output.PkScript,
 		h.broadcastHeight, h.Notifier, h.quit,
 	)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
+	// TODO(yy): should also update the `RecoveredBalance` and
+	// `LimboBalance` like other paths?
+
 	// Checkpoint the resolver, and write the outcome to disk.
-	return nil, h.checkpointClaim(sweepTxDetails.SpenderTxHash)
+	return h.checkpointClaim(sweepTxDetails.SpenderTxHash)
 }
 
 // checkpointClaim checkpoints the success resolver with the reports it needs.
@@ -316,6 +235,9 @@ func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash) error {
 //
 // NOTE: Part of the ContractResolver interface.
 func (h *htlcSuccessResolver) Stop() {
+	h.log.Debugf("stopping...")
+	defer h.log.Debugf("stopped")
+
 	close(h.quit)
 }
 
@@ -799,4 +721,48 @@ func (h *htlcSuccessResolver) resolveSuccessTxOutput(op wire.OutPoint) error {
 	h.reportLock.Unlock()
 
 	return h.checkpointClaim(spend.SpenderTxHash)
+}
+
+// Launch creates an input based on the details of the incoming htlc resolution
+// and offers it to the sweeper.
+func (h *htlcSuccessResolver) Launch() error {
+	if h.launched {
+		h.log.Tracef("already launched")
+		return nil
+	}
+
+	h.log.Debugf("launching resolver...")
+	h.launched = true
+
+	switch {
+	// If we're already resolved, then we can exit early.
+	case h.resolved:
+		h.log.Errorf("already resolved")
+		return nil
+
+	// If this is an output on the remote party's commitment transaction,
+	// use the direct-spend path.
+	case h.isRemoteCommitOutput():
+		return h.sweepRemoteCommitOutput()
+
+	// If this is an anchor type channel, we now sweep either the
+	// second-level success tx or the output from the second-level success
+	// tx.
+	case h.isZeroFeeOutput():
+		// If the second-level success tx has already been swept, we
+		// can go ahead and sweep its output.
+		if h.outputIncubating {
+			return h.sweepSuccessTxOutput()
+		}
+
+		// Otherwise, sweep the second level tx.
+		return h.sweepSuccessTx()
+
+	// If this is a legacy channel type, the output is handled by the
+	// nursery.
+	//
+	// TODO(yy): handle the legacy output by offering it to the sweeper.
+	default:
+		return nil
+	}
 }

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -146,6 +146,9 @@ func (i *htlcResolverTestContext) resolve() {
 	i.resolverResultChan = make(chan resolveResult, 1)
 
 	go func() {
+		err := i.resolver.Launch()
+		require.NoError(i.t, err)
+
 		nextResolver, err := i.resolver.Resolve()
 		i.resolverResultChan <- resolveResult{
 			nextResolver: nextResolver,

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -20,6 +21,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntest/mock"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
 )
 
 var testHtlcAmt = lnwire.MilliSatoshi(200000)
@@ -37,6 +39,15 @@ type htlcResolverTestContext struct {
 	finalHtlcOutcomeStored bool
 
 	t *testing.T
+}
+
+func newHtlcResolverTestContextFromReader(t *testing.T,
+	newResolver func(htlc channeldb.HTLC,
+		cfg ResolverConfig) ContractResolver) *htlcResolverTestContext {
+
+	ctx := newHtlcResolverTestContext(t, newResolver)
+
+	return ctx
 }
 
 func newHtlcResolverTestContext(t *testing.T,
@@ -133,6 +144,7 @@ func newHtlcResolverTestContext(t *testing.T,
 func (i *htlcResolverTestContext) resolve() {
 	// Start resolver.
 	i.resolverResultChan = make(chan resolveResult, 1)
+
 	go func() {
 		nextResolver, err := i.resolver.Resolve()
 		i.resolverResultChan <- resolveResult{
@@ -192,6 +204,7 @@ func TestHtlcSuccessSingleStage(t *testing.T) {
 				// sweeper.
 				details := &chainntnfs.SpendDetail{
 					SpendingTx:    sweepTx,
+					SpentOutPoint: &htlcOutpoint,
 					SpenderTxHash: &sweepTxid,
 				}
 				ctx.notifier.SpendChan <- details
@@ -279,6 +292,7 @@ func TestHtlcSuccessSecondStageResolution(t *testing.T) {
 
 				ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
 					SpendingTx:    sweepTx,
+					SpentOutPoint: &htlcOutpoint,
 					SpenderTxHash: &sweepHash,
 				}
 
@@ -302,6 +316,8 @@ func TestHtlcSuccessSecondStageResolution(t *testing.T) {
 // TestHtlcSuccessSecondStageResolutionSweeper test that a resolver with
 // non-nil SignDetails will offer the second-level transaction to the sweeper
 // for re-signing.
+//
+//nolint:lll
 func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 	commitOutpoint := wire.OutPoint{Index: 2}
 	htlcOutpoint := wire.OutPoint{Index: 3}
@@ -399,7 +415,20 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 				_ bool) error {
 
 				resolver := ctx.resolver.(*htlcSuccessResolver)
-				inp := <-resolver.Sweeper.(*mockSweeper).sweptInputs
+
+				var (
+					inp input.Input
+					ok  bool
+				)
+
+				select {
+				case inp, ok = <-resolver.Sweeper.(*mockSweeper).sweptInputs:
+					require.True(t, ok)
+
+				case <-time.After(1 * time.Second):
+					t.Fatal("expected input to be swept")
+				}
+
 				op := inp.OutPoint()
 				if op != commitOutpoint {
 					return fmt.Errorf("outpoint %v swept, "+
@@ -412,6 +441,7 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 					SpenderTxHash:     &reSignedHash,
 					SpenderInputIndex: 1,
 					SpendingHeight:    10,
+					SpentOutPoint:     &commitOutpoint,
 				}
 				return nil
 			},
@@ -434,13 +464,37 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 						SpenderTxHash:     &reSignedHash,
 						SpenderInputIndex: 1,
 						SpendingHeight:    10,
+						SpentOutPoint:     &commitOutpoint,
 					}
 				}
 
 				// We expect it to sweep the second-level
 				// transaction we notfied about above.
 				resolver := ctx.resolver.(*htlcSuccessResolver)
-				inp := <-resolver.Sweeper.(*mockSweeper).sweptInputs
+
+				// Mock `waitForSpend` to return the commit
+				// spend.
+				ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
+					SpendingTx:        reSignedSuccessTx,
+					SpenderTxHash:     &reSignedHash,
+					SpenderInputIndex: 1,
+					SpendingHeight:    10,
+					SpentOutPoint:     &commitOutpoint,
+				}
+
+				var (
+					inp input.Input
+					ok  bool
+				)
+
+				select {
+				case inp, ok = <-resolver.Sweeper.(*mockSweeper).sweptInputs:
+					require.True(t, ok)
+
+				case <-time.After(1 * time.Second):
+					t.Fatal("expected input to be swept")
+				}
+
 				op := inp.OutPoint()
 				exp := wire.OutPoint{
 					Hash:  reSignedHash,
@@ -457,6 +511,7 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 					SpendingTx:     sweepTx,
 					SpenderTxHash:  &sweepHash,
 					SpendingHeight: 14,
+					SpentOutPoint:  &op,
 				}
 
 				return nil
@@ -504,11 +559,14 @@ func testHtlcSuccess(t *testing.T, resolution lnwallet.IncomingHtlcResolution,
 	// for the next portion of the test.
 	ctx := newHtlcResolverTestContext(t,
 		func(htlc channeldb.HTLC, cfg ResolverConfig) ContractResolver {
-			return &htlcSuccessResolver{
+			r := &htlcSuccessResolver{
 				contractResolverKit: *newContractResolverKit(cfg),
 				htlc:                htlc,
 				htlcResolution:      resolution,
 			}
+			r.initLogger("htlcSuccessResolver")
+
+			return r
 		},
 	)
 
@@ -606,7 +664,12 @@ func runFromCheckpoint(t *testing.T, ctx *htlcResolverTestContext,
 
 		checkpointedState = append(checkpointedState, b.Bytes())
 		nextCheckpoint++
-		checkpointChan <- struct{}{}
+		select {
+		case checkpointChan <- struct{}{}:
+		case <-time.After(1 * time.Second):
+			t.Fatal("checkpoint timeout")
+		}
+
 		return nil
 	}
 
@@ -617,6 +680,8 @@ func runFromCheckpoint(t *testing.T, ctx *htlcResolverTestContext,
 	// preCheckpoint logic if needed.
 	resumed := true
 	for i, cp := range expectedCheckpoints {
+		t.Logf("Running checkpoint %d", i)
+
 		if cp.preCheckpoint != nil {
 			if err := cp.preCheckpoint(ctx, resumed); err != nil {
 				t.Fatalf("failure at stage %d: %v", i, err)
@@ -625,15 +690,15 @@ func runFromCheckpoint(t *testing.T, ctx *htlcResolverTestContext,
 		resumed = false
 
 		// Wait for the resolver to have checkpointed its state.
-		<-checkpointChan
+		select {
+		case <-checkpointChan:
+		case <-time.After(1 * time.Second):
+			t.Fatalf("resolver did not checkpoint at stage %d", i)
+		}
 	}
 
 	// Wait for the resolver to fully complete.
 	ctx.waitForResult()
-
-	if nextCheckpoint < len(expectedCheckpoints) {
-		t.Fatalf("not all checkpoints hit")
-	}
 
 	return checkpointedState
 }

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -619,11 +619,11 @@ func runFromCheckpoint(t *testing.T, ctx *htlcResolverTestContext,
 
 		var resolved, incubating bool
 		if h, ok := resolver.(*htlcSuccessResolver); ok {
-			resolved = h.resolved
+			resolved = h.resolved.Load()
 			incubating = h.outputIncubating
 		}
 		if h, ok := resolver.(*htlcTimeoutResolver); ok {
-			resolved = h.resolved
+			resolved = h.resolved.Load()
 			incubating = h.outputIncubating
 		}
 

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -160,7 +160,7 @@ const (
 // by the remote party. It'll extract the preimage, add it to the global cache,
 // and finally send the appropriate clean up message.
 func (h *htlcTimeoutResolver) claimCleanUp(
-	commitSpend *chainntnfs.SpendDetail) (ContractResolver, error) {
+	commitSpend *chainntnfs.SpendDetail) error {
 
 	// Depending on if this is our commitment or not, then we'll be looking
 	// for a different witness pattern.
@@ -195,7 +195,7 @@ func (h *htlcTimeoutResolver) claimCleanUp(
 	// element, then we're actually on the losing side of a breach
 	// attempt...
 	case h.isTaproot() && len(spendingInput.Witness) == 1:
-		return nil, fmt.Errorf("breach attempt failed")
+		return fmt.Errorf("breach attempt failed")
 
 	// Otherwise, they'll be spending directly from our commitment output.
 	// In which case the witness stack looks like:
@@ -212,8 +212,8 @@ func (h *htlcTimeoutResolver) claimCleanUp(
 
 	preimage, err := lntypes.MakePreimage(preimageBytes)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create pre-image from "+
-			"witness: %v", err)
+		return fmt.Errorf("unable to create pre-image from witness: %w",
+			err)
 	}
 
 	log.Infof("%T(%v): extracting preimage=%v from on-chain "+
@@ -235,7 +235,7 @@ func (h *htlcTimeoutResolver) claimCleanUp(
 		HtlcIndex:  h.htlc.HtlcIndex,
 		PreImage:   &pre,
 	}); err != nil {
-		return nil, err
+		return err
 	}
 	h.resolved = true
 
@@ -250,7 +250,7 @@ func (h *htlcTimeoutResolver) claimCleanUp(
 		SpendTxID:       commitSpend.SpenderTxHash,
 	}
 
-	return nil, h.Checkpoint(h, report)
+	return h.Checkpoint(h, report)
 }
 
 // chainDetailsToWatch returns the output and script which we use to watch for
@@ -448,7 +448,7 @@ func (h *htlcTimeoutResolver) Resolve() (ContractResolver, error) {
 			"witness cache", h, h.htlc.RHash[:],
 			h.htlcResolution.ClaimOutpoint)
 
-		return h.claimCleanUp(commitSpend)
+		return nil, h.claimCleanUp(commitSpend)
 	}
 
 	log.Infof("%T(%v): resolving htlc with incoming fail msg, fully "+
@@ -472,13 +472,9 @@ func (h *htlcTimeoutResolver) Resolve() (ContractResolver, error) {
 	return h.handleCommitSpend(commitSpend)
 }
 
-// sweepSecondLevelTx sends a second level timeout transaction to the sweeper.
+// sweepTimeoutTx sends a second level timeout transaction to the sweeper.
 // This transaction uses the SINLGE|ANYONECANPAY flag.
-func (h *htlcTimeoutResolver) sweepSecondLevelTx() error {
-	log.Infof("%T(%x): offering second-layer timeout tx to sweeper: %v",
-		h, h.htlc.RHash[:],
-		spew.Sdump(h.htlcResolution.SignedTimeoutTx))
-
+func (h *htlcTimeoutResolver) sweepTimeoutTx() error {
 	var inp input.Input
 	if h.isTaproot() {
 		inp = lnutils.Ptr(input.MakeHtlcSecondLevelTimeoutTaprootInput(
@@ -506,27 +502,12 @@ func (h *htlcTimeoutResolver) sweepSecondLevelTx() error {
 		btcutil.Amount(inp.SignDesc().Output.Value), 2, 0,
 	)
 
-	// For an outgoing HTLC, it must be swept before the RefundTimeout of
-	// its incoming HTLC is reached.
-	//
-	// TODO(yy): we may end up mixing inputs with different time locks.
-	// Suppose we have two outgoing HTLCs,
-	// - HTLC1: nLocktime is 800000, CLTV delta is 80.
-	// - HTLC2: nLocktime is 800001, CLTV delta is 79.
-	// This means they would both have an incoming HTLC that expires at
-	// 800080, hence they share the same deadline but different locktimes.
-	// However, with current design, when we are at block 800000, HTLC1 is
-	// offered to the sweeper. When block 800001 is reached, HTLC1's
-	// sweeping process is already started, while HTLC2 is being offered to
-	// the sweeper, so they won't be mixed. This can become an issue tho,
-	// if we decide to sweep per X blocks. Or the contractcourt sees the
-	// block first while the sweeper is only aware of the last block. To
-	// properly fix it, we need `blockbeat` to make sure subsystems are in
-	// sync.
-	log.Infof("%T(%x): offering second-level HTLC timeout tx to sweeper "+
+	h.log.Infof("%T(%x): offering 2nd-level HTLC timeout tx to sweeper "+
 		"with deadline=%v, budget=%v", h, h.htlc.RHash[:],
 		h.incomingHTLCExpiryHeight, budget)
 
+	// For an outgoing HTLC, it must be swept before the RefundTimeout of
+	// its incoming HTLC is reached.
 	_, err := h.Sweeper.SweepInput(
 		inp,
 		sweep.Params{
@@ -538,28 +519,19 @@ func (h *htlcTimeoutResolver) sweepSecondLevelTx() error {
 		return err
 	}
 
-	// TODO(yy): checkpoint here?
 	return err
 }
 
 // sendSecondLevelTxLegacy sends a second level timeout transaction to the utxo
 // nursery. This transaction uses the legacy SIGHASH_ALL flag.
 func (h *htlcTimeoutResolver) sendSecondLevelTxLegacy() error {
-	log.Debugf("%T(%v): incubating htlc output", h,
-		h.htlcResolution.ClaimOutpoint)
+	h.log.Debug("incubating htlc output")
 
-	err := h.IncubateOutputs(
+	return h.IncubateOutputs(
 		h.ChanPoint, fn.Some(h.htlcResolution),
 		fn.None[lnwallet.IncomingHtlcResolution](),
 		h.broadcastHeight, h.incomingHTLCExpiryHeight,
 	)
-	if err != nil {
-		return err
-	}
-
-	h.outputIncubating = true
-
-	return h.Checkpoint(h)
 }
 
 // spendHtlcOutput handles the initial spend of an HTLC output via the timeout
@@ -576,7 +548,7 @@ func (h *htlcTimeoutResolver) spendHtlcOutput() (
 	// (the case for anchor type channels). In this case we can re-sign it
 	// and attach fees at will. We let the sweeper handle this job.
 	case h.isZeroFeeOutput() && !h.outputIncubating:
-		if err := h.sweepSecondLevelTx(); err != nil {
+		if err := h.sweepTimeoutTx(); err != nil {
 			log.Errorf("Sending timeout tx to sweeper: %v", err)
 
 			return nil, err
@@ -585,8 +557,16 @@ func (h *htlcTimeoutResolver) spendHtlcOutput() (
 	// If we have no SignDetails, and we haven't already sent the output to
 	// the utxo nursery, then we'll do so now.
 	case !h.isRemoteCommitOutput() && !h.outputIncubating:
-		if err := h.sendSecondLevelTxLegacy(); err != nil {
+		if err := h.sweepLegacyTimeoutTx(); err != nil {
 			log.Errorf("Sending timeout tx to nursery: %v", err)
+
+			return nil, err
+		}
+
+	default:
+		err := h.sweepRemoteCommitOutput()
+		if err != nil {
+			log.Errorf("Sweeping remote commit output: %v", err)
 
 			return nil, err
 		}
@@ -626,9 +606,6 @@ func (h *htlcTimeoutResolver) watchHtlcSpend() (*chainntnfs.SpendDetail,
 // a block, returns the spend details.
 func (h *htlcTimeoutResolver) waitForConfirmedSpend(op *wire.OutPoint,
 	pkScript []byte) (*chainntnfs.SpendDetail, error) {
-
-	log.Infof("%T(%v): waiting for spent of HTLC output %v to be "+
-		"fully confirmed", h, h.htlcResolution.ClaimOutpoint, op)
 
 	// We'll block here until either we exit, or the HTLC output on the
 	// commitment transaction has been spent.
@@ -694,80 +671,11 @@ func (h *htlcTimeoutResolver) handleCommitSpend(
 	// the CSV and possible CLTV lock to expire, before sweeping the output
 	// on the second-level.
 	case h.isZeroFeeOutput():
-		waitHeight := h.deriveWaitHeight(
-			h.htlcResolution.CsvDelay, commitSpend,
-		)
-
-		h.reportLock.Lock()
-		h.currentReport.Stage = 2
-		h.currentReport.MaturityHeight = waitHeight
-		h.reportLock.Unlock()
-
-		if h.hasCLTV() {
-			log.Infof("%T(%x): waiting for CSV and CLTV lock to "+
-				"expire at height %v", h, h.htlc.RHash[:],
-				waitHeight)
-		} else {
-			log.Infof("%T(%x): waiting for CSV lock to expire at "+
-				"height %v", h, h.htlc.RHash[:], waitHeight)
-		}
-
-		// We'll use this input index to determine the second-level
-		// output index on the transaction, as the signatures requires
-		// the indexes to be the same. We don't look for the
-		// second-level output script directly, as there might be more
-		// than one HTLC output to the same pkScript.
-		op := &wire.OutPoint{
-			Hash:  *commitSpend.SpenderTxHash,
-			Index: commitSpend.SpenderInputIndex,
-		}
-
-		var csvWitnessType input.StandardWitnessType
-		if h.isTaproot() {
-			//nolint:lll
-			csvWitnessType = input.TaprootHtlcOfferedTimeoutSecondLevel
-		} else {
-			csvWitnessType = input.HtlcOfferedTimeoutSecondLevel
-		}
-
-		// Let the sweeper sweep the second-level output now that the
-		// CSV/CLTV locks have expired.
-		inp := h.makeSweepInput(
-			op, csvWitnessType,
-			input.LeaseHtlcOfferedTimeoutSecondLevel,
-			&h.htlcResolution.SweepSignDesc,
-			h.htlcResolution.CsvDelay,
-			uint32(commitSpend.SpendingHeight), h.htlc.RHash,
-		)
-		// Calculate the budget for this sweep.
-		budget := calculateBudget(
-			btcutil.Amount(inp.SignDesc().Output.Value),
-			h.Budget.NoDeadlineHTLCRatio,
-			h.Budget.NoDeadlineHTLC,
-		)
-
-		log.Infof("%T(%x): offering second-level timeout tx output to "+
-			"sweeper with no deadline and budget=%v at height=%v",
-			h, h.htlc.RHash[:], budget, waitHeight)
-
-		_, err := h.Sweeper.SweepInput(
-			inp,
-			sweep.Params{
-				Budget: budget,
-
-				// For second level success tx, there's no rush
-				// to get it confirmed, so we use a nil
-				// deadline.
-				DeadlineHeight: fn.None[int32](),
-			},
-		)
+		err := h.sweepTimeoutTxOutput()
 		if err != nil {
 			return nil, err
 		}
 
-		// Update the claim outpoint to point to the second-level
-		// transaction created by the sweeper.
-		claimOutpoint = *op
 		fallthrough
 
 	// Finally, if this was an output on our commitment transaction, we'll
@@ -1190,4 +1098,137 @@ func (h *htlcTimeoutResolver) isZeroFeeOutput() bool {
 	// attach fees at will.
 	return h.htlcResolution.SignedTimeoutTx != nil &&
 		h.htlcResolution.SignDetails != nil
+}
+
+// sweepRemoteCommitOutput creates a sweep request to sweep the HTLC output on
+// the remote commitment via the direct timeout-spend.
+func (h *htlcTimeoutResolver) sweepRemoteCommitOutput() error {
+	// If the output has already been handled, we can exit early.
+	if h.outputIncubating {
+		return nil
+	}
+
+	h.log.Info("broadcasting direct-timeout spend from remote commit")
+
+	// TODO(yy): here we mimic the behavior of the legacy resolver used in
+	// 0.18.1. What we should do instead is to create a sweep request and
+	// offer it to the sweeper, like how it's done for htlcSuccessResolver.
+	err := h.sendSecondLevelTxLegacy()
+	if err != nil {
+		return err
+	}
+
+	h.outputIncubating = true
+
+	return h.Checkpoint(h)
+}
+
+// sweepLegacyTimeoutTx sweeps the timeout tx using the nursery.
+//
+// TODO(yy): handle the legacy output by offering it to the sweeper.
+func (h *htlcTimeoutResolver) sweepLegacyTimeoutTx() error {
+	// We'll publish the second-level transaction directly and
+	// offer the resolution to the nursery to handle.
+	h.log.Infof("broadcasting second-level timeout transition tx: %v",
+		h.htlcResolution.SignedTimeoutTx.TxHash())
+
+	// The utxo nursery will take care of broadcasting the second-level
+	// timeout tx and sweeping its output once it confirms.
+	return h.sendSecondLevelTxLegacy()
+}
+
+// sweepTimeoutTxOutput attempts to sweep the output of the second level
+// timeout tx.
+func (h *htlcTimeoutResolver) sweepTimeoutTxOutput() error {
+	h.log.Debugf("sweeping output %v from 2nd-level HTLC timeout tx",
+		h.htlcResolution.ClaimOutpoint)
+
+	// This should be non-blocking as we will only attempt to sweep the
+	// output when the second level tx has already been confirmed. In other
+	// words, watchHtlcSpend will return immediately.
+	commitSpend, err := h.watchHtlcSpend()
+	if err != nil {
+		return err
+	}
+
+	// If the spend reveals the pre-image, then we'll enter the clean up
+	// workflow to pass the pre-image back to the incoming link, add it to
+	// the witness cache, and exit.
+	if isPreimageSpend(
+		h.isTaproot(), commitSpend, !h.isRemoteCommitOutput(),
+	) {
+
+		return h.claimCleanUp(commitSpend)
+	}
+
+	waitHeight := h.deriveWaitHeight(h.htlcResolution.CsvDelay, commitSpend)
+
+	// Now that the sweeper has broadcasted the second-level transaction,
+	// it has confirmed, and we have checkpointed our state, we'll sweep
+	// the second level output. We report the resolver has moved the next
+	// stage.
+	h.reportLock.Lock()
+	h.currentReport.Stage = 2
+	h.currentReport.MaturityHeight = waitHeight
+	h.reportLock.Unlock()
+
+	if h.hasCLTV() {
+		h.log.Infof("waiting for CSV and CLTV lock to expire at "+
+			"height %v", waitHeight)
+	} else {
+		h.log.Infof("waiting for CSV lock to expire at height %v",
+			waitHeight)
+	}
+
+	// We'll use this input index to determine the second-level output
+	// index on the transaction, as the signatures requires the indexes to
+	// be the same. We don't look for the second-level output script
+	// directly, as there might be more than one HTLC output to the same
+	// pkScript.
+	op := &wire.OutPoint{
+		Hash:  *commitSpend.SpenderTxHash,
+		Index: commitSpend.SpenderInputIndex,
+	}
+
+	var witType input.StandardWitnessType
+	if h.isTaproot() {
+		witType = input.TaprootHtlcOfferedTimeoutSecondLevel
+	} else {
+		witType = input.HtlcOfferedTimeoutSecondLevel
+	}
+
+	// Let the sweeper sweep the second-level output now that the CSV/CLTV
+	// locks have expired.
+	inp := h.makeSweepInput(
+		op, witType,
+		input.LeaseHtlcOfferedTimeoutSecondLevel,
+		&h.htlcResolution.SweepSignDesc,
+		h.htlcResolution.CsvDelay, uint32(commitSpend.SpendingHeight),
+		h.htlc.RHash,
+	)
+
+	// Calculate the budget for this sweep.
+	budget := calculateBudget(
+		btcutil.Amount(inp.SignDesc().Output.Value),
+		h.Budget.NoDeadlineHTLCRatio,
+		h.Budget.NoDeadlineHTLC,
+	)
+
+	h.log.Infof("offering output from 2nd-level timeout tx to sweeper "+
+		"with no deadline and budget=%v", budget)
+
+	// TODO(yy): use the result chan returned from SweepInput.
+	_, err = h.Sweeper.SweepInput(
+		inp,
+		sweep.Params{
+			Budget: budget,
+
+			// For second level success tx, there's no rush
+			// to get it confirmed, so we use a nil
+			// deadline.
+			DeadlineHeight: fn.None[int32](),
+		},
+	)
+
+	return err
 }

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -575,7 +575,7 @@ func (h *htlcTimeoutResolver) spendHtlcOutput() (
 	// HTLC transaction that is signed using sighash SINGLE|ANYONECANPAY
 	// (the case for anchor type channels). In this case we can re-sign it
 	// and attach fees at will. We let the sweeper handle this job.
-	case h.htlcResolution.SignDetails != nil && !h.outputIncubating:
+	case h.isZeroFeeOutput() && !h.outputIncubating:
 		if err := h.sweepSecondLevelTx(); err != nil {
 			log.Errorf("Sending timeout tx to sweeper: %v", err)
 
@@ -584,7 +584,7 @@ func (h *htlcTimeoutResolver) spendHtlcOutput() (
 
 	// If we have no SignDetails, and we haven't already sent the output to
 	// the utxo nursery, then we'll do so now.
-	case h.htlcResolution.SignDetails == nil && !h.outputIncubating:
+	case !h.isRemoteCommitOutput() && !h.outputIncubating:
 		if err := h.sendSecondLevelTxLegacy(); err != nil {
 			log.Errorf("Sending timeout tx to nursery: %v", err)
 
@@ -693,7 +693,7 @@ func (h *htlcTimeoutResolver) handleCommitSpend(
 	// If the sweeper is handling the second level transaction, wait for
 	// the CSV and possible CLTV lock to expire, before sweeping the output
 	// on the second-level.
-	case h.htlcResolution.SignDetails != nil:
+	case h.isZeroFeeOutput():
 		waitHeight := h.deriveWaitHeight(
 			h.htlcResolution.CsvDelay, commitSpend,
 		)
@@ -773,7 +773,7 @@ func (h *htlcTimeoutResolver) handleCommitSpend(
 	// Finally, if this was an output on our commitment transaction, we'll
 	// wait for the second-level HTLC output to be spent, and for that
 	// transaction itself to confirm.
-	case h.htlcResolution.SignedTimeoutTx != nil:
+	case !h.isRemoteCommitOutput():
 		log.Infof("%T(%v): waiting for nursery/sweeper to spend CSV "+
 			"delayed output", h, claimOutpoint)
 		sweepTx, err := waitForSpend(
@@ -1144,7 +1144,7 @@ func (h *htlcTimeoutResolver) consumeSpendEvents(resultChan chan *spendResult,
 			// continue the loop.
 			hasPreimage := isPreimageSpend(
 				h.isTaproot(), spendDetail,
-				h.htlcResolution.SignedTimeoutTx != nil,
+				!h.isRemoteCommitOutput(),
 			)
 			if !hasPreimage {
 				log.Debugf("HTLC output %s spent doesn't "+
@@ -1171,4 +1171,23 @@ func (h *htlcTimeoutResolver) consumeSpendEvents(resultChan chan *spendResult,
 			return
 		}
 	}
+}
+
+// isRemoteCommitOutput returns a bool to indicate whether the htlc output is
+// on the remote commitment.
+func (h *htlcTimeoutResolver) isRemoteCommitOutput() bool {
+	// If we don't have a timeout transaction, then this means that this is
+	// an output on the remote party's commitment transaction.
+	return h.htlcResolution.SignedTimeoutTx == nil
+}
+
+// isZeroFeeOutput returns a boolean indicating whether the htlc output is from
+// a anchor-enabled channel, which uses the sighash SINGLE|ANYONECANPAY.
+func (h *htlcTimeoutResolver) isZeroFeeOutput() bool {
+	// If we have non-nil SignDetails, this means it has a 2nd level HTLC
+	// transaction that is signed using sighash SINGLE|ANYONECANPAY (the
+	// case for anchor type channels). In this case we can re-sign it and
+	// attach fees at will.
+	return h.htlcResolution.SignedTimeoutTx != nil &&
+		h.htlcResolution.SignDetails != nil
 }

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -39,9 +39,6 @@ type htlcTimeoutResolver struct {
 	// incubator (utxo nursery).
 	outputIncubating bool
 
-	// resolved reflects if the contract has been fully resolved or not.
-	resolved bool
-
 	// broadcastHeight is the height that the original contract was
 	// broadcast to the main-chain at. We'll use this value to bound any
 	// historical queries to the chain for spends/confirmations.
@@ -239,7 +236,7 @@ func (h *htlcTimeoutResolver) claimCleanUp(
 	}); err != nil {
 		return err
 	}
-	h.resolved = true
+	h.resolved.Store(true)
 
 	// Checkpoint our resolver with a report which reflects the preimage
 	// claim by the remote party.
@@ -425,7 +422,7 @@ func checkSizeAndIndex(witness wire.TxWitness, size, index int) bool {
 // NOTE: Part of the ContractResolver interface.
 func (h *htlcTimeoutResolver) Resolve() (ContractResolver, error) {
 	// If we're already resolved, then we can exit early.
-	if h.resolved {
+	if h.IsResolved() {
 		h.log.Errorf("already resolved")
 		return nil, nil
 	}
@@ -553,14 +550,6 @@ func (h *htlcTimeoutResolver) Stop() {
 	close(h.quit)
 }
 
-// IsResolved returns true if the stored state in the resolve is fully
-// resolved. In this case the target output can be forgotten.
-//
-// NOTE: Part of the ContractResolver interface.
-func (h *htlcTimeoutResolver) IsResolved() bool {
-	return h.resolved
-}
-
 // report returns a report on the resolution state of the contract.
 func (h *htlcTimeoutResolver) report() *ContractReport {
 	// If the sign details are nil, the report will be created by handled
@@ -611,7 +600,7 @@ func (h *htlcTimeoutResolver) Encode(w io.Writer) error {
 	if err := binary.Write(w, endian, h.outputIncubating); err != nil {
 		return err
 	}
-	if err := binary.Write(w, endian, h.resolved); err != nil {
+	if err := binary.Write(w, endian, h.IsResolved()); err != nil {
 		return err
 	}
 	if err := binary.Write(w, endian, h.broadcastHeight); err != nil {
@@ -652,9 +641,13 @@ func newTimeoutResolverFromReader(r io.Reader, resCfg ResolverConfig) (
 	if err := binary.Read(r, endian, &h.outputIncubating); err != nil {
 		return nil, err
 	}
-	if err := binary.Read(r, endian, &h.resolved); err != nil {
+
+	var resolved bool
+	if err := binary.Read(r, endian, &resolved); err != nil {
 		return nil, err
 	}
+	h.resolved.Store(resolved)
+
 	if err := binary.Read(r, endian, &h.broadcastHeight); err != nil {
 		return nil, err
 	}
@@ -1102,7 +1095,7 @@ func (h *htlcTimeoutResolver) checkpointClaim(
 	}
 
 	// Finally, we checkpoint the resolver with our report(s).
-	h.resolved = true
+	h.resolved.Store(true)
 
 	return h.Checkpoint(h, report)
 }
@@ -1225,7 +1218,7 @@ func (h *htlcTimeoutResolver) Launch() error {
 
 	switch {
 	// If we're already resolved, then we can exit early.
-	case h.resolved:
+	case h.IsResolved():
 		h.log.Errorf("already resolved")
 		return nil
 

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -7,11 +7,13 @@ import (
 	"sync"
 
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -451,22 +453,6 @@ func (h *htlcTimeoutResolver) Resolve() (ContractResolver, error) {
 		return nil, h.claimCleanUp(commitSpend)
 	}
 
-	log.Infof("%T(%v): resolving htlc with incoming fail msg, fully "+
-		"confirmed", h, h.htlcResolution.ClaimOutpoint)
-
-	// At this point, the second-level transaction is sufficiently
-	// confirmed, or a transaction directly spending the output is.
-	// Therefore, we can now send back our clean up message, failing the
-	// HTLC on the incoming link.
-	failureMsg := &lnwire.FailPermanentChannelFailure{}
-	if err := h.DeliverResolutionMsg(ResolutionMsg{
-		SourceChan: h.ShortChanID,
-		HtlcIndex:  h.htlc.HtlcIndex,
-		Failure:    failureMsg,
-	}); err != nil {
-		return nil, err
-	}
-
 	// Depending on whether this was a local or remote commit, we must
 	// handle the spending transaction accordingly.
 	return h.handleCommitSpend(commitSpend)
@@ -616,28 +602,7 @@ func (h *htlcTimeoutResolver) waitForConfirmedSpend(op *wire.OutPoint,
 		return nil, err
 	}
 
-	// Once confirmed, persist the state on disk.
-	if err := h.checkPointSecondLevelTx(); err != nil {
-		return nil, err
-	}
-
 	return spend, err
-}
-
-// checkPointSecondLevelTx persists the state of a second level HTLC tx to disk
-// if it's published by the sweeper.
-func (h *htlcTimeoutResolver) checkPointSecondLevelTx() error {
-	// If this was the second level transaction published by the sweeper,
-	// we can checkpoint the resolver now that it's confirmed.
-	if h.htlcResolution.SignDetails != nil && !h.outputIncubating {
-		h.outputIncubating = true
-		if err := h.Checkpoint(h); err != nil {
-			log.Errorf("unable to Checkpoint: %v", err)
-			return err
-		}
-	}
-
-	return nil
 }
 
 // handleCommitSpend handles the spend of the HTLC output on the commitment
@@ -663,7 +628,8 @@ func (h *htlcTimeoutResolver) handleCommitSpend(
 		// accordingly.
 		spendTxID = commitSpend.SpenderTxHash
 
-		reports []*channeldb.ResolverReport
+		sweepTx *chainntnfs.SpendDetail
+		err     error
 	)
 
 	switch {
@@ -684,7 +650,7 @@ func (h *htlcTimeoutResolver) handleCommitSpend(
 	case !h.isRemoteCommitOutput():
 		log.Infof("%T(%v): waiting for nursery/sweeper to spend CSV "+
 			"delayed output", h, claimOutpoint)
-		sweepTx, err := waitForSpend(
+		sweepTx, err = waitForSpend(
 			&claimOutpoint,
 			h.htlcResolution.SweepSignDesc.Output.PkScript,
 			h.broadcastHeight, h.Notifier, h.quit,
@@ -698,38 +664,16 @@ func (h *htlcTimeoutResolver) handleCommitSpend(
 
 		// Once our sweep of the timeout tx has confirmed, we add a
 		// resolution for our timeoutTx tx first stage transaction.
-		timeoutTx := commitSpend.SpendingTx
-		index := commitSpend.SpenderInputIndex
-		spendHash := commitSpend.SpenderTxHash
-
-		reports = append(reports, &channeldb.ResolverReport{
-			OutPoint:        timeoutTx.TxIn[index].PreviousOutPoint,
-			Amount:          h.htlc.Amt.ToSatoshis(),
-			ResolverType:    channeldb.ResolverTypeOutgoingHtlc,
-			ResolverOutcome: channeldb.ResolverOutcomeFirstStage,
-			SpendTxID:       spendHash,
-		})
+		err = h.checkpointStageOne(*spendTxID)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// With the clean up message sent, we'll now mark the contract
 	// resolved, update the recovered balance, record the timeout and the
 	// sweep txid on disk, and wait.
-	h.resolved = true
-	h.reportLock.Lock()
-	h.currentReport.RecoveredBalance = h.currentReport.LimboBalance
-	h.currentReport.LimboBalance = 0
-	h.reportLock.Unlock()
-
-	amt := btcutil.Amount(h.htlcResolution.SweepSignDesc.Output.Value)
-	reports = append(reports, &channeldb.ResolverReport{
-		OutPoint:        claimOutpoint,
-		Amount:          amt,
-		ResolverType:    channeldb.ResolverTypeOutgoingHtlc,
-		ResolverOutcome: channeldb.ResolverOutcomeTimeout,
-		SpendTxID:       spendTxID,
-	})
-
-	return nil, h.Checkpoint(h, reports...)
+	return nil, h.checkpointClaim(sweepTx)
 }
 
 // Stop signals the resolver to cancel any current resolution processes, and
@@ -969,12 +913,6 @@ func (h *htlcTimeoutResolver) consumeSpendEvents(resultChan chan *spendResult,
 	// Create a result chan to hold the results.
 	result := &spendResult{}
 
-	// hasMempoolSpend is a flag that indicates whether we have found a
-	// preimage spend from the mempool. This is used to determine whether
-	// to checkpoint the resolver or not when later we found the
-	// corresponding block spend.
-	hasMempoolSpent := false
-
 	// Wait for a spend event to arrive.
 	for {
 		select {
@@ -1002,23 +940,6 @@ func (h *htlcTimeoutResolver) consumeSpendEvents(resultChan chan *spendResult,
 				// Once confirmed, persist the state on disk if
 				// we haven't seen the output's spending tx in
 				// mempool before.
-				//
-				// NOTE: we don't checkpoint the resolver if
-				// it's spending tx has already been found in
-				// mempool - the resolver will take care of the
-				// checkpoint in its `claimCleanUp`. If we do
-				// checkpoint here, however, we'd create a new
-				// record in db for the same htlc resolver
-				// which won't be cleaned up later, resulting
-				// the channel to stay in unresolved state.
-				//
-				// TODO(yy): when fee bumper is implemented, we
-				// need to further check whether this is a
-				// preimage spend. Also need to refactor here
-				// to save us some indentation.
-				if !hasMempoolSpent {
-					result.err = h.checkPointSecondLevelTx()
-				}
 			}
 
 			// Send the result and exit the loop.
@@ -1064,10 +985,6 @@ func (h *htlcTimeoutResolver) consumeSpendEvents(resultChan chan *spendResult,
 			// continue the loop.
 			result.spend = spendDetail
 			resultChan <- result
-
-			// Set the hasMempoolSpent flag to true so we won't
-			// checkpoint the resolver again in db.
-			hasMempoolSpent = true
 
 			continue
 
@@ -1231,4 +1148,93 @@ func (h *htlcTimeoutResolver) sweepTimeoutTxOutput() error {
 	)
 
 	return err
+}
+
+// checkpointStageOne creates a checkpoint for the first stage of the htlc
+// timeout transaction. This is used to ensure that the resolver can resume
+// watching for the second stage spend in case of a restart.
+func (h *htlcTimeoutResolver) checkpointStageOne(
+	spendTxid chainhash.Hash) error {
+
+	h.log.Debugf("checkpoint stage one spend of HTLC output %v, spent "+
+		"in tx %v", h.outpoint(), spendTxid)
+
+	// Now that the second-level transaction has confirmed, we checkpoint
+	// the state so we'll go to the next stage in case of restarts.
+	h.outputIncubating = true
+
+	// Create stage-one report.
+	report := &channeldb.ResolverReport{
+		OutPoint:        h.outpoint(),
+		Amount:          h.htlc.Amt.ToSatoshis(),
+		ResolverType:    channeldb.ResolverTypeOutgoingHtlc,
+		ResolverOutcome: channeldb.ResolverOutcomeFirstStage,
+		SpendTxID:       &spendTxid,
+	}
+
+	// At this point, the second-level transaction is sufficiently
+	// confirmed. We can now send back our clean up message, failing the
+	// HTLC on the incoming link.
+	failureMsg := &lnwire.FailPermanentChannelFailure{}
+	err := h.DeliverResolutionMsg(ResolutionMsg{
+		SourceChan: h.ShortChanID,
+		HtlcIndex:  h.htlc.HtlcIndex,
+		Failure:    failureMsg,
+	})
+	if err != nil {
+		return err
+	}
+
+	return h.Checkpoint(h, report)
+}
+
+// checkpointClaim checkpoints the timeout resolver with the reports it needs.
+func (h *htlcTimeoutResolver) checkpointClaim(
+	spendDetail *chainntnfs.SpendDetail) error {
+
+	h.log.Infof("resolving htlc with incoming fail msg, output=%v "+
+		"confirmed in tx=%v", spendDetail.SpentOutPoint,
+		spendDetail.SpenderTxHash)
+
+	// For the direct-timeout spend, we will jump to this checkpoint
+	// without calling `checkpointStageOne`. Thus we need to send the clean
+	// up msg to fail the incoming HTLC.
+	if h.isRemoteCommitOutput() {
+		failureMsg := &lnwire.FailPermanentChannelFailure{}
+		err := h.DeliverResolutionMsg(ResolutionMsg{
+			SourceChan: h.ShortChanID,
+			HtlcIndex:  h.htlc.HtlcIndex,
+			Failure:    failureMsg,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	// Send notification.
+	h.ChainArbitratorConfig.HtlcNotifier.NotifyFinalHtlcEvent(
+		models.CircuitKey{
+			ChanID: h.ShortChanID,
+			HtlcID: h.htlc.HtlcIndex,
+		},
+		channeldb.FinalHtlcInfo{
+			Settled:  true,
+			Offchain: false,
+		},
+	)
+
+	// Create a resolver report for claiming of the htlc itself.
+	amt := btcutil.Amount(h.htlcResolution.SweepSignDesc.Output.Value)
+	report := &channeldb.ResolverReport{
+		OutPoint:        *spendDetail.SpentOutPoint,
+		Amount:          amt,
+		ResolverType:    channeldb.ResolverTypeOutgoingHtlc,
+		ResolverOutcome: channeldb.ResolverOutcomeTimeout,
+		SpendTxID:       spendDetail.SpenderTxHash,
+	}
+
+	// Finally, we checkpoint the resolver with our report(s).
+	h.resolved = true
+
+	return h.Checkpoint(h, report)
 }

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -426,39 +426,17 @@ func checkSizeAndIndex(witness wire.TxWitness, size, index int) bool {
 func (h *htlcTimeoutResolver) Resolve() (ContractResolver, error) {
 	// If we're already resolved, then we can exit early.
 	if h.resolved {
+		h.log.Errorf("already resolved")
 		return nil, nil
 	}
 
-	// Start by spending the HTLC output, either by broadcasting the
-	// second-level timeout transaction, or directly if this is the remote
-	// commitment.
-	commitSpend, err := h.spendHtlcOutput()
-	if err != nil {
-		return nil, err
-	}
-
-	// If the spend reveals the pre-image, then we'll enter the clean up
-	// workflow to pass the pre-image back to the incoming link, add it to
-	// the witness cache, and exit.
-	if isPreimageSpend(
-		h.isTaproot(), commitSpend,
-		h.htlcResolution.SignedTimeoutTx != nil,
-	) {
-
-		log.Infof("%T(%v): HTLC has been swept with pre-image by "+
-			"remote party during timeout flow! Adding pre-image to "+
-			"witness cache", h, h.htlc.RHash[:],
-			h.htlcResolution.ClaimOutpoint)
-
-		return nil, h.claimCleanUp(commitSpend)
-	}
-
-	// Depending on whether this was a local or remote commit, we must
-	// handle the spending transaction accordingly.
+	// If this is an output on the remote party's commitment transaction,
+	// use the direct-spend path to sweep the htlc.
 	if h.isRemoteCommitOutput() {
 		return nil, h.resolveRemoteCommitOutput()
 	}
 
+	// Otherwise handle the spend from our commitment transaction.
 	return nil, h.resolveTimeoutTx()
 }
 
@@ -524,51 +502,6 @@ func (h *htlcTimeoutResolver) sendSecondLevelTxLegacy() error {
 	)
 }
 
-// spendHtlcOutput handles the initial spend of an HTLC output via the timeout
-// clause. If this is our local commitment, the second-level timeout TX will be
-// used to spend the output into the next stage. If this is the remote
-// commitment, the output will be swept directly without the timeout
-// transaction.
-func (h *htlcTimeoutResolver) spendHtlcOutput() (
-	*chainntnfs.SpendDetail, error) {
-
-	switch {
-	// If we have non-nil SignDetails, this means that have a 2nd level
-	// HTLC transaction that is signed using sighash SINGLE|ANYONECANPAY
-	// (the case for anchor type channels). In this case we can re-sign it
-	// and attach fees at will. We let the sweeper handle this job.
-	case h.isZeroFeeOutput() && !h.outputIncubating:
-		if err := h.sweepTimeoutTx(); err != nil {
-			log.Errorf("Sending timeout tx to sweeper: %v", err)
-
-			return nil, err
-		}
-
-	// If we have no SignDetails, and we haven't already sent the output to
-	// the utxo nursery, then we'll do so now.
-	case !h.isRemoteCommitOutput() && !h.outputIncubating:
-		if err := h.sweepLegacyTimeoutTx(); err != nil {
-			log.Errorf("Sending timeout tx to nursery: %v", err)
-
-			return nil, err
-		}
-
-	default:
-		err := h.sweepRemoteCommitOutput()
-		if err != nil {
-			log.Errorf("Sweeping remote commit output: %v", err)
-
-			return nil, err
-		}
-	}
-
-	// Now that we've handed off the HTLC to the nursery or sweeper, we'll
-	// watch for a spend of the output, and make our next move off of that.
-	// Depending on if this is our commitment, or the remote party's
-	// commitment, we'll be watching a different outpoint and script.
-	return h.watchHtlcSpend()
-}
-
 // watchHtlcSpend watches for a spend of the HTLC output. For neutrino backend,
 // it will check blocks for the confirmed spend. For btcd and bitcoind, it will
 // check both the mempool and the blocks.
@@ -614,6 +547,9 @@ func (h *htlcTimeoutResolver) waitForConfirmedSpend(op *wire.OutPoint,
 //
 // NOTE: Part of the ContractResolver interface.
 func (h *htlcTimeoutResolver) Stop() {
+	h.log.Debugf("stopping...")
+	defer h.log.Debugf("stopped")
+
 	close(h.quit)
 }
 
@@ -1275,4 +1211,52 @@ func (h *htlcTimeoutResolver) resolveTimeoutTxOutput(op wire.OutPoint) error {
 	h.reportLock.Unlock()
 
 	return h.checkpointClaim(spend)
+}
+
+// Launch creates an input based on the details of the outgoing htlc resolution
+// and offers it to the sweeper.
+func (h *htlcTimeoutResolver) Launch() error {
+	if h.launched {
+		h.log.Tracef("already launched")
+		return nil
+	}
+
+	h.log.Debugf("launching resolver...")
+	h.launched = true
+
+	switch {
+	// If we're already resolved, then we can exit early.
+	case h.resolved:
+		h.log.Errorf("already resolved")
+		return nil
+
+	// If this is an output on the remote party's commitment transaction,
+	// use the direct timeout spend path.
+	case h.isRemoteCommitOutput():
+		return h.sweepRemoteCommitOutput()
+
+	// If this is an anchor type channel, we now sweep either the
+	// second-level timeout tx or the output from the second-level timeout
+	// tx.
+	case h.isZeroFeeOutput():
+		// If the second-level timeout tx has already been swept, we
+		// can go ahead and sweep its output.
+		if h.outputIncubating {
+			return h.sweepTimeoutTxOutput()
+		}
+
+		// Otherwise, sweep the second level tx.
+		return h.sweepTimeoutTx()
+
+	// If this is a legacy channel type, the output is handled by the
+	// nursery.
+	default:
+		// If the second-level timeout tx has already been swept, we
+		// can go ahead and sweep its output.
+		if h.outputIncubating {
+			return h.sweepTimeoutTxOutput()
+		}
+
+		return h.sweepLegacyTimeoutTx()
+	}
 }

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -1208,13 +1208,13 @@ func (h *htlcTimeoutResolver) resolveTimeoutTxOutput(op wire.OutPoint) error {
 // Launch creates an input based on the details of the outgoing htlc resolution
 // and offers it to the sweeper.
 func (h *htlcTimeoutResolver) Launch() error {
-	if h.launched {
+	if h.launched.Load() {
 		h.log.Tracef("already launched")
 		return nil
 	}
 
 	h.log.Debugf("launching resolver...")
-	h.launched = true
+	h.launched.Store(true)
 
 	switch {
 	// If we're already resolved, then we can exit early.

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -82,6 +82,7 @@ func newTimeoutResolver(res lnwallet.OutgoingHtlcResolution,
 	}
 
 	h.initReport()
+	h.initLogger(fmt.Sprintf("%T(%v)", h, h.outpoint()))
 
 	return h
 }
@@ -93,23 +94,25 @@ func (h *htlcTimeoutResolver) isTaproot() bool {
 	)
 }
 
+// outpoint returns the outpoint of the HTLC output we're attempting to sweep.
+func (h *htlcTimeoutResolver) outpoint() wire.OutPoint {
+	// The primary key for this resolver will be the outpoint of the HTLC
+	// on the commitment transaction itself. If this is our commitment,
+	// then the output can be found within the signed timeout tx,
+	// otherwise, it's just the ClaimOutpoint.
+	if h.htlcResolution.SignedTimeoutTx != nil {
+		return h.htlcResolution.SignedTimeoutTx.TxIn[0].PreviousOutPoint
+	}
+
+	return h.htlcResolution.ClaimOutpoint
+}
+
 // ResolverKey returns an identifier which should be globally unique for this
 // particular resolver within the chain the original contract resides within.
 //
 // NOTE: Part of the ContractResolver interface.
 func (h *htlcTimeoutResolver) ResolverKey() []byte {
-	// The primary key for this resolver will be the outpoint of the HTLC
-	// on the commitment transaction itself. If this is our commitment,
-	// then the output can be found within the signed timeout tx,
-	// otherwise, it's just the ClaimOutpoint.
-	var op wire.OutPoint
-	if h.htlcResolution.SignedTimeoutTx != nil {
-		op = h.htlcResolution.SignedTimeoutTx.TxIn[0].PreviousOutPoint
-	} else {
-		op = h.htlcResolution.ClaimOutpoint
-	}
-
-	key := newResolverID(op)
+	key := newResolverID(h.outpoint())
 	return key[:]
 }
 
@@ -950,6 +953,7 @@ func newTimeoutResolverFromReader(r io.Reader, resCfg ResolverConfig) (
 	}
 
 	h.initReport()
+	h.initLogger(fmt.Sprintf("%T(%v)", h, h.outpoint()))
 
 	return h, nil
 }

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -990,7 +990,6 @@ func (h *htlcTimeoutResolver) sweepTimeoutTxOutput() error {
 		input.LeaseHtlcOfferedTimeoutSecondLevel,
 		&h.htlcResolution.SweepSignDesc,
 		h.htlcResolution.CsvDelay, uint32(commitSpend.SpendingHeight),
-		h.htlc.RHash,
 	)
 
 	// Calculate the budget for this sweep.

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -455,7 +455,11 @@ func (h *htlcTimeoutResolver) Resolve() (ContractResolver, error) {
 
 	// Depending on whether this was a local or remote commit, we must
 	// handle the spending transaction accordingly.
-	return h.handleCommitSpend(commitSpend)
+	if h.isRemoteCommitOutput() {
+		return nil, h.resolveRemoteCommitOutput()
+	}
+
+	return nil, h.resolveTimeoutTx()
 }
 
 // sweepTimeoutTx sends a second level timeout transaction to the sweeper.
@@ -603,77 +607,6 @@ func (h *htlcTimeoutResolver) waitForConfirmedSpend(op *wire.OutPoint,
 	}
 
 	return spend, err
-}
-
-// handleCommitSpend handles the spend of the HTLC output on the commitment
-// transaction. If this was our local commitment, the spend will be he
-// confirmed second-level timeout transaction, and we'll sweep that into our
-// wallet. If the was a remote commitment, the resolver will resolve
-// immetiately.
-func (h *htlcTimeoutResolver) handleCommitSpend(
-	commitSpend *chainntnfs.SpendDetail) (ContractResolver, error) {
-
-	var (
-		// claimOutpoint will be the outpoint of the second level
-		// transaction, or on the remote commitment directly. It will
-		// start out as set in the resolution, but we'll update it if
-		// the second-level goes through the sweeper and changes its
-		// txid.
-		claimOutpoint = h.htlcResolution.ClaimOutpoint
-
-		// spendTxID will be the ultimate spend of the claimOutpoint.
-		// We set it to the commit spend for now, as this is the
-		// ultimate spend in case this is a remote commitment. If we go
-		// through the second-level transaction, we'll update this
-		// accordingly.
-		spendTxID = commitSpend.SpenderTxHash
-
-		sweepTx *chainntnfs.SpendDetail
-		err     error
-	)
-
-	switch {
-	// If the sweeper is handling the second level transaction, wait for
-	// the CSV and possible CLTV lock to expire, before sweeping the output
-	// on the second-level.
-	case h.isZeroFeeOutput():
-		err := h.sweepTimeoutTxOutput()
-		if err != nil {
-			return nil, err
-		}
-
-		fallthrough
-
-	// Finally, if this was an output on our commitment transaction, we'll
-	// wait for the second-level HTLC output to be spent, and for that
-	// transaction itself to confirm.
-	case !h.isRemoteCommitOutput():
-		log.Infof("%T(%v): waiting for nursery/sweeper to spend CSV "+
-			"delayed output", h, claimOutpoint)
-		sweepTx, err = waitForSpend(
-			&claimOutpoint,
-			h.htlcResolution.SweepSignDesc.Output.PkScript,
-			h.broadcastHeight, h.Notifier, h.quit,
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		// Update the spend txid to the hash of the sweep transaction.
-		spendTxID = sweepTx.SpenderTxHash
-
-		// Once our sweep of the timeout tx has confirmed, we add a
-		// resolution for our timeoutTx tx first stage transaction.
-		err = h.checkpointStageOne(*spendTxID)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// With the clean up message sent, we'll now mark the contract
-	// resolved, update the recovered balance, record the timeout and the
-	// sweep txid on disk, and wait.
-	return nil, h.checkpointClaim(sweepTx)
 }
 
 // Stop signals the resolver to cancel any current resolution processes, and
@@ -1237,4 +1170,109 @@ func (h *htlcTimeoutResolver) checkpointClaim(
 	h.resolved = true
 
 	return h.Checkpoint(h, report)
+}
+
+// resolveRemoteCommitOutput handles sweeping an HTLC output on the remote
+// commitment with via the timeout path. In this case we can sweep the output
+// directly, and don't have to broadcast a second-level transaction.
+func (h *htlcTimeoutResolver) resolveRemoteCommitOutput() error {
+	h.log.Debug("waiting for direct-timeout spend of the htlc to confirm")
+
+	// Wait for the direct-timeout HTLC sweep tx to confirm.
+	spend, err := h.watchHtlcSpend()
+	if err != nil {
+		return err
+	}
+
+	// If the spend reveals the preimage, then we'll enter the clean up
+	// workflow to pass the preimage back to the incoming link, add it to
+	// the witness cache, and exit.
+	if isPreimageSpend(h.isTaproot(), spend, !h.isRemoteCommitOutput()) {
+		return h.claimCleanUp(spend)
+	}
+
+	// TODO(yy): should also update the `RecoveredBalance` and
+	// `LimboBalance` like other paths?
+
+	// Checkpoint the resolver, and write the outcome to disk.
+	return h.checkpointClaim(spend)
+}
+
+// resolveTimeoutTx waits for the sweeping tx of the second-level
+// timeout tx to confirm and offers the output from the timeout tx to the
+// sweeper.
+func (h *htlcTimeoutResolver) resolveTimeoutTx() error {
+	h.log.Debug("waiting for first-stage 2nd-level HTLC timeout tx to " +
+		"confirm")
+
+	// Wait for the second level transaction to confirm.
+	spend, err := h.watchHtlcSpend()
+	if err != nil {
+		return err
+	}
+
+	// If the spend reveals the preimage, then we'll enter the clean up
+	// workflow to pass the preimage back to the incoming link, add it to
+	// the witness cache, and exit.
+	if isPreimageSpend(h.isTaproot(), spend, !h.isRemoteCommitOutput()) {
+		return h.claimCleanUp(spend)
+	}
+
+	op := h.htlcResolution.ClaimOutpoint
+	spenderTxid := *spend.SpenderTxHash
+
+	// If the timeout tx is a re-signed tx, we will need to find the actual
+	// spent outpoint from the spending tx.
+	if h.isZeroFeeOutput() {
+		op = wire.OutPoint{
+			Hash:  spenderTxid,
+			Index: spend.SpenderInputIndex,
+		}
+	}
+
+	// If the 2nd-stage sweeping has already been started, we can
+	// fast-forward to start the resolving process for the stage two
+	// output.
+	if h.outputIncubating {
+		return h.resolveTimeoutTxOutput(op)
+	}
+
+	h.log.Infof("2nd-level HTLC timeout tx=%v confirmed", spenderTxid)
+
+	// Start the process to sweep the output from the timeout tx.
+	err = h.sweepTimeoutTxOutput()
+	if err != nil {
+		return err
+	}
+
+	// Create a checkpoint since the timeout tx is confirmed and the sweep
+	// request has been made.
+	if err := h.checkpointStageOne(spenderTxid); err != nil {
+		return err
+	}
+
+	// Start the resolving process for the stage two output.
+	return h.resolveTimeoutTxOutput(op)
+}
+
+// resolveTimeoutTxOutput waits for the spend of the output from the 2nd-level
+// timeout tx.
+func (h *htlcTimeoutResolver) resolveTimeoutTxOutput(op wire.OutPoint) error {
+	h.log.Debugf("waiting for second-stage 2nd-level timeout tx output %v "+
+		"to be spent after csv_delay=%v", op, h.htlcResolution.CsvDelay)
+
+	spend, err := waitForSpend(
+		&op, h.htlcResolution.SweepSignDesc.Output.PkScript,
+		h.broadcastHeight, h.Notifier, h.quit,
+	)
+	if err != nil {
+		return err
+	}
+
+	h.reportLock.Lock()
+	h.currentReport.RecoveredBalance = h.currentReport.LimboBalance
+	h.currentReport.LimboBalance = 0
+	h.reportLock.Unlock()
+
+	return h.checkpointClaim(spend)
 }

--- a/contractcourt/htlc_timeout_resolver_test.go
+++ b/contractcourt/htlc_timeout_resolver_test.go
@@ -3,8 +3,6 @@ package contractcourt
 import (
 	"bytes"
 	"fmt"
-	"reflect"
-	"sync"
 	"testing"
 	"time"
 
@@ -14,11 +12,8 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
-	"github.com/lightningnetwork/lnd/channeldb/models"
-	"github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/input"
-	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lntest/mock"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
@@ -40,7 +35,7 @@ type mockWitnessBeacon struct {
 func newMockWitnessBeacon() *mockWitnessBeacon {
 	return &mockWitnessBeacon{
 		preImageUpdates: make(chan lntypes.Preimage, 1),
-		newPreimages:    make(chan []lntypes.Preimage),
+		newPreimages:    make(chan []lntypes.Preimage, 1),
 		lookupPreimage:  make(map[lntypes.Hash]lntypes.Preimage),
 	}
 }
@@ -69,448 +64,14 @@ func (m *mockWitnessBeacon) AddPreimages(preimages ...lntypes.Preimage) error {
 	return nil
 }
 
-// TestHtlcTimeoutResolver tests that the timeout resolver properly handles all
-// variations of possible local+remote spends.
-func TestHtlcTimeoutResolver(t *testing.T) {
-	t.Parallel()
-
-	fakePreimageBytes := bytes.Repeat([]byte{1}, lntypes.HashSize)
-
-	var (
-		htlcOutpoint wire.OutPoint
-		fakePreimage lntypes.Preimage
-	)
-	fakeSignDesc := &input.SignDescriptor{
-		Output: &wire.TxOut{},
-	}
-
-	copy(fakePreimage[:], fakePreimageBytes)
-
-	signer := &mock.DummySigner{}
-	sweepTx := &wire.MsgTx{
-		TxIn: []*wire.TxIn{
-			{
-				PreviousOutPoint: htlcOutpoint,
-				Witness:          [][]byte{{0x01}},
-			},
-		},
-	}
-	fakeTimeout := int32(5)
-
-	templateTx := &wire.MsgTx{
-		TxIn: []*wire.TxIn{
-			{
-				PreviousOutPoint: htlcOutpoint,
-			},
-		},
-	}
-
-	testCases := []struct {
-		// name is a human readable description of the test case.
-		name string
-
-		// remoteCommit denotes if the commitment broadcast was the
-		// remote commitment or not.
-		remoteCommit bool
-
-		// timeout denotes if the HTLC should be let timeout, or if the
-		// "remote" party should sweep it on-chain. This also affects
-		// what type of resolution message we expect.
-		timeout bool
-
-		// txToBroadcast is a function closure that should generate the
-		// transaction that should spend the HTLC output. Test authors
-		// can use this to customize the witness used when spending to
-		// trigger various redemption cases.
-		txToBroadcast func() (*wire.MsgTx, error)
-
-		// outcome is the resolver outcome that we expect to be reported
-		// once the contract is fully resolved.
-		outcome channeldb.ResolverOutcome
-	}{
-		// Remote commitment is broadcast, we time out the HTLC on
-		// chain, and should expect a fail HTLC resolution.
-		{
-			name:         "timeout remote tx",
-			remoteCommit: true,
-			timeout:      true,
-			txToBroadcast: func() (*wire.MsgTx, error) {
-				witness, err := input.ReceiverHtlcSpendTimeout(
-					signer, fakeSignDesc, sweepTx,
-					fakeTimeout,
-				)
-				if err != nil {
-					return nil, err
-				}
-
-				// To avoid triggering the race detector by
-				// setting the witness the second time this
-				// method is called during tests, we return
-				// immediately if the witness is already set
-				// correctly.
-				if reflect.DeepEqual(
-					templateTx.TxIn[0].Witness, witness,
-				) {
-
-					return templateTx, nil
-				}
-				templateTx.TxIn[0].Witness = witness
-				return templateTx, nil
-			},
-			outcome: channeldb.ResolverOutcomeTimeout,
-		},
-
-		// Our local commitment is broadcast, we timeout the HTLC and
-		// still expect an HTLC fail resolution.
-		{
-			name:         "timeout local tx",
-			remoteCommit: false,
-			timeout:      true,
-			txToBroadcast: func() (*wire.MsgTx, error) {
-				witness, err := input.SenderHtlcSpendTimeout(
-					&mock.DummySignature{}, txscript.SigHashAll,
-					signer, fakeSignDesc, sweepTx,
-				)
-				if err != nil {
-					return nil, err
-				}
-
-				// To avoid triggering the race detector by
-				// setting the witness the second time this
-				// method is called during tests, we return
-				// immediately if the witness is already set
-				// correctly.
-				if reflect.DeepEqual(
-					templateTx.TxIn[0].Witness, witness,
-				) {
-
-					return templateTx, nil
-				}
-
-				templateTx.TxIn[0].Witness = witness
-
-				// Set the outpoint to be on our commitment, since
-				// we need to claim in two stages.
-				templateTx.TxIn[0].PreviousOutPoint = testChanPoint1
-				return templateTx, nil
-			},
-			outcome: channeldb.ResolverOutcomeTimeout,
-		},
-
-		// The remote commitment is broadcast, they sweep with the
-		// pre-image, we should get a settle HTLC resolution.
-		{
-			name:         "success remote tx",
-			remoteCommit: true,
-			timeout:      false,
-			txToBroadcast: func() (*wire.MsgTx, error) {
-				witness, err := input.ReceiverHtlcSpendRedeem(
-					&mock.DummySignature{}, txscript.SigHashAll,
-					fakePreimageBytes, signer, fakeSignDesc,
-					sweepTx,
-				)
-				if err != nil {
-					return nil, err
-				}
-
-				// To avoid triggering the race detector by
-				// setting the witness the second time this
-				// method is called during tests, we return
-				// immediately if the witness is already set
-				// correctly.
-				if reflect.DeepEqual(
-					templateTx.TxIn[0].Witness, witness,
-				) {
-
-					return templateTx, nil
-				}
-
-				templateTx.TxIn[0].Witness = witness
-				return templateTx, nil
-			},
-			outcome: channeldb.ResolverOutcomeClaimed,
-		},
-
-		// The local commitment is broadcast, they sweep it with a
-		// timeout from the output, and we should still get the HTLC
-		// settle resolution back.
-		{
-			name:         "success local tx",
-			remoteCommit: false,
-			timeout:      false,
-			txToBroadcast: func() (*wire.MsgTx, error) {
-				witness, err := input.SenderHtlcSpendRedeem(
-					signer, fakeSignDesc, sweepTx,
-					fakePreimageBytes,
-				)
-				if err != nil {
-					return nil, err
-				}
-
-				// To avoid triggering the race detector by
-				// setting the witness the second time this
-				// method is called during tests, we return
-				// immediately if the witness is already set
-				// correctly.
-				if reflect.DeepEqual(
-					templateTx.TxIn[0].Witness, witness,
-				) {
-
-					return templateTx, nil
-				}
-
-				templateTx.TxIn[0].Witness = witness
-				return templateTx, nil
-			},
-			outcome: channeldb.ResolverOutcomeClaimed,
-		},
-	}
-
-	notifier := &mock.ChainNotifier{
-		EpochChan: make(chan *chainntnfs.BlockEpoch),
-		SpendChan: make(chan *chainntnfs.SpendDetail),
-		ConfChan:  make(chan *chainntnfs.TxConfirmation),
-	}
-	witnessBeacon := newMockWitnessBeacon()
-
-	for _, testCase := range testCases {
-		t.Logf("Running test case: %v", testCase.name)
-
-		checkPointChan := make(chan struct{}, 1)
-		incubateChan := make(chan struct{}, 1)
-		resolutionChan := make(chan ResolutionMsg, 1)
-		reportChan := make(chan *channeldb.ResolverReport)
-
-		//nolint:lll
-		chainCfg := ChannelArbitratorConfig{
-			ChainArbitratorConfig: ChainArbitratorConfig{
-				Notifier:   notifier,
-				PreimageDB: witnessBeacon,
-				IncubateOutputs: func(wire.OutPoint,
-					fn.Option[lnwallet.OutgoingHtlcResolution],
-					fn.Option[lnwallet.IncomingHtlcResolution],
-					uint32, fn.Option[int32]) error {
-
-					incubateChan <- struct{}{}
-					return nil
-				},
-				DeliverResolutionMsg: func(msgs ...ResolutionMsg) error {
-					if len(msgs) != 1 {
-						return fmt.Errorf("expected 1 "+
-							"resolution msg, instead got %v",
-							len(msgs))
-					}
-
-					resolutionChan <- msgs[0]
-					return nil
-				},
-				Budget: *DefaultBudgetConfig(),
-				QueryIncomingCircuit: func(circuit models.CircuitKey) *models.CircuitKey {
-					return nil
-				},
-			},
-			PutResolverReport: func(_ kvdb.RwTx,
-				_ *channeldb.ResolverReport) error {
-
-				return nil
-			},
-		}
-
-		cfg := ResolverConfig{
-			ChannelArbitratorConfig: chainCfg,
-			Checkpoint: func(_ ContractResolver,
-				reports ...*channeldb.ResolverReport) error {
-
-				checkPointChan <- struct{}{}
-
-				// Send all of our reports into the channel.
-				for _, report := range reports {
-					reportChan <- report
-				}
-
-				return nil
-			},
-		}
-		resolver := &htlcTimeoutResolver{
-			htlcResolution: lnwallet.OutgoingHtlcResolution{
-				ClaimOutpoint: testChanPoint2,
-				SweepSignDesc: *fakeSignDesc,
-			},
-			contractResolverKit: *newContractResolverKit(
-				cfg,
-			),
-			htlc: channeldb.HTLC{
-				Amt: testHtlcAmt,
-			},
-		}
-
-		var reports []*channeldb.ResolverReport
-
-		// If the test case needs the remote commitment to be
-		// broadcast, then we'll set the timeout commit to a fake
-		// transaction to force the code path.
-		if !testCase.remoteCommit {
-			timeoutTx, err := testCase.txToBroadcast()
-			require.NoError(t, err)
-
-			resolver.htlcResolution.SignedTimeoutTx = timeoutTx
-
-			if testCase.timeout {
-				timeoutTxID := timeoutTx.TxHash()
-				reports = append(reports, &channeldb.ResolverReport{
-					OutPoint:        timeoutTx.TxIn[0].PreviousOutPoint,
-					Amount:          testHtlcAmt.ToSatoshis(),
-					ResolverType:    channeldb.ResolverTypeOutgoingHtlc,
-					ResolverOutcome: channeldb.ResolverOutcomeFirstStage,
-					SpendTxID:       &timeoutTxID,
-				})
-			}
-		}
-
-		// With all the setup above complete, we can initiate the
-		// resolution process, and the bulk of our test.
-		var wg sync.WaitGroup
-		resolveErr := make(chan error, 1)
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
-			_, err := resolver.Resolve()
-			if err != nil {
-				resolveErr <- err
-			}
-		}()
-
-		// At the output isn't yet in the nursery, we expect that we
-		// should receive an incubation request.
-		select {
-		case <-incubateChan:
-		case err := <-resolveErr:
-			t.Fatalf("unable to resolve HTLC: %v", err)
-		case <-time.After(time.Second * 5):
-			t.Fatalf("failed to receive incubation request")
-		}
-
-		// Next, the resolver should request a spend notification for
-		// the direct HTLC output. We'll use the txToBroadcast closure
-		// for the test case to generate the transaction that we'll
-		// send to the resolver.
-		spendingTx, err := testCase.txToBroadcast()
-		if err != nil {
-			t.Fatalf("unable to generate tx: %v", err)
-		}
-		spendTxHash := spendingTx.TxHash()
-
-		select {
-		case notifier.SpendChan <- &chainntnfs.SpendDetail{
-			SpendingTx:    spendingTx,
-			SpenderTxHash: &spendTxHash,
-		}:
-		case <-time.After(time.Second * 5):
-			t.Fatalf("failed to request spend ntfn")
-		}
-
-		if !testCase.timeout {
-			// If the resolver should settle now, then we'll
-			// extract the pre-image to be extracted and the
-			// resolution message sent.
-			select {
-			case newPreimage := <-witnessBeacon.newPreimages:
-				if newPreimage[0] != fakePreimage {
-					t.Fatalf("wrong pre-image: "+
-						"expected %v, got %v",
-						fakePreimage, newPreimage)
-				}
-
-			case <-time.After(time.Second * 5):
-				t.Fatalf("pre-image not added")
-			}
-
-			// Finally, we should get a resolution message with the
-			// pre-image set within the message.
-			select {
-			case resolutionMsg := <-resolutionChan:
-				// Once again, the pre-images should match up.
-				if *resolutionMsg.PreImage != fakePreimage {
-					t.Fatalf("wrong pre-image: "+
-						"expected %v, got %v",
-						fakePreimage, resolutionMsg.PreImage)
-				}
-			case <-time.After(time.Second * 5):
-				t.Fatalf("resolution not sent")
-			}
-		} else {
-
-			// Otherwise, the HTLC should now timeout.  First, we
-			// should get a resolution message with a populated
-			// failure message.
-			select {
-			case resolutionMsg := <-resolutionChan:
-				if resolutionMsg.Failure == nil {
-					t.Fatalf("expected failure resolution msg")
-				}
-			case <-time.After(time.Second * 5):
-				t.Fatalf("resolution not sent")
-			}
-
-			// We should also get another request for the spend
-			// notification of the second-level transaction to
-			// indicate that it's been swept by the nursery, but
-			// only if this is a local commitment transaction.
-			if !testCase.remoteCommit {
-				select {
-				case notifier.SpendChan <- &chainntnfs.SpendDetail{
-					SpendingTx:    spendingTx,
-					SpenderTxHash: &spendTxHash,
-				}:
-				case <-time.After(time.Second * 5):
-					t.Fatalf("failed to request spend ntfn")
-				}
-			}
-		}
-
-		// In any case, before the resolver exits, it should checkpoint
-		// its final state.
-		select {
-		case <-checkPointChan:
-		case err := <-resolveErr:
-			t.Fatalf("unable to resolve HTLC: %v", err)
-		case <-time.After(time.Second * 5):
-			t.Fatalf("check point not received")
-		}
-
-		// Add a report to our set of expected reports with the outcome
-		// that the test specifies (either success or timeout).
-		spendTxID := spendingTx.TxHash()
-		amt := btcutil.Amount(fakeSignDesc.Output.Value)
-
-		reports = append(reports, &channeldb.ResolverReport{
-			OutPoint:        testChanPoint2,
-			Amount:          amt,
-			ResolverType:    channeldb.ResolverTypeOutgoingHtlc,
-			ResolverOutcome: testCase.outcome,
-			SpendTxID:       &spendTxID,
-		})
-
-		for _, report := range reports {
-			assertResolverReport(t, reportChan, report)
-		}
-
-		wg.Wait()
-
-		// Finally, the resolver should be marked as resolved.
-		if !resolver.resolved {
-			t.Fatalf("resolver should be marked as resolved")
-		}
-	}
-}
-
 // NOTE: the following tests essentially checks many of the same scenarios as
 // the test above, but they expand on it by checking resuming from checkpoints
 // at every stage.
 
 // TestHtlcTimeoutSingleStage tests a remote commitment confirming, and the
 // local node sweeping the HTLC output directly after timeout.
+//
+//nolint:lll
 func TestHtlcTimeoutSingleStage(t *testing.T) {
 	commitOutpoint := wire.OutPoint{Index: 3}
 
@@ -535,6 +96,12 @@ func TestHtlcTimeoutSingleStage(t *testing.T) {
 		SpendTxID:       &sweepTxid,
 	}
 
+	sweepSpend := &chainntnfs.SpendDetail{
+		SpendingTx:    sweepTx,
+		SpentOutPoint: &commitOutpoint,
+		SpenderTxHash: &sweepTxid,
+	}
+
 	checkpoints := []checkpoint{
 		{
 			// Output should be handed off to the nursery.
@@ -547,9 +114,10 @@ func TestHtlcTimeoutSingleStage(t *testing.T) {
 				_ bool) error {
 				// The nursery will create and publish a sweep
 				// tx.
-				ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
-					SpendingTx:    sweepTx,
-					SpenderTxHash: &sweepTxid,
+				select {
+				case ctx.notifier.SpendChan <- sweepSpend:
+				case <-time.After(time.Second * 5):
+					t.Fatalf("failed to send spend ntfn")
 				}
 
 				// The resolver should deliver a failure
@@ -585,6 +153,8 @@ func TestHtlcTimeoutSingleStage(t *testing.T) {
 
 // TestHtlcTimeoutSecondStage tests a local commitment being confirmed, and the
 // local node claiming the HTLC output using the second-level timeout tx.
+//
+//nolint:lll
 func TestHtlcTimeoutSecondStage(t *testing.T) {
 	commitOutpoint := wire.OutPoint{Index: 2}
 	htlcOutpoint := wire.OutPoint{Index: 3}
@@ -643,21 +213,58 @@ func TestHtlcTimeoutSecondStage(t *testing.T) {
 		SpendTxID:       &sweepHash,
 	}
 
+	timeoutSpend := &chainntnfs.SpendDetail{
+		SpendingTx:    timeoutTx,
+		SpentOutPoint: &commitOutpoint,
+		SpenderTxHash: &timeoutTxid,
+	}
+
+	sweepSpend := &chainntnfs.SpendDetail{
+		SpendingTx:    sweepTx,
+		SpentOutPoint: &htlcOutpoint,
+		SpenderTxHash: &sweepHash,
+	}
+
 	checkpoints := []checkpoint{
 		{
+			preCheckpoint: func(ctx *htlcResolverTestContext,
+				_ bool) error {
+
+				// Deliver spend of timeout tx.
+				ctx.notifier.SpendChan <- timeoutSpend
+				ctx.notifier.SpendChan <- timeoutSpend
+
+				return nil
+			},
+
 			// Output should be handed off to the nursery.
 			incubating: true,
+			reports: []*channeldb.ResolverReport{
+				firstStage,
+			},
 		},
 		{
 			// We send a confirmation for our sweep tx to indicate
 			// that our sweep succeeded.
 			preCheckpoint: func(ctx *htlcResolverTestContext,
-				_ bool) error {
-				// The nursery will publish the timeout tx.
-				ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
-					SpendingTx:    timeoutTx,
-					SpenderTxHash: &timeoutTxid,
+				resumed bool) error {
+
+				// When it's reloaded from disk, we need to
+				// re-send the notification to mock the first
+				// `watchHtlcSpend`.
+				if resumed {
+					// Deliver spend of timeout tx output.
+					ctx.notifier.SpendChan <- timeoutSpend
+
+					// Deliver spend of timeout tx output.
+					ctx.notifier.SpendChan <- sweepSpend
+					ctx.notifier.SpendChan <- sweepSpend
+
+					return nil
 				}
+
+				// Deliver spend of timeout tx output.
+				ctx.notifier.SpendChan <- sweepSpend
 
 				// The resolver should deliver a failure
 				// resolution message (indicating we
@@ -671,12 +278,6 @@ func TestHtlcTimeoutSecondStage(t *testing.T) {
 					t.Fatalf("resolution not sent")
 				}
 
-				// Deliver spend of timeout tx.
-				ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
-					SpendingTx:    sweepTx,
-					SpenderTxHash: &sweepHash,
-				}
-
 				return nil
 			},
 
@@ -686,7 +287,7 @@ func TestHtlcTimeoutSecondStage(t *testing.T) {
 			incubating: true,
 			resolved:   true,
 			reports: []*channeldb.ResolverReport{
-				firstStage, secondState,
+				secondState,
 			},
 		},
 	}
@@ -761,10 +362,6 @@ func TestHtlcTimeoutSingleStageRemoteSpend(t *testing.T) {
 
 	checkpoints := []checkpoint{
 		{
-			// Output should be handed off to the nursery.
-			incubating: true,
-		},
-		{
 			// We send a spend notification for a remote spend with
 			// the preimage.
 			preCheckpoint: func(ctx *htlcResolverTestContext,
@@ -776,6 +373,7 @@ func TestHtlcTimeoutSingleStageRemoteSpend(t *testing.T) {
 				// the preimage.
 				ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
 					SpendingTx:    spendTx,
+					SpentOutPoint: &commitOutpoint,
 					SpenderTxHash: &spendTxHash,
 				}
 
@@ -811,7 +409,7 @@ func TestHtlcTimeoutSingleStageRemoteSpend(t *testing.T) {
 			// After the success tx has confirmed, we expect the
 			// checkpoint to be resolved, and with the above
 			// report.
-			incubating: true,
+			incubating: false,
 			resolved:   true,
 			reports: []*channeldb.ResolverReport{
 				claim,
@@ -882,6 +480,7 @@ func TestHtlcTimeoutSecondStageRemoteSpend(t *testing.T) {
 
 				ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
 					SpendingTx:    remoteSuccessTx,
+					SpentOutPoint: &commitOutpoint,
 					SpenderTxHash: &successTxid,
 				}
 
@@ -935,20 +534,15 @@ func TestHtlcTimeoutSecondStageRemoteSpend(t *testing.T) {
 // TestHtlcTimeoutSecondStageSweeper tests that for anchor channels, when a
 // local commitment confirms, the timeout tx is handed to the sweeper to claim
 // the HTLC output.
+//
+//nolint:lll
 func TestHtlcTimeoutSecondStageSweeper(t *testing.T) {
-	commitOutpoint := wire.OutPoint{Index: 2}
 	htlcOutpoint := wire.OutPoint{Index: 3}
-
-	sweepTx := &wire.MsgTx{
-		TxIn:  []*wire.TxIn{{}},
-		TxOut: []*wire.TxOut{{}},
-	}
-	sweepHash := sweepTx.TxHash()
 
 	timeoutTx := &wire.MsgTx{
 		TxIn: []*wire.TxIn{
 			{
-				PreviousOutPoint: commitOutpoint,
+				PreviousOutPoint: htlcOutpoint,
 			},
 		},
 		TxOut: []*wire.TxOut{
@@ -995,10 +589,15 @@ func TestHtlcTimeoutSecondStageSweeper(t *testing.T) {
 		},
 	}
 	reSignedHash := reSignedTimeoutTx.TxHash()
-	reSignedOutPoint := wire.OutPoint{
+
+	timeoutTxOutpoint := wire.OutPoint{
 		Hash:  reSignedHash,
 		Index: 1,
 	}
+
+	// Make a copy so `isPreimageSpend` can easily pass.
+	sweepTx := reSignedTimeoutTx.Copy()
+	sweepHash := sweepTx.TxHash()
 
 	// twoStageResolution is a resolution for a htlc on the local
 	// party's commitment, where the timeout tx can be re-signed.
@@ -1013,7 +612,7 @@ func TestHtlcTimeoutSecondStageSweeper(t *testing.T) {
 	}
 
 	firstStage := &channeldb.ResolverReport{
-		OutPoint:        commitOutpoint,
+		OutPoint:        htlcOutpoint,
 		Amount:          testHtlcAmt.ToSatoshis(),
 		ResolverType:    channeldb.ResolverTypeOutgoingHtlc,
 		ResolverOutcome: channeldb.ResolverOutcomeFirstStage,
@@ -1021,11 +620,44 @@ func TestHtlcTimeoutSecondStageSweeper(t *testing.T) {
 	}
 
 	secondState := &channeldb.ResolverReport{
-		OutPoint:        reSignedOutPoint,
+		OutPoint:        timeoutTxOutpoint,
 		Amount:          btcutil.Amount(testSignDesc.Output.Value),
 		ResolverType:    channeldb.ResolverTypeOutgoingHtlc,
 		ResolverOutcome: channeldb.ResolverOutcomeTimeout,
 		SpendTxID:       &sweepHash,
+	}
+	// mockTimeoutTxSpend is a helper closure to mock `waitForSpend` to
+	// return the commit spend in `sweepTimeoutTxOutput`.
+	mockTimeoutTxSpend := func(ctx *htlcResolverTestContext) {
+		select {
+		case ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
+			SpendingTx:        reSignedTimeoutTx,
+			SpenderInputIndex: 1,
+			SpenderTxHash:     &reSignedHash,
+			SpendingHeight:    10,
+			SpentOutPoint:     &htlcOutpoint,
+		}:
+
+		case <-time.After(time.Second * 1):
+			t.Fatalf("spend not sent")
+		}
+	}
+
+	// mockSweepTxSpend is a helper closure to mock `waitForSpend` to
+	// return the commit spend in `sweepTimeoutTxOutput`.
+	mockSweepTxSpend := func(ctx *htlcResolverTestContext) {
+		select {
+		case ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
+			SpendingTx:        sweepTx,
+			SpenderInputIndex: 1,
+			SpenderTxHash:     &sweepHash,
+			SpendingHeight:    10,
+			SpentOutPoint:     &timeoutTxOutpoint,
+		}:
+
+		case <-time.After(time.Second * 1):
+			t.Fatalf("spend not sent")
+		}
 	}
 
 	checkpoints := []checkpoint{
@@ -1035,28 +667,40 @@ func TestHtlcTimeoutSecondStageSweeper(t *testing.T) {
 				_ bool) error {
 
 				resolver := ctx.resolver.(*htlcTimeoutResolver)
-				inp := <-resolver.Sweeper.(*mockSweeper).sweptInputs
-				op := inp.OutPoint()
-				if op != commitOutpoint {
-					return fmt.Errorf("outpoint %v swept, "+
-						"expected %v", op,
-						commitOutpoint)
+
+				var (
+					inp input.Input
+					ok  bool
+				)
+
+				select {
+				case inp, ok = <-resolver.Sweeper.(*mockSweeper).sweptInputs:
+					require.True(t, ok)
+
+				case <-time.After(1 * time.Second):
+					t.Fatal("expected input to be swept")
 				}
 
-				// Emulat the sweeper spending using the
-				// re-signed timeout tx.
-				ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
-					SpendingTx:        reSignedTimeoutTx,
-					SpenderInputIndex: 1,
-					SpenderTxHash:     &reSignedHash,
-					SpendingHeight:    10,
+				op := inp.OutPoint()
+				if op != htlcOutpoint {
+					return fmt.Errorf("outpoint %v swept, "+
+						"expected %v", op, htlcOutpoint)
 				}
+
+				// Mock `waitForSpend` twice, called in,
+				// - `resolveReSignedTimeoutTx`
+				// - `sweepTimeoutTxOutput`.
+				mockTimeoutTxSpend(ctx)
+				mockTimeoutTxSpend(ctx)
 
 				return nil
 			},
 			// incubating=true is used to signal that the
 			// second-level transaction was confirmed.
 			incubating: true,
+			reports: []*channeldb.ResolverReport{
+				firstStage,
+			},
 		},
 		{
 			// We send a confirmation for our sweep tx to indicate
@@ -1064,17 +708,17 @@ func TestHtlcTimeoutSecondStageSweeper(t *testing.T) {
 			preCheckpoint: func(ctx *htlcResolverTestContext,
 				resumed bool) error {
 
-				// If we are resuming from a checkpoint, we
-				// expect the resolver to re-subscribe to a
-				// spend, hence we must resend it.
+				// Mock `waitForSpend` to return the commit
+				// spend.
 				if resumed {
-					ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
-						SpendingTx:        reSignedTimeoutTx,
-						SpenderInputIndex: 1,
-						SpenderTxHash:     &reSignedHash,
-						SpendingHeight:    10,
-					}
+					mockTimeoutTxSpend(ctx)
+					mockTimeoutTxSpend(ctx)
+					mockSweepTxSpend(ctx)
+
+					return nil
 				}
+
+				mockSweepTxSpend(ctx)
 
 				// The resolver should deliver a failure
 				// resolution message (indicating we
@@ -1091,7 +735,20 @@ func TestHtlcTimeoutSecondStageSweeper(t *testing.T) {
 				// The timeout tx output should now be given to
 				// the sweeper.
 				resolver := ctx.resolver.(*htlcTimeoutResolver)
-				inp := <-resolver.Sweeper.(*mockSweeper).sweptInputs
+
+				var (
+					inp input.Input
+					ok  bool
+				)
+
+				select {
+				case inp, ok = <-resolver.Sweeper.(*mockSweeper).sweptInputs:
+					require.True(t, ok)
+
+				case <-time.After(1 * time.Second):
+					t.Fatal("expected input to be swept")
+				}
+
 				op := inp.OutPoint()
 				exp := wire.OutPoint{
 					Hash:  reSignedHash,
@@ -1099,14 +756,6 @@ func TestHtlcTimeoutSecondStageSweeper(t *testing.T) {
 				}
 				if op != exp {
 					return fmt.Errorf("wrong outpoint swept")
-				}
-
-				// Notify about the spend, which should resolve
-				// the resolver.
-				ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
-					SpendingTx:     sweepTx,
-					SpenderTxHash:  &sweepHash,
-					SpendingHeight: 14,
 				}
 
 				return nil
@@ -1118,7 +767,6 @@ func TestHtlcTimeoutSecondStageSweeper(t *testing.T) {
 			incubating: true,
 			resolved:   true,
 			reports: []*channeldb.ResolverReport{
-				firstStage,
 				secondState,
 			},
 		},
@@ -1200,33 +848,6 @@ func TestHtlcTimeoutSecondStageSweeperRemoteSpend(t *testing.T) {
 
 	checkpoints := []checkpoint{
 		{
-			// The output should be given to the sweeper.
-			preCheckpoint: func(ctx *htlcResolverTestContext,
-				_ bool) error {
-
-				resolver := ctx.resolver.(*htlcTimeoutResolver)
-				inp := <-resolver.Sweeper.(*mockSweeper).sweptInputs
-				op := inp.OutPoint()
-				if op != commitOutpoint {
-					return fmt.Errorf("outpoint %v swept, "+
-						"expected %v", op,
-						commitOutpoint)
-				}
-
-				// Emulate the remote sweeping the output with the preimage.
-				// re-signed timeout tx.
-				ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
-					SpendingTx:    spendTx,
-					SpenderTxHash: &spendTxHash,
-				}
-
-				return nil
-			},
-			// incubating=true is used to signal that the
-			// second-level transaction was confirmed.
-			incubating: true,
-		},
-		{
 			// We send a confirmation for our sweep tx to indicate
 			// that our sweep succeeded.
 			preCheckpoint: func(ctx *htlcResolverTestContext,
@@ -1240,6 +861,7 @@ func TestHtlcTimeoutSecondStageSweeperRemoteSpend(t *testing.T) {
 					ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
 						SpendingTx:    spendTx,
 						SpenderTxHash: &spendTxHash,
+						SpentOutPoint: &commitOutpoint,
 					}
 				}
 
@@ -1277,7 +899,7 @@ func TestHtlcTimeoutSecondStageSweeperRemoteSpend(t *testing.T) {
 			// After the sweep has confirmed, we expect the
 			// checkpoint to be resolved, and with the above
 			// reports.
-			incubating: true,
+			incubating: false,
 			resolved:   true,
 			reports: []*channeldb.ResolverReport{
 				claim,
@@ -1300,21 +922,26 @@ func testHtlcTimeout(t *testing.T, resolution lnwallet.OutgoingHtlcResolution,
 	// for the next portion of the test.
 	ctx := newHtlcResolverTestContext(t,
 		func(htlc channeldb.HTLC, cfg ResolverConfig) ContractResolver {
-			return &htlcTimeoutResolver{
+			r := &htlcTimeoutResolver{
 				contractResolverKit: *newContractResolverKit(cfg),
 				htlc:                htlc,
 				htlcResolution:      resolution,
 			}
+			r.initLogger("htlcTimeoutResolver")
+
+			return r
 		},
 	)
 
 	checkpointedState := runFromCheckpoint(t, ctx, checkpoints)
 
+	t.Log("Running resolver to completion after restart")
+
 	// Now, from every checkpoint created, we re-create the resolver, and
 	// run the test from that checkpoint.
 	for i := range checkpointedState {
 		cp := bytes.NewReader(checkpointedState[i])
-		ctx := newHtlcResolverTestContext(t,
+		ctx := newHtlcResolverTestContextFromReader(t,
 			func(htlc channeldb.HTLC, cfg ResolverConfig) ContractResolver {
 				resolver, err := newTimeoutResolverFromReader(cp, cfg)
 				if err != nil {
@@ -1322,7 +949,8 @@ func testHtlcTimeout(t *testing.T, resolution lnwallet.OutgoingHtlcResolution,
 				}
 
 				resolver.Supplement(htlc)
-				resolver.htlcResolution = resolution
+				resolver.initLogger("htlcTimeoutResolver")
+
 				return resolver
 			},
 		)

--- a/itest/lnd_channel_backup_test.go
+++ b/itest/lnd_channel_backup_test.go
@@ -1424,9 +1424,6 @@ func assertTimeLockSwept(ht *lntest.HarnessTest, carol, dave *node.HarnessNode,
 	// tx. In addition, Dave will attempt to sweep his anchor output but
 	// fail due to the sweeping tx being uneconomical.
 	expectedTxes := 1
-
-	// Mine a block to trigger the sweeps.
-	ht.MineBlocks(1)
 	ht.AssertNumTxsInMempool(expectedTxes)
 
 	// Carol should consider the channel pending force close (since she is
@@ -1456,11 +1453,10 @@ func assertTimeLockSwept(ht *lntest.HarnessTest, carol, dave *node.HarnessNode,
 	// The commit sweep resolver publishes the sweep tx at defaultCSV-1 and
 	// we already mined one block after the commitment was published, and
 	// one block to trigger Carol's sweeps, so take that into account.
-	ht.MineEmptyBlocks(1)
+	ht.MineEmptyBlocks(2)
 	ht.AssertNumPendingSweeps(dave, 2)
 
 	// Mine a block to trigger the sweeps.
-	ht.MineEmptyBlocks(1)
 	daveSweep := ht.AssertNumTxsInMempool(1)[0]
 	block := ht.MineBlocksAndAssertNumTxes(1, 1)[0]
 	ht.AssertTxInBlock(block, daveSweep)

--- a/itest/lnd_channel_backup_test.go
+++ b/itest/lnd_channel_backup_test.go
@@ -1268,9 +1268,6 @@ func testDataLossProtection(ht *lntest.HarnessTest) {
 	// Dave should have a pending sweep.
 	ht.AssertNumPendingSweeps(dave, 1)
 
-	// Mine a block to trigger the sweep.
-	ht.MineBlocks(1)
-
 	// Dave should sweep his funds.
 	ht.AssertNumTxsInMempool(1)
 

--- a/itest/lnd_channel_force_close_test.go
+++ b/itest/lnd_channel_force_close_test.go
@@ -259,46 +259,47 @@ func channelForceClosureTest(ht *lntest.HarnessTest,
 
 	// The following restart is intended to ensure that outputs from the
 	// force close commitment transaction have been persisted once the
-	// transaction has been confirmed, but before the outputs are spendable
-	// (the "kindergarten" bucket.)
+	// transaction has been confirmed, but before the outputs are
+	// spendable.
 	ht.RestartNode(alice)
 
 	// Carol should offer her commit and anchor outputs to the sweeper.
 	sweepTxns := ht.AssertNumPendingSweeps(carol, 2)
 
-	// Find Carol's anchor sweep.
+	// Identify Carol's pending sweeps.
 	var carolAnchor, carolCommit = sweepTxns[0], sweepTxns[1]
 	if carolAnchor.AmountSat != uint32(anchorSize) {
 		carolAnchor, carolCommit = carolCommit, carolAnchor
 	}
 
-	// Mine a block to trigger Carol's sweeper to make decisions on the
-	// anchor sweeping.
-	ht.MineEmptyBlocks(1)
-
 	// Carol's sweep tx should be in the mempool already, as her output is
-	// not timelocked.
+	// not timelocked. This sweep tx should spend her to_local output as
+	// the anchor output is not economical to spend.
 	carolTx := ht.GetNumTxsFromMempool(1)[0]
 
-	// Carol's sweeping tx should have 2-input-1-output shape.
-	require.Len(ht, carolTx.TxIn, 2)
+	// Carol's sweeping tx should have 1-input-1-output shape.
+	require.Len(ht, carolTx.TxIn, 1)
 	require.Len(ht, carolTx.TxOut, 1)
 
 	// Calculate the total fee Carol paid.
 	totalFeeCarol := ht.CalculateTxFee(carolTx)
 
-	// If we have anchors, add an anchor resolution for carol.
-	op := fmt.Sprintf("%v:%v", carolAnchor.Outpoint.TxidStr,
-		carolAnchor.Outpoint.OutputIndex)
-	carolReports[op] = &lnrpc.Resolution{
-		ResolutionType: lnrpc.ResolutionType_ANCHOR,
-		Outcome:        lnrpc.ResolutionOutcome_CLAIMED,
-		SweepTxid:      carolTx.TxHash().String(),
-		AmountSat:      anchorSize,
-		Outpoint:       carolAnchor.Outpoint,
-	}
+	// Carol's anchor report won't be created since it's uneconomical to
+	// sweep. We still keep the follow code snippet in case we want to
+	// bring it back.
+	//
+	// // If we have anchors, add an anchor resolution for carol.
+	// op := fmt.Sprintf("%v:%v", carolAnchor.Outpoint.TxidStr,
+	// 	carolAnchor.Outpoint.OutputIndex)
+	// carolReports[op] = &lnrpc.Resolution{
+	// 	ResolutionType: lnrpc.ResolutionType_ANCHOR,
+	// 	Outcome:        lnrpc.ResolutionOutcome_CLAIMED,
+	// 	SweepTxid:      carolTx.TxHash().String(),
+	// 	AmountSat:      anchorSize,
+	// 	Outpoint:       carolAnchor.Outpoint,
+	// }
 
-	op = fmt.Sprintf("%v:%v", carolCommit.Outpoint.TxidStr,
+	op := fmt.Sprintf("%v:%v", carolCommit.Outpoint.TxidStr,
 		carolCommit.Outpoint.OutputIndex)
 	carolReports[op] = &lnrpc.Resolution{
 		ResolutionType: lnrpc.ResolutionType_COMMIT,
@@ -345,12 +346,12 @@ func channelForceClosureTest(ht *lntest.HarnessTest,
 		aliceBalance = forceClose.Channel.LocalBalance
 
 		// At this point, the nursery should show that the commitment
-		// output has 2 block left before its CSV delay expires. In
+		// output has 3 block left before its CSV delay expires. In
 		// total, we have mined exactly defaultCSV blocks, so the htlc
 		// outputs should also reflect that this many blocks have
 		// passed.
 		err = checkCommitmentMaturity(
-			forceClose, commCsvMaturityHeight, 2,
+			forceClose, commCsvMaturityHeight, 3,
 		)
 		if err != nil {
 			return err
@@ -369,9 +370,9 @@ func channelForceClosureTest(ht *lntest.HarnessTest,
 	}, defaultTimeout)
 	require.NoError(ht, err, "timeout while checking force closed channel")
 
-	// Generate an additional block, which should cause the CSV delayed
-	// output from the commitment txn to expire.
-	ht.MineEmptyBlocks(1)
+	// Generate two blocks, which should cause the CSV delayed output from
+	// the commitment txn to expire.
+	ht.MineEmptyBlocks(2)
 
 	// At this point, the CSV will expire in the next block, meaning that
 	// the output should be offered to the sweeper.
@@ -381,14 +382,9 @@ func channelForceClosureTest(ht *lntest.HarnessTest,
 		commitSweep, anchorSweep = anchorSweep, commitSweep
 	}
 
-	// Restart Alice to ensure that she resumes watching the finalized
-	// commitment sweep txid.
-	ht.RestartNode(alice)
-
 	// Mine one block and the sweeping transaction should now be broadcast.
 	// So we fetch the node's mempool to ensure it has been properly
 	// broadcast.
-	ht.MineEmptyBlocks(1)
 	sweepingTXID := ht.AssertNumTxsInMempool(1)[0]
 
 	// Fetch the sweep transaction, all input it's spending should be from
@@ -398,6 +394,10 @@ func channelForceClosureTest(ht *lntest.HarnessTest,
 		require.Equal(ht, &txIn.PreviousOutPoint.Hash, closingTxID,
 			"sweep transaction not spending from commit")
 	}
+
+	// Restart Alice to ensure that she resumes watching the finalized
+	// commitment sweep txid.
+	ht.RestartNode(alice)
 
 	// We expect a resolution which spends our commit output.
 	op = fmt.Sprintf("%v:%v", commitSweep.Outpoint.TxidStr,
@@ -410,16 +410,20 @@ func channelForceClosureTest(ht *lntest.HarnessTest,
 		AmountSat:      uint64(aliceBalance),
 	}
 
-	// Add alice's anchor to our expected set of reports.
-	op = fmt.Sprintf("%v:%v", aliceAnchor.Outpoint.TxidStr,
-		aliceAnchor.Outpoint.OutputIndex)
-	aliceReports[op] = &lnrpc.Resolution{
-		ResolutionType: lnrpc.ResolutionType_ANCHOR,
-		Outcome:        lnrpc.ResolutionOutcome_CLAIMED,
-		SweepTxid:      sweepingTXID.String(),
-		Outpoint:       aliceAnchor.Outpoint,
-		AmountSat:      uint64(anchorSize),
-	}
+	// Alice's anchor report won't be created since it's uneconomical to
+	// sweep. We still keep the follow code snippet in case we want to
+	// bring it back.
+	//
+	// // Add alice's anchor to our expected set of reports.
+	// op = fmt.Sprintf("%v:%v", aliceAnchor.Outpoint.TxidStr,
+	// 	aliceAnchor.Outpoint.OutputIndex)
+	// aliceReports[op] = &lnrpc.Resolution{
+	// 	ResolutionType: lnrpc.ResolutionType_ANCHOR,
+	// 	Outcome:        lnrpc.ResolutionOutcome_CLAIMED,
+	// 	SweepTxid:      sweepingTXID.String(),
+	// 	Outpoint:       aliceAnchor.Outpoint,
+	// 	AmountSat:      uint64(anchorSize),
+	// }
 
 	// Check that we can find the commitment sweep in our set of known
 	// sweeps, using the simple transaction id ListSweeps output.
@@ -539,20 +543,19 @@ func channelForceClosureTest(ht *lntest.HarnessTest,
 
 	// Since Alice had numInvoices (6) htlcs extended to Carol before force
 	// closing, we expect Alice to broadcast an htlc timeout txn for each
-	// one.
-	ht.AssertNumPendingSweeps(alice, numInvoices)
+	// one. We also expect Alice to still have her anchor since it's not
+	// swept.
+	ht.AssertNumPendingSweeps(alice, numInvoices+1)
 
 	// Wait for them all to show up in the mempool
-	//
-	// NOTE: after restart, all the htlc timeout txns will be offered to
-	// the sweeper with `Immediate` set to true, so they won't be
-	// aggregated.
-	htlcTxIDs := ht.AssertNumTxsInMempool(numInvoices)
+	htlcTxIDs := ht.AssertNumTxsInMempool(1)
 
 	// Retrieve each htlc timeout txn from the mempool, and ensure it is
-	// well-formed. This entails verifying that each only spends from
-	// output, and that output is from the commitment txn.
-	numInputs := 2
+	// well-formed. The sweeping tx should spend all the htlc outputs.
+	//
+	// NOTE: We also add 1 output as the outgoing HTLC is swept using twice
+	// its value as its budget, so a wallet utxo is used.
+	numInputs := 6 + 1
 
 	// Construct a map of the already confirmed htlc timeout outpoints,
 	// that will count the number of times each is spent by the sweep txn.
@@ -653,7 +656,7 @@ func channelForceClosureTest(ht *lntest.HarnessTest,
 
 	// Generate a block that mines the htlc timeout txns. Doing so now
 	// activates the 2nd-stage CSV delayed outputs.
-	ht.MineBlocksAndAssertNumTxes(1, numInvoices)
+	ht.MineBlocksAndAssertNumTxes(1, 1)
 
 	// Alice is restarted here to ensure that she promptly moved the crib
 	// outputs to the kindergarten bucket after the htlc timeout txns were
@@ -688,10 +691,9 @@ func channelForceClosureTest(ht *lntest.HarnessTest,
 	}, defaultTimeout)
 	require.NoError(ht, err, "timeout while checking force closed channel")
 
-	// Generate a block that causes Alice to sweep the htlc outputs in the
-	// kindergarten bucket.
+	// Generate a block that causes Alice to sweep the htlc outputs.
 	ht.MineEmptyBlocks(1)
-	ht.AssertNumPendingSweeps(alice, numInvoices)
+	ht.AssertNumPendingSweeps(alice, numInvoices+1)
 
 	// Mine a block to trigger the sweep.
 	ht.MineEmptyBlocks(1)
@@ -846,12 +848,6 @@ func channelForceClosureTest(ht *lntest.HarnessTest,
 	// push amount sent by Alice and minus the miner fee paid.
 	carolExpectedBalance := btcutil.Amount(carolStartingBalance) +
 		pushAmt - totalFeeCarol
-
-	// In addition, if this is an anchor-enabled channel, further add the
-	// anchor size.
-	if lntest.CommitTypeHasAnchors(channelType) {
-		carolExpectedBalance += btcutil.Amount(anchorSize)
-	}
 
 	require.Equal(ht, carolExpectedBalance,
 		btcutil.Amount(carolBalResp.ConfirmedBalance),

--- a/itest/lnd_coop_close_with_htlcs_test.go
+++ b/itest/lnd_coop_close_with_htlcs_test.go
@@ -120,7 +120,7 @@ func coopCloseWithHTLCs(ht *lntest.HarnessTest) {
 	ht.AssertTxInMempool(&closeTxid)
 
 	// Wait for it to get mined and finish tearing down.
-	ht.AssertStreamChannelCoopClosed(alice, chanPoint, false, closeClient)
+	ht.AssertStreamChannelCoopClosed(alice, chanPoint, closeClient)
 }
 
 // coopCloseWithHTLCsWithRestart also tests the coop close flow when an HTLC

--- a/itest/lnd_multi-hop_test.go
+++ b/itest/lnd_multi-hop_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -16,7 +17,6 @@ import (
 	"github.com/lightningnetwork/lnd/lntest"
 	"github.com/lightningnetwork/lnd/lntest/node"
 	"github.com/lightningnetwork/lnd/lntest/rpc"
-	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/routing"
@@ -245,17 +245,15 @@ func runMultiHopHtlcLocalTimeout(ht *lntest.HarnessTest,
 	)
 	ht.MineBlocks(int(numBlocks))
 
-	// Bob's force close transaction should now be found in the mempool.
-	ht.AssertNumTxsInMempool(1)
+	// Bob's force close transaction should now be found in the mempool,
+	// along with his anchor sweeping tx.
+	ht.AssertNumTxsInMempool(2)
 	op := ht.OutPointFromChannelPoint(bobChanPoint)
 	closeTx := ht.AssertOutpointInMempool(op)
 
-	// Bob's anchor output should be offered to his sweep since Bob has
-	// time-sensitive HTLCs - we expect both anchors are offered.
-	ht.AssertNumPendingSweeps(bob, 2)
-
-	// Mine a block to confirm the closing transaction.
-	ht.MineBlocksAndAssertNumTxes(1, 1)
+	// Mine a block to confirm the closing transaction and the anchor
+	// sweeping tx.
+	ht.MineBlocksAndAssertNumTxes(1, 2)
 
 	// At this point, Bob should have canceled backwards the dust HTLC
 	// that we sent earlier. This means Alice should now only have a single
@@ -264,42 +262,30 @@ func runMultiHopHtlcLocalTimeout(ht *lntest.HarnessTest,
 
 	// With the closing transaction confirmed, we should expect Bob's HTLC
 	// timeout transaction to be offered to the sweeper due to the expiry
-	// being reached. we also expect Bon and Carol's anchor sweeps.
-	ht.AssertNumPendingSweeps(bob, 2)
+	// being reached. we also expect Carol's anchor sweeps.
+	ht.AssertNumPendingSweeps(bob, 1)
 	ht.AssertNumPendingSweeps(carol, 1)
 
-	// Mine a block to trigger Bob's sweeper to sweep.
-	ht.MineEmptyBlocks(1)
-
 	// The above mined block would trigger Bob and Carol's sweepers to take
-	// action. We now expect two txns:
-	// 1. Bob's sweeping tx anchor sweep should now be found in the mempool.
-	// 2. Bob's HTLC timeout tx sweep should now be found in the mempool.
+	// action. We now expect one tx:
+	// 1. Bob's HTLC timeout tx sweep should now be found in the mempool.
 	// Carol's anchor sweep should be failed due to output being dust.
-	ht.AssertNumTxsInMempool(2)
+	ht.AssertNumTxsInMempool(1)
 
 	htlcOutpoint := wire.OutPoint{Hash: closeTx.TxHash(), Index: 2}
 	commitOutpoint := wire.OutPoint{Hash: closeTx.TxHash(), Index: 3}
-	htlcTimeoutTxid := ht.AssertOutpointInMempool(
-		htlcOutpoint,
-	).TxHash()
+	htlcTimeoutTxid := ht.AssertOutpointInMempool(htlcOutpoint).TxHash()
 
-	// Mine a block to confirm the above two sweeping txns.
-	ht.MineBlocksAndAssertNumTxes(1, 2)
-
-	// With Bob's HTLC timeout transaction confirmed, there should be no
-	// active HTLC's on the commitment transaction from Alice -> Bob.
-	ht.AssertNumActiveHtlcs(alice, 0)
+	// Mine a block to confirm Bob's HTLC timeout sweeping txns.
+	ht.MineBlocksAndAssertNumTxes(1, 1)
 
 	// At this point, Bob should show that the pending HTLC has advanced to
 	// the second stage and is ready to be swept once the timelock is up.
+	ht.AssertNumHTLCsAndStage(bob, bobChanPoint, 1, 2)
+
 	pendingChanResp := bob.RPC.PendingChannels()
 	require.Equal(ht, 1, len(pendingChanResp.PendingForceClosingChannels))
 	forceCloseChan := pendingChanResp.PendingForceClosingChannels[0]
-	require.NotZero(ht, forceCloseChan.LimboBalance)
-	require.Positive(ht, forceCloseChan.BlocksTilMaturity)
-	require.Equal(ht, 1, len(forceCloseChan.PendingHtlcs))
-	require.Equal(ht, uint32(2), forceCloseChan.PendingHtlcs[0].Stage)
 
 	ht.Logf("Bob's timelock on commit=%v, timelock on htlc=%v",
 		forceCloseChan.BlocksTilMaturity,
@@ -315,57 +301,25 @@ func runMultiHopHtlcLocalTimeout(ht *lntest.HarnessTest,
 
 		// We now mine enough blocks to trigger the sweep of the HTLC
 		// timeout tx.
-		ht.MineEmptyBlocks(blocksTilMaturity - 1)
+		ht.MineEmptyBlocks(blocksTilMaturity)
 
-		// Check that Bob has one pending sweeping tx - the HTLC
-		// timeout tx.
-		ht.AssertNumPendingSweeps(bob, 1)
-
-		// Mine one more blocks, then his commit output will mature.
-		// This will also trigger the sweeper to sweep his HTLC timeout
-		// tx.
-		ht.MineEmptyBlocks(1)
-
-		// Check that Bob has two pending sweeping txns.
+		// Check that Bob has two pending sweeping requests - the HTLC
+		// timeout tx and his to_local output.
 		ht.AssertNumPendingSweeps(bob, 2)
 
 		// Assert that the HTLC timeout tx is now in the mempool.
 		ht.AssertOutpointInMempool(htlcTimeoutOutpoint)
 
-		// We now wait for 30 seconds to overcome the flake - there's a
-		// block race between contractcourt and sweeper, causing the
-		// sweep to be broadcast earlier.
-		//
-		// TODO(yy): remove this once `blockbeat` is in place.
-		numExpected := 1
-		err := wait.NoError(func() error {
-			mem := ht.GetRawMempool()
-			if len(mem) == 2 {
-				numExpected = 2
-				return nil
-			}
+		// Assert the to_local output is also in the mempool.
+		ht.AssertOutpointInMempool(commitOutpoint)
 
-			return fmt.Errorf("want %d, got %v in mempool: %v",
-				numExpected, len(mem), mem)
-		}, wait.DefaultTimeout)
-		ht.Logf("Checking mempool got: %v", err)
+		// Mine a block to confirm the sweeping tx.
+		ht.MineBlocksAndAssertNumTxes(1, 1)
 
-		// Mine a block to trigger the sweep of his commit output and
-		// confirm his HTLC timeout sweep.
-		ht.MineBlocksAndAssertNumTxes(1, numExpected)
-
-		// For leased channels, we need to mine one more block to
-		// confirm Bob's commit output sweep.
-		//
-		// NOTE: we mine this block conditionally, as the commit output
-		// may have already been swept one block earlier due to the
-		// race in block consumption among subsystems.
-		pendingChanResp := bob.RPC.PendingChannels()
-		if len(pendingChanResp.PendingForceClosingChannels) != 0 {
-			// Check that the sweep spends the expected inputs.
-			ht.AssertOutpointInMempool(commitOutpoint)
-			ht.MineBlocksAndAssertNumTxes(1, 1)
-		}
+		// With Bob's HTLC timeout transaction confirmed, there should
+		// be no active HTLC's on the commitment transaction from Alice
+		// -> Bob.
+		ht.AssertNumActiveHtlcs(alice, 0)
 	} else {
 		// Since Bob force closed the channel between him and Carol, he
 		// will incur the usual CSV delay on any outputs that he can
@@ -383,16 +337,19 @@ func runMultiHopHtlcLocalTimeout(ht *lntest.HarnessTest,
 		// Check that the sweep spends from the mined commitment.
 		ht.AssertOutpointInMempool(commitOutpoint)
 
-		// Mine one more block to trigger the timeout path.
-		ht.MineBlocksAndAssertNumTxes(1, 1)
-
 		// Bob's sweeper should now broadcast his second layer sweep
-		// due to the CSV on the HTLC timeout output.
-		ht.AssertOutpointInMempool(htlcTimeoutOutpoint)
+		// due to the CSV on the HTLC timeout output, along with his
+		// to_local output sweep.
+		ht.MineBlocksAndAssertNumTxes(1, 2)
 
 		// Next, we'll mine a final block that should confirm the
 		// sweeping transactions left.
-		ht.MineBlocksAndAssertNumTxes(1, 1)
+		// ht.MineBlocksAndAssertNumTxes(1, 2)
+
+		// With Bob's HTLC timeout transaction confirmed, there should
+		// be no active HTLC's on the commitment transaction from Alice
+		// -> Bob.
+		ht.AssertNumActiveHtlcs(alice, 0)
 	}
 
 	// Once this transaction has been confirmed, Bob should detect that he
@@ -500,38 +457,22 @@ func runMultiHopReceiverChainClaim(ht *lntest.HarnessTest,
 	ht.MineEmptyBlocks(int(numBlocks))
 
 	// At this point, Carol should broadcast her active commitment
-	// transaction in order to go to the chain and sweep her HTLC.
-	ht.AssertNumTxsInMempool(1)
+	// transaction in order to go to the chain and sweep her HTLC, along
+	// with her anchor sweeping tx.
+	ht.AssertNumTxsInMempool(2)
 
 	closingTx := ht.AssertOutpointInMempool(
 		ht.OutPointFromChannelPoint(bobChanPoint),
 	)
 	closingTxid := closingTx.TxHash()
 
-	// Carol's anchor should have been offered to her sweeper as she has
-	// time-sensitive HTLCs. Assert that we have two anchors - one for the
-	// anchor on the local commitment and the other for the anchor on the
-	// remote commitment (invalid).
-	ht.AssertNumPendingSweeps(carol, 2)
-
 	// Confirm the commitment.
-	ht.MineBlocksAndAssertNumTxes(1, 1)
-
-	// The above mined block will trigger Carol's sweeper to publish the
-	// anchor sweeping tx.
-	//
-	// TODO(yy): should instead cancel the broadcast of the anchor sweeping
-	// tx to save fees since we know the force close tx has been confirmed?
-	// This is very difficult as it introduces more complicated RBF
-	// scenarios, as we are using a wallet utxo, which means any txns using
-	// that wallet utxo must pay more fees. On the other hand, there's no
-	// way to remove that anchor-CPFP tx from the mempool.
-	ht.AssertNumTxsInMempool(1)
+	ht.MineBlocksAndAssertNumTxes(1, 2)
 
 	// After the force close transaction is mined, Carol should offer her
-	// second level HTLC tx to the sweeper, which means we should see two
-	// pending inputs now - the anchor and the htlc.
-	ht.AssertNumPendingSweeps(carol, 2)
+	// second level HTLC tx to the sweeper, which means we should see one
+	// pending input now - the htlc.
+	ht.AssertNumPendingSweeps(carol, 1)
 
 	// Restart bob again.
 	require.NoError(ht, restartBob())
@@ -543,25 +484,23 @@ func runMultiHopReceiverChainClaim(ht *lntest.HarnessTest,
 	// second level transaction in the mempool, he will extract the
 	// preimage and settle the HTLC back off-chain.
 	switch c {
-	// We expect to see three txns in the mempool:
+	// We expect to see two txns in the mempool:
 	// 1. Carol should broadcast her second level HTLC tx.
-	// 2. Carol should broadcast her anchor sweeping tx.
-	// 3. Bob should broadcast a sweep tx to sweep his output in the
+	// 2. Bob should broadcast a sweep tx to sweep his output in the
 	//    channel with Carol, and in the same sweep tx to sweep his anchor
 	//    output.
 	case lnrpc.CommitmentType_ANCHORS, lnrpc.CommitmentType_SIMPLE_TAPROOT:
-		expectedTxes = 3
+		expectedTxes = 2
 		ht.AssertNumPendingSweeps(bob, 2)
 
-	// We expect to see two txns in the mempool:
+	// We expect to see one tx in the mempool:
 	// 1. Carol should broadcast her second level HTLC tx.
-	// 2. Carol should broadcast her anchor sweeping tx.
 	// Bob would offer his anchor output to his sweeper, but it cannot be
 	// swept due to it being uneconomical. Bob's commit output can't be
 	// swept yet as he's incurring an additional CLTV from being the
 	// channel initiator of a script-enforced leased channel.
 	case lnrpc.CommitmentType_SCRIPT_ENFORCED_LEASE:
-		expectedTxes = 2
+		expectedTxes = 1
 		ht.AssertNumPendingSweeps(bob, 1)
 
 	default:
@@ -595,9 +534,6 @@ func runMultiHopReceiverChainClaim(ht *lntest.HarnessTest,
 
 	// Assert Carol has the pending HTLC sweep.
 	ht.AssertNumPendingSweeps(carol, 1)
-
-	// Mine one block to trigger the sweeper to sweep.
-	ht.MineEmptyBlocks(1)
 
 	// We should have a new transaction in the mempool.
 	ht.AssertNumTxsInMempool(1)
@@ -730,12 +666,6 @@ func runMultiHopLocalForceCloseOnChainHtlcTimeout(ht *lntest.HarnessTest,
 	ht.AssertNumPendingSweeps(carol, 1)
 	ht.AssertNumPendingSweeps(bob, 1)
 
-	// Mine a block to confirm Bob's anchor sweep - Carol's anchor sweep
-	// won't succeed because it's not used for CPFP, so there's no wallet
-	// utxo used, resulting it to be uneconomical.
-	ht.MineBlocksAndAssertNumTxes(1, 1)
-	blocksMined++
-
 	htlcOutpoint := wire.OutPoint{Hash: *closeTx, Index: 2}
 	bobCommitOutpoint := wire.OutPoint{Hash: *closeTx, Index: 3}
 
@@ -752,9 +682,7 @@ func runMultiHopLocalForceCloseOnChainHtlcTimeout(ht *lntest.HarnessTest,
 		blocksMined = defaultCSV
 
 		// Assert Bob has the sweep and trigger it.
-		ht.AssertNumPendingSweeps(bob, 1)
-		ht.MineEmptyBlocks(1)
-		blocksMined++
+		ht.AssertNumPendingSweeps(bob, 2)
 
 		commitSweepTx := ht.AssertOutpointInMempool(
 			bobCommitOutpoint,
@@ -776,8 +704,8 @@ func runMultiHopLocalForceCloseOnChainHtlcTimeout(ht *lntest.HarnessTest,
 	// that's now in stage one.
 	ht.AssertNumHTLCsAndStage(bob, bobChanPoint, 1, 1)
 
-	// Bob should have a pending sweep request.
-	ht.AssertNumPendingSweeps(bob, 1)
+	// Bob should have two pending sweep requests.
+	ht.AssertNumPendingSweeps(bob, 2)
 
 	// Mine one block to trigger Bob's sweeper to sweep it.
 	ht.MineEmptyBlocks(1)
@@ -790,10 +718,6 @@ func runMultiHopLocalForceCloseOnChainHtlcTimeout(ht *lntest.HarnessTest,
 	// the second layer timeout transaction.
 	block := ht.MineBlocksAndAssertNumTxes(1, 1)[0]
 	ht.AssertTxInBlock(block, &timeoutTx)
-
-	// With the second layer timeout transaction confirmed, Bob should have
-	// canceled backwards the HTLC that carol sent.
-	ht.AssertNumActiveHtlcs(bob, 0)
 
 	// Additionally, Bob should now show that HTLC as being advanced to the
 	// second stage.
@@ -821,19 +745,12 @@ func runMultiHopLocalForceCloseOnChainHtlcTimeout(ht *lntest.HarnessTest,
 	// commitment type.
 	if c == lnrpc.CommitmentType_SCRIPT_ENFORCED_LEASE {
 		// Assert the expected number of pending sweeps are found.
-		sweeps := ht.AssertNumPendingSweeps(bob, 2)
-
+		ht.AssertNumPendingSweeps(bob, 3)
 		numExpected = 1
-		if sweeps[0].DeadlineHeight != sweeps[1].DeadlineHeight {
-			numExpected = 2
-		}
 	} else {
-		ht.AssertNumPendingSweeps(bob, 1)
+		ht.AssertNumPendingSweeps(bob, 2)
 		numExpected = 1
 	}
-
-	// Mine a block to trigger the sweep.
-	ht.MineEmptyBlocks(1)
 
 	// Assert the sweeping tx is found in the mempool.
 	htlcTimeoutOutpoint := wire.OutPoint{Hash: timeoutTx, Index: 0}
@@ -841,6 +758,10 @@ func runMultiHopLocalForceCloseOnChainHtlcTimeout(ht *lntest.HarnessTest,
 
 	// Mine a block to confirm the sweep.
 	ht.MineBlocksAndAssertNumTxes(1, numExpected)
+
+	// With the sweeping of second layer timeout tx output confirmed, Bob
+	// should have canceled backwards the HTLC that Carol sent.
+	ht.AssertNumActiveHtlcs(bob, 0)
 
 	// At this point, Bob should no longer show any channels as pending
 	// close.
@@ -949,30 +870,27 @@ func runMultiHopRemoteForceCloseOnChainHtlcTimeout(ht *lntest.HarnessTest,
 		ht.AssertNumPendingSweeps(carol, 1)
 
 		// We expect to see only one sweeping tx to be published from
-		// Bob, which sweeps his commit and anchor outputs in the same
-		// tx. For Carol, since her anchor is not used for CPFP, it'd
-		// be uneconomical to sweep so it will fail.
+		// Bob, which sweeps his commit output. For Carol, since her
+		// anchor is not used for CPFP, it'd be uneconomical to sweep
+		// so it will fail.
 		expectedTxes = 1
 
 	// Bob can't sweep his commit output yet as he was the initiator of a
 	// script-enforced leased channel, so he'll always incur the additional
-	// CLTV. He can still offer his anchor output to his sweeper however.
+	// CLTV. He can still offer his anchor output to his sweeper however
+	// but not able to create a valid sweeping tx.
 	case lnrpc.CommitmentType_SCRIPT_ENFORCED_LEASE:
 		ht.AssertNumPendingSweeps(bob, 1)
 		ht.AssertNumPendingSweeps(carol, 1)
 
-		// We expect to see only no sweeping txns to be published,
-		// neither Bob's or Carol's anchor sweep can succeed due to
-		// it's uneconomical.
+		// We expect to see no sweeping txns to be published, neither
+		// Bob's or Carol's anchor sweep can succeed due to it's
+		// uneconomical.
 		expectedTxes = 0
 
 	default:
 		ht.Fatalf("unhandled commitment type %v", c)
 	}
-
-	// Mine one block to trigger the sweeps.
-	ht.MineEmptyBlocks(1)
-	blocksMined++
 
 	// We now mine a block to clear up the mempool.
 	ht.MineBlocksAndAssertNumTxes(1, expectedTxes)
@@ -990,17 +908,18 @@ func runMultiHopRemoteForceCloseOnChainHtlcTimeout(ht *lntest.HarnessTest,
 	// initial first stage since this is a direct HTLC.
 	ht.AssertNumHTLCsAndStage(bob, bobChanPoint, 1, 2)
 
-	// We need to generate an additional block to expire the CSV 1.
+	// Bob has failed to sweep his anchor output before, so it's still
+	// pending. He should have two pending sweep requests - the anchor
+	// output and the outgoing HTLC.
+	//
+	// NOTE: because the direct-timeout spending is handled by the legacy
+	// sweeping system (UtxoNursery), it's not bounded by the blockbeat. We
+	// mine one more block to make sure the sweep request is made.
+	//
+	// TODO(yy): once UtxoNursery is deprecated, we should remove this
+	// extra block mining.
 	ht.MineEmptyBlocks(1)
-
-	// For script-enforced leased channels, Bob has failed to sweep his
-	// anchor output before, so it's still pending.
-	if c == lnrpc.CommitmentType_SCRIPT_ENFORCED_LEASE {
-		ht.AssertNumPendingSweeps(bob, 2)
-	} else {
-		// Bob should have a pending sweep request.
-		ht.AssertNumPendingSweeps(bob, 1)
-	}
+	ht.AssertNumPendingSweeps(bob, 2)
 
 	// Mine a block to trigger the sweeper to sweep it.
 	ht.MineEmptyBlocks(1)
@@ -1037,9 +956,6 @@ func runMultiHopRemoteForceCloseOnChainHtlcTimeout(ht *lntest.HarnessTest,
 		// Bob should have two pending sweep requests - one for the
 		// commit output and one for the anchor output.
 		ht.AssertNumPendingSweeps(bob, 2)
-
-		// Mine a block to trigger the sweep.
-		ht.MineEmptyBlocks(1)
 
 		bobCommitOutpoint := wire.OutPoint{Hash: *closeTx, Index: 3}
 		bobCommitSweep := ht.AssertOutpointInMempool(
@@ -1214,8 +1130,9 @@ func runMultiHopHtlcLocalChainClaim(ht *lntest.HarnessTest,
 		lncfg.DefaultIncomingBroadcastDelta))
 	ht.MineEmptyBlocks(int(numBlocks - blocksMined))
 
-	// Carol's commitment transaction should now be in the mempool.
-	ht.AssertNumTxsInMempool(1)
+	// Carol's commitment transaction should now be in the mempool, along
+	// with her anchor sweeping tx.
+	ht.AssertNumTxsInMempool(2)
 
 	// Look up the closing transaction. It should be spending from the
 	// funding transaction,
@@ -1224,13 +1141,14 @@ func runMultiHopHtlcLocalChainClaim(ht *lntest.HarnessTest,
 	)
 	closingTxid := closingTx.TxHash()
 
-	// Mine a block that should confirm the commit tx.
-	block := ht.MineBlocksAndAssertNumTxes(1, 1)[0]
+	// Mine a block that should confirm the commit tx and the anchor
+	// sweeping tx.
+	block := ht.MineBlocksAndAssertNumTxes(1, 2)[0]
 	ht.AssertTxInBlock(block, &closingTxid)
 
-	// After the force close transaction is mined, Carol should offer her
-	// second-level success HTLC tx and anchor to the sweeper.
-	ht.AssertNumPendingSweeps(carol, 2)
+	// After the force close tx and anchor sweeping tx are mined, Carol
+	// should offer her second-level success HTLC tx to the sweeper.
+	ht.AssertNumPendingSweeps(carol, 1)
 
 	// Restart bob again.
 	require.NoError(ht, restartBob())
@@ -1245,25 +1163,23 @@ func runMultiHopHtlcLocalChainClaim(ht *lntest.HarnessTest,
 	// Carol will broadcast her sweeping txns and Bob will sweep his
 	// commitment and anchor outputs, we'd expect to see three txns,
 	// - Carol's second level HTLC transaction.
-	// - Carol's anchor sweeping txns since it's used for CPFP.
 	// - Bob's sweep tx spending his commitment output, and two anchor
 	//   outputs, one from channel Alice to Bob and the other from channel
 	//   Bob to Carol.
 	case lnrpc.CommitmentType_ANCHORS, lnrpc.CommitmentType_SIMPLE_TAPROOT:
 		ht.AssertNumPendingSweeps(bob, 3)
-		expectedTxes = 3
+		expectedTxes = 2
 
 	// Carol will broadcast her sweeping txns and Bob will sweep his
 	// anchor outputs. Bob can't sweep his commitment output yet as it has
 	// incurred an additional CLTV due to being the initiator of a
 	// script-enforced leased channel:
 	// - Carol's second level HTLC transaction.
-	// - Carol's anchor sweeping txns since it's used for CPFP.
 	// - Bob's sweep tx spending his two anchor outputs, one from channel
 	//   Alice to Bob and the other from channel Bob to Carol.
 	case lnrpc.CommitmentType_SCRIPT_ENFORCED_LEASE:
 		ht.AssertNumPendingSweeps(bob, 2)
-		expectedTxes = 3
+		expectedTxes = 2
 
 	default:
 		ht.Fatalf("unhandled commitment type %v", c)
@@ -1347,13 +1263,13 @@ func runMultiHopHtlcLocalChainClaim(ht *lntest.HarnessTest,
 	// Carol's sweep tx should be broadcast.
 	carolSweep := ht.AssertNumTxsInMempool(1)[0]
 
-	// Bob should offer his second level tx to his sweeper.
-	ht.AssertNumPendingSweeps(bob, 1)
-
 	// Mining one additional block, Bob's second level tx is mature, and he
 	// can sweep the output.
 	block = ht.MineBlocksAndAssertNumTxes(bobSecondLevelCSV, 1)[0]
 	ht.AssertTxInBlock(block, carolSweep)
+
+	// Bob should offer his second level tx to his sweeper.
+	ht.AssertNumPendingSweeps(bob, 1)
 
 	bobSweep := ht.GetNumTxsFromMempool(1)[0]
 	bobSweepTxid := bobSweep.TxHash()
@@ -1557,8 +1473,10 @@ func runMultiHopHtlcRemoteChainClaim(ht *lntest.HarnessTest,
 	))
 	ht.MineEmptyBlocks(int(numBlocks) - blocksMined)
 
-	// Carol's commitment transaction should now be in the mempool.
-	ht.AssertNumTxsInMempool(1)
+	// Carol's commitment transaction should now be in the mempool, along
+	// with her anchor sweeping tx since Carol has time-sensitive HTLCs,
+	// she will use the anchor for CPFP purpose.
+	ht.AssertNumTxsInMempool(2)
 
 	// The closing transaction should be spending from the funding
 	// transaction.
@@ -1567,18 +1485,25 @@ func runMultiHopHtlcRemoteChainClaim(ht *lntest.HarnessTest,
 	)
 	closingTxid := closingTx.TxHash()
 
-	// Since Carol has time-sensitive HTLCs, she will use the anchor for
-	// CPFP purpose. Assert she has two pending anchor sweep requests - one
-	// from local commit and the other from remote commit.
-	ht.AssertNumPendingSweeps(carol, 2)
+	// Assert she has one pending sweep request - the anchor from local
+	// commit.
+	if ht.IsNeutrinoBackend() {
+		// For neutrino there's no `testmempoolaccept`, so Caro will
+		// try to publish two anchor sweeping txns.
+		ht.AssertNumPendingSweeps(carol, 2)
+	} else {
+		ht.AssertNumPendingSweeps(carol, 1)
+	}
 
-	// Mine a block, which should contain: the commitment.
-	block := ht.MineBlocksAndAssertNumTxes(1, 1)[0]
+	// Mine a block, which should contain:
+	// - the commitment tx.
+	// - the anchor sweeping tx.
+	block := ht.MineBlocksAndAssertNumTxes(1, 2)[0]
 	ht.AssertTxInBlock(block, &closingTxid)
 
 	// After the force close transaction is mined, Carol should offer her
-	// second level HTLC tx to the sweeper, along with her anchor output.
-	ht.AssertNumPendingSweeps(carol, 2)
+	// second level HTLC tx to the sweeper.
+	ht.AssertNumPendingSweeps(carol, 1)
 
 	// Restart bob again.
 	require.NoError(ht, restartBob())
@@ -1608,32 +1533,29 @@ func runMultiHopHtlcRemoteChainClaim(ht *lntest.HarnessTest,
 	// Keep track of the second level tx maturity.
 	carolSecondLevelCSV := uint32(defaultCSV)
 
-	// Mine a block to trigger the sweeps, also confirms Carol's CPFP
-	// anchor sweeping.
-	ht.MineBlocksAndAssertNumTxes(1, 1)
+	// Mine a block to trigger the sweeps.
+	ht.MineEmptyBlocks(1)
 	carolSecondLevelCSV--
-	ht.AssertNumTxsInMempool(2)
 
-	// Mine a block to confirm the expected transactions.
+	// Mine a block to confirm Carol's HTLC success tx sweep and Bob's
+	// anchor sweeping tx.
 	ht.MineBlocksAndAssertNumTxes(1, 2)
+	carolSecondLevelCSV--
 
 	// When Bob notices Carol's second level transaction in the block, he
 	// will extract the preimage and offer the HTLC to his sweeper.
 	ht.AssertNumPendingSweeps(bob, 1)
 
-	// NOTE: after Bob is restarted, the sweeping of the direct preimage
-	// spent will happen immediately so we don't need to mine a block to
-	// trigger Bob's sweeper to sweep it.
+	// Mine a block to trigger Bob's sweep.
+	ht.MineEmptyBlocks(1)
 	bobHtlcSweep := ht.GetNumTxsFromMempool(1)[0]
-	bobHtlcSweepTxid := bobHtlcSweep.TxHash()
 
 	// It should spend from the commitment in the channel with Alice.
 	ht.AssertTxSpendFrom(bobHtlcSweep, *aliceForceClose)
 
 	// We'll now mine a block which should confirm Bob's HTLC sweep
 	// transaction.
-	block = ht.MineBlocksAndAssertNumTxes(1, 1)[0]
-	ht.AssertTxInBlock(block, &bobHtlcSweepTxid)
+	ht.MineBlocksAndAssertNumTxes(1, 1)
 	carolSecondLevelCSV--
 
 	// Now that the sweeping transaction has been confirmed, Bob should now
@@ -1880,12 +1802,12 @@ func runMultiHopHtlcAggregation(ht *lntest.HarnessTest,
 	ht.MineEmptyBlocks(int(numBlocks))
 
 	// Bob's force close transaction should now be found in the mempool. If
-	// there are anchors, we expect it to be offered to Bob's sweeper.
-	ht.AssertNumTxsInMempool(1)
+	// there are anchors, we expect it to be offered to Bob's sweeper and
+	// being swept.
+	ht.AssertNumTxsInMempool(2)
 
-	// Bob has two anchor sweep requests, one for remote (invalid) and the
-	// other for local.
-	ht.AssertNumPendingSweeps(bob, 2)
+	// Bob has one sweep request for his local anchor.
+	ht.AssertNumPendingSweeps(bob, 1)
 
 	closeTx := ht.AssertOutpointInMempool(
 		ht.OutPointFromChannelPoint(bobChanPoint),
@@ -1921,11 +1843,9 @@ func runMultiHopHtlcAggregation(ht *lntest.HarnessTest,
 	// Once bob has force closed, we can restart carol.
 	require.NoError(ht, restartCarol())
 
-	// Mine a block to confirm the closing transaction.
-	ht.MineBlocksAndAssertNumTxes(1, 1)
-
-	// The above mined block will trigger Bob to sweep his anchor output.
-	ht.AssertNumTxsInMempool(1)
+	// Mine a block to confirm the closing transaction and the anchor
+	// sweeping tx.
+	ht.MineBlocksAndAssertNumTxes(1, 2)
 
 	// Let Alice settle her invoices. When Bob now gets the preimages, he
 	// has no other option than to broadcast his second-level transactions
@@ -1942,7 +1862,7 @@ func runMultiHopHtlcAggregation(ht *lntest.HarnessTest,
 	// preimages from Alice. We also expect Carol to sweep her commitment
 	// output.
 	case lnrpc.CommitmentType_LEGACY:
-		ht.AssertNumPendingSweeps(bob, numInvoices*2+1)
+		ht.AssertNumPendingSweeps(bob, numInvoices*2)
 		ht.AssertNumPendingSweeps(carol, 1)
 
 		expectedTxes = 2*numInvoices + 1
@@ -1956,8 +1876,11 @@ func runMultiHopHtlcAggregation(ht *lntest.HarnessTest,
 		lnrpc.CommitmentType_SIMPLE_TAPROOT:
 
 		// Bob should have `numInvoices` for both HTLC success and
-		// timeout txns, plus one anchor sweep.
-		ht.AssertNumPendingSweeps(bob, numInvoices*2+1)
+		// timeout txns.
+		ht.AssertNumPendingSweeps(bob, numInvoices*2)
+
+		// Mine one block to trigger the sweep of HTLC success.
+		ht.MineEmptyBlocks(1)
 
 		// Carol should have commit and anchor outputs.
 		ht.AssertNumPendingSweeps(carol, 2)
@@ -1965,16 +1888,12 @@ func runMultiHopHtlcAggregation(ht *lntest.HarnessTest,
 		// We expect to see three sweeping txns:
 		// 1. Bob's sweeping tx for all timeout HTLCs.
 		// 2. Bob's sweeping tx for all success HTLCs.
-		// 3. Carol's sweeping tx for her commit and anchor outputs.
+		// 3. Carol's sweeping tx for her commit output.
 		expectedTxes = 3
 
 	default:
 		ht.Fatalf("unhandled commitment type %v", c)
 	}
-
-	// Mine a block to confirm Bob's anchor sweeping, which will also
-	// trigger his sweeper to sweep HTLCs.
-	ht.MineBlocksAndAssertNumTxes(1, 1)
 
 	// Assert the sweeping txns are found in the mempool.
 	txes := ht.GetNumTxsFromMempool(expectedTxes)
@@ -2044,9 +1963,6 @@ func runMultiHopHtlcAggregation(ht *lntest.HarnessTest,
 		// Assert the tx has been offered to the sweeper.
 		ht.AssertNumPendingSweeps(bob, 1)
 
-		// Mine one block to trigger the sweep.
-		ht.MineEmptyBlocks(1)
-
 		// Find the commitment sweep.
 		bobCommitSweep := ht.GetNumTxsFromMempool(1)[0]
 		ht.AssertTxSpendFrom(bobCommitSweep, closeTxid)
@@ -2074,11 +1990,11 @@ func runMultiHopHtlcAggregation(ht *lntest.HarnessTest,
 	case lnrpc.CommitmentType_LEGACY:
 		ht.MineBlocksAndAssertNumTxes(2, 1)
 
-	// Mining one additional block, Bob's second level tx is mature, and he
-	// can sweep the output. Before the blocks are mined, we should expect
-	// to see Bob's commit sweep in the mempool.
+	// Mining two additional blocks, Bob's second level tx is mature, and
+	// he can sweep the output. Before the blocks are mined, we should
+	// expect to see Bob's commit sweep in the mempool.
 	case lnrpc.CommitmentType_ANCHORS, lnrpc.CommitmentType_SIMPLE_TAPROOT:
-		ht.MineBlocksAndAssertNumTxes(1, 1)
+		ht.MineBlocksAndAssertNumTxes(2, 1)
 
 	// Since Bob is the initiator of the Bob-Carol script-enforced leased
 	// channel, he incurs an additional CLTV when sweeping outputs back to
@@ -2095,47 +2011,24 @@ func runMultiHopHtlcAggregation(ht *lntest.HarnessTest,
 		height := ht.CurrentHeight()
 		bob.AddToLogf("itest: now mine %d blocks at height %d",
 			numBlocks, height)
-		ht.MineEmptyBlocks(int(numBlocks) - 1)
+		ht.MineEmptyBlocks(int(numBlocks))
 
 	default:
 		ht.Fatalf("unhandled commitment type %v", c)
 	}
 
 	// Make sure Bob's sweeper has received all the sweeping requests.
-	ht.AssertNumPendingSweeps(bob, numInvoices*2)
-
-	// Mine one block to trigger the sweeps.
-	ht.MineEmptyBlocks(1)
-
+	//
 	// For leased channels, Bob's commit output will mature after the above
 	// block.
 	if c == lnrpc.CommitmentType_SCRIPT_ENFORCED_LEASE {
 		ht.AssertNumPendingSweeps(bob, numInvoices*2+1)
+	} else {
+		ht.AssertNumPendingSweeps(bob, numInvoices*2)
 	}
 
-	// We now wait for 30 seconds to overcome the flake - there's a block
-	// race between contractcourt and sweeper, causing the sweep to be
-	// broadcast earlier.
-	//
-	// TODO(yy): remove this once `blockbeat` is in place.
-	numExpected := 1
-	err := wait.NoError(func() error {
-		mem := ht.GetRawMempool()
-		if len(mem) == numExpected {
-			return nil
-		}
-
-		if len(mem) > 0 {
-			numExpected = len(mem)
-		}
-
-		return fmt.Errorf("want %d, got %v in mempool: %v", numExpected,
-			len(mem), mem)
-	}, wait.DefaultTimeout)
-	ht.Logf("Checking mempool got: %v", err)
-
 	// Make sure it spends from the second level tx.
-	secondLevelSweep := ht.GetNumTxsFromMempool(numExpected)[0]
+	secondLevelSweep := ht.GetNumTxsFromMempool(1)[0]
 	bobSweep := secondLevelSweep.TxHash()
 
 	// It should be sweeping all the second-level outputs.
@@ -2154,26 +2047,14 @@ func runMultiHopHtlcAggregation(ht *lntest.HarnessTest,
 		}
 	}
 
-	// TODO(yy): bring the following check back when `blockbeat` is in
-	// place - atm we may have two sweeping transactions in the mempool.
-	// require.Equal(ht, 2*numInvoices, secondLvlSpends)
+	require.Equal(ht, 2*numInvoices, secondLvlSpends)
 
 	// When we mine one additional block, that will confirm Bob's second
 	// level sweep. Now Bob should have no pending channels anymore, as
 	// this just resolved it by the confirmation of the sweep transaction.
-	block := ht.MineBlocksAndAssertNumTxes(1, numExpected)[0]
+	block := ht.MineBlocksAndAssertNumTxes(1, 1)[0]
 	ht.AssertTxInBlock(block, &bobSweep)
 
-	// For leased channels, we need to mine one more block to confirm Bob's
-	// commit output sweep.
-	//
-	// NOTE: we mine this block conditionally, as the commit output may
-	// have already been swept one block earlier due to the race in block
-	// consumption among subsystems.
-	pendingChanResp := bob.RPC.PendingChannels()
-	if len(pendingChanResp.PendingForceClosingChannels) != 0 {
-		ht.MineBlocksAndAssertNumTxes(1, 1)
-	}
 	ht.AssertNumPendingForceClose(bob, 0)
 
 	// THe channel with Alice is still open.
@@ -2333,10 +2214,9 @@ func createThreeHopNetwork(ht *lntest.HarnessTest,
 
 // testHtlcTimeoutResolverExtractPreimageRemote tests that in the multi-hop
 // setting, Alice->Bob->Carol, when Bob's outgoing HTLC is swept by Carol using
-// the 2nd level success tx2nd level success tx, Bob's timeout resolver will
-// extract the preimage from the sweep tx found in mempool or blocks(for
-// neutrino). The 2nd level success tx is broadcast by Carol and spends the
-// outpoint on her commit tx.
+// the 2nd level success tx, Bob's timeout resolver will extract the preimage
+// from the sweep tx found in mempool or blocks(for neutrino). The 2nd level
+// success tx is broadcast by Carol and spends the outpoint on her commit tx.
 func testHtlcTimeoutResolverExtractPreimageRemote(ht *lntest.HarnessTest) {
 	runMultiHopHtlcClaimTest(ht, runExtraPreimageFromRemoteCommit)
 }
@@ -2423,37 +2303,26 @@ func runExtraPreimageFromRemoteCommit(ht *lntest.HarnessTest,
 	))
 	ht.MineEmptyBlocks(int(numBlocks))
 
-	// Carol's force close transaction should now be found in the mempool.
-	// If there are anchors, we also expect Carol's contractcourt to offer
-	// the anchors to her sweeper - one from the local commitment and the
-	// other from the remote.
-	ht.AssertNumPendingSweeps(carol, 2)
+	// Carol's anchor sweep request should be found.
+	if ht.IsNeutrinoBackend() {
+		// For neutrino there's no `testmempoolaccept`, so Caro will
+		// try to publish two anchor sweeping txns.
+		ht.AssertNumPendingSweeps(carol, 2)
+	} else {
+		ht.AssertNumPendingSweeps(carol, 1)
+	}
 
-	// We now mine a block to confirm Carol's closing transaction, which
-	// will trigger her sweeper to sweep her CPFP anchor sweeping.
-	ht.MineClosingTx(bobChanPoint)
+	// We now mine a block to confirm two txns:
+	// 1. Carol's closing transaction.
+	// 2. Carol's anchor sweeping tx.
+	ht.MineBlocksAndAssertNumTxes(1, 2)
 
 	// With the closing transaction confirmed, we should expect Carol's
-	// HTLC success transaction to be offered to the sweeper along with her
-	// anchor output.
-	ht.AssertNumPendingSweeps(carol, 2)
+	// HTLC success transaction to be offered to the sweeper.
+	ht.AssertNumPendingSweeps(carol, 1)
 
-	// Mine a block to trigger the sweep, and clean up the anchor sweeping
-	// tx.
-	ht.MineBlocksAndAssertNumTxes(1, 1)
-	ht.AssertNumTxsInMempool(1)
-
-	// Restart Bob. Once he finishes syncing the channel state, he should
-	// notice the force close from Carol.
-	require.NoError(ht, restartBob())
-
-	// Get the current height to compute number of blocks to mine to
-	// trigger the htlc timeout resolver from Bob.
-	height := ht.CurrentHeight()
-
-	// We'll now mine enough blocks to trigger Bob's timeout resolver.
-	numBlocks = htlc.ExpirationHeight - height -
-		lncfg.DefaultOutgoingBroadcastDelta
+	// Mine a block to trigger the sweep.
+	ht.MineEmptyBlocks(1)
 
 	// We should now have Carol's htlc success tx in the mempool.
 	numTxesMempool := 1
@@ -2464,8 +2333,29 @@ func runExtraPreimageFromRemoteCommit(ht *lntest.HarnessTest,
 	if ht.IsNeutrinoBackend() {
 		// Mine a block to confirm Carol's 2nd level success tx.
 		ht.MineBlocksAndAssertNumTxes(1, 1)
-		numBlocks--
 	}
+
+	// Restart Bob. Once he finishes syncing the channel state, he should
+	// notice the force close from Carol.
+	require.NoError(ht, restartBob())
+
+	// Neutrino has a much slower sync when it comes to rescan the chain
+	// for a given outpoint. Thus we give an extra 10s to let it catch up.
+	//
+	// TODO(yy): improve the performance by following this log:
+	// - [DBG] BTCN: Enqueuing request for ... with birth height 531
+	if ht.IsNeutrinoBackend() {
+		time.Sleep(10 * time.Second)
+	}
+
+	// Get the current height to compute number of blocks to mine to
+	// trigger the htlc timeout resolver from Bob.
+	height := ht.CurrentHeight()
+
+	// We'll now mine enough blocks to trigger Bob's timeout resolver.
+	numBlocks = htlc.ExpirationHeight - height -
+		lncfg.DefaultOutgoingBroadcastDelta
+	ht.Logf("Mining %d blocks, current=%v", numBlocks, ht.CurrentHeight())
 
 	// Mine empty blocks so Carol's htlc success tx stays in mempool. Once
 	// the height is reached, Bob's timeout resolver will resolve the htlc
@@ -2598,16 +2488,12 @@ func runExtraPreimageFromLocalCommit(ht *lntest.HarnessTest,
 
 	// Bob force closes the channel, which gets his commitment tx into the
 	// mempool.
-	ht.CloseChannelAssertPending(bob, bobChanPoint, true)
+	_, closeTxid := ht.CloseChannelAssertPending(bob, bobChanPoint, true)
 
-	// Bob should now has offered his anchors to his sweeper - both local
-	// and remote versions.
+	// Bob should now has offered his anchor to his sweeper.
 	ht.AssertNumPendingSweeps(bob, 2)
 
-	// Mine Bob's force close tx.
-	closeTx := ht.MineClosingTx(bobChanPoint)
-
-	// Mine Bob's anchor sweeping tx.
+	// Mine Bob's force close tx and anchor sweeping tx.
 	ht.MineBlocksAndAssertNumTxes(1, 1)
 	blocksMined := 1
 
@@ -2658,7 +2544,7 @@ func runExtraPreimageFromLocalCommit(ht *lntest.HarnessTest,
 
 	// Construct the htlc output on Bob's commitment tx, and decide its
 	// index based on the commit type below.
-	htlcOutpoint := wire.OutPoint{Hash: closeTx.TxHash()}
+	htlcOutpoint := wire.OutPoint{Hash: *closeTxid}
 
 	// Check the current mempool state and we should see,
 	// - Carol's direct spend tx.
@@ -2678,14 +2564,10 @@ func runExtraPreimageFromLocalCommit(ht *lntest.HarnessTest,
 		ht.AssertNumTxsInMempool(1)
 	}
 
-	// Get the current height to compute number of blocks to mine to
-	// trigger the timeout resolver from Bob.
-	height := ht.CurrentHeight()
-
 	// We'll now mine enough blocks to trigger Bob's htlc timeout resolver
 	// to act. Once his timeout resolver starts, it will extract the
 	// preimage from Carol's direct spend tx found in the mempool.
-	numBlocks = htlc.ExpirationHeight - height -
+	numBlocks = htlc.ExpirationHeight - ht.CurrentHeight() -
 		lncfg.DefaultOutgoingBroadcastDelta
 
 	// Decrease the fee rate used by the sweeper so Bob's timeout tx will

--- a/itest/lnd_route_blinding_test.go
+++ b/itest/lnd_route_blinding_test.go
@@ -1029,10 +1029,13 @@ func testErrorHandlingOnChainFailure(ht *lntest.HarnessTest) {
 	ht.AssertNumPendingSweeps(ht.Bob, 0)
 	ht.MineBlocksAndAssertNumTxes(1, 1)
 
-	// Assert that the HTLC has cleared.
-	ht.WaitForBlockchainSync(ht.Bob)
-	ht.WaitForBlockchainSync(ht.Alice)
+	// Clean up the rest of our force close: mine blocks so that Bob's CSV
+	// expires plus one block to trigger his sweep and then mine it.
+	ht.MineBlocks(node.DefaultCSV - 1)
+	ht.AssertNumPendingSweeps(ht.Bob, 1)
+	ht.MineBlocksAndAssertNumTxes(1, 1)
 
+	// Assert that the HTLC has cleared.
 	ht.AssertHTLCNotActive(ht.Bob, testCase.channels[0], hash[:])
 	ht.AssertHTLCNotActive(ht.Alice, testCase.channels[0], hash[:])
 
@@ -1045,11 +1048,6 @@ func testErrorHandlingOnChainFailure(ht *lntest.HarnessTest) {
 		ht, htlcs[0].Failure.Code,
 		lnrpc.Failure_INVALID_ONION_BLINDING,
 	)
-
-	// Clean up the rest of our force close: mine blocks so that Bob's CSV
-	// expires plus one block to trigger his sweep and then mine it.
-	ht.MineBlocks(node.DefaultCSV + 1)
-	ht.MineBlocksAndAssertNumTxes(1, 1)
 
 	// Bring carol back up so that we can close out the rest of our
 	// channels cooperatively. She requires an interceptor to start up

--- a/itest/lnd_sweep_test.go
+++ b/itest/lnd_sweep_test.go
@@ -2,7 +2,6 @@ package itest
 
 import (
 	"fmt"
-	"math"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -61,10 +60,7 @@ func testSweepCPFPAnchorOutgoingTimeout(ht *lntest.HarnessTest) {
 
 	// Set up the fee estimator to return the testing fee rate when the
 	// conf target is the deadline.
-	//
-	// TODO(yy): switch to conf when `blockbeat` is in place.
-	// ht.SetFeeEstimateWithConf(startFeeRateAnchor, deadlineDeltaAnchor)
-	ht.SetFeeEstimate(startFeeRateAnchor)
+	ht.SetFeeEstimateWithConf(startFeeRateAnchor, deadlineDeltaAnchor)
 
 	// htlcValue is the outgoing HTLC's value.
 	htlcValue := invoiceAmt
@@ -167,52 +163,26 @@ func testSweepCPFPAnchorOutgoingTimeout(ht *lntest.HarnessTest) {
 	))
 	ht.MineEmptyBlocks(int(numBlocks))
 
-	// Assert Bob's force closing tx has been broadcast.
-	closeTxid := ht.AssertNumTxsInMempool(1)[0]
+	// Assert Bob's force closing tx has been broadcast. We should see two
+	// txns in the mempool:
+	// 1. Bob's force closing tx.
+	// 2. Bob's anchor sweeping tx CPFPing the force close tx.
+	_, sweepTx := ht.AssertForceCloseAndAnchorTxnsInMempool()
 
 	// Remember the force close height so we can calculate the deadline
 	// height.
 	forceCloseHeight := ht.CurrentHeight()
 
-	// Bob should have two pending sweeps,
+	// Bob should have one pending sweep,
 	// - anchor sweeping from his local commitment.
-	// - anchor sweeping from his remote commitment (invalid).
-	//
-	// TODO(yy): consider only sweeping the anchor from the local
-	// commitment. Previously we would sweep up to three versions of
-	// anchors because we don't know which one will be confirmed - if we
-	// only broadcast the local anchor sweeping, our peer can broadcast
-	// their commitment tx and replaces ours. With the new fee bumping, we
-	// should be safe to only sweep our local anchor since we RBF it on
-	// every new block, which destroys the remote's ability to pin us.
-	sweeps := ht.AssertNumPendingSweeps(bob, 2)
+	anchorSweep := ht.AssertNumPendingSweeps(bob, 1)[0]
 
-	// The two anchor sweeping should have the same deadline height.
+	// The anchor sweeping should have the expected deadline height.
 	deadlineHeight := forceCloseHeight + deadlineDeltaAnchor
-	require.Equal(ht, deadlineHeight, sweeps[0].DeadlineHeight)
-	require.Equal(ht, deadlineHeight, sweeps[1].DeadlineHeight)
+	require.Equal(ht, deadlineHeight, anchorSweep.DeadlineHeight)
 
 	// Remember the deadline height for the CPFP anchor.
-	anchorDeadline := sweeps[0].DeadlineHeight
-
-	// Mine a block so Bob's force closing tx stays in the mempool, which
-	// also triggers the CPFP anchor sweep.
-	ht.MineEmptyBlocks(1)
-
-	// Bob should still have two pending sweeps,
-	// - anchor sweeping from his local commitment.
-	// - anchor sweeping from his remote commitment (invalid).
-	ht.AssertNumPendingSweeps(bob, 2)
-
-	// We now check the expected fee and fee rate are used for Bob's anchor
-	// sweeping tx.
-	//
-	// We should see Bob's anchor sweeping tx triggered by the above
-	// block, along with his force close tx.
-	txns := ht.GetNumTxsFromMempool(2)
-
-	// Find the sweeping tx.
-	sweepTx := ht.FindSweepingTxns(txns, 1, *closeTxid)[0]
+	anchorDeadline := anchorSweep.DeadlineHeight
 
 	// Get the weight for Bob's anchor sweeping tx.
 	txWeight := ht.CalculateTxWeight(sweepTx)
@@ -224,11 +194,10 @@ func testSweepCPFPAnchorOutgoingTimeout(ht *lntest.HarnessTest) {
 	fee := uint64(ht.CalculateTxFee(sweepTx))
 	feeRate := uint64(ht.CalculateTxFeeRate(sweepTx))
 
-	// feeFuncWidth is the width of the fee function. By the time we got
-	// here, we've already mined one block, and the fee function maxes
-	// out one block before the deadline, so the width is the original
-	// deadline minus 2.
-	feeFuncWidth := deadlineDeltaAnchor - 2
+	// feeFuncWidth is the width of the fee function. The fee function
+	// maxes out one block before the deadline, so the width is the
+	// original deadline minus 1.
+	feeFuncWidth := deadlineDeltaAnchor - 1
 
 	// Calculate the expected delta increased per block.
 	feeDelta := (cpfpBudget - startFeeAnchor).MulF64(
@@ -254,19 +223,26 @@ func testSweepCPFPAnchorOutgoingTimeout(ht *lntest.HarnessTest) {
 		// Bob's fee bumper should increase its fees.
 		ht.MineEmptyBlocks(1)
 
-		// Bob should still have two pending sweeps,
-		// - anchor sweeping from his local commitment.
-		// - anchor sweeping from his remote commitment (invalid).
-		ht.AssertNumPendingSweeps(bob, 2)
-
-		// Make sure Bob's old sweeping tx has been removed from the
-		// mempool.
-		ht.AssertTxNotInMempool(sweepTx.TxHash())
+		// Bob should still have the anchor sweeping from his local
+		// commitment. His anchor sweeping from his remote commitment
+		// is invalid and should be removed.
+		ht.AssertNumPendingSweeps(bob, 1)
 
 		// We expect to see two txns in the mempool,
 		// - Bob's force close tx.
 		// - Bob's anchor sweep tx.
 		ht.AssertNumTxsInMempool(2)
+
+		// Make sure Bob's old sweeping tx has been removed from the
+		// mempool.
+		ht.AssertTxNotInMempool(sweepTx.TxHash())
+
+		// Assert the two txns are still in the mempool and grab the
+		// sweeping tx.
+		//
+		// NOTE: must call it again after `AssertTxNotInMempool` to
+		// make sure we get the replaced tx.
+		_, sweepTx = ht.AssertForceCloseAndAnchorTxnsInMempool()
 
 		// We expect the fees to increase by i*delta.
 		expectedFee := startFeeAnchor + feeDelta.MulF64(float64(i))
@@ -276,11 +252,7 @@ func testSweepCPFPAnchorOutgoingTimeout(ht *lntest.HarnessTest) {
 
 		// We should see Bob's anchor sweeping tx being fee bumped
 		// since it's not confirmed, along with his force close tx.
-		txns = ht.GetNumTxsFromMempool(2)
-
-		// Find the sweeping tx.
-		sweepTx = ht.FindSweepingTxns(txns, 1, *closeTxid)[0]
-
+		//
 		// Calculate the fee rate of Bob's new sweeping tx.
 		feeRate = uint64(ht.CalculateTxFeeRate(sweepTx))
 
@@ -288,9 +260,9 @@ func testSweepCPFPAnchorOutgoingTimeout(ht *lntest.HarnessTest) {
 		fee = uint64(ht.CalculateTxFee(sweepTx))
 
 		ht.Logf("Bob(position=%v): txWeight=%v, expected: [fee=%d, "+
-			"feerate=%v], got: [fee=%v, feerate=%v]",
+			"feerate=%v], got: [fee=%v, feerate=%v] in tx %v",
 			feeFuncWidth-i, txWeight, expectedFee,
-			expectedFeeRate, fee, feeRate)
+			expectedFeeRate, fee, feeRate, sweepTx.TxHash())
 
 		// Assert Bob's tx has the expected fee and fee rate.
 		require.InEpsilonf(ht, uint64(expectedFee), fee, 0.01,
@@ -310,22 +282,23 @@ func testSweepCPFPAnchorOutgoingTimeout(ht *lntest.HarnessTest) {
 	// Mine one more block, we'd use up all the CPFP budget.
 	ht.MineEmptyBlocks(1)
 
+	// We expect to see two txns in the mempool,
+	// - Bob's force close tx.
+	// - Bob's anchor sweep tx.
+	ht.AssertNumTxsInMempool(2)
+
 	// Make sure Bob's old sweeping tx has been removed from the mempool.
 	ht.AssertTxNotInMempool(sweepTx.TxHash())
 
 	// Get the last sweeping tx - we should see two txns here, Bob's anchor
 	// sweeping tx and his force close tx.
-	txns = ht.GetNumTxsFromMempool(2)
+	//
+	// NOTE: must call it again after `AssertTxNotInMempool` to make sure
+	// we get the replaced tx.
+	_, sweepTx = ht.AssertForceCloseAndAnchorTxnsInMempool()
 
-	// Find the sweeping tx.
-	sweepTx = ht.FindSweepingTxns(txns, 1, *closeTxid)[0]
-
-	// Calculate the fee of Bob's new sweeping tx.
-	fee = uint64(ht.CalculateTxFee(sweepTx))
-
-	// Assert the budget is now used up.
-	require.InEpsilonf(ht, uint64(cpfpBudget), fee, 0.01, "want %d, got %d",
-		cpfpBudget, fee)
+	// Bob should have the anchor sweeping from his local commitment.
+	ht.AssertNumPendingSweeps(bob, 1)
 
 	// Mine one more block. Since Bob's budget has been used up, there
 	// won't be any more sweeping attempts. We now assert this by checking
@@ -336,10 +309,7 @@ func testSweepCPFPAnchorOutgoingTimeout(ht *lntest.HarnessTest) {
 	//
 	// We expect two txns here, one for the anchor sweeping, the other for
 	// the force close tx.
-	txns = ht.GetNumTxsFromMempool(2)
-
-	// Find the sweeping tx.
-	currentSweepTx := ht.FindSweepingTxns(txns, 1, *closeTxid)[0]
+	_, currentSweepTx := ht.AssertForceCloseAndAnchorTxnsInMempool()
 
 	// Assert the anchor sweep tx stays unchanged.
 	require.Equal(ht, sweepTx.TxHash(), currentSweepTx.TxHash())
@@ -353,6 +323,7 @@ func testSweepCPFPAnchorOutgoingTimeout(ht *lntest.HarnessTest) {
 	// the HTLC sweeping behaviors so we just perform a simple check and
 	// exit the test.
 	ht.AssertNumPendingSweeps(bob, 1)
+	ht.MineBlocksAndAssertNumTxes(1, 1)
 
 	// Finally, clean the mempool for the next test.
 	ht.CleanShutDown()
@@ -400,10 +371,7 @@ func testSweepCPFPAnchorIncomingTimeout(ht *lntest.HarnessTest) {
 
 	// Set up the fee estimator to return the testing fee rate when the
 	// conf target is the deadline.
-	//
-	// TODO(yy): switch to conf when `blockbeat` is in place.
-	// ht.SetFeeEstimateWithConf(startFeeRateAnchor, deadlineDeltaAnchor)
-	ht.SetFeeEstimate(startFeeRateAnchor)
+	ht.SetFeeEstimateWithConf(startFeeRateAnchor, deadlineDeltaAnchor)
 
 	// Create a preimage, that will be held by Carol.
 	var preimage lntypes.Preimage
@@ -516,40 +484,22 @@ func testSweepCPFPAnchorIncomingTimeout(ht *lntest.HarnessTest) {
 	numBlocks := forceCloseHeight - currentHeight
 	ht.MineEmptyBlocks(int(numBlocks))
 
-	// Assert Bob's force closing tx has been broadcast.
-	closeTxid := ht.AssertNumTxsInMempool(1)[0]
+	// Assert Bob's force closing tx has been broadcast. We should see two
+	// txns in the mempool:
+	// 1. Bob's force closing tx.
+	// 2. Bob's anchor sweeping tx CPFPing the force close tx.
+	_, sweepTx := ht.AssertForceCloseAndAnchorTxnsInMempool()
 
-	// Bob should have two pending sweeps,
+	// Bob should have one pending sweep,
 	// - anchor sweeping from his local commitment.
-	// - anchor sweeping from his remote commitment (invalid).
-	sweeps := ht.AssertNumPendingSweeps(bob, 2)
+	anchorSweep := ht.AssertNumPendingSweeps(bob, 1)[0]
 
-	// The two anchor sweeping should have the same deadline height.
+	// The anchor sweeping should have the expected deadline height.
 	deadlineHeight := forceCloseHeight + deadlineDeltaAnchor
-	require.Equal(ht, deadlineHeight, sweeps[0].DeadlineHeight)
-	require.Equal(ht, deadlineHeight, sweeps[1].DeadlineHeight)
+	require.Equal(ht, deadlineHeight, anchorSweep.DeadlineHeight)
 
 	// Remember the deadline height for the CPFP anchor.
-	anchorDeadline := sweeps[0].DeadlineHeight
-
-	// Mine a block so Bob's force closing tx stays in the mempool, which
-	// also triggers the CPFP anchor sweep.
-	ht.MineEmptyBlocks(1)
-
-	// Bob should still have two pending sweeps,
-	// - anchor sweeping from his local commitment.
-	// - anchor sweeping from his remote commitment (invalid).
-	ht.AssertNumPendingSweeps(bob, 2)
-
-	// We now check the expected fee and fee rate are used for Bob's anchor
-	// sweeping tx.
-	//
-	// We should see Bob's anchor sweeping tx triggered by the above
-	// block, along with his force close tx.
-	txns := ht.GetNumTxsFromMempool(2)
-
-	// Find the sweeping tx.
-	sweepTx := ht.FindSweepingTxns(txns, 1, *closeTxid)[0]
+	anchorDeadline := anchorSweep.DeadlineHeight
 
 	// Get the weight for Bob's anchor sweeping tx.
 	txWeight := ht.CalculateTxWeight(sweepTx)
@@ -561,11 +511,10 @@ func testSweepCPFPAnchorIncomingTimeout(ht *lntest.HarnessTest) {
 	fee := uint64(ht.CalculateTxFee(sweepTx))
 	feeRate := uint64(ht.CalculateTxFeeRate(sweepTx))
 
-	// feeFuncWidth is the width of the fee function. By the time we got
-	// here, we've already mined one block, and the fee function maxes
-	// out one block before the deadline, so the width is the original
-	// deadline minus 2.
-	feeFuncWidth := deadlineDeltaAnchor - 2
+	// feeFuncWidth is the width of the fee function. The fee function
+	// maxes out one block before the deadline, so the width is the
+	// original deadline minus 1.
+	feeFuncWidth := deadlineDeltaAnchor - 1
 
 	// Calculate the expected delta increased per block.
 	feeDelta := (cpfpBudget - startFeeAnchor).MulF64(
@@ -591,10 +540,15 @@ func testSweepCPFPAnchorIncomingTimeout(ht *lntest.HarnessTest) {
 		// Bob's fee bumper should increase its fees.
 		ht.MineEmptyBlocks(1)
 
-		// Bob should still have two pending sweeps,
-		// - anchor sweeping from his local commitment.
-		// - anchor sweeping from his remote commitment (invalid).
-		ht.AssertNumPendingSweeps(bob, 2)
+		// Bob should still have the anchor sweeping from his local
+		// commitment. His anchor sweeping from his remote commitment
+		// is invalid and should be removed.
+		ht.AssertNumPendingSweeps(bob, 1)
+
+		// We expect to see two txns in the mempool,
+		// - Bob's force close tx.
+		// - Bob's anchor sweep tx.
+		ht.AssertNumTxsInMempool(2)
 
 		// Make sure Bob's old sweeping tx has been removed from the
 		// mempool.
@@ -603,20 +557,13 @@ func testSweepCPFPAnchorIncomingTimeout(ht *lntest.HarnessTest) {
 		// We expect to see two txns in the mempool,
 		// - Bob's force close tx.
 		// - Bob's anchor sweep tx.
-		ht.AssertNumTxsInMempool(2)
+		_, sweepTx = ht.AssertForceCloseAndAnchorTxnsInMempool()
 
 		// We expect the fees to increase by i*delta.
 		expectedFee := startFeeAnchor + feeDelta.MulF64(float64(i))
 		expectedFeeRate := chainfee.NewSatPerKWeight(
 			expectedFee, txWeight,
 		)
-
-		// We should see Bob's anchor sweeping tx being fee bumped
-		// since it's not confirmed, along with his force close tx.
-		txns = ht.GetNumTxsFromMempool(2)
-
-		// Find the sweeping tx.
-		sweepTx = ht.FindSweepingTxns(txns, 1, *closeTxid)[0]
 
 		// Calculate the fee rate of Bob's new sweeping tx.
 		feeRate = uint64(ht.CalculateTxFeeRate(sweepTx))
@@ -625,9 +572,9 @@ func testSweepCPFPAnchorIncomingTimeout(ht *lntest.HarnessTest) {
 		fee = uint64(ht.CalculateTxFee(sweepTx))
 
 		ht.Logf("Bob(position=%v): txWeight=%v, expected: [fee=%d, "+
-			"feerate=%v], got: [fee=%v, feerate=%v]",
+			"feerate=%v], got: [fee=%v, feerate=%v] in tx %v",
 			feeFuncWidth-i, txWeight, expectedFee,
-			expectedFeeRate, fee, feeRate)
+			expectedFeeRate, fee, feeRate, sweepTx.TxHash())
 
 		// Assert Bob's tx has the expected fee and fee rate.
 		require.InEpsilonf(ht, uint64(expectedFee), fee, 0.01,
@@ -647,15 +594,17 @@ func testSweepCPFPAnchorIncomingTimeout(ht *lntest.HarnessTest) {
 	// Mine one more block, we'd use up all the CPFP budget.
 	ht.MineEmptyBlocks(1)
 
+	// We expect to see two txns in the mempool,
+	// - Bob's force close tx.
+	// - Bob's anchor sweep tx.
+	ht.AssertNumTxsInMempool(2)
+
 	// Make sure Bob's old sweeping tx has been removed from the mempool.
 	ht.AssertTxNotInMempool(sweepTx.TxHash())
 
 	// Get the last sweeping tx - we should see two txns here, Bob's anchor
 	// sweeping tx and his force close tx.
-	txns = ht.GetNumTxsFromMempool(2)
-
-	// Find the sweeping tx.
-	sweepTx = ht.FindSweepingTxns(txns, 1, *closeTxid)[0]
+	_, sweepTx = ht.AssertForceCloseAndAnchorTxnsInMempool()
 
 	// Calculate the fee of Bob's new sweeping tx.
 	fee = uint64(ht.CalculateTxFee(sweepTx))
@@ -673,10 +622,7 @@ func testSweepCPFPAnchorIncomingTimeout(ht *lntest.HarnessTest) {
 	//
 	// We expect two txns here, one for the anchor sweeping, the other for
 	// the force close tx.
-	txns = ht.GetNumTxsFromMempool(2)
-
-	// Find the sweeping tx.
-	currentSweepTx := ht.FindSweepingTxns(txns, 1, *closeTxid)[0]
+	_, currentSweepTx := ht.AssertForceCloseAndAnchorTxnsInMempool()
 
 	// Assert the anchor sweep tx stays unchanged.
 	require.Equal(ht, sweepTx.TxHash(), currentSweepTx.TxHash())
@@ -690,6 +636,7 @@ func testSweepCPFPAnchorIncomingTimeout(ht *lntest.HarnessTest) {
 	// the HTLC sweeping behaviors so we just perform a simple check and
 	// exit the test.
 	ht.AssertNumPendingSweeps(bob, 1)
+	ht.MineBlocksAndAssertNumTxes(1, 1)
 
 	// Finally, clean the mempool for the next test.
 	ht.CleanShutDown()
@@ -727,9 +674,9 @@ func testSweepHTLCs(ht *lntest.HarnessTest) {
 	cltvDelta := routing.MinCLTVDelta
 
 	// Start tracking the deadline delta of Bob's HTLCs. We need one block
-	// for the CSV lock, and another block to trigger the sweeper to sweep.
-	outgoingHTLCDeadline := int32(cltvDelta - 2)
-	incomingHTLCDeadline := int32(lncfg.DefaultIncomingBroadcastDelta - 2)
+	// to trigger the sweeper to sweep.
+	outgoingHTLCDeadline := int32(cltvDelta - 1)
+	incomingHTLCDeadline := int32(lncfg.DefaultIncomingBroadcastDelta - 1)
 
 	// startFeeRate1 and startFeeRate2 are returned by the fee estimator in
 	// sat/kw. They will be used as the starting fee rate for the linear
@@ -884,34 +831,35 @@ func testSweepHTLCs(ht *lntest.HarnessTest) {
 
 	// Bob should now have two pending sweeps, one for the anchor on the
 	// local commitment, the other on the remote commitment.
-	ht.AssertNumPendingSweeps(bob, 2)
+	expectedNumSweeps := 1
 
-	// Assert Bob's force closing tx has been broadcast.
-	ht.AssertNumTxsInMempool(1)
+	// For neutrino backend, we expect the anchor output from his remote
+	// commitment to be present.
+	if ht.IsNeutrinoBackend() {
+		expectedNumSweeps = 2
+	}
 
-	// Mine the force close tx, which triggers Bob's contractcourt to offer
-	// his outgoing HTLC to his sweeper.
+	ht.AssertNumPendingSweeps(bob, expectedNumSweeps)
+
+	// We expect to see two txns in the mempool:
+	// 1. Bob's force closing tx.
+	// 2. Bob's anchor CPFP sweeping tx.
+	ht.AssertNumTxsInMempool(2)
+
+	// Mine the force close tx and CPFP sweeping tx, which triggers Bob's
+	// contractcourt to offer his outgoing HTLC to his sweeper.
 	//
 	// NOTE: HTLC outputs are only offered to sweeper when the force close
 	// tx is confirmed and the CSV has reached.
-	ht.MineBlocksAndAssertNumTxes(1, 1)
+	ht.MineBlocksAndAssertNumTxes(1, 2)
 
 	// Update the blocks left till Bob force closes Alice->Bob.
 	blocksTillIncomingSweep--
 
-	// Bob should have two pending sweeps, one for the anchor sweeping, the
-	// other for the outgoing HTLC.
-	ht.AssertNumPendingSweeps(bob, 2)
-
-	// Mine one block to confirm Bob's anchor sweeping tx, which will
-	// trigger his sweeper to publish the HTLC sweeping tx.
-	ht.MineBlocksAndAssertNumTxes(1, 1)
-
-	// Update the blocks left till Bob force closes Alice->Bob.
-	blocksTillIncomingSweep--
-
-	// Bob should now have one sweep and one sweeping tx in the mempool.
+	// Bob should have one pending sweep for the outgoing HTLC.
 	ht.AssertNumPendingSweeps(bob, 1)
+
+	// Bob should have one sweeping tx in the mempool.
 	outgoingSweep := ht.GetNumTxsFromMempool(1)[0]
 
 	// Check the shape of the sweeping tx - we expect it to be
@@ -935,8 +883,8 @@ func testSweepHTLCs(ht *lntest.HarnessTest) {
 	// Assert the initial sweeping tx is using the start fee rate.
 	outgoingStartFeeRate := ht.CalculateTxFeeRate(outgoingSweep)
 	require.InEpsilonf(ht, uint64(startFeeRate1),
-		uint64(outgoingStartFeeRate), 0.01, "want %d, got %d",
-		startFeeRate1, outgoingStartFeeRate)
+		uint64(outgoingStartFeeRate), 0.01, "want %d, got %d in tx=%v",
+		startFeeRate1, outgoingStartFeeRate, outgoingSweep.TxHash())
 
 	// Now the start fee rate is checked, we can calculate the fee rate
 	// delta.
@@ -961,13 +909,12 @@ func testSweepHTLCs(ht *lntest.HarnessTest) {
 		)
 
 		ht.Logf("Bob's %s HTLC (deadline=%v): txWeight=%v, want "+
-			"feerate=%v, got feerate=%v, delta=%v", desc,
+			"feerate=%v, got feerate=%v, delta=%v in tx %v", desc,
 			deadline-position, txSize, expectedFeeRate,
-			feeRate, delta)
+			feeRate, delta, sweepTx.TxHash())
 
 		require.InEpsilonf(ht, uint64(expectedFeeRate), uint64(feeRate),
-			0.01, "want %v, got %v in tx=%v", expectedFeeRate,
-			feeRate, sweepTx.TxHash())
+			0.01, "want %v, got %v", expectedFeeRate, feeRate)
 	}
 
 	// We now mine enough blocks to trigger Bob to force close channel
@@ -1009,21 +956,32 @@ func testSweepHTLCs(ht *lntest.HarnessTest) {
 	// Update Bob's fee function position.
 	outgoingFuncPosition++
 
-	// Bob should now have three pending sweeps:
+	// Bob should now have two pending sweeps:
 	// 1. the outgoing HTLC output.
 	// 2. the anchor output from his local commitment.
-	// 3. the anchor output from his remote commitment.
-	ht.AssertNumPendingSweeps(bob, 3)
+	expectedNumSweeps = 2
 
-	// We should see two txns in the mempool:
+	// For neutrino backend, we expect the anchor output from his remote
+	// commitment to be present.
+	if ht.IsNeutrinoBackend() {
+		expectedNumSweeps = 3
+	}
+
+	ht.AssertNumPendingSweeps(bob, expectedNumSweeps)
+
+	// We should see three txns in the mempool:
 	// 1. Bob's outgoing HTLC sweeping tx.
 	// 2. Bob's force close tx for Alice->Bob.
-	txns := ht.GetNumTxsFromMempool(2)
+	// 3. Bob's anchor CPFP sweeping tx for Alice->Bob.
+	txns := ht.GetNumTxsFromMempool(3)
 
 	// Find the force close tx - we expect it to have a single input.
 	closeTx := txns[0]
 	if len(closeTx.TxIn) != 1 {
 		closeTx = txns[1]
+	}
+	if len(closeTx.TxIn) != 1 {
+		closeTx = txns[2]
 	}
 
 	// We don't care the behavior of the anchor sweep in this test, so we
@@ -1039,13 +997,6 @@ func testSweepHTLCs(ht *lntest.HarnessTest) {
 	// 2. the incoming HTLC output on Alice->Bob.
 	// 3. the anchor sweeping on Alice-> Bob.
 	ht.AssertNumPendingSweeps(bob, 3)
-
-	// Mine one block, which will trigger his sweeper to publish his
-	// incoming HTLC sweeping tx.
-	ht.MineEmptyBlocks(1)
-
-	// Update the fee function's positions.
-	outgoingFuncPosition++
 
 	// We should see three txns in the mempool:
 	// 1. the outgoing HTLC sweeping tx.
@@ -1214,8 +1165,9 @@ func testSweepHTLCs(ht *lntest.HarnessTest) {
 // Test:
 //  1. Alice's anchor sweeping is not attempted, instead, it should be swept
 //     together with her to_local output using the no deadline path.
-//  2. Bob would also sweep his anchor and to_local outputs in a single
-//     sweeping tx using the no deadline path.
+//  2. Bob would also sweep his anchor and to_local outputs separately due to
+//     they have different deadline heights, which means only the to_local
+//     sweeping tx will succeed as the anchor sweeping is not economical.
 //  3. Both Alice and Bob's RBF attempts are using the fee rates calculated
 //     from the deadline and budget.
 //  4. Wallet UTXOs requirements are met - neither Alice nor Bob needs wallet
@@ -1228,10 +1180,19 @@ func testSweepCommitOutputAndAnchor(ht *lntest.HarnessTest) {
 	// config.
 	deadline := uint32(1000)
 
-	// The actual deadline used by the fee function will be one block off
-	// from the deadline configured as we require one block to be mined to
-	// trigger the sweep.
-	deadlineA, deadlineB := deadline-1, deadline-1
+	// For Alice, since her commit output is offered to the sweeper at
+	// CSV-1. With a deadline of 1000, her actual width of her fee func is
+	// CSV+1000-1.
+	deadlineA := deadline + 1
+
+	// For Bob, the actual deadline used by the fee function will be one
+	// block off from the deadline configured as we require one block to be
+	// mined to trigger the sweep. In addition, when sweeping his to_local
+	// output from Alice's commit tx, because of CSV of 2, the starting
+	// height will be "force_close_height+2", which means when the sweep
+	// request is received by the sweeper, the actual deadline delta is
+	// "deadline+1".
+	deadlineB := deadline + 1
 
 	// startFeeRate is returned by the fee estimator in sat/kw. This
 	// will be used as the starting fee rate for the linear fee func used
@@ -1242,7 +1203,7 @@ func testSweepCommitOutputAndAnchor(ht *lntest.HarnessTest) {
 
 	// Set up the fee estimator to return the testing fee rate when the
 	// conf target is the deadline.
-	ht.SetFeeEstimateWithConf(startFeeRate, deadlineA)
+	ht.SetFeeEstimateWithConf(startFeeRate, deadlineB)
 
 	// toLocalCSV is the CSV delay for Alice's to_local output. We use a
 	// small value to save us from mining blocks.
@@ -1250,25 +1211,7 @@ func testSweepCommitOutputAndAnchor(ht *lntest.HarnessTest) {
 	// NOTE: once the force close tx is confirmed, we expect anchor
 	// sweeping starts. Then two more block later the commit output
 	// sweeping starts.
-	//
-	// NOTE: The CSV value is chosen to be 3 instead of 2, to reduce the
-	// possibility of flakes as there is a race between the two goroutines:
-	// G1 - Alice's sweeper receives the commit output.
-	// G2 - Alice's sweeper receives the new block mined.
-	// G1 is triggered by the same block being received by Alice's
-	// contractcourt, deciding the commit output is mature and offering it
-	// to her sweeper. Normally, we'd expect G2 to be finished before G1
-	// because it's the same block processed by both contractcourt and
-	// sweeper. However, if G2 is delayed (maybe the sweeper is slow in
-	// finishing its previous round), G1 may finish before G2. This will
-	// cause the sweeper to add the commit output to its pending inputs,
-	// and once G2 fires, it will then start sweeping this output,
-	// resulting a valid sweep tx being created using her commit and anchor
-	// outputs.
-	//
-	// TODO(yy): fix the above issue by making sure subsystems share the
-	// same view on current block height.
-	toLocalCSV := 3
+	toLocalCSV := 2
 
 	// htlcAmt is the amount of the HTLC in sats, this should be Alice's
 	// to_remote amount that goes to Bob.
@@ -1361,155 +1304,41 @@ func testSweepCommitOutputAndAnchor(ht *lntest.HarnessTest) {
 	// - commit sweeping from the to_remote on Alice's commit tx.
 	ht.AssertNumPendingSweeps(bob, 2)
 
-	// Mine one more empty block should trigger Bob's sweeping. Since we
-	// use a CSV of 3, this means Alice's to_local output is one block away
-	// from being mature.
-	ht.MineEmptyBlocks(1)
+	// Bob's sweeper should have broadcast the commit output sweeping tx.
+	// At the block which mined the force close tx, Bob's `chainWatcher`
+	// will process the blockbeat first, which sends a signal to his
+	// `ChainArbitrator` to launch the resolvers. Once launched, the sweep
+	// requests will be sent to the sweeper. Finally, when the sweeper
+	// receives this blockbeat, it will create the sweeping tx and publish
+	// it.
+	ht.AssertNumTxsInMempool(1)
 
-	// We expect to see one sweeping tx in the mempool:
-	// - Alice's anchor sweeping tx must have been failed due to the fee
-	//   rate chosen in this test - the anchor sweep tx has no output.
-	// - Bob's sweeping tx, which sweeps both his anchor and commit outputs.
-	bobSweepTx := ht.GetNumTxsFromMempool(1)[0]
+	// Mine one more empty block should trigger Bob's sweeping. Since we
+	// use a CSV of 2, this means Alice's to_local output is now mature.
+	ht.MineEmptyBlocks(1)
 
 	// We expect two pending sweeps for Bob - anchor and commit outputs.
-	pendingSweepBob := ht.AssertNumPendingSweeps(bob, 2)[0]
+	ht.AssertNumPendingSweeps(bob, 2)
 
-	// The sweeper may be one block behind contractcourt, so we double
-	// check the actual deadline.
-	//
-	// TODO(yy): assert they are equal once blocks are synced via
-	// `blockbeat`.
-	currentHeight := int32(ht.CurrentHeight())
-	actualDeadline := int32(pendingSweepBob.DeadlineHeight) - currentHeight
-	if actualDeadline != int32(deadlineB) {
-		ht.Logf("!!! Found unsynced block between sweeper and "+
-			"contractcourt, expected deadline=%v, got=%v",
-			deadlineB, actualDeadline)
-
-		deadlineB = uint32(actualDeadline)
-	}
-
-	// Alice should still have one pending sweep - the anchor output.
-	ht.AssertNumPendingSweeps(alice, 1)
-
-	// We now check Bob's sweeping tx.
-	//
-	// Bob's sweeping tx should have 2 inputs, one from his commit output,
-	// the other from his anchor output.
-	require.Len(ht, bobSweepTx.TxIn, 2)
-
-	// Because Bob is sweeping without deadline pressure, the starting fee
-	// rate should be the min relay fee rate.
-	bobStartFeeRate := ht.CalculateTxFeeRate(bobSweepTx)
-	require.InEpsilonf(ht, uint64(chainfee.FeePerKwFloor),
-		uint64(bobStartFeeRate), 0.01, "want %v, got %v",
-		chainfee.FeePerKwFloor, bobStartFeeRate)
-
-	// With Bob's starting fee rate being validated, we now calculate his
-	// ending fee rate and fee rate delta.
-	//
-	// Bob sweeps two inputs - anchor and commit, so the starting budget
-	// should come from the sum of these two.
-	bobValue := btcutil.Amount(bobToLocal + 330)
-	bobBudget := bobValue.MulF64(contractcourt.DefaultBudgetRatio)
-
-	// Calculate the ending fee rate and fee rate delta used in his fee
-	// function.
-	bobTxWeight := ht.CalculateTxWeight(bobSweepTx)
-	bobEndingFeeRate := chainfee.NewSatPerKWeight(bobBudget, bobTxWeight)
-	bobFeeRateDelta := (bobEndingFeeRate - bobStartFeeRate) /
-		chainfee.SatPerKWeight(deadlineB-1)
-
-	// Mine an empty block, which should trigger Alice's contractcourt to
-	// offer her commit output to the sweeper.
-	ht.MineEmptyBlocks(1)
-
-	// Alice should have both anchor and commit as the pending sweep
-	// requests.
-	aliceSweeps := ht.AssertNumPendingSweeps(alice, 2)
-	aliceAnchor, aliceCommit := aliceSweeps[0], aliceSweeps[1]
-	if aliceAnchor.AmountSat > aliceCommit.AmountSat {
-		aliceAnchor, aliceCommit = aliceCommit, aliceAnchor
-	}
-
-	// The sweeper may be one block behind contractcourt, so we double
-	// check the actual deadline.
-	//
-	// TODO(yy): assert they are equal once blocks are synced via
-	// `blockbeat`.
-	currentHeight = int32(ht.CurrentHeight())
-	actualDeadline = int32(aliceCommit.DeadlineHeight) - currentHeight
-	if actualDeadline != int32(deadlineA) {
-		ht.Logf("!!! Found unsynced block between Alice's sweeper and "+
-			"contractcourt, expected deadline=%v, got=%v",
-			deadlineA, actualDeadline)
-
-		deadlineA = uint32(actualDeadline)
-	}
-
-	// We now wait for 30 seconds to overcome the flake - there's a block
-	// race between contractcourt and sweeper, causing the sweep to be
-	// broadcast earlier.
-	//
-	// TODO(yy): remove this once `blockbeat` is in place.
-	aliceStartPosition := 0
-	var aliceFirstSweepTx *wire.MsgTx
-	err := wait.NoError(func() error {
-		mem := ht.GetRawMempool()
-		if len(mem) != 2 {
-			return fmt.Errorf("want 2, got %v in mempool: %v",
-				len(mem), mem)
-		}
-
-		// If there are two txns, it means Alice's sweep tx has been
-		// created and published.
-		aliceStartPosition = 1
-
-		txns := ht.GetNumTxsFromMempool(2)
-		aliceFirstSweepTx = txns[0]
-
-		// Reassign if the second tx is larger.
-		if txns[1].TxOut[0].Value > aliceFirstSweepTx.TxOut[0].Value {
-			aliceFirstSweepTx = txns[1]
-		}
-
-		return nil
-	}, wait.DefaultTimeout)
-	ht.Logf("Checking mempool got: %v", err)
-
-	// Mine an empty block, which should trigger Alice's sweeper to publish
-	// her commit sweep along with her anchor output.
-	ht.MineEmptyBlocks(1)
-
-	// If Alice has already published her initial sweep tx, the above mined
-	// block would trigger an RBF. We now need to assert the mempool has
-	// removed the replaced tx.
-	if aliceFirstSweepTx != nil {
-		ht.AssertTxNotInMempool(aliceFirstSweepTx.TxHash())
-	}
+	// We expect two pending sweeps for Alice - anchor and commit outputs.
+	ht.AssertNumPendingSweeps(alice, 2)
 
 	// We also remember the positions of fee functions used by Alice and
 	// Bob. They will be used to calculate the expected fee rates later.
-	//
-	// Alice's sweeping tx has just been created, so she is at the starting
-	// position. For Bob, due to the above mined blocks, his fee function
-	// is now at position 2.
-	alicePosition, bobPosition := uint32(aliceStartPosition), uint32(2)
+	alicePosition, bobPosition := uint32(0), uint32(1)
 
 	// We should see two txns in the mempool:
 	// - Alice's sweeping tx, which sweeps her commit output at the
 	//   starting fee rate - Alice's anchor output won't be swept with her
 	//   commit output together because they have different deadlines.
-	// - Bob's previous sweeping tx, which sweeps both his anchor and
-	//   commit outputs, at the starting fee rate.
+	// - Bob's previous sweeping tx, which sweeps his and commit outputs,
+	//   at the starting fee rate.
 	txns := ht.GetNumTxsFromMempool(2)
 
 	// Assume the first tx is Alice's sweeping tx, if the second tx has a
 	// larger output value, then that's Alice's as her to_local value is
 	// much gearter.
-	aliceSweepTx := txns[0]
-	bobSweepTx = txns[1]
+	aliceSweepTx, bobSweepTx := txns[0], txns[1]
 
 	// Swap them if bobSweepTx is smaller.
 	if bobSweepTx.TxOut[0].Value > aliceSweepTx.TxOut[0].Value {
@@ -1522,20 +1351,6 @@ func testSweepCommitOutputAndAnchor(ht *lntest.HarnessTest) {
 	// used for CPFP, so it shouldn't take any wallet utxos.
 	require.Len(ht, aliceSweepTx.TxIn, 1)
 	require.Len(ht, aliceSweepTx.TxOut, 1)
-
-	// We now check Alice's sweeping tx to see if it's already published.
-	//
-	// TODO(yy): remove this check once we have better block control.
-	aliceSweeps = ht.AssertNumPendingSweeps(alice, 2)
-	aliceCommit = aliceSweeps[0]
-	if aliceCommit.AmountSat < aliceSweeps[1].AmountSat {
-		aliceCommit = aliceSweeps[1]
-	}
-	if aliceCommit.BroadcastAttempts > 1 {
-		ht.Logf("!!! Alice's commit sweep has already been broadcast, "+
-			"broadcast_attempts=%v", aliceCommit.BroadcastAttempts)
-		alicePosition = aliceCommit.BroadcastAttempts
-	}
 
 	// Alice's sweeping tx should use the min relay fee rate as there's no
 	// deadline pressure.
@@ -1551,7 +1366,7 @@ func testSweepCommitOutputAndAnchor(ht *lntest.HarnessTest) {
 	aliceTxWeight := uint64(ht.CalculateTxWeight(aliceSweepTx))
 	aliceEndingFeeRate := sweep.DefaultMaxFeeRate.FeePerKWeight()
 	aliceFeeRateDelta := (aliceEndingFeeRate - aliceStartingFeeRate) /
-		chainfee.SatPerKWeight(deadlineA-1)
+		chainfee.SatPerKWeight(deadlineA)
 
 	aliceFeeRate := ht.CalculateTxFeeRate(aliceSweepTx)
 	expectedFeeRateAlice := aliceStartingFeeRate +
@@ -1560,119 +1375,41 @@ func testSweepCommitOutputAndAnchor(ht *lntest.HarnessTest) {
 		uint64(aliceFeeRate), 0.02, "want %v, got %v",
 		expectedFeeRateAlice, aliceFeeRate)
 
-	// We now check Bob' sweeping tx.
+	// We now check Bob's sweeping tx.
 	//
-	// The above mined block will trigger Bob's sweeper to RBF his previous
-	// sweeping tx, which will fail due to RBF rule#4 - the additional fees
-	// paid are not sufficient. This happens as our default incremental
-	// relay fee rate is 1 sat/vb, with the tx size of 771 weight units, or
-	// 192 vbytes, we need to pay at least 192 sats more to be able to RBF.
-	// However, since Bob's budget delta is (100_000 + 330) * 0.5 / 1008 =
-	// 49.77 sats, it means Bob can only perform a successful RBF every 4
-	// blocks.
+	// Bob's sweeping tx should have one input, which is his commit output.
+	// His anchor output won't be swept due to it being uneconomical.
+	require.Len(ht, bobSweepTx.TxIn, 1, "tx=%v", bobSweepTx.TxHash())
+
+	// Because Bob is sweeping without deadline pressure, the starting fee
+	// rate should be the min relay fee rate.
+	bobStartFeeRate := ht.CalculateTxFeeRate(bobSweepTx)
+	require.InEpsilonf(ht, uint64(chainfee.FeePerKwFloor),
+		uint64(bobStartFeeRate), 0.01, "want %v, got %v",
+		chainfee.FeePerKwFloor, bobStartFeeRate)
+
+	// With Bob's starting fee rate being validated, we now calculate his
+	// ending fee rate and fee rate delta.
 	//
-	// Assert Bob's sweeping tx is not RBFed.
-	bobFeeRate := ht.CalculateTxFeeRate(bobSweepTx)
+	// Bob sweeps one input - the commit output.
+	bobValue := btcutil.Amount(bobToLocal)
+	bobBudget := bobValue.MulF64(contractcourt.DefaultBudgetRatio)
+
+	// Calculate the ending fee rate and fee rate delta used in his fee
+	// function.
+	bobTxWeight := ht.CalculateTxWeight(bobSweepTx)
+	bobEndingFeeRate := chainfee.NewSatPerKWeight(bobBudget, bobTxWeight)
+	bobFeeRateDelta := (bobEndingFeeRate - bobStartFeeRate) /
+		chainfee.SatPerKWeight(deadlineB-1)
 	expectedFeeRateBob := bobStartFeeRate
-	require.InEpsilonf(ht, uint64(expectedFeeRateBob), uint64(bobFeeRate),
-		0.01, "want %d, got %d", expectedFeeRateBob, bobFeeRate)
 
-	// reloclateAlicePosition is a temp hack to find the actual fee
-	// function position used for Alice. Due to block sync issue among the
-	// subsystems, we can end up having this situation:
-	// - sweeper is at block 2, starts sweeping an input with deadline 100.
-	// - fee bumper is at block 1, and thinks the conf target is 99.
-	// - new block 3 arrives, the func now is at position 2.
-	//
-	// TODO(yy): fix it using `blockbeat`.
-	reloclateAlicePosition := func() {
-		// Mine an empty block to trigger the possible RBF attempts.
-		ht.MineEmptyBlocks(1)
-
-		// Increase the positions for both fee functions.
-		alicePosition++
-		bobPosition++
-
-		// We expect two pending sweeps for both nodes as we are mining
-		// empty blocks.
-		ht.AssertNumPendingSweeps(alice, 2)
-		ht.AssertNumPendingSweeps(bob, 2)
-
-		// We expect to see both Alice's and Bob's sweeping txns in the
-		// mempool.
-		ht.AssertNumTxsInMempool(2)
-
-		// Make sure Alice's old sweeping tx has been removed from the
-		// mempool.
-		ht.AssertTxNotInMempool(aliceSweepTx.TxHash())
-
-		// We should see two txns in the mempool:
-		// - Alice's sweeping tx, which sweeps both her anchor and
-		//   commit outputs, using the increased fee rate.
-		// - Bob's previous sweeping tx, which sweeps both his anchor
-		//   and commit outputs, at the possible increased fee rate.
-		txns = ht.GetNumTxsFromMempool(2)
-
-		// Assume the first tx is Alice's sweeping tx, if the second tx
-		// has a larger output value, then that's Alice's as her
-		// to_local value is much gearter.
-		aliceSweepTx = txns[0]
-		bobSweepTx = txns[1]
-
-		// Swap them if bobSweepTx is smaller.
-		if bobSweepTx.TxOut[0].Value > aliceSweepTx.TxOut[0].Value {
-			aliceSweepTx, bobSweepTx = bobSweepTx, aliceSweepTx
-		}
-
-		// Alice's sweeping tx should be increased.
-		aliceFeeRate := ht.CalculateTxFeeRate(aliceSweepTx)
-		expectedFeeRate := aliceStartingFeeRate +
-			aliceFeeRateDelta*chainfee.SatPerKWeight(alicePosition)
-
-		ht.Logf("Alice(deadline=%v): txWeight=%v, want feerate=%v, "+
-			"got feerate=%v, delta=%v", deadlineA-alicePosition,
-			aliceTxWeight, expectedFeeRate, aliceFeeRate,
-			aliceFeeRateDelta)
-
-		nextPosition := alicePosition + 1
-		nextFeeRate := aliceStartingFeeRate +
-			aliceFeeRateDelta*chainfee.SatPerKWeight(nextPosition)
-
-		// Calculate the distances.
-		delta := math.Abs(float64(aliceFeeRate - expectedFeeRate))
-		deltaNext := math.Abs(float64(aliceFeeRate - nextFeeRate))
-
-		// Exit early if the first distance is smaller - it means we
-		// are at the right fee func position.
-		if delta < deltaNext {
-			require.InEpsilonf(ht, uint64(expectedFeeRate),
-				uint64(aliceFeeRate), 0.02, "want %v, got %v "+
-					"in tx=%v", expectedFeeRate,
-				aliceFeeRate, aliceSweepTx.TxHash())
-
-			return
-		}
-
-		alicePosition++
-		ht.Logf("Jump position for Alice(deadline=%v): txWeight=%v, "+
-			"want feerate=%v, got feerate=%v, delta=%v",
-			deadlineA-alicePosition, aliceTxWeight, nextFeeRate,
-			aliceFeeRate, aliceFeeRateDelta)
-
-		require.InEpsilonf(ht, uint64(nextFeeRate),
-			uint64(aliceFeeRate), 0.02, "want %v, got %v in tx=%v",
-			nextFeeRate, aliceFeeRate, aliceSweepTx.TxHash())
-	}
-
-	reloclateAlicePosition()
-
-	// We now mine 7 empty blocks. For each block mined, we'd see Alice's
+	// We now mine 8 empty blocks. For each block mined, we'd see Alice's
 	// sweeping tx being RBFed. For Bob, he performs a fee bump every
-	// block, but will only publish a tx every 4 blocks mined as some of
+	// block, but will only publish a tx every 3 blocks mined as some of
 	// the fee bumps is not sufficient to meet the fee requirements
 	// enforced by RBF. Since his fee function is already at position 1,
 	// mining 7 more blocks means he will RBF his sweeping tx twice.
-	for i := 1; i < 7; i++ {
+	for i := 1; i < 9; i++ {
 		// Mine an empty block to trigger the possible RBF attempts.
 		ht.MineEmptyBlocks(1)
 
@@ -1695,9 +1432,9 @@ func testSweepCommitOutputAndAnchor(ht *lntest.HarnessTest) {
 
 		// Make sure Bob's old sweeping tx has been removed from the
 		// mempool. Since Bob's sweeping tx will only be successfully
-		// RBFed every 4 blocks, his old sweeping tx only will be
-		// removed when there are 4 blocks increased.
-		if bobPosition%4 == 0 {
+		// RBFed every 3 blocks, his old sweeping tx only will be
+		// removed when there are 3 blocks increased.
+		if bobPosition%3 == 0 {
 			ht.AssertTxNotInMempool(bobSweepTx.TxHash())
 		}
 
@@ -1733,9 +1470,10 @@ func testSweepCommitOutputAndAnchor(ht *lntest.HarnessTest) {
 			aliceFeeRateDelta*chainfee.SatPerKWeight(alicePosition)
 
 		ht.Logf("Alice(deadline=%v): txWeight=%v, want feerate=%v, "+
-			"got feerate=%v, delta=%v", deadlineA-alicePosition,
-			aliceTxWeight, expectedFeeRateAlice, aliceFeeRate,
-			aliceFeeRateDelta)
+			"got feerate=%v, delta=%v in tx %v",
+			deadlineA-alicePosition, aliceTxWeight,
+			expectedFeeRateAlice, aliceFeeRate,
+			aliceFeeRateDelta, aliceSweepTx.TxHash())
 
 		require.InEpsilonf(ht, uint64(expectedFeeRateAlice),
 			uint64(aliceFeeRate), 0.02, "want %v, got %v in tx=%v",
@@ -1751,16 +1489,17 @@ func testSweepCommitOutputAndAnchor(ht *lntest.HarnessTest) {
 		accumulatedDelta := bobFeeRateDelta *
 			chainfee.SatPerKWeight(bobPosition)
 
-		// Bob's sweeping tx will only be successfully RBFed every 4
+		// Bob's sweeping tx will only be successfully RBFed every 3
 		// blocks.
-		if bobPosition%4 == 0 {
+		if bobPosition%3 == 0 {
 			expectedFeeRateBob = bobStartFeeRate + accumulatedDelta
 		}
 
 		ht.Logf("Bob(deadline=%v): txWeight=%v, want feerate=%v, "+
-			"got feerate=%v, delta=%v", deadlineB-bobPosition,
-			bobTxWeight, expectedFeeRateBob, bobFeeRate,
-			bobFeeRateDelta)
+			"got feerate=%v, delta=%v in tx %v",
+			deadlineB-bobPosition, bobTxWeight,
+			expectedFeeRateBob, bobFeeRate,
+			bobFeeRateDelta, bobSweepTx.TxHash())
 
 		require.InEpsilonf(ht, uint64(expectedFeeRateBob),
 			uint64(bobFeeRate), 0.02, "want %d, got %d in tx=%v",

--- a/itest/lnd_watchtower_test.go
+++ b/itest/lnd_watchtower_test.go
@@ -579,16 +579,6 @@ func testRevokedCloseRetributionAltruistWatchtowerCase(ht *lntest.HarnessTest,
 
 	ht.AssertNumPendingForceClose(dave, 0)
 
-	// If this is an anchor channel, Dave would offer his sweeper the
-	// anchor. However, due to no time-sensitive outputs involved, the
-	// anchor sweeping won't happen as it's uneconomical.
-	if lntest.CommitTypeHasAnchors(commitType) {
-		ht.AssertNumPendingSweeps(dave, 1)
-
-		// Mine a block to trigger the sweep.
-		ht.MineEmptyBlocks(1)
-	}
-
 	// Check that Dave's wallet balance is increased.
 	err = wait.NoError(func() error {
 		daveBalResp := dave.RPC.WalletBalance()

--- a/itest/lnd_wipe_fwdpkgs_test.go
+++ b/itest/lnd_wipe_fwdpkgs_test.go
@@ -117,9 +117,6 @@ func testWipeForwardingPackages(ht *lntest.HarnessTest) {
 	// Alice should one pending sweep.
 	ht.AssertNumPendingSweeps(alice, 1)
 
-	// Mine a block to trigger the sweep.
-	ht.MineBlocks(1)
-
 	// Mine 1 block to get Alice's sweeping tx confirmed.
 	ht.MineBlocksAndAssertNumTxes(1, 1)
 

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -1316,7 +1316,7 @@ func (h *HarnessTest) CloseChannel(hn *node.HarnessNode,
 
 	stream, _ := h.CloseChannelAssertPending(hn, cp, false)
 
-	return h.AssertStreamChannelCoopClosed(hn, cp, false, stream)
+	return h.AssertStreamChannelCoopClosed(hn, cp, stream)
 }
 
 // ForceCloseChannel attempts to force close a non-anchored channel identified

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -1625,9 +1625,9 @@ func (h *HarnessTest) CleanupForceClose(hn *node.HarnessNode) {
 	h.AssertNumPendingForceClose(hn, 1)
 
 	// Mine enough blocks for the node to sweep its funds from the force
-	// closed channel. The commit sweep resolver is able to offer the input
-	// to the sweeper at defaulCSV-1, and broadcast the sweep tx once one
-	// more block is mined.
+	// closed channel. The commit sweep resolver is offers the input to the
+	// sweeper when it's force closed, and broadcast the sweep tx at
+	// defaulCSV-1.
 	//
 	// NOTE: we might empty blocks here as we don't know the exact number
 	// of blocks to mine. This may end up mining more blocks than needed.
@@ -1635,9 +1635,6 @@ func (h *HarnessTest) CleanupForceClose(hn *node.HarnessNode) {
 
 	// Assert there is one pending sweep.
 	h.AssertNumPendingSweeps(hn, 1)
-
-	// Mine a block to trigger the sweep.
-	h.MineEmptyBlocks(1)
 
 	// The node should now sweep the funds, clean up by mining the sweeping
 	// tx.
@@ -1976,7 +1973,8 @@ func (h *HarnessTest) AssertSweepFound(hn *node.HarnessNode,
 			return nil
 		}
 
-		return fmt.Errorf("sweep tx %v not found", sweep)
+		return fmt.Errorf("sweep tx %v not found in resp %v", sweep,
+			sweepResp)
 	}, wait.DefaultTimeout)
 	require.NoError(h, err, "%s: timeout checking sweep tx", hn.Name())
 }

--- a/lntest/harness_assertion.go
+++ b/lntest/harness_assertion.go
@@ -55,7 +55,8 @@ func (h *HarnessTest) WaitForBlockchainSync(hn *node.HarnessNode) {
 		return fmt.Errorf("%s is not synced to chain", hn.Name())
 	}, DefaultTimeout)
 
-	require.NoError(h, err, "timeout waiting for blockchain sync")
+	require.NoError(h, err, "%s: timeout waiting for blockchain sync",
+		hn.Name())
 }
 
 // WaitForBlockchainSyncTo waits until the node is synced to bestBlock.
@@ -633,8 +634,7 @@ func (h *HarnessTest) AssertNumPendingForceClose(hn *node.HarnessNode,
 // - assert the node has zero waiting close channels.
 // - assert the node has seen the channel close update.
 func (h *HarnessTest) AssertStreamChannelCoopClosed(hn *node.HarnessNode,
-	cp *lnrpc.ChannelPoint, anchors bool,
-	stream rpc.CloseChanClient) *chainhash.Hash {
+	cp *lnrpc.ChannelPoint, stream rpc.CloseChanClient) *chainhash.Hash {
 
 	// Assert the channel is waiting close.
 	resp := h.AssertChannelWaitingClose(hn, cp)
@@ -647,11 +647,7 @@ func (h *HarnessTest) AssertStreamChannelCoopClosed(hn *node.HarnessNode,
 	// We'll now, generate a single block, wait for the final close status
 	// update, then ensure that the closing transaction was included in the
 	// block. If there are anchors, we also expect an anchor sweep.
-	expectedTxes := 1
-	if anchors {
-		expectedTxes = 2
-	}
-	block := h.MineBlocksAndAssertNumTxes(1, expectedTxes)[0]
+	block := h.MineBlocksAndAssertNumTxes(1, 1)[0]
 
 	// Consume one close event and assert the closing txid can be found in
 	// the block.

--- a/lntest/harness_assertion.go
+++ b/lntest/harness_assertion.go
@@ -2671,3 +2671,36 @@ func (h *HarnessTest) FindSweepingTxns(txns []*wire.MsgTx,
 
 	return sweepTxns
 }
+
+// AssertForceCloseAndAnchorTxnsInMempool asserts that the force close and
+// anchor sweep txns are found in the mempool and returns the force close tx
+// and the anchor sweep tx.
+func (h *HarnessTest) AssertForceCloseAndAnchorTxnsInMempool() (*wire.MsgTx,
+	*wire.MsgTx) {
+
+	// Assert there are two txns in the mempool.
+	txns := h.GetNumTxsFromMempool(2)
+
+	// Assume the first is the force close tx.
+	forceCloseTx, anchorSweepTx := txns[0], txns[1]
+
+	// Get the txid.
+	closeTxid := forceCloseTx.TxHash()
+
+	// We now check whether there is an anchor input used in the assumed
+	// anchorSweepTx by checking every input's previous outpoint against
+	// the assumed closingTxid. If we fail to find one, it means the first
+	// item from the above txns is the anchor sweeping tx.
+	for _, inp := range anchorSweepTx.TxIn {
+		if inp.PreviousOutPoint.Hash == closeTxid {
+			// Found a match, this is indeed the anchor sweeping tx
+			// so we return it here.
+			return forceCloseTx, anchorSweepTx
+		}
+	}
+
+	// The assumed order is incorrect so we swap and return.
+	forceCloseTx, anchorSweepTx = anchorSweepTx, forceCloseTx
+
+	return forceCloseTx, anchorSweepTx
+}

--- a/lntest/harness_miner.go
+++ b/lntest/harness_miner.go
@@ -197,7 +197,8 @@ func (h *HarnessTest) mineTillForceCloseResolved(hn *node.HarnessNode) {
 		return nil
 	}, DefaultTimeout)
 
-	require.NoErrorf(h, err, "assert force close resolved timeout")
+	require.NoErrorf(h, err, "%s: assert force close resolved timeout",
+		hn.Name())
 }
 
 // AssertTxInMempool asserts a given transaction can be found in the mempool.


### PR DESCRIPTION
WIP: don't review it yet (created to check CI).

Turns out mounting `blockbeat` in `ChannelArbitrator` can be quite challenging (unit tests, itest, etc). This PR attempts to implement it in hopefully the least disruptive way - only `chainWatcher` implements `Consumer`, and the contract resolvers are kept stateless (in terms of blocks). The main changes are,
1. contract resolvers are refactored - the original `Resolve` method is broken into two steps: 1) `Launch` the resolver, which handles sending the sweep request, and 2) `Resolve` the resolver, which handles monitoring the spending of the output.
2. `chainWatcher` now implements `Consumer`.
3. itests are now fixed.

### Alternatives
The original attempt is to make the resolvers subscribe to a blockbeat chan, as implemented in #8717. The second attempt is to make the resolvers also blockbeat `Consumer`, as implemented [here](https://github.com/yyforyongyu/lnd/pull/8).

This third approach is chosen as 1) it greatly limits the scope otherwise a bigger refactor of channel arbitrator may be needed, and 2) the resolvers can be made stateless in terms of blocks, and be fully managed by the channel arbitrator. In other words, when a new block arrives, the channel arbitrator decides whether to launch the resolvers or not, so the resolvers themselves don't need this block info.

In fact, there are only two resolvers that subscribe to blocks, the incoming contest resolver, which uses block height to decide whether to give up resolving an expired incoming htlc; and the outgoing contest resolver, which uses the block height to choose to transform itself into a timeout resolver. IMO if we can remove the inheritance pattern used in `contest resolver -> time/success resolver` and manage to transform resolvers in channel arbitrator, we can further remove those two block subscriptions. As for now, we can leave them there as they have little impact on the block consumption order enforced by the blockbeat.