### PR TITLE
lncli openchannel fix

### DIFF
--- a/docs/release-notes/release-notes-0.18.3.md
+++ b/docs/release-notes/release-notes-0.18.3.md
@@ -33,6 +33,9 @@
   created](https://github.com/lightningnetwork/lnd/pull/8921) when multiple RPC
   calls are made concurrently.
 
+* [Uses the openchannel sync call](https://github.com/lightningnetwork/lnd/pull/8934)
+ when opening a channel via the `lncli` in the non-blocking case.
+
 # New Features
 ## Functional Enhancements
 ## RPC Additions

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -102,6 +102,10 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testRescanAddressDetection,
 	},
 	{
+		Name:     "open channel sync funding",
+		TestFunc: testChannelOpeningSync,
+	},
+	{
 		Name:     "basic funding flow with all input types",
 		TestFunc: testChannelFundingInputTypes,
 	},

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -1094,6 +1094,16 @@ func (h *HarnessTest) openChannelAssertPending(srcNode,
 	return update.ChanPending, respStream
 }
 
+// OpenChannelSync attempts to open a channel between srcNode and destNode with
+// the passed channel funding parameters.
+func (h *HarnessTest) OpenChannelSync(srcNode,
+	destNode *node.HarnessNode, p OpenChannelParams) *lnrpc.ChannelPoint {
+
+	// Prepare the request and open the channel.
+	openReq := h.prepareOpenChannel(srcNode, destNode, p)
+	return srcNode.RPC.OpenChannelSync(openReq)
+}
+
 // OpenChannelAssertPending attempts to open a channel between srcNode and
 // destNode with the passed channel funding parameters. Once the `OpenChannel`
 // is called, it will consume the first event it receives from the open channel

--- a/lntest/rpc/lnd.go
+++ b/lntest/rpc/lnd.go
@@ -243,6 +243,17 @@ func (h *HarnessRPC) OpenChannel(req *lnrpc.OpenChannelRequest) OpenChanClient {
 	return stream
 }
 
+// OpenChannelSync makes a rpc call to LightningClient and returns the pending
+// channel point.
+func (h *HarnessRPC) OpenChannelSync(
+	req *lnrpc.OpenChannelRequest) *lnrpc.ChannelPoint {
+
+	chanPoint, err := h.LN.OpenChannelSync(h.runCtx, req)
+	h.NoError(err, "OpenChannelSync")
+
+	return chanPoint
+}
+
 type CloseChanClient lnrpc.Lightning_CloseChannelClient
 
 // CloseChannel makes a rpc call to LightningClient and returns the close


### PR DESCRIPTION
A minor fix which resulted from https://github.com/lightningnetwork/lnd/pull/8896.

Basically when opening a channel in the non-blocking case we would still keep a goroutine open on the LND server side although the `lncli` part would already have been exited after the funding transaction was broadcasted to the mempool. For this case we should use the OpenChannelSync API rather than the async call.

I verified the behavior on regtest and we would indeed keep a goroutine until the channel reached its `MinDepthHeight`.

EDIT: Moreover we add a itest for the OpenChannelSync cmd.

