### PR TITLE
Don't serve channels in the range reply without a valid ChanUpdate.

### DIFF
--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -2335,15 +2335,6 @@ func (c *ChannelGraph) FilterChannelRange(startHeight,
 				cid, time.Time{}, time.Time{},
 			)
 
-			if !withTimestamps {
-				channelsPerBlock[cid.BlockHeight] = append(
-					channelsPerBlock[cid.BlockHeight],
-					chanInfo,
-				)
-
-				continue
-			}
-
 			node1Key, node2Key := computeEdgePolicyKeys(&edgeInfo)
 
 			rawPolicy := edges.Get(node1Key)
@@ -2374,6 +2365,15 @@ func (c *ChannelGraph) FilterChannelRange(startHeight,
 				}
 
 				chanInfo.Node2UpdateTimestamp = edge.LastUpdate
+			}
+
+			//nolint:lll
+			// We don't serve Channels we havn't seen any ChanUpdate
+			// msg from.
+			if chanInfo.Node1UpdateTimestamp.Equal(time.Unix(0, 0)) &&
+				chanInfo.Node2UpdateTimestamp.Equal(time.Unix(0, 0)) {
+
+				continue
 			}
 
 			channelsPerBlock[cid.BlockHeight] = append(


### PR DESCRIPTION
Related to https://github.com/lightningnetwork/lnd/issues/8889

The problem:

Currently nodes which were infected with Channel Announcements without any valid ChanUpdate would never delete those old `EdgeInfo` entries in their db. When receiving `query_channel_range ` requests, they would serve those channels. LND Nodes depending on whether they send the range request with timestamps or not, would in the latter case query those channels and receive "invalid channel announments", this would lead the lnd node to ban this peer after hitting the banning limit. Although direct channel peers are not disconnected, node runners would probably notice this spam of the node and close the channel.
Not sending those bad channel ids in general might be a good mitigation for a infected node, which is probably not aware that he is infected in the first place.

The only other solution the infected node runner has, to get rid of its old channels is to drop its channel graph via chantools.
