### PR TITLE
discovery: fix bug that can lead to sending invalid chan_ann msgs

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -2232,7 +2232,7 @@ func (d *AuthenticatedGossiper) updateChannel(info *models.ChannelEdgeInfo,
 			BitcoinKey1:     info.BitcoinKey1Bytes,
 			Features:        lnwire.NewRawFeatureVector(),
 			BitcoinKey2:     info.BitcoinKey2Bytes,
-			ExtraOpaqueData: edge.ExtraOpaqueData,
+			ExtraOpaqueData: info.ExtraOpaqueData,
 		}
 		chanAnn.NodeSig1, err = lnwire.NewSigFromECDSARawSignature(
 			info.AuthProof.NodeSig1Bytes,

--- a/docs/release-notes/release-notes-0.18.3.md
+++ b/docs/release-notes/release-notes-0.18.3.md
@@ -60,6 +60,10 @@ commitment when the channel was force closed.
 * We'll now always send [channel updates to our remote peer for open
   channels](https://github.com/lightningnetwork/lnd/pull/8963).
 
+* [A bug has been fixed that could cause invalid channel
+  announcements](https://github.com/lightningnetwork/lnd/pull/9002) to be
+  generated if the inbound fee discount is used.
+
 # New Features
 ## Functional Enhancements
 ## RPC Additions


### PR DESCRIPTION
Initially in lnd, we didn't store the extra TLV data that could be dangling off of gossip messages. This was fixed initially in lnd v0.5 with this PR: https://github.com/lightningnetwork/lnd/pull/1825.

Within the PR, we incorrectly set the `ExtraOpaqueData` (extra TLV blob) of the `ChannelAnnouncement` to the value stored in `edge`, which is actually our channel update. As 6-ish years ago we didn't yet have anything that used the TLV gossip fields, this went unnoticed.

Fast forward to 2024, we shipped an experimental version of inbound fee discounts. This starts to store additional data in the `ExtraOpaqueData` field: the TLV for the inbound fee discount. Initially, everything is valid when the first `ChannelAnnouncement` is sent, but as soon as a user attempts to set an inbound fee policy, we'd incorrectly swap in that new serialized TLV for the _channel announcement_:
https://github.com/lightningnetwork/lnd/commit/841e24399c5e4b211c10f0282c7a1bff3ad8372e#diff-1eda595bbebe495bd74a6a0431c46b66cb4e8b53beb311067c010feac2665dcbR2560.

Since we're just trying to generate a new `channel_update`, we don't also regenerate the signature for the `channel_announcement` message. As a result, we end up storing a `channel_announcement` with an invalid sig on disk, continuing to broadcast that to peers.

Fixes https://github.com/lightningnetwork/lnd/issues/9000