### PR TITLE
lnwallet: ensure we re-sign retransmitted commits for taproot channels 

### DIFF
--- a/docs/release-notes/release-notes-0.18.3.md
+++ b/docs/release-notes/release-notes-0.18.3.md
@@ -80,6 +80,10 @@ blinded path expiry.
 * [Fix a bug](https://github.com/lightningnetwork/lnd/pull/9039) that would
   cause UpdateAddHTLC message with blinding point fields to not be re-forwarded
   correctly on restart.
+
+* [A bug related to sending dangling channel
+  updates](https://github.com/lightningnetwork/lnd/pull/9046) after a
+  reconnection for taproot channels has been fixed.
  
 # New Features
 ## Functional Enhancements

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -4151,6 +4151,27 @@ func (lc *LightningChannel) SignNextCommitment() (*NewCommitState, error) {
 	}, nil
 }
 
+// resignMusigCommit is used to resign a commitment transaction for taproot
+// channels when we need to retransmit a signature after a channel reestablish
+// message. Taproot channels use musig2, which means we must use fresh nonces
+// each time. After we receive the channel reestablish message, we learn the
+// nonce we need to use for the remote party. As a result, we need to generate
+// the partial signature again with the new nonce.
+func (lc *LightningChannel) resignMusigCommit(commitTx *wire.MsgTx,
+) (lnwire.OptPartialSigWithNonceTLV, error) {
+
+	remoteSession := lc.musigSessions.RemoteSession
+	musig, err := remoteSession.SignCommit(commitTx)
+	if err != nil {
+		var none lnwire.OptPartialSigWithNonceTLV
+		return none, err
+	}
+
+	partialSig := lnwire.MaybePartialSigWithNonce(musig.ToWireSig())
+
+	return partialSig, nil
+}
+
 // ProcessChanSyncMsg processes a ChannelReestablish message sent by the remote
 // connection upon re establishment of our connection with them. This method
 // will return a single message if we are currently out of sync, otherwise a
@@ -4428,12 +4449,23 @@ func (lc *LightningChannel) ProcessChanSyncMsg(
 			commitUpdates = append(commitUpdates, logUpdate.UpdateMsg)
 		}
 
+		// If this is a taproot channel, then we need to regenerate the
+		// musig2 signature for the remote party, using their fresh
+		// nonce.
+		if lc.channelState.ChanType.IsTaproot() {
+			partialSig, err := lc.resignMusigCommit(
+				commitDiff.Commitment.CommitTx,
+			)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+
+			commitDiff.CommitSig.PartialSig = partialSig
+		}
+
 		// With the batch of updates accumulated, we'll now re-send the
 		// original CommitSig message required to re-sync their remote
 		// commitment chain with our local version of their chain.
-		//
-		// TODO(roasbeef): need to re-sign commitment states w/
-		// fresh nonce
 		commitUpdates = append(commitUpdates, commitDiff.CommitSig)
 
 		// NOTE: If a revocation is not owed, then updates is empty.

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -435,6 +435,28 @@ func CreateTestChannels(t *testing.T, chanType channeldb.ChannelType,
 	return channelAlice, channelBob, nil
 }
 
+// initMusigNonce is used to manually setup musig2 nonces for a new channel,
+// outside the normal chan-reest flow.
+func initMusigNonce(chanA, chanB *LightningChannel) error {
+	chanANonces, err := chanA.GenMusigNonces()
+	if err != nil {
+		return err
+	}
+	chanBNonces, err := chanB.GenMusigNonces()
+	if err != nil {
+		return err
+	}
+
+	if err := chanA.InitRemoteMusigNonces(chanBNonces); err != nil {
+		return err
+	}
+	if err := chanB.InitRemoteMusigNonces(chanANonces); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // initRevocationWindows simulates a new channel being opened within the p2p
 // network by populating the initial revocation windows of the passed
 // commitment state machines.
@@ -443,19 +465,7 @@ func initRevocationWindows(chanA, chanB *LightningChannel) error {
 	// either FundingLocked or ChannelReestablish by calling
 	// InitRemoteMusigNonces for both sides.
 	if chanA.channelState.ChanType.IsTaproot() {
-		chanANonces, err := chanA.GenMusigNonces()
-		if err != nil {
-			return err
-		}
-		chanBNonces, err := chanB.GenMusigNonces()
-		if err != nil {
-			return err
-		}
-
-		if err := chanA.InitRemoteMusigNonces(chanBNonces); err != nil {
-			return err
-		}
-		if err := chanB.InitRemoteMusigNonces(chanANonces); err != nil {
+		if err := initMusigNonce(chanA, chanB); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
In this PR, we fix an existing bug with the taproot channel type
that can cause force closes if a peer disconnects while attempting to
send the commitment signature.

Before this commit, since the `PartialSig` we send is never committed to
disk, the version read wouldn't contain the musig2 partial sig. We never
write these signatures to disk, as each time we make a new session, we
need to generate fresh nonces to avoid nonce-reuse.

Due to the above interaction, if we went to re-send a signature after a
disconnection, the `CommitSig` message we sent wouldn't actually contain
a `PartialSigWithNonce`, causing a protocol error.