### PR TITLE
[MICRO]: channeldb+lnwallet: add OpeningParty API

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -889,6 +889,18 @@ func (c *OpenChannel) String() string {
 	)
 }
 
+// Initiator returns the ChannelParty that originally opened this channel.
+func (c *OpenChannel) Initiator() lntypes.ChannelParty {
+	c.RLock()
+	defer c.RUnlock()
+
+	if c.IsInitiator {
+		return lntypes.Local
+	}
+
+	return lntypes.Remote
+}
+
 // ShortChanID returns the current ShortChannelID of this channel.
 func (c *OpenChannel) ShortChanID() lnwire.ShortChannelID {
 	c.RLock()

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -8709,6 +8709,14 @@ func (lc *LightningChannel) ChanType() channeldb.ChannelType {
 	return lc.channelState.ChanType
 }
 
+// Initiator returns the ChannelParty that originally opened this channel.
+func (lc *LightningChannel) Initiator() lntypes.ChannelParty {
+	lc.RLock()
+	defer lc.RUnlock()
+
+	return lc.channelState.Initiator()
+}
+
 // FundingTxOut returns the funding output of the channel.
 func (lc *LightningChannel) FundingTxOut() *wire.TxOut {
 	lc.RLock()


### PR DESCRIPTION
## Change Description
Spinoff from #8755. Useful for #8270 refactor. Simple API addition to convert database boolean representation to the ChannelParty domain type.

## Steps to Test
n/a

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
