### PR TITLE
itest: ensure LND gets correct CLI options when itest are parallel

### DIFF
--- a/docs/release-notes/release-notes-0.18.3.md
+++ b/docs/release-notes/release-notes-0.18.3.md
@@ -73,6 +73,9 @@ would create a blinded route with a minHTLC greater than the actual payment
 amount. Moreover remove strict correlation between min_cltv_delta and the
 blinded path expiry.
 
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/9021) an issue with some
+  command-line arguments not being passed when running `make itest-parallel`.
+
 # New Features
 ## Functional Enhancements
 ## RPC Additions

--- a/scripts/itest_parallel.sh
+++ b/scripts/itest_parallel.sh
@@ -3,8 +3,9 @@
 # Get all the variables.
 PROCESSES=$1
 TRANCHES=$2
-TEST_FLAGS=$3
-ITEST_FLAGS=$4
+
+# Here we also shift 2 times and get the rest of our flags to pass on in $@.
+shift 2
 
 # Create a variable to hold the final exit code.
 exit_code=0
@@ -12,7 +13,7 @@ exit_code=0
 # Run commands using xargs in parallel and capture their PIDs
 pids=()
 for ((i=0; i<PROCESSES; i++)); do 
-    scripts/itest_part.sh $i $TRANCHES $TEST_FLAGS $ITEST_FLAGS &
+    scripts/itest_part.sh $i $TRANCHES $@ &
     pids+=($!)
 done
 


### PR DESCRIPTION
## Change Description

This PR ensures that when running itests in CI with `nativesql=true`, that option is passed correctly to LND. [Currently](https://github.com/lightningnetwork/lnd/actions/runs/10499052273/job/29085120784#step:6:253), `itest_parallel.sh` doesn't pass the option on to the per-tranche workers.

Note that this will cause the nativesql itests to fail, as there are test failures that have been masked by the fact that the tests aren't actually running with `nativesql=true`. #9022 fixes one, and several others will need to be fixed as well.

## Steps to Test
See the difference between the itests running on this PR vs. [on `master`](https://github.com/lightningnetwork/lnd/actions/runs/10499052273/job/29085120784#step:6:253).

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
