### PR TITLE
[MICRO]: lntypes: Add Dual[A] primitive type

### DIFF
--- a/lntypes/channel_party.go
+++ b/lntypes/channel_party.go
@@ -50,3 +50,70 @@ func (p ChannelParty) IsLocal() bool {
 func (p ChannelParty) IsRemote() bool {
 	return p == Remote
 }
+
+// Dual represents a structure when we are tracking the same parameter for both
+// the Local and Remote parties.
+type Dual[A any] struct {
+	// Local is the value tracked for the Local ChannelParty.
+	Local A
+
+	// Remote is the value tracked for the Remote ChannelParty.
+	Remote A
+}
+
+// GetForParty gives Dual an access method that takes a ChannelParty as an
+// argument. It is included for ergonomics in cases where the ChannelParty is
+// in a variable and which party determines how we want to access the Dual.
+func (d *Dual[A]) GetForParty(p ChannelParty) A {
+	switch p {
+	case Local:
+		return d.Local
+	case Remote:
+		return d.Remote
+	default:
+		panic(fmt.Sprintf(
+			"switch default triggered in ForParty: %v", p,
+		))
+	}
+}
+
+// SetForParty sets the value in the Dual for the given ChannelParty. This
+// returns a copy of the original value.
+func (d *Dual[A]) SetForParty(p ChannelParty, value A) {
+	switch p {
+	case Local:
+		d.Local = value
+	case Remote:
+		d.Remote = value
+	default:
+		panic(fmt.Sprintf(
+			"switch default triggered in ForParty: %v", p,
+		))
+	}
+}
+
+// ModifyForParty applies the function argument to the given ChannelParty field
+// and returns a new copy of the Dual.
+func (d *Dual[A]) ModifyForParty(p ChannelParty, f func(A) A) A {
+	switch p {
+	case Local:
+		d.Local = f(d.Local)
+		return d.Local
+	case Remote:
+		d.Remote = f(d.Remote)
+		return d.Remote
+	default:
+		panic(fmt.Sprintf(
+			"switch default triggered in ForParty: %v", p,
+		))
+	}
+}
+
+// MapDual applies the function argument to both the Local and Remote fields of
+// the Dual[A] and returns a Dual[B] with that function applied.
+func MapDual[A, B any](d Dual[A], f func(A) B) Dual[B] {
+	return Dual[B]{
+		Local:  f(d.Local),
+		Remote: f(d.Remote),
+	}
+}


### PR DESCRIPTION
This commit introduces a new type Dual[A] to make it easier to manage symmetric configurations or state for lightning channels.

## Change Description
I'm extracting this commit from #8755 because it is proving to be useful in #8270 as well. It has applications anywhere we have symmetric structure, which in the channel state machine is ubiquitous.

## Steps to Test
N/A

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
