### PR TITLE
[MICRO]: fn: add uncons, unsnoc and its component projections

### DIFF
--- a/fn/slice.go
+++ b/fn/slice.go
@@ -258,3 +258,63 @@ func ForEachConc[A, B any](f func(A) B,
 
 	return bs
 }
+
+// Head returns the first element of the slice, assuming it is non-empty.
+func Head[A any](items []A) Option[A] {
+	if len(items) == 0 {
+		return None[A]()
+	}
+
+	return Some(items[0])
+}
+
+// Tail returns the slice without the first element, assuming the slice is not
+// empty. Note this makes a copy of the slice.
+func Tail[A any](items []A) Option[[]A] {
+	if len(items) == 0 {
+		return None[[]A]()
+	}
+
+	res := make([]A, len(items)-1)
+	copy(res, items[1:])
+
+	return Some(res)
+}
+
+// Init returns the slice without the last element, assuming the slice is not
+// empty. Note this makes a copy of the slice.
+func Init[A any](items []A) Option[[]A] {
+	if len(items) == 0 {
+		return None[[]A]()
+	}
+
+	res := make([]A, len(items)-1)
+	copy(res, items[0:len(items)-1])
+
+	return Some(res)
+}
+
+// Last returns the last element of the slice, assuming it is non-empty.
+func Last[A any](items []A) Option[A] {
+	if len(items) == 0 {
+		return None[A]()
+	}
+
+	return Some(items[len(items)-1])
+}
+
+// Uncons splits a slice into a pair of its Head and Tail.
+func Uncons[A any](items []A) Option[T2[A, []A]] {
+	return LiftA2Option(NewT2[A, []A])(Head(items), Tail(items))
+}
+
+// Unsnoc splits a slice into a pair of its Init and Last.
+func Unsnoc[A any](items []A) Option[T2[[]A, A]] {
+	return LiftA2Option(NewT2[[]A, A])(Init(items), Last(items))
+}
+
+// Len is the len function that is defined in a way that makes it usable in
+// higher-order contexts.
+func Len[A any](items []A) uint {
+	return uint(len(items))
+}

--- a/fn/slice_test.go
+++ b/fn/slice_test.go
@@ -374,3 +374,61 @@ func TestPropFindIdxFindIdentity(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestPropLastTailIsLast(t *testing.T) {
+	f := func(s []uint8) bool {
+		// We exclude the singleton case because the Tail is empty.
+		if len(s) <= 1 {
+			return true
+		}
+
+		return Last(s) == ChainOption(Last[uint8])(Tail(s))
+	}
+
+	require.NoError(t, quick.Check(f, nil))
+}
+
+func TestPropHeadInitIsHead(t *testing.T) {
+	f := func(s []uint8) bool {
+		// We exclude the singleton case because the Init is empty.
+		if len(s) <= 1 {
+			return true
+		}
+
+		return Head(s) == ChainOption(Head[uint8])(Init(s))
+	}
+
+	require.NoError(t, quick.Check(f, nil))
+}
+
+func TestPropTailDecrementsLength(t *testing.T) {
+	f := func(s []uint8) bool {
+		if len(s) == 0 {
+			return true
+		}
+
+		return Some(Len(s)-1) == MapOption(Len[uint8])(Tail(s))
+	}
+
+	require.NoError(t, quick.Check(f, nil))
+}
+
+func TestPropInitDecrementsLength(t *testing.T) {
+	f := func(s []uint8) bool {
+		if len(s) == 0 {
+			return true
+		}
+
+		return Some(Len(s)-1) == MapOption(Len[uint8])(Init(s))
+	}
+
+	require.NoError(t, quick.Check(f, nil))
+}
+
+func TestSingletonTailIsEmpty(t *testing.T) {
+	require.Equal(t, Tail([]int{1}), Some([]int{}))
+}
+
+func TestSingletonInitIsEmpty(t *testing.T) {
+	require.Equal(t, Init([]int{1}), Some([]int{}))
+}


### PR DESCRIPTION
## Change Description
This adds a handful of useful fundamental slice projections. It is motivated by [this discussion](https://github.com/lightningnetwork/lnd/pull/9097#discussion_r1761797734). I'm not attached to the names but they are not arbitrary:

[uncons](https://hackage.haskell.org/package/base-4.20.0.1/docs/Data-List.html#v:uncons), [unsnoc](https://hackage.haskell.org/package/base-4.20.0.1/docs/Data-List.html#v:unsnoc), [head](https://hackage.haskell.org/package/base-4.20.0.1/docs/Data-List.html#v:head), [tail](https://hackage.haskell.org/package/base-4.20.0.1/docs/Data-List.html#v:tail), [init](https://hackage.haskell.org/package/base-4.20.0.1/docs/Data-List.html#v:init), [last](https://hackage.haskell.org/package/base-4.20.0.1/docs/Data-List.html#v:last)

## Steps to Test
make unit pkg=fn

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
