### PR TITLE
[MICRO]: multi: break ChannelConstraints into two sub-structures

### DIFF
--- a/chanbackup/single_test.go
+++ b/chanbackup/single_test.go
@@ -126,6 +126,64 @@ func genRandomOpenChannelShell() (*channeldb.OpenChannel, error) {
 
 	chanType := channeldb.ChannelType(rand.Intn(8))
 
+	localCfg := channeldb.ChannelConfig{
+		ChannelStateBounds: channeldb.ChannelStateBounds{},
+		CommitmentParams: channeldb.CommitmentParams{
+			CsvDelay: uint16(rand.Int63()),
+		},
+		MultiSigKey: keychain.KeyDescriptor{
+			KeyLocator: keychain.KeyLocator{
+				Family: keychain.KeyFamily(rand.Int63()),
+				Index:  uint32(rand.Int63()),
+			},
+		},
+		RevocationBasePoint: keychain.KeyDescriptor{
+			KeyLocator: keychain.KeyLocator{
+				Family: keychain.KeyFamily(rand.Int63()),
+				Index:  uint32(rand.Int63()),
+			},
+		},
+		PaymentBasePoint: keychain.KeyDescriptor{
+			KeyLocator: keychain.KeyLocator{
+				Family: keychain.KeyFamily(rand.Int63()),
+				Index:  uint32(rand.Int63()),
+			},
+		},
+		DelayBasePoint: keychain.KeyDescriptor{
+			KeyLocator: keychain.KeyLocator{
+				Family: keychain.KeyFamily(rand.Int63()),
+				Index:  uint32(rand.Int63()),
+			},
+		},
+		HtlcBasePoint: keychain.KeyDescriptor{
+			KeyLocator: keychain.KeyLocator{
+				Family: keychain.KeyFamily(rand.Int63()),
+				Index:  uint32(rand.Int63()),
+			},
+		},
+	}
+
+	remoteCfg := channeldb.ChannelConfig{
+		CommitmentParams: channeldb.CommitmentParams{
+			CsvDelay: uint16(rand.Int63()),
+		},
+		MultiSigKey: keychain.KeyDescriptor{
+			PubKey: pub,
+		},
+		RevocationBasePoint: keychain.KeyDescriptor{
+			PubKey: pub,
+		},
+		PaymentBasePoint: keychain.KeyDescriptor{
+			PubKey: pub,
+		},
+		DelayBasePoint: keychain.KeyDescriptor{
+			PubKey: pub,
+		},
+		HtlcBasePoint: keychain.KeyDescriptor{
+			PubKey: pub,
+		},
+	}
+
 	return &channeldb.OpenChannel{
 		ChainHash:       chainHash,
 		ChanType:        chanType,
@@ -134,63 +192,10 @@ func genRandomOpenChannelShell() (*channeldb.OpenChannel, error) {
 		ShortChannelID: lnwire.NewShortChanIDFromInt(
 			uint64(rand.Int63()),
 		),
-		ThawHeight:  rand.Uint32(),
-		IdentityPub: pub,
-		LocalChanCfg: channeldb.ChannelConfig{
-			ChannelConstraints: channeldb.ChannelConstraints{
-				CsvDelay: uint16(rand.Int63()),
-			},
-			MultiSigKey: keychain.KeyDescriptor{
-				KeyLocator: keychain.KeyLocator{
-					Family: keychain.KeyFamily(rand.Int63()),
-					Index:  uint32(rand.Int63()),
-				},
-			},
-			RevocationBasePoint: keychain.KeyDescriptor{
-				KeyLocator: keychain.KeyLocator{
-					Family: keychain.KeyFamily(rand.Int63()),
-					Index:  uint32(rand.Int63()),
-				},
-			},
-			PaymentBasePoint: keychain.KeyDescriptor{
-				KeyLocator: keychain.KeyLocator{
-					Family: keychain.KeyFamily(rand.Int63()),
-					Index:  uint32(rand.Int63()),
-				},
-			},
-			DelayBasePoint: keychain.KeyDescriptor{
-				KeyLocator: keychain.KeyLocator{
-					Family: keychain.KeyFamily(rand.Int63()),
-					Index:  uint32(rand.Int63()),
-				},
-			},
-			HtlcBasePoint: keychain.KeyDescriptor{
-				KeyLocator: keychain.KeyLocator{
-					Family: keychain.KeyFamily(rand.Int63()),
-					Index:  uint32(rand.Int63()),
-				},
-			},
-		},
-		RemoteChanCfg: channeldb.ChannelConfig{
-			ChannelConstraints: channeldb.ChannelConstraints{
-				CsvDelay: uint16(rand.Int63()),
-			},
-			MultiSigKey: keychain.KeyDescriptor{
-				PubKey: pub,
-			},
-			RevocationBasePoint: keychain.KeyDescriptor{
-				PubKey: pub,
-			},
-			PaymentBasePoint: keychain.KeyDescriptor{
-				PubKey: pub,
-			},
-			DelayBasePoint: keychain.KeyDescriptor{
-				PubKey: pub,
-			},
-			HtlcBasePoint: keychain.KeyDescriptor{
-				PubKey: pub,
-			},
-		},
+		ThawHeight:         rand.Uint32(),
+		IdentityPub:        pub,
+		LocalChanCfg:       localCfg,
+		RemoteChanCfg:      remoteCfg,
 		RevocationProducer: shaChainProducer,
 	}, nil
 }

--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -235,15 +235,21 @@ func createTestChannelState(t *testing.T, cdb *ChannelStateDB) *OpenChannel {
 		}
 	}
 
+	localStateBounds := ChannelStateBounds{
+		MaxPendingAmount: lnwire.MilliSatoshi(rand.Int63()),
+		ChanReserve:      btcutil.Amount(rand.Int63()),
+		MinHTLC:          lnwire.MilliSatoshi(rand.Int63()),
+		MaxAcceptedHtlcs: uint16(rand.Int31()),
+	}
+
+	localRenderingParams := CommitmentParams{
+		DustLimit: btcutil.Amount(rand.Int63()),
+		CsvDelay:  uint16(rand.Int31()),
+	}
+
 	localCfg := ChannelConfig{
-		ChannelConstraints: ChannelConstraints{
-			DustLimit:        btcutil.Amount(rand.Int63()),
-			MaxPendingAmount: lnwire.MilliSatoshi(rand.Int63()),
-			ChanReserve:      btcutil.Amount(rand.Int63()),
-			MinHTLC:          lnwire.MilliSatoshi(rand.Int63()),
-			MaxAcceptedHtlcs: uint16(rand.Int31()),
-			CsvDelay:         uint16(rand.Int31()),
-		},
+		ChannelStateBounds: localStateBounds,
+		CommitmentParams:   localRenderingParams,
 		MultiSigKey: keychain.KeyDescriptor{
 			PubKey: privKey.PubKey(),
 		},
@@ -260,15 +266,22 @@ func createTestChannelState(t *testing.T, cdb *ChannelStateDB) *OpenChannel {
 			PubKey: privKey.PubKey(),
 		},
 	}
+
+	remoteStateBounds := ChannelStateBounds{
+		MaxPendingAmount: lnwire.MilliSatoshi(rand.Int63()),
+		ChanReserve:      btcutil.Amount(rand.Int63()),
+		MinHTLC:          lnwire.MilliSatoshi(rand.Int63()),
+		MaxAcceptedHtlcs: uint16(rand.Int31()),
+	}
+
+	remoteRenderingParams := CommitmentParams{
+		DustLimit: btcutil.Amount(rand.Int63()),
+		CsvDelay:  uint16(rand.Int31()),
+	}
+
 	remoteCfg := ChannelConfig{
-		ChannelConstraints: ChannelConstraints{
-			DustLimit:        btcutil.Amount(rand.Int63()),
-			MaxPendingAmount: lnwire.MilliSatoshi(rand.Int63()),
-			ChanReserve:      btcutil.Amount(rand.Int63()),
-			MinHTLC:          lnwire.MilliSatoshi(rand.Int63()),
-			MaxAcceptedHtlcs: uint16(rand.Int31()),
-			CsvDelay:         uint16(rand.Int31()),
-		},
+		ChannelStateBounds: remoteStateBounds,
+		CommitmentParams:   remoteRenderingParams,
 		MultiSigKey: keychain.KeyDescriptor{
 			PubKey: privKey.PubKey(),
 			KeyLocator: keychain.KeyLocator{

--- a/channeldb/db_test.go
+++ b/channeldb/db_test.go
@@ -292,6 +292,10 @@ func genRandomChannelShell() (*ChannelShell, error) {
 	}
 	shaChainProducer := shachain.NewRevocationProducer(*revRoot)
 
+	commitParams := CommitmentParams{
+		CsvDelay: uint16(rand.Int63()),
+	}
+
 	return &ChannelShell{
 		NodeAddrs: []net.Addr{&net.TCPAddr{
 			IP:   net.ParseIP("127.0.0.1"),
@@ -306,9 +310,7 @@ func genRandomChannelShell() (*ChannelShell, error) {
 			),
 			IdentityPub: pub,
 			LocalChanCfg: ChannelConfig{
-				ChannelConstraints: ChannelConstraints{
-					CsvDelay: uint16(rand.Int63()),
-				},
+				CommitmentParams: commitParams,
 				PaymentBasePoint: keychain.KeyDescriptor{
 					KeyLocator: keychain.KeyLocator{
 						Family: keychain.KeyFamily(rand.Int63()),

--- a/contractcourt/breach_arbitrator_test.go
+++ b/contractcourt/breach_arbitrator_test.go
@@ -2178,13 +2178,15 @@ func createInitChannels(t *testing.T) (
 	fundingTxIn := wire.NewTxIn(prevOut, nil, nil)
 
 	aliceCfg := channeldb.ChannelConfig{
-		ChannelConstraints: channeldb.ChannelConstraints{
-			DustLimit:        aliceDustLimit,
+		ChannelStateBounds: channeldb.ChannelStateBounds{
 			MaxPendingAmount: lnwire.MilliSatoshi(rand.Int63()),
 			ChanReserve:      0,
 			MinHTLC:          0,
 			MaxAcceptedHtlcs: uint16(rand.Int31()),
-			CsvDelay:         uint16(csvTimeoutAlice),
+		},
+		CommitmentParams: channeldb.CommitmentParams{
+			DustLimit: aliceDustLimit,
+			CsvDelay:  uint16(csvTimeoutAlice),
 		},
 		MultiSigKey: keychain.KeyDescriptor{
 			PubKey: aliceKeyPub,
@@ -2203,13 +2205,15 @@ func createInitChannels(t *testing.T) (
 		},
 	}
 	bobCfg := channeldb.ChannelConfig{
-		ChannelConstraints: channeldb.ChannelConstraints{
-			DustLimit:        bobDustLimit,
+		ChannelStateBounds: channeldb.ChannelStateBounds{
 			MaxPendingAmount: lnwire.MilliSatoshi(rand.Int63()),
 			ChanReserve:      0,
 			MinHTLC:          0,
 			MaxAcceptedHtlcs: uint16(rand.Int31()),
-			CsvDelay:         uint16(csvTimeoutBob),
+		},
+		CommitmentParams: channeldb.CommitmentParams{
+			DustLimit: bobDustLimit,
+			CsvDelay:  uint16(csvTimeoutBob),
 		},
 		MultiSigKey: keychain.KeyDescriptor{
 			PubKey: bobKeyPub,

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -1875,10 +1875,10 @@ func (f *Manager) fundeeProcessOpenChannel(peer lnpeer.Peer,
 		msg.PendingChannelID)
 	bounds := remoteContribution.ChannelConfig.ChannelStateBounds
 	log.Debugf("Remote party accepted channel state space bounds: %v",
-		spew.Sdump(bounds))
+		lnutils.SpewLogClosure(bounds))
 	params := remoteContribution.ChannelConfig.CommitmentParams
 	log.Debugf("Remote party accepted commitment rendering params: %v",
-		spew.Sdump(params))
+		lnutils.SpewLogClosure(params))
 
 	// With the initiator's contribution recorded, respond with our
 	// contribution in the next message of the workflow.
@@ -2167,10 +2167,10 @@ func (f *Manager) funderProcessAcceptChannel(peer lnpeer.Peer,
 		msg.CsvDelay)
 	bounds = remoteContribution.ChannelConfig.ChannelStateBounds
 	log.Debugf("Remote party accepted channel state space bounds: %v",
-		spew.Sdump(bounds))
+		lnutils.SpewLogClosure(bounds))
 	commitParams = remoteContribution.ChannelConfig.CommitmentParams
 	log.Debugf("Remote party accepted commitment rendering params: %v",
-		spew.Sdump(commitParams))
+		lnutils.SpewLogClosure(commitParams))
 
 	// If the user requested funding through a PSBT, we cannot directly
 	// continue now and need to wait for the fully funded and signed PSBT

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -138,24 +138,28 @@ func createTestChannel(t *testing.T, alicePrivKey, bobPrivKey []byte,
 	csvTimeoutBob := uint32(4)
 	isAliceInitiator := true
 
-	aliceConstraints := &channeldb.ChannelConstraints{
-		DustLimit: btcutil.Amount(200),
+	aliceBounds := channeldb.ChannelStateBounds{
 		MaxPendingAmount: lnwire.NewMSatFromSatoshis(
 			channelCapacity),
 		ChanReserve:      aliceReserve,
 		MinHTLC:          0,
 		MaxAcceptedHtlcs: input.MaxHTLCNumber / 2,
-		CsvDelay:         uint16(csvTimeoutAlice),
+	}
+	aliceCommitParams := channeldb.CommitmentParams{
+		DustLimit: btcutil.Amount(200),
+		CsvDelay:  uint16(csvTimeoutAlice),
 	}
 
-	bobConstraints := &channeldb.ChannelConstraints{
-		DustLimit: btcutil.Amount(800),
+	bobBounds := channeldb.ChannelStateBounds{
 		MaxPendingAmount: lnwire.NewMSatFromSatoshis(
 			channelCapacity),
 		ChanReserve:      bobReserve,
 		MinHTLC:          0,
 		MaxAcceptedHtlcs: input.MaxHTLCNumber / 2,
-		CsvDelay:         uint16(csvTimeoutBob),
+	}
+	bobCommitParams := channeldb.CommitmentParams{
+		DustLimit: btcutil.Amount(800),
+		CsvDelay:  uint16(csvTimeoutBob),
 	}
 
 	var hash [sha256.Size]byte
@@ -172,7 +176,8 @@ func createTestChannel(t *testing.T, alicePrivKey, bobPrivKey []byte,
 	fundingTxIn := wire.NewTxIn(prevOut, nil, nil)
 
 	aliceCfg := channeldb.ChannelConfig{
-		ChannelConstraints: *aliceConstraints,
+		ChannelStateBounds: aliceBounds,
+		CommitmentParams:   aliceCommitParams,
 		MultiSigKey: keychain.KeyDescriptor{
 			PubKey: aliceKeyPub,
 		},
@@ -190,7 +195,8 @@ func createTestChannel(t *testing.T, alicePrivKey, bobPrivKey []byte,
 		},
 	}
 	bobCfg := channeldb.ChannelConfig{
-		ChannelConstraints: *bobConstraints,
+		ChannelStateBounds: bobBounds,
+		CommitmentParams:   bobCommitParams,
 		MultiSigKey: keychain.KeyDescriptor{
 			PubKey: bobKeyPub,
 		},

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -422,16 +422,18 @@ func testDualFundingReservationWorkflow(miner *rpctest.Harness,
 	aliceChanReservation, err := alice.InitChannelReservation(aliceReq)
 	require.NoError(t, err, "unable to initialize funding reservation")
 	aliceChanReservation.SetNumConfsRequired(numReqConfs)
-	channelConstraints := &channeldb.ChannelConstraints{
-		DustLimit:        lnwallet.DustLimitUnknownWitness(),
+	bounds := &channeldb.ChannelStateBounds{
 		ChanReserve:      fundingAmount / 100,
 		MaxPendingAmount: lnwire.NewMSatFromSatoshis(fundingAmount),
 		MinHTLC:          1,
 		MaxAcceptedHtlcs: input.MaxHTLCNumber / 2,
-		CsvDelay:         csvDelay,
+	}
+	commitParams := &channeldb.CommitmentParams{
+		DustLimit: lnwallet.DustLimitUnknownWitness(),
+		CsvDelay:  csvDelay,
 	}
 	err = aliceChanReservation.CommitConstraints(
-		channelConstraints, defaultMaxLocalCsvDelay, false,
+		bounds, commitParams, defaultMaxLocalCsvDelay, false,
 	)
 	require.NoError(t, err, "unable to verify constraints")
 
@@ -463,7 +465,7 @@ func testDualFundingReservationWorkflow(miner *rpctest.Harness,
 	bobChanReservation, err := bob.InitChannelReservation(bobReq)
 	require.NoError(t, err, "bob unable to init channel reservation")
 	err = bobChanReservation.CommitConstraints(
-		channelConstraints, defaultMaxLocalCsvDelay, true,
+		bounds, commitParams, defaultMaxLocalCsvDelay, true,
 	)
 	require.NoError(t, err, "unable to verify constraints")
 	bobChanReservation.SetNumConfsRequired(numReqConfs)
@@ -827,16 +829,18 @@ func testSingleFunderReservationWorkflow(miner *rpctest.Harness,
 	aliceChanReservation, err := alice.InitChannelReservation(aliceReq)
 	require.NoError(t, err, "unable to init channel reservation")
 	aliceChanReservation.SetNumConfsRequired(numReqConfs)
-	channelConstraints := &channeldb.ChannelConstraints{
-		DustLimit:        lnwallet.DustLimitUnknownWitness(),
+	bounds := &channeldb.ChannelStateBounds{
 		ChanReserve:      fundingAmt / 100,
 		MaxPendingAmount: lnwire.NewMSatFromSatoshis(fundingAmt),
 		MinHTLC:          1,
 		MaxAcceptedHtlcs: input.MaxHTLCNumber / 2,
-		CsvDelay:         csvDelay,
+	}
+	commitParams := &channeldb.CommitmentParams{
+		DustLimit: lnwallet.DustLimitUnknownWitness(),
+		CsvDelay:  csvDelay,
 	}
 	err = aliceChanReservation.CommitConstraints(
-		channelConstraints, defaultMaxLocalCsvDelay, false,
+		bounds, commitParams, defaultMaxLocalCsvDelay, false,
 	)
 	require.NoError(t, err, "unable to verify constraints")
 
@@ -875,7 +879,7 @@ func testSingleFunderReservationWorkflow(miner *rpctest.Harness,
 	bobChanReservation, err := bob.InitChannelReservation(bobReq)
 	require.NoError(t, err, "unable to create bob reservation")
 	err = bobChanReservation.CommitConstraints(
-		channelConstraints, defaultMaxLocalCsvDelay, true,
+		bounds, commitParams, defaultMaxLocalCsvDelay, true,
 	)
 	require.NoError(t, err, "unable to verify constraints")
 	bobChanReservation.SetNumConfsRequired(numReqConfs)

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -150,13 +150,15 @@ func CreateTestChannels(t *testing.T, chanType channeldb.ChannelType,
 	}
 
 	aliceCfg := channeldb.ChannelConfig{
-		ChannelConstraints: channeldb.ChannelConstraints{
-			DustLimit:        aliceDustLimit,
+		ChannelStateBounds: channeldb.ChannelStateBounds{
 			MaxPendingAmount: lnwire.NewMSatFromSatoshis(channelCapacity),
 			ChanReserve:      channelCapacity / 100,
 			MinHTLC:          0,
 			MaxAcceptedHtlcs: input.MaxHTLCNumber / 2,
-			CsvDelay:         uint16(csvTimeoutAlice),
+		},
+		CommitmentParams: channeldb.CommitmentParams{
+			DustLimit: aliceDustLimit,
+			CsvDelay:  uint16(csvTimeoutAlice),
 		},
 		MultiSigKey: keychain.KeyDescriptor{
 			PubKey: aliceKeys[0].PubKey(),
@@ -175,13 +177,15 @@ func CreateTestChannels(t *testing.T, chanType channeldb.ChannelType,
 		},
 	}
 	bobCfg := channeldb.ChannelConfig{
-		ChannelConstraints: channeldb.ChannelConstraints{
-			DustLimit:        bobDustLimit,
+		ChannelStateBounds: channeldb.ChannelStateBounds{
 			MaxPendingAmount: lnwire.NewMSatFromSatoshis(channelCapacity),
 			ChanReserve:      channelCapacity / 100,
 			MinHTLC:          0,
 			MaxAcceptedHtlcs: input.MaxHTLCNumber / 2,
-			CsvDelay:         uint16(csvTimeoutBob),
+		},
+		CommitmentParams: channeldb.CommitmentParams{
+			DustLimit: bobDustLimit,
+			CsvDelay:  uint16(csvTimeoutBob),
 		},
 		MultiSigKey: keychain.KeyDescriptor{
 			PubKey: bobKeys[0].PubKey(),

--- a/lnwallet/transactions_test.go
+++ b/lnwallet/transactions_test.go
@@ -603,14 +603,14 @@ func testSpendValidation(t *testing.T, tweakless bool) {
 	dustLimit := DustLimitForSize(input.UnknownWitnessSize)
 
 	aliceChanCfg := &channeldb.ChannelConfig{
-		ChannelConstraints: channeldb.ChannelConstraints{
+		CommitmentParams: channeldb.CommitmentParams{
 			DustLimit: dustLimit,
 			CsvDelay:  csvTimeout,
 		},
 	}
 
 	bobChanCfg := &channeldb.ChannelConfig{
-		ChannelConstraints: channeldb.ChannelConstraints{
+		CommitmentParams: channeldb.CommitmentParams{
 			DustLimit: dustLimit,
 			CsvDelay:  csvTimeout,
 		},
@@ -834,15 +834,17 @@ func createTestChannelsForVectors(tc *testContext, chanType channeldb.ChannelTyp
 
 	// Define channel configurations.
 	remoteCfg := channeldb.ChannelConfig{
-		ChannelConstraints: channeldb.ChannelConstraints{
-			DustLimit: tc.dustLimit,
+		ChannelStateBounds: channeldb.ChannelStateBounds{
 			MaxPendingAmount: lnwire.NewMSatFromSatoshis(
 				tc.fundingAmount,
 			),
 			ChanReserve:      0,
 			MinHTLC:          0,
 			MaxAcceptedHtlcs: input.MaxHTLCNumber / 2,
-			CsvDelay:         tc.localCsvDelay,
+		},
+		CommitmentParams: channeldb.CommitmentParams{
+			DustLimit: tc.dustLimit,
+			CsvDelay:  tc.localCsvDelay,
 		},
 		MultiSigKey: keychain.KeyDescriptor{
 			PubKey: tc.remoteFundingPrivkey.PubKey(),
@@ -861,15 +863,17 @@ func createTestChannelsForVectors(tc *testContext, chanType channeldb.ChannelTyp
 		},
 	}
 	localCfg := channeldb.ChannelConfig{
-		ChannelConstraints: channeldb.ChannelConstraints{
-			DustLimit: tc.dustLimit,
+		ChannelStateBounds: channeldb.ChannelStateBounds{
 			MaxPendingAmount: lnwire.NewMSatFromSatoshis(
 				tc.fundingAmount,
 			),
 			ChanReserve:      0,
 			MinHTLC:          0,
 			MaxAcceptedHtlcs: input.MaxHTLCNumber / 2,
-			CsvDelay:         tc.localCsvDelay,
+		},
+		CommitmentParams: channeldb.CommitmentParams{
+			DustLimit: tc.dustLimit,
+			CsvDelay:  tc.localCsvDelay,
 		},
 		MultiSigKey: keychain.KeyDescriptor{
 			PubKey: tc.localFundingPrivkey.PubKey(),

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -1379,7 +1379,7 @@ func (l *LightningWallet) initOurContribution(reservation *ChannelReservation,
 	)
 
 	reservation.partialState.RevocationProducer = producer
-	reservation.ourContribution.ChannelConstraints.DustLimit =
+	reservation.ourContribution.CommitmentParams.DustLimit =
 		DustLimitUnknownWitness()
 
 	// If taproot channels are active, then we'll generate our verification

--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -115,13 +115,15 @@ func createTestPeerWithChannel(t *testing.T, updateChan func(a,
 	)
 
 	aliceCfg := channeldb.ChannelConfig{
-		ChannelConstraints: channeldb.ChannelConstraints{
-			DustLimit:        aliceDustLimit,
+		ChannelStateBounds: channeldb.ChannelStateBounds{
 			MaxPendingAmount: lnwire.MilliSatoshi(rand.Int63()),
 			ChanReserve:      btcutil.Amount(rand.Int63()),
 			MinHTLC:          lnwire.MilliSatoshi(rand.Int63()),
 			MaxAcceptedHtlcs: uint16(rand.Int31()),
-			CsvDelay:         uint16(csvTimeoutAlice),
+		},
+		CommitmentParams: channeldb.CommitmentParams{
+			DustLimit: aliceDustLimit,
+			CsvDelay:  uint16(csvTimeoutAlice),
 		},
 		MultiSigKey: keychain.KeyDescriptor{
 			PubKey: aliceKeyPub,
@@ -140,13 +142,15 @@ func createTestPeerWithChannel(t *testing.T, updateChan func(a,
 		},
 	}
 	bobCfg := channeldb.ChannelConfig{
-		ChannelConstraints: channeldb.ChannelConstraints{
-			DustLimit:        bobDustLimit,
+		ChannelStateBounds: channeldb.ChannelStateBounds{
 			MaxPendingAmount: lnwire.MilliSatoshi(rand.Int63()),
 			ChanReserve:      btcutil.Amount(rand.Int63()),
 			MinHTLC:          lnwire.MilliSatoshi(rand.Int63()),
 			MaxAcceptedHtlcs: uint16(rand.Int31()),
-			CsvDelay:         uint16(csvTimeoutBob),
+		},
+		CommitmentParams: channeldb.CommitmentParams{
+			DustLimit: bobDustLimit,
+			CsvDelay:  uint16(csvTimeoutBob),
 		},
 		MultiSigKey: keychain.KeyDescriptor{
 			PubKey: bobKeyPub,

--- a/routing/localchans/manager.go
+++ b/routing/localchans/manager.go
@@ -279,7 +279,7 @@ func (r *Manager) getHtlcAmtLimits(tx kvdb.RTx, chanPoint wire.OutPoint) (
 	// capacity AND less than or equal to the max in-flight HTLC value.
 	// Since the latter is always less than or equal to the former, just
 	// return the max in-flight value.
-	maxAmt := ch.LocalChanCfg.ChannelConstraints.MaxPendingAmount
+	maxAmt := ch.LocalChanCfg.ChannelStateBounds.MaxPendingAmount
 
 	return ch.LocalChanCfg.MinHTLC, maxAmt, nil
 }

--- a/routing/localchans/manager_test.go
+++ b/routing/localchans/manager_test.go
@@ -125,14 +125,14 @@ func TestManager(t *testing.T) {
 			return &channeldb.OpenChannel{}, channeldb.ErrChannelNotFound
 		}
 
-		constraints := channeldb.ChannelConstraints{
+		bounds := channeldb.ChannelStateBounds{
 			MaxPendingAmount: maxPendingAmount,
 			MinHTLC:          minHTLC,
 		}
 
 		return &channeldb.OpenChannel{
 			LocalChanCfg: channeldb.ChannelConfig{
-				ChannelConstraints: constraints,
+				ChannelStateBounds: bounds,
 			},
 		}, nil
 	}


### PR DESCRIPTION
This commit breaks the ChannelConstraints structure into two sub-structures that reflect the fundamental differences in how these parameters are used. On its face it may not seem necessary, however the distinction introduced here is relevant for how we will be implementing the Dynamic Commitments proposal.

## Change Description
Description of change / link to associated issue.

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
