### PR TITLE
Makefile: add `-test.v` for `make itest`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ endif
 itest-only: db-instance
 	@$(call print, "Running integration tests with ${backend} backend.")
 	rm -rf itest/*.log itest/.logs-*; date
-	EXEC_SUFFIX=$(EXEC_SUFFIX) scripts/itest_part.sh 0 1 $(TEST_FLAGS) $(ITEST_FLAGS)
+	EXEC_SUFFIX=$(EXEC_SUFFIX) scripts/itest_part.sh 0 1 $(TEST_FLAGS) $(ITEST_FLAGS) -test.v
 	$(COLLECT_ITEST_COVERAGE)
 
 #? itest: Build and run integration tests


### PR DESCRIPTION
Just realized #9028 doesn't show the debug log if running through `make itest icase=xxx`.