### PR TITLE
rpc: fix ordering of feature bit check in rpcCommitmentType

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4547,11 +4547,11 @@ func rpcCommitmentType(chanType channeldb.ChannelType) lnrpc.CommitmentType {
 	// first check whether it has anchors, since in that case it would also
 	// be tweakless.
 	switch {
-	case chanType.IsTaproot():
-		return lnrpc.CommitmentType_SIMPLE_TAPROOT
-
 	case chanType.HasTapscriptRoot():
 		return lnrpc.CommitmentType_SIMPLE_TAPROOT_OVERLAY
+
+	case chanType.IsTaproot():
+		return lnrpc.CommitmentType_SIMPLE_TAPROOT
 
 	case chanType.HasLeaseExpiration():
 		return lnrpc.CommitmentType_SCRIPT_ENFORCED_LEASE
@@ -4561,6 +4561,7 @@ func rpcCommitmentType(chanType channeldb.ChannelType) lnrpc.CommitmentType {
 
 	case chanType.IsTweakless():
 		return lnrpc.CommitmentType_STATIC_REMOTE_KEY
+
 	default:
 
 		return lnrpc.CommitmentType_LEGACY

--- a/rpcserver_test.go
+++ b/rpcserver_test.go
@@ -77,3 +77,53 @@ func TestAuxDataParser(t *testing.T) {
 	require.NotNil(t, resp)
 	require.Equal(t, []byte{0x00, 0x00}, resp.CustomChannelData)
 }
+
+// TestRpcCommitmentType tests the rpcCommitmentType returns the corect
+// commitment type given a channel type.
+func TestRpcCommitmentType(t *testing.T) {
+	tests := []struct {
+		name     string
+		chanType channeldb.ChannelType
+		want     lnrpc.CommitmentType
+	}{
+		{
+			name: "tapscript overlay",
+			chanType: channeldb.SimpleTaprootFeatureBit |
+				channeldb.TapscriptRootBit,
+			want: lnrpc.CommitmentType_SIMPLE_TAPROOT_OVERLAY,
+		},
+		{
+			name:     "simple taproot",
+			chanType: channeldb.SimpleTaprootFeatureBit,
+			want:     lnrpc.CommitmentType_SIMPLE_TAPROOT,
+		},
+		{
+			name:     "lease expiration",
+			chanType: channeldb.LeaseExpirationBit,
+			want:     lnrpc.CommitmentType_SCRIPT_ENFORCED_LEASE,
+		},
+		{
+			name:     "anchors",
+			chanType: channeldb.AnchorOutputsBit,
+			want:     lnrpc.CommitmentType_ANCHORS,
+		},
+		{
+			name:     "tweakless",
+			chanType: channeldb.SingleFunderTweaklessBit,
+			want:     lnrpc.CommitmentType_STATIC_REMOTE_KEY,
+		},
+		{
+			name:     "legacy",
+			chanType: channeldb.SingleFunderBit,
+			want:     lnrpc.CommitmentType_LEGACY,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(
+				t, tt.want, rpcCommitmentType(tt.chanType),
+			)
+		})
+	}
+}


### PR DESCRIPTION
We need to check if it has a tapsript root first, as if it has a tapscript root, then it's also a taproot channel. By checking if it has a tapscript root first, we'll now display the proper commitment type for RPC responses.

