### PR TITLE
contractcourt: increase the default deadline for anchor sweeping

### DIFF
--- a/docs/release-notes/release-notes-0.18.3.md
+++ b/docs/release-notes/release-notes-0.18.3.md
@@ -94,6 +94,12 @@ commitment when the channel was force closed.
 * [Allow](https://github.com/lightningnetwork/lnd/pull/8845) multiple etcd hosts
   to be specified in db.etcd.host.
 
+* The deadline delta used for sweeping non-CPFP-purpose anchor inputs is now
+  [changed](https://github.com/lightningnetwork/lnd/pull/8983), which prevents
+  the anchors to be grouped with other kinds of inputs. In addition, the
+  sweeping of inputs with large deadlines (more than two weeks away) is paused
+  and will only be resumed when they are within the two weeks range again.
+
 ## RPC Updates
 
 * [`xImportMissionControl`](https://github.com/lightningnetwork/lnd/pull/8779) 

--- a/itest/lnd_onchain_test.go
+++ b/itest/lnd_onchain_test.go
@@ -477,10 +477,10 @@ func testAnchorThirdPartySpend(ht *lntest.HarnessTest) {
 	// other for commit output.
 	sweeps := ht.AssertNumPendingSweeps(alice, 2)
 
-	// Identify the sweep requests - the anchor sweep should have a smaller
-	// deadline height since it's been offered to the sweeper earlier.
+	// Identify the sweep requests - the anchor sweep should have a much
+	// larger deadline.
 	anchor, commit := sweeps[0], sweeps[1]
-	if anchor.DeadlineHeight > commit.DeadlineHeight {
+	if anchor.DeadlineHeight < commit.DeadlineHeight {
 		anchor, commit = commit, anchor
 	}
 

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1513,6 +1513,17 @@ func (s *UtxoSweeper) updateSweeperInputs() InputsMap {
 			continue
 		}
 
+		// If the input has a deadline that's two weeks away, we won't
+		// attempt to create a sweeping tx and fee bump it now.
+		deadline := input.params.DeadlineHeight.UnwrapOr(0)
+		if deadline > s.currentHeight+DefaultDeadlineDelta*2 {
+			log.Infof("Skipping input %v since its deadline=%v is "+
+				"far in the future, current height is %v", op,
+				deadline, s.currentHeight)
+
+			continue
+		}
+
 		// If this input is new or has been failed to be published,
 		// we'd retry it. The assumption here is that when an error is
 		// returned from `PublishTransaction`, it means the tx has


### PR DESCRIPTION
This commit changes the default anchor sweeping deadline from 1 week to 10 weeks so they won't be grouped with other inputs, which mitigates the pinning issue.