### PR TITLE
lnd: allow shutdown signal during `IsSynced` check

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -27,6 +27,10 @@
   cause a nil pointer dereference during the probing of a payment request that 
   does not contain a payment address.
 
+* [Fix a bug](https://github.com/lightningnetwork/lnd/pull/9137) that prevented
+  a graceful shutdown of LND during the main chain backend sync check in certain
+  cases.
+
 # New Features
 ## Functional Enhancements
 ## RPC Additions
@@ -75,4 +79,5 @@
 * CharlieZKSmith
 * Elle Mouton
 * Pins
+* Viktor Tigerström
 * Ziggie


### PR DESCRIPTION
**Fixes** https://github.com/lightningnetwork/lnd/issues/9109

Before this PR, lnd could become unresponsive to shutdown signals during the `IsSynced` check, which can sometimes take a long time to complete. This caused delays in shutting down lnd.

I'm pushing this as a draft PR for now, as there are several possible solutions to consider:

1. **Cancelable context**: The cleanest approach might be to pass a cancelable context into the `IsSynced` function, allowing it to exit immediately when a shutdown signal is received. However, this would require updates to both the `btcwallet` and `btcd` repositories, and we would need to wait for new releases with these changes. There are also two `activeChainControl.ChainIO.GetBestBlock()` calls in `lnd.go`—just before and after this PR’s changes—which could block as well, though we haven't seen extended delays in those calls.

2. **Listening to async channels**: Another option is to modify the `IsSynced` function to listen to the underlying async channels from `GetBestBlock` and `GetBlockHeader`. This would also require changes to the `btcwallet` repo and a release.

To reviewers: I would appreciate feedback on which approach you think is best. :)