### PR TITLE
routing: Namespaced Mission Control

### DIFF
--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -27,6 +27,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb/migration30"
 	"github.com/lightningnetwork/lnd/channeldb/migration31"
 	"github.com/lightningnetwork/lnd/channeldb/migration32"
+	"github.com/lightningnetwork/lnd/channeldb/migration33"
 	"github.com/lightningnetwork/lnd/channeldb/migration_01_to_11"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/invoices"
@@ -290,6 +291,10 @@ var (
 		{
 			number:    32,
 			migration: migration32.MigrateMCRouteSerialisation,
+		},
+		{
+			number:    33,
+			migration: migration33.MigrateMCStoreNameSpacedResults,
 		},
 	}
 

--- a/channeldb/log.go
+++ b/channeldb/log.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb/migration30"
 	"github.com/lightningnetwork/lnd/channeldb/migration31"
 	"github.com/lightningnetwork/lnd/channeldb/migration32"
+	"github.com/lightningnetwork/lnd/channeldb/migration33"
 	"github.com/lightningnetwork/lnd/channeldb/migration_01_to_11"
 	"github.com/lightningnetwork/lnd/kvdb"
 )
@@ -44,5 +45,6 @@ func UseLogger(logger btclog.Logger) {
 	migration30.UseLogger(logger)
 	migration31.UseLogger(logger)
 	migration32.UseLogger(logger)
+	migration33.UseLogger(logger)
 	kvdb.UseLogger(logger)
 }

--- a/channeldb/migration33/log.go
+++ b/channeldb/migration33/log.go
@@ -1,0 +1,14 @@
+package migration33
+
+import (
+	"github.com/btcsuite/btclog"
+)
+
+// log is a logger that is initialized as disabled.  This means the package will
+// not perform any logging by default until a logger is set.
+var log = btclog.Disabled
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/channeldb/migration33/migration.go
+++ b/channeldb/migration33/migration.go
@@ -1,0 +1,69 @@
+package migration33
+
+import (
+	"bytes"
+
+	"github.com/lightningnetwork/lnd/kvdb"
+)
+
+var (
+	// resultsKey is the fixed key under which the attempt results are
+	// stored.
+	resultsKey = []byte("missioncontrol-results")
+
+	// defaultMCNamespaceKey is the key of the default mission control store
+	// namespace.
+	defaultMCNamespaceKey = []byte("default")
+)
+
+// MigrateMCStoreNameSpacedResults reads in all the current mission control
+// entries and re-writes them under a new default namespace.
+func MigrateMCStoreNameSpacedResults(tx kvdb.RwTx) error {
+	log.Infof("Migrating Mission Control store to use namespaced results")
+
+	// Get the top level bucket. All the MC results are currently stored
+	// as KV pairs in this bucket
+	topLevelBucket := tx.ReadWriteBucket(resultsKey)
+
+	// If the results bucket does not exist then there are no entries in
+	// the mission control store yet and so there is nothing to migrate.
+	if topLevelBucket == nil {
+		return nil
+	}
+
+	// Create a new default namespace bucket under the top-level bucket.
+	defaultNSBkt, err := topLevelBucket.CreateBucket(defaultMCNamespaceKey)
+	if err != nil {
+		return err
+	}
+
+	// Iterate through each of the existing result pairs, write them to the
+	// new namespaced bucket. Also collect the set of keys so that we can
+	// later delete them from the top level bucket.
+	var keys [][]byte
+	err = topLevelBucket.ForEach(func(k, v []byte) error {
+		// Skip the new default namespace key.
+		if bytes.Equal(k, defaultMCNamespaceKey) {
+			return nil
+		}
+
+		// Collect the key.
+		keys = append(keys, k)
+
+		// Write the pair under the default namespace.
+		return defaultNSBkt.Put(k, v)
+	})
+	if err != nil {
+		return err
+	}
+
+	// Finally, iterate through the set of keys and delete them from the
+	// top level bucket.
+	for _, k := range keys {
+		if err := topLevelBucket.Delete(k); err != nil {
+			return err
+		}
+	}
+
+	return err
+}

--- a/channeldb/migration33/migration_test.go
+++ b/channeldb/migration33/migration_test.go
@@ -1,0 +1,41 @@
+package migration33
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/channeldb/migtest"
+	"github.com/lightningnetwork/lnd/kvdb"
+)
+
+var (
+	// before represents the structure of the MC store before the migration.
+	before = map[string]interface{}{
+		"key1": "result1",
+		"key2": "result2",
+		"key3": "result3",
+		"key4": "result4",
+	}
+
+	// after represents the expected structure of the store after the
+	// migration. It should be identical to before except all the kv pairs
+	// are now under a new default namespace key.
+	after = map[string]interface{}{
+		string(defaultMCNamespaceKey): before,
+	}
+)
+
+// TestMigrateMCStoreNameSpacedResults tests that the MC store results are
+// correctly moved to be under a new default namespace bucket.
+func TestMigrateMCStoreNameSpacedResults(t *testing.T) {
+	before := func(tx kvdb.RwTx) error {
+		return migtest.RestoreDB(tx, resultsKey, before)
+	}
+
+	after := func(tx kvdb.RwTx) error {
+		return migtest.VerifyDB(tx, resultsKey, after)
+	}
+
+	migtest.ApplyMigration(
+		t, before, after, MigrateMCStoreNameSpacedResults, false,
+	)
+}

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -66,6 +66,10 @@
   store](https://github.com/lightningnetwork/lnd/pull/8911) to use a more 
   minimal encoding for payment attempt routes.
 
+* [Migrate the mission control 
+  store](https://github.com/lightningnetwork/lnd/pull/9001) so that results are 
+  namespaced. All existing results are written to the "default" namespace.
+
 ## Code Health
 
 ## Tooling and Documentation

--- a/routing/integrated_routing_context_test.go
+++ b/routing/integrated_routing_context_test.go
@@ -168,7 +168,10 @@ func (c *integratedRoutingContext) testPayment(maxParts uint32,
 	mcController, err := NewMissionController(db, c.source.pubkey, &c.mcCfg)
 	require.NoError(c.t, err)
 
-	mc := mcController.GetDefaultStore()
+	mc, err := mcController.GetNamespacedStore(
+		DefaultMissionControlNamespace,
+	)
+	require.NoError(c.t, err)
 
 	getBandwidthHints := func(_ Graph) (bandwidthHints, error) {
 		// Create bandwidth hints based on local channel balances.

--- a/routing/integrated_routing_context_test.go
+++ b/routing/integrated_routing_context_test.go
@@ -163,12 +163,12 @@ func (c *integratedRoutingContext) testPayment(maxParts uint32,
 		}
 	})
 
-	// Instantiate a new mission control with the current configuration
+	// Instantiate a new mission controller with the current configuration
 	// values.
-	mc, err := NewMissionControl(db, c.source.pubkey, &c.mcCfg)
-	if err != nil {
-		c.t.Fatal(err)
-	}
+	mcController, err := NewMissionController(db, c.source.pubkey, &c.mcCfg)
+	require.NoError(c.t, err)
+
+	mc := mcController.GetDefaultStore()
 
 	getBandwidthHints := func(_ Graph) (bandwidthHints, error) {
 		// Create bandwidth hints based on local channel balances.

--- a/routing/missioncontrol.go
+++ b/routing/missioncontrol.go
@@ -69,6 +69,11 @@ const (
 	// FeeEstimationTimeout. It defines the maximum duration that the
 	// probing fee estimation is allowed to take.
 	DefaultFeeEstimationTimeout = time.Minute
+
+	// DefaultMissionControlNamespace is the name of the default mission
+	// control name space. This is used as the sub-bucket key within the
+	// top level DB bucket to store mission control results.
+	DefaultMissionControlNamespace = "default"
 )
 
 var (
@@ -227,7 +232,7 @@ func NewMissionControl(db kvdb.Backend, self route.Vertex,
 	}
 
 	store, err := newMissionControlStore(
-		newNamespacedDB(db), cfg.MaxMcHistory,
+		newDefaultNamespacedStore(db), cfg.MaxMcHistory,
 		cfg.McFlushInterval,
 	)
 	if err != nil {
@@ -549,22 +554,30 @@ func (m *MissionControl) applyPaymentResult(
 }
 
 // namespacedDB is an implementation of the missionControlDB that gives a user
-// of the interface access to the top level mission control bucket. In a
-// follow-up commit (accompanied by a migration), this will change to giving
-// the user of the interface access to a namespaced sub-bucket instead.
+// of the interface access to a namespaced bucket within the top level mission
+// control bucket.
 type namespacedDB struct {
 	topLevelBucketKey []byte
+	namespace         []byte
 	db                kvdb.Backend
 }
 
 // A compile-time check to ensure that namespacedDB implements missionControlDB.
 var _ missionControlDB = (*namespacedDB)(nil)
 
+// newDefaultNamespacedStore creates an instance of namespaceDB that uses the
+// default namespace.
+func newDefaultNamespacedStore(db kvdb.Backend) missionControlDB {
+	return newNamespacedDB(db, DefaultMissionControlNamespace)
+}
+
 // newNamespacedDB creates a new instance of missionControlDB where the DB will
-// have access to the top level bucket.
-func newNamespacedDB(db kvdb.Backend) missionControlDB {
+// have access to a namespaced bucket within the top level mission control
+// bucket.
+func newNamespacedDB(db kvdb.Backend, namespace string) missionControlDB {
 	return &namespacedDB{
 		db:                db,
+		namespace:         []byte(namespace),
 		topLevelBucketKey: resultsKey,
 	}
 }
@@ -582,7 +595,16 @@ func (n *namespacedDB) update(f func(bkt walletdb.ReadWriteBucket) error,
 				"control bucket: %w", err)
 		}
 
-		return f(mcStoreBkt)
+		namespacedBkt, err := mcStoreBkt.CreateBucketIfNotExists(
+			n.namespace,
+		)
+		if err != nil {
+			return fmt.Errorf("cannot create namespaced bucket "+
+				"(%s) in mission control store: %w",
+				n.namespace, err)
+		}
+
+		return f(namespacedBkt)
 	}, reset)
 }
 
@@ -599,7 +621,13 @@ func (n *namespacedDB) view(f func(bkt walletdb.ReadBucket) error,
 				"not found")
 		}
 
-		return f(mcStoreBkt)
+		namespacedBkt := mcStoreBkt.NestedReadBucket(n.namespace)
+		if namespacedBkt == nil {
+			return fmt.Errorf("namespaced bucket (%s) not found "+
+				"in mission control store", n.namespace)
+		}
+
+		return f(namespacedBkt)
 	}, reset)
 }
 
@@ -608,12 +636,17 @@ func (n *namespacedDB) view(f func(bkt walletdb.ReadBucket) error,
 // NOTE: this is part of the missionControlDB interface.
 func (n *namespacedDB) purge() error {
 	return n.db.Update(func(tx kvdb.RwTx) error {
-		err := tx.DeleteTopLevelBucket(n.topLevelBucketKey)
+		mcStoreBkt := tx.ReadWriteBucket(n.topLevelBucketKey)
+		if mcStoreBkt == nil {
+			return nil
+		}
+
+		err := mcStoreBkt.DeleteNestedBucket(n.namespace)
 		if err != nil {
 			return err
 		}
 
-		_, err = tx.CreateTopLevelBucket(n.topLevelBucketKey)
+		_, err = mcStoreBkt.CreateBucket(n.namespace)
 
 		return err
 	}, func() {})

--- a/routing/missioncontrol_state.go
+++ b/routing/missioncontrol_state.go
@@ -37,7 +37,8 @@ func newMissionControlState(
 	}
 }
 
-// getLastPairResult returns the current state for connections to the given node.
+// getLastPairResult returns the current state for connections to the given
+// node.
 func (m *missionControlState) getLastPairResult(node route.Vertex) (NodeResults,
 	bool) {
 
@@ -45,8 +46,8 @@ func (m *missionControlState) getLastPairResult(node route.Vertex) (NodeResults,
 	return result, ok
 }
 
-// ResetHistory resets the history of MissionControl returning it to a state as
-// if no payment attempts have been made.
+// ResetHistory resets the history of missionControlState returning it to a
+// state as if no payment attempts have been made.
 func (m *missionControlState) resetHistory() {
 	m.lastPairResult = make(map[route.Vertex]NodeResults)
 	m.lastSecondChance = make(map[DirectedNodePair]time.Time)

--- a/routing/missioncontrol_store_test.go
+++ b/routing/missioncontrol_store_test.go
@@ -63,7 +63,7 @@ func newMCStoreTestHarness(t testing.TB, maxRecords int,
 	})
 
 	store, err := newMissionControlStore(
-		newNamespacedDB(db), maxRecords, flushInterval,
+		newDefaultNamespacedStore(db), maxRecords, flushInterval,
 	)
 	require.NoError(t, err)
 
@@ -118,7 +118,7 @@ func TestMissionControlStore(t *testing.T) {
 
 	// Recreate store to test pruning.
 	store, err = newMissionControlStore(
-		newNamespacedDB(db), testMaxRecords, time.Second,
+		newDefaultNamespacedStore(db), testMaxRecords, time.Second,
 	)
 	require.NoError(t, err)
 
@@ -218,7 +218,7 @@ func TestMissionControlStoreFlushing(t *testing.T) {
 
 	// Recreate store.
 	store, err := newMissionControlStore(
-		newNamespacedDB(db), testMaxRecords, flushInterval,
+		newDefaultNamespacedStore(db), testMaxRecords, flushInterval,
 	)
 	require.NoError(t, err)
 	store.run()

--- a/routing/missioncontrol_store_test.go
+++ b/routing/missioncontrol_store_test.go
@@ -62,7 +62,9 @@ func newMCStoreTestHarness(t testing.TB, maxRecords int,
 		require.NoError(t, db.Close())
 	})
 
-	store, err := newMissionControlStore(db, maxRecords, flushInterval)
+	store, err := newMissionControlStore(
+		newNamespacedDB(db), maxRecords, flushInterval,
+	)
 	require.NoError(t, err)
 
 	return mcStoreTestHarness{db: db, store: store}
@@ -115,7 +117,9 @@ func TestMissionControlStore(t *testing.T) {
 	require.Equal(t, &result2, results[1])
 
 	// Recreate store to test pruning.
-	store, err = newMissionControlStore(db, testMaxRecords, time.Second)
+	store, err = newMissionControlStore(
+		newNamespacedDB(db), testMaxRecords, time.Second,
+	)
 	require.NoError(t, err)
 
 	// Add a newer result which failed due to mpp timeout.
@@ -213,7 +217,9 @@ func TestMissionControlStoreFlushing(t *testing.T) {
 	store.stop()
 
 	// Recreate store.
-	store, err := newMissionControlStore(db, testMaxRecords, flushInterval)
+	store, err := newMissionControlStore(
+		newNamespacedDB(db), testMaxRecords, flushInterval,
+	)
 	require.NoError(t, err)
 	store.run()
 	defer store.stop()

--- a/routing/mock_test.go
+++ b/routing/mock_test.go
@@ -125,10 +125,10 @@ func (m *mockPaymentSessionSourceOld) NewPaymentSessionEmpty() PaymentSession {
 }
 
 type mockMissionControlOld struct {
-	MissionControl
+	MissionController
 }
 
-var _ MissionController = (*mockMissionControlOld)(nil)
+var _ MissionControlQuerier = (*mockMissionControlOld)(nil)
 
 func (m *mockMissionControlOld) ReportPaymentFail(
 	paymentID uint64, rt *route.Route,
@@ -657,7 +657,7 @@ type mockMissionControl struct {
 	mock.Mock
 }
 
-var _ MissionController = (*mockMissionControl)(nil)
+var _ MissionControlQuerier = (*mockMissionControl)(nil)
 
 func (m *mockMissionControl) ReportPaymentFail(
 	paymentID uint64, rt *route.Route,

--- a/routing/payment_session.go
+++ b/routing/payment_session.go
@@ -159,7 +159,7 @@ type PaymentSession interface {
 
 // paymentSession is used during an HTLC routings session to prune the local
 // chain view in response to failures, and also report those failures back to
-// MissionControl. The snapshot copied for this session will only ever grow,
+// MissionController. The snapshot copied for this session will only ever grow,
 // and will now be pruned after a decay like the main view within mission
 // control. We do this as we want to avoid the case where we continually try a
 // bad edge or route multiple times in a session. This can lead to an infinite
@@ -184,7 +184,7 @@ type paymentSession struct {
 	// trade-off in path finding between fees and probability.
 	pathFindingConfig PathFindingConfig
 
-	missionControl MissionController
+	missionControl MissionControlQuerier
 
 	// minShardAmt is the amount beyond which we won't try to further split
 	// the payment if no route is found. If the maximum number of htlcs
@@ -199,7 +199,8 @@ type paymentSession struct {
 // newPaymentSession instantiates a new payment session.
 func newPaymentSession(p *LightningPayment, selfNode route.Vertex,
 	getBandwidthHints func(Graph) (bandwidthHints, error),
-	graphSessFactory GraphSessionFactory, missionControl MissionController,
+	graphSessFactory GraphSessionFactory,
+	missionControl MissionControlQuerier,
 	pathFindingConfig PathFindingConfig) (*paymentSession, error) {
 
 	edges, err := RouteHintsToEdges(p.RouteHints, p.Target)
@@ -266,7 +267,7 @@ func (p *paymentSession) RequestRoute(maxAmt, feeLimit lnwire.MilliSatoshi,
 
 	// Taking into account this prune view, we'll attempt to locate a path
 	// to our destination, respecting the recommendations from
-	// MissionControl.
+	// MissionController.
 	restrictions := &RestrictParams{
 		ProbabilitySource:     p.missionControl.GetProbability,
 		FeeLimit:              feeLimit,

--- a/routing/payment_session_source.go
+++ b/routing/payment_session_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/lightningnetwork/lnd/zpay32"
 )
 
-// A compile time assertion to ensure MissionControl meets the
+// A compile time assertion to ensure SessionSource meets the
 // PaymentSessionSource interface.
 var _ PaymentSessionSource = (*SessionSource)(nil)
 
@@ -40,7 +40,7 @@ type SessionSource struct {
 	// then take into account this set of pruned vertexes/edges to reduce
 	// route failure and pass on graph information gained to the next
 	// execution.
-	MissionControl MissionController
+	MissionControl MissionControlQuerier
 
 	// PathFindingConfig defines global parameters that control the
 	// trade-off in path finding between fees and probability.

--- a/routing/router.go
+++ b/routing/router.go
@@ -167,9 +167,9 @@ type PaymentSessionSource interface {
 	NewPaymentSessionEmpty() PaymentSession
 }
 
-// MissionController is an interface that exposes failure reporting and
+// MissionControlQuerier is an interface that exposes failure reporting and
 // probability estimation.
-type MissionController interface {
+type MissionControlQuerier interface {
 	// ReportPaymentFail reports a failed payment to mission control as
 	// input for future probability estimates. It returns a bool indicating
 	// whether this error is a final error and no further payment attempts
@@ -260,7 +260,7 @@ type Config struct {
 	// Each run will then take into account this set of pruned
 	// vertexes/edges to reduce route failure and pass on graph information
 	// gained to the next execution.
-	MissionControl MissionController
+	MissionControl MissionControlQuerier
 
 	// SessionSource defines a source for the router to retrieve new payment
 	// sessions.

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -132,7 +132,11 @@ func createTestCtxFromGraphInstanceAssumeValid(t *testing.T,
 		graphInstance.graphBackend, route.Vertex{}, mcConfig,
 	)
 	require.NoError(t, err, "failed to create missioncontrol")
-	mc := mcController.GetDefaultStore()
+
+	mc, err := mcController.GetNamespacedStore(
+		DefaultMissionControlNamespace,
+	)
+	require.NoError(t, err)
 
 	sourceNode, err := graphInstance.graph.SourceNode()
 	require.NoError(t, err)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -729,7 +729,7 @@ func (r *rpcServer) addDeps(s *server, macService *macaroons.Service,
 			return info.NodeKey1Bytes, info.NodeKey2Bytes, nil
 		},
 		FindRoute:              s.chanRouter.FindRoute,
-		MissionControl:         s.missionControl,
+		MissionControl:         s.missionControl.GetDefaultStore(),
 		ActiveNetParams:        r.cfg.ActiveNetParams.Params,
 		Tower:                  s.controlTower,
 		MaxTotalTimelock:       r.cfg.MaxOutgoingCltvExpiry,
@@ -6071,7 +6071,8 @@ func (r *rpcServer) AddInvoice(ctx context.Context,
 
 			return r.server.chanRouter.FindBlindedPaths(
 				r.selfNode, amt,
-				r.server.missionControl.GetProbability,
+				r.server.missionControl.GetDefaultStore().
+					GetProbability,
 				blindingRestrictions,
 			)
 		},

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -729,7 +729,7 @@ func (r *rpcServer) addDeps(s *server, macService *macaroons.Service,
 			return info.NodeKey1Bytes, info.NodeKey2Bytes, nil
 		},
 		FindRoute:              s.chanRouter.FindRoute,
-		MissionControl:         s.missionControl.GetDefaultStore(),
+		MissionControl:         s.defaultMC,
 		ActiveNetParams:        r.cfg.ActiveNetParams.Params,
 		Tower:                  s.controlTower,
 		MaxTotalTimelock:       r.cfg.MaxOutgoingCltvExpiry,
@@ -6071,8 +6071,7 @@ func (r *rpcServer) AddInvoice(ctx context.Context,
 
 			return r.server.chanRouter.FindBlindedPaths(
 				r.selfNode, amt,
-				r.server.missionControl.GetDefaultStore().
-					GetProbability,
+				r.server.defaultMC.GetProbability,
 				blindingRestrictions,
 			)
 		},

--- a/server.go
+++ b/server.go
@@ -275,7 +275,7 @@ type server struct {
 
 	breachArbitrator *contractcourt.BreachArbitrator
 
-	missionControl *routing.MissionControl
+	missionControl *routing.MissionController
 
 	graphBuilder *graph.Builder
 
@@ -955,7 +955,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		McFlushInterval:         routingConfig.McFlushInterval,
 		MinFailureRelaxInterval: routing.DefaultMinFailureRelaxInterval,
 	}
-	s.missionControl, err = routing.NewMissionControl(
+	s.missionControl, err = routing.NewMissionController(
 		dbs.ChanStateDB, selfNode.PubKeyBytes, mcCfg,
 	)
 	if err != nil {
@@ -985,7 +985,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 			chanGraph,
 		),
 		SourceNode:        sourceNode,
-		MissionControl:    s.missionControl,
+		MissionControl:    s.missionControl.GetDefaultStore(),
 		GetLink:           s.htlcSwitch.GetLinkByShortID,
 		PathFindingConfig: pathFindingConfig,
 	}
@@ -1020,7 +1020,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		Chain:              cc.ChainIO,
 		Payer:              s.htlcSwitch,
 		Control:            s.controlTower,
-		MissionControl:     s.missionControl,
+		MissionControl:     s.missionControl.GetDefaultStore(),
 		SessionSource:      paymentSessionSource,
 		GetLink:            s.htlcSwitch.GetLinkByShortID,
 		NextPaymentID:      sequencer.NextID,


### PR DESCRIPTION
This PR:
- migrates the Mission control store so that all existing entries are moved to a new "default" namespace sub-bucket. 
- The MissionControlManager now handles returning mission control instances based on namespace. 

With this PR we still only use the default namespace, but this is a starting point for starting to make use of other namespaces. A follow up could add functionality to combine the results of 2 or more on-disk namespaces into one in-memory. 

Required for https://github.com/lightningnetwork/lnd/issues/8991 where we will want to report MC results in a different (non payment related) namespace. 
Addresses part of https://github.com/lightningnetwork/lnd/issues/7812
Addresses part of https://github.com/lightningnetwork/lnd/issues/8849

Depends on https://github.com/lightningnetwork/lnd/pull/8911


## Visual

MC DB structure currently:
```
missioncontrol-results ---> < result ID 1> --> <encoded result 1> 
                       ---> < result ID 2> --> <encoded result 2> 
                       ---> < result ID 3> --> <encoded result 3> 
                                        .....
```

MC DB structure after this PR:

```
missioncontrol-results ---> "default" ---> < result ID 1> --> <encoded result 1> 
                                      ---> < result ID 2> --> <encoded result 2> 
                                      ---> < result ID 3> --> <encoded result 3> 
                                                      .....
```
