### PR TITLE
build: bump master to version v0.18.99-beta

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -43,7 +43,7 @@ const (
 	AppMinor uint = 18
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 00
+	AppPatch uint = 99
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.


### PR DESCRIPTION
As is customary when preparing for the next major (or minor) release, we bump the version to .99 to allow us to set the minimum required version to something like v0.18.4-beta in lndclient and it would still accept the master branch (even if that target version hasn't been released/tagged yet).

See https://github.com/lightningnetwork/lnd/pull/8513 or https://github.com/lightningnetwork/lnd/pull/7574.