### PR TITLE
Add errors to `protofsm.MsgEndpoint` methods

### DIFF
--- a/protofsm/msg_router_test.go
+++ b/protofsm/msg_router_test.go
@@ -18,16 +18,16 @@ func (m *mockEndpoint) Name() string {
 	return args.String(0)
 }
 
-func (m *mockEndpoint) CanHandle(msg PeerMsg) bool {
+func (m *mockEndpoint) CanHandle(msg PeerMsg) (bool, error) {
 	args := m.Called(msg)
 
-	return args.Bool(0)
+	return args.Bool(0), nil
 }
 
-func (m *mockEndpoint) SendMessage(msg PeerMsg) bool {
+func (m *mockEndpoint) SendMessage(msg PeerMsg) (bool, error) {
 	args := m.Called(msg)
 
-	return args.Bool(0)
+	return args.Bool(0), nil
 }
 
 // TestMessageRouterOperation tests the basic operation of the message router:


### PR DESCRIPTION
This PR adds an extra `error` return field to the `MsgEndpoint` interface methods