### PR TITLE
lnwallet: fix panic on aux sig handling

### DIFF
--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -5553,6 +5553,11 @@ func genHtlcSigValidationJobs(chanState *channeldb.OpenChannel,
 			// disk later.
 			sigType := htlcCustomSigType.TypeVal()
 			auxSig.WhenSome(func(sigB tlv.Blob) {
+				if htlc.CustomRecords == nil {
+					htlc.CustomRecords =
+						make(lnwire.CustomRecords)
+				}
+
 				htlc.CustomRecords[uint64(sigType)] = sigB
 			})
 


### PR DESCRIPTION
Fixes a panic caused by sending regular payments over a custom channel, in which case the `htlc.CustomRecords` map would be uninitialized. 