### PR TITLE
commands: update interactive input in create command description

### DIFF
--- a/cmd/commands/cmd_walletunlocker.go
+++ b/cmd/commands/cmd_walletunlocker.go
@@ -34,17 +34,16 @@ var createCommand = cli.Command{
 	Usage:    "Initialize a wallet when starting lnd for the first time.",
 	Description: `
 	The create command is used to initialize an lnd wallet from scratch for
-	the very first time. This is interactive command with one required
-	argument (the password), and one optional argument (the mnemonic
-	passphrase).
+	the very first time. This is an interactive command with one required
+	input (the password), and one optional input (the mnemonic passphrase).
 
-	The first argument (the password) is required and MUST be greater than
-	8 characters. This will be used to encrypt the wallet within lnd. This
+	The first input (the password) is required and MUST be greater than 8
+	characters. This will be used to encrypt the wallet within lnd. This
 	MUST be remembered as it will be required to fully start up the daemon.
 
-	The second argument is an optional 24-word mnemonic derived from BIP
-	39. If provided, then the internal wallet will use the seed derived
-	from this mnemonic to generate all keys.
+	The second input is an optional 24-word mnemonic derived from BIP 39.
+	If provided, then the internal wallet will use the seed derived from
+	this mnemonic to generate all keys.
 
 	This command returns a 24-word seed in the scenario that NO mnemonic
 	was provided by the user. This should be written down as it can be used

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -55,7 +55,12 @@
 
 ## Tooling and Documentation
 
+* [Improved `lncli create` command help text](https://github.com/lightningnetwork/lnd/pull/9077)
+  by replacing the word `argument` with `input` in the command description,
+  clarifying that the command requires interactive inputs rather than arguments.
+
 # Contributors (Alphabetical Order)
 
+* CharlieZKSmith
 * Pins
 * Ziggie


### PR DESCRIPTION
## Change Description
Update interactive input in create command description. Fixes #8897.

## Steps to Test
Run lnd and bitcoin backend, check the create command help text description by the command "lncli create --help".

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [Y] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [Y] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [Y] Any new logging statements use an appropriate subsystem and logging level.
- [Y] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [Y] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
