### PR TITLE
invoices/sqldb: query by ChanID when updating AMP invoice preimage

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -93,11 +93,13 @@ linters-settings:
       - 'errors.Wrap'
   
   gomoddirectives:
+    replace-local: true
     replace-allow-list:
       # See go.mod for the explanation why these are needed.
       - github.com/ulikunitz/xz
       - github.com/gogo/protobuf
       - google.golang.org/protobuf
+      - github.com/lightningnetwork/lnd/sqldb
 
 
 linters:

--- a/docs/release-notes/release-notes-0.18.3.md
+++ b/docs/release-notes/release-notes-0.18.3.md
@@ -81,6 +81,10 @@ blinded path expiry.
   cause UpdateAddHTLC message with blinding point fields to not be re-forwarded
   correctly on restart.
  
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/9022) a native SQL
+  invoice issue where AMP subinvoice HTLCs are sometimes updated incorrectly on
+  settlement.
+
 # New Features
 ## Functional Enhancements
 
@@ -278,6 +282,7 @@ that validate `ChannelAnnouncement` messages.
 
 # Contributors (Alphabetical Order)
 
+* Alex Akselrod
 * Andras Banki-Horvath
 * bitromortac
 * Bufo

--- a/go.mod
+++ b/go.mod
@@ -204,6 +204,9 @@ replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 // allows us to specify that as an option.
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display
 
+// Temporary replace until the next version of sqldb is taged.
+replace github.com/lightningnetwork/lnd/sqldb => ./sqldb
+
 // If you change this please also update .github/pull_request_template.md,
 // docs/INSTALL.md and GO_IMAGE in lnrpc/gen_protos_docker.sh.
 go 1.22.6

--- a/go.sum
+++ b/go.sum
@@ -458,8 +458,6 @@ github.com/lightningnetwork/lnd/kvdb v1.4.10 h1:vK89IVv1oVH9ubQWU+EmoCQFeVRaC8kf
 github.com/lightningnetwork/lnd/kvdb v1.4.10/go.mod h1:J2diNABOoII9UrMnxXS5w7vZwP7CA1CStrl8MnIrb3A=
 github.com/lightningnetwork/lnd/queue v1.1.1 h1:99ovBlpM9B0FRCGYJo6RSFDlt8/vOkQQZznVb18iNMI=
 github.com/lightningnetwork/lnd/queue v1.1.1/go.mod h1:7A6nC1Qrm32FHuhx/mi1cieAiBZo5O6l8IBIoQxvkz4=
-github.com/lightningnetwork/lnd/sqldb v1.0.3 h1:zLfAwOvM+6+3+hahYO9Q3h8pVV0TghAR7iJ5YMLCd3I=
-github.com/lightningnetwork/lnd/sqldb v1.0.3/go.mod h1:4cQOkdymlZ1znnjuRNvMoatQGJkRneTj2CoPSPaQhWo=
 github.com/lightningnetwork/lnd/ticker v1.1.1 h1:J/b6N2hibFtC7JLV77ULQp++QLtCwT6ijJlbdiZFbSM=
 github.com/lightningnetwork/lnd/ticker v1.1.1/go.mod h1:waPTRAAcwtu7Ji3+3k+u/xH5GHovTsCoSVpho0KDvdA=
 github.com/lightningnetwork/lnd/tlv v1.2.6 h1:icvQG2yDr6k3ZuZzfRdG3EJp6pHurcuh3R6dg0gv/Mw=

--- a/invoices/sql_store.go
+++ b/invoices/sql_store.go
@@ -925,8 +925,10 @@ func (i *SQLStore) QueryInvoices(ctx context.Context,
 			}
 
 			if q.CreationDateEnd != 0 {
+				// We need to add 1 to the end date as we're
+				// checking less than the end date in SQL.
 				params.CreatedBefore = sqldb.SQLTime(
-					time.Unix(q.CreationDateEnd, 0).UTC(),
+					time.Unix(q.CreationDateEnd+1, 0).UTC(),
 				)
 			}
 

--- a/invoices/sql_store.go
+++ b/invoices/sql_store.go
@@ -1116,6 +1116,9 @@ func (s *sqlInvoiceUpdater) AddAmpHtlcPreimage(setID [32]byte,
 			SetID:     setID[:],
 			HtlcID:    int64(circuitKey.HtlcID),
 			Preimage:  preimage[:],
+			ChanID: strconv.FormatUint(
+				circuitKey.ChanID.ToUint64(), 10,
+			),
 		},
 	)
 	if err != nil {

--- a/invoices/sql_store.go
+++ b/invoices/sql_store.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -45,6 +46,9 @@ type SQLInvoiceQueries interface { //nolint:interfacebloat
 
 	GetInvoice(ctx context.Context,
 		arg sqlc.GetInvoiceParams) ([]sqlc.Invoice, error)
+
+	GetInvoiceBySetID(ctx context.Context, setID []byte) ([]sqlc.Invoice,
+		error)
 
 	GetInvoiceFeatures(ctx context.Context,
 		invoiceID int64) ([]sqlc.InvoiceFeature, error)
@@ -343,7 +347,22 @@ func (i *SQLStore) fetchInvoice(ctx context.Context,
 		params.SetID = ref.SetID()[:]
 	}
 
-	rows, err := db.GetInvoice(ctx, params)
+	var (
+		rows []sqlc.Invoice
+		err  error
+	)
+
+	// We need to split the query based on how we intend to look up the
+	// invoice. If only the set ID is given then we want to have an exact
+	// match on the set ID. If other fields are given, we want to match on
+	// those fields and the set ID but with a less strict join condition.
+	if params.Hash == nil && params.PaymentAddr == nil &&
+		params.SetID != nil {
+
+		rows, err = db.GetInvoiceBySetID(ctx, params.SetID)
+	} else {
+		rows, err = db.GetInvoice(ctx, params)
+	}
 	switch {
 	case len(rows) == 0:
 		return nil, ErrInvoiceNotFound
@@ -351,8 +370,8 @@ func (i *SQLStore) fetchInvoice(ctx context.Context,
 	case len(rows) > 1:
 		// In case the reference is ambiguous, meaning it matches more
 		// than	one invoice, we'll return an error.
-		return nil, fmt.Errorf("ambiguous invoice ref: %s",
-			ref.String())
+		return nil, fmt.Errorf("ambiguous invoice ref: %s: %s",
+			ref.String(), spew.Sdump(rows))
 
 	case err != nil:
 		return nil, fmt.Errorf("unable to fetch invoice: %w", err)
@@ -1308,13 +1327,24 @@ func (s *sqlInvoiceUpdater) Finalize(_ UpdateType) error {
 // invoice and is therefore atomic. The fields to update are controlled by the
 // supplied callback.
 func (i *SQLStore) UpdateInvoice(ctx context.Context, ref InvoiceRef,
-	_ *SetID, callback InvoiceUpdateCallback) (
+	setID *SetID, callback InvoiceUpdateCallback) (
 	*Invoice, error) {
 
 	var updatedInvoice *Invoice
 
 	txOpt := SQLInvoiceQueriesTxOptions{readOnly: false}
 	txErr := i.db.ExecTx(ctx, &txOpt, func(db SQLInvoiceQueries) error {
+		if setID != nil {
+			// Make sure to use the set ID if this is an AMP update.
+			var setIDBytes [32]byte
+			copy(setIDBytes[:], setID[:])
+			ref.setID = &setIDBytes
+
+			// If we're updating an AMP invoice, we'll also only
+			// need to fetch the HTLCs for the given set ID.
+			ref.refModifier = HtlcSetOnlyModifier
+		}
+
 		invoice, err := i.fetchInvoice(ctx, db, ref)
 		if err != nil {
 			return err

--- a/invoices/sql_store.go
+++ b/invoices/sql_store.go
@@ -1283,6 +1283,13 @@ func (s *sqlInvoiceUpdater) UpdateAmpState(setID [32]byte,
 		return err
 	}
 
+	if settleIndex.Valid {
+		updatedState := s.invoice.AMPState[setID]
+		updatedState.SettleIndex = uint64(settleIndex.Int64)
+		updatedState.SettleDate = s.updateTime.UTC()
+		s.invoice.AMPState[setID] = updatedState
+	}
+
 	return nil
 }
 

--- a/itest/lnd_amp_test.go
+++ b/itest/lnd_amp_test.go
@@ -260,7 +260,8 @@ func testSendPaymentAMPInvoiceRepeat(ht *lntest.HarnessTest) {
 	invoiceNtfn := ht.ReceiveInvoiceUpdate(invSubscription)
 
 	// The notification should signal that the invoice is now settled, and
-	// should also include the set ID, and show the proper amount paid.
+	// should also include the set ID, show the proper amount paid, and have
+	// the correct settle index and time.
 	require.True(ht, invoiceNtfn.Settled)
 	require.Equal(ht, lnrpc.Invoice_SETTLED, invoiceNtfn.State)
 	require.Equal(ht, paymentAmt, int(invoiceNtfn.AmtPaidSat))
@@ -270,6 +271,9 @@ func testSendPaymentAMPInvoiceRepeat(ht *lntest.HarnessTest) {
 		firstSetID, _ = hex.DecodeString(setIDStr)
 		require.Equal(ht, lnrpc.InvoiceHTLCState_SETTLED,
 			ampState.State)
+		require.GreaterOrEqual(ht, ampState.SettleTime,
+			rpcInvoice.CreationDate)
+		require.Equal(ht, uint64(1), ampState.SettleIndex)
 	}
 
 	// Pay the invoice again, we should get another notification that Dave

--- a/itest/lnd_amp_test.go
+++ b/itest/lnd_amp_test.go
@@ -303,9 +303,9 @@ func testSendPaymentAMPInvoiceRepeat(ht *lntest.HarnessTest) {
 	// return the "projected" sub-invoice for a given setID.
 	require.Equal(ht, 1, len(invoiceNtfn.Htlcs))
 
-	// However the AMP state index should show that there've been two
-	// repeated payments to this invoice so far.
-	require.Equal(ht, 2, len(invoiceNtfn.AmpInvoiceState))
+	// The AMP state should also be restricted to a single entry for the
+	// "projected" sub-invoice.
+	require.Equal(ht, 1, len(invoiceNtfn.AmpInvoiceState))
 
 	// Now we'll look up the invoice using the new LookupInvoice2 RPC call
 	// by the set ID of each of the invoices.
@@ -364,7 +364,7 @@ func testSendPaymentAMPInvoiceRepeat(ht *lntest.HarnessTest) {
 	// through.
 	backlogInv := ht.ReceiveInvoiceUpdate(invSub2)
 	require.Equal(ht, 1, len(backlogInv.Htlcs))
-	require.Equal(ht, 2, len(backlogInv.AmpInvoiceState))
+	require.Equal(ht, 1, len(backlogInv.AmpInvoiceState))
 	require.True(ht, backlogInv.Settled)
 	require.Equal(ht, paymentAmt*2, int(backlogInv.AmtPaidSat))
 }

--- a/sqldb/sqlc/amp_invoices.sql.go
+++ b/sqldb/sqlc/amp_invoices.sql.go
@@ -268,15 +268,16 @@ func (q *Queries) InsertAMPSubInvoiceHTLC(ctx context.Context, arg InsertAMPSubI
 
 const updateAMPSubInvoiceHTLCPreimage = `-- name: UpdateAMPSubInvoiceHTLCPreimage :execresult
 UPDATE amp_sub_invoice_htlcs AS a
-SET preimage = $4
+SET preimage = $5
 WHERE a.invoice_id = $1 AND a.set_id = $2 AND a.htlc_id = (
-    SELECT id FROM invoice_htlcs AS i WHERE i.htlc_id = $3
+    SELECT id FROM invoice_htlcs AS i WHERE i.chan_id = $3 AND i.htlc_id = $4
 )
 `
 
 type UpdateAMPSubInvoiceHTLCPreimageParams struct {
 	InvoiceID int64
 	SetID     []byte
+	ChanID    string
 	HtlcID    int64
 	Preimage  []byte
 }
@@ -285,6 +286,7 @@ func (q *Queries) UpdateAMPSubInvoiceHTLCPreimage(ctx context.Context, arg Updat
 	return q.db.ExecContext(ctx, updateAMPSubInvoiceHTLCPreimage,
 		arg.InvoiceID,
 		arg.SetID,
+		arg.ChanID,
 		arg.HtlcID,
 		arg.Preimage,
 	)

--- a/sqldb/sqlc/invoices.sql.go
+++ b/sqldb/sqlc/invoices.sql.go
@@ -170,21 +170,22 @@ const getInvoice = `-- name: GetInvoice :many
 
 SELECT i.id, i.hash, i.preimage, i.settle_index, i.settled_at, i.memo, i.amount_msat, i.cltv_delta, i.expiry, i.payment_addr, i.payment_request, i.payment_request_hash, i.state, i.amount_paid_msat, i.is_amp, i.is_hodl, i.is_keysend, i.created_at
 FROM invoices i
-LEFT JOIN amp_sub_invoices a on i.id = a.invoice_id
+LEFT JOIN amp_sub_invoices a 
+ON i.id = a.invoice_id
+AND (
+    a.set_id = $1 OR $1 IS NULL
+)
 WHERE (
-    i.id = $1 OR 
-    $1 IS NULL
-) AND (
-    i.hash = $2 OR 
+    i.id = $2 OR 
     $2 IS NULL
 ) AND (
-    i.preimage = $3 OR 
+    i.hash = $3 OR 
     $3 IS NULL
 ) AND (
-    i.payment_addr = $4 OR 
+    i.preimage = $4 OR 
     $4 IS NULL
 ) AND (
-    a.set_id = $5 OR
+    i.payment_addr = $5 OR 
     $5 IS NULL
 )
 GROUP BY i.id
@@ -192,11 +193,11 @@ LIMIT 2
 `
 
 type GetInvoiceParams struct {
+	SetID       []byte
 	AddIndex    sql.NullInt64
 	Hash        []byte
 	Preimage    []byte
 	PaymentAddr []byte
-	SetID       []byte
 }
 
 // This method may return more than one invoice if filter using multiple fields
@@ -204,12 +205,61 @@ type GetInvoiceParams struct {
 // we bubble up an error in those cases.
 func (q *Queries) GetInvoice(ctx context.Context, arg GetInvoiceParams) ([]Invoice, error) {
 	rows, err := q.db.QueryContext(ctx, getInvoice,
+		arg.SetID,
 		arg.AddIndex,
 		arg.Hash,
 		arg.Preimage,
 		arg.PaymentAddr,
-		arg.SetID,
 	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Invoice
+	for rows.Next() {
+		var i Invoice
+		if err := rows.Scan(
+			&i.ID,
+			&i.Hash,
+			&i.Preimage,
+			&i.SettleIndex,
+			&i.SettledAt,
+			&i.Memo,
+			&i.AmountMsat,
+			&i.CltvDelta,
+			&i.Expiry,
+			&i.PaymentAddr,
+			&i.PaymentRequest,
+			&i.PaymentRequestHash,
+			&i.State,
+			&i.AmountPaidMsat,
+			&i.IsAmp,
+			&i.IsHodl,
+			&i.IsKeysend,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getInvoiceBySetID = `-- name: GetInvoiceBySetID :many
+SELECT i.id, i.hash, i.preimage, i.settle_index, i.settled_at, i.memo, i.amount_msat, i.cltv_delta, i.expiry, i.payment_addr, i.payment_request, i.payment_request_hash, i.state, i.amount_paid_msat, i.is_amp, i.is_hodl, i.is_keysend, i.created_at
+FROM invoices i
+INNER JOIN amp_sub_invoices a 
+ON i.id = a.invoice_id AND a.set_id = $1
+`
+
+func (q *Queries) GetInvoiceBySetID(ctx context.Context, setID []byte) ([]Invoice, error) {
+	rows, err := q.db.QueryContext(ctx, getInvoiceBySetID, setID)
 	if err != nil {
 		return nil, err
 	}

--- a/sqldb/sqlc/invoices.sql.go
+++ b/sqldb/sqlc/invoices.sql.go
@@ -78,7 +78,7 @@ WHERE (
     created_at >= $6 OR
     $6 IS NULL
 ) AND (
-    created_at <= $7 OR 
+    created_at < $7 OR 
     $7 IS NULL
 ) AND (
     CASE

--- a/sqldb/sqlc/querier.go
+++ b/sqldb/sqlc/querier.go
@@ -21,6 +21,7 @@ type Querier interface {
 	// from different invoices. It is the caller's responsibility to ensure that
 	// we bubble up an error in those cases.
 	GetInvoice(ctx context.Context, arg GetInvoiceParams) ([]Invoice, error)
+	GetInvoiceBySetID(ctx context.Context, setID []byte) ([]Invoice, error)
 	GetInvoiceFeatures(ctx context.Context, invoiceID int64) ([]InvoiceFeature, error)
 	GetInvoiceHTLCCustomRecords(ctx context.Context, invoiceID int64) ([]GetInvoiceHTLCCustomRecordsRow, error)
 	GetInvoiceHTLCs(ctx context.Context, invoiceID int64) ([]InvoiceHtlc, error)

--- a/sqldb/sqlc/queries/amp_invoices.sql
+++ b/sqldb/sqlc/queries/amp_invoices.sql
@@ -61,7 +61,7 @@ WHERE (
 
 -- name: UpdateAMPSubInvoiceHTLCPreimage :execresult
 UPDATE amp_sub_invoice_htlcs AS a
-SET preimage = $4
+SET preimage = $5
 WHERE a.invoice_id = $1 AND a.set_id = $2 AND a.htlc_id = (
-    SELECT id FROM invoice_htlcs AS i WHERE i.htlc_id = $3
+    SELECT id FROM invoice_htlcs AS i WHERE i.chan_id = $3 AND i.htlc_id = $4
 );

--- a/sqldb/sqlc/queries/invoices.sql
+++ b/sqldb/sqlc/queries/invoices.sql
@@ -26,7 +26,11 @@ WHERE invoice_id = $1;
 -- name: GetInvoice :many
 SELECT i.*
 FROM invoices i
-LEFT JOIN amp_sub_invoices a on i.id = a.invoice_id
+LEFT JOIN amp_sub_invoices a 
+ON i.id = a.invoice_id
+AND (
+    a.set_id = sqlc.narg('set_id') OR sqlc.narg('set_id') IS NULL
+)
 WHERE (
     i.id = sqlc.narg('add_index') OR 
     sqlc.narg('add_index') IS NULL
@@ -39,12 +43,15 @@ WHERE (
 ) AND (
     i.payment_addr = sqlc.narg('payment_addr') OR 
     sqlc.narg('payment_addr') IS NULL
-) AND (
-    a.set_id = sqlc.narg('set_id') OR
-    sqlc.narg('set_id') IS NULL
 )
 GROUP BY i.id
 LIMIT 2;
+
+-- name: GetInvoiceBySetID :many
+SELECT i.*
+FROM invoices i
+INNER JOIN amp_sub_invoices a 
+ON i.id = a.invoice_id AND a.set_id = $1;
 
 -- name: FilterInvoices :many
 SELECT

--- a/sqldb/sqlc/queries/invoices.sql
+++ b/sqldb/sqlc/queries/invoices.sql
@@ -76,7 +76,7 @@ WHERE (
     created_at >= sqlc.narg('created_after') OR
     sqlc.narg('created_after') IS NULL
 ) AND (
-    created_at <= sqlc.narg('created_before') OR 
+    created_at < sqlc.narg('created_before') OR 
     sqlc.narg('created_before') IS NULL
 ) AND (
     CASE


### PR DESCRIPTION
## Change Description

This PR fixes the following test:

```
make itest backend=btcd dbbackend=postgres nativesql=true icase=sendpayment_amp_invoice
```

Note that the `sendpayment_amp_invoice_repeat` test is not fixed by this. Also note that this depends on #9021 to unmask the test failure.

## Steps to Test

Run the itest as above before and after applying this PR.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
