### PR TITLE
build: Add integrity pinning to Docker build images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,11 +26,10 @@ env:
   TRANCHES: 8
 
   # If you change this value, please change it in the following files as well:
-  # /.travis.yml
   # /Dockerfile
   # /dev.Dockerfile
   # /make/builder.Dockerfile
-  # /.github/workflows/release.yml
+  # /.github/workflows/release.yaml
   GO_VERSION: 1.22.6
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # /make/builder.Dockerfile
 # /.github/workflows/main.yml
 # /.github/workflows/release.yml
-FROM golang:1.22.6-alpine as builder
+FROM golang:1.22.6-alpine@sha256:1a478681b671001b7f029f94b5016aed984a23ad99c707f6a0ab6563860ae2f3 as builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # /dev.Dockerfile
 # /make/builder.Dockerfile
 # /.github/workflows/main.yml
-# /.github/workflows/release.yml
+# /.github/workflows/release.yaml
 FROM golang:1.22.6-alpine@sha256:1a478681b671001b7f029f94b5016aed984a23ad99c707f6a0ab6563860ae2f3 as builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS

--- a/brontide/README.md
+++ b/brontide/README.md
@@ -1,7 +1,6 @@
 brontide
 ==========
 
-[![Build Status](http://img.shields.io/travis/lightningnetwork/lnd.svg)](https://travis-ci.org/lightningnetwork/lnd) 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/lightningnetwork/lnd/brontide)
 

--- a/chainntnfs/README.md
+++ b/chainntnfs/README.md
@@ -1,7 +1,6 @@
 chainntnfs
 ==========
 
-[![Build Status](http://img.shields.io/travis/lightningnetwork/lnd.svg)](https://travis-ci.org/lightningnetwork/lnd) 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/lightningnetwork/lnd/chainntnfs)
 

--- a/channeldb/README.md
+++ b/channeldb/README.md
@@ -1,7 +1,6 @@
 channeldb
 ==========
 
-[![Build Status](http://img.shields.io/travis/lightningnetwork/lnd.svg)](https://travis-ci.org/lightningnetwork/lnd) 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/lightningnetwork/lnd/channeldb)
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -3,7 +3,7 @@
 # /make/builder.Dockerfile
 # /.github/workflows/main.yml
 # /.github/workflows/release.yml
-FROM golang:1.22.6-alpine as builder
+FROM golang:1.22.6-alpine@sha256:1a478681b671001b7f029f94b5016aed984a23ad99c707f6a0ab6563860ae2f3 as builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -2,7 +2,7 @@
 # /Dockerfile
 # /make/builder.Dockerfile
 # /.github/workflows/main.yml
-# /.github/workflows/release.yml
+# /.github/workflows/release.yaml
 FROM golang:1.22.6-alpine@sha256:1a478681b671001b7f029f94b5016aed984a23ad99c707f6a0ab6563860ae2f3 as builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"

--- a/docker/btcd/Dockerfile
+++ b/docker/btcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.6-alpine as builder
+FROM golang:1.22.6-alpine@sha256:1a478681b671001b7f029f94b5016aed984a23ad99c707f6a0ab6563860ae2f3 as builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 

--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -44,7 +44,6 @@ Commands
 - [`list`](#list)
 - [`rpc`](#rpc)
 - [`scratch`](#scratch)
-- [`travis`](#travis)
 - [`unit`](#unit)
 - [`unit-cover`](#unit-cover)
 - [`unit-race`](#unit-race)

--- a/lnrpc/Dockerfile
+++ b/lnrpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.6-bookworm
+FROM golang:1.22.6-bookworm@sha256:d31e093e3aeaee68ccee6c4c96e554ef0f192ea37ae684d91b206bec17377f19
 
 RUN apt-get update && apt-get install -y \
   git \

--- a/lnwallet/README.md
+++ b/lnwallet/README.md
@@ -1,7 +1,6 @@
 lnwallet
 =========
 
-[![Build Status](http://img.shields.io/travis/lightningnetwork/lnd.svg)](https://travis-ci.org/lightningnetwork/lnd) 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/lightningnetwork/lnd/lnwallet)
 

--- a/lnwire/README.md
+++ b/lnwire/README.md
@@ -1,7 +1,6 @@
 lnwire
 ======
 
-[![Build Status](http://img.shields.io/travis/lightningnetwork/lnd.svg)](https://travis-ci.org/lightningnetwork/lnd) 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/lightningnetwork/lnd/lnwire)
 

--- a/make/builder.Dockerfile
+++ b/make/builder.Dockerfile
@@ -2,7 +2,7 @@
 # /Dockerfile
 # /dev.Dockerfile
 # /.github/workflows/main.yml
-# /.github/workflows/release.yml
+# /.github/workflows/release.yaml
 FROM golang:1.22.6-bookworm@sha256:d31e093e3aeaee68ccee6c4c96e554ef0f192ea37ae684d91b206bec17377f19
 
 MAINTAINER Olaoluwa Osuntokun <laolu@lightning.engineering>

--- a/make/builder.Dockerfile
+++ b/make/builder.Dockerfile
@@ -3,7 +3,7 @@
 # /dev.Dockerfile
 # /.github/workflows/main.yml
 # /.github/workflows/release.yml
-FROM golang:1.22.6-bookworm
+FROM golang:1.22.6-bookworm@sha256:d31e093e3aeaee68ccee6c4c96e554ef0f192ea37ae684d91b206bec17377f19
 
 MAINTAINER Olaoluwa Osuntokun <laolu@lightning.engineering>
 

--- a/routing/README.md
+++ b/routing/README.md
@@ -1,7 +1,6 @@
 routing
 =======
 
-[![Build Status](http://img.shields.io/travis/lightningnetwork/lnd.svg)](https://travis-ci.org/lightningnetwork/lnd) 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/lightningnetwork/lnd/routing)
 

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.6
+FROM golang:1.22.6@sha256:4594271250150c1a322ed749abfd218e1a8c6eb1ade90872e325a664412e2037
 
 RUN apt-get update && apt-get install -y git
 ENV GOCACHE=/tmp/build/.cache

--- a/zpay32/README.md
+++ b/zpay32/README.md
@@ -1,7 +1,6 @@
 zpay32
 =======
 
-[![Build Status](http://img.shields.io/travis/lightningnetwork/lnd.svg)](https://travis-ci.org/lightningnetwork/lnd) 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/lightningnetwork/lnd/zpay32)
 


### PR DESCRIPTION
## Change Description
This PR Adding integrity pinning to Docker build images. Referencing the Docker environment by a specified SHA hash reduces the need to trust Dockerhub or data-transport.

Before this change, build Dockerfiles referenced docker images by notional content which could be malicously swapped without alerting.

Docker Image digests exist under a cohesive `index digest` which account for the fact that different architectures will obtain different image files.  See: https://github.com/docker/hub-feedback/issues/1925#issuecomment-565646445

## Producing Integrity Pinning Digests
Local:
```bash
docker inspect $image_name
```

HTTP:
https://hub.docker.com/layers/library/golang/1.22.6-bookworm/images/sha256-8ae92b0f1598356df80f4e9bd682c4cdbae8f1a3fc9cee1f05ce88a00462f05f

JSON API:
https://registry.hub.docker.com/v2/repositories/library/golang/tags/1.22

## Steps to Test
```sh
# Fetch
gh pr checkout $this_PR_NUMBER

git checkout docker-build-image-integrity-tag
SKIP_VERSION_CHECK=1 make docker-release tag=docker-build-image-integrity
```

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.
