### PR TITLE
docs: clarify skipping the CI checks

### DIFF
--- a/docs/code_contribution_guidelines.md
+++ b/docs/code_contribution_guidelines.md
@@ -335,7 +335,10 @@ Examples of common patterns w.r.t commit structures within the project:
     codebase.
   * If a PR only fixes a trivial issue, such as updating documentation on a
     small scale, fix typos, or any changes that do not modify the code, the
-    commit message should end with `[skip ci]` to skip the CI checks.
+    commit message of the HEAD commit of the PR should end with `[skip ci]` to
+    skip the CI checks. When pushing to such an existing PR, the latest commit
+    being pushed should end with `[skip ci]` as to not inadvertantly trigger the
+    CI checks.
     
 ## Sign your git commits
 

--- a/docs/code_contribution_guidelines.md
+++ b/docs/code_contribution_guidelines.md
@@ -339,6 +339,7 @@ Examples of common patterns w.r.t commit structures within the project:
     skip the CI checks. When pushing to such an existing PR, the latest commit
     being pushed should end with `[skip ci]` as to not inadvertantly trigger the
     CI checks.
+
     
 ## Sign your git commits
 


### PR DESCRIPTION
Following discussion amongst contributors it was clear that the contribution guidelines might benefit from a better explanation of the tags used for skipping CI.

**N.B.: Please wait with merging this PR. I need to check CI tag behavior to confirm my assumptions. Expect a few pushes to this PR.**
