### PR TITLE
chainntnfs+lntest: fix `TestInterfaces`

### DIFF
--- a/chainntnfs/bitcoindnotify/bitcoind_test.go
+++ b/chainntnfs/bitcoindnotify/bitcoind_test.go
@@ -93,6 +93,9 @@ func syncNotifierWithMiner(t *testing.T, notifier *BitcoindNotifier,
 				"height: %v", err)
 		}
 
+		t.Logf("miner height=%v, bitcoind height=%v", minerHeight,
+			bitcoindHeight)
+
 		if bitcoindHeight == minerHeight {
 			return uint32(bitcoindHeight)
 		}

--- a/lntest/unittest/backend.go
+++ b/lntest/unittest/backend.go
@@ -59,6 +59,12 @@ func NewMiner(t *testing.T, netParams *chaincfg.Params, extraArgs []string,
 		t.Fatalf("unable to set up backend node: %v", err)
 	}
 
+	// Next mine enough blocks in order for segwit and the CSV package
+	// soft-fork to activate.
+	numBlocks := netParams.MinerConfirmationWindow*2 + 17
+	_, err = node.Client.Generate(numBlocks)
+	require.NoError(t, err, "failed to generate blocks")
+
 	return node
 }
 


### PR DESCRIPTION
[This flake](https://github.com/lightningnetwork/lnd/actions/runs/9987408253/job/27601725201) has popped up multiple times,
```
2024/07/18 08:06:20 Running ChainNotifier interface tests for: btcd
--- FAIL: TestInterfaces (67.92s)
    --- FAIL: TestInterfaces/btcd_historical_spend_dispatch (30.06s)
        test_interface.go:872: spend ntfn never received
FAIL
FAIL	github.com/lightningnetwork/lnd/chainntnfs/test/btcd	67.937s
FAIL
```

Turns out it's failing here, where we rescan blocks to find the relevant spending tx,
https://github.com/lightningnetwork/lnd/blob/6dea86428d031171af30119e3f6599820dc5454a/chainntnfs/txnotifier.go#L1310-L1315

It's also easy to reproduce - need to run it multiple times tho,
```sh
case=TestInterfaces/btcd_historical_spend_dispatch_with_script_dispatch
pkg=chainntnfs/test/btcd
go clean -testcache | make unit-debug log="stdlog trace" pkg=$pkg case=$case timeout=10s
```
And the relevant logs,
```
2024-06-28 06:10:19.764 [CRT] NTFN: Found spending tx for outpoint=0000000000000000000000000000000000000000000000000000000000000000:0, but the transaction f78dafeb14b356ae7f2aefacc725b8700b6e9b206fdaa1d43d52d4a26a5cde63 does not have witness
2024-06-28 06:10:19.764 [ERR] NTFN: Unable to process transaction f78dafeb14b356ae7f2aefacc725b8700b6e9b206fdaa1d43d52d4a26a5cde63: witness stack is empty
```


Since we don't ever allow pre-segwit utxos to be used, we now update the tests to always create segwit v0 txns.