### PR TITLE
log: structured logging

### DIFF
--- a/autopilot/log.go
+++ b/autopilot/log.go
@@ -1,7 +1,7 @@
 package autopilot
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/build/config.go
+++ b/build/config.go
@@ -1,0 +1,38 @@
+package build
+
+import "github.com/btcsuite/btclog/v2"
+
+// LogConfig holds logging configuration options.
+//
+//nolint:lll
+type LogConfig struct {
+	Console *LoggerConfig `group:"console" namespace:"console" description:"The logger writing to stdout and stderr."`
+	File    *LoggerConfig `group:"file" namespace:"file" description:"The logger writing to LND's standard log file."`
+}
+
+// DefaultLogConfig returns the default logging config options.
+func DefaultLogConfig() *LogConfig {
+	return &LogConfig{
+		Console: &LoggerConfig{},
+		File:    &LoggerConfig{},
+	}
+}
+
+// LoggerConfig holds options for a particular logger.
+//
+//nolint:lll
+type LoggerConfig struct {
+	Disable      bool `long:"disable" description:"Disable this logger."`
+	NoTimestamps bool `long:"no-timestamps" description:"Omit timestamps from log lines."`
+}
+
+// HandlerOptions returns the set of btclog.HandlerOptions that the state of the
+// config struct translates to.
+func (cfg *LoggerConfig) HandlerOptions() []btclog.HandlerOption {
+	var opts []btclog.HandlerOption
+	if cfg.NoTimestamps {
+		opts = append(opts, btclog.WithNoTimestamp())
+	}
+
+	return opts
+}

--- a/build/config.go
+++ b/build/config.go
@@ -1,3 +1,6 @@
+//go:build !dev
+// +build !dev
+
 package build
 
 import "github.com/btcsuite/btclog/v2"

--- a/build/config_dev.go
+++ b/build/config_dev.go
@@ -1,0 +1,137 @@
+//go:build dev
+// +build dev
+
+package build
+
+import (
+	"fmt"
+	"strings"
+
+	btclogv1 "github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
+)
+
+const (
+	resetSeq = "0"
+	boldSeq  = "1"
+	faintSeq = "2"
+	esc      = '\x1b'
+	csi      = string(esc) + "["
+)
+
+// LogConfig holds logging configuration options.
+//
+//nolint:lll
+type LogConfig struct {
+	Console *consoleLoggerCfg `group:"console" namespace:"console" description:"The logger writing to stdout and stderr."`
+	File    *LoggerConfig     `group:"file" namespace:"file" description:"The logger writing to LND's standard log file."`
+}
+
+// LoggerConfig holds options for a particular logger.
+//
+//nolint:lll
+type LoggerConfig struct {
+	Disable      bool `long:"disable" description:"Disable this logger."`
+	NoTimestamps bool `long:"no-timestamps" description:"Omit timestamps from log lines."`
+}
+
+// HandlerOptions returns the set of btclog.HandlerOptions that the state of the
+// config struct translates to.
+func (cfg *LoggerConfig) HandlerOptions() []btclog.HandlerOption {
+	var opts []btclog.HandlerOption
+	if cfg.NoTimestamps {
+		opts = append(opts, btclog.WithNoTimestamp())
+	}
+
+	return opts
+}
+
+// consoleLoggerCfg extends the LoggerConfig struct by adding a Color option
+// which is only available for a console logger.
+//
+//nolint:lll
+type consoleLoggerCfg struct {
+	LoggerConfig
+	Style bool `long:"style" description:"If set, the output will be styled with color and fonts"`
+}
+
+// HandlerOptions returns the set of btclog.HandlerOptions that the state of the
+// config struct translates to.
+func (cfg *consoleLoggerCfg) HandlerOptions() []btclog.HandlerOption {
+	opts := cfg.LoggerConfig.HandlerOptions()
+
+	if !cfg.Style {
+		return opts
+	}
+
+	return append(
+		opts, btclog.WithStyledLevel(
+			func(l btclogv1.Level) string {
+				return styleString(
+					fmt.Sprintf("[%s]", l),
+					boldSeq,
+					string(ansiColoSeq(l)),
+				)
+			},
+		),
+		btclog.WithStyledCallSite(
+			func(file string, line int) string {
+				str := fmt.Sprintf("%s:%d", file, line)
+
+				return styleString(str, faintSeq)
+			},
+		),
+		btclog.WithStyledKeys(func(key string) string {
+			return styleString(key, faintSeq)
+		}),
+	)
+}
+
+// DefaultLogConfig returns the default logging config options.
+func DefaultLogConfig() *LogConfig {
+	return &LogConfig{
+		Console: &consoleLoggerCfg{},
+		File:    &LoggerConfig{},
+	}
+}
+
+func styleString(s string, styles ...string) string {
+	if len(styles) == 0 {
+		return s
+	}
+
+	seq := strings.Join(styles, ";")
+	if seq == "" {
+		return s
+	}
+
+	return fmt.Sprintf("%s%sm%s%sm", csi, seq, s, csi+resetSeq)
+}
+
+type ansiColorSeq string
+
+const (
+	ansiColorSeqDarkTeal  ansiColorSeq = "38;5;30"
+	ansiColorSeqDarkBlue  ansiColorSeq = "38;5;63"
+	ansiColorSeqLightBlue ansiColorSeq = "38;5;86"
+	ansiColorSeqYellow    ansiColorSeq = "38;5;192"
+	ansiColorSeqRed       ansiColorSeq = "38;5;204"
+	ansiColorSeqPink      ansiColorSeq = "38;5;134"
+)
+
+func ansiColoSeq(l btclogv1.Level) ansiColorSeq {
+	switch l {
+	case btclog.LevelTrace:
+		return ansiColorSeqDarkTeal
+	case btclog.LevelDebug:
+		return ansiColorSeqDarkBlue
+	case btclog.LevelWarn:
+		return ansiColorSeqYellow
+	case btclog.LevelError:
+		return ansiColorSeqRed
+	case btclog.LevelCritical:
+		return ansiColorSeqPink
+	default:
+		return ansiColorSeqLightBlue
+	}
+}

--- a/build/config_dev.go
+++ b/build/config_dev.go
@@ -17,6 +17,10 @@ const (
 	faintSeq = "2"
 	esc      = '\x1b'
 	csi      = string(esc) + "["
+
+	callSiteOff   = "off"
+	callSiteShort = "short"
+	callSiteLong  = "long"
 )
 
 // LogConfig holds logging configuration options.
@@ -27,20 +31,49 @@ type LogConfig struct {
 	File    *LoggerConfig     `group:"file" namespace:"file" description:"The logger writing to LND's standard log file."`
 }
 
+// DefaultLogConfig returns the default logging config options.
+func DefaultLogConfig() *LogConfig {
+	return &LogConfig{
+		Console: &consoleLoggerCfg{
+			LoggerConfig: LoggerConfig{
+				CallSite: callSiteShort,
+			},
+		},
+		File: &LoggerConfig{
+			CallSite: callSiteOff,
+		},
+	}
+}
+
 // LoggerConfig holds options for a particular logger.
 //
 //nolint:lll
 type LoggerConfig struct {
-	Disable      bool `long:"disable" description:"Disable this logger."`
-	NoTimestamps bool `long:"no-timestamps" description:"Omit timestamps from log lines."`
+	Disable      bool   `long:"disable" description:"Disable this logger."`
+	NoTimestamps bool   `long:"no-timestamps" description:"Omit timestamps from log lines."`
+	CallSite     string `long:"call-site" description:"Include the call-site of each log line." choice:"off" choice:"short" choice:"long"`
 }
 
 // HandlerOptions returns the set of btclog.HandlerOptions that the state of the
 // config struct translates to.
 func (cfg *LoggerConfig) HandlerOptions() []btclog.HandlerOption {
-	var opts []btclog.HandlerOption
+	opts := []btclog.HandlerOption{
+		// The default skip depth used by the logging library is 6 but
+		// since we wrap the logging handlers with another level of
+		// abstraction with the handlerSet, we increase the skip depth
+		// to 7 here.
+		btclog.WithCallSiteSkipDepth(7),
+	}
+
 	if cfg.NoTimestamps {
 		opts = append(opts, btclog.WithNoTimestamp())
+	}
+
+	switch cfg.CallSite {
+	case callSiteShort:
+		opts = append(opts, btclog.WithCallerFlags(btclog.Lshortfile))
+	case callSiteLong:
+		opts = append(opts, btclog.WithCallerFlags(btclog.Llongfile))
 	}
 
 	return opts
@@ -85,14 +118,6 @@ func (cfg *consoleLoggerCfg) HandlerOptions() []btclog.HandlerOption {
 			return styleString(key, faintSeq)
 		}),
 	)
-}
-
-// DefaultLogConfig returns the default logging config options.
-func DefaultLogConfig() *LogConfig {
-	return &LogConfig{
-		Console: &consoleLoggerCfg{},
-		File:    &LoggerConfig{},
-	}
 }
 
 func styleString(s string, styles ...string) string {

--- a/build/handler_sets.go
+++ b/build/handler_sets.go
@@ -175,3 +175,27 @@ func (r *reducedSet) WithGroup(name string) slog.Handler {
 
 // A compile-time check to ensure that handlerSet implements slog.Handler.
 var _ slog.Handler = (*reducedSet)(nil)
+
+// subLogGenerator implements the SubLogCreator backed by a Handler.
+type subLogGenerator struct {
+	handler btclog.Handler
+}
+
+// newSubLogGenerator constructs a new subLogGenerator from a Handler.
+func newSubLogGenerator(handler btclog.Handler) *subLogGenerator {
+	return &subLogGenerator{
+		handler: handler,
+	}
+}
+
+// Logger returns a new logger for a particular sub-system.
+//
+// NOTE: this is part of the SubLogCreator interface.
+func (b *subLogGenerator) Logger(subsystemTag string) btclog.Logger {
+	handler := b.handler.SubSystem(subsystemTag)
+
+	return btclog.NewSLogger(handler)
+}
+
+// A compile-time check to ensure that handlerSet implements slog.Handler.
+var _ SubLogCreator = (*subLogGenerator)(nil)

--- a/build/handler_sets.go
+++ b/build/handler_sets.go
@@ -1,0 +1,177 @@
+package build
+
+import (
+	"context"
+	"log/slog"
+
+	btclogv1 "github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
+)
+
+// handlerSet is an implementation of Handler that abstracts away multiple
+// Handlers.
+type handlerSet struct {
+	level btclogv1.Level
+	set   []btclog.Handler
+}
+
+// newHandlerSet constructs a new HandlerSet.
+func newHandlerSet(level btclogv1.Level, set ...btclog.Handler) *handlerSet {
+	h := &handlerSet{
+		set:   set,
+		level: level,
+	}
+	h.SetLevel(level)
+
+	return h
+}
+
+// Enabled reports whether the handler handles records at the given level.
+//
+// NOTE: this is part of the slog.Handler interface.
+func (h *handlerSet) Enabled(ctx context.Context, level slog.Level) bool {
+	for _, handler := range h.set {
+		if !handler.Enabled(ctx, level) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Handle handles the Record.
+//
+// NOTE: this is part of the slog.Handler interface.
+func (h *handlerSet) Handle(ctx context.Context, record slog.Record) error {
+	for _, handler := range h.set {
+		if err := handler.Handle(ctx, record); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// WithAttrs returns a new Handler whose attributes consist of both the
+// receiver's attributes and the arguments.
+//
+// NOTE: this is part of the slog.Handler interface.
+func (h *handlerSet) WithAttrs(attrs []slog.Attr) slog.Handler {
+	newSet := &reducedSet{set: make([]slog.Handler, len(h.set))}
+	for i, handler := range h.set {
+		newSet.set[i] = handler.WithAttrs(attrs)
+	}
+
+	return newSet
+}
+
+// WithGroup returns a new Handler with the given group appended to the
+// receiver's existing groups.
+//
+// NOTE: this is part of the slog.Handler interface.
+func (h *handlerSet) WithGroup(name string) slog.Handler {
+	newSet := &reducedSet{set: make([]slog.Handler, len(h.set))}
+	for i, handler := range h.set {
+		newSet.set[i] = handler.WithGroup(name)
+	}
+
+	return newSet
+}
+
+// SubSystem creates a new Handler with the given sub-system tag.
+//
+// NOTE: this is part of the Handler interface.
+func (h *handlerSet) SubSystem(tag string) btclog.Handler {
+	newSet := &handlerSet{set: make([]btclog.Handler, len(h.set))}
+	for i, handler := range h.set {
+		newSet.set[i] = handler.SubSystem(tag)
+	}
+
+	return newSet
+}
+
+// SetLevel changes the logging level of the Handler to the passed
+// level.
+//
+// NOTE: this is part of the btclog.Handler interface.
+func (h *handlerSet) SetLevel(level btclogv1.Level) {
+	for _, handler := range h.set {
+		handler.SetLevel(level)
+	}
+	h.level = level
+}
+
+// Level returns the current logging level of the Handler.
+//
+// NOTE: this is part of the btclog.Handler interface.
+func (h *handlerSet) Level() btclogv1.Level {
+	return h.level
+}
+
+// A compile-time check to ensure that handlerSet implements btclog.Handler.
+var _ btclog.Handler = (*handlerSet)(nil)
+
+// reducedSet is an implementation of the slog.Handler interface which is
+// itself backed by multiple slog.Handlers. This is used by the handlerSet
+// WithGroup and WithAttrs methods so that we can apply the WithGroup and
+// WithAttrs to the underlying handlers in the set. These calls, however,
+// produce slog.Handlers and not btclog.Handlers. So the reducedSet represents
+// the resulting set produced.
+type reducedSet struct {
+	set []slog.Handler
+}
+
+// Enabled reports whether the handler handles records at the given level.
+//
+// NOTE: this is part of the slog.Handler interface.
+func (r *reducedSet) Enabled(ctx context.Context, level slog.Level) bool {
+	for _, handler := range r.set {
+		if !handler.Enabled(ctx, level) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Handle handles the Record.
+//
+// NOTE: this is part of the slog.Handler interface.
+func (r *reducedSet) Handle(ctx context.Context, record slog.Record) error {
+	for _, handler := range r.set {
+		if err := handler.Handle(ctx, record); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// WithAttrs returns a new Handler whose attributes consist of both the
+// receiver's attributes and the arguments.
+//
+// NOTE: this is part of the slog.Handler interface.
+func (r *reducedSet) WithAttrs(attrs []slog.Attr) slog.Handler {
+	newSet := &reducedSet{set: make([]slog.Handler, len(r.set))}
+	for i, handler := range r.set {
+		newSet.set[i] = handler.WithAttrs(attrs)
+	}
+
+	return newSet
+}
+
+// WithGroup returns a new Handler with the given group appended to the
+// receiver's existing groups.
+//
+// NOTE: this is part of the slog.Handler interface.
+func (r *reducedSet) WithGroup(name string) slog.Handler {
+	newSet := &reducedSet{set: make([]slog.Handler, len(r.set))}
+	for i, handler := range r.set {
+		newSet.set[i] = handler.WithGroup(name)
+	}
+
+	return newSet
+}
+
+// A compile-time check to ensure that handlerSet implements slog.Handler.
+var _ slog.Handler = (*reducedSet)(nil)

--- a/build/handlers.go
+++ b/build/handlers.go
@@ -1,0 +1,23 @@
+package build
+
+import (
+	"os"
+
+	"github.com/btcsuite/btclog/v2"
+)
+
+// NewDefaultLogHandlers returns the standard console logger and rotating log
+// writer handlers that we generally want to use. It also applies the various
+// config options to the loggers.
+func NewDefaultLogHandlers(cfg *LogConfig, rotator *RotatingLogWriter) (
+	btclog.Handler, btclog.Handler) {
+
+	consoleLogHandler := btclog.NewDefaultHandler(
+		os.Stdout, cfg.Console.HandlerOptions()...,
+	)
+	logFileHandler := btclog.NewDefaultHandler(
+		rotator, cfg.File.HandlerOptions()...,
+	)
+
+	return consoleLogHandler, logFileHandler
+}

--- a/build/log.go
+++ b/build/log.go
@@ -1,9 +1,7 @@
 package build
 
 import (
-	"fmt"
 	"io"
-	"strings"
 
 	"github.com/btcsuite/btclog"
 )
@@ -120,115 +118,4 @@ func NewSubLogger(subsystem string,
 
 	// For any other configurations, we'll disable logging.
 	return btclog.Disabled
-}
-
-// SubLoggers is a type that holds a map of subsystem loggers keyed by their
-// subsystem name.
-type SubLoggers map[string]btclog.Logger
-
-// LeveledSubLogger provides the ability to retrieve the subsystem loggers of
-// a logger and set their log levels individually or all at once.
-type LeveledSubLogger interface {
-	// SubLoggers returns the map of all registered subsystem loggers.
-	SubLoggers() SubLoggers
-
-	// SupportedSubsystems returns a slice of strings containing the names
-	// of the supported subsystems. Should ideally correspond to the keys
-	// of the subsystem logger map and be sorted.
-	SupportedSubsystems() []string
-
-	// SetLogLevel assigns an individual subsystem logger a new log level.
-	SetLogLevel(subsystemID string, logLevel string)
-
-	// SetLogLevels assigns all subsystem loggers the same new log level.
-	SetLogLevels(logLevel string)
-}
-
-// ParseAndSetDebugLevels attempts to parse the specified debug level and set
-// the levels accordingly on the given logger. An appropriate error is returned
-// if anything is invalid.
-func ParseAndSetDebugLevels(level string, logger LeveledSubLogger) error {
-	// Split at the delimiter.
-	levels := strings.Split(level, ",")
-	if len(levels) == 0 {
-		return fmt.Errorf("invalid log level: %v", level)
-	}
-
-	// If the first entry has no =, treat is as the log level for all
-	// subsystems.
-	globalLevel := levels[0]
-	if !strings.Contains(globalLevel, "=") {
-		// Validate debug log level.
-		if !validLogLevel(globalLevel) {
-			str := "the specified debug level [%v] is invalid"
-			return fmt.Errorf(str, globalLevel)
-		}
-
-		// Change the logging level for all subsystems.
-		logger.SetLogLevels(globalLevel)
-
-		// The rest will target specific subsystems.
-		levels = levels[1:]
-	}
-
-	// Go through the subsystem/level pairs while detecting issues and
-	// update the log levels accordingly.
-	for _, logLevelPair := range levels {
-		if !strings.Contains(logLevelPair, "=") {
-			str := "the specified debug level contains an " +
-				"invalid subsystem/level pair [%v]"
-			return fmt.Errorf(str, logLevelPair)
-		}
-
-		// Extract the specified subsystem and log level.
-		fields := strings.Split(logLevelPair, "=")
-		if len(fields) != 2 {
-			str := "the specified debug level has an invalid " +
-				"format [%v] -- use format subsystem1=level1," +
-				"subsystem2=level2"
-			return fmt.Errorf(str, logLevelPair)
-		}
-		subsysID, logLevel := fields[0], fields[1]
-		subLoggers := logger.SubLoggers()
-
-		// Validate subsystem.
-		if _, exists := subLoggers[subsysID]; !exists {
-			str := "the specified subsystem [%v] is invalid -- " +
-				"supported subsystems are %v"
-			return fmt.Errorf(
-				str, subsysID, logger.SupportedSubsystems(),
-			)
-		}
-
-		// Validate log level.
-		if !validLogLevel(logLevel) {
-			str := "the specified debug level [%v] is invalid"
-			return fmt.Errorf(str, logLevel)
-		}
-
-		logger.SetLogLevel(subsysID, logLevel)
-	}
-
-	return nil
-}
-
-// validLogLevel returns whether or not logLevel is a valid debug log level.
-func validLogLevel(logLevel string) bool {
-	switch logLevel {
-	case "trace":
-		fallthrough
-	case "debug":
-		fallthrough
-	case "info":
-		fallthrough
-	case "warn":
-		fallthrough
-	case "error":
-		fallthrough
-	case "critical":
-		fallthrough
-	case "off":
-		return true
-	}
-	return false
 }

--- a/build/log_default.go
+++ b/build/log_default.go
@@ -3,17 +3,6 @@
 
 package build
 
-import "os"
-
 // LoggingType is a log type that writes to both stdout and the log rotator, if
 // present.
 const LoggingType = LogTypeDefault
-
-// Write writes the byte slice to both stdout and the log rotator, if present.
-func (w *LogWriter) Write(b []byte) (int, error) {
-	os.Stdout.Write(b)
-	if w.RotatorPipe != nil {
-		w.RotatorPipe.Write(b)
-	}
-	return len(b), nil
-}

--- a/build/log_nolog.go
+++ b/build/log_nolog.go
@@ -5,8 +5,3 @@ package build
 
 // LoggingType is a log type that writes no logs.
 const LoggingType = LogTypeNone
-
-// Write is a noop.
-func (w *LogWriter) Write(b []byte) (int, error) {
-	return len(b), nil
-}

--- a/build/log_shutdown.go
+++ b/build/log_shutdown.go
@@ -1,6 +1,8 @@
 package build
 
 import (
+	"context"
+
 	"github.com/btcsuite/btclog/v2"
 )
 
@@ -38,6 +40,19 @@ func (s *ShutdownLogger) Criticalf(format string, params ...interface{}) {
 // Note: it is part of the btclog.Logger interface.
 func (s *ShutdownLogger) Critical(v ...interface{}) {
 	s.Logger.Critical(v)
+	s.Logger.Info("Sending request for shutdown")
+	s.shutdown()
+}
+
+// CriticalS writes a structured log with the given message and key-value pair
+// attributes with LevelCritical to the log. It will then call the shutdown
+// logger's shutdown function to prompt safe shutdown.
+//
+// Note: it is part of the btclog.Logger interface.
+func (s *ShutdownLogger) CriticalS(ctx context.Context, msg string, err error,
+	attr ...interface{}) {
+
+	s.Logger.CriticalS(ctx, msg, err, attr...)
 	s.Logger.Info("Sending request for shutdown")
 	s.shutdown()
 }

--- a/build/log_shutdown.go
+++ b/build/log_shutdown.go
@@ -1,7 +1,7 @@
 package build
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // ShutdownLogger wraps an existing logger with a shutdown function which will

--- a/build/log_stdlog.go
+++ b/build/log_stdlog.go
@@ -3,13 +3,5 @@
 
 package build
 
-import "os"
-
 // LoggingType is a log type that only writes to stdout.
 const LoggingType = LogTypeStdOut
-
-// Write writes the provided byte slice to stdout.
-func (w *LogWriter) Write(b []byte) (int, error) {
-	os.Stdout.Write(b)
-	return len(b), nil
-}

--- a/build/log_test.go
+++ b/build/log_test.go
@@ -3,7 +3,7 @@ package build_test
 import (
 	"testing"
 
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/stretchr/testify/require"
 )

--- a/build/logrotator.go
+++ b/build/logrotator.go
@@ -6,9 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
 
-	"github.com/btcsuite/btclog"
 	"github.com/jrick/logrotate/rotator"
 	"github.com/klauspost/compress/zstd"
 )
@@ -18,43 +16,15 @@ import (
 type RotatingLogWriter struct {
 	logWriter *LogWriter
 
-	backendLog *btclog.Backend
-
-	logRotator *rotator.Rotator
-
-	subsystemLoggers SubLoggers
+	rotator *rotator.Rotator
 }
-
-// A compile time check to ensure RotatingLogWriter implements the
-// LeveledSubLogger interface.
-var _ LeveledSubLogger = (*RotatingLogWriter)(nil)
 
 // NewRotatingLogWriter creates a new file rotating log writer.
 //
 // NOTE: `InitLogRotator` must be called to set up log rotation after creating
 // the writer.
-func NewRotatingLogWriter() *RotatingLogWriter {
-	logWriter := &LogWriter{}
-	backendLog := btclog.NewBackend(logWriter)
-	return &RotatingLogWriter{
-		logWriter:        logWriter,
-		backendLog:       backendLog,
-		subsystemLoggers: SubLoggers{},
-	}
-}
-
-// GenSubLogger creates a new sublogger. A shutdown callback function
-// is provided to be able to shutdown in case of a critical error.
-func (r *RotatingLogWriter) GenSubLogger(tag string, shutdown func()) btclog.Logger {
-	logger := r.backendLog.Logger(tag)
-	return NewShutdownLogger(logger, shutdown)
-}
-
-// RegisterSubLogger registers a new subsystem logger.
-func (r *RotatingLogWriter) RegisterSubLogger(subsystem string,
-	logger btclog.Logger) {
-
-	r.subsystemLoggers[subsystem] = logger
+func NewRotatingLogWriter(w *LogWriter) *RotatingLogWriter {
+	return &RotatingLogWriter{logWriter: w}
 }
 
 // InitLogRotator initializes the log file rotator to write logs to logFile and
@@ -68,7 +38,8 @@ func (r *RotatingLogWriter) InitLogRotator(logFile, logCompressor string,
 	if err != nil {
 		return fmt.Errorf("failed to create log directory: %w", err)
 	}
-	r.logRotator, err = rotator.New(
+
+	r.rotator, err = rotator.New(
 		logFile, int64(maxLogFileSize*1024), false, maxLogFiles,
 	)
 	if err != nil {
@@ -94,7 +65,7 @@ func (r *RotatingLogWriter) InitLogRotator(logFile, logCompressor string,
 	}
 
 	// Apply the compressor and its file suffix to the log rotator.
-	r.logRotator.SetCompressor(c, logCompressors[logCompressor])
+	r.rotator.SetCompressor(c, logCompressors[logCompressor])
 
 	// Run rotator as a goroutine now but make sure we catch any errors
 	// that happen in case something with the rotation goes wrong during
@@ -102,7 +73,7 @@ func (r *RotatingLogWriter) InitLogRotator(logFile, logCompressor string,
 	// create a new logfile for whatever reason).
 	pr, pw := io.Pipe()
 	go func() {
-		err := r.logRotator.Run(pr)
+		err := r.rotator.Run(pr)
 		if err != nil {
 			_, _ = fmt.Fprintf(os.Stderr,
 				"failed to run file rotator: %v\n", err)
@@ -110,67 +81,15 @@ func (r *RotatingLogWriter) InitLogRotator(logFile, logCompressor string,
 	}()
 
 	r.logWriter.RotatorPipe = pw
+
 	return nil
 }
 
 // Close closes the underlying log rotator if it has already been created.
 func (r *RotatingLogWriter) Close() error {
-	if r.logRotator != nil {
-		return r.logRotator.Close()
+	if r.rotator != nil {
+		return r.rotator.Close()
 	}
+
 	return nil
-}
-
-// SubLoggers returns all currently registered subsystem loggers for this log
-// writer.
-//
-// NOTE: This is part of the LeveledSubLogger interface.
-func (r *RotatingLogWriter) SubLoggers() SubLoggers {
-	return r.subsystemLoggers
-}
-
-// SupportedSubsystems returns a sorted string slice of all keys in the
-// subsystems map, corresponding to the names of the subsystems.
-//
-// NOTE: This is part of the LeveledSubLogger interface.
-func (r *RotatingLogWriter) SupportedSubsystems() []string {
-	// Convert the subsystemLoggers map keys to a string slice.
-	subsystems := make([]string, 0, len(r.subsystemLoggers))
-	for subsysID := range r.subsystemLoggers {
-		subsystems = append(subsystems, subsysID)
-	}
-
-	// Sort the subsystems for stable display.
-	sort.Strings(subsystems)
-	return subsystems
-}
-
-// SetLogLevel sets the logging level for provided subsystem. Invalid
-// subsystems are ignored. Uninitialized subsystems are dynamically created as
-// needed.
-//
-// NOTE: This is part of the LeveledSubLogger interface.
-func (r *RotatingLogWriter) SetLogLevel(subsystemID string, logLevel string) {
-	// Ignore invalid subsystems.
-	logger, ok := r.subsystemLoggers[subsystemID]
-	if !ok {
-		return
-	}
-
-	// Defaults to info if the log level is invalid.
-	level, _ := btclog.LevelFromString(logLevel)
-	logger.SetLevel(level)
-}
-
-// SetLogLevels sets the log level for all subsystem loggers to the passed
-// level. It also dynamically creates the subsystem loggers as needed, so it
-// can be used to initialize the logging system.
-//
-// NOTE: This is part of the LeveledSubLogger interface.
-func (r *RotatingLogWriter) SetLogLevels(logLevel string) {
-	// Configure all sub-systems with the new logging level. Dynamically
-	// create loggers as needed.
-	for subsystemID := range r.subsystemLoggers {
-		r.SetLogLevel(subsystemID, logLevel)
-	}
 }

--- a/build/prefix_log.go
+++ b/build/prefix_log.go
@@ -1,18 +1,25 @@
 package build
 
-import "github.com/btcsuite/btclog"
+import (
+	"context"
+
+	btclogv1 "github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
+)
 
 // PrefixLog is a pass-through logger that adds a prefix to every logged line.
 type PrefixLog struct {
 	log    btclog.Logger
 	prefix string
+	attr   []any
 }
 
 // NewPrefixLog instantiates a new prefixed logger.
-func NewPrefixLog(prefix string, log btclog.Logger) *PrefixLog {
+func NewPrefixLog(prefix string, log btclog.Logger, attrs ...any) *PrefixLog {
 	return &PrefixLog{
-		prefix: prefix,
 		log:    log,
+		prefix: prefix,
+		attr:   attrs,
 	}
 }
 
@@ -22,8 +29,14 @@ func (p *PrefixLog) addFormatPrefix(s string) string {
 }
 
 // addArgsPrefix prepends the prefix to a list of arguments.
-func (p *PrefixLog) addArgsPrefix(args []interface{}) []interface{} {
+func (p *PrefixLog) addArgsPrefix(args []any) []any {
 	return append([]interface{}{p.prefix}, args...)
+}
+
+// mergeAttr merges the given set of attributes with any attributes that the
+// logger was initialised with.
+func (p *PrefixLog) mergeAttr(attrs []any) []any {
+	return append(append([]any{}, attrs...), p.attr...)
 }
 
 // Tracef formats message according to format specifier and writes to to log
@@ -98,13 +111,55 @@ func (p *PrefixLog) Critical(v ...interface{}) {
 	p.log.Critical(p.addArgsPrefix(v)...)
 }
 
+// TraceS writes a structured log with the given message and key-value pair
+// attributes with LevelTrace to the log.
+func (p *PrefixLog) TraceS(ctx context.Context, msg string, attrs ...any) {
+	p.log.TraceS(ctx, p.addFormatPrefix(msg), p.mergeAttr(attrs)...)
+}
+
+// DebugS writes a structured log with the given message and key-value pair
+// attributes with LevelDebug to the log.
+func (p *PrefixLog) DebugS(ctx context.Context, msg string, attrs ...any) {
+	p.log.DebugS(ctx, p.addFormatPrefix(msg), p.mergeAttr(attrs)...)
+}
+
+// InfoS writes a structured log with the given message and key-value pair
+// attributes with LevelInfo to the log.
+func (p *PrefixLog) InfoS(ctx context.Context, msg string, attrs ...any) {
+	p.log.InfoS(ctx, p.addFormatPrefix(msg), p.mergeAttr(attrs)...)
+}
+
+// WarnS writes a structured log with the given message and key-value pair
+// attributes with LevelWarn to the log.
+func (p *PrefixLog) WarnS(ctx context.Context, msg string, err error,
+	attrs ...any) {
+
+	p.log.WarnS(ctx, p.addFormatPrefix(msg), err, p.mergeAttr(attrs)...)
+}
+
+// ErrorS writes a structured log with the given message and key-value pair
+// attributes with LevelError to the log.
+func (p *PrefixLog) ErrorS(ctx context.Context, msg string, err error,
+	attrs ...any) {
+
+	p.log.ErrorS(ctx, p.addFormatPrefix(msg), err, p.mergeAttr(attrs)...)
+}
+
+// CriticalS writes a structured log with the given message and key-value pair
+// attributes with LevelCritical to the log.
+func (p *PrefixLog) CriticalS(ctx context.Context, msg string, err error,
+	attrs ...any) {
+
+	p.log.CriticalS(ctx, p.addFormatPrefix(msg), err, p.mergeAttr(attrs)...)
+}
+
 // Level returns the current logging level.
-func (p *PrefixLog) Level() btclog.Level {
+func (p *PrefixLog) Level() btclogv1.Level {
 	return p.log.Level()
 }
 
 // SetLevel changes the logging level to the passed level.
-func (p *PrefixLog) SetLevel(level btclog.Level) {
+func (p *PrefixLog) SetLevel(level btclogv1.Level) {
 	p.log.SetLevel(level)
 }
 

--- a/build/sub_logger.go
+++ b/build/sub_logger.go
@@ -2,12 +2,11 @@ package build
 
 import (
 	"fmt"
-	"io"
 	"sort"
 	"strings"
 	"sync"
 
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // SubLogCreator can be used to create a new logger for a particular subsystem.
@@ -30,10 +29,12 @@ type SubLoggerManager struct {
 var _ LeveledSubLogger = (*SubLoggerManager)(nil)
 
 // NewSubLoggerManager constructs a new SubLoggerManager.
-func NewSubLoggerManager(w io.Writer) *SubLoggerManager {
+func NewSubLoggerManager(handlers ...btclog.Handler) *SubLoggerManager {
 	return &SubLoggerManager{
-		loggers:   SubLoggers{},
-		genLogger: btclog.NewBackend(w),
+		loggers: make(SubLoggers),
+		genLogger: newSubLogGenerator(
+			newHandlerSet(btclog.LevelInfo, handlers...),
+		),
 	}
 }
 

--- a/build/sub_logger.go
+++ b/build/sub_logger.go
@@ -2,10 +2,148 @@ package build
 
 import (
 	"fmt"
+	"io"
+	"sort"
 	"strings"
+	"sync"
 
 	"github.com/btcsuite/btclog"
 )
+
+// SubLogCreator can be used to create a new logger for a particular subsystem.
+type SubLogCreator interface {
+	// Logger returns a new logger for a particular subsytem.
+	Logger(subsystemTag string) btclog.Logger
+}
+
+// SubLoggerManager manages a set of subsystem loggers. Level updates will be
+// applied to all the loggers managed by the manager.
+type SubLoggerManager struct {
+	genLogger SubLogCreator
+
+	loggers SubLoggers
+	mu      sync.Mutex
+}
+
+// A compile time check to ensure SubLoggerManager implements the
+// LeveledSubLogger interface.
+var _ LeveledSubLogger = (*SubLoggerManager)(nil)
+
+// NewSubLoggerManager constructs a new SubLoggerManager.
+func NewSubLoggerManager(w io.Writer) *SubLoggerManager {
+	return &SubLoggerManager{
+		loggers:   SubLoggers{},
+		genLogger: btclog.NewBackend(w),
+	}
+}
+
+// GenSubLogger creates a new sub-logger and adds it to the set managed by the
+// SubLoggerManager. A shutdown callback function is provided to be able to shut
+// down in case of a critical error.
+func (r *SubLoggerManager) GenSubLogger(subsystem string,
+	shutdown func()) btclog.Logger {
+
+	// Create a new logger with the given subsystem tag.
+	logger := r.genLogger.Logger(subsystem)
+
+	// Wrap the new logger in a Shutdown logger so that the shutdown
+	// call back is called if a critical log is ever written via this new
+	// logger.
+	l := NewShutdownLogger(logger, shutdown)
+
+	r.RegisterSubLogger(subsystem, l)
+
+	return l
+}
+
+// RegisterSubLogger registers the given logger under the given subsystem name.
+func (r *SubLoggerManager) RegisterSubLogger(subsystem string,
+	logger btclog.Logger) {
+
+	// Add the new logger to the set of loggers managed by the manager.
+	r.mu.Lock()
+	r.loggers[subsystem] = logger
+	r.mu.Unlock()
+}
+
+// SubLoggers returns all currently registered subsystem loggers for this log
+// writer.
+//
+// NOTE: This is part of the LeveledSubLogger interface.
+func (r *SubLoggerManager) SubLoggers() SubLoggers {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.loggers
+}
+
+// SupportedSubsystems returns a sorted string slice of all keys in the
+// subsystems map, corresponding to the names of the subsystems.
+//
+// NOTE: This is part of the LeveledSubLogger interface.
+func (r *SubLoggerManager) SupportedSubsystems() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Convert the subsystemLoggers map keys to a string slice.
+	subsystems := make([]string, 0, len(r.loggers))
+	for subsysID := range r.loggers {
+		subsystems = append(subsystems, subsysID)
+	}
+
+	// Sort the subsystems for stable display.
+	sort.Strings(subsystems)
+
+	return subsystems
+}
+
+// SetLogLevel sets the logging level for provided subsystem. Invalid
+// subsystems are ignored. Uninitialized subsystems are dynamically created as
+// needed.
+//
+// NOTE: This is part of the LeveledSubLogger interface.
+func (r *SubLoggerManager) SetLogLevel(subsystemID string, logLevel string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.setLogLevelUnsafe(subsystemID, logLevel)
+}
+
+// setLogLevelUnsafe sets the logging level for provided subsystem. Invalid
+// subsystems are ignored. Uninitialized subsystems are dynamically created as
+// needed.
+//
+// NOTE: the SubLoggerManager mutex must be held before calling this method.
+func (r *SubLoggerManager) setLogLevelUnsafe(subsystemID string,
+	logLevel string) {
+
+	// Ignore invalid subsystems.
+	logger, ok := r.loggers[subsystemID]
+	if !ok {
+		return
+	}
+
+	// Defaults to info if the log level is invalid.
+	level, _ := btclog.LevelFromString(logLevel)
+
+	logger.SetLevel(level)
+}
+
+// SetLogLevels sets the log level for all subsystem loggers to the passed
+// level. It also dynamically creates the subsystem loggers as needed, so it
+// can be used to initialize the logging system.
+//
+// NOTE: This is part of the LeveledSubLogger interface.
+func (r *SubLoggerManager) SetLogLevels(logLevel string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Configure all sub-systems with the new logging level. Dynamically
+	// create loggers as needed.
+	for subsystemID := range r.loggers {
+		r.setLogLevelUnsafe(subsystemID, logLevel)
+	}
+}
 
 // SubLoggers is a type that holds a map of subsystem loggers keyed by their
 // subsystem name.

--- a/build/sub_logger.go
+++ b/build/sub_logger.go
@@ -1,0 +1,124 @@
+package build
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/btcsuite/btclog"
+)
+
+// SubLoggers is a type that holds a map of subsystem loggers keyed by their
+// subsystem name.
+type SubLoggers map[string]btclog.Logger
+
+// LeveledSubLogger provides the ability to retrieve the subsystem loggers of
+// a logger and set their log levels individually or all at once.
+type LeveledSubLogger interface {
+	// SubLoggers returns the map of all registered subsystem loggers.
+	SubLoggers() SubLoggers
+
+	// SupportedSubsystems returns a slice of strings containing the names
+	// of the supported subsystems. Should ideally correspond to the keys
+	// of the subsystem logger map and be sorted.
+	SupportedSubsystems() []string
+
+	// SetLogLevel assigns an individual subsystem logger a new log level.
+	SetLogLevel(subsystemID string, logLevel string)
+
+	// SetLogLevels assigns all subsystem loggers the same new log level.
+	SetLogLevels(logLevel string)
+}
+
+// ParseAndSetDebugLevels attempts to parse the specified debug level and set
+// the levels accordingly on the given logger. An appropriate error is returned
+// if anything is invalid.
+func ParseAndSetDebugLevels(level string, logger LeveledSubLogger) error {
+	// Split at the delimiter.
+	levels := strings.Split(level, ",")
+	if len(levels) == 0 {
+		return fmt.Errorf("invalid log level: %v", level)
+	}
+
+	// If the first entry has no =, treat is as the log level for all
+	// subsystems.
+	globalLevel := levels[0]
+	if !strings.Contains(globalLevel, "=") {
+		// Validate debug log level.
+		if !validLogLevel(globalLevel) {
+			str := "the specified debug level [%v] is invalid"
+
+			return fmt.Errorf(str, globalLevel)
+		}
+
+		// Change the logging level for all subsystems.
+		logger.SetLogLevels(globalLevel)
+
+		// The rest will target specific subsystems.
+		levels = levels[1:]
+	}
+
+	// Go through the subsystem/level pairs while detecting issues and
+	// update the log levels accordingly.
+	for _, logLevelPair := range levels {
+		if !strings.Contains(logLevelPair, "=") {
+			str := "the specified debug level contains an " +
+				"invalid subsystem/level pair [%v]"
+
+			return fmt.Errorf(str, logLevelPair)
+		}
+
+		// Extract the specified subsystem and log level.
+		fields := strings.Split(logLevelPair, "=")
+		if len(fields) != 2 {
+			str := "the specified debug level has an invalid " +
+				"format [%v] -- use format subsystem1=level1," +
+				"subsystem2=level2"
+
+			return fmt.Errorf(str, logLevelPair)
+		}
+		subsysID, logLevel := fields[0], fields[1]
+		subLoggers := logger.SubLoggers()
+
+		// Validate subsystem.
+		if _, exists := subLoggers[subsysID]; !exists {
+			str := "the specified subsystem [%v] is invalid -- " +
+				"supported subsystems are %v"
+
+			return fmt.Errorf(
+				str, subsysID, logger.SupportedSubsystems(),
+			)
+		}
+
+		// Validate log level.
+		if !validLogLevel(logLevel) {
+			str := "the specified debug level [%v] is invalid"
+			return fmt.Errorf(str, logLevel)
+		}
+
+		logger.SetLogLevel(subsysID, logLevel)
+	}
+
+	return nil
+}
+
+// validLogLevel returns whether or not logLevel is a valid debug log level.
+func validLogLevel(logLevel string) bool {
+	switch logLevel {
+	case "trace":
+		fallthrough
+	case "debug":
+		fallthrough
+	case "info":
+		fallthrough
+	case "warn":
+		fallthrough
+	case "error":
+		fallthrough
+	case "critical":
+		fallthrough
+	case "off":
+		return true
+	}
+
+	return false
+}

--- a/chainntnfs/log.go
+++ b/chainntnfs/log.go
@@ -1,7 +1,7 @@
 package chainntnfs
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/chainreg/log.go
+++ b/chainreg/log.go
@@ -1,7 +1,7 @@
 package chainreg
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/chanacceptor/log.go
+++ b/chanacceptor/log.go
@@ -1,7 +1,7 @@
 package chanacceptor
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/chanbackup/log.go
+++ b/chanbackup/log.go
@@ -1,7 +1,7 @@
 package chanbackup
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/chanfitness/log.go
+++ b/chanfitness/log.go
@@ -1,7 +1,7 @@
 package chanfitness
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/channeldb/log.go
+++ b/channeldb/log.go
@@ -1,7 +1,7 @@
 package channeldb
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 	mig "github.com/lightningnetwork/lnd/channeldb/migration"
 	"github.com/lightningnetwork/lnd/channeldb/migration12"

--- a/channeldb/migration/log.go
+++ b/channeldb/migration/log.go
@@ -1,6 +1,6 @@
 package migration
 
-import "github.com/btcsuite/btclog"
+import "github.com/btcsuite/btclog/v2"
 
 // log is a logger that is initialized as disabled.  This means the package will
 // not perform any logging by default until a logger is set.

--- a/channeldb/migration12/log.go
+++ b/channeldb/migration12/log.go
@@ -1,7 +1,7 @@
 package migration12
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // log is a logger that is initialized as disabled.  This means the package will

--- a/channeldb/migration13/log.go
+++ b/channeldb/migration13/log.go
@@ -1,7 +1,7 @@
 package migration13
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // log is a logger that is initialized as disabled.  This means the package will

--- a/channeldb/migration16/log.go
+++ b/channeldb/migration16/log.go
@@ -1,7 +1,7 @@
 package migration16
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // log is a logger that is initialized as disabled.  This means the package will

--- a/channeldb/migration20/log.go
+++ b/channeldb/migration20/log.go
@@ -1,7 +1,7 @@
 package migration20
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // log is a logger that is initialized as disabled. This means the package

--- a/channeldb/migration24/log.go
+++ b/channeldb/migration24/log.go
@@ -1,7 +1,7 @@
 package migration24
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // log is a logger that is initialized as disabled.  This means the package will

--- a/channeldb/migration25/log.go
+++ b/channeldb/migration25/log.go
@@ -1,7 +1,7 @@
 package migration25
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // log is a logger that is initialized as disabled.  This means the package will

--- a/channeldb/migration26/log.go
+++ b/channeldb/migration26/log.go
@@ -1,7 +1,7 @@
 package migration26
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // log is a logger that is initialized as disabled.  This means the package will

--- a/channeldb/migration27/log.go
+++ b/channeldb/migration27/log.go
@@ -1,7 +1,7 @@
 package migration27
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // log is a logger that is initialized as disabled.  This means the package will

--- a/channeldb/migration29/log.go
+++ b/channeldb/migration29/log.go
@@ -1,6 +1,6 @@
 package migration29
 
-import "github.com/btcsuite/btclog"
+import "github.com/btcsuite/btclog/v2"
 
 // log is a logger that is initialized as disabled. This means the package will
 // not perform any logging by default until a logger is set.

--- a/channeldb/migration30/log.go
+++ b/channeldb/migration30/log.go
@@ -1,7 +1,7 @@
 package migration30
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // log is a logger that is initialized as disabled.  This means the package will

--- a/channeldb/migration31/log.go
+++ b/channeldb/migration31/log.go
@@ -1,7 +1,7 @@
 package migration31
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // log is a logger that is initialized as disabled.  This means the package will

--- a/channeldb/migration32/log.go
+++ b/channeldb/migration32/log.go
@@ -1,7 +1,7 @@
 package migration32
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // log is a logger that is initialized as disabled.  This means the package will

--- a/channeldb/migration33/log.go
+++ b/channeldb/migration33/log.go
@@ -1,7 +1,7 @@
 package migration33
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // log is a logger that is initialized as disabled.  This means the package will

--- a/channeldb/migration_01_to_11/log.go
+++ b/channeldb/migration_01_to_11/log.go
@@ -1,7 +1,7 @@
 package migration_01_to_11
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // log is a logger that is initialized as disabled.  This means the package will

--- a/channelnotifier/log.go
+++ b/channelnotifier/log.go
@@ -1,7 +1,7 @@
 package channelnotifier
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/cluster/log.go
+++ b/cluster/log.go
@@ -1,7 +1,7 @@
 package cluster
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/config.go
+++ b/config.go
@@ -1404,15 +1404,13 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 		lncfg.NormalizeNetwork(cfg.ActiveNetParams.Name),
 	)
 
-	var logCfg = cfg.LogConfig
-	consoleLogHandler := btclog.NewDefaultHandler(
-		os.Stdout, logCfg.Console.HandlerOptions()...,
+	var (
+		logCfg                            = cfg.LogConfig
+		logHandlers                       []btclog.Handler
+		consoleLogHandler, logFileHandler = build.NewDefaultLogHandlers(
+			logCfg, cfg.LogRotator,
+		)
 	)
-	logFileHandler := btclog.NewDefaultHandler(
-		cfg.LogRotator, logCfg.File.HandlerOptions()...,
-	)
-
-	var logHandlers []btclog.Handler
 	maybeAddLogger := func(cmdOptionDisable bool, handler btclog.Handler) {
 		if !cmdOptionDisable {
 			logHandlers = append(logHandlers, handler)

--- a/config_builder.go
+++ b/config_builder.go
@@ -18,7 +18,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet"

--- a/contractcourt/contract_resolver.go
+++ b/contractcourt/contract_resolver.go
@@ -7,7 +7,7 @@ import (
 	"io"
 
 	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/fn"

--- a/contractcourt/log.go
+++ b/contractcourt/log.go
@@ -1,7 +1,7 @@
 package contractcourt
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/discovery/log.go
+++ b/discovery/log.go
@@ -1,7 +1,7 @@
 package discovery
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -75,6 +75,16 @@
   config settings to its own dedicated group. The old ones still work but will
   be removed in a future release.
  
+* [Update to use structured 
+  logging](https://github.com/lightningnetwork/lnd/pull/9083). This also 
+  introduces a new `--logging.console.disable` option to disable logs being 
+  written to stdout and a new `--logging.file.disable` option to disable writing 
+  logs to the standard log file. It also adds `--logging.console.no-timestamps`
+  and `--logging.file.no-timestamps` which can be used to omit timestamps in
+  log messages for the respective loggers. Finally, the new 
+  `--logging.console.style` option can be used under the `dev` build tag to add
+   styling to console logging.
+ 
 ## Breaking Changes
 ## Performance Improvements
 

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -81,9 +81,12 @@
   written to stdout and a new `--logging.file.disable` option to disable writing 
   logs to the standard log file. It also adds `--logging.console.no-timestamps`
   and `--logging.file.no-timestamps` which can be used to omit timestamps in
-  log messages for the respective loggers. Finally, the new 
-  `--logging.console.style` option can be used under the `dev` build tag to add
-   styling to console logging.
+  log messages for the respective loggers. The new `--logging.console.call-site`
+  and `--logging.file.call-site` options can be used to include the call-site of
+  a log line. The options for this include "off" (default), "short" (source file
+  name and line number) and "long" (full path to source file and line number). 
+  Finally, the new `--logging.console.style` option can be used under the `dev` 
+  build tag to add styling to console logging.
  
 ## Breaking Changes
 ## Performance Improvements

--- a/funding/log.go
+++ b/funding/log.go
@@ -1,7 +1,7 @@
 package funding
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,8 @@ require (
 	github.com/btcsuite/btcd/btcutil v1.1.5
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.8
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
-	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
+	github.com/btcsuite/btclog v0.0.0-20241003133417-09c4e92e319c
+	github.com/btcsuite/btclog/v2 v2.0.0-20241017175713-3428138b75c7
 	github.com/btcsuite/btcwallet v0.16.10-0.20240912233857-ffb143c77cc5
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.3.5
 	github.com/btcsuite/btcwallet/wallet/txrules v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,11 @@ github.com/btcsuite/btcd/chaincfg/chainhash v1.0.0/go.mod h1:7SFka0XMvUgj3hfZtyd
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 h1:59Kx4K6lzOW5w6nFlA0v5+lk/6sjybR934QNHSJZPTQ=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
-github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
+github.com/btcsuite/btclog v0.0.0-20241003133417-09c4e92e319c h1:4HxD1lBUGUddhzgaNgrCPsFWd7cGYNpeFUgd9ZIgyM0=
+github.com/btcsuite/btclog v0.0.0-20241003133417-09c4e92e319c/go.mod h1:w7xnGOhwT3lmrS4H3b/D1XAXxvh+tbhUm8xeHN2y3TQ=
+github.com/btcsuite/btclog/v2 v2.0.0-20241017175713-3428138b75c7 h1:3Ct3zN3VCEKVm5nceWBBEKczc+jvTfVyOEG71ob2Yuc=
+github.com/btcsuite/btclog/v2 v2.0.0-20241017175713-3428138b75c7/go.mod h1:XItGUfVOxotJL8kkuk2Hj3EVow5KCugXl3wWfQ6K0AE=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
 github.com/btcsuite/btcwallet v0.16.10-0.20240912233857-ffb143c77cc5 h1:zYy233eUBvkF3lq2MUkybEhxhDsrRDSgiToIKN57mtk=
 github.com/btcsuite/btcwallet v0.16.10-0.20240912233857-ffb143c77cc5/go.mod h1:1HJXYbjJzgumlnxOC2+ViR1U+gnHWoOn7WeK5OfY1eU=

--- a/graph/log.go
+++ b/graph/log.go
@@ -1,7 +1,7 @@
 package graph
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/htlcswitch/hop/log.go
+++ b/htlcswitch/hop/log.go
@@ -1,7 +1,7 @@
 package hop
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // log is a logger that is initialized with no output filters.  This

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/channeldb/models"

--- a/htlcswitch/log.go
+++ b/htlcswitch/log.go
@@ -1,7 +1,7 @@
 package htlcswitch
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 )

--- a/invoices/log.go
+++ b/invoices/log.go
@@ -1,7 +1,7 @@
 package invoices
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/lncfg/db.go
+++ b/lncfg/db.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/kvdb/etcd"
 	"github.com/lightningnetwork/lnd/kvdb/postgres"

--- a/lncfg/log.go
+++ b/lncfg/log.go
@@ -1,7 +1,7 @@
 package lncfg
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/lnd.go
+++ b/lnd.go
@@ -149,7 +149,7 @@ func Main(cfg *Config, lisCfg ListenerCfg, implCfg *ImplementationCfg,
 
 	defer func() {
 		ltndLog.Info("Shutdown complete\n")
-		err := cfg.LogWriter.Close()
+		err := cfg.LogRotator.Close()
 		if err != nil {
 			ltndLog.Errorf("Could not close log rotator: %v", err)
 		}

--- a/lnrpc/autopilotrpc/log.go
+++ b/lnrpc/autopilotrpc/log.go
@@ -1,7 +1,7 @@
 package autopilotrpc
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/lnrpc/chainrpc/log.go
+++ b/lnrpc/chainrpc/log.go
@@ -1,7 +1,7 @@
 package chainrpc
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/lnrpc/devrpc/log.go
+++ b/lnrpc/devrpc/log.go
@@ -1,7 +1,7 @@
 package devrpc
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/lnrpc/invoicesrpc/log.go
+++ b/lnrpc/invoicesrpc/log.go
@@ -1,7 +1,7 @@
 package invoicesrpc
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/lnrpc/neutrinorpc/log.go
+++ b/lnrpc/neutrinorpc/log.go
@@ -1,7 +1,7 @@
 package neutrinorpc
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/lnrpc/peersrpc/log.go
+++ b/lnrpc/peersrpc/log.go
@@ -1,7 +1,7 @@
 package peersrpc
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/lnrpc/routerrpc/log.go
+++ b/lnrpc/routerrpc/log.go
@@ -1,7 +1,7 @@
 package routerrpc
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/lnrpc/signrpc/log.go
+++ b/lnrpc/signrpc/log.go
@@ -1,7 +1,7 @@
 package signrpc
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/lnrpc/verrpc/log.go
+++ b/lnrpc/verrpc/log.go
@@ -1,7 +1,7 @@
 package verrpc
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/lnrpc/walletrpc/log.go
+++ b/lnrpc/walletrpc/log.go
@@ -1,7 +1,7 @@
 package walletrpc
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/lnrpc/watchtowerrpc/log.go
+++ b/lnrpc/watchtowerrpc/log.go
@@ -1,7 +1,7 @@
 package watchtowerrpc
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/lnrpc/websocket_proxy.go
+++ b/lnrpc/websocket_proxy.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/gorilla/websocket"
 	"golang.org/x/net/context"
 )

--- a/lnrpc/wtclientrpc/config.go
+++ b/lnrpc/wtclientrpc/config.go
@@ -1,7 +1,7 @@
 package wtclientrpc
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/watchtower/wtclient"
 )

--- a/lnwallet/btcwallet/log.go
+++ b/lnwallet/btcwallet/log.go
@@ -1,7 +1,7 @@
 package btcwallet
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/lnwallet/chainfee/log.go
+++ b/lnwallet/chainfee/log.go
@@ -1,7 +1,7 @@
 package chainfee
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/lnwallet/chancloser/log.go
+++ b/lnwallet/chancloser/log.go
@@ -1,7 +1,7 @@
 package chancloser
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/lnwallet/chanfunding/log.go
+++ b/lnwallet/chanfunding/log.go
@@ -1,7 +1,7 @@
 package chanfunding
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -21,7 +21,7 @@ import (
 	"github.com/btcsuite/btcd/mempool"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/chainntnfs"

--- a/lnwallet/log.go
+++ b/lnwallet/log.go
@@ -1,7 +1,7 @@
 package lnwallet
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/btcsuite/btcwallet/chain"
 	btcwallet "github.com/btcsuite/btcwallet/wallet"
 	"github.com/btcsuite/btcwallet/wtxmgr"

--- a/lnwallet/rpcwallet/log.go
+++ b/lnwallet/rpcwallet/log.go
@@ -1,7 +1,7 @@
 package rpcwallet
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/log.go
+++ b/log.go
@@ -126,7 +126,7 @@ func SetupLoggers(root *build.SubLoggerManager, interceptor signal.Interceptor) 
 	// placeholder lnd package loggers.
 	for _, l := range lndPkgLoggers {
 		l.Logger = build.NewSubLogger(l.subsystem, genLogger)
-		SetV1SubLogger(root, l.subsystem, l.Logger)
+		SetSubLogger(root, l.subsystem, l.Logger)
 	}
 
 	// Initialize loggers from packages outside of `lnd` first. The
@@ -144,54 +144,80 @@ func SetupLoggers(root *build.SubLoggerManager, interceptor signal.Interceptor) 
 	signal.UseLogger(ltndLog)
 	autopilot.UseLogger(atplLog)
 
-	AddV1SubLogger(root, "LNWL", interceptor, lnwallet.UseLogger)
-	AddV1SubLogger(root, "DISC", interceptor, discovery.UseLogger)
-	AddV1SubLogger(root, "NTFN", interceptor, chainntnfs.UseLogger)
-	AddV1SubLogger(root, "CHDB", interceptor, channeldb.UseLogger)
-	AddV1SubLogger(root, "HSWC", interceptor, htlcswitch.UseLogger)
-	AddV1SubLogger(root, "CNCT", interceptor, contractcourt.UseLogger)
-	AddV1SubLogger(root, "UTXN", interceptor, contractcourt.UseNurseryLogger)
-	AddV1SubLogger(root, "BRAR", interceptor, contractcourt.UseBreachLogger)
+	AddSubLogger(root, "LNWL", interceptor, lnwallet.UseLogger)
+	AddSubLogger(root, "DISC", interceptor, discovery.UseLogger)
+	AddSubLogger(root, "NTFN", interceptor, chainntnfs.UseLogger)
+	AddSubLogger(root, "CHDB", interceptor, channeldb.UseLogger)
+	AddSubLogger(root, "HSWC", interceptor, htlcswitch.UseLogger)
+	AddSubLogger(root, "CNCT", interceptor, contractcourt.UseLogger)
+	AddSubLogger(root, "UTXN", interceptor, contractcourt.UseNurseryLogger)
+	AddSubLogger(root, "BRAR", interceptor, contractcourt.UseBreachLogger)
 	AddV1SubLogger(root, "SPHX", interceptor, sphinx.UseLogger)
-	AddV1SubLogger(root, "SWPR", interceptor, sweep.UseLogger)
-	AddV1SubLogger(root, "SGNR", interceptor, signrpc.UseLogger)
-	AddV1SubLogger(root, "WLKT", interceptor, walletrpc.UseLogger)
-	AddV1SubLogger(root, "ARPC", interceptor, autopilotrpc.UseLogger)
-	AddV1SubLogger(root, "NRPC", interceptor, neutrinorpc.UseLogger)
-	AddV1SubLogger(root, "DRPC", interceptor, devrpc.UseLogger)
-	AddV1SubLogger(root, "INVC", interceptor, invoices.UseLogger)
-	AddV1SubLogger(root, "NANN", interceptor, netann.UseLogger)
-	AddV1SubLogger(root, "WTWR", interceptor, watchtower.UseLogger)
-	AddV1SubLogger(root, "NTFR", interceptor, chainrpc.UseLogger)
-	AddV1SubLogger(root, "IRPC", interceptor, invoicesrpc.UseLogger)
-	AddV1SubLogger(root, "CHNF", interceptor, channelnotifier.UseLogger)
-	AddV1SubLogger(root, "CHBU", interceptor, chanbackup.UseLogger)
-	AddV1SubLogger(root, "PROM", interceptor, monitoring.UseLogger)
-	AddV1SubLogger(root, "WTCL", interceptor, wtclient.UseLogger)
-	AddV1SubLogger(root, "PRNF", interceptor, peernotifier.UseLogger)
-	AddV1SubLogger(root, "CHFD", interceptor, chanfunding.UseLogger)
-	AddV1SubLogger(root, "PEER", interceptor, peer.UseLogger)
-	AddV1SubLogger(root, "CHCL", interceptor, chancloser.UseLogger)
+	AddSubLogger(root, "SWPR", interceptor, sweep.UseLogger)
+	AddSubLogger(root, "SGNR", interceptor, signrpc.UseLogger)
+	AddSubLogger(root, "WLKT", interceptor, walletrpc.UseLogger)
+	AddSubLogger(root, "ARPC", interceptor, autopilotrpc.UseLogger)
+	AddSubLogger(root, "NRPC", interceptor, neutrinorpc.UseLogger)
+	AddSubLogger(root, "DRPC", interceptor, devrpc.UseLogger)
+	AddSubLogger(root, "INVC", interceptor, invoices.UseLogger)
+	AddSubLogger(root, "NANN", interceptor, netann.UseLogger)
+	AddSubLogger(root, "WTWR", interceptor, watchtower.UseLogger)
+	AddSubLogger(root, "NTFR", interceptor, chainrpc.UseLogger)
+	AddSubLogger(root, "IRPC", interceptor, invoicesrpc.UseLogger)
+	AddSubLogger(root, "CHNF", interceptor, channelnotifier.UseLogger)
+	AddSubLogger(root, "CHBU", interceptor, chanbackup.UseLogger)
+	AddSubLogger(root, "PROM", interceptor, monitoring.UseLogger)
+	AddSubLogger(root, "WTCL", interceptor, wtclient.UseLogger)
+	AddSubLogger(root, "PRNF", interceptor, peernotifier.UseLogger)
+	AddSubLogger(root, "CHFD", interceptor, chanfunding.UseLogger)
+	AddSubLogger(root, "PEER", interceptor, peer.UseLogger)
+	AddSubLogger(root, "CHCL", interceptor, chancloser.UseLogger)
 
-	AddV1SubLogger(root, routing.Subsystem, interceptor, routing.UseLogger)
-	AddV1SubLogger(root, routerrpc.Subsystem, interceptor, routerrpc.UseLogger)
-	AddV1SubLogger(root, chanfitness.Subsystem, interceptor, chanfitness.UseLogger)
-	AddV1SubLogger(root, verrpc.Subsystem, interceptor, verrpc.UseLogger)
+	AddSubLogger(root, routing.Subsystem, interceptor, routing.UseLogger)
+	AddSubLogger(root, routerrpc.Subsystem, interceptor, routerrpc.UseLogger)
+	AddSubLogger(root, chanfitness.Subsystem, interceptor, chanfitness.UseLogger)
+	AddSubLogger(root, verrpc.Subsystem, interceptor, verrpc.UseLogger)
 	AddV1SubLogger(root, healthcheck.Subsystem, interceptor, healthcheck.UseLogger)
-	AddV1SubLogger(root, chainreg.Subsystem, interceptor, chainreg.UseLogger)
-	AddV1SubLogger(root, chanacceptor.Subsystem, interceptor, chanacceptor.UseLogger)
-	AddV1SubLogger(root, funding.Subsystem, interceptor, funding.UseLogger)
-	AddV1SubLogger(root, cluster.Subsystem, interceptor, cluster.UseLogger)
-	AddV1SubLogger(root, rpcperms.Subsystem, interceptor, rpcperms.UseLogger)
+	AddSubLogger(root, chainreg.Subsystem, interceptor, chainreg.UseLogger)
+	AddSubLogger(root, chanacceptor.Subsystem, interceptor, chanacceptor.UseLogger)
+	AddSubLogger(root, funding.Subsystem, interceptor, funding.UseLogger)
+	AddSubLogger(root, cluster.Subsystem, interceptor, cluster.UseLogger)
+	AddSubLogger(root, rpcperms.Subsystem, interceptor, rpcperms.UseLogger)
 	AddV1SubLogger(root, tor.Subsystem, interceptor, tor.UseLogger)
-	AddV1SubLogger(root, btcwallet.Subsystem, interceptor, btcwallet.UseLogger)
-	AddV1SubLogger(root, rpcwallet.Subsystem, interceptor, rpcwallet.UseLogger)
-	AddV1SubLogger(root, peersrpc.Subsystem, interceptor, peersrpc.UseLogger)
-	AddV1SubLogger(root, graph.Subsystem, interceptor, graph.UseLogger)
-	AddV1SubLogger(root, lncfg.Subsystem, interceptor, lncfg.UseLogger)
-	AddV1SubLogger(
+	AddSubLogger(root, btcwallet.Subsystem, interceptor, btcwallet.UseLogger)
+	AddSubLogger(root, rpcwallet.Subsystem, interceptor, rpcwallet.UseLogger)
+	AddSubLogger(root, peersrpc.Subsystem, interceptor, peersrpc.UseLogger)
+	AddSubLogger(root, graph.Subsystem, interceptor, graph.UseLogger)
+	AddSubLogger(root, lncfg.Subsystem, interceptor, lncfg.UseLogger)
+	AddSubLogger(
 		root, blindedpath.Subsystem, interceptor, blindedpath.UseLogger,
 	)
+}
+
+// AddSubLogger is a helper method to conveniently create and register the
+// logger of one or more sub systems.
+func AddSubLogger(root *build.SubLoggerManager, subsystem string,
+	interceptor signal.Interceptor, useLoggers ...func(btclog.Logger)) {
+
+	// genSubLogger will return a callback for creating a logger instance,
+	// which we will give to the root logger.
+	genLogger := genSubLogger(root, interceptor)
+
+	// Create and register just a single logger to prevent them from
+	// overwriting each other internally.
+	logger := build.NewSubLogger(subsystem, genLogger)
+	SetSubLogger(root, subsystem, logger, useLoggers...)
+}
+
+// SetSubLogger is a helper method to conveniently register the logger of a
+// sub system.
+func SetSubLogger(root *build.SubLoggerManager, subsystem string,
+	logger btclog.Logger, useLoggers ...func(btclog.Logger)) {
+
+	root.RegisterSubLogger(subsystem, logger)
+	for _, useLogger := range useLoggers {
+		useLogger(logger)
+	}
 }
 
 // AddV1SubLogger is a helper method to conveniently create and register the

--- a/log.go
+++ b/log.go
@@ -3,7 +3,8 @@ package lnd
 import (
 	"github.com/btcsuite/btcd/connmgr"
 	"github.com/btcsuite/btcd/rpcclient"
-	"github.com/btcsuite/btclog"
+	btclogv1 "github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/neutrino"
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/autopilot"
@@ -116,6 +117,8 @@ func genSubLogger(root *build.SubLoggerManager,
 }
 
 // SetupLoggers initializes all package-global logger variables.
+//
+//nolint:lll
 func SetupLoggers(root *build.SubLoggerManager, interceptor signal.Interceptor) {
 	genLogger := genSubLogger(root, interceptor)
 
@@ -123,7 +126,7 @@ func SetupLoggers(root *build.SubLoggerManager, interceptor signal.Interceptor) 
 	// placeholder lnd package loggers.
 	for _, l := range lndPkgLoggers {
 		l.Logger = build.NewSubLogger(l.subsystem, genLogger)
-		SetSubLogger(root, l.subsystem, l.Logger)
+		SetV1SubLogger(root, l.subsystem, l.Logger)
 	}
 
 	// Initialize loggers from packages outside of `lnd` first. The
@@ -132,69 +135,69 @@ func SetupLoggers(root *build.SubLoggerManager, interceptor signal.Interceptor) 
 	// `btcwallet.chain`, which is overwritten by `lnwallet`. To ensure the
 	// overwriting works, we need to initialize the loggers here so they
 	// can be overwritten later.
-	AddSubLogger(root, "BTCN", interceptor, neutrino.UseLogger)
-	AddSubLogger(root, "CMGR", interceptor, connmgr.UseLogger)
-	AddSubLogger(root, "RPCC", interceptor, rpcclient.UseLogger)
+	AddV1SubLogger(root, "BTCN", interceptor, neutrino.UseLogger)
+	AddV1SubLogger(root, "CMGR", interceptor, connmgr.UseLogger)
+	AddV1SubLogger(root, "RPCC", interceptor, rpcclient.UseLogger)
 
 	// Some of the loggers declared in the main lnd package are also used
 	// in sub packages.
 	signal.UseLogger(ltndLog)
 	autopilot.UseLogger(atplLog)
 
-	AddSubLogger(root, "LNWL", interceptor, lnwallet.UseLogger)
-	AddSubLogger(root, "DISC", interceptor, discovery.UseLogger)
-	AddSubLogger(root, "NTFN", interceptor, chainntnfs.UseLogger)
-	AddSubLogger(root, "CHDB", interceptor, channeldb.UseLogger)
-	AddSubLogger(root, "HSWC", interceptor, htlcswitch.UseLogger)
-	AddSubLogger(root, "CNCT", interceptor, contractcourt.UseLogger)
-	AddSubLogger(root, "UTXN", interceptor, contractcourt.UseNurseryLogger)
-	AddSubLogger(root, "BRAR", interceptor, contractcourt.UseBreachLogger)
-	AddSubLogger(root, "SPHX", interceptor, sphinx.UseLogger)
-	AddSubLogger(root, "SWPR", interceptor, sweep.UseLogger)
-	AddSubLogger(root, "SGNR", interceptor, signrpc.UseLogger)
-	AddSubLogger(root, "WLKT", interceptor, walletrpc.UseLogger)
-	AddSubLogger(root, "ARPC", interceptor, autopilotrpc.UseLogger)
-	AddSubLogger(root, "NRPC", interceptor, neutrinorpc.UseLogger)
-	AddSubLogger(root, "DRPC", interceptor, devrpc.UseLogger)
-	AddSubLogger(root, "INVC", interceptor, invoices.UseLogger)
-	AddSubLogger(root, "NANN", interceptor, netann.UseLogger)
-	AddSubLogger(root, "WTWR", interceptor, watchtower.UseLogger)
-	AddSubLogger(root, "NTFR", interceptor, chainrpc.UseLogger)
-	AddSubLogger(root, "IRPC", interceptor, invoicesrpc.UseLogger)
-	AddSubLogger(root, "CHNF", interceptor, channelnotifier.UseLogger)
-	AddSubLogger(root, "CHBU", interceptor, chanbackup.UseLogger)
-	AddSubLogger(root, "PROM", interceptor, monitoring.UseLogger)
-	AddSubLogger(root, "WTCL", interceptor, wtclient.UseLogger)
-	AddSubLogger(root, "PRNF", interceptor, peernotifier.UseLogger)
-	AddSubLogger(root, "CHFD", interceptor, chanfunding.UseLogger)
-	AddSubLogger(root, "PEER", interceptor, peer.UseLogger)
-	AddSubLogger(root, "CHCL", interceptor, chancloser.UseLogger)
+	AddV1SubLogger(root, "LNWL", interceptor, lnwallet.UseLogger)
+	AddV1SubLogger(root, "DISC", interceptor, discovery.UseLogger)
+	AddV1SubLogger(root, "NTFN", interceptor, chainntnfs.UseLogger)
+	AddV1SubLogger(root, "CHDB", interceptor, channeldb.UseLogger)
+	AddV1SubLogger(root, "HSWC", interceptor, htlcswitch.UseLogger)
+	AddV1SubLogger(root, "CNCT", interceptor, contractcourt.UseLogger)
+	AddV1SubLogger(root, "UTXN", interceptor, contractcourt.UseNurseryLogger)
+	AddV1SubLogger(root, "BRAR", interceptor, contractcourt.UseBreachLogger)
+	AddV1SubLogger(root, "SPHX", interceptor, sphinx.UseLogger)
+	AddV1SubLogger(root, "SWPR", interceptor, sweep.UseLogger)
+	AddV1SubLogger(root, "SGNR", interceptor, signrpc.UseLogger)
+	AddV1SubLogger(root, "WLKT", interceptor, walletrpc.UseLogger)
+	AddV1SubLogger(root, "ARPC", interceptor, autopilotrpc.UseLogger)
+	AddV1SubLogger(root, "NRPC", interceptor, neutrinorpc.UseLogger)
+	AddV1SubLogger(root, "DRPC", interceptor, devrpc.UseLogger)
+	AddV1SubLogger(root, "INVC", interceptor, invoices.UseLogger)
+	AddV1SubLogger(root, "NANN", interceptor, netann.UseLogger)
+	AddV1SubLogger(root, "WTWR", interceptor, watchtower.UseLogger)
+	AddV1SubLogger(root, "NTFR", interceptor, chainrpc.UseLogger)
+	AddV1SubLogger(root, "IRPC", interceptor, invoicesrpc.UseLogger)
+	AddV1SubLogger(root, "CHNF", interceptor, channelnotifier.UseLogger)
+	AddV1SubLogger(root, "CHBU", interceptor, chanbackup.UseLogger)
+	AddV1SubLogger(root, "PROM", interceptor, monitoring.UseLogger)
+	AddV1SubLogger(root, "WTCL", interceptor, wtclient.UseLogger)
+	AddV1SubLogger(root, "PRNF", interceptor, peernotifier.UseLogger)
+	AddV1SubLogger(root, "CHFD", interceptor, chanfunding.UseLogger)
+	AddV1SubLogger(root, "PEER", interceptor, peer.UseLogger)
+	AddV1SubLogger(root, "CHCL", interceptor, chancloser.UseLogger)
 
-	AddSubLogger(root, routing.Subsystem, interceptor, routing.UseLogger)
-	AddSubLogger(root, routerrpc.Subsystem, interceptor, routerrpc.UseLogger)
-	AddSubLogger(root, chanfitness.Subsystem, interceptor, chanfitness.UseLogger)
-	AddSubLogger(root, verrpc.Subsystem, interceptor, verrpc.UseLogger)
-	AddSubLogger(root, healthcheck.Subsystem, interceptor, healthcheck.UseLogger)
-	AddSubLogger(root, chainreg.Subsystem, interceptor, chainreg.UseLogger)
-	AddSubLogger(root, chanacceptor.Subsystem, interceptor, chanacceptor.UseLogger)
-	AddSubLogger(root, funding.Subsystem, interceptor, funding.UseLogger)
-	AddSubLogger(root, cluster.Subsystem, interceptor, cluster.UseLogger)
-	AddSubLogger(root, rpcperms.Subsystem, interceptor, rpcperms.UseLogger)
-	AddSubLogger(root, tor.Subsystem, interceptor, tor.UseLogger)
-	AddSubLogger(root, btcwallet.Subsystem, interceptor, btcwallet.UseLogger)
-	AddSubLogger(root, rpcwallet.Subsystem, interceptor, rpcwallet.UseLogger)
-	AddSubLogger(root, peersrpc.Subsystem, interceptor, peersrpc.UseLogger)
-	AddSubLogger(root, graph.Subsystem, interceptor, graph.UseLogger)
-	AddSubLogger(root, lncfg.Subsystem, interceptor, lncfg.UseLogger)
-	AddSubLogger(
+	AddV1SubLogger(root, routing.Subsystem, interceptor, routing.UseLogger)
+	AddV1SubLogger(root, routerrpc.Subsystem, interceptor, routerrpc.UseLogger)
+	AddV1SubLogger(root, chanfitness.Subsystem, interceptor, chanfitness.UseLogger)
+	AddV1SubLogger(root, verrpc.Subsystem, interceptor, verrpc.UseLogger)
+	AddV1SubLogger(root, healthcheck.Subsystem, interceptor, healthcheck.UseLogger)
+	AddV1SubLogger(root, chainreg.Subsystem, interceptor, chainreg.UseLogger)
+	AddV1SubLogger(root, chanacceptor.Subsystem, interceptor, chanacceptor.UseLogger)
+	AddV1SubLogger(root, funding.Subsystem, interceptor, funding.UseLogger)
+	AddV1SubLogger(root, cluster.Subsystem, interceptor, cluster.UseLogger)
+	AddV1SubLogger(root, rpcperms.Subsystem, interceptor, rpcperms.UseLogger)
+	AddV1SubLogger(root, tor.Subsystem, interceptor, tor.UseLogger)
+	AddV1SubLogger(root, btcwallet.Subsystem, interceptor, btcwallet.UseLogger)
+	AddV1SubLogger(root, rpcwallet.Subsystem, interceptor, rpcwallet.UseLogger)
+	AddV1SubLogger(root, peersrpc.Subsystem, interceptor, peersrpc.UseLogger)
+	AddV1SubLogger(root, graph.Subsystem, interceptor, graph.UseLogger)
+	AddV1SubLogger(root, lncfg.Subsystem, interceptor, lncfg.UseLogger)
+	AddV1SubLogger(
 		root, blindedpath.Subsystem, interceptor, blindedpath.UseLogger,
 	)
 }
 
-// AddSubLogger is a helper method to conveniently create and register the
+// AddV1SubLogger is a helper method to conveniently create and register the
 // logger of one or more sub systems.
-func AddSubLogger(root *build.SubLoggerManager, subsystem string,
-	interceptor signal.Interceptor, useLoggers ...func(btclog.Logger)) {
+func AddV1SubLogger(root *build.SubLoggerManager, subsystem string,
+	interceptor signal.Interceptor, useLoggers ...func(btclogv1.Logger)) {
 
 	// genSubLogger will return a callback for creating a logger instance,
 	// which we will give to the root logger.
@@ -203,13 +206,15 @@ func AddSubLogger(root *build.SubLoggerManager, subsystem string,
 	// Create and register just a single logger to prevent them from
 	// overwriting each other internally.
 	logger := build.NewSubLogger(subsystem, genLogger)
-	SetSubLogger(root, subsystem, logger, useLoggers...)
+	SetV1SubLogger(root, subsystem, logger, useLoggers...)
 }
 
-// SetSubLogger is a helper method to conveniently register the logger of a sub
-// system.
-func SetSubLogger(root *build.SubLoggerManager, subsystem string,
-	logger btclog.Logger, useLoggers ...func(btclog.Logger)) {
+// SetV1SubLogger is a helper method to conveniently register the logger of a
+// sub system. Note that the btclog v2 logger implements the btclog v1 logger
+// which is why we can pass the v2 logger to the UseLogger call-backs that
+// expect the v1 logger.
+func SetV1SubLogger(root *build.SubLoggerManager, subsystem string,
+	logger btclog.Logger, useLoggers ...func(btclogv1.Logger)) {
 
 	root.RegisterSubLogger(subsystem, logger)
 	for _, useLogger := range useLoggers {

--- a/log.go
+++ b/log.go
@@ -95,7 +95,7 @@ var (
 
 // genSubLogger creates a logger for a subsystem. We provide an instance of
 // a signal.Interceptor to be able to shutdown in the case of a critical error.
-func genSubLogger(root *build.RotatingLogWriter,
+func genSubLogger(root *build.SubLoggerManager,
 	interceptor signal.Interceptor) func(string) btclog.Logger {
 
 	// Create a shutdown function which will request shutdown from our
@@ -116,7 +116,7 @@ func genSubLogger(root *build.RotatingLogWriter,
 }
 
 // SetupLoggers initializes all package-global logger variables.
-func SetupLoggers(root *build.RotatingLogWriter, interceptor signal.Interceptor) {
+func SetupLoggers(root *build.SubLoggerManager, interceptor signal.Interceptor) {
 	genLogger := genSubLogger(root, interceptor)
 
 	// Now that we have the proper root logger, we can replace the
@@ -193,7 +193,7 @@ func SetupLoggers(root *build.RotatingLogWriter, interceptor signal.Interceptor)
 
 // AddSubLogger is a helper method to conveniently create and register the
 // logger of one or more sub systems.
-func AddSubLogger(root *build.RotatingLogWriter, subsystem string,
+func AddSubLogger(root *build.SubLoggerManager, subsystem string,
 	interceptor signal.Interceptor, useLoggers ...func(btclog.Logger)) {
 
 	// genSubLogger will return a callback for creating a logger instance,
@@ -208,7 +208,7 @@ func AddSubLogger(root *build.RotatingLogWriter, subsystem string,
 
 // SetSubLogger is a helper method to conveniently register the logger of a sub
 // system.
-func SetSubLogger(root *build.RotatingLogWriter, subsystem string,
+func SetSubLogger(root *build.SubLoggerManager, subsystem string,
 	logger btclog.Logger, useLoggers ...func(btclog.Logger)) {
 
 	root.RegisterSubLogger(subsystem, logger)

--- a/monitoring/log.go
+++ b/monitoring/log.go
@@ -1,7 +1,7 @@
 package monitoring
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/msgmux/log.go
+++ b/msgmux/log.go
@@ -1,7 +1,7 @@
 package msgmux
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/netann/log.go
+++ b/netann/log.go
@@ -1,7 +1,7 @@
 package netann
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -17,7 +17,7 @@ import (
 	"github.com/btcsuite/btcd/connmgr"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/buffer"
 	"github.com/lightningnetwork/lnd/build"

--- a/peer/log.go
+++ b/peer/log.go
@@ -1,7 +1,7 @@
 package peer
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/peernotifier/log.go
+++ b/peernotifier/log.go
@@ -1,7 +1,7 @@
 package peernotifier
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/routing/blindedpath/log.go
+++ b/routing/blindedpath/log.go
@@ -1,7 +1,7 @@
 package blindedpath
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/routing/chainview/log.go
+++ b/routing/chainview/log.go
@@ -1,7 +1,7 @@
 package chainview
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/routing/log.go
+++ b/routing/log.go
@@ -1,7 +1,7 @@
 package routing
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/routing/chainview"
 )

--- a/routing/missioncontrol.go
+++ b/routing/missioncontrol.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/channeldb"

--- a/routing/payment_session.go
+++ b/routing/payment_session.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/channeldb/models"

--- a/rpcperms/interceptor.go
+++ b/rpcperms/interceptor.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/macaroons"

--- a/rpcperms/log.go
+++ b/rpcperms/log.go
@@ -1,7 +1,7 @@
 package rpcperms
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -7341,7 +7341,7 @@ func (r *rpcServer) DebugLevel(ctx context.Context,
 	if req.Show {
 		return &lnrpc.DebugLevelResponse{
 			SubSystems: strings.Join(
-				r.cfg.LogWriter.SupportedSubsystems(), " ",
+				r.cfg.SubLogMgr.SupportedSubsystems(), " ",
 			),
 		}, nil
 	}
@@ -7350,12 +7350,12 @@ func (r *rpcServer) DebugLevel(ctx context.Context,
 
 	// Otherwise, we'll attempt to set the logging level using the
 	// specified level spec.
-	err := build.ParseAndSetDebugLevels(req.LevelSpec, r.cfg.LogWriter)
+	err := build.ParseAndSetDebugLevels(req.LevelSpec, r.cfg.SubLogMgr)
 	if err != nil {
 		return nil, err
 	}
 
-	subLoggers := r.cfg.LogWriter.SubLoggers()
+	subLoggers := r.cfg.SubLogMgr.SubLoggers()
 	// Sort alphabetically by subsystem name.
 	var tags []string
 	for t := range subLoggers {

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -970,6 +970,19 @@
 ; Instructs lnd to encrypt the private key using the wallet's seed.
 ; tor.encryptkey=false
 
+[logging]
+
+; Disable logging to stdout and stderror.
+; logging.console.disable=false
+
+; Don't add timestamps to logs written to stdout and stderr.
+; logging.console.no-timestamps=false
+
+; Disable logging to the standard LND log file.
+; logging.file.disable=false
+
+; Don't add timestamps to logs written to the standard LND log file.
+; logging.file.no-timestamps=false
 
 [watchtower]
 

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -978,11 +978,25 @@
 ; Don't add timestamps to logs written to stdout and stderr.
 ; logging.console.no-timestamps=false
 
+; Include the log call-site in the log line written to stdout
+; and stderr. Options include 'off', 'short' and 'long'.
+; Default:
+;   logging.console.call-site=off
+; Example:
+;   logging.console.call-site=short
+
 ; Disable logging to the standard LND log file.
 ; logging.file.disable=false
 
 ; Don't add timestamps to logs written to the standard LND log file.
 ; logging.file.no-timestamps=false
+
+; Include the log call-site in the log line written the standard LND
+; log file. Options include 'off', 'short' and 'long'.
+; Default:
+;   logging.file.call-site=off
+; Example:
+;   logging.file.call-site=short
 
 [watchtower]
 

--- a/signal/log.go
+++ b/signal/log.go
@@ -1,6 +1,6 @@
 package signal
 
-import "github.com/btcsuite/btclog"
+import "github.com/btcsuite/btclog/v2"
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller

--- a/subrpcserver_config.go
+++ b/subrpcserver_config.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 
 	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/aliasmgr"
 	"github.com/lightningnetwork/lnd/autopilot"
 	"github.com/lightningnetwork/lnd/chainreg"

--- a/sweep/log.go
+++ b/sweep/log.go
@@ -1,7 +1,7 @@
 package sweep
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/watchtower/log.go
+++ b/watchtower/log.go
@@ -1,7 +1,7 @@
 package watchtower
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/watchtower/lookout"
 	"github.com/lightningnetwork/lnd/watchtower/wtclient"

--- a/watchtower/lookout/log.go
+++ b/watchtower/lookout/log.go
@@ -1,7 +1,7 @@
 package lookout
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/keychain"

--- a/watchtower/wtclient/log.go
+++ b/watchtower/wtclient/log.go
@@ -1,7 +1,7 @@
 package wtclient
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 

--- a/watchtower/wtclient/queue.go
+++ b/watchtower/wtclient/queue.go
@@ -7,7 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb"
 )
 

--- a/watchtower/wtclient/queue_test.go
+++ b/watchtower/wtclient/queue_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb"

--- a/watchtower/wtclient/session_negotiator.go
+++ b/watchtower/wtclient/session_negotiator.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/watchtower/blob"

--- a/watchtower/wtclient/session_queue.go
+++ b/watchtower/wtclient/session_queue.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwire"

--- a/watchtower/wtdb/log.go
+++ b/watchtower/wtdb/log.go
@@ -1,7 +1,7 @@
 package wtdb
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration1"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration2"

--- a/watchtower/wtdb/migration1/log.go
+++ b/watchtower/wtdb/migration1/log.go
@@ -1,7 +1,7 @@
 package migration1
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // log is a logger that is initialized as disabled.  This means the package will

--- a/watchtower/wtdb/migration2/log.go
+++ b/watchtower/wtdb/migration2/log.go
@@ -1,7 +1,7 @@
 package migration2
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // log is a logger that is initialized as disabled.  This means the package will

--- a/watchtower/wtdb/migration3/log.go
+++ b/watchtower/wtdb/migration3/log.go
@@ -1,7 +1,7 @@
 package migration3
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // log is a logger that is initialized as disabled.  This means the package will

--- a/watchtower/wtdb/migration4/log.go
+++ b/watchtower/wtdb/migration4/log.go
@@ -1,7 +1,7 @@
 package migration4
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // log is a logger that is initialized as disabled.  This means the package will

--- a/watchtower/wtdb/migration5/log.go
+++ b/watchtower/wtdb/migration5/log.go
@@ -1,7 +1,7 @@
 package migration5
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // log is a logger that is initialized as disabled.  This means the package will

--- a/watchtower/wtdb/migration6/log.go
+++ b/watchtower/wtdb/migration6/log.go
@@ -1,7 +1,7 @@
 package migration6
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // log is a logger that is initialized as disabled.  This means the package will

--- a/watchtower/wtdb/migration7/log.go
+++ b/watchtower/wtdb/migration7/log.go
@@ -1,7 +1,7 @@
 package migration7
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // log is a logger that is initialized as disabled.  This means the package will

--- a/watchtower/wtdb/migration8/log.go
+++ b/watchtower/wtdb/migration8/log.go
@@ -1,7 +1,7 @@
 package migration8
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 )
 
 // log is a logger that is initialized as disabled.  This means the package will

--- a/watchtower/wtserver/log.go
+++ b/watchtower/wtserver/log.go
@@ -1,7 +1,7 @@
 package wtserver
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/build"
 )
 


### PR DESCRIPTION
Update LND logger(s) to make use of structured logging (the `Logger` interface now has structured logging messages (`DebugS`, `InfoS` etc)) 

See btclog update here: https://github.com/btcsuite/btclog/pull/17

### Tracing

The big bonus of this update is that you only need to add your identifier(s) once to the context when the request comes in and then as long as you pass that context through & use it when you log, you dont need to remember to specify the identifiers again.  This can take the form of a `request_id=??` for incoming user requests or `channel_id=xyz` for anything channel related. 

### Searchable logs

With the tracing above, each log will have a `request_id=abcd` in it and each log will use this same structure. So log searches will now become way easier. 

The other thing is that the way we generally write logs today is using formatted strings like: 

❌  **Out with the old**
```
log.Infof("Finalizing pending_id(%x) over ChannelPoint(%v), "+
		"waiting for channel open on-chain", pendingChanID[:],
		fundingPoint)
```
Which appears in the logs as:
```
[INF] FNDG: Finalizing pending_id(xyz) over ChannelPoint(abc), waiting for channel open on-chain"
```

This is not ideal for a few reasons:
1) This log line is called from the funding manager but if a user initiated 2 fundings at the same time, then how do you know which one this log is referring to? The log author would need to remember to add some request identifier and then would need to remember to add that to each and every log within the funding manager so that it always shows up.
2) When actually writing the log, you always need to go line up which param goes to which directive which makes it hard & bug-prone.  
3) If we want to go search through our logs (via grepping the log file or w/e) for how many times this exact log line occurred, it is actually really difficult because each directive (`%d``%v`) makes the log unique... And you cant necessarily just grep on `Finalizing pending_id` because what if there is another log line somewhere that starts the same way?
4) Similarly to 3, if we want to go find where in the code base a log is being emitted from, this can be tricky if there are many directives to work around. 

Enter structured logging:

✅  **In with the new**

The above log line could now be converted into something like this:
```
log.InfoS(ctx, "Finalizing channel ID. Waiting for channel open on-chain",
		btclog.Hex("pending_id", pendingChanID[:]),
		"channel_point", fundingPoint.String())
```
Which will result in the following log line:
```
[INF] FNDG: Finalizing channel ID. Waiting for channel open on-chain request_id=123 pending_id=xyz channel_point=abc
```

A few things to note: 
- it takes a context from which it may extract other key-value pairs (such as `request_id`) at log time.
- The log message is a constant. This makes it easy to search both the logs and the code base for this log line.
- All variables with in the log are now key value pairs. This makes constructing the log line easy to do. 
- You as the dev dont need to remember to go add the `request_id` each time you add a new log line! It will just automagically appear 🪄 

## Details

- This new implementation is flexible enough to allow callers to pass in their own `slog.Handlers` (which underneath could be a json formatter, a logfmt formatter or any anything else like a [charm Handler](https://github.com/charmbracelet/log) 

## Usage

The idea is that the `msg` passed to an `S` method should be a constant. The `attr...` params are then used for key-value pairs. 

```
log.InfoS(ctx, "User performed a request",
			"user_id", id,
			"request_uri: ", uri)
```

Each new method also takes a `context.Context`.  The `WithCtx` helper can be used to attach any key-value pairs to a 
context and then when the logger is called, the pairs will be extracted from the context and added as attributes in the log. 

For example:

```
ctx := WithCtx(context.Background(), "user_id", id)

// This log will include both the `user_id` and `request_uri` attributes.
log.InfoS(ctx, "User performed a request", "request_uri", uri)
```

# Other additions:

### Config options

- This also introduces a new `--logging.console.disable` option to disable logs being written 
to stdout and a new `--logging.file.disable` option to disable writing logs to the standard log file.

- It also has `--logging.console.no-timestamps` & `--logging.file.no-timestamps` to omit timestamps from the logs

- It also adds new `--logging.console.call-site` and `--logging.console.call-site` options which can be used to include log line source call-site in the log lines. The options are "off", "short" (source file name and line number) and "long" (full path to source file and line number)

- finally, there is a new `--logging.console.style` option which can be set to use color formatting - this is only available if the `dev` build flag is set. 

## TODO: 
- update docs with guidelines for using structured logging methods


Fixes #8713
Fixes #6828
Fixes #6163