### PR TITLE
peer: always send channel update on reconnect

### DIFF
--- a/docs/release-notes/release-notes-0.18.3.md
+++ b/docs/release-notes/release-notes-0.18.3.md
@@ -57,6 +57,9 @@ commitment when the channel was force closed.
   [here](https://github.com/lightningnetwork/lnd/issues/8146) for a summary of
   the issue.
 
+* We'll now always send [channel updates to our remote peer for open
+  channels](https://github.com/lightningnetwork/lnd/pull/8963).
+
 # New Features
 ## Functional Enhancements
 ## RPC Additions
@@ -243,6 +246,7 @@ commitment when the channel was force closed.
 * Elle Mouton
 * Eugene Siegel
 * Matheus Degiovani
+* Olaoluwa Osuntokun
 * Oliver Gugger
 * Slyghtning
 * Yong Yu

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -1100,6 +1100,51 @@ func TestUpdateNextRevocation(t *testing.T) {
 	// `lnwallet.LightningWallet` once it's interfaced.
 }
 
+func assertMsgSent(t *testing.T, conn *mockMessageConn,
+	msgType lnwire.MessageType) {
+
+	t.Helper()
+
+	require := require.New(t)
+
+	rawMsg, err := fn.RecvOrTimeout(conn.writtenMessages, timeout)
+	require.NoError(err)
+
+	msgReader := bytes.NewReader(rawMsg)
+	msg, err := lnwire.ReadMessage(msgReader, 0)
+	require.NoError(err)
+
+	require.Equal(msgType, msg.MsgType())
+}
+
+// TestAlwaysSendChannelUpdate tests that each time we connect to the peer if
+// an active channel, we always send the latest channel update.
+func TestAlwaysSendChannelUpdate(t *testing.T) {
+	require := require.New(t)
+
+	var channel *channeldb.OpenChannel
+	channelIntercept := func(a, b *channeldb.OpenChannel) {
+		channel = a
+	}
+
+	harness, err := createTestPeerWithChannel(t, channelIntercept)
+	require.NoError(err, "unable to create test channels")
+
+	// Avoid the need to mock the channel graph by marking the channel
+	// borked. Borked channels still get a reestablish message sent on
+	// reconnect, while skipping channel graph checks and link creation.
+	require.NoError(channel.MarkBorked())
+
+	// Start the peer, which'll trigger the normal init and start up logic.
+	startPeerDone := startPeer(t, harness.mockConn, harness.peer)
+	_, err = fn.RecvOrTimeout(startPeerDone, 2*timeout)
+	require.NoError(err)
+
+	// Assert that we eventually send a channel update.
+	assertMsgSent(t, harness.mockConn, lnwire.MsgChannelReestablish)
+	assertMsgSent(t, harness.mockConn, lnwire.MsgChannelUpdate)
+}
+
 // TODO(yy): add test for `addActiveChannel` and `handleNewActiveChannel` once
 // we have interfaced `lnwallet.LightningChannel` and
 // `*contractcourt.ChainArbitrator`.


### PR DESCRIPTION
We have existing logic to attempt to reliably send a channel update to the remote peer. In the wild, we've seen this fail, as it's possible right when we send the update the peer disconnects.

In this commit, we implement a simple fix which is just to send the chan update each time we connect to the remote party.

Fixes https://github.com/lightningnetwork/lnd/issues/6870.

