### PR TITLE
fn: add Filter to List

### DIFF
--- a/fn/list.go
+++ b/fn/list.go
@@ -300,3 +300,18 @@ func (l *List[A]) PushFrontList(other *List[A]) {
 		n = n.Prev()
 	}
 }
+
+// Filter gives a slice of all of the node values that satisfy the given
+// predicate.
+func (l *List[A]) Filter(f Pred[A]) []A {
+	var acc []A
+
+	for cursor := l.Front(); cursor != nil; cursor = cursor.Next() {
+		a := cursor.Value
+		if f(a) {
+			acc = append(acc, a)
+		}
+	}
+
+	return acc
+}


### PR DESCRIPTION
This commit adds an immutable Filter method to the linked List API. This is useful because there are several instances wherein we iterate through the linked List and only process a subset of it in some way or another.

## Change Description
This adds a library method to capture the most common case we have where we iterate over the linked List structure.

## Steps to Test
make unit

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
