### PR TITLE
lnwallet: store aux sig in custom data within the HTLC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/lightningnetwork/lnd/queue v1.1.1
 	github.com/lightningnetwork/lnd/sqldb v1.0.2
 	github.com/lightningnetwork/lnd/ticker v1.1.1
-	github.com/lightningnetwork/lnd/tlv v1.2.5
+	github.com/lightningnetwork/lnd/tlv v1.2.6
 	github.com/lightningnetwork/lnd/tor v1.1.2
 	github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796
 	github.com/miekg/dns v1.1.43

--- a/go.sum
+++ b/go.sum
@@ -460,8 +460,8 @@ github.com/lightningnetwork/lnd/sqldb v1.0.2 h1:PfuYzScYMD9/QonKo/QvgsbXfTnH5Dfl
 github.com/lightningnetwork/lnd/sqldb v1.0.2/go.mod h1:V2Xl6JNWLTKE97WJnwfs0d0TYJdIQTqK8/3aAwkd3qI=
 github.com/lightningnetwork/lnd/ticker v1.1.1 h1:J/b6N2hibFtC7JLV77ULQp++QLtCwT6ijJlbdiZFbSM=
 github.com/lightningnetwork/lnd/ticker v1.1.1/go.mod h1:waPTRAAcwtu7Ji3+3k+u/xH5GHovTsCoSVpho0KDvdA=
-github.com/lightningnetwork/lnd/tlv v1.2.5 h1:/VsoWw628t78OiDN90pHDbqwOcuZ9JMicxXZVQjBwX0=
-github.com/lightningnetwork/lnd/tlv v1.2.5/go.mod h1:/CmY4VbItpOldksocmGT4lxiJqRP9oLxwSZOda2kzNQ=
+github.com/lightningnetwork/lnd/tlv v1.2.6 h1:icvQG2yDr6k3ZuZzfRdG3EJp6pHurcuh3R6dg0gv/Mw=
+github.com/lightningnetwork/lnd/tlv v1.2.6/go.mod h1:/CmY4VbItpOldksocmGT4lxiJqRP9oLxwSZOda2kzNQ=
 github.com/lightningnetwork/lnd/tor v1.1.2 h1:3zv9z/EivNFaMF89v3ciBjCS7kvCj4ZFG7XvD2Qq0/k=
 github.com/lightningnetwork/lnd/tor v1.1.2/go.mod h1:j7T9uJ2NLMaHwE7GiBGnpYLn4f7NRoTM6qj+ul6/ycA=
 github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796 h1:sjOGyegMIhvgfq5oaue6Td+hxZuf3tDC8lAPrFldqFw=

--- a/lnwallet/aux_signer.go
+++ b/lnwallet/aux_signer.go
@@ -125,6 +125,10 @@ func NewAuxVerifyJob(sig fn.Option[tlv.Blob], keyRing CommitmentKeyRing,
 	}
 }
 
+// htlcCustomSigType is the TLV type that is used to encode the custom HTLC
+// signatures within the custom data for an existing HTLC.
+var htlcCustomSigType tlv.TlvType65543
+
 // AuxSigner is an interface that is used to sign and verify HTLCs for custom
 // channels. It is similar to the existing SigPool, but uses opaque blobs to
 // shuffle around signature information and other metadata.

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -5496,6 +5496,14 @@ func genHtlcSigValidationJobs(chanState *channeldb.OpenChannel,
 				localCommitmentView.customBlob, auxLeaf,
 			)
 
+			// As this HTLC has a custom sign associated with it,
+			// store in the custom records map so we can write to
+			// disk later.
+			sigType := htlcCustomSigType.TypeVal()
+			htlc.CustomRecords[uint64(sigType)] = auxSig.UnwrapOr(
+				nil,
+			)
+
 			auxVerifyJobs = append(auxVerifyJobs, auxVerifyJob)
 		}
 


### PR DESCRIPTION
We can use this space as we'll properly encode the blinded paths data along with our custom fields before we go to write the HTLCs to the wire.
