### PR TITLE
routing: fix fee limit condition

### DIFF
--- a/docs/release-notes/release-notes-0.18.3.md
+++ b/docs/release-notes/release-notes-0.18.3.md
@@ -36,6 +36,10 @@
 * [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/8896) that caused
   LND to use a default fee rate for the batch channel opening flow.
 
+* The fee limit for payments [was made
+  compatible](https://github.com/lightningnetwork/lnd/pull/8941) with inbound
+  fees.
+
 # New Features
 ## Functional Enhancements
 ## RPC Additions
@@ -150,6 +154,7 @@
 # Contributors (Alphabetical Order)
 
 * Andras Banki-Horvath
+* bitromortac
 * Bufo
 * Elle Mouton
 * Matheus Degiovani

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -355,6 +355,10 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testRouteFeeCutoff,
 	},
 	{
+		Name:     "route fee limit after queryroutes",
+		TestFunc: testFeeLimitAfterQueryRoutes,
+	},
+	{
 		Name:     "rpc middleware interceptor",
 		TestFunc: testRPCMiddlewareInterceptor,
 	},

--- a/itest/lnd_routing_test.go
+++ b/itest/lnd_routing_test.go
@@ -1397,12 +1397,8 @@ func testFeeLimitAfterQueryRoutes(ht *lntest.HarnessTest) {
 		FeeLimitMsat:   0,
 	}
 
-	// We assert that the payment fails because the fee limit doesn't work
-	// correctly. This is fixed in the next commit.
-	ht.SendPaymentAssertFail(
-		alice, sendReq,
-		lnrpc.PaymentFailureReason_FAILURE_REASON_NO_ROUTE,
-	)
+	// We assert that a route compatible with the fee limit is available.
+	ht.SendPaymentAssertSettled(alice, sendReq)
 
 	// Once we're done, close the channels.
 	ht.CloseChannel(alice, chanPointAliceBob)

--- a/lntest/node/watcher.go
+++ b/lntest/node/watcher.go
@@ -221,7 +221,7 @@ func (nw *nodeWatcher) WaitForChannelPolicyUpdate(
 		select {
 		// Send a watch request every second.
 		case <-ticker.C:
-			// Did the event can close in the meantime? We want to
+			// Did the event chan close in the meantime? We want to
 			// avoid a "close of closed channel" panic since we're
 			// re-using the same event chan for multiple requests.
 			select {

--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -823,7 +823,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		// weight composed of the fee that this node will charge and
 		// the amount that will be locked for timeLockDelta blocks in
 		// the HTLC that is handed out to fromVertex.
-		weight := edgeWeight(netAmountToReceive, fee, timeLockDelta)
+		weight := edgeWeight(amountToSend, fee, timeLockDelta)
 
 		// Compute the tentative weight to this new channel/edge
 		// which is the weight from our toNode to the target node

--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -697,7 +697,6 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 	// processEdge is a helper closure that will be used to make sure edges
 	// satisfy our specific requirements.
 	processEdge := func(fromVertex route.Vertex,
-		fromFeatures *lnwire.FeatureVector,
 		edge *unifiedEdge, toNodeDist *nodeWithDist) {
 
 		edgesExpanded++
@@ -783,6 +782,17 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		// Check if accumulated fees would exceed fee limit when this
 		// node would be added to the path.
 		totalFee := int64(netAmountToReceive) - int64(amt)
+
+		log.Trace(lnutils.NewLogClosure(func() string {
+			return fmt.Sprintf(
+				"Checking fromVertex (%v) with "+
+					"minInboundFee=%v, inboundFee=%v, "+
+					"amountToSend=%v, amt=%v, totalFee=%v",
+				fromVertex, minInboundFee, inboundFee,
+				amountToSend, amt, totalFee,
+			)
+		}))
+
 		if totalFee > 0 && lnwire.MilliSatoshi(totalFee) > r.FeeLimit {
 			return
 		}
@@ -1035,7 +1045,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 
 			// Check if this candidate node is better than what we
 			// already have.
-			processEdge(fromNode, fromFeatures, edge, partialPath)
+			processEdge(fromNode, edge, partialPath)
 		}
 
 		if nodeHeap.Len() == 0 {


### PR DESCRIPTION
## Change Description
When iterating edges, pathfinding checks early whether using an edge would violate the requested total fee limit for a route. This check is done on the net amount (an amount the inbound fee is calculated with). However, a possible next hop's fee discount leads to a reduction in fees and as such using the net amount leads to assuming a higher cumulative fee than the route really has, excluding the path erroneously. With this PR, we perform the fee limit check on the amount to send, which includes both inbound and outbound fees, to fix #8940.

Todo:
- remove itest, add more lightweight test?