### PR TITLE
channeldb/mig/lnwire21: fix FailInvalidBlinding Encode sig

### DIFF
--- a/channeldb/migration/lnwire21/onion_error.go
+++ b/channeldb/migration/lnwire21/onion_error.go
@@ -583,6 +583,10 @@ type FailInvalidBlinding struct {
 	OnionSHA256 [sha256.Size]byte
 }
 
+// A compile-time check to ensure that FailInvalidBlinding implements the
+// Serializable interface.
+var _ Serializable = (*FailInvalidBlinding)(nil)
+
 // Code returns the failure unique code.
 //
 // NOTE: Part of the FailureMessage interface.
@@ -607,7 +611,7 @@ func (f *FailInvalidBlinding) Decode(r io.Reader, _ uint32) error {
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
-func (f *FailInvalidBlinding) Encode(w *bytes.Buffer, _ uint32) error {
+func (f *FailInvalidBlinding) Encode(w io.Writer, _ uint32) error {
 	return WriteElement(w, f.OnionSHA256[:])
 }
 


### PR DESCRIPTION
Fix the signature of the Encode method so that it does in fact 
implement the Serializable interface defined in the lnwire21 
package. This differs slightly from the interface defined in the 
main lnwire package.

The issue was introduced in [this](https://github.com/lightningnetwork/lnd/pull/8911/commits/33ab4b9db95719d2e0d2803dc54e028d7a6805a1) commit which copied over the FailInvalidBlinding type over from lnwire to lnwire21. The issue was that the Serializable interface in lnwire differs slightly from the Serializable interface in lnwire21. 

No change log since this fixes a migration that is only in master.  

Fixes https://github.com/lightningnetwork/lnd/issues/9160
