### PR TITLE
lnrpc: avoid needing to download Golang

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -204,8 +204,8 @@ replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 // allows us to specify that as an option.
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display
 
-// If you change this please also update .github/pull_request_template.md and
-// docs/INSTALL.md.
+// If you change this please also update .github/pull_request_template.md,
+// docs/INSTALL.md and GO_IMAGE in lnrpc/gen_protos_docker.sh.
 go 1.21.4
 
 retract v0.0.2

--- a/lnrpc/gen_protos_docker.sh
+++ b/lnrpc/gen_protos_docker.sh
@@ -6,7 +6,7 @@ set -e
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
 # golang docker image version used in this script.
-GO_IMAGE=docker.io/library/golang:1.21.0-alpine
+GO_IMAGE=docker.io/library/golang:1.21.4-alpine
 
 PROTOBUF_VERSION=$(docker run --rm -v $DIR/../:/lnd -w /lnd $GO_IMAGE \
   go list -f '{{.Version}}' -m google.golang.org/protobuf)


### PR DESCRIPTION
Because the Go version used to run the `go list` commands is below the minimum version specified in the main go.mod file, every time the `make rpc` command is executed, the Golang runtime is downloaded twice, which looks like this and takes a couple of seconds at least:

```
go: downloading go1.21.4 (linux/amd64)
go: downloading go1.21.4 (linux/amd64)
```

Example run: https://github.com/lightningnetwork/lnd/actions/runs/10270305816/job/28417733765

We fix this by using the correct minimum version.

