### PR TITLE
lnwallet: correctly set UpdateAddHTLC.BlindingPoint on reload from disk

### DIFF
--- a/docs/release-notes/release-notes-0.18.3.md
+++ b/docs/release-notes/release-notes-0.18.3.md
@@ -59,7 +59,11 @@ commitment when the channel was force closed.
 
 * We'll now always send [channel updates to our remote peer for open
   channels](https://github.com/lightningnetwork/lnd/pull/8963).
-
+ 
+* [Fix a bug](https://github.com/lightningnetwork/lnd/pull/9023) that would
+  cause UpdateAddHTLC message with blinding point fields to not be re-forwarded
+  correctly on restart.
+ 
 # New Features
 ## Functional Enhancements
 ## RPC Additions

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -579,6 +579,10 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testUpdateOnPendingOpenChannels,
 	},
 	{
+		Name:     "blinded payment htlc re-forward",
+		TestFunc: testBlindedPaymentHTLCReForward,
+	},
+	{
 		Name:     "query blinded route",
 		TestFunc: testQueryBlindedRoutes,
 	},

--- a/itest/lnd_route_blinding_test.go
+++ b/itest/lnd_route_blinding_test.go
@@ -1432,10 +1432,6 @@ func testMPPToMultipleBlindedPaths(ht *lntest.HarnessTest) {
 // a blinded path payment since this adds a new blinding point field to
 // UpdateAddHTLC which we need to ensure gets included in the message on
 // restart.
-//
-// NOTE: this first version of this test asserts that this fails. This is to
-// demonstrate that a bug exists in the reloading and forwarding code. This will
-// be fixed in a following commit.
 func testBlindedPaymentHTLCReForward(ht *lntest.HarnessTest) {
 	// Setup a test case.
 	ctx, testCase := newBlindedForwardTest(ht)
@@ -1456,9 +1452,6 @@ func testBlindedPaymentHTLCReForward(ht *lntest.HarnessTest) {
 	}
 
 	// In a goroutine, we let Alice pay the invoice from dave.
-	//
-	// NOTE: for now, we assert that this attempt fails. Once the noted bug
-	// is fixed, this will be changed to a success assertion.
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
@@ -1468,7 +1461,7 @@ func testBlindedPaymentHTLCReForward(ht *lntest.HarnessTest) {
 		)
 		require.NoError(testCase.ht, err)
 		require.Equal(
-			testCase.ht, lnrpc.HTLCAttempt_FAILED,
+			testCase.ht, lnrpc.HTLCAttempt_SUCCEEDED,
 			htlcAttempt.Status,
 		)
 	}()

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -205,7 +205,7 @@ func PayDescsFromRemoteLogUpdates(chanID lnwire.ShortChannelID, height uint64,
 					Height: height,
 					Index:  uint16(i),
 				},
-				BlindingPoint: pd.BlindingPoint,
+				BlindingPoint: wireMsg.BlindingPoint,
 			}
 			pd.OnionBlob = make([]byte, len(wireMsg.OnionBlob))
 			copy(pd.OnionBlob[:], wireMsg.OnionBlob[:])


### PR DESCRIPTION
Correctly set the UpdateAddHTLC.BlindingPoint member when reading LogUpdates from disk. This PR also adds a test to cover this case. 