### PR TITLE
error out when non-anchor channels are tried to bump the force close fee.

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -26,6 +26,11 @@
 * [Fix a bug](https://github.com/lightningnetwork/lnd/pull/9134) that would 
   cause a nil pointer dereference during the probing of a payment request that 
   does not contain a payment address.
+  
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/9033) where we
+  would not signal an error when trying to bump an non-anchor channel but
+  instead report a successful cpfp registration although no fee bumping is
+  possible for non-anchor channels anyways.
 
 # New Features
 ## Functional Enhancements

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -1179,6 +1179,11 @@ func (w *WalletKit) BumpForceCloseFee(_ context.Context,
 		return nil, err
 	}
 
+	if !channel.ChanType.HasAnchors() {
+		return nil, fmt.Errorf("not able to bump the fee of a " +
+			"non-anchor channel")
+	}
+
 	// Match pending sweeps with commitments of the channel for which a bump
 	// is requested. Depending on the commitment state when force closing
 	// the channel we might have up to 3 commitments to consider when
@@ -1236,6 +1241,10 @@ func (w *WalletKit) BumpForceCloseFee(_ context.Context,
 
 		return commitSet.Contains(sweep.OutPoint.Hash)
 	}, pendingSweeps)
+
+	if len(anchors) == 0 {
+		return nil, fmt.Errorf("unable to find pending anchor outputs")
+	}
 
 	// Filter all relevant anchor sweeps and update the sweep request.
 	for _, anchor := range anchors {


### PR DESCRIPTION
Small bug-fix for the new `bumpforceclose` api.
