### PR TITLE
release: bump version to v0.18.3 rc2

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -47,7 +47,7 @@ const (
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.
-	AppPreRelease = "beta.rc1"
+	AppPreRelease = "beta.rc2"
 )
 
 func init() {

--- a/channeldb/error.go
+++ b/channeldb/error.go
@@ -43,6 +43,10 @@ var (
 	// created.
 	ErrMetaNotFound = fmt.Errorf("unable to locate meta information")
 
+	// ErrClosedScidsNotFound is returned when the closed scid bucket
+	// hasn't been created.
+	ErrClosedScidsNotFound = fmt.Errorf("closed scid bucket doesn't exist")
+
 	// ErrGraphNotFound is returned when at least one of the components of
 	// graph doesn't exist.
 	ErrGraphNotFound = fmt.Errorf("graph bucket not initialized")

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -153,6 +153,14 @@ var (
 	// case we'll remove all entries from the prune log with a block height
 	// that no longer exists.
 	pruneLogBucket = []byte("prune-log")
+
+	// closedScidBucket is a top-level bucket that stores scids for
+	// channels that we know to be closed. This is used so that we don't
+	// need to perform expensive validation checks if we receive a channel
+	// announcement for the channel again.
+	//
+	// maps: scid -> []byte{}
+	closedScidBucket = []byte("closed-scid")
 )
 
 const (
@@ -318,6 +326,7 @@ var graphTopLevelBuckets = [][]byte{
 	nodeBucket,
 	edgeBucket,
 	graphMetaBucket,
+	closedScidBucket,
 }
 
 // Wipe completely deletes all saved state within all used buckets within the
@@ -3882,6 +3891,53 @@ func (c *ChannelGraph) NumZombies() (uint64, error) {
 	}
 
 	return numZombies, nil
+}
+
+// PutClosedScid stores a SCID for a closed channel in the database. This is so
+// that we can ignore channel announcements that we know to be closed without
+// having to validate them and fetch a block.
+func (c *ChannelGraph) PutClosedScid(scid lnwire.ShortChannelID) error {
+	return kvdb.Update(c.db, func(tx kvdb.RwTx) error {
+		closedScids, err := tx.CreateTopLevelBucket(closedScidBucket)
+		if err != nil {
+			return err
+		}
+
+		var k [8]byte
+		byteOrder.PutUint64(k[:], scid.ToUint64())
+
+		return closedScids.Put(k[:], []byte{})
+	}, func() {})
+}
+
+// IsClosedScid checks whether a channel identified by the passed in scid is
+// closed. This helps avoid having to perform expensive validation checks.
+// TODO: Add an LRU cache to cut down on disc reads.
+func (c *ChannelGraph) IsClosedScid(scid lnwire.ShortChannelID) (bool, error) {
+	var isClosed bool
+	err := kvdb.View(c.db, func(tx kvdb.RTx) error {
+		closedScids := tx.ReadBucket(closedScidBucket)
+		if closedScids == nil {
+			return ErrClosedScidsNotFound
+		}
+
+		var k [8]byte
+		byteOrder.PutUint64(k[:], scid.ToUint64())
+
+		if closedScids.Get(k[:]) != nil {
+			isClosed = true
+			return nil
+		}
+
+		return nil
+	}, func() {
+		isClosed = false
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return isClosed, nil
 }
 
 func putLightningNode(nodeBucket kvdb.RwBucket, aliasBucket kvdb.RwBucket, // nolint:dupl

--- a/channeldb/graph_test.go
+++ b/channeldb/graph_test.go
@@ -1980,9 +1980,9 @@ func TestFilterKnownChanIDs(t *testing.T) {
 			t.Fatalf("unable to create channel edge: %v", err)
 		}
 
-		chanIDs = append(chanIDs, ChannelUpdateInfo{
-			ShortChannelID: chanID,
-		})
+		chanIDs = append(chanIDs, NewChannelUpdateInfo(
+			chanID, time.Time{}, time.Time{},
+		))
 	}
 
 	const numZombies = 5
@@ -2024,20 +2024,28 @@ func TestFilterKnownChanIDs(t *testing.T) {
 		// should get the same set back.
 		{
 			queryIDs: []ChannelUpdateInfo{
-				{ShortChannelID: lnwire.ShortChannelID{
-					BlockHeight: 99,
-				}},
-				{ShortChannelID: lnwire.ShortChannelID{
-					BlockHeight: 100,
-				}},
+				{
+					ShortChannelID: lnwire.ShortChannelID{
+						BlockHeight: 99,
+					},
+				},
+				{
+					ShortChannelID: lnwire.ShortChannelID{
+						BlockHeight: 100,
+					},
+				},
 			},
 			resp: []ChannelUpdateInfo{
-				{ShortChannelID: lnwire.ShortChannelID{
-					BlockHeight: 99,
-				}},
-				{ShortChannelID: lnwire.ShortChannelID{
-					BlockHeight: 100,
-				}},
+				{
+					ShortChannelID: lnwire.ShortChannelID{
+						BlockHeight: 99,
+					},
+				},
+				{
+					ShortChannelID: lnwire.ShortChannelID{
+						BlockHeight: 100,
+					},
+				},
 			},
 		},
 
@@ -2419,7 +2427,7 @@ func TestFilterChannelRange(t *testing.T) {
 		)
 	)
 
-	updateTimeSeed := int64(1)
+	updateTimeSeed := time.Now().Unix()
 	maybeAddPolicy := func(chanID uint64, node *LightningNode,
 		node2 bool) time.Time {
 
@@ -2428,7 +2436,7 @@ func TestFilterChannelRange(t *testing.T) {
 			chanFlags = lnwire.ChanUpdateDirection
 		}
 
-		var updateTime time.Time
+		var updateTime = time.Unix(0, 0)
 		if rand.Int31n(2) == 0 {
 			updateTime = time.Unix(updateTimeSeed, 0)
 			err = graph.UpdateEdgePolicy(&models.ChannelEdgePolicy{
@@ -2456,11 +2464,16 @@ func TestFilterChannelRange(t *testing.T) {
 		)
 		require.NoError(t, graph.AddChannelEdge(&channel2))
 
+		chanInfo1 := NewChannelUpdateInfo(
+			chanID1, time.Time{}, time.Time{},
+		)
+		chanInfo2 := NewChannelUpdateInfo(
+			chanID2, time.Time{}, time.Time{},
+		)
 		channelRanges = append(channelRanges, BlockChannelRange{
 			Height: chanHeight,
 			Channels: []ChannelUpdateInfo{
-				{ShortChannelID: chanID1},
-				{ShortChannelID: chanID2},
+				chanInfo1, chanInfo2,
 			},
 		})
 
@@ -2471,20 +2484,17 @@ func TestFilterChannelRange(t *testing.T) {
 			time4 = maybeAddPolicy(channel2.ChannelID, node2, true)
 		)
 
+		chanInfo1 = NewChannelUpdateInfo(
+			chanID1, time1, time2,
+		)
+		chanInfo2 = NewChannelUpdateInfo(
+			chanID2, time3, time4,
+		)
 		channelRangesWithTimestamps = append(
 			channelRangesWithTimestamps, BlockChannelRange{
 				Height: chanHeight,
 				Channels: []ChannelUpdateInfo{
-					{
-						ShortChannelID:       chanID1,
-						Node1UpdateTimestamp: time1,
-						Node2UpdateTimestamp: time2,
-					},
-					{
-						ShortChannelID:       chanID2,
-						Node1UpdateTimestamp: time3,
-						Node2UpdateTimestamp: time4,
-					},
+					chanInfo1, chanInfo2,
 				},
 			},
 		)

--- a/channeldb/graph_test.go
+++ b/channeldb/graph_test.go
@@ -4037,3 +4037,28 @@ func TestGraphLoading(t *testing.T) {
 		graphReloaded.graphCache.nodeFeatures,
 	)
 }
+
+// TestClosedScid tests that we can correctly insert a SCID into the index of
+// closed short channel ids.
+func TestClosedScid(t *testing.T) {
+	t.Parallel()
+
+	graph, err := MakeTestGraph(t)
+	require.Nil(t, err)
+
+	scid := lnwire.ShortChannelID{}
+
+	// The scid should not exist in the closedScidBucket.
+	exists, err := graph.IsClosedScid(scid)
+	require.Nil(t, err)
+	require.False(t, exists)
+
+	// After we call PutClosedScid, the call to IsClosedScid should return
+	// true.
+	err = graph.PutClosedScid(scid)
+	require.Nil(t, err)
+
+	exists, err = graph.IsClosedScid(scid)
+	require.Nil(t, err)
+	require.True(t, exists)
+}

--- a/discovery/ban.go
+++ b/discovery/ban.go
@@ -1,0 +1,252 @@
+package discovery
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/neutrino/cache"
+	"github.com/lightninglabs/neutrino/cache/lru"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+const (
+	// maxBannedPeers limits the maximum number of banned pubkeys that
+	// we'll store.
+	// TODO(eugene): tune.
+	maxBannedPeers = 10_000
+
+	// banThreshold is the point at which non-channel peers will be banned.
+	// TODO(eugene): tune.
+	banThreshold = 100
+
+	// banTime is the amount of time that the non-channel peer will be
+	// banned for. Channel announcements from channel peers will be dropped
+	// if it's not one of our channels.
+	// TODO(eugene): tune.
+	banTime = time.Hour * 48
+
+	// resetDelta is the time after a peer's last ban update that we'll
+	// reset its ban score.
+	// TODO(eugene): tune.
+	resetDelta = time.Hour * 48
+
+	// purgeInterval is how often we'll remove entries from the
+	// peerBanIndex and allow peers to be un-banned. This interval is also
+	// used to reset ban scores of peers that aren't banned.
+	purgeInterval = time.Minute * 10
+)
+
+var ErrPeerBanned = errors.New("peer has bypassed ban threshold - banning")
+
+// ClosedChannelTracker handles closed channels being gossiped to us.
+type ClosedChannelTracker interface {
+	// GraphCloser is used to mark channels as closed and to check whether
+	// certain channels are closed.
+	GraphCloser
+
+	// IsChannelPeer checks whether we have a channel with a peer.
+	IsChannelPeer(*btcec.PublicKey) (bool, error)
+}
+
+// GraphCloser handles tracking closed channels by their scid.
+type GraphCloser interface {
+	// PutClosedScid marks a channel as closed so that we won't validate
+	// channel announcements for it again.
+	PutClosedScid(lnwire.ShortChannelID) error
+
+	// IsClosedScid checks if a short channel id is closed.
+	IsClosedScid(lnwire.ShortChannelID) (bool, error)
+}
+
+// NodeInfoInquirier handles queries relating to specific nodes and channels
+// they may have with us.
+type NodeInfoInquirer interface {
+	// FetchOpenChannels returns the set of channels that we have with the
+	// peer identified by the passed-in public key.
+	FetchOpenChannels(*btcec.PublicKey) ([]*channeldb.OpenChannel, error)
+}
+
+// ScidCloserMan helps the gossiper handle closed channels that are in the
+// ChannelGraph.
+type ScidCloserMan struct {
+	graph     GraphCloser
+	channelDB NodeInfoInquirer
+}
+
+// NewScidCloserMan creates a new ScidCloserMan.
+func NewScidCloserMan(graph GraphCloser,
+	channelDB NodeInfoInquirer) *ScidCloserMan {
+
+	return &ScidCloserMan{
+		graph:     graph,
+		channelDB: channelDB,
+	}
+}
+
+// PutClosedScid marks scid as closed so the gossiper can ignore this channel
+// in the future.
+func (s *ScidCloserMan) PutClosedScid(scid lnwire.ShortChannelID) error {
+	return s.graph.PutClosedScid(scid)
+}
+
+// IsClosedScid checks whether scid is closed so that the gossiper can ignore
+// it.
+func (s *ScidCloserMan) IsClosedScid(scid lnwire.ShortChannelID) (bool,
+	error) {
+
+	return s.graph.IsClosedScid(scid)
+}
+
+// IsChannelPeer checks whether we have a channel with the peer.
+func (s *ScidCloserMan) IsChannelPeer(peerKey *btcec.PublicKey) (bool, error) {
+	chans, err := s.channelDB.FetchOpenChannels(peerKey)
+	if err != nil {
+		return false, err
+	}
+
+	return len(chans) > 0, nil
+}
+
+// A compile-time constraint to ensure ScidCloserMan implements
+// ClosedChannelTracker.
+var _ ClosedChannelTracker = (*ScidCloserMan)(nil)
+
+// cachedBanInfo is used to track a peer's ban score and if it is banned.
+type cachedBanInfo struct {
+	score      uint64
+	lastUpdate time.Time
+}
+
+// Size returns the "size" of an entry.
+func (c *cachedBanInfo) Size() (uint64, error) {
+	return 1, nil
+}
+
+// isBanned returns true if the ban score is greater than the ban threshold.
+func (c *cachedBanInfo) isBanned() bool {
+	return c.score >= banThreshold
+}
+
+// banman is responsible for banning peers that are misbehaving. The banman is
+// in-memory and will be reset upon restart of LND. If a node's pubkey is in
+// the peerBanIndex, it has a ban score. Ban scores start at 1 and are
+// incremented by 1 for each instance of misbehavior. It uses an LRU cache to
+// cut down on memory usage in case there are many banned peers and to protect
+// against DoS.
+type banman struct {
+	// peerBanIndex tracks our peers' ban scores and if they are banned and
+	// for how long. The ban score is incremented when our peer gives us
+	// gossip messages that are invalid.
+	peerBanIndex *lru.Cache[[33]byte, *cachedBanInfo]
+
+	wg   sync.WaitGroup
+	quit chan struct{}
+}
+
+// newBanman creates a new banman with the default maxBannedPeers.
+func newBanman() *banman {
+	return &banman{
+		peerBanIndex: lru.NewCache[[33]byte, *cachedBanInfo](
+			maxBannedPeers,
+		),
+		quit: make(chan struct{}),
+	}
+}
+
+// start kicks off the banman by calling purgeExpiredBans.
+func (b *banman) start() {
+	b.wg.Add(1)
+	go b.purgeExpiredBans()
+}
+
+// stop halts the banman.
+func (b *banman) stop() {
+	close(b.quit)
+	b.wg.Wait()
+}
+
+// purgeOldEntries removes ban entries if their ban has expired.
+func (b *banman) purgeExpiredBans() {
+	defer b.wg.Done()
+
+	purgeTicker := time.NewTicker(purgeInterval)
+	defer purgeTicker.Stop()
+
+	for {
+		select {
+		case <-purgeTicker.C:
+			b.purgeBanEntries()
+
+		case <-b.quit:
+			return
+		}
+	}
+}
+
+// purgeBanEntries does two things:
+// - removes peers from our ban list whose ban timer is up
+// - removes peers whose ban scores have expired.
+func (b *banman) purgeBanEntries() {
+	keysToRemove := make([][33]byte, 0)
+
+	sweepEntries := func(pubkey [33]byte, banInfo *cachedBanInfo) bool {
+		if banInfo.isBanned() {
+			// If the peer is banned, check if the ban timer has
+			// expired.
+			if banInfo.lastUpdate.Add(banTime).Before(time.Now()) {
+				keysToRemove = append(keysToRemove, pubkey)
+			}
+
+			return true
+		}
+
+		if banInfo.lastUpdate.Add(resetDelta).Before(time.Now()) {
+			// Remove non-banned peers whose ban scores have
+			// expired.
+			keysToRemove = append(keysToRemove, pubkey)
+		}
+
+		return true
+	}
+
+	b.peerBanIndex.Range(sweepEntries)
+
+	for _, key := range keysToRemove {
+		b.peerBanIndex.Delete(key)
+	}
+}
+
+// isBanned checks whether the peer identified by the pubkey is banned.
+func (b *banman) isBanned(pubkey [33]byte) bool {
+	banInfo, err := b.peerBanIndex.Get(pubkey)
+	switch {
+	case errors.Is(err, cache.ErrElementNotFound):
+		return false
+
+	default:
+		return banInfo.isBanned()
+	}
+}
+
+// incrementBanScore increments a peer's ban score.
+func (b *banman) incrementBanScore(pubkey [33]byte) {
+	banInfo, err := b.peerBanIndex.Get(pubkey)
+	switch {
+	case errors.Is(err, cache.ErrElementNotFound):
+		cachedInfo := &cachedBanInfo{
+			score:      1,
+			lastUpdate: time.Now(),
+		}
+		_, _ = b.peerBanIndex.Put(pubkey, cachedInfo)
+	default:
+		cachedInfo := &cachedBanInfo{
+			score:      banInfo.score + 1,
+			lastUpdate: time.Now(),
+		}
+
+		_, _ = b.peerBanIndex.Put(pubkey, cachedInfo)
+	}
+}

--- a/discovery/ban_test.go
+++ b/discovery/ban_test.go
@@ -1,0 +1,60 @@
+package discovery
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/neutrino/cache"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPurgeBanEntries tests that we properly purge ban entries on a timer.
+func TestPurgeBanEntries(t *testing.T) {
+	t.Parallel()
+
+	b := newBanman()
+
+	// Ban a peer by repeatedly incrementing its ban score.
+	peer1 := [33]byte{0x00}
+
+	for i := 0; i < banThreshold; i++ {
+		b.incrementBanScore(peer1)
+	}
+
+	// Assert that the peer is now banned.
+	require.True(t, b.isBanned(peer1))
+
+	// A call to purgeBanEntries should not remove the peer from the index.
+	b.purgeBanEntries()
+	require.True(t, b.isBanned(peer1))
+
+	// Now set the peer's last update time to two banTimes in the past so
+	// that we can assert that purgeBanEntries does remove it from the
+	// index.
+	banInfo, err := b.peerBanIndex.Get(peer1)
+	require.NoError(t, err)
+
+	banInfo.lastUpdate = time.Now().Add(-2 * banTime)
+
+	b.purgeBanEntries()
+	_, err = b.peerBanIndex.Get(peer1)
+	require.ErrorIs(t, err, cache.ErrElementNotFound)
+
+	// Increment the peer's ban score again but don't get it banned.
+	b.incrementBanScore(peer1)
+	require.False(t, b.isBanned(peer1))
+
+	// Assert that purgeBanEntries does nothing.
+	b.purgeBanEntries()
+	banInfo, err = b.peerBanIndex.Get(peer1)
+	require.Nil(t, err)
+
+	// Set its lastUpdate time to 2 resetDelta's in the past so that
+	// purgeBanEntries removes it.
+	banInfo.lastUpdate = time.Now().Add(-2 * resetDelta)
+
+	b.purgeBanEntries()
+
+	_, err = b.peerBanIndex.Get(peer1)
+	require.ErrorIs(t, err, cache.ErrElementNotFound)
+}

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -2232,7 +2232,7 @@ func (d *AuthenticatedGossiper) updateChannel(info *models.ChannelEdgeInfo,
 			BitcoinKey1:     info.BitcoinKey1Bytes,
 			Features:        lnwire.NewRawFeatureVector(),
 			BitcoinKey2:     info.BitcoinKey2Bytes,
-			ExtraOpaqueData: edge.ExtraOpaqueData,
+			ExtraOpaqueData: info.ExtraOpaqueData,
 		}
 		chanAnn.NodeSig1, err = lnwire.NewSigFromECDSARawSignature(
 			info.AuthProof.NodeSig1Bytes,

--- a/discovery/reliable_sender_test.go
+++ b/discovery/reliable_sender_test.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -74,7 +75,7 @@ func TestReliableSenderFlow(t *testing.T) {
 	// Create a mock peer to send the messages to.
 	pubKey := randPubKey(t)
 	msgsSent := make(chan lnwire.Message)
-	peer := &mockPeer{pubKey, msgsSent, reliableSender.quit}
+	peer := &mockPeer{pubKey, msgsSent, reliableSender.quit, atomic.Bool{}}
 
 	// Override NotifyWhenOnline and NotifyWhenOffline to provide the
 	// notification channels so that we can control when notifications get
@@ -193,7 +194,7 @@ func TestReliableSenderStaleMessages(t *testing.T) {
 	// Create a mock peer to send the messages to.
 	pubKey := randPubKey(t)
 	msgsSent := make(chan lnwire.Message)
-	peer := &mockPeer{pubKey, msgsSent, reliableSender.quit}
+	peer := &mockPeer{pubKey, msgsSent, reliableSender.quit, atomic.Bool{}}
 
 	// Override NotifyWhenOnline to provide the notification channel so that
 	// we can control when notifications get dispatched.

--- a/discovery/sync_manager.go
+++ b/discovery/sync_manager.go
@@ -561,7 +561,7 @@ func (m *SyncManager) removeGossipSyncer(peer route.Vertex) {
 		return
 	}
 
-	log.Debugf("Replaced active GossipSyncer(%x) with GossipSyncer(%x)",
+	log.Debugf("Replaced active GossipSyncer(%v) with GossipSyncer(%x)",
 		peer, newActiveSyncer.cfg.peerPub)
 }
 

--- a/discovery/syncer_test.go
+++ b/discovery/syncer_test.go
@@ -211,7 +211,11 @@ func newTestSyncer(hID lnwire.ShortChannelID,
 		markGraphSynced:          func() {},
 		maxQueryChanRangeReplies: maxQueryChanRangeReplies,
 	}
-	syncer := newGossipSyncer(cfg)
+
+	syncerSema := make(chan struct{}, 1)
+	syncerSema <- struct{}{}
+
+	syncer := newGossipSyncer(cfg, syncerSema)
 
 	return msgChan, syncer, cfg.channelSeries.(*mockChannelGraphTimeSeries)
 }

--- a/discovery/syncer_test.go
+++ b/discovery/syncer_test.go
@@ -1229,6 +1229,12 @@ func testGossipSyncerProcessChanRangeReply(t *testing.T, legacy bool) {
 	query, err := syncer.genChanRangeQuery(true)
 	require.NoError(t, err, "unable to generate channel range query")
 
+	currentTimestamp := time.Now().Unix()
+	// Timestamp more than 2 weeks in the past hence expired.
+	expiredTimestamp := time.Unix(0, 0).Unix()
+	// Timestamp three weeks in the future.
+	skewedTimestamp := time.Now().Add(time.Hour * 24 * 18).Unix()
+
 	// When interpreting block ranges, the first reply should start from
 	// our requested first block, and the last should end at our requested
 	// last block.
@@ -1253,11 +1259,75 @@ func testGossipSyncerProcessChanRangeReply(t *testing.T, legacy bool) {
 		},
 		{
 			FirstBlockHeight: 12,
-			NumBlocks:        query.NumBlocks - 12,
-			Complete:         1,
+			NumBlocks:        1,
 			ShortChanIDs: []lnwire.ShortChannelID{
 				{
 					BlockHeight: 12,
+				},
+			},
+		},
+		{
+			FirstBlockHeight: 13,
+			NumBlocks:        query.NumBlocks - 13,
+			Complete:         1,
+			ShortChanIDs: []lnwire.ShortChannelID{
+				{
+					BlockHeight: 13,
+					TxIndex:     1,
+				},
+				{
+					BlockHeight: 13,
+					TxIndex:     2,
+				},
+				{
+					BlockHeight: 13,
+					TxIndex:     3,
+				},
+				{
+					BlockHeight: 13,
+					TxIndex:     4,
+				},
+				{
+					BlockHeight: 13,
+					TxIndex:     5,
+				},
+				{
+					BlockHeight: 13,
+					TxIndex:     6,
+				},
+			},
+			Timestamps: []lnwire.ChanUpdateTimestamps{
+				{
+					// Both timestamps are valid.
+					Timestamp1: uint32(currentTimestamp),
+					Timestamp2: uint32(currentTimestamp),
+				},
+				{
+					// One of the timestamps is valid.
+					Timestamp1: uint32(currentTimestamp),
+					Timestamp2: uint32(expiredTimestamp),
+				},
+				{
+					// Both timestamps are expired.
+					Timestamp1: uint32(expiredTimestamp),
+					Timestamp2: uint32(expiredTimestamp),
+				},
+				{
+					// Both timestamps are skewed.
+					Timestamp1: uint32(skewedTimestamp),
+					Timestamp2: uint32(skewedTimestamp),
+				},
+				{
+					// One timestamp is skewed the other
+					// expired.
+					Timestamp1: uint32(expiredTimestamp),
+					Timestamp2: uint32(skewedTimestamp),
+				},
+				{
+					// One timestamp is skewed the other
+					// expired.
+					Timestamp1: uint32(skewedTimestamp),
+					Timestamp2: uint32(expiredTimestamp),
 				},
 			},
 		},
@@ -1274,6 +1344,9 @@ func testGossipSyncerProcessChanRangeReply(t *testing.T, legacy bool) {
 
 		replies[2].FirstBlockHeight = query.FirstBlockHeight
 		replies[2].NumBlocks = query.NumBlocks
+
+		replies[3].FirstBlockHeight = query.FirstBlockHeight
+		replies[3].NumBlocks = query.NumBlocks
 	}
 
 	// We'll begin by sending the syncer a set of non-complete channel
@@ -1282,6 +1355,9 @@ func testGossipSyncerProcessChanRangeReply(t *testing.T, legacy bool) {
 		t.Fatalf("unable to process reply: %v", err)
 	}
 	if err := syncer.processChanRangeReply(replies[1]); err != nil {
+		t.Fatalf("unable to process reply: %v", err)
+	}
+	if err := syncer.processChanRangeReply(replies[2]); err != nil {
 		t.Fatalf("unable to process reply: %v", err)
 	}
 
@@ -1300,6 +1376,14 @@ func testGossipSyncerProcessChanRangeReply(t *testing.T, legacy bool) {
 		},
 		{
 			BlockHeight: 12,
+		},
+		{
+			BlockHeight: 13,
+			TxIndex:     1,
+		},
+		{
+			BlockHeight: 13,
+			TxIndex:     2,
 		},
 	}
 
@@ -1335,7 +1419,7 @@ func testGossipSyncerProcessChanRangeReply(t *testing.T, legacy bool) {
 
 	// If we send the final message, then we should transition to
 	// queryNewChannels as we've sent a non-empty set of new channels.
-	if err := syncer.processChanRangeReply(replies[2]); err != nil {
+	if err := syncer.processChanRangeReply(replies[3]); err != nil {
 		t.Fatalf("unable to process reply: %v", err)
 	}
 

--- a/docs/release-notes/release-notes-0.18.3.md
+++ b/docs/release-notes/release-notes-0.18.3.md
@@ -64,6 +64,10 @@ commitment when the channel was force closed.
   cause UpdateAddHTLC message with blinding point fields to not be re-forwarded
   correctly on restart.
  
+* [A bug has been fixed that could cause invalid channel
+  announcements](https://github.com/lightningnetwork/lnd/pull/9002) to be
+  generated if the inbound fee discount is used.
+
 # New Features
 ## Functional Enhancements
 ## RPC Additions

--- a/docs/release-notes/release-notes-0.18.3.md
+++ b/docs/release-notes/release-notes-0.18.3.md
@@ -67,6 +67,10 @@ commitment when the channel was force closed.
 * [A bug has been fixed that could cause invalid channel
   announcements](https://github.com/lightningnetwork/lnd/pull/9002) to be
   generated if the inbound fee discount is used.
+  
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/9011) a timestamp issue
+  in the `ReplyChannelRange` msg and introduced a check that ChanUpdates with a
+  timestamp too far into the future will be discarded.
 
 # New Features
 ## Functional Enhancements

--- a/docs/release-notes/release-notes-0.18.3.md
+++ b/docs/release-notes/release-notes-0.18.3.md
@@ -79,6 +79,11 @@ blinded path expiry.
 
 # New Features
 ## Functional Enhancements
+
+* LND will now [temporarily ban peers](https://github.com/lightningnetwork/lnd/pull/9009)
+that send too many invalid `ChannelAnnouncement`. This is only done for LND nodes
+that validate `ChannelAnnouncement` messages.
+
 ## RPC Additions
 
 * The [SendPaymentRequest](https://github.com/lightningnetwork/lnd/pull/8734) 

--- a/docs/release-notes/release-notes-0.18.3.md
+++ b/docs/release-notes/release-notes-0.18.3.md
@@ -72,6 +72,11 @@ commitment when the channel was force closed.
   in the `ReplyChannelRange` msg and introduced a check that ChanUpdates with a
   timestamp too far into the future will be discarded.
 
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/9026) a bug where we
+would create a blinded route with a minHTLC greater than the actual payment
+amount. Moreover remove strict correlation between min_cltv_delta and the
+blinded path expiry.
+
 # New Features
 ## Functional Enhancements
 ## RPC Additions

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -283,6 +283,8 @@ type testNode struct {
 
 var _ lnpeer.Peer = (*testNode)(nil)
 
+func (n *testNode) Disconnect(err error) {}
+
 func (n *testNode) IdentityKey() *btcec.PublicKey {
 	return n.addr.IdentityKey
 }

--- a/graph/builder.go
+++ b/graph/builder.go
@@ -681,7 +681,7 @@ func (b *Builder) handleNetworkUpdate(vb *ValidationBarrier,
 			update.err <- err
 
 		case IsError(err, ErrParentValidationFailed):
-			update.err <- newErrf(ErrIgnored, err.Error())
+			update.err <- NewErrf(ErrIgnored, err.Error()) //nolint
 
 		default:
 			log.Warnf("unexpected error during validation "+
@@ -1053,7 +1053,7 @@ func (b *Builder) assertNodeAnnFreshness(node route.Vertex,
 			"existence of node: %v", err)
 	}
 	if !exists {
-		return newErrf(ErrIgnored, "Ignoring node announcement"+
+		return NewErrf(ErrIgnored, "Ignoring node announcement"+
 			" for node not found in channel graph (%x)",
 			node[:])
 	}
@@ -1063,7 +1063,7 @@ func (b *Builder) assertNodeAnnFreshness(node route.Vertex,
 	// if not then we won't accept the new data as it would override newer
 	// data.
 	if !lastUpdate.Before(msgTimestamp) {
-		return newErrf(ErrOutdated, "Ignoring outdated "+
+		return NewErrf(ErrOutdated, "Ignoring outdated "+
 			"announcement for %x", node[:])
 	}
 
@@ -1193,11 +1193,11 @@ func (b *Builder) processUpdate(msg interface{},
 				"existence: %v", err)
 		}
 		if isZombie {
-			return newErrf(ErrIgnored, "ignoring msg for zombie "+
+			return NewErrf(ErrIgnored, "ignoring msg for zombie "+
 				"chan_id=%v", msg.ChannelID)
 		}
 		if exists {
-			return newErrf(ErrIgnored, "ignoring msg for known "+
+			return NewErrf(ErrIgnored, "ignoring msg for known "+
 				"chan_id=%v", msg.ChannelID)
 		}
 
@@ -1259,7 +1259,7 @@ func (b *Builder) processUpdate(msg interface{},
 			default:
 			}
 
-			return newErrf(ErrNoFundingTransaction, "unable to "+
+			return NewErrf(ErrNoFundingTransaction, "unable to "+
 				"locate funding tx: %v", err)
 		}
 
@@ -1294,7 +1294,7 @@ func (b *Builder) processUpdate(msg interface{},
 				return err
 			}
 
-			return newErrf(ErrInvalidFundingOutput, "output "+
+			return NewErrf(ErrInvalidFundingOutput, "output "+
 				"failed validation: %w", err)
 		}
 
@@ -1313,7 +1313,7 @@ func (b *Builder) processUpdate(msg interface{},
 				}
 			}
 
-			return newErrf(ErrChannelSpent, "unable to fetch utxo "+
+			return NewErrf(ErrChannelSpent, "unable to fetch utxo "+
 				"for chan_id=%v, chan_point=%v: %v",
 				msg.ChannelID, fundingPoint, err)
 		}
@@ -1378,7 +1378,7 @@ func (b *Builder) processUpdate(msg interface{},
 			b.cfg.ChannelPruneExpiry
 
 		if isZombie && isStaleUpdate {
-			return newErrf(ErrIgnored, "ignoring stale update "+
+			return NewErrf(ErrIgnored, "ignoring stale update "+
 				"(flags=%v|%v) for zombie chan_id=%v",
 				msg.MessageFlags, msg.ChannelFlags,
 				msg.ChannelID)
@@ -1387,7 +1387,7 @@ func (b *Builder) processUpdate(msg interface{},
 		// If the channel doesn't exist in our database, we cannot
 		// apply the updated policy.
 		if !exists {
-			return newErrf(ErrIgnored, "ignoring update "+
+			return NewErrf(ErrIgnored, "ignoring update "+
 				"(flags=%v|%v) for unknown chan_id=%v",
 				msg.MessageFlags, msg.ChannelFlags,
 				msg.ChannelID)
@@ -1405,7 +1405,7 @@ func (b *Builder) processUpdate(msg interface{},
 
 			// Ignore outdated message.
 			if !edge1Timestamp.Before(msg.LastUpdate) {
-				return newErrf(ErrOutdated, "Ignoring "+
+				return NewErrf(ErrOutdated, "Ignoring "+
 					"outdated update (flags=%v|%v) for "+
 					"known chan_id=%v", msg.MessageFlags,
 					msg.ChannelFlags, msg.ChannelID)
@@ -1417,7 +1417,7 @@ func (b *Builder) processUpdate(msg interface{},
 
 			// Ignore outdated message.
 			if !edge2Timestamp.Before(msg.LastUpdate) {
-				return newErrf(ErrOutdated, "Ignoring "+
+				return NewErrf(ErrOutdated, "Ignoring "+
 					"outdated update (flags=%v|%v) for "+
 					"known chan_id=%v", msg.MessageFlags,
 					msg.ChannelFlags, msg.ChannelID)

--- a/graph/builder_test.go
+++ b/graph/builder_test.go
@@ -1275,7 +1275,7 @@ func newChannelEdgeInfo(t *testing.T, ctx *testCtx, fundingHeight uint32,
 }
 
 func assertChanChainRejection(t *testing.T, ctx *testCtx,
-	edge *models.ChannelEdgeInfo, failCode errorCode) {
+	edge *models.ChannelEdgeInfo, failCode ErrorCode) {
 
 	t.Helper()
 

--- a/graph/errors.go
+++ b/graph/errors.go
@@ -2,14 +2,14 @@ package graph
 
 import "github.com/go-errors/errors"
 
-// errorCode is used to represent the various errors that can occur within this
+// ErrorCode is used to represent the various errors that can occur within this
 // package.
-type errorCode uint8
+type ErrorCode uint8
 
 const (
 	// ErrOutdated is returned when the routing update already have
 	// been applied, or a newer update is already known.
-	ErrOutdated errorCode = iota
+	ErrOutdated ErrorCode = iota
 
 	// ErrIgnored is returned when the update have been ignored because
 	// this update can't bring us something new, or because a node
@@ -39,27 +39,27 @@ const (
 	ErrParentValidationFailed
 )
 
-// graphError is a structure that represent the error inside the graph package,
+// Error is a structure that represent the error inside the graph package,
 // this structure carries additional information about error code in order to
 // be able distinguish errors outside of the current package.
-type graphError struct {
+type Error struct {
 	err  *errors.Error
-	code errorCode
+	code ErrorCode
 }
 
 // Error represents errors as the string
 // NOTE: Part of the error interface.
-func (e *graphError) Error() string {
+func (e *Error) Error() string {
 	return e.err.Error()
 }
 
-// A compile time check to ensure graphError implements the error interface.
-var _ error = (*graphError)(nil)
+// A compile time check to ensure Error implements the error interface.
+var _ error = (*Error)(nil)
 
-// newErrf creates a graphError by the given error formatted description and
+// NewErrf creates a Error by the given error formatted description and
 // its corresponding error code.
-func newErrf(code errorCode, format string, a ...interface{}) *graphError {
-	return &graphError{
+func NewErrf(code ErrorCode, format string, a ...interface{}) *Error {
+	return &Error{
 		code: code,
 		err:  errors.Errorf(format, a...),
 	}
@@ -67,8 +67,8 @@ func newErrf(code errorCode, format string, a ...interface{}) *graphError {
 
 // IsError is a helper function which is needed to have ability to check that
 // returned error has specific error code.
-func IsError(e interface{}, codes ...errorCode) bool {
-	err, ok := e.(*graphError)
+func IsError(e interface{}, codes ...ErrorCode) bool {
+	err, ok := e.(*Error)
 	if !ok {
 		return false
 	}

--- a/graph/validation_barrier.go
+++ b/graph/validation_barrier.go
@@ -238,12 +238,12 @@ func (v *ValidationBarrier) WaitForDependants(job interface{}) error {
 	// is closed, or the set of jobs exits.
 	select {
 	case <-v.quit:
-		return newErrf(ErrVBarrierShuttingDown,
+		return NewErrf(ErrVBarrierShuttingDown,
 			"validation barrier shutting down")
 
 	case <-signals.deny:
 		log.Debugf("Signal deny for %s", jobDesc)
-		return newErrf(ErrParentValidationFailed,
+		return NewErrf(ErrParentValidationFailed,
 			"parent validation failed")
 
 	case <-signals.allow:

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -2072,6 +2072,8 @@ func (m *mockPeer) QuitSignal() <-chan struct{} {
 	return m.quit
 }
 
+func (m *mockPeer) Disconnect(err error) {}
+
 var _ lnpeer.Peer = (*mockPeer)(nil)
 
 func (m *mockPeer) SendMessage(sync bool, msgs ...lnwire.Message) error {

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -684,6 +684,8 @@ func (s *mockServer) RemoteFeatures() *lnwire.FeatureVector {
 	return nil
 }
 
+func (s *mockServer) Disconnect(err error) {}
+
 func (s *mockServer) Stop() error {
 	if !atomic.CompareAndSwapInt32(&s.shutdown, 0, 1) {
 		return nil

--- a/lnpeer/mock_peer.go
+++ b/lnpeer/mock_peer.go
@@ -79,3 +79,5 @@ func (m *MockPeer) RemoteFeatures() *lnwire.FeatureVector {
 	args := m.Called()
 	return args.Get(0).(*lnwire.FeatureVector)
 }
+
+func (m *MockPeer) Disconnect(err error) {}

--- a/lnpeer/peer.go
+++ b/lnpeer/peer.go
@@ -74,4 +74,7 @@ type Peer interface {
 	// by the remote peer. This allows sub-systems that use this interface
 	// to gate their behavior off the set of negotiated feature bits.
 	RemoteFeatures() *lnwire.FeatureVector
+
+	// Disconnect halts communication with the peer.
+	Disconnect(error)
 }


### PR DESCRIPTION
Staging PR for the creation of v0.18.3 rc2. 

This PR includes cherry picks of the following PRs:
  * #9002 
  * #9026 
  * #9011 

We also seek to include:
  * https://github.com/lightningnetwork/lnd/pull/9009

PRs on deck for the next rc:
  * https://github.com/lightningnetwork/lnd/pull/9022
     * Fixes an issue in CI, which uncovered additional issues related to the SQL backend. May require another PR to resolve everything we've found so far. 

Once #9009 has been merged, I'll tack on an extra commit that bumps the version. 