### PR TITLE
blindedpath: Minor bug fixes and feature addition.

### DIFF
--- a/docs/release-notes/release-notes-0.18.3.md
+++ b/docs/release-notes/release-notes-0.18.3.md
@@ -68,6 +68,11 @@ commitment when the channel was force closed.
   in the `ReplyChannelRange` msg and introduced a check that ChanUpdates with a
   timestamp too far into the future will be discarded.
 
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/9026) a bug where we
+would create a blinded route with a minHTLC greater than the actual payment
+amount. Moreover remove strict correlation between min_cltv_delta and the
+blinded path expiry.
+
 # New Features
 ## Functional Enhancements
 ## RPC Additions

--- a/routing/blindedpath/blinded_path.go
+++ b/routing/blindedpath/blinded_path.go
@@ -82,7 +82,16 @@ type BuildBlindedPathCfg struct {
 	MinFinalCLTVExpiryDelta uint32
 
 	// BlocksUntilExpiry is the number of blocks that this blinded path
-	// should remain valid for.
+	// should remain valid for. This is a relative number of blocks. This
+	// number in addition with a potential minimum cltv delta for the last
+	// hop and some block padding will be the payment constraint which is
+	// part of the blinded hop info. Every htlc using the provided blinded
+	// hops cannot have a higher cltv delta otherwise it will get rejected
+	// by the forwarding nodes or the final node.
+	//
+	// This number should at least be greater than the invoice expiry time
+	// so that the blinded route is always valid as long as the invoice is
+	// valid.
 	BlocksUntilExpiry uint32
 
 	// MinNumHops is the minimum number of hops that each blinded path
@@ -104,13 +113,6 @@ type BuildBlindedPathCfg struct {
 // payment paths that can be added to the invoice.
 func BuildBlindedPaymentPaths(cfg *BuildBlindedPathCfg) (
 	[]*zpay32.BlindedPaymentPath, error) {
-
-	if cfg.MinFinalCLTVExpiryDelta >= cfg.BlocksUntilExpiry {
-		return nil, fmt.Errorf("blinded path CLTV expiry delta (%d) "+
-			"must be greater than the minimum final CLTV expiry "+
-			"delta (%d)", cfg.BlocksUntilExpiry,
-			cfg.MinFinalCLTVExpiryDelta)
-	}
 
 	// Find some appropriate routes for the value to be routed. This will
 	// return a set of routes made up of real nodes.

--- a/routing/blindedpath/blinded_path.go
+++ b/routing/blindedpath/blinded_path.go
@@ -150,7 +150,7 @@ func BuildBlindedPaymentPaths(cfg *BuildBlindedPathCfg) (
 			continue
 		} else if err != nil {
 			log.Errorf("Not using route (%s) as a blinded path: %v",
-				err)
+				route, err)
 
 			continue
 		}


### PR DESCRIPTION
Fixes 2 bugs:
1. We don't need to strictly correlate the invoice expiry with the min_cltv_delta value.
2. Moreover we should respect the minHTLC constraint when creating the blinded route and moreover when adding a buffer to the channel policy when we try to blur the real policy values. 

~~Planning to also add the `SendToBlindedPath` feature when when the sending node is the introduction point.~~

