### PR TITLE
[MICRO]: lnwallet: refactor channel to use new typed List

### DIFF
--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -2474,7 +2474,7 @@ type htlcView struct {
 func (lc *LightningChannel) fetchHTLCView(theirLogIndex, ourLogIndex uint64) *htlcView {
 	var ourHTLCs []*PaymentDescriptor
 	for e := lc.localUpdateLog.Front(); e != nil; e = e.Next() {
-		htlc := e.Value.(*PaymentDescriptor)
+		htlc := e.Value
 
 		// This HTLC is active from this point-of-view iff the log
 		// index of the state update is below the specified index in
@@ -2486,7 +2486,7 @@ func (lc *LightningChannel) fetchHTLCView(theirLogIndex, ourLogIndex uint64) *ht
 
 	var theirHTLCs []*PaymentDescriptor
 	for e := lc.remoteUpdateLog.Front(); e != nil; e = e.Next() {
-		htlc := e.Value.(*PaymentDescriptor)
+		htlc := e.Value
 
 		// If this is an incoming HTLC, then it is only active from
 		// this point-of-view if the index of the HTLC addition in
@@ -3112,7 +3112,7 @@ func (lc *LightningChannel) createCommitDiff(
 	// set of items we need to retransmit if we reconnect and find that
 	// they didn't process this new state fully.
 	for e := lc.localUpdateLog.Front(); e != nil; e = e.Next() {
-		pd := e.Value.(*PaymentDescriptor)
+		pd := e.Value
 
 		// If this entry wasn't committed at the exact height of this
 		// remote commitment, then we'll skip it as it was already
@@ -3250,7 +3250,7 @@ func (lc *LightningChannel) getUnsignedAckedUpdates() []channeldb.LogUpdate {
 	// remote party expects.
 	var logUpdates []channeldb.LogUpdate
 	for e := lc.remoteUpdateLog.Front(); e != nil; e = e.Next() {
-		pd := e.Value.(*PaymentDescriptor)
+		pd := e.Value
 
 		// Skip all remote updates that we have already included in our
 		// commit chain.
@@ -5195,7 +5195,7 @@ func (lc *LightningChannel) ReceiveRevocation(revMsg *lnwire.RevokeAndAck) (
 
 	var addIndex, settleFailIndex uint16
 	for e := lc.remoteUpdateLog.Front(); e != nil; e = e.Next() {
-		pd := e.Value.(*PaymentDescriptor)
+		pd := e.Value
 
 		// Fee updates are local to this particular channel, and should
 		// never be forwarded.
@@ -5525,7 +5525,7 @@ func (lc *LightningChannel) GetDustSum(remote bool,
 
 	// Grab all of our HTLCs and evaluate against the dust limit.
 	for e := lc.localUpdateLog.Front(); e != nil; e = e.Next() {
-		pd := e.Value.(*PaymentDescriptor)
+		pd := e.Value
 		if pd.EntryType != Add {
 			continue
 		}
@@ -5544,7 +5544,7 @@ func (lc *LightningChannel) GetDustSum(remote bool,
 
 	// Grab all of their HTLCs and evaluate against the dust limit.
 	for e := lc.remoteUpdateLog.Front(); e != nil; e = e.Next() {
-		pd := e.Value.(*PaymentDescriptor)
+		pd := e.Value
 		if pd.EntryType != Add {
 			continue
 		}
@@ -8545,7 +8545,7 @@ func (lc *LightningChannel) unsignedLocalUpdates(remoteMessageIndex,
 
 	var localPeerUpdates []channeldb.LogUpdate
 	for e := lc.localUpdateLog.Front(); e != nil; e = e.Next() {
-		pd := e.Value.(*PaymentDescriptor)
+		pd := e.Value
 
 		// We don't save add updates as they are restored from the
 		// remote commitment in restoreStateLogs.

--- a/lnwallet/commitment_chain.go
+++ b/lnwallet/commitment_chain.go
@@ -1,6 +1,8 @@
 package lnwallet
 
-import "container/list"
+import (
+	"github.com/lightningnetwork/lnd/fn"
+)
 
 // commitmentChain represents a chain of unrevoked commitments. The tail of the
 // chain is the latest fully signed, yet unrevoked commitment. Two chains are
@@ -15,13 +17,13 @@ type commitmentChain struct {
 	// commitments are added to the end of the chain with increase height.
 	// Once a commitment transaction is revoked, the tail is incremented,
 	// freeing up the revocation window for new commitments.
-	commitments *list.List
+	commitments *fn.List[*commitment]
 }
 
 // newCommitmentChain creates a new commitment chain.
 func newCommitmentChain() *commitmentChain {
 	return &commitmentChain{
-		commitments: list.New(),
+		commitments: fn.NewList[*commitment](),
 	}
 }
 
@@ -42,14 +44,12 @@ func (s *commitmentChain) advanceTail() {
 
 // tip returns the latest commitment added to the chain.
 func (s *commitmentChain) tip() *commitment {
-	//nolint:forcetypeassert
-	return s.commitments.Back().Value.(*commitment)
+	return s.commitments.Back().Value
 }
 
 // tail returns the lowest unrevoked commitment transaction in the chain.
 func (s *commitmentChain) tail() *commitment {
-	//nolint:forcetypeassert
-	return s.commitments.Front().Value.(*commitment)
+	return s.commitments.Front().Value
 }
 
 // hasUnackedCommitment returns true if the commitment chain has more than one


### PR DESCRIPTION
## Change Description
depends on #8950.

lnwallet: refactor channel to use new typed List

Go didn't used to have parametric polymorphism (generics). Now it does. In a prior commit we introduced a more principled type to encapsulate a linked list, here we move the core structures in lnwallet/channel to use the new parametric type.

## Steps to Test
make unit pkg=lnwallet

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
