### PR TITLE
route blinding: update MC on receive from blinded path

### DIFF
--- a/channeldb/invoices.go
+++ b/channeldb/invoices.go
@@ -109,22 +109,23 @@ const (
 	// prevents against the database being rolled back to an older
 	// format where the surrounding logic might assume a different set of
 	// fields are known.
-	memoType            tlv.Type = 0
-	payReqType          tlv.Type = 1
-	createTimeType      tlv.Type = 2
-	settleTimeType      tlv.Type = 3
-	addIndexType        tlv.Type = 4
-	settleIndexType     tlv.Type = 5
-	preimageType        tlv.Type = 6
-	valueType           tlv.Type = 7
-	cltvDeltaType       tlv.Type = 8
-	expiryType          tlv.Type = 9
-	paymentAddrType     tlv.Type = 10
-	featuresType        tlv.Type = 11
-	invStateType        tlv.Type = 12
-	amtPaidType         tlv.Type = 13
-	hodlInvoiceType     tlv.Type = 14
-	invoiceAmpStateType tlv.Type = 15
+	memoType             tlv.Type = 0
+	payReqType           tlv.Type = 1
+	createTimeType       tlv.Type = 2
+	settleTimeType       tlv.Type = 3
+	addIndexType         tlv.Type = 4
+	settleIndexType      tlv.Type = 5
+	preimageType         tlv.Type = 6
+	valueType            tlv.Type = 7
+	cltvDeltaType        tlv.Type = 8
+	expiryType           tlv.Type = 9
+	paymentAddrType      tlv.Type = 10
+	featuresType         tlv.Type = 11
+	invStateType         tlv.Type = 12
+	amtPaidType          tlv.Type = 13
+	hodlInvoiceType      tlv.Type = 14
+	invoiceAmpStateType  tlv.Type = 15
+	blindedPathsInfoType tlv.Type = 16
 
 	// A set of tlv type definitions used to serialize the invoice AMP
 	// state along-side the main invoice body.
@@ -1145,6 +1146,26 @@ func putInvoice(invoices, invoiceIndex, payAddrIndex, addIndex kvdb.RwBucket,
 	return nextAddSeqNo, nil
 }
 
+func blindedPathMapRecordSize(a models.BlindedPathsInfo) func() uint64 {
+	var (
+		b   bytes.Buffer
+		buf [8]byte
+	)
+
+	// We know that encoding works since the tests pass in the build this
+	// file is checked into, so we'll simplify things and simply encode it
+	// ourselves then report the total amount of bytes used.
+	if err := models.BlindedPathInfoEncoder(&b, a, &buf); err != nil {
+		// This should never error out, but we log it just in case it
+		// does.
+		log.Errorf("encoding the blinded path map failed: %v", err)
+	}
+
+	return func() uint64 {
+		return uint64(len(b.Bytes()))
+	}
+}
+
 // recordSize returns the amount of bytes this TLV record will occupy when
 // encoded.
 func ampRecordSize(a *invpkg.AMPInvoiceState) func() uint64 {
@@ -1239,6 +1260,14 @@ func serializeInvoice(w io.Writer, i *invpkg.Invoice) error {
 			invoiceAmpStateType, &i.AMPState,
 			ampRecordSize(&i.AMPState),
 			ampStateEncoder, ampStateDecoder,
+		),
+
+		// Blinded Path info.
+		tlv.MakeDynamicRecord(
+			blindedPathsInfoType, &i.BlindedPaths,
+			blindedPathMapRecordSize(i.BlindedPaths),
+			models.BlindedPathInfoEncoder,
+			models.BlindedPathInfoDecoder,
 		),
 	)
 	if err != nil {
@@ -1603,6 +1632,7 @@ func deserializeInvoice(r io.Reader) (invpkg.Invoice, error) {
 
 	var i invpkg.Invoice
 	i.AMPState = make(invpkg.AMPInvoiceState)
+	i.BlindedPaths = make(models.BlindedPathsInfo)
 	tlvStream, err := tlv.NewStream(
 		// Memo and payreq.
 		tlv.MakePrimitiveRecord(memoType, &i.Memo),
@@ -1632,6 +1662,13 @@ func deserializeInvoice(r io.Reader) (invpkg.Invoice, error) {
 		tlv.MakeDynamicRecord(
 			invoiceAmpStateType, &i.AMPState, nil,
 			ampStateEncoder, ampStateDecoder,
+		),
+
+		// Blinded Path info.
+		tlv.MakeDynamicRecord(
+			blindedPathsInfoType, &i.BlindedPaths, nil,
+			models.BlindedPathInfoEncoder,
+			models.BlindedPathInfoDecoder,
 		),
 	)
 	if err != nil {

--- a/channeldb/models/blinded_path_test.go
+++ b/channeldb/models/blinded_path_test.go
@@ -1,0 +1,118 @@
+package models
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightningnetwork/lnd/routing/route"
+	"github.com/stretchr/testify/require"
+)
+
+func genPubKey(t *testing.T) route.Vertex {
+	pk, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	return route.NewVertex(pk.PubKey())
+}
+
+func genPrivKey(t *testing.T) *btcec.PrivateKey {
+	pk, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	return pk
+}
+
+// TestBlindedPathInfoSerialise tests the BlindedPathInfo TLV encoder and
+// decoder.
+func TestBlindedPathInfoSerialise(t *testing.T) {
+	info := &BlindedPathInfo{
+		Route: &MCRoute{
+			SourcePubKey: genPubKey(t),
+			TotalAmount:  600,
+			Hops: []*MCHop{
+				{
+					PubKeyBytes: genPubKey(t),
+					AmtToFwd:    60,
+					ChannelID:   40,
+				},
+				{
+					PubKeyBytes:      genPubKey(t),
+					AmtToFwd:         50,
+					ChannelID:        10,
+					HasBlindingPoint: true,
+				},
+			},
+		},
+		SessionKey: genPrivKey(t),
+	}
+
+	var b bytes.Buffer
+	err := info.Serialize(&b)
+	require.NoError(t, err)
+
+	info2, err := DeserializeBlindedPathInfo(&b)
+	require.NoError(t, err)
+
+	compareBlindedPathInfo(t, info, info2)
+
+	infoSet := &BlindedPathsInfo{
+		genPubKey(t): &BlindedPathInfo{
+			Route: &MCRoute{
+				SourcePubKey: genPubKey(t),
+				TotalAmount:  600,
+				Hops: []*MCHop{
+					{
+						PubKeyBytes: genPubKey(t),
+						AmtToFwd:    60,
+						ChannelID:   40,
+					},
+					{
+						PubKeyBytes:      genPubKey(t),
+						AmtToFwd:         50,
+						ChannelID:        10,
+						HasBlindingPoint: true,
+					},
+				},
+			},
+			SessionKey: genPrivKey(t),
+		},
+		genPubKey(t): &BlindedPathInfo{
+			Route: &MCRoute{
+				SourcePubKey: genPubKey(t),
+				TotalAmount:  60,
+				Hops: []*MCHop{
+					{
+						PubKeyBytes: genPubKey(t),
+						AmtToFwd:    60,
+						ChannelID:   400,
+					},
+				},
+			},
+			SessionKey: genPrivKey(t),
+		},
+	}
+
+	var b1 bytes.Buffer
+	err = BlindedPathInfoEncoder(&b1, infoSet, nil)
+	require.NoError(t, err)
+
+	infoSet2 := make(BlindedPathsInfo)
+	err = BlindedPathInfoDecoder(&b1, &infoSet2, nil, uint64(len(b1.Bytes())))
+	require.NoError(t, err)
+}
+
+func compareBlindedPathInfo(t *testing.T, info, info2 *BlindedPathInfo) {
+	require.EqualValues(t, info.SessionKey, info2.SessionKey)
+	require.EqualValues(t, info.Route.SourcePubKey, info2.Route.SourcePubKey)
+	require.EqualValues(t, info.Route.TotalAmount, info2.Route.TotalAmount)
+	require.Len(t, info.Route.Hops, len(info2.Route.Hops))
+
+	for i, hop := range info.Route.Hops {
+		hop2 := info2.Route.Hops[i]
+		require.EqualValues(t, hop.PubKeyBytes, hop2.PubKeyBytes)
+		require.EqualValues(t, hop.ChannelID, hop2.ChannelID)
+		require.EqualValues(t, hop.HasBlindingPoint, hop2.HasBlindingPoint)
+		require.EqualValues(t, hop.AmtToFwd, hop2.AmtToFwd)
+	}
+}

--- a/channeldb/models/blinded_paths.go
+++ b/channeldb/models/blinded_paths.go
@@ -1,8 +1,18 @@
 package models
 
 import (
+	"bytes"
+	"io"
+
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/routing/route"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+const (
+	blindedPathInfoRouteType      tlv.Type = 0
+	blindedPathInfoSessionKeyType tlv.Type = 1
 )
 
 // BlindedPathsInfo is a map from an incoming blinding key to the associated
@@ -11,6 +21,86 @@ import (
 // receipt of a payment along a blinded path, we can use the incoming blinding
 // key to thus identify which blinded path in the invoice was used.
 type BlindedPathsInfo map[route.Vertex]*BlindedPathInfo
+
+// BlindedPathInfoEncoder is a custom TLV encoder for a BlindedPathInfo
+// record.
+func BlindedPathInfoEncoder(w io.Writer, val interface{}, _ *[8]byte) error {
+	if v, ok := val.(*BlindedPathsInfo); ok {
+		for key, info := range *v {
+			// Write 33 byte key.
+			if err := wire.WriteVarBytes(w, 0, key[:]); err != nil {
+				return err
+			}
+
+			// Serialise the info.
+			var infoBytes bytes.Buffer
+			err := info.Serialize(&infoBytes)
+			if err != nil {
+				return err
+			}
+
+			// Write the length of the serialised info.
+			err = wire.WriteVarInt(w, 0, uint64(infoBytes.Len()))
+			if err != nil {
+				return err
+			}
+
+			// Finally, write the serialise info.
+			if _, err := w.Write(infoBytes.Bytes()); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "*BlindedPathsInfo")
+}
+
+// BlindedPathInfoDecoder is a custom TLV decoder for a BlindedPathInfo
+// record.
+func BlindedPathInfoDecoder(r io.Reader, val interface{}, _ *[8]byte,
+	l uint64) error {
+
+	if v, ok := val.(*BlindedPathsInfo); ok {
+		for {
+			key, err := wire.ReadVarBytes(r, 0, 66000, "[]byte")
+			switch {
+
+			// We'll silence an EOF when zero bytes remain, meaning
+			// the stream was cleanly encoded.
+			case err == io.EOF:
+				return nil
+
+			// Other unexpected errors.
+			case err != nil:
+				return err
+			}
+
+			// Read the length of the serialised info.
+			infoLen, err := wire.ReadVarInt(r, 0)
+			if err != nil {
+				return err
+			}
+
+			// Create a limited reader using the info length.
+			lr := io.LimitReader(r, int64(infoLen))
+
+			// Deserialize the path info using the limited reader.
+			info, err := DeserializeBlindedPathInfo(lr)
+			if err != nil {
+				return err
+			}
+
+			var k route.Vertex
+			copy(k[:], key)
+
+			(*v)[k] = info
+		}
+	}
+
+	return tlv.NewTypeForDecodingErr(val, "*BlindedPathsInfo", l, l)
+}
 
 // BlindedPathInfo holds information we may need regarding a blinded path
 // included in an invoice
@@ -22,4 +112,98 @@ type BlindedPathInfo struct {
 	// path. We can use this key to decrypt any data we encrypted for the
 	// path.
 	SessionKey *btcec.PrivateKey
+}
+
+// Copy makes a deep copy of the BlindedPathInfo.
+func (i *BlindedPathInfo) Copy() *BlindedPathInfo {
+	hops := make([]*MCHop, len(i.Route.Hops))
+	for i, hop := range i.Route.Hops {
+		hops[i] = &MCHop{
+			ChannelID:        hop.ChannelID,
+			AmtToFwd:         hop.AmtToFwd,
+			HasBlindingPoint: hop.HasBlindingPoint,
+		}
+
+		copy(hops[i].PubKeyBytes[:], hop.PubKeyBytes[:])
+	}
+
+	r := &MCRoute{
+		TotalAmount: i.Route.TotalAmount,
+		Hops:        hops,
+	}
+	copy(r.SourcePubKey[:], i.Route.SourcePubKey[:])
+
+	return &BlindedPathInfo{
+		Route:      r,
+		SessionKey: btcec.PrivKeyFromScalar(&i.SessionKey.Key),
+	}
+}
+
+// Serialize serializes the BlindedPathInfo into a TLV stream and writes the
+// resulting bytes to the given io.Writer.
+func (i *BlindedPathInfo) Serialize(w io.Writer) error {
+	var routeBuffer bytes.Buffer
+	if err := i.Route.Serialize(&routeBuffer); err != nil {
+		return err
+	}
+
+	var (
+		privKeyBytes = i.SessionKey.Serialize()
+		routeBytes   = routeBuffer.Bytes()
+	)
+
+	stream, err := tlv.NewStream(
+		tlv.MakePrimitiveRecord(
+			blindedPathInfoRouteType, &routeBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			blindedPathInfoSessionKeyType, &privKeyBytes,
+		),
+	)
+	if err != nil {
+		return err
+	}
+
+	return stream.Encode(w)
+}
+
+// DeserializeBlindedPathInfo attempts to deserialize a BlindedPathInfo from the
+// given io.Reader.
+func DeserializeBlindedPathInfo(r io.Reader) (*BlindedPathInfo, error) {
+	var (
+		privKeyBytes []byte
+		routeBytes   []byte
+	)
+
+	stream, err := tlv.NewStream(
+		tlv.MakePrimitiveRecord(
+			blindedPathInfoRouteType, &routeBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			blindedPathInfoSessionKeyType, &privKeyBytes,
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := stream.Decode(r); err != nil {
+		return nil, err
+	}
+
+	routeReader := bytes.NewReader(routeBytes)
+	mcRoute, err := DeserializeRoute(routeReader)
+	if err != nil {
+		return nil, err
+	}
+
+	sessionKey, _ := btcec.PrivKeyFromBytes(privKeyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &BlindedPathInfo{
+		Route:      mcRoute,
+		SessionKey: sessionKey,
+	}, nil
 }

--- a/channeldb/models/blinded_paths.go
+++ b/channeldb/models/blinded_paths.go
@@ -1,0 +1,25 @@
+package models
+
+import (
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightningnetwork/lnd/routing/route"
+)
+
+// BlindedPathsInfo is a map from an incoming blinding key to the associated
+// blinded path info. An invoice may contain multiple blinded paths but each one
+// will have a unique session key and thus a unique final ephemeral key. One
+// receipt of a payment along a blinded path, we can use the incoming blinding
+// key to thus identify which blinded path in the invoice was used.
+type BlindedPathsInfo map[route.Vertex]*BlindedPathInfo
+
+// BlindedPathInfo holds information we may need regarding a blinded path
+// included in an invoice
+type BlindedPathInfo struct {
+	// Route is the real route of the blinded path.
+	Route *MCRoute
+
+	// SessionKey is the private key used as the first ephemeral key of the
+	// path. We can use this key to decrypt any data we encrypted for the
+	// path.
+	SessionKey *btcec.PrivateKey
+}

--- a/channeldb/models/route.go
+++ b/channeldb/models/route.go
@@ -1,0 +1,170 @@
+package models
+
+import (
+	"encoding/binary"
+	"io"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/route"
+)
+
+var byteOrder = binary.BigEndian
+
+// MCRoute holds the bare minimum info about a payment attempt route that MC
+// requires.
+type MCRoute struct {
+	SourcePubKey route.Vertex
+	TotalAmount  lnwire.MilliSatoshi
+	Hops         []*MCHop
+}
+
+// MCHop holds the bare minimum info about a payment attempt route hop that MC
+// requires.
+type MCHop struct {
+	ChannelID        uint64
+	PubKeyBytes      route.Vertex
+	AmtToFwd         lnwire.MilliSatoshi
+	HasBlindingPoint bool
+}
+
+// DeserializeRoute deserializes the MCRoute from the given io.Reader.
+func DeserializeRoute(r io.Reader) (*MCRoute, error) {
+	var (
+		rt      MCRoute
+		numHops uint32
+	)
+
+	if err := binary.Read(r, byteOrder, &rt.TotalAmount); err != nil {
+		return nil, err
+	}
+
+	pub, err := wire.ReadVarBytes(r, 0, 66000, "[]byte")
+	if err != nil {
+		return nil, err
+	}
+	copy(rt.SourcePubKey[:], pub)
+
+	if err := binary.Read(r, byteOrder, &numHops); err != nil {
+		return nil, err
+	}
+
+	hops := make([]*MCHop, numHops)
+	for i := uint32(0); i < numHops; i++ {
+		hop, err := deserializeHop(r)
+		if err != nil {
+			return nil, err
+		}
+
+		hops[i] = hop
+	}
+	rt.Hops = hops
+
+	return &rt, nil
+}
+
+// deserializeHop deserializes the MCHop from the given io.Reader.
+func deserializeHop(r io.Reader) (*MCHop, error) {
+	var h MCHop
+
+	pub, err := wire.ReadVarBytes(r, 0, 66000, "[]byte")
+	if err != nil {
+		return nil, err
+	}
+	copy(h.PubKeyBytes[:], pub)
+
+	var a uint64
+	if err := binary.Read(r, byteOrder, &a); err != nil {
+		return nil, err
+	}
+	h.AmtToFwd = lnwire.MilliSatoshi(a)
+
+	if err := binary.Read(r, byteOrder, &h.ChannelID); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Read(r, byteOrder, &h.HasBlindingPoint); err != nil {
+		return nil, err
+	}
+
+	return &h, nil
+}
+
+// Serialize serializes a mcRouter and writes the resulting bytes to the given
+// io.Writer.
+func (r *MCRoute) Serialize(w io.Writer) error {
+	err := binary.Write(w, byteOrder, uint64(r.TotalAmount))
+	if err != nil {
+		return err
+	}
+
+	if err := wire.WriteVarBytes(w, 0, r.SourcePubKey[:]); err != nil {
+		return err
+	}
+
+	if err := binary.Write(w, byteOrder, uint32(len(r.Hops))); err != nil {
+		return err
+	}
+
+	for _, h := range r.Hops {
+		if err := serializeHop(w, h); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// SerializeHop serializes a MCHop and writes the resulting bytes to the given
+// io.Writer.
+func serializeHop(w io.Writer, h *MCHop) error {
+	if err := wire.WriteVarBytes(w, 0, h.PubKeyBytes[:]); err != nil {
+		return err
+	}
+
+	err := binary.Write(w, byteOrder, uint64(h.AmtToFwd))
+	if err != nil {
+		return err
+	}
+
+	if err := binary.Write(w, byteOrder, h.ChannelID); err != nil {
+		return err
+	}
+
+	if err := binary.Write(w, byteOrder, h.HasBlindingPoint); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ToMCRoute extracts the fields required by MC from the Route struct to create
+// the more minima MCRoute struct.
+func ToMCRoute(route *route.Route) *MCRoute {
+	return &MCRoute{
+		SourcePubKey: route.SourcePubKey,
+		TotalAmount:  route.TotalAmount,
+		Hops:         extractMCHops(route.Hops),
+	}
+}
+
+// extractMCHops extracts the Hop fields that MC actually uses from a slice of
+// Hops.
+func extractMCHops(hops []*route.Hop) []*MCHop {
+	mcHops := make([]*MCHop, len(hops))
+	for i, hop := range hops {
+		mcHops[i] = extractMCHop(hop)
+	}
+
+	return mcHops
+}
+
+// extractMCHop extracts the Hop fields that MC actually uses from a Hop.
+func extractMCHop(hop *route.Hop) *MCHop {
+	return &MCHop{
+		ChannelID:        hop.ChannelID,
+		PubKeyBytes:      hop.PubKeyBytes,
+		AmtToFwd:         hop.AmtToForward,
+		HasBlindingPoint: hop.BlindingPoint != nil,
+	}
+}

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -32,6 +32,8 @@
 # Improvements
 ## Functional Updates
 
+* Start reporting successful recieves from blinded paths to mission control.
+
 ## RPC Updates
 
 ## lncli Updates

--- a/go.mod
+++ b/go.mod
@@ -206,6 +206,8 @@ replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-d
 
 replace github.com/lightningnetwork/lightning-onion => github.com/ellemouton/lightning-onion v1.2.1-0.20240814083821-8826a6b7cf2f
 
+replace github.com/lightningnetwork/lnd/sqldb => github.com/ellemouton/lnd/sqldb v0.0.0-20240814143155-40c067be62c8
+
 // If you change this please also update .github/pull_request_template.md,
 // docs/INSTALL.md and GO_IMAGE in lnrpc/gen_protos_docker.sh.
 go 1.21.4

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
 	github.com/go-errors/errors v1.0.1
+	github.com/golang/protobuf v1.5.3
 	github.com/gorilla/websocket v1.5.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
@@ -94,7 +95,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
 	github.com/golang-migrate/migrate/v4 v4.17.0 // indirect
-	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
@@ -203,6 +203,8 @@ replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 // We want to format raw bytes as hex instead of base64. The forked version
 // allows us to specify that as an option.
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display
+
+replace github.com/lightningnetwork/lightning-onion => github.com/ellemouton/lightning-onion v1.2.1-0.20240814083821-8826a6b7cf2f
 
 // If you change this please also update .github/pull_request_template.md,
 // docs/INSTALL.md and GO_IMAGE in lnrpc/gen_protos_docker.sh.

--- a/go.sum
+++ b/go.sum
@@ -187,6 +187,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/ellemouton/lightning-onion v1.2.1-0.20240814083821-8826a6b7cf2f h1:MiRJ3zdJcIm+sna4EXL0+7uH0RPgGWZRfBcuHmRSYdk=
 github.com/ellemouton/lightning-onion v1.2.1-0.20240814083821-8826a6b7cf2f/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
+github.com/ellemouton/lnd/sqldb v0.0.0-20240814143155-40c067be62c8 h1:Cw94HvQvZmnI0WmQCnItR91GFNsRgOIui2x4OrtfePo=
+github.com/ellemouton/lnd/sqldb v0.0.0-20240814143155-40c067be62c8/go.mod h1:4cQOkdymlZ1znnjuRNvMoatQGJkRneTj2CoPSPaQhWo=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -458,8 +460,6 @@ github.com/lightningnetwork/lnd/kvdb v1.4.10 h1:vK89IVv1oVH9ubQWU+EmoCQFeVRaC8kf
 github.com/lightningnetwork/lnd/kvdb v1.4.10/go.mod h1:J2diNABOoII9UrMnxXS5w7vZwP7CA1CStrl8MnIrb3A=
 github.com/lightningnetwork/lnd/queue v1.1.1 h1:99ovBlpM9B0FRCGYJo6RSFDlt8/vOkQQZznVb18iNMI=
 github.com/lightningnetwork/lnd/queue v1.1.1/go.mod h1:7A6nC1Qrm32FHuhx/mi1cieAiBZo5O6l8IBIoQxvkz4=
-github.com/lightningnetwork/lnd/sqldb v1.0.3 h1:zLfAwOvM+6+3+hahYO9Q3h8pVV0TghAR7iJ5YMLCd3I=
-github.com/lightningnetwork/lnd/sqldb v1.0.3/go.mod h1:4cQOkdymlZ1znnjuRNvMoatQGJkRneTj2CoPSPaQhWo=
 github.com/lightningnetwork/lnd/ticker v1.1.1 h1:J/b6N2hibFtC7JLV77ULQp++QLtCwT6ijJlbdiZFbSM=
 github.com/lightningnetwork/lnd/ticker v1.1.1/go.mod h1:waPTRAAcwtu7Ji3+3k+u/xH5GHovTsCoSVpho0KDvdA=
 github.com/lightningnetwork/lnd/tlv v1.2.3 h1:If5ibokA/UoCBGuCKaY6Vn2SJU0l9uAbehCnhTZjEP8=

--- a/go.sum
+++ b/go.sum
@@ -185,6 +185,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/ellemouton/lightning-onion v1.2.1-0.20240814083821-8826a6b7cf2f h1:MiRJ3zdJcIm+sna4EXL0+7uH0RPgGWZRfBcuHmRSYdk=
+github.com/ellemouton/lightning-onion v1.2.1-0.20240814083821-8826a6b7cf2f/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -444,8 +446,6 @@ github.com/lightninglabs/neutrino/cache v1.1.2 h1:C9DY/DAPaPxbFC+xNNEI/z1SJY9GS3
 github.com/lightninglabs/neutrino/cache v1.1.2/go.mod h1:XJNcgdOw1LQnanGjw8Vj44CvguYA25IMKjWFZczwZuo=
 github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display h1:pRdza2wleRN1L2fJXd6ZoQ9ZegVFTAb2bOQfruJPKcY=
 github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-github.com/lightningnetwork/lightning-onion v1.2.1-0.20240712235311-98bd56499dfb h1:yfM05S8DXKhuCBp5qSMZdtSwvJ+GFzl94KbXMNB1JDY=
-github.com/lightningnetwork/lightning-onion v1.2.1-0.20240712235311-98bd56499dfb/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
 github.com/lightningnetwork/lnd/cert v1.2.2 h1:71YK6hogeJtxSxw2teq3eGeuy4rHGKcFf0d0Uy4qBjI=
 github.com/lightningnetwork/lnd/cert v1.2.2/go.mod h1:jQmFn/Ez4zhDgq2hnYSw8r35bqGVxViXhX6Cd7HXM6U=
 github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsDIBjgjWdZgA0=

--- a/invoices/interface.go
+++ b/invoices/interface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -114,6 +115,10 @@ type Payload interface {
 	// TotalAmtMsat returns the total amount sent to the final hop, as set
 	// by the payee.
 	TotalAmtMsat() lnwire.MilliSatoshi
+
+	// BlindingPoint returns the route blinding point parsed from the onion
+	// payload.
+	BlindingPoint() *btcec.PublicKey
 }
 
 // InvoiceQuery represents a query to the invoice database. The query allows a

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -8,11 +8,13 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/queue"
 	"github.com/lightningnetwork/lnd/record"
+	"github.com/lightningnetwork/lnd/routing/route"
 )
 
 var (
@@ -74,6 +76,11 @@ type RegistryConfig struct {
 	// KeysendHoldTime indicates for how long we want to accept and hold
 	// spontaneous keysend payments.
 	KeysendHoldTime time.Duration
+
+	// ReportBlindedPathReceive can be used to indicate the successful
+	// receive along a chosen blinded path.
+	ReportBlindedPathReceive func(invoiceAddIndex uint64,
+		rt *models.MCRoute) error
 }
 
 // htlcReleaseEvent describes an htlc auto-release event. It is used to release
@@ -931,6 +938,7 @@ func (i *InvoiceRegistry) NotifyExitHopHtlc(rHash lntypes.Hash,
 		metadata:             payload.Metadata(),
 		pathID:               payload.PathID(),
 		totalAmtMsat:         payload.TotalAmtMsat(),
+		blindingPoint:        payload.BlindingPoint(),
 	}
 
 	switch {
@@ -1024,9 +1032,13 @@ func (i *InvoiceRegistry) notifyExitHopHtlcLocked(
 	var (
 		resolution        HtlcResolution
 		updateSubscribers bool
+		blindedPath       *models.BlindedPathInfo
+		addIndex          uint64
 	)
 
 	callback := func(inv *Invoice) (*InvoiceUpdateDesc, error) {
+		addIndex = inv.AddIndex
+
 		updateDesc, res, err := updateInvoice(ctx, inv)
 		if err != nil {
 			return nil, err
@@ -1038,6 +1050,24 @@ func (i *InvoiceRegistry) notifyExitHopHtlcLocked(
 
 		// Assign resolution to outer scope variable.
 		resolution = res
+
+		if ctx.blindingPoint == nil {
+			return updateDesc, nil
+		}
+
+		// If this invoice was created before we started persisting the
+		// blinded path info for an invoice, exit.
+		if inv.BlindedPaths == nil {
+			return updateDesc, nil
+		}
+
+		path, ok := inv.BlindedPaths[route.NewVertex(ctx.blindingPoint)]
+		if !ok {
+			return nil, fmt.Errorf("expected a blinding path " +
+				"matching the received ephemeral key")
+		}
+
+		blindedPath = path
 
 		return updateDesc, nil
 	}
@@ -1076,6 +1106,18 @@ func (i *InvoiceRegistry) notifyExitHopHtlcLocked(
 	default:
 		ctx.log(err.Error())
 		return nil, nil, err
+	}
+
+	if blindedPath != nil {
+		// Regardless of what we will do with the HTLC, we want to
+		// report to mission control that the blinded path route it
+		// chose successfully reached us.
+		err = i.cfg.ReportBlindedPathReceive(
+			addIndex, blindedPath.Route,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	var invoiceToExpire invoiceExpiry

--- a/invoices/invoices.go
+++ b/invoices/invoices.go
@@ -840,8 +840,9 @@ func CopyInvoice(src *Invoice) (*Invoice, error) {
 		Htlcs: make(
 			map[CircuitKey]*InvoiceHTLC, len(src.Htlcs),
 		),
-		AMPState:    make(map[SetID]InvoiceStateAMP),
-		HodlInvoice: src.HodlInvoice,
+		AMPState:     make(map[SetID]InvoiceStateAMP),
+		BlindedPaths: make(models.BlindedPathsInfo),
+		HodlInvoice:  src.HodlInvoice,
 	}
 
 	dest.Terms.Features = src.Terms.Features.Clone()
@@ -855,7 +856,7 @@ func CopyInvoice(src *Invoice) (*Invoice, error) {
 		dest.Htlcs[k] = v.Copy()
 	}
 
-	// Lastly, copy the amp invoice state.
+	// Copy the amp invoice state.
 	for k, v := range src.AMPState {
 		ampInvState, err := v.copy()
 		if err != nil {
@@ -863,6 +864,13 @@ func CopyInvoice(src *Invoice) (*Invoice, error) {
 		}
 
 		dest.AMPState[k] = ampInvState
+	}
+
+	// Lastly, copy the blinded path info.
+	for k, info := range src.BlindedPaths {
+		info := info.Copy()
+
+		dest.BlindedPaths[k] = info
 	}
 
 	return &dest, nil

--- a/invoices/invoices.go
+++ b/invoices/invoices.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/feature"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -419,6 +420,14 @@ type Invoice struct {
 	// HodlInvoice indicates whether the invoice should be held in the
 	// Accepted state or be settled right away.
 	HodlInvoice bool
+
+	// BlindedPaths is a map from an incoming blinding key to the associated
+	// blinded path info. An invoice may contain multiple blinded paths but
+	// each one will have a unique session key and thus a unique final
+	// ephemeral key. One receipt of a payment along a blinded path, we can
+	// use the incoming blinding key to thus identify which blinded path in
+	// the invoice was used.
+	BlindedPaths models.BlindedPathsInfo
 }
 
 // HTLCSet returns the set of HTLCs belonging to setID and in the provided

--- a/invoices/invoices_test.go
+++ b/invoices/invoices_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
+	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/sqldb"
 	"github.com/stretchr/testify/require"
 )
@@ -75,8 +76,9 @@ func randInvoice(value lnwire.MilliSatoshi) (*invpkg.Invoice, error) {
 			Value:           value,
 			Features:        emptyFeatures,
 		},
-		Htlcs:    map[models.CircuitKey]*invpkg.InvoiceHTLC{},
-		AMPState: map[invpkg.SetID]invpkg.InvoiceStateAMP{},
+		Htlcs:        map[models.CircuitKey]*invpkg.InvoiceHTLC{},
+		AMPState:     map[invpkg.SetID]invpkg.InvoiceStateAMP{},
+		BlindedPaths: map[route.Vertex]*models.BlindedPathInfo{},
 	}
 	i.Memo = []byte("memo")
 

--- a/invoices/sql_store.go
+++ b/invoices/sql_store.go
@@ -10,11 +10,13 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
+	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/sqldb"
 	"github.com/lightningnetwork/lnd/sqldb/sqlc"
 )
@@ -70,6 +72,19 @@ type SQLInvoiceQueries interface { //nolint:interfacebloat
 		sql.Result, error)
 
 	DeleteCanceledInvoices(ctx context.Context) (sql.Result, error)
+
+	// Blinded path specific methods.
+	FetchBlindedPathHops(ctx context.Context, blindedPathID int64) (
+		[]sqlc.BlindedPathHop, error)
+
+	FetchBlindedPaths(ctx context.Context, invoiceID int64) (
+		[]sqlc.BlindedPath, error)
+
+	InsertBlindedPath(ctx context.Context,
+		arg sqlc.InsertBlindedPathParams) (int64, error)
+
+	InsertBlindedPathHop(ctx context.Context,
+		arg sqlc.InsertBlindedPathHopParams) error
 
 	// AMP sub invoice specific methods.
 	UpsertAMPSubInvoice(ctx context.Context,
@@ -285,6 +300,32 @@ func (i *SQLStore) AddInvoice(ctx context.Context,
 			}
 		}
 
+		for lastEphem, path := range newInvoice.BlindedPaths {
+			pathID, err := db.InsertBlindedPath(ctx, sqlc.InsertBlindedPathParams{
+				InvoiceID:        invoiceID,
+				LastEphemeralPub: lastEphem[:],
+				SessionKey:       path.SessionKey.Serialize(),
+				IntroductionNode: path.Route.SourcePubKey[:],
+				AmountMsat:       int64(path.Route.TotalAmount),
+			})
+			if err != nil {
+				return err
+			}
+
+			for hopIndex, hop := range path.Route.Hops {
+				err = db.InsertBlindedPathHop(ctx, sqlc.InsertBlindedPathHopParams{
+					BlindedPathID: pathID,
+					HopIndex:      int64(hopIndex),
+					ChannelID:     int64(hop.ChannelID),
+					NodePubKey:    hop.PubKeyBytes[:],
+					AmountToFwd:   int64(hop.AmtToFwd),
+				})
+				if err != nil {
+					return err
+				}
+			}
+		}
+
 		// Finally add a new event for this invoice.
 		return db.OnInvoiceCreated(ctx, sqlc.OnInvoiceCreatedParams{
 			AddedAt:   newInvoice.CreationDate.UTC(),
@@ -401,6 +442,72 @@ func (i *SQLStore) fetchInvoice(ctx context.Context,
 	}
 
 	return invoice, nil
+}
+
+func fetchBlindedPaths(ctx context.Context, db SQLInvoiceQueries,
+	invoiceID int64) (models.BlindedPathsInfo, error) {
+
+	blindedPathRows, err := db.FetchBlindedPaths(ctx, invoiceID)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(blindedPathRows) == 0 {
+		return nil, err
+	}
+
+	info := make(models.BlindedPathsInfo, len(blindedPathRows))
+
+	for _, sqlPath := range blindedPathRows {
+		lastEphem, err := btcec.ParsePubKey(sqlPath.LastEphemeralPub)
+		if err != nil {
+			return nil, err
+		}
+
+		sessKey, _ := btcec.PrivKeyFromBytes(sqlPath.SessionKey)
+		if err != nil {
+			return nil, err
+		}
+
+		introNode, err := btcec.ParsePubKey(sqlPath.IntroductionNode)
+		if err != nil {
+			return nil, err
+		}
+
+		sqlHops, err := db.FetchBlindedPathHops(ctx, sqlPath.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		hops := make([]*models.MCHop, len(sqlHops))
+		for i, sqlHop := range sqlHops {
+			hopKey, err := btcec.ParsePubKey(sqlHop.NodePubKey)
+			if err != nil {
+				return nil, err
+			}
+			hops[i] = &models.MCHop{
+				ChannelID:   uint64(sqlHop.ChannelID),
+				PubKeyBytes: route.NewVertex(hopKey),
+				AmtToFwd: lnwire.MilliSatoshi(
+					sqlHop.AmountToFwd,
+				),
+				HasBlindingPoint: true,
+			}
+		}
+
+		info[route.NewVertex(lastEphem)] = &models.BlindedPathInfo{
+			Route: &models.MCRoute{
+				SourcePubKey: route.NewVertex(introNode),
+				TotalAmount: lnwire.MilliSatoshi(
+					sqlPath.AmountMsat,
+				),
+				Hops: hops,
+			},
+			SessionKey: sessKey,
+		}
+	}
+
+	return info, err
 }
 
 // fetchAmpState fetches the AMP state for the invoice with the given ID.
@@ -1456,6 +1563,18 @@ func fetchInvoiceData(ctx context.Context, db SQLInvoiceQueries,
 		return hash, invoice, nil
 	}
 
+	// If this is a blinded invoice, we'll fetch the blinded path info if it
+	// exists.
+	if invoice.IsBlinded() {
+		invoiceID := int64(invoice.AddIndex)
+		blindedPathInfo, err := fetchBlindedPaths(ctx, db, invoiceID)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		invoice.BlindedPaths = blindedPathInfo
+	}
+
 	// Otherwise simply fetch the invoice HTLCs.
 	htlcs, err := getInvoiceHtlcs(ctx, db, row.ID)
 	if err != nil {
@@ -1613,12 +1732,13 @@ func unmarshalInvoice(row sqlc.Invoice) (*lntypes.Hash, *Invoice,
 			Value:           lnwire.MilliSatoshi(row.AmountMsat),
 			PaymentAddr:     paymentAddr,
 		},
-		AddIndex:    uint64(row.ID),
-		State:       ContractState(row.State),
-		AmtPaid:     lnwire.MilliSatoshi(row.AmountPaidMsat),
-		Htlcs:       make(map[models.CircuitKey]*InvoiceHTLC),
-		AMPState:    AMPInvoiceState{},
-		HodlInvoice: row.IsHodl,
+		AddIndex:     uint64(row.ID),
+		State:        ContractState(row.State),
+		AmtPaid:      lnwire.MilliSatoshi(row.AmountPaidMsat),
+		Htlcs:        make(map[models.CircuitKey]*InvoiceHTLC),
+		AMPState:     AMPInvoiceState{},
+		HodlInvoice:  row.IsHodl,
+		BlindedPaths: models.BlindedPathsInfo{},
 	}
 
 	return &hash, invoice, nil

--- a/invoices/test_utils_test.go
+++ b/invoices/test_utils_test.go
@@ -46,6 +46,10 @@ func (p *mockPayload) PathID() *chainhash.Hash {
 	return p.pathID
 }
 
+func (p *mockPayload) BlindingPoint() *btcec.PublicKey {
+	return nil
+}
+
 func (p *mockPayload) TotalAmtMsat() lnwire.MilliSatoshi {
 	return p.totalAmtMsat
 }

--- a/invoices/update.go
+++ b/invoices/update.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightningnetwork/lnd/amp"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -27,6 +28,7 @@ type invoiceUpdateCtx struct {
 	metadata             []byte
 	pathID               *chainhash.Hash
 	totalAmtMsat         lnwire.MilliSatoshi
+	blindingPoint        *btcec.PublicKey
 }
 
 // invoiceRef returns an identifier that can be used to lookup or update the

--- a/lnrpc/invoicesrpc/addinvoice.go
+++ b/lnrpc/invoicesrpc/addinvoice.go
@@ -500,6 +500,7 @@ func AddInvoice(ctx context.Context, cfg *AddInvoiceConfig,
 		return nil, nil, err
 	}
 
+	blindedPathMap := make(models.BlindedPathsInfo)
 	if blind {
 		blindCfg := invoice.BlindedPathCfg
 
@@ -551,6 +552,13 @@ func AddInvoice(ctx context.Context, cfg *AddInvoiceConfig,
 			options = append(options, zpay32.WithBlindedPaymentPath(
 				path.Path,
 			))
+
+			lastEphem := route.NewVertex(path.LastEphemeralKey)
+
+			blindedPathMap[lastEphem] = &models.BlindedPathInfo{
+				Route:      path.Route,
+				SessionKey: path.SessionKey,
+			}
 		}
 	} else {
 		options = append(options, zpay32.PaymentAddr(paymentAddr))
@@ -606,7 +614,8 @@ func AddInvoice(ctx context.Context, cfg *AddInvoiceConfig,
 			PaymentAddr:     paymentAddr,
 			Features:        invoiceFeatures,
 		},
-		HodlInvoice: invoice.HodlInvoice,
+		HodlInvoice:  invoice.HodlInvoice,
+		BlindedPaths: blindedPathMap,
 	}
 
 	log.Tracef("[addinvoice] adding new invoice %v",

--- a/lnrpc/invoicesrpc/addinvoice.go
+++ b/lnrpc/invoicesrpc/addinvoice.go
@@ -549,7 +549,7 @@ func AddInvoice(ctx context.Context, cfg *AddInvoiceConfig,
 
 		for _, path := range paths {
 			options = append(options, zpay32.WithBlindedPaymentPath(
-				path,
+				path.Path,
 			))
 		}
 	} else {

--- a/routing/blindedpath/blinded_path.go
+++ b/routing/blindedpath/blinded_path.go
@@ -281,7 +281,7 @@ func buildBlindedPaymentPath(cfg *BuildBlindedPathCfg, path *candidatePath) (
 	}
 
 	// Encrypt the hop info.
-	blindedPath, err := sphinx.BuildBlindedPath(sessionKey, paymentPath)
+	blindedPath, _, err := sphinx.BuildBlindedPath(sessionKey, paymentPath)
 	if err != nil {
 		return nil, err
 	}

--- a/routing/blindedpath/blinded_path.go
+++ b/routing/blindedpath/blinded_path.go
@@ -117,6 +117,10 @@ type PathInfo struct {
 	// This can be used to uniquely identify a path when an incoming payment
 	// is received.
 	LastEphemeralKey *btcec.PublicKey
+
+	// Route is the real un-blinded route that was used to construct the
+	// Path.
+	Route *models.MCRoute
 }
 
 // BuildBlindedPaymentPaths uses the passed config to construct a set of blinded
@@ -148,9 +152,9 @@ func BuildBlindedPaymentPaths(cfg *BuildBlindedPathCfg) ([]*PathInfo, error) {
 
 	// For each route returned, we will construct the associated blinded
 	// payment path.
-	for _, route := range routes {
+	for _, r := range routes {
 		// Extract the information we need from the route.
-		candidatePath := extractCandidatePath(route)
+		candidatePath := extractCandidatePath(r)
 
 		// Pad the given route with dummy hops until the minimum number
 		// of hops is met.
@@ -160,7 +164,7 @@ func BuildBlindedPaymentPaths(cfg *BuildBlindedPathCfg) ([]*PathInfo, error) {
 		if errors.Is(err, errInvalidBlindedPath) {
 			log.Debugf("Not using route (%s) as a blinded path "+
 				"since it resulted in an invalid blinded path",
-				route)
+				r)
 
 			continue
 		} else if err != nil {
@@ -169,6 +173,8 @@ func BuildBlindedPaymentPaths(cfg *BuildBlindedPathCfg) ([]*PathInfo, error) {
 
 			continue
 		}
+
+		path.Route = models.ToMCRoute(r)
 
 		log.Debugf("Route selected for blinded path: %s", candidatePath)
 

--- a/routing/blindedpath/blinded_path_test.go
+++ b/routing/blindedpath/blinded_path_test.go
@@ -844,48 +844,67 @@ func TestBuildBlindedPathWithDummyHops(t *testing.T) {
 		data          *record.BlindedRouteData
 	)
 
+	// checkCarolData is a helper that we can use to check that the blinded
+	// path record contains the info we expect for Carol.
+	checkCarolData := func(data *record.BlindedRouteData) {
+		require.Equal(
+			t, lnwire.NewShortChanIDFromInt(chanCB),
+			data.ShortChannelID.UnwrapOrFail(t).Val,
+		)
+
+		require.Equal(t, record.PaymentRelayInfo{
+			CltvExpiryDelta: 144,
+			FeeRate:         500,
+			BaseFee:         100,
+		}, data.RelayInfo.UnwrapOrFail(t).Val)
+
+		require.Equal(t, record.PaymentConstraints{
+			MaxCltvExpiry:   1788,
+			HtlcMinimumMsat: 1000,
+		}, data.Constraints.UnwrapOrFail(t).Val)
+	}
+
+	// We make a copy of the cipher text here because we want to also check
+	// later that we can do this same decryption from Alice's (the path
+	// creator's) perspective later on.
+	carolCipherText := make([]byte, len(hop.CipherText))
+	copy(carolCipherText[:], hop.CipherText)
+
 	// Check that Carol's info is correct.
 	data, blindingPoint = decryptAndDecodeHopData(
 		t, privC, blindingPoint, hop.CipherText,
 	)
-
-	require.Equal(
-		t, lnwire.NewShortChanIDFromInt(chanCB),
-		data.ShortChannelID.UnwrapOrFail(t).Val,
-	)
-
-	require.Equal(t, record.PaymentRelayInfo{
-		CltvExpiryDelta: 144,
-		FeeRate:         500,
-		BaseFee:         100,
-	}, data.RelayInfo.UnwrapOrFail(t).Val)
-
-	require.Equal(t, record.PaymentConstraints{
-		MaxCltvExpiry:   1788,
-		HtlcMinimumMsat: 1000,
-	}, data.Constraints.UnwrapOrFail(t).Val)
+	checkCarolData(data)
 
 	// Check that all Bob's info is correct.
+	checkBobData := func(data *record.BlindedRouteData) {
+		require.Equal(
+			t, lnwire.NewShortChanIDFromInt(chanBA),
+			data.ShortChannelID.UnwrapOrFail(t).Val,
+		)
+
+		require.Equal(t, record.PaymentRelayInfo{
+			CltvExpiryDelta: 144,
+			FeeRate:         500,
+			BaseFee:         100,
+		}, data.RelayInfo.UnwrapOrFail(t).Val)
+
+		require.Equal(t, record.PaymentConstraints{
+			MaxCltvExpiry:   1644,
+			HtlcMinimumMsat: 1000,
+		}, data.Constraints.UnwrapOrFail(t).Val)
+	}
+
 	hop = path.Hops[1]
+
+	bobCipherText := make([]byte, len(hop.CipherText))
+	copy(bobCipherText[:], hop.CipherText)
+
+	// Decrypt and check the data from Bob's perspective.
 	data, blindingPoint = decryptAndDecodeHopData(
 		t, privB, blindingPoint, hop.CipherText,
 	)
-
-	require.Equal(
-		t, lnwire.NewShortChanIDFromInt(chanBA),
-		data.ShortChannelID.UnwrapOrFail(t).Val,
-	)
-
-	require.Equal(t, record.PaymentRelayInfo{
-		CltvExpiryDelta: 144,
-		FeeRate:         500,
-		BaseFee:         100,
-	}, data.RelayInfo.UnwrapOrFail(t).Val)
-
-	require.Equal(t, record.PaymentConstraints{
-		MaxCltvExpiry:   1644,
-		HtlcMinimumMsat: 1000,
-	}, data.Constraints.UnwrapOrFail(t).Val)
+	checkBobData(data)
 
 	// Check that all Alice's info is correct. The payload should contain
 	// a next_node_id field that is equal to Alice's public key. This
@@ -922,6 +941,23 @@ func TestBuildBlindedPathWithDummyHops(t *testing.T) {
 		HtlcMinimumMsat: 1000,
 	}, data.Constraints.UnwrapOrFail(t).Val)
 	require.Equal(t, []byte{1, 2, 3}, data.PathID.UnwrapOrFail(t).Val)
+
+	// Now, we demonstrate that from Alice's perspective, we can also
+	// decrypt the payloads that were encrypted for Carol and Bob. Alice can
+	// do this using the session key for the path.
+	ephemPrivKey := pathInfos[0].SessionKey
+	data, _ = decryptAndDecodeHopData(t, ephemPrivKey, pkC, carolCipherText)
+	checkCarolData(data)
+
+	// Let Alice calculate the next ephemeral private key so that she can
+	// then also decrypt Bob's payload.
+	ephemPrivKey, err = sphinx.NextEphemeralPriv(
+		&sphinx.PrivKeyECDH{PrivKey: ephemPrivKey}, pkC,
+	)
+	require.NoError(t, err)
+
+	data, _ = decryptAndDecodeHopData(t, ephemPrivKey, pkB, bobCipherText)
+	checkBobData(data)
 
 	// Demonstrate that BuildBlindedPaymentPaths continues to use any
 	// functioning paths even if some routes cant be used to build a blinded

--- a/routing/blindedpath/blinded_path_test.go
+++ b/routing/blindedpath/blinded_path_test.go
@@ -591,7 +591,7 @@ func TestBuildBlindedPath(t *testing.T) {
 		},
 	}
 
-	paths, err := BuildBlindedPaymentPaths(&BuildBlindedPathCfg{
+	pathInfos, err := BuildBlindedPaymentPaths(&BuildBlindedPathCfg{
 		FindRoutes: func(_ lnwire.MilliSatoshi) ([]*route.Route,
 			error) {
 
@@ -625,9 +625,9 @@ func TestBuildBlindedPath(t *testing.T) {
 		BlocksUntilExpiry:       200,
 	})
 	require.NoError(t, err)
-	require.Len(t, paths, 1)
+	require.Len(t, pathInfos, 1)
 
-	path := paths[0]
+	path := pathInfos[0].Path
 
 	// Check that all the accumulated policy values are correct.
 	require.EqualValues(t, 201, path.FeeBaseMsat)
@@ -759,7 +759,7 @@ func TestBuildBlindedPathWithDummyHops(t *testing.T) {
 		},
 	}
 
-	paths, err := BuildBlindedPaymentPaths(&BuildBlindedPathCfg{
+	pathInfos, err := BuildBlindedPaymentPaths(&BuildBlindedPathCfg{
 		FindRoutes: func(_ lnwire.MilliSatoshi) ([]*route.Route,
 			error) {
 
@@ -811,9 +811,9 @@ func TestBuildBlindedPathWithDummyHops(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.Len(t, paths, 1)
+	require.Len(t, pathInfos, 1)
 
-	path := paths[0]
+	path := pathInfos[0].Path
 
 	// Check that all the accumulated policy values are correct.
 	require.EqualValues(t, 403, path.FeeBaseMsat)
@@ -929,7 +929,7 @@ func TestBuildBlindedPathWithDummyHops(t *testing.T) {
 	// the first 2 calls. FindRoutes returns 3 routes and so by the end, we
 	// still get 1 valid path.
 	var errCount int
-	paths, err = BuildBlindedPaymentPaths(&BuildBlindedPathCfg{
+	pathInfos, err = BuildBlindedPaymentPaths(&BuildBlindedPathCfg{
 		FindRoutes: func(_ lnwire.MilliSatoshi) ([]*route.Route,
 			error) {
 
@@ -990,7 +990,7 @@ func TestBuildBlindedPathWithDummyHops(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.Len(t, paths, 1)
+	require.Len(t, pathInfos, 1)
 }
 
 // TestSingleHopBlindedPath tests that blinded path construction is done
@@ -1009,7 +1009,7 @@ func TestSingleHopBlindedPath(t *testing.T) {
 		Hops: []*route.Hop{},
 	}
 
-	paths, err := BuildBlindedPaymentPaths(&BuildBlindedPathCfg{
+	pathInfos, err := BuildBlindedPaymentPaths(&BuildBlindedPathCfg{
 		FindRoutes: func(_ lnwire.MilliSatoshi) ([]*route.Route,
 			error) {
 
@@ -1024,9 +1024,9 @@ func TestSingleHopBlindedPath(t *testing.T) {
 		BlocksUntilExpiry:       200,
 	})
 	require.NoError(t, err)
-	require.Len(t, paths, 1)
+	require.Len(t, pathInfos, 1)
 
-	path := paths[0]
+	path := pathInfos[0].Path
 
 	// Check that all the accumulated policy values are correct. Since this
 	// is a unique case where the destination node is also the introduction

--- a/routing/integrated_routing_context_test.go
+++ b/routing/integrated_routing_context_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
@@ -258,7 +259,9 @@ func (c *integratedRoutingContext) testPayment(maxParts uint32,
 		if success {
 			inFlightHtlcs++
 
-			err := mc.ReportPaymentSuccess(pid, route)
+			err := mc.ReportPaymentSuccess(
+				pid, models.ToMCRoute(route),
+			)
 			if err != nil {
 				c.t.Fatal(err)
 			}
@@ -277,7 +280,7 @@ func (c *integratedRoutingContext) testPayment(maxParts uint32,
 
 		// Failure, update mission control and retry.
 		finalResult, err := mc.ReportPaymentFail(
-			pid, route,
+			pid, models.ToMCRoute(route),
 			getNodeIndex(route, htlcResult.failureSource),
 			htlcResult.failure,
 		)

--- a/routing/missioncontrol.go
+++ b/routing/missioncontrol.go
@@ -11,6 +11,7 @@ import (
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
@@ -256,7 +257,7 @@ type MissionControlPairSnapshot struct {
 type paymentResult struct {
 	id                 uint64
 	timeFwd, timeReply time.Time
-	route              *mcRoute
+	route              *models.MCRoute
 	success            bool
 	failureSourceIdx   *int
 	failure            lnwire.FailureMessage
@@ -559,7 +560,7 @@ func (m *MissionControl) ReportPaymentFail(paymentID uint64, rt *route.Route,
 		id:               paymentID,
 		failureSourceIdx: failureSourceIdx,
 		failure:          failure,
-		route:            extractMCRoute(rt),
+		route:            models.ToMCRoute(rt),
 	}
 
 	return m.processPaymentResult(result)
@@ -577,7 +578,7 @@ func (m *MissionControl) ReportPaymentSuccess(paymentID uint64,
 		timeReply: timestamp,
 		id:        paymentID,
 		success:   true,
-		route:     extractMCRoute(rt),
+		route:     models.ToMCRoute(rt),
 	}
 
 	_, err := m.processPaymentResult(result)

--- a/routing/missioncontrol.go
+++ b/routing/missioncontrol.go
@@ -76,6 +76,11 @@ const (
 	// control name space. This is used as the sub-bucket key within the
 	// top level DB bucket to store mission control results.
 	DefaultMissionControlNamespace = "default"
+
+	// BlindedPathMissionControlNamespace is the name of the mission control
+	// namespace where results from successful blinded path receives will
+	// be stored.
+	BlindedPathMissionControlNamespace = "blinded-paths"
 )
 
 var (

--- a/routing/missioncontrol.go
+++ b/routing/missioncontrol.go
@@ -547,7 +547,7 @@ func (m *MissionControl) GetPairHistorySnapshot(
 // failure source. If it is nil, the failure source is unknown. This function
 // returns a reason if this failure is a final failure. In that case no further
 // payment attempts need to be made.
-func (m *MissionControl) ReportPaymentFail(paymentID uint64, rt *route.Route,
+func (m *MissionControl) ReportPaymentFail(paymentID uint64, rt *models.MCRoute,
 	failureSourceIdx *int, failure lnwire.FailureMessage) (
 	*channeldb.FailureReason, error) {
 
@@ -560,7 +560,7 @@ func (m *MissionControl) ReportPaymentFail(paymentID uint64, rt *route.Route,
 		id:               paymentID,
 		failureSourceIdx: failureSourceIdx,
 		failure:          failure,
-		route:            models.ToMCRoute(rt),
+		route:            rt,
 	}
 
 	return m.processPaymentResult(result)
@@ -569,7 +569,7 @@ func (m *MissionControl) ReportPaymentFail(paymentID uint64, rt *route.Route,
 // ReportPaymentSuccess reports a successful payment to mission control as input
 // for future probability estimates.
 func (m *MissionControl) ReportPaymentSuccess(paymentID uint64,
-	rt *route.Route) error {
+	rt *models.MCRoute) error {
 
 	timestamp := m.now()
 
@@ -578,7 +578,7 @@ func (m *MissionControl) ReportPaymentSuccess(paymentID uint64,
 		timeReply: timestamp,
 		id:        paymentID,
 		success:   true,
-		route:     models.ToMCRoute(rt),
+		route:     rt,
 	}
 
 	_, err := m.processPaymentResult(result)

--- a/routing/missioncontrol_store.go
+++ b/routing/missioncontrol_store.go
@@ -5,13 +5,13 @@ import (
 	"container/list"
 	"encoding/binary"
 	"fmt"
-	"io"
 	"math"
 	"sync"
 	"time"
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
@@ -188,7 +188,7 @@ func serializeResult(rp *paymentResult) ([]byte, []byte, error) {
 		return nil, nil, err
 	}
 
-	if err := serializeRoute(&b, rp.route); err != nil {
+	if err := rp.route.Serialize(&b); err != nil {
 		return nil, nil, err
 	}
 
@@ -210,88 +210,6 @@ func serializeResult(rp *paymentResult) ([]byte, []byte, error) {
 	key := getResultKey(rp)
 
 	return key, b.Bytes(), nil
-}
-
-// deserializeRoute deserializes the mcRoute from the given io.Reader.
-func deserializeRoute(r io.Reader) (*mcRoute, error) {
-	var rt mcRoute
-	if err := channeldb.ReadElements(r, &rt.totalAmount); err != nil {
-		return nil, err
-	}
-
-	var pub []byte
-	if err := channeldb.ReadElements(r, &pub); err != nil {
-		return nil, err
-	}
-	copy(rt.sourcePubKey[:], pub)
-
-	var numHops uint32
-	if err := channeldb.ReadElements(r, &numHops); err != nil {
-		return nil, err
-	}
-
-	var hops []*mcHop
-	for i := uint32(0); i < numHops; i++ {
-		hop, err := deserializeHop(r)
-		if err != nil {
-			return nil, err
-		}
-		hops = append(hops, hop)
-	}
-	rt.hops = hops
-
-	return &rt, nil
-}
-
-// deserializeHop deserializes the mcHop from the given io.Reader.
-func deserializeHop(r io.Reader) (*mcHop, error) {
-	var h mcHop
-
-	var pub []byte
-	if err := channeldb.ReadElements(r, &pub); err != nil {
-		return nil, err
-	}
-	copy(h.pubKeyBytes[:], pub)
-
-	if err := channeldb.ReadElements(r,
-		&h.channelID, &h.amtToFwd, &h.hasBlindingPoint,
-	); err != nil {
-		return nil, err
-	}
-
-	return &h, nil
-}
-
-// serializeRoute serializes a mcRouter and writes the resulting bytes to the
-// given io.Writer.
-func serializeRoute(w io.Writer, r *mcRoute) error {
-	err := channeldb.WriteElements(w, r.totalAmount, r.sourcePubKey[:])
-	if err != nil {
-		return err
-	}
-
-	if err := channeldb.WriteElements(w, uint32(len(r.hops))); err != nil {
-		return err
-	}
-
-	for _, h := range r.hops {
-		if err := serializeHop(w, h); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// serializeHop serializes a mcHop and writes the resulting bytes to the given
-// io.Writer.
-func serializeHop(w io.Writer, h *mcHop) error {
-	return channeldb.WriteElements(w,
-		h.pubKeyBytes[:],
-		h.channelID,
-		h.amtToFwd,
-		h.hasBlindingPoint,
-	)
 }
 
 // deserializeResult deserializes a payment result.
@@ -327,7 +245,7 @@ func deserializeResult(k, v []byte) (*paymentResult, error) {
 	}
 
 	// Read route.
-	route, err := deserializeRoute(r)
+	route, err := models.DeserializeRoute(r)
 	if err != nil {
 		return nil, err
 	}
@@ -580,7 +498,7 @@ func getResultKey(rp *paymentResult) []byte {
 	// chronologically.
 	byteOrder.PutUint64(keyBytes[:], uint64(rp.timeReply.UnixNano()))
 	byteOrder.PutUint64(keyBytes[8:], rp.id)
-	copy(keyBytes[16:], rp.route.sourcePubKey[:])
+	copy(keyBytes[16:], rp.route.SourcePubKey[:])
 
 	return keyBytes[:]
 }

--- a/routing/missioncontrol_store_test.go
+++ b/routing/missioncontrol_store_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -18,11 +19,11 @@ const testMaxRecords = 2
 
 var (
 	// mcStoreTestRoute is a test route for the mission control store tests.
-	mcStoreTestRoute = mcRoute{
-		sourcePubKey: route.Vertex{1},
-		hops: []*mcHop{
+	mcStoreTestRoute = models.MCRoute{
+		SourcePubKey: route.Vertex{1},
+		Hops: []*models.MCHop{
 			{
-				pubKeyBytes: route.Vertex{2},
+				PubKeyBytes: route.Vertex{2},
 			},
 		},
 	}

--- a/routing/missioncontrol_test.go
+++ b/routing/missioncontrol_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
@@ -12,19 +13,17 @@ import (
 )
 
 var (
-	mcTestRoute = &route.Route{
+	mcTestRoute = &models.MCRoute{
 		SourcePubKey: mcTestSelf,
-		Hops: []*route.Hop{
+		Hops: []*models.MCHop{
 			{
-				ChannelID:     1,
-				PubKeyBytes:   route.Vertex{11},
-				AmtToForward:  1000,
-				LegacyPayload: true,
+				ChannelID:   1,
+				PubKeyBytes: route.Vertex{11},
+				AmtToFwd:    1000,
 			},
 			{
-				ChannelID:     2,
-				PubKeyBytes:   route.Vertex{12},
-				LegacyPayload: true,
+				ChannelID:   2,
+				PubKeyBytes: route.Vertex{12},
 			},
 		},
 	}
@@ -142,7 +141,7 @@ func (ctx *mcTestContext) expectP(amt lnwire.MilliSatoshi, expected float64) {
 func (ctx *mcTestContext) reportFailure(amt lnwire.MilliSatoshi,
 	failure lnwire.FailureMessage) {
 
-	mcTestRoute.Hops[0].AmtToForward = amt
+	mcTestRoute.Hops[0].AmtToFwd = amt
 
 	errorSourceIdx := 1
 	ctx.mc.ReportPaymentFail(

--- a/routing/missioncontrol_test.go
+++ b/routing/missioncontrol_test.go
@@ -151,7 +151,9 @@ func (ctx *mcTestContext) reportFailure(amt lnwire.MilliSatoshi,
 
 // reportSuccess reports a success by using a test route.
 func (ctx *mcTestContext) reportSuccess() {
-	err := ctx.mc.ReportPaymentSuccess(ctx.pid, mcTestRoute)
+	err := ctx.mc.ReportPaymentSuccess(
+		ctx.pid, mcTestRoute,
+	)
 	if err != nil {
 		ctx.t.Fatal(err)
 	}

--- a/routing/mock_test.go
+++ b/routing/mock_test.go
@@ -128,7 +128,7 @@ type mockMissionControlOld struct {
 var _ MissionControlQuerier = (*mockMissionControlOld)(nil)
 
 func (m *mockMissionControlOld) ReportPaymentFail(
-	paymentID uint64, rt *route.Route,
+	paymentID uint64, rt *models.MCRoute,
 	failureSourceIdx *int, failure lnwire.FailureMessage) (
 	*channeldb.FailureReason, error) {
 
@@ -143,7 +143,7 @@ func (m *mockMissionControlOld) ReportPaymentFail(
 }
 
 func (m *mockMissionControlOld) ReportPaymentSuccess(paymentID uint64,
-	rt *route.Route) error {
+	rt *models.MCRoute) error {
 
 	return nil
 }
@@ -655,7 +655,7 @@ type mockMissionControl struct {
 var _ MissionControlQuerier = (*mockMissionControl)(nil)
 
 func (m *mockMissionControl) ReportPaymentFail(
-	paymentID uint64, rt *route.Route,
+	paymentID uint64, rt *models.MCRoute,
 	failureSourceIdx *int, failure lnwire.FailureMessage) (
 	*channeldb.FailureReason, error) {
 
@@ -670,7 +670,7 @@ func (m *mockMissionControl) ReportPaymentFail(
 }
 
 func (m *mockMissionControl) ReportPaymentSuccess(paymentID uint64,
-	rt *route.Route) error {
+	rt *models.MCRoute) error {
 
 	args := m.Called(paymentID, rt)
 	return args.Error(0)

--- a/routing/payment_lifecycle.go
+++ b/routing/payment_lifecycle.go
@@ -551,7 +551,7 @@ func (p *paymentLifecycle) collectResult(attempt *channeldb.HTLCAttempt) (
 
 	// Report success to mission control.
 	err = p.router.cfg.MissionControl.ReportPaymentSuccess(
-		attempt.AttemptID, &attempt.Route,
+		attempt.AttemptID, models.ToMCRoute(&attempt.Route),
 	)
 	if err != nil {
 		log.Errorf("Error reporting payment success to mc: %v", err)
@@ -765,7 +765,8 @@ func (p *paymentLifecycle) handleSwitchErr(attempt *channeldb.HTLCAttempt,
 
 		// Report outcome to mission control.
 		reason, err := p.router.cfg.MissionControl.ReportPaymentFail(
-			attemptID, &attempt.Route, srcIdx, msg,
+			attemptID, models.ToMCRoute(&attempt.Route), srcIdx,
+			msg,
 		)
 		if err != nil {
 			log.Errorf("Error reporting payment result to mc: %v",

--- a/routing/payment_lifecycle_test.go
+++ b/routing/payment_lifecycle_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/lnmock"
 	"github.com/lightningnetwork/lnd/lntest/wait"
@@ -1502,7 +1503,7 @@ func TestCollectResultExitOnSettleErr(t *testing.T) {
 	// Once the result is received, `ReportPaymentSuccess` should be
 	// called.
 	m.missionControl.On("ReportPaymentSuccess",
-		attempt.AttemptID, &attempt.Route,
+		attempt.AttemptID, models.ToMCRoute(&attempt.Route),
 	).Return(nil).Once()
 
 	// Now mock an error being returned from `SettleAttempt`.
@@ -1549,7 +1550,7 @@ func TestCollectResultSuccess(t *testing.T) {
 	// Once the result is received, `ReportPaymentSuccess` should be
 	// called.
 	m.missionControl.On("ReportPaymentSuccess",
-		attempt.AttemptID, &attempt.Route,
+		attempt.AttemptID, models.ToMCRoute(&attempt.Route),
 	).Return(nil).Once()
 
 	// Now the settled htlc being returned from `SettleAttempt`.
@@ -1597,7 +1598,7 @@ func TestCollectResultAsyncSuccess(t *testing.T) {
 	// Once the result is received, `ReportPaymentSuccess` should be
 	// called.
 	m.missionControl.On("ReportPaymentSuccess",
-		attempt.AttemptID, &attempt.Route,
+		attempt.AttemptID, models.ToMCRoute(&attempt.Route),
 	).Return(nil).Once()
 
 	// Now the settled htlc being returned from `SettleAttempt`.

--- a/routing/result_interpretation.go
+++ b/routing/result_interpretation.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
 )
@@ -76,7 +77,7 @@ type interpretedResult struct {
 
 // interpretResult interprets a payment outcome and returns an object that
 // contains information required to update mission control.
-func interpretResult(rt *mcRoute, success bool, failureSrcIdx *int,
+func interpretResult(rt *models.MCRoute, success bool, failureSrcIdx *int,
 	failure lnwire.FailureMessage) *interpretedResult {
 
 	i := &interpretedResult{
@@ -92,14 +93,14 @@ func interpretResult(rt *mcRoute, success bool, failureSrcIdx *int,
 }
 
 // processSuccess processes a successful payment attempt.
-func (i *interpretedResult) processSuccess(route *mcRoute) {
+func (i *interpretedResult) processSuccess(route *models.MCRoute) {
 	// For successes, all nodes must have acted in the right way. Therefore
 	// we mark all of them with a success result.
-	i.successPairRange(route, 0, len(route.hops)-1)
+	i.successPairRange(route, 0, len(route.Hops)-1)
 }
 
 // processFail processes a failed payment attempt.
-func (i *interpretedResult) processFail(rt *mcRoute, errSourceIdx *int,
+func (i *interpretedResult) processFail(rt *models.MCRoute, errSourceIdx *int,
 	failure lnwire.FailureMessage) {
 
 	if errSourceIdx == nil {
@@ -124,7 +125,7 @@ func (i *interpretedResult) processFail(rt *mcRoute, errSourceIdx *int,
 		i.processPaymentOutcomeSelf(rt, failure)
 
 	// A failure from the final hop was received.
-	case len(rt.hops):
+	case len(rt.Hops):
 		i.processPaymentOutcomeFinal(rt, failure)
 
 	// An intermediate hop failed. Interpret the outcome, update reputation
@@ -141,7 +142,7 @@ func (i *interpretedResult) processFail(rt *mcRoute, errSourceIdx *int,
 // node. This indicates that the introduction node is not obeying the route
 // blinding specification, as we expect all errors from the introduction node
 // to be source from it.
-func (i *interpretedResult) processPaymentOutcomeBadIntro(route *mcRoute,
+func (i *interpretedResult) processPaymentOutcomeBadIntro(route *models.MCRoute,
 	introIdx, errSourceIdx int) {
 
 	// We fail the introduction node for not obeying the specification.
@@ -158,13 +159,13 @@ func (i *interpretedResult) processPaymentOutcomeBadIntro(route *mcRoute,
 	// a final failure reason because the recipient can't process the
 	// payment (independent of the introduction failing to convert the
 	// error, we can't complete the payment if the last hop fails).
-	if errSourceIdx == len(route.hops) {
+	if errSourceIdx == len(route.Hops) {
 		i.finalFailureReason = &reasonError
 	}
 }
 
 // processPaymentOutcomeSelf handles failures sent by ourselves.
-func (i *interpretedResult) processPaymentOutcomeSelf(rt *mcRoute,
+func (i *interpretedResult) processPaymentOutcomeSelf(rt *models.MCRoute,
 	failure lnwire.FailureMessage) {
 
 	switch failure.(type) {
@@ -178,7 +179,7 @@ func (i *interpretedResult) processPaymentOutcomeSelf(rt *mcRoute,
 		i.failNode(rt, 1)
 
 		// If this was a payment to a direct peer, we can stop trying.
-		if len(rt.hops) == 1 {
+		if len(rt.Hops) == 1 {
 			i.finalFailureReason = &reasonError
 		}
 
@@ -188,15 +189,15 @@ func (i *interpretedResult) processPaymentOutcomeSelf(rt *mcRoute,
 	// available in the link has been updated.
 	default:
 		log.Warnf("Routing failure for local channel %v occurred",
-			rt.hops[0].channelID)
+			rt.Hops[0].ChannelID)
 	}
 }
 
 // processPaymentOutcomeFinal handles failures sent by the final hop.
-func (i *interpretedResult) processPaymentOutcomeFinal(route *mcRoute,
+func (i *interpretedResult) processPaymentOutcomeFinal(route *models.MCRoute,
 	failure lnwire.FailureMessage) {
 
-	n := len(route.hops)
+	n := len(route.Hops)
 
 	failNode := func() {
 		i.failNode(route, n)
@@ -291,7 +292,7 @@ func (i *interpretedResult) processPaymentOutcomeFinal(route *mcRoute,
 // hop.
 //
 //nolint:funlen
-func (i *interpretedResult) processPaymentOutcomeIntermediate(route *mcRoute,
+func (i *interpretedResult) processPaymentOutcomeIntermediate(route *models.MCRoute,
 	errorSourceIdx int, failure lnwire.FailureMessage) {
 
 	reportOutgoing := func() {
@@ -396,8 +397,8 @@ func (i *interpretedResult) processPaymentOutcomeIntermediate(route *mcRoute,
 		// Set the node pair for which a channel update may be out of
 		// date. The second chance logic uses the policyFailure field.
 		i.policyFailure = &DirectedNodePair{
-			From: route.hops[errorSourceIdx-1].pubKeyBytes,
-			To:   route.hops[errorSourceIdx].pubKeyBytes,
+			From: route.Hops[errorSourceIdx-1].PubKeyBytes,
+			To:   route.Hops[errorSourceIdx].PubKeyBytes,
 		}
 
 		reportOutgoing()
@@ -425,8 +426,8 @@ func (i *interpretedResult) processPaymentOutcomeIntermediate(route *mcRoute,
 		// Set the node pair for which a channel update may be out of
 		// date. The second chance logic uses the policyFailure field.
 		i.policyFailure = &DirectedNodePair{
-			From: route.hops[errorSourceIdx-1].pubKeyBytes,
-			To:   route.hops[errorSourceIdx].pubKeyBytes,
+			From: route.Hops[errorSourceIdx-1].PubKeyBytes,
+			To:   route.Hops[errorSourceIdx].PubKeyBytes,
 		}
 
 		// We report incoming channel. If a second pair is granted in
@@ -500,14 +501,14 @@ func (i *interpretedResult) processPaymentOutcomeIntermediate(route *mcRoute,
 		// Note that if LND is extended to support multiple blinded
 		// routes, this will terminate the payment without re-trying
 		// the other routes.
-		if introIdx == len(route.hops)-1 {
+		if introIdx == len(route.Hops)-1 {
 			i.finalFailureReason = &reasonError
 		} else {
 			// If there are other hops between the recipient and
 			// introduction node, then we just penalize the last
 			// hop in the blinded route to minimize the storage of
 			// results for ephemeral keys.
-			i.failPairBalance(route, len(route.hops)-1)
+			i.failPairBalance(route, len(route.Hops)-1)
 		}
 
 	// In all other cases, we penalize the reporting node. These are all
@@ -521,9 +522,9 @@ func (i *interpretedResult) processPaymentOutcomeIntermediate(route *mcRoute,
 // route, using the same indexing in the route that we use for errorSourceIdx
 // (i.e., that we consider our own node to be at index zero). A boolean is
 // returned to indicate whether the route contains a blinded portion at all.
-func introductionPointIndex(route *mcRoute) (int, bool) {
-	for i, hop := range route.hops {
-		if hop.hasBlindingPoint {
+func introductionPointIndex(route *models.MCRoute) (int, bool) {
+	for i, hop := range route.Hops {
+		if hop.HasBlindingPoint {
 			return i + 1, true
 		}
 	}
@@ -533,8 +534,8 @@ func introductionPointIndex(route *mcRoute) (int, bool) {
 
 // processPaymentOutcomeUnknown processes a payment outcome for which no failure
 // message or source is available.
-func (i *interpretedResult) processPaymentOutcomeUnknown(route *mcRoute) {
-	n := len(route.hops)
+func (i *interpretedResult) processPaymentOutcomeUnknown(route *models.MCRoute) {
+	n := len(route.Hops)
 
 	// If this is a direct payment, the destination must be at fault.
 	if n == 1 {
@@ -549,60 +550,12 @@ func (i *interpretedResult) processPaymentOutcomeUnknown(route *mcRoute) {
 	i.failPairRange(route, 0, n-1)
 }
 
-// extractMCRoute extracts the fields required by MC from the Route struct to
-// create the more minima mcRoute struct.
-func extractMCRoute(route *route.Route) *mcRoute {
-	return &mcRoute{
-		sourcePubKey: route.SourcePubKey,
-		totalAmount:  route.TotalAmount,
-		hops:         extractMCHops(route.Hops),
-	}
-}
-
-// extractMCHops extracts the Hop fields that MC actually uses from a slice of
-// Hops.
-func extractMCHops(hops []*route.Hop) []*mcHop {
-	mcHops := make([]*mcHop, len(hops))
-	for i, hop := range hops {
-		mcHops[i] = extractMCHop(hop)
-	}
-
-	return mcHops
-}
-
-// extractMCHop extracts the Hop fields that MC actually uses from a Hop.
-func extractMCHop(hop *route.Hop) *mcHop {
-	return &mcHop{
-		channelID:        hop.ChannelID,
-		pubKeyBytes:      hop.PubKeyBytes,
-		amtToFwd:         hop.AmtToForward,
-		hasBlindingPoint: hop.BlindingPoint != nil,
-	}
-}
-
-// mcRoute holds the bare minimum info about a payment attempt route that MC
-// requires.
-type mcRoute struct {
-	sourcePubKey route.Vertex
-	totalAmount  lnwire.MilliSatoshi
-	hops         []*mcHop
-}
-
-// mcHop holds the bare minimum info about a payment attempt route hop that MC
-// requires.
-type mcHop struct {
-	channelID        uint64
-	pubKeyBytes      route.Vertex
-	amtToFwd         lnwire.MilliSatoshi
-	hasBlindingPoint bool
-}
-
 // failNode marks the node indicated by idx in the route as failed. It also
 // marks the incoming and outgoing channels of the node as failed. This function
 // intentionally panics when the self node is failed.
-func (i *interpretedResult) failNode(rt *mcRoute, idx int) {
+func (i *interpretedResult) failNode(rt *models.MCRoute, idx int) {
 	// Mark the node as failing.
-	i.nodeFailure = &rt.hops[idx-1].pubKeyBytes
+	i.nodeFailure = &rt.Hops[idx-1].PubKeyBytes
 
 	// Mark the incoming connection as failed for the node. We intent to
 	// penalize as much as we can for a node level failure, including future
@@ -618,7 +571,7 @@ func (i *interpretedResult) failNode(rt *mcRoute, idx int) {
 
 	// If not the ultimate node, mark the outgoing connection as failed for
 	// the node.
-	if idx < len(rt.hops) {
+	if idx < len(rt.Hops) {
 		outgoingChannelIdx := idx
 		outPair, _ := getPair(rt, outgoingChannelIdx)
 		i.pairResults[outPair] = failPairResult(0)
@@ -628,14 +581,14 @@ func (i *interpretedResult) failNode(rt *mcRoute, idx int) {
 
 // failPairRange marks the node pairs from node fromIdx to node toIdx as failed
 // in both direction.
-func (i *interpretedResult) failPairRange(rt *mcRoute, fromIdx, toIdx int) {
+func (i *interpretedResult) failPairRange(rt *models.MCRoute, fromIdx, toIdx int) {
 	for idx := fromIdx; idx <= toIdx; idx++ {
 		i.failPair(rt, idx)
 	}
 }
 
 // failPair marks a pair as failed in both directions.
-func (i *interpretedResult) failPair(rt *mcRoute, idx int) {
+func (i *interpretedResult) failPair(rt *models.MCRoute, idx int) {
 	pair, _ := getPair(rt, idx)
 
 	// Report pair in both directions without a minimum penalization amount.
@@ -644,7 +597,7 @@ func (i *interpretedResult) failPair(rt *mcRoute, idx int) {
 }
 
 // failPairBalance marks a pair as failed with a minimum penalization amount.
-func (i *interpretedResult) failPairBalance(rt *mcRoute, channelIdx int) {
+func (i *interpretedResult) failPairBalance(rt *models.MCRoute, channelIdx int) {
 	pair, amt := getPair(rt, channelIdx)
 
 	i.pairResults[pair] = failPairResult(amt)
@@ -652,7 +605,7 @@ func (i *interpretedResult) failPairBalance(rt *mcRoute, channelIdx int) {
 
 // successPairRange marks the node pairs from node fromIdx to node toIdx as
 // succeeded.
-func (i *interpretedResult) successPairRange(rt *mcRoute, fromIdx, toIdx int) {
+func (i *interpretedResult) successPairRange(rt *models.MCRoute, fromIdx, toIdx int) {
 	for idx := fromIdx; idx <= toIdx; idx++ {
 		pair, amt := getPair(rt, idx)
 
@@ -662,21 +615,21 @@ func (i *interpretedResult) successPairRange(rt *mcRoute, fromIdx, toIdx int) {
 
 // getPair returns a node pair from the route and the amount passed between that
 // pair.
-func getPair(rt *mcRoute, channelIdx int) (DirectedNodePair,
+func getPair(rt *models.MCRoute, channelIdx int) (DirectedNodePair,
 	lnwire.MilliSatoshi) {
 
-	nodeTo := rt.hops[channelIdx].pubKeyBytes
+	nodeTo := rt.Hops[channelIdx].PubKeyBytes
 	var (
 		nodeFrom route.Vertex
 		amt      lnwire.MilliSatoshi
 	)
 
 	if channelIdx == 0 {
-		nodeFrom = rt.sourcePubKey
-		amt = rt.totalAmount
+		nodeFrom = rt.SourcePubKey
+		amt = rt.TotalAmount
 	} else {
-		nodeFrom = rt.hops[channelIdx-1].pubKeyBytes
-		amt = rt.hops[channelIdx-1].amtToFwd
+		nodeFrom = rt.Hops[channelIdx-1].PubKeyBytes
+		amt = rt.Hops[channelIdx-1].AmtToFwd
 	}
 
 	pair := NewDirectedNodePair(nodeFrom, nodeTo)

--- a/routing/result_interpretation_test.go
+++ b/routing/result_interpretation_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
 )
@@ -14,105 +15,105 @@ var (
 		{1, 0}, {1, 1}, {1, 2}, {1, 3}, {1, 4},
 	}
 
-	routeOneHop = mcRoute{
-		sourcePubKey: hops[0],
-		totalAmount:  100,
-		hops: []*mcHop{
-			{pubKeyBytes: hops[1], amtToFwd: 99},
+	routeOneHop = models.MCRoute{
+		SourcePubKey: hops[0],
+		TotalAmount:  100,
+		Hops: []*models.MCHop{
+			{PubKeyBytes: hops[1], AmtToFwd: 99},
 		},
 	}
 
-	routeTwoHop = mcRoute{
-		sourcePubKey: hops[0],
-		totalAmount:  100,
-		hops: []*mcHop{
-			{pubKeyBytes: hops[1], amtToFwd: 99},
-			{pubKeyBytes: hops[2], amtToFwd: 97},
+	routeTwoHop = models.MCRoute{
+		SourcePubKey: hops[0],
+		TotalAmount:  100,
+		Hops: []*models.MCHop{
+			{PubKeyBytes: hops[1], AmtToFwd: 99},
+			{PubKeyBytes: hops[2], AmtToFwd: 97},
 		},
 	}
 
-	routeThreeHop = mcRoute{
-		sourcePubKey: hops[0],
-		totalAmount:  100,
-		hops: []*mcHop{
-			{pubKeyBytes: hops[1], amtToFwd: 99},
-			{pubKeyBytes: hops[2], amtToFwd: 97},
-			{pubKeyBytes: hops[3], amtToFwd: 94},
+	routeThreeHop = models.MCRoute{
+		SourcePubKey: hops[0],
+		TotalAmount:  100,
+		Hops: []*models.MCHop{
+			{PubKeyBytes: hops[1], AmtToFwd: 99},
+			{PubKeyBytes: hops[2], AmtToFwd: 97},
+			{PubKeyBytes: hops[3], AmtToFwd: 94},
 		},
 	}
 
-	routeFourHop = mcRoute{
-		sourcePubKey: hops[0],
-		totalAmount:  100,
-		hops: []*mcHop{
-			{pubKeyBytes: hops[1], amtToFwd: 99},
-			{pubKeyBytes: hops[2], amtToFwd: 97},
-			{pubKeyBytes: hops[3], amtToFwd: 94},
-			{pubKeyBytes: hops[4], amtToFwd: 90},
+	routeFourHop = models.MCRoute{
+		SourcePubKey: hops[0],
+		TotalAmount:  100,
+		Hops: []*models.MCHop{
+			{PubKeyBytes: hops[1], AmtToFwd: 99},
+			{PubKeyBytes: hops[2], AmtToFwd: 97},
+			{PubKeyBytes: hops[3], AmtToFwd: 94},
+			{PubKeyBytes: hops[4], AmtToFwd: 90},
 		},
 	}
 
 	// blindedMultiHop is a blinded path where there are cleartext hops
 	// before the introduction node, and an intermediate blinded hop before
 	// the recipient after it.
-	blindedMultiHop = mcRoute{
-		sourcePubKey: hops[0],
-		totalAmount:  100,
-		hops: []*mcHop{
-			{pubKeyBytes: hops[1], amtToFwd: 99},
+	blindedMultiHop = models.MCRoute{
+		SourcePubKey: hops[0],
+		TotalAmount:  100,
+		Hops: []*models.MCHop{
+			{PubKeyBytes: hops[1], AmtToFwd: 99},
 			{
-				pubKeyBytes:      hops[2],
-				amtToFwd:         95,
-				hasBlindingPoint: true,
+				PubKeyBytes:      hops[2],
+				AmtToFwd:         95,
+				HasBlindingPoint: true,
 			},
-			{pubKeyBytes: hops[3], amtToFwd: 88},
-			{pubKeyBytes: hops[4], amtToFwd: 77},
+			{PubKeyBytes: hops[3], AmtToFwd: 88},
+			{PubKeyBytes: hops[4], AmtToFwd: 77},
 		},
 	}
 
 	// blindedSingleHop is a blinded path with a single blinded hop after
 	// the introduction node.
-	blindedSingleHop = mcRoute{
-		sourcePubKey: hops[0],
-		totalAmount:  100,
-		hops: []*mcHop{
-			{pubKeyBytes: hops[1], amtToFwd: 99},
+	blindedSingleHop = models.MCRoute{
+		SourcePubKey: hops[0],
+		TotalAmount:  100,
+		Hops: []*models.MCHop{
+			{PubKeyBytes: hops[1], AmtToFwd: 99},
 			{
-				pubKeyBytes:      hops[2],
-				amtToFwd:         95,
-				hasBlindingPoint: true,
+				PubKeyBytes:      hops[2],
+				AmtToFwd:         95,
+				HasBlindingPoint: true,
 			},
-			{pubKeyBytes: hops[3], amtToFwd: 88},
+			{PubKeyBytes: hops[3], AmtToFwd: 88},
 		},
 	}
 
 	// blindedMultiToIntroduction is a blinded path which goes directly
 	// to the introduction node, with multiple blinded hops after it.
-	blindedMultiToIntroduction = mcRoute{
-		sourcePubKey: hops[0],
-		totalAmount:  100,
-		hops: []*mcHop{
+	blindedMultiToIntroduction = models.MCRoute{
+		SourcePubKey: hops[0],
+		TotalAmount:  100,
+		Hops: []*models.MCHop{
 			{
-				pubKeyBytes:      hops[1],
-				amtToFwd:         90,
-				hasBlindingPoint: true,
+				PubKeyBytes:      hops[1],
+				AmtToFwd:         90,
+				HasBlindingPoint: true,
 			},
-			{pubKeyBytes: hops[2], amtToFwd: 75},
-			{pubKeyBytes: hops[3], amtToFwd: 58},
+			{PubKeyBytes: hops[2], AmtToFwd: 75},
+			{PubKeyBytes: hops[3], AmtToFwd: 58},
 		},
 	}
 
 	// blindedIntroReceiver is a blinded path where the introduction node
 	// is the recipient.
-	blindedIntroReceiver = mcRoute{
-		sourcePubKey: hops[0],
-		totalAmount:  100,
-		hops: []*mcHop{
-			{pubKeyBytes: hops[1], amtToFwd: 95},
+	blindedIntroReceiver = models.MCRoute{
+		SourcePubKey: hops[0],
+		TotalAmount:  100,
+		Hops: []*models.MCHop{
+			{PubKeyBytes: hops[1], AmtToFwd: 95},
 			{
-				pubKeyBytes:      hops[2],
-				amtToFwd:         90,
-				hasBlindingPoint: true,
+				PubKeyBytes:      hops[2],
+				AmtToFwd:         90,
+				HasBlindingPoint: true,
 			},
 		},
 	}
@@ -129,7 +130,7 @@ func getPolicyFailure(from, to int) *DirectedNodePair {
 
 type resultTestCase struct {
 	name          string
-	route         *mcRoute
+	route         *models.MCRoute
 	success       bool
 	failureSrcIdx int
 	failure       lnwire.FailureMessage

--- a/routing/router.go
+++ b/routing/router.go
@@ -170,13 +170,13 @@ type MissionControlQuerier interface {
 	// input for future probability estimates. It returns a bool indicating
 	// whether this error is a final error and no further payment attempts
 	// need to be made.
-	ReportPaymentFail(attemptID uint64, rt *route.Route,
+	ReportPaymentFail(attemptID uint64, rt *models.MCRoute,
 		failureSourceIdx *int, failure lnwire.FailureMessage) (
 		*channeldb.FailureReason, error)
 
 	// ReportPaymentSuccess reports a successful payment to mission control
 	// as input for future probability estimates.
-	ReportPaymentSuccess(attemptID uint64, rt *route.Route) error
+	ReportPaymentSuccess(attemptID uint64, rt *models.MCRoute) error
 
 	// GetProbability is expected to return the success probability of a
 	// payment from fromNode along edge.

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -2210,7 +2210,7 @@ func TestSendToRouteSkipTempErrSuccess(t *testing.T) {
 	})
 
 	missionControl.On("ReportPaymentSuccess",
-		mock.Anything, rt,
+		mock.Anything, models.ToMCRoute(rt),
 	).Return(nil)
 
 	// Mock the control tower to return the mocked payment.
@@ -2351,7 +2351,8 @@ func TestSendToRouteSkipTempErrTempFailure(t *testing.T) {
 	// Mock the mission control to return a nil reason from reporting the
 	// attempt failure.
 	missionControl.On("ReportPaymentFail",
-		mock.Anything, rt, mock.Anything, mock.Anything,
+		mock.Anything, models.ToMCRoute(rt), mock.Anything,
+		mock.Anything,
 	).Return(nil, nil)
 
 	// Mock the payment to return nil failure reason.
@@ -2434,7 +2435,8 @@ func TestSendToRouteSkipTempErrPermanentFailure(t *testing.T) {
 
 	failureReason := channeldb.FailureReasonPaymentDetails
 	missionControl.On("ReportPaymentFail",
-		mock.Anything, rt, mock.Anything, mock.Anything,
+		mock.Anything, models.ToMCRoute(rt), mock.Anything,
+		mock.Anything,
 	).Return(&failureReason, nil)
 
 	// Mock the control tower to return the mocked payment.
@@ -2526,7 +2528,8 @@ func TestSendToRouteTempFailure(t *testing.T) {
 
 	// Return a nil reason to mock a temporary failure.
 	missionControl.On("ReportPaymentFail",
-		mock.Anything, rt, mock.Anything, mock.Anything,
+		mock.Anything, models.ToMCRoute(rt), mock.Anything,
+		mock.Anything,
 	).Return(nil, nil)
 
 	// Expect a failed send to route.

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -5829,6 +5829,14 @@ func (r *rpcServer) AddInvoice(ctx context.Context,
 			"be included in each path")
 	}
 
+	blindedPathMC, err := r.server.missionController.GetNamespacedStore(
+		routing.BlindedPathMissionControlNamespace,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not initialise mission control "+
+			"in the blinded paths namespace: %w", err)
+	}
+
 	addInvoiceCfg := &invoicesrpc.AddInvoiceConfig{
 		AddInvoice:        r.server.invoices.AddInvoice,
 		IsChannelActive:   r.server.htlcSwitch.HasActiveLink,
@@ -5867,8 +5875,7 @@ func (r *rpcServer) AddInvoice(ctx context.Context,
 			[]*route.Route, error) {
 
 			return r.server.chanRouter.FindBlindedPaths(
-				r.selfNode, amt,
-				r.server.defaultMC.GetProbability,
+				r.selfNode, amt, blindedPathMC.GetProbability,
 				blindingRestrictions,
 			)
 		},

--- a/server.go
+++ b/server.go
@@ -932,7 +932,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 	}
 
 	blindedPathMC, err := s.missionController.GetNamespacedStore(
-		"blinded-path",
+		routing.BlindedPathMissionControlNamespace,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("can't create mission control in the "+


### PR DESCRIPTION
In this PR, we start persisting invoice blinded path info. Then, when we receive a payment from a blinded path, we can use this info to report success to mission control. This will then ensure that future selected routes for blinded paths are of better quality. 

Fixes: https://github.com/lightningnetwork/lnd/issues/8991

Depends on: 
- https://github.com/lightningnetwork/lightning-onion/pull/65
- https://github.com/lightningnetwork/lnd/pull/8911
- https://github.com/lightningnetwork/lnd/pull/9001
- https://github.com/lightningnetwork/lnd/pull/9003

TODO: 
- write an itest. 
- figure out why postgres itest is failing on restart