### PR TITLE
Improve the performace of `LeaseOutput`

### DIFF
--- a/docs/release-notes/release-notes-0.18.3.md
+++ b/docs/release-notes/release-notes-0.18.3.md
@@ -151,6 +151,11 @@ commitment when the channel was force closed.
 * [Allow](https://github.com/lightningnetwork/lnd/pull/8845) multiple etcd hosts
   to be specified in db.etcd.host.
 
+* Improved the internal [`LeaseOutput`
+  method](https://github.com/lightningnetwork/lnd/pull/8961) to be more
+  efficient, which improves the performance of related RPC calls such as
+  `LeaseOutput`, `SendCoins`, and PSBT funding process. 
+
 ## RPC Updates
 
 * [`xImportMissionControl`](https://github.com/lightningnetwork/lnd/pull/8779) 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.8
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
-	github.com/btcsuite/btcwallet v0.16.10-0.20240718224643-db3a4a2543bd
+	github.com/btcsuite/btcwallet v0.16.10-0.20240809133323-7d3434c65ae2
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.3.4
 	github.com/btcsuite/btcwallet/wallet/txrules v1.2.1
 	github.com/btcsuite/btcwallet/walletdb v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0/go.mod h1:7SFka0XMvUgj3hfZtyd
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
-github.com/btcsuite/btcwallet v0.16.10-0.20240718224643-db3a4a2543bd h1:QDb8foTCRoXrfoZVEzSYgSde16MJh4gCtCin8OCS0kI=
-github.com/btcsuite/btcwallet v0.16.10-0.20240718224643-db3a4a2543bd/go.mod h1:X2xDre+j1QphTRo54y2TikUzeSvreL1t1aMXrD8Kc5A=
+github.com/btcsuite/btcwallet v0.16.10-0.20240809133323-7d3434c65ae2 h1:qa4Avm7p97JroZZyMJADbEb9u853pjleJYSeitENvLc=
+github.com/btcsuite/btcwallet v0.16.10-0.20240809133323-7d3434c65ae2/go.mod h1:X2xDre+j1QphTRo54y2TikUzeSvreL1t1aMXrD8Kc5A=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.4 h1:poyHFf7+5+RdxNp5r2T6IBRD7RyraUsYARYbp/7t4D8=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.4/go.mod h1:GETGDQuyq+VFfH1S/+/7slLM/9aNa4l7P4ejX6dJfb0=
 github.com/btcsuite/btcwallet/wallet/txrules v1.2.1 h1:UZo7YRzdHbwhK7Rhv3PO9bXgTxiOH45edK5qdsdiatk=

--- a/itest/lnd_hold_invoice_force_test.go
+++ b/itest/lnd_hold_invoice_force_test.go
@@ -95,10 +95,6 @@ func testHoldInvoiceForceClose(ht *lntest.HarnessTest) {
 	// We first mine enough blocks to trigger an invoice cancelation.
 	ht.MineBlocks(int(blocksTillCancel))
 
-	// Wait for the nodes to be synced.
-	ht.WaitForBlockchainSync(alice)
-	ht.WaitForBlockchainSync(bob)
-
 	// Check that the invoice is canceled by Bob.
 	err := wait.NoError(func() error {
 		inv := bob.RPC.LookupInvoice(payHash[:])
@@ -134,10 +130,6 @@ func testHoldInvoiceForceClose(ht *lntest.HarnessTest) {
 	// than Bob's INVC, causing the channel being force closed before the
 	// invoice cancelation message was received by Alice.
 	ht.MineBlocks(int(blocksTillForce - blocksTillCancel))
-
-	// Wait for the nodes to be synced.
-	ht.WaitForBlockchainSync(alice)
-	ht.WaitForBlockchainSync(bob)
 
 	// Check that Alice has not closed the channel because there are no
 	// outgoing HTLCs in her channel as the only HTLC has already been

--- a/itest/lnd_psbt_test.go
+++ b/itest/lnd_psbt_test.go
@@ -1578,7 +1578,6 @@ func sendAllCoinsToAddrType(ht *lntest.HarnessTest,
 	})
 
 	ht.MineBlocksAndAssertNumTxes(1, 1)
-	ht.WaitForBlockchainSync(hn)
 }
 
 // testPsbtChanFundingFailFlow tests the failing of a funding flow by the

--- a/itest/lnd_route_blinding_test.go
+++ b/itest/lnd_route_blinding_test.go
@@ -852,10 +852,6 @@ func testErrorHandlingOnChainFailure(ht *lntest.HarnessTest) {
 	ht.AssertNumPendingSweeps(ht.Bob, 0)
 	ht.MineBlocksAndAssertNumTxes(1, 1)
 
-	// Assert that the HTLC has cleared.
-	ht.WaitForBlockchainSync(ht.Bob)
-	ht.WaitForBlockchainSync(ht.Alice)
-
 	ht.AssertHTLCNotActive(ht.Bob, testCase.channels[0], hash[:])
 	ht.AssertHTLCNotActive(ht.Alice, testCase.channels[0], hash[:])
 

--- a/lnrpc/walletrpc/psbt.go
+++ b/lnrpc/walletrpc/psbt.go
@@ -56,7 +56,13 @@ func lockInputs(w lnwallet.WalletController,
 			},
 		}
 
-		expiration, pkScript, value, err := w.LeaseOutput(
+		// Get the details about this outpoint.
+		utxo, err := w.FetchOutpointInfo(&lock.Outpoint)
+		if err != nil {
+			return nil, fmt.Errorf("fetch outpoint info: %w", err)
+		}
+
+		expiration, _, _, err := w.LeaseOutput(
 			lock.LockID, lock.Outpoint,
 			chanfunding.DefaultLockDuration,
 		)
@@ -80,8 +86,8 @@ func lockInputs(w lnwallet.WalletController,
 		}
 
 		lock.Expiration = expiration
-		lock.PkScript = pkScript
-		lock.Value = int64(value)
+		lock.PkScript = utxo.PkScript
+		lock.Value = int64(utxo.Value)
 		locks[idx] = lock
 	}
 

--- a/lnrpc/walletrpc/psbt.go
+++ b/lnrpc/walletrpc/psbt.go
@@ -62,7 +62,7 @@ func lockInputs(w lnwallet.WalletController,
 			return nil, fmt.Errorf("fetch outpoint info: %w", err)
 		}
 
-		expiration, _, _, err := w.LeaseOutput(
+		expiration, err := w.LeaseOutput(
 			lock.LockID, lock.Outpoint,
 			chanfunding.DefaultLockDuration,
 		)

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -490,7 +490,7 @@ func (w *WalletKit) LeaseOutput(ctx context.Context,
 	// other concurrent processes attempting to lease the same UTXO.
 	var expiration time.Time
 	err = w.cfg.CoinSelectionLocker.WithCoinSelectLock(func() error {
-		expiration, _, _, err = w.cfg.Wallet.LeaseOutput(
+		expiration, err = w.cfg.Wallet.LeaseOutput(
 			lockID, *op, duration,
 		)
 		return err

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -1142,7 +1142,7 @@ func (w *WalletKit) sweepNewInput(op *wire.OutPoint, currentHeight uint32,
 	//
 	// We'll gather all of the information required by the UtxoSweeper in
 	// order to sweep the output.
-	utxo, err := w.cfg.Wallet.FetchInputInfo(op)
+	utxo, err := w.cfg.Wallet.FetchOutpointInfo(op)
 	if err != nil {
 		return err
 	}

--- a/lntest/mock/walletcontroller.go
+++ b/lntest/mock/walletcontroller.go
@@ -195,9 +195,9 @@ func (w *WalletController) ListTransactionDetails(int32, int32,
 
 // LeaseOutput returns the current time and a nil error.
 func (w *WalletController) LeaseOutput(wtxmgr.LockID, wire.OutPoint,
-	time.Duration) (time.Time, []byte, btcutil.Amount, error) {
+	time.Duration) (time.Time, error) {
 
-	return time.Now(), nil, 0, nil
+	return time.Now(), nil
 }
 
 // ReleaseOutput currently does nothing.

--- a/lntest/mock/walletcontroller.go
+++ b/lntest/mock/walletcontroller.go
@@ -58,6 +58,21 @@ func (w *WalletController) FetchInputInfo(
 	return utxo, nil
 }
 
+// FetchOutpointInfo will be called to get info about the inputs to the funding
+// transaction.
+func (w *WalletController) FetchOutpointInfo(
+	prevOut *wire.OutPoint) (*lnwallet.Utxo, error) {
+
+	utxo := &lnwallet.Utxo{
+		AddressType:   lnwallet.WitnessPubKey,
+		Value:         10 * btcutil.SatoshiPerBitcoin,
+		PkScript:      []byte("dummy"),
+		Confirmations: 1,
+		OutPoint:      *prevOut,
+	}
+	return utxo, nil
+}
+
 // ScriptForOutput returns the address, witness program and redeem script for a
 // given UTXO. An error is returned if the UTXO does not belong to our wallet or
 // it is not a managed pubKey address.
@@ -291,4 +306,12 @@ func (w *WalletController) RemoveDescendants(*wire.MsgTx) error {
 
 func (w *WalletController) CheckMempoolAcceptance(tx *wire.MsgTx) error {
 	return nil
+}
+
+// FetchDerivationInfo queries for the wallet's knowledge of the passed
+// pkScript and constructs the derivation info and returns it.
+func (w *WalletController) FetchDerivationInfo(
+	pkScript []byte) (*psbt.Bip32Derivation, error) {
+
+	return nil, nil
 }

--- a/lntest/mock/walletcontroller.go
+++ b/lntest/mock/walletcontroller.go
@@ -43,21 +43,6 @@ func (w *WalletController) BackEnd() string {
 	return "mock"
 }
 
-// FetchInputInfo will be called to get info about the inputs to the funding
-// transaction.
-func (w *WalletController) FetchInputInfo(
-	prevOut *wire.OutPoint) (*lnwallet.Utxo, error) {
-
-	utxo := &lnwallet.Utxo{
-		AddressType:   lnwallet.WitnessPubKey,
-		Value:         10 * btcutil.SatoshiPerBitcoin,
-		PkScript:      []byte("dummy"),
-		Confirmations: 1,
-		OutPoint:      *prevOut,
-	}
-	return utxo, nil
-}
-
 // FetchOutpointInfo will be called to get info about the inputs to the funding
 // transaction.
 func (w *WalletController) FetchOutpointInfo(

--- a/lnwallet/btcwallet/signer.go
+++ b/lnwallet/btcwallet/signer.go
@@ -19,44 +19,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet"
 )
 
-// FetchInputInfo queries for the WalletController's knowledge of the passed
-// outpoint. If the base wallet determines this output is under its control,
-// then the original txout should be returned. Otherwise, a non-nil error value
-// of ErrNotMine should be returned instead.
-//
-// This is a part of the WalletController interface.
-func (b *BtcWallet) FetchInputInfo(prevOut *wire.OutPoint) (*lnwallet.Utxo,
-	error) {
-
-	prevTx, txOut, bip32, confirmations, err := b.wallet.FetchInputInfo(
-		prevOut,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	// Then, we'll populate all of the information required by the struct.
-	addressType := lnwallet.UnknownAddressType
-	switch {
-	case txscript.IsPayToWitnessPubKeyHash(txOut.PkScript):
-		addressType = lnwallet.WitnessPubKey
-	case txscript.IsPayToScriptHash(txOut.PkScript):
-		addressType = lnwallet.NestedWitnessPubKey
-	case txscript.IsPayToTaproot(txOut.PkScript):
-		addressType = lnwallet.TaprootPubkey
-	}
-
-	return &lnwallet.Utxo{
-		AddressType:   addressType,
-		Value:         btcutil.Amount(txOut.Value),
-		PkScript:      txOut.PkScript,
-		Confirmations: confirmations,
-		OutPoint:      *prevOut,
-		Derivation:    bip32,
-		PrevTx:        prevTx,
-	}, nil
-}
-
 // FetchOutpointInfo queries for the WalletController's knowledge of the passed
 // outpoint. If the base wallet determines this output is under its control,
 // then the original txout should be returned. Otherwise, a non-nil error value

--- a/lnwallet/chanfunding/assembler.go
+++ b/lnwallet/chanfunding/assembler.go
@@ -44,7 +44,7 @@ type OutputLeaser interface {
 	// LeaseOutput leases a target output, rendering it unusable for coin
 	// selection.
 	LeaseOutput(i wtxmgr.LockID, o wire.OutPoint, d time.Duration) (
-		time.Time, []byte, btcutil.Amount, error)
+		time.Time, error)
 
 	// ReleaseOutput releases a target output, allowing it to be used for
 	// coin selection once again.

--- a/lnwallet/chanfunding/wallet_assembler.go
+++ b/lnwallet/chanfunding/wallet_assembler.go
@@ -525,7 +525,7 @@ func (w *WalletAssembler) ProvisionChannel(r *Request) (Intent, error) {
 		for _, coin := range selectedCoins {
 			outpoint := coin.OutPoint
 
-			_, _, _, err = w.cfg.CoinLeaser.LeaseOutput(
+			_, err = w.cfg.CoinLeaser.LeaseOutput(
 				LndInternalLockID, outpoint,
 				DefaultReservationTimeout,
 			)

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -228,10 +228,20 @@ type TransactionSubscription interface {
 // across all concrete implementations.
 type WalletController interface {
 	// FetchInputInfo queries for the WalletController's knowledge of the
-	// passed outpoint. If the base wallet determines this output is under
-	// its control, then the original txout should be returned.  Otherwise,
-	// a non-nil error value of ErrNotMine should be returned instead.
+	// passed outpoint. It returns the same info as `FetchOutpointInfo`
+	// plus the Bip32Derivation info.
 	FetchInputInfo(prevOut *wire.OutPoint) (*Utxo, error)
+
+	// FetchOutpointInfo queries for the WalletController's knowledge of
+	// the passed outpoint. If the base wallet determines this output is
+	// under its control, then the original txout should be returned.
+	// Otherwise, a non-nil error value of ErrNotMine should be returned
+	// instead.
+	FetchOutpointInfo(prevOut *wire.OutPoint) (*Utxo, error)
+
+	// FetchDerivationInfo queries for the wallet's knowledge of the passed
+	// pkScript and constructs the derivation info and returns it.
+	FetchDerivationInfo(pkScript []byte) (*psbt.Bip32Derivation, error)
 
 	// ScriptForOutput returns the address, witness program and redeem
 	// script for a given UTXO. An error is returned if the UTXO does not

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -126,8 +126,7 @@ type Utxo struct {
 	Confirmations int64
 	PkScript      []byte
 	wire.OutPoint
-	Derivation *psbt.Bip32Derivation
-	PrevTx     *wire.MsgTx
+	PrevTx *wire.MsgTx
 }
 
 // OutputDetail contains additional information on a destination address.
@@ -227,11 +226,6 @@ type TransactionSubscription interface {
 // behavior of all interface methods in order to ensure identical behavior
 // across all concrete implementations.
 type WalletController interface {
-	// FetchInputInfo queries for the WalletController's knowledge of the
-	// passed outpoint. It returns the same info as `FetchOutpointInfo`
-	// plus the Bip32Derivation info.
-	FetchInputInfo(prevOut *wire.OutPoint) (*Utxo, error)
-
 	// FetchOutpointInfo queries for the WalletController's knowledge of
 	// the passed outpoint. If the base wallet determines this output is
 	// under its control, then the original txout should be returned.

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -413,8 +413,7 @@ type WalletController interface {
 	//
 	// NOTE: This method requires the global coin selection lock to be held.
 	LeaseOutput(id wtxmgr.LockID, op wire.OutPoint,
-		duration time.Duration) (time.Time, []byte, btcutil.Amount,
-		error)
+		duration time.Duration) (time.Time, error)
 
 	// ReleaseOutput unlocks an output, allowing it to be available for coin
 	// selection if it remains unspent. The ID should match the one used to

--- a/lnwallet/mock.go
+++ b/lnwallet/mock.go
@@ -61,6 +61,22 @@ func (w *mockWalletController) FetchInputInfo(
 	return utxo, nil
 }
 
+// FetchOutpointInfo will be called to get info about the inputs to the funding
+// transaction.
+func (w *mockWalletController) FetchOutpointInfo(
+	prevOut *wire.OutPoint) (*Utxo, error) {
+
+	utxo := &Utxo{
+		AddressType:   WitnessPubKey,
+		Value:         10 * btcutil.SatoshiPerBitcoin,
+		PkScript:      []byte("dummy"),
+		Confirmations: 1,
+		OutPoint:      *prevOut,
+	}
+
+	return utxo, nil
+}
+
 // ScriptForOutput returns the address, witness program and redeem script for a
 // given UTXO. An error is returned if the UTXO does not belong to our wallet or
 // it is not a managed pubKey address.
@@ -298,6 +314,14 @@ func (w *mockWalletController) FetchTx(chainhash.Hash) (*wire.MsgTx, error) {
 
 func (w *mockWalletController) RemoveDescendants(*wire.MsgTx) error {
 	return nil
+}
+
+// FetchDerivationInfo queries for the wallet's knowledge of the passed
+// pkScript and constructs the derivation info and returns it.
+func (w *mockWalletController) FetchDerivationInfo(
+	pkScript []byte) (*psbt.Bip32Derivation, error) {
+
+	return nil, nil
 }
 
 func (w *mockWalletController) CheckMempoolAcceptance(tx *wire.MsgTx) error {

--- a/lnwallet/mock.go
+++ b/lnwallet/mock.go
@@ -45,22 +45,6 @@ func (w *mockWalletController) BackEnd() string {
 	return "mock"
 }
 
-// FetchInputInfo will be called to get info about the inputs to the funding
-// transaction.
-func (w *mockWalletController) FetchInputInfo(
-	prevOut *wire.OutPoint) (*Utxo, error) {
-
-	utxo := &Utxo{
-		AddressType:   WitnessPubKey,
-		Value:         10 * btcutil.SatoshiPerBitcoin,
-		PkScript:      []byte("dummy"),
-		Confirmations: 1,
-		OutPoint:      *prevOut,
-	}
-
-	return utxo, nil
-}
-
 // FetchOutpointInfo will be called to get info about the inputs to the funding
 // transaction.
 func (w *mockWalletController) FetchOutpointInfo(

--- a/lnwallet/mock.go
+++ b/lnwallet/mock.go
@@ -201,9 +201,9 @@ func (w *mockWalletController) ListTransactionDetails(int32, int32,
 
 // LeaseOutput returns the current time and a nil error.
 func (w *mockWalletController) LeaseOutput(wtxmgr.LockID, wire.OutPoint,
-	time.Duration) (time.Time, []byte, btcutil.Amount, error) {
+	time.Duration) (time.Time, error) {
 
-	return time.Now(), nil, 0, nil
+	return time.Now(), nil
 }
 
 // ReleaseOutput currently does nothing.

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -1646,7 +1646,7 @@ func (l *LightningWallet) handleContributionMsg(req *addContributionMsg) {
 			[]*input.Script, 0, len(ourContribution.Inputs),
 		)
 		for _, txIn := range fundingTx.TxIn {
-			_, err := l.FetchInputInfo(&txIn.PreviousOutPoint)
+			_, err := l.FetchOutpointInfo(&txIn.PreviousOutPoint)
 			if err != nil {
 				continue
 			}
@@ -2592,7 +2592,7 @@ func (c *CoinSource) ListCoins(minConfs int32,
 // its outpoint. If the coin isn't under the control of the backing CoinSource,
 // then an error should be returned.
 func (c *CoinSource) CoinFromOutPoint(op wire.OutPoint) (*wallet.Coin, error) {
-	inputInfo, err := c.wallet.FetchInputInfo(&op)
+	inputInfo, err := c.wallet.FetchOutpointInfo(&op)
 	if err != nil {
 		return nil, err
 	}
@@ -2689,7 +2689,7 @@ func NewWalletPrevOutputFetcher(wc WalletController) *WalletPrevOutputFetcher {
 // passed outpoint. A nil value will be returned if the passed outpoint doesn't
 // exist.
 func (w *WalletPrevOutputFetcher) FetchPrevOutput(op wire.OutPoint) *wire.TxOut {
-	utxo, err := w.wc.FetchInputInfo(&op)
+	utxo, err := w.wc.FetchOutpointInfo(&op)
 	if err != nil {
 		return nil
 	}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3488,14 +3488,7 @@ func (r *rpcServer) WalletBalance(ctx context.Context,
 		return nil, err
 	}
 	for _, leasedOutput := range leases {
-		utxoInfo, err := r.server.cc.Wallet.FetchInputInfo(
-			&leasedOutput.Outpoint,
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		lockedBalance += utxoInfo.Value
+		lockedBalance += btcutil.Amount(leasedOutput.Value)
 	}
 
 	// Get the current number of non-private anchor channels.

--- a/sweep/walletsweep.go
+++ b/sweep/walletsweep.go
@@ -179,7 +179,7 @@ type OutputLeaser interface {
 	// LeaseOutput leases a target output, rendering it unusable for coin
 	// selection.
 	LeaseOutput(i wtxmgr.LockID, o wire.OutPoint, d time.Duration) (
-		time.Time, []byte, btcutil.Amount, error)
+		time.Time, error)
 
 	// ReleaseOutput releases a target output, allowing it to be used for
 	// coin selection once again.
@@ -284,7 +284,7 @@ func CraftSweepAllTx(feeRate, maxFeeRate chainfee.SatPerKWeight,
 			log.Tracef("[WithCoinSelectLock] leasing utxo: %v",
 				utxo.OutPoint)
 
-			_, _, _, err = outputLeaser.LeaseOutput(
+			_, err = outputLeaser.LeaseOutput(
 				chanfunding.LndInternalLockID, utxo.OutPoint,
 				chanfunding.DefaultLockDuration,
 			)

--- a/sweep/walletsweep_test.go
+++ b/sweep/walletsweep_test.go
@@ -199,11 +199,11 @@ func newMockOutputLeaser() *mockOutputLeaser {
 }
 
 func (m *mockOutputLeaser) LeaseOutput(_ wtxmgr.LockID, o wire.OutPoint,
-	t time.Duration) (time.Time, []byte, btcutil.Amount, error) {
+	t time.Duration) (time.Time, error) {
 
 	m.leasedOutputs[o] = struct{}{}
 
-	return time.Now().Add(t), nil, 0, nil
+	return time.Now().Add(t), nil
 }
 
 func (m *mockOutputLeaser) ReleaseOutput(_ wtxmgr.LockID,


### PR DESCRIPTION
There's a wrapper built around `btcwallet.LeaseOutput` in `lnwallet`, which additionally calls `ListLeasedOutputs` to fetch the script and value info, which is rarely used and can be replaced with other queries when needed. More importantly this `ListLeasedOutputs` is very slow (detailed in https://github.com/btcsuite/btcwallet/issues/943), so we remove this call.

Once removed, we gained roughly 30s back in this test,
```
make itest icase=sign_psbt/fund_and_sign_psbt backend=bitcoind dbbackend=postgres
```

On this branch
```
--- PASS: TestLightningNetworkDaemon (185.49s)
    --- PASS: TestLightningNetworkDaemon/tranche00/74-of-167/bitcoind/sign_psbt (95.03s)
        --- PASS: TestLightningNetworkDaemon/tranche00/74-of-167/bitcoind/sign_psbt/fund_and_sign_psbt (88.34s)
```

On master,
```
--- PASS: TestLightningNetworkDaemon (230.91s)
    --- PASS: TestLightningNetworkDaemon/tranche00/74-of-167/bitcoind/sign_psbt (139.04s)
        --- PASS: TestLightningNetworkDaemon/tranche00/74-of-167/bitcoind/sign_psbt/fund_and_sign_psbt (133.73s)
```

Fix #8809.