### PR TITLE
routing: skip fuzzing when capacity is 0

### DIFF
--- a/routing/probability_bimodal_test.go
+++ b/routing/probability_bimodal_test.go
@@ -692,10 +692,11 @@ func FuzzProbability(f *testing.F) {
 		BimodalConfig: BimodalConfig{BimodalScaleMsat: scale},
 	}
 
-	// We don't start fuzzing at zero, because that would cause an error.
-	f.Add(uint64(1), uint64(0), uint64(0), uint64(0))
-
 	f.Fuzz(func(t *testing.T, capacity, successAmt, failAmt, amt uint64) {
+		if capacity == 0 {
+			return
+		}
+
 		_, err := estimator.probabilityFormula(
 			lnwire.MilliSatoshi(capacity),
 			lnwire.MilliSatoshi(successAmt),


### PR DESCRIPTION
`probabilityFormula` is expected to return an error if capacity is 0, so we should exclude that case from fuzzing.

Previously it was attempted to avoid this case by seeding the corpus with an input that had capacity 1. That is not an effective solution since the fuzzer can still generate an input with capacity 0.