### PR TITLE
lnwire: detect invalid timestamp field

### DIFF
--- a/discovery/syncer.go
+++ b/discovery/syncer.go
@@ -835,12 +835,6 @@ func (g *GossipSyncer) processChanRangeReply(msg *lnwire.ReplyChannelRange) erro
 	}
 
 	g.prevReplyChannelRange = msg
-	if len(msg.Timestamps) != 0 &&
-		len(msg.Timestamps) != len(msg.ShortChanIDs) {
-
-		return fmt.Errorf("number of timestamps not equal to " +
-			"number of SCIDs")
-	}
 
 	for i, scid := range msg.ShortChanIDs {
 		info := channeldb.NewChannelUpdateInfo(

--- a/lnwire/reply_channel_range.go
+++ b/lnwire/reply_channel_range.go
@@ -104,6 +104,12 @@ func (c *ReplyChannelRange) Decode(r io.Reader, pver uint32) error {
 	// Set the corresponding TLV types if they were included in the stream.
 	if val, ok := typeMap[TimestampsRecordType]; ok && val == nil {
 		c.Timestamps = timeStamps
+
+		// Check that a timestamp was provided for each SCID.
+		if len(c.Timestamps) != len(c.ShortChanIDs) {
+			return fmt.Errorf("number of timestamps does not " +
+				"match number of SCIDs")
+		}
 	}
 
 	if len(tlvRecords) != 0 {


### PR DESCRIPTION
Currently if an incorrect number of timestamps is given, we fail later on in the GossipSyncer. It makes more sense to fail right away, since we already do that for incorrect SCID formats (e.g., unsorted or duplicate SCIDs). There is already a matching check in Encode for incorrect number of timestamps, so adding this check to Decode makes things symmetric.

@dergoegge found this by running the existing `FuzzReplyChannelRange` fuzz target.

Input:
```
go test fuzz v1
[]byte("00000000000000000000000000000000000000000\x00\x00\x01\t\x0000000000")
```

Trace:

```
--- FAIL: FuzzReplyChannelRange (0.15s)
    --- FAIL: FuzzReplyChannelRange (0.00s)
        fuzz_test.go:488:
                Error Trace:    /workdir/lnd/lnwire/fuzz_test.go:47
                                                        /workdir/lnd/lnwire/fuzz_test.go:488
                                                        /usr/local/go/src/reflect/value.go:596
                                                        /usr/local/go/src/reflect/value.go:380
                                                        /usr/local/go/src/testing/fuzz.go:335
                Error:          Received unexpected error:
                                failed to encode message to buffer, got must provide a timestamp pair for each of the given SCIDs
                Test:           FuzzReplyChannelRange

FAIL
exit status 1
FAIL    github.com/lightningnetwork/lnd/lnwire  0.161s
```