### PR TITLE
Return peer info when batch open fails.

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -38,6 +38,10 @@
 
 ## RPC Updates
 
+* [Add peer info](https://github.com/lightningnetwork/lnd/pull/9018) in
+  `BatchOpenChannel` rpc return error as soon as the batch opening fails due
+  to a specific peer interaction.
+
 ## lncli Updates
 
 ## Code Health


### PR DESCRIPTION
Addresses https://github.com/lightningnetwork/lnd/issues/9016, which makes it easy to point out the problematic peer if the batch open fails.

Went for this simple fix, because I think a more structured error might be an overkill ? But open for other ways.
