### PR TITLE
sweep, rpcserver: optimize SendAll cost wise

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1356,8 +1356,7 @@ func (r *rpcServer) SendCoins(ctx context.Context,
 		// transaction that will sweep ALL outputs from the wallet in a
 		// single transaction. This will be generated in a concurrent
 		// safe manner, so no need to worry about locking. The tx will
-		// pay to the change address created above if we needed to
-		// reserve any value, the rest will go to targetAddr.
+		// pay everything to targetAddr.
 		sweepTxPkg, err := sweep.CraftSweepAllTx(
 			feePerKw, maxFeeRate, uint32(bestHeight), nil,
 			targetAddr, wallet, wallet, wallet.WalletController,


### PR DESCRIPTION
## Change Description

If there is a coin of value equal to the amount reserved for anchor bumping (e.g. 100k sats), SendAll used to spend it and to create another coin of such size. Now it just does not touch the coin in this scenario.

To achieve this, added argument `skipInputAmount` to fn `sweep.CraftSweepAllTx`. If it is not 0, it looks for an input of that value and skips it. If it can't find an input, it skips locking UTXOs and returns `ErrMissingInputToSkip`.

Added unit test for new functionality of `CraftSweepAllTx`.

Added itest to test the optimization in SendAll.

SendAll is used by `lncli sendcoins --sweepall`.

## Steps to Test

 - Run LND node built from this PR
 - Open few channels
 - Fund node's wallet with with 0.01 BTC
 - Run `lncli sendcoins --sweepall` moving all the funds to an external address
 - That tx should have a change output of value equal to reserved funds (e.g. 100k if there are 10+ channels)
 - Fund node's wallet again with 0.01 BTC
 - Run `lncli sendcoins --sweepall` again moving all the funds to an external address
 - The tx should be 1-to-1, not 2-to-2, as it would be before this PR

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

## Example transaction

```
lncli sendcoins --sweepall
```

![image](https://github.com/user-attachments/assets/0e0f0122-a71d-4ef5-8ef5-f1eaad51d32c)

If this PR was applied, the transaction wouldn't include its last input and first output (0.001 BTC each).