### PR TITLE
routing+migration32: update migration 32 to use pure TLV encoding for mission control results

### DIFF
--- a/channeldb/migration/lnwire21/msat.go
+++ b/channeldb/migration/lnwire21/msat.go
@@ -2,8 +2,10 @@ package lnwire
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/lightningnetwork/lnd/tlv"
 )
 
 const (
@@ -49,3 +51,39 @@ func (m MilliSatoshi) String() string {
 }
 
 // TODO(roasbeef): extend with arithmetic operations?
+
+// Record returns a TLV record that can be used to encode/decode a MilliSatoshi
+// to/from a TLV stream.
+func (m *MilliSatoshi) Record() tlv.Record {
+	return tlv.MakeDynamicRecord(
+		0, m, tlv.SizeBigSize(m), encodeMilliSatoshis,
+		decodeMilliSatoshis,
+	)
+}
+func encodeMilliSatoshis(w io.Writer, val interface{}, buf *[8]byte) error {
+	if v, ok := val.(*MilliSatoshi); ok {
+		bigSize := uint64(*v)
+
+		return tlv.EBigSize(w, &bigSize, buf)
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "lnwire.MilliSatoshi")
+}
+
+func decodeMilliSatoshis(r io.Reader, val interface{}, buf *[8]byte,
+	l uint64) error {
+
+	if v, ok := val.(*MilliSatoshi); ok {
+		var bigSize uint64
+		err := tlv.DBigSize(r, &bigSize, buf, l)
+		if err != nil {
+			return err
+		}
+
+		*v = MilliSatoshi(bigSize)
+
+		return nil
+	}
+
+	return tlv.NewTypeForDecodingErr(val, "lnwire.MilliSatoshi", l, l)
+}

--- a/channeldb/migration/lnwire21/true_boolean.go
+++ b/channeldb/migration/lnwire21/true_boolean.go
@@ -1,0 +1,37 @@
+package lnwire
+
+import (
+	"io"
+
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// TrueBoolean is a record that indicates true or false using the presence of
+// the record. If the record is absent, it indicates false. If it is present,
+// it indicates true.
+type TrueBoolean struct{}
+
+// Record returns the tlv record for the boolean entry.
+func (b *TrueBoolean) Record() tlv.Record {
+	return tlv.MakeStaticRecord(
+		0, b, 0, booleanEncoder, booleanDecoder,
+	)
+}
+
+func booleanEncoder(_ io.Writer, val interface{}, _ *[8]byte) error {
+	if _, ok := val.(*TrueBoolean); ok {
+		return nil
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "TrueBoolean")
+}
+
+func booleanDecoder(_ io.Reader, val interface{}, _ *[8]byte,
+	l uint64) error {
+
+	if _, ok := val.(*TrueBoolean); ok && (l == 0 || l == 1) {
+		return nil
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "TrueBoolean")
+}

--- a/channeldb/migration32/migration_test.go
+++ b/channeldb/migration32/migration_test.go
@@ -9,6 +9,7 @@ import (
 	lnwire "github.com/lightningnetwork/lnd/channeldb/migration/lnwire21"
 	"github.com/lightningnetwork/lnd/channeldb/migtest"
 	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/tlv"
 )
 
 var (
@@ -24,20 +25,197 @@ var (
 	_       = pubKeyY.SetByteSlice(pubkeyBytes)
 	pubkey  = btcec.NewPublicKey(new(btcec.FieldVal).SetInt(4), pubKeyY)
 
-	paymentResultCommon1 = paymentResultCommon{
+	customRecord = map[uint64][]byte{
+		65536: {4, 2, 2},
+	}
+
+	resultOld1 = paymentResultOld{
 		id:               0,
 		timeFwd:          time.Unix(0, 1),
 		timeReply:        time.Unix(0, 2),
 		success:          false,
 		failureSourceIdx: &failureIndex,
 		failure:          &lnwire.FailFeeInsufficient{},
+		route: &Route{
+			TotalTimeLock: 100,
+			TotalAmount:   400,
+			SourcePubKey:  testPub,
+			Hops: []*Hop{
+				// A hop with MPP, AMP and custom
+				// records.
+				{
+					PubKeyBytes:      testPub,
+					ChannelID:        100,
+					OutgoingTimeLock: 300,
+					AmtToForward:     500,
+					MPP: &MPP{
+						paymentAddr: [32]byte{4, 5},
+						totalMsat:   900,
+					},
+					AMP: &AMP{
+						rootShare:  [32]byte{0, 0},
+						setID:      [32]byte{5, 5, 5},
+						childIndex: 90,
+					},
+					CustomRecords: customRecord,
+					Metadata:      []byte{6, 7, 7},
+				},
+				// A legacy hop.
+				{
+					PubKeyBytes:      testPub,
+					ChannelID:        800,
+					OutgoingTimeLock: 4,
+					AmtToForward:     4,
+					LegacyPayload:    true,
+				},
+				// A hop with a blinding key.
+				{
+					PubKeyBytes:      testPub,
+					ChannelID:        800,
+					OutgoingTimeLock: 4,
+					AmtToForward:     4,
+					BlindingPoint:    pubkey,
+					EncryptedData:    []byte{1, 2, 3},
+					TotalAmtMsat:     600,
+				},
+				// A hop with a blinding key and custom
+				// records.
+				{
+					PubKeyBytes:      testPub,
+					ChannelID:        800,
+					OutgoingTimeLock: 4,
+					AmtToForward:     4,
+					CustomRecords:    customRecord,
+					BlindingPoint:    pubkey,
+					EncryptedData:    []byte{1, 2, 3},
+					TotalAmtMsat:     600,
+				},
+			},
+		},
 	}
 
-	paymentResultCommon2 = paymentResultCommon{
+	resultOld2 = paymentResultOld{
 		id:        2,
 		timeFwd:   time.Unix(0, 4),
 		timeReply: time.Unix(0, 7),
 		success:   true,
+		route: &Route{
+			TotalTimeLock: 101,
+			TotalAmount:   401,
+			SourcePubKey:  testPub2,
+			Hops: []*Hop{
+				{
+					PubKeyBytes:      testPub,
+					ChannelID:        800,
+					OutgoingTimeLock: 4,
+					AmtToForward:     4,
+					BlindingPoint:    pubkey,
+					EncryptedData:    []byte{1, 2, 3},
+					CustomRecords:    customRecord,
+					TotalAmtMsat:     600,
+				},
+			},
+		},
+	}
+
+	//nolint:lll
+	resultNew1Hop1 = &mcHop{
+		channelID:   tlv.NewPrimitiveRecord[tlv.TlvType0, uint64](100),
+		pubKeyBytes: tlv.NewRecordT[tlv.TlvType1](testPub),
+		amtToFwd:    tlv.NewPrimitiveRecord[tlv.TlvType2, lnwire.MilliSatoshi](500),
+		hasCustomRecords: tlv.SomeRecordT(
+			tlv.ZeroRecordT[tlv.TlvType4, lnwire.TrueBoolean](),
+		),
+	}
+
+	//nolint:lll
+	resultNew1Hop2 = &mcHop{
+		channelID:   tlv.NewPrimitiveRecord[tlv.TlvType0, uint64](800),
+		pubKeyBytes: tlv.NewRecordT[tlv.TlvType1](testPub),
+		amtToFwd:    tlv.NewPrimitiveRecord[tlv.TlvType2, lnwire.MilliSatoshi](4),
+	}
+
+	//nolint:lll
+	resultNew1Hop3 = &mcHop{
+		channelID:   tlv.NewPrimitiveRecord[tlv.TlvType0, uint64](800),
+		pubKeyBytes: tlv.NewRecordT[tlv.TlvType1](testPub),
+		amtToFwd:    tlv.NewPrimitiveRecord[tlv.TlvType2, lnwire.MilliSatoshi](4),
+		hasBlindingPoint: tlv.SomeRecordT(
+			tlv.ZeroRecordT[tlv.TlvType3, lnwire.TrueBoolean](),
+		),
+	}
+
+	//nolint:lll
+	resultNew1Hop4 = &mcHop{
+		channelID:   tlv.NewPrimitiveRecord[tlv.TlvType0, uint64](800),
+		pubKeyBytes: tlv.NewRecordT[tlv.TlvType1](testPub),
+		amtToFwd:    tlv.NewPrimitiveRecord[tlv.TlvType2, lnwire.MilliSatoshi](4),
+		hasCustomRecords: tlv.SomeRecordT(
+			tlv.ZeroRecordT[tlv.TlvType4, lnwire.TrueBoolean](),
+		),
+		hasBlindingPoint: tlv.SomeRecordT(
+			tlv.ZeroRecordT[tlv.TlvType3, lnwire.TrueBoolean](),
+		),
+	}
+
+	//nolint:lll
+	resultNew2Hop1 = &mcHop{
+		channelID:   tlv.NewPrimitiveRecord[tlv.TlvType0, uint64](800),
+		pubKeyBytes: tlv.NewRecordT[tlv.TlvType1](testPub),
+		amtToFwd:    tlv.NewPrimitiveRecord[tlv.TlvType2, lnwire.MilliSatoshi](4),
+		hasCustomRecords: tlv.SomeRecordT(
+			tlv.ZeroRecordT[tlv.TlvType4, lnwire.TrueBoolean](),
+		),
+		hasBlindingPoint: tlv.SomeRecordT(
+			tlv.ZeroRecordT[tlv.TlvType3, lnwire.TrueBoolean](),
+		),
+	}
+
+	//nolint:lll
+	resultNew1 = paymentResultNew{
+		id: 0,
+		timeFwd: tlv.NewPrimitiveRecord[tlv.TlvType0](
+			uint64(time.Unix(0, 1).UnixNano()),
+		),
+		timeReply: tlv.NewPrimitiveRecord[tlv.TlvType1](
+			uint64(time.Unix(0, 2).UnixNano()),
+		),
+		failure: tlv.SomeRecordT(
+			tlv.NewRecordT[tlv.TlvType3](
+				*newPaymentFailure(
+					&failureIndex,
+					&lnwire.FailFeeInsufficient{},
+				),
+			),
+		),
+		route: tlv.NewRecordT[tlv.TlvType2](mcRoute{
+			sourcePubKey: tlv.NewRecordT[tlv.TlvType0](testPub),
+			totalAmount:  tlv.NewRecordT[tlv.TlvType1, lnwire.MilliSatoshi](400),
+			hops: tlv.NewRecordT[tlv.TlvType2, mcHops](mcHops{
+				resultNew1Hop1,
+				resultNew1Hop2,
+				resultNew1Hop3,
+				resultNew1Hop4,
+			}),
+		}),
+	}
+
+	//nolint:lll
+	resultNew2 = paymentResultNew{
+		id: 2,
+		timeFwd: tlv.NewPrimitiveRecord[tlv.TlvType0, uint64](
+			uint64(time.Unix(0, 4).UnixNano()),
+		),
+		timeReply: tlv.NewPrimitiveRecord[tlv.TlvType1, uint64](
+			uint64(time.Unix(0, 7).UnixNano()),
+		),
+		route: tlv.NewRecordT[tlv.TlvType2](mcRoute{
+			sourcePubKey: tlv.NewRecordT[tlv.TlvType0](testPub2),
+			totalAmount:  tlv.NewRecordT[tlv.TlvType1, lnwire.MilliSatoshi](401),
+			hops: tlv.NewRecordT[tlv.TlvType2](mcHops{
+				resultNew2Hop1,
+			}),
+		}),
 	}
 )
 
@@ -45,153 +223,14 @@ var (
 // migration function correctly migrates the MC store from using the old route
 // encoding to using the newer, more minimal route encoding.
 func TestMigrateMCRouteSerialisation(t *testing.T) {
-	customRecord := map[uint64][]byte{
-		65536: {4, 2, 2},
-	}
-
-	resultsOld := []*paymentResultOld{
-		{
-			paymentResultCommon: paymentResultCommon1,
-			route: &Route{
-				TotalTimeLock: 100,
-				TotalAmount:   400,
-				SourcePubKey:  testPub,
-				Hops: []*Hop{
-					// A hop with MPP, AMP and custom
-					// records.
-					{
-						PubKeyBytes:      testPub,
-						ChannelID:        100,
-						OutgoingTimeLock: 300,
-						AmtToForward:     500,
-						MPP: &MPP{
-							paymentAddr: [32]byte{
-								4, 5,
-							},
-							totalMsat: 900,
-						},
-						AMP: &AMP{
-							rootShare: [32]byte{
-								0, 0,
-							},
-							setID: [32]byte{
-								5, 5, 5,
-							},
-							childIndex: 90,
-						},
-						CustomRecords: customRecord,
-						Metadata:      []byte{6, 7, 7},
-					},
-					// A legacy hop.
-					{
-						PubKeyBytes:      testPub,
-						ChannelID:        800,
-						OutgoingTimeLock: 4,
-						AmtToForward:     4,
-						LegacyPayload:    true,
-					},
-					// A hop with a blinding key.
-					{
-						PubKeyBytes:      testPub,
-						ChannelID:        800,
-						OutgoingTimeLock: 4,
-						AmtToForward:     4,
-						BlindingPoint:    pubkey,
-						EncryptedData: []byte{
-							1, 2, 3,
-						},
-						TotalAmtMsat: 600,
-					},
-					// A hop with a blinding key and custom
-					// records.
-					{
-						PubKeyBytes:      testPub,
-						ChannelID:        800,
-						OutgoingTimeLock: 4,
-						AmtToForward:     4,
-						CustomRecords:    customRecord,
-						BlindingPoint:    pubkey,
-						EncryptedData: []byte{
-							1, 2, 3,
-						},
-						TotalAmtMsat: 600,
-					},
-				},
-			},
-		},
-		{
-			paymentResultCommon: paymentResultCommon2,
-			route: &Route{
-				TotalTimeLock: 101,
-				TotalAmount:   401,
-				SourcePubKey:  testPub2,
-				Hops: []*Hop{
-					{
-						PubKeyBytes:      testPub,
-						ChannelID:        800,
-						OutgoingTimeLock: 4,
-						AmtToForward:     4,
-						BlindingPoint:    pubkey,
-						EncryptedData: []byte{
-							1, 2, 3,
-						},
-						TotalAmtMsat: 600,
-					},
-				},
-			},
-		},
-	}
-
-	expectedResultsNew := []*paymentResultNew{
-		{
-			paymentResultCommon: paymentResultCommon1,
-			route: &mcRoute{
-				sourcePubKey: testPub,
-				totalAmount:  400,
-				hops: []*mcHop{
-					{
-						channelID:        100,
-						pubKeyBytes:      testPub,
-						amtToFwd:         500,
-						hasCustomRecords: true,
-					},
-					{
-						channelID:   800,
-						pubKeyBytes: testPub,
-						amtToFwd:    4,
-					},
-					{
-						channelID:        800,
-						pubKeyBytes:      testPub,
-						amtToFwd:         4,
-						hasBlindingPoint: true,
-					},
-					{
-						channelID:        800,
-						pubKeyBytes:      testPub,
-						amtToFwd:         4,
-						hasBlindingPoint: true,
-						hasCustomRecords: true,
-					},
-				},
-			},
-		},
-		{
-			paymentResultCommon: paymentResultCommon2,
-			route: &mcRoute{
-				sourcePubKey: testPub2,
-				totalAmount:  401,
-				hops: []*mcHop{
-					{
-						channelID:        800,
-						pubKeyBytes:      testPub,
-						amtToFwd:         4,
-						hasBlindingPoint: true,
-					},
-				},
-			},
-		},
-	}
+	var (
+		resultsOld = []*paymentResultOld{
+			&resultOld1, &resultOld2,
+		}
+		expectedResultsNew = []*paymentResultNew{
+			&resultNew1, &resultNew2,
+		}
+	)
 
 	// Prime the database with some mission control data that uses the
 	// old route encoding.

--- a/channeldb/migration32/mission_control_store.go
+++ b/channeldb/migration32/mission_control_store.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/btcsuite/btcd/wire"
 	lnwire "github.com/lightningnetwork/lnd/channeldb/migration/lnwire21"
+	"github.com/lightningnetwork/lnd/fn"
+	"github.com/lightningnetwork/lnd/tlv"
 )
 
 const (
@@ -22,30 +24,22 @@ var (
 	resultsKey = []byte("missioncontrol-results")
 )
 
-// paymentResultCommon holds the fields that are shared by the old and new
-// payment result encoding.
-type paymentResultCommon struct {
-	id                 uint64
-	timeFwd, timeReply time.Time
-	success            bool
-	failureSourceIdx   *int
-	failure            lnwire.FailureMessage
-}
-
 // paymentResultOld is the information that becomes available when a payment
 // attempt completes.
 type paymentResultOld struct {
-	paymentResultCommon
-	route *Route
+	id                 uint64
+	timeFwd, timeReply time.Time
+	route              *Route
+	success            bool
+	failureSourceIdx   *int
+	failure            lnwire.FailureMessage
 }
 
 // deserializeOldResult deserializes a payment result using the old encoding.
 func deserializeOldResult(k, v []byte) (*paymentResultOld, error) {
 	// Parse payment id.
 	result := paymentResultOld{
-		paymentResultCommon: paymentResultCommon{
-			id: byteOrder.Uint64(k[8:]),
-		},
+		id: byteOrder.Uint64(k[8:]),
 	}
 
 	r := bytes.NewReader(v)
@@ -99,67 +93,563 @@ func deserializeOldResult(k, v []byte) (*paymentResultOld, error) {
 
 // convertPaymentResult converts a paymentResultOld to a paymentResultNew.
 func convertPaymentResult(old *paymentResultOld) *paymentResultNew {
-	return &paymentResultNew{
-		paymentResultCommon: old.paymentResultCommon,
-		route:               extractMCRoute(old.route),
+	var failure *paymentFailure
+	if !old.success {
+		failure = newPaymentFailure(old.failureSourceIdx, old.failure)
 	}
+
+	return newPaymentResult(
+		old.id, extractMCRoute(old.route), old.timeFwd, old.timeReply,
+		failure,
+	)
+}
+
+// newPaymentResult constructs a new paymentResult.
+func newPaymentResult(id uint64, rt *mcRoute, timeFwd, timeReply time.Time,
+	failure *paymentFailure) *paymentResultNew {
+
+	result := &paymentResultNew{
+		id: id,
+		timeFwd: tlv.NewPrimitiveRecord[tlv.TlvType0](
+			uint64(timeFwd.UnixNano()),
+		),
+		timeReply: tlv.NewPrimitiveRecord[tlv.TlvType1](
+			uint64(timeReply.UnixNano()),
+		),
+		route: tlv.NewRecordT[tlv.TlvType2](*rt),
+	}
+
+	if failure != nil {
+		result.failure = tlv.SomeRecordT(
+			tlv.NewRecordT[tlv.TlvType3](*failure),
+		)
+	}
+
+	return result
 }
 
 // paymentResultNew is the information that becomes available when a payment
 // attempt completes.
 type paymentResultNew struct {
-	paymentResultCommon
-	route *mcRoute
+	id        uint64
+	timeFwd   tlv.RecordT[tlv.TlvType0, uint64]
+	timeReply tlv.RecordT[tlv.TlvType1, uint64]
+	route     tlv.RecordT[tlv.TlvType2, mcRoute]
+
+	// failure holds information related to the failure of a payment. The
+	// presence of this record indicates a payment failure. The absence of
+	// this record indicates a successful payment.
+	failure tlv.OptionalRecordT[tlv.TlvType3, paymentFailure]
+}
+
+// paymentFailure represents the presence of a payment failure. It may or may
+// not include additional information about said failure.
+type paymentFailure struct {
+	info tlv.OptionalRecordT[tlv.TlvType0, paymentFailureInfo]
+}
+
+// newPaymentFailure constructs a new paymentFailure struct. If the source
+// index is nil, then an empty paymentFailure is returned. This represents a
+// failure with unknown details. Otherwise, the index and failure message are
+// used to populate the info field of the paymentFailure.
+func newPaymentFailure(sourceIdx *int,
+	failureMsg lnwire.FailureMessage) *paymentFailure {
+
+	if sourceIdx == nil {
+		return &paymentFailure{}
+	}
+
+	info := paymentFailureInfo{
+		sourceIdx: tlv.NewPrimitiveRecord[tlv.TlvType0](
+			uint8(*sourceIdx),
+		),
+		msg: tlv.NewRecordT[tlv.TlvType1](failureMessage{failureMsg}),
+	}
+
+	return &paymentFailure{
+		info: tlv.SomeRecordT(tlv.NewRecordT[tlv.TlvType0](info)),
+	}
+}
+
+// Record returns a TLV record that can be used to encode/decode a
+// paymentFailure to/from a TLV stream.
+func (r *paymentFailure) Record() tlv.Record {
+	recordSize := func() uint64 {
+		var (
+			b   bytes.Buffer
+			buf [8]byte
+		)
+		if err := encodePaymentFailure(&b, r, &buf); err != nil {
+			panic(err)
+		}
+
+		return uint64(len(b.Bytes()))
+	}
+
+	return tlv.MakeDynamicRecord(
+		0, r, recordSize, encodePaymentFailure, decodePaymentFailure,
+	)
+}
+
+func encodePaymentFailure(w io.Writer, val interface{}, _ *[8]byte) error {
+	if v, ok := val.(*paymentFailure); ok {
+		var recordProducers []tlv.RecordProducer
+		v.info.WhenSome(
+			func(r tlv.RecordT[tlv.TlvType0, paymentFailureInfo]) {
+				recordProducers = append(recordProducers, &r)
+			},
+		)
+
+		return lnwire.EncodeRecordsTo(
+			w, lnwire.ProduceRecordsSorted(recordProducers...),
+		)
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "routing.paymentFailure")
+}
+
+func decodePaymentFailure(r io.Reader, val interface{}, _ *[8]byte,
+	l uint64) error {
+
+	if v, ok := val.(*paymentFailure); ok {
+		var h paymentFailure
+
+		info := tlv.ZeroRecordT[tlv.TlvType0, paymentFailureInfo]()
+		typeMap, err := lnwire.DecodeRecords(
+			r, lnwire.ProduceRecordsSorted(&info)...,
+		)
+		if err != nil {
+			return err
+		}
+
+		if _, ok := typeMap[h.info.TlvType()]; ok {
+			h.info = tlv.SomeRecordT(info)
+		}
+
+		*v = h
+
+		return nil
+	}
+
+	return tlv.NewTypeForDecodingErr(val, "routing.paymentFailure", l, l)
+}
+
+// paymentFailureInfo holds additional information about a payment failure.
+type paymentFailureInfo struct {
+	sourceIdx tlv.RecordT[tlv.TlvType0, uint8]
+	msg       tlv.RecordT[tlv.TlvType1, failureMessage]
+}
+
+// Record returns a TLV record that can be used to encode/decode a
+// paymentFailureInfo to/from a TLV stream.
+func (r *paymentFailureInfo) Record() tlv.Record {
+	recordSize := func() uint64 {
+		var (
+			b   bytes.Buffer
+			buf [8]byte
+		)
+		if err := encodePaymentFailureInfo(&b, r, &buf); err != nil {
+			panic(err)
+		}
+
+		return uint64(len(b.Bytes()))
+	}
+
+	return tlv.MakeDynamicRecord(
+		0, r, recordSize, encodePaymentFailureInfo,
+		decodePaymentFailureInfo,
+	)
+}
+
+func encodePaymentFailureInfo(w io.Writer, val interface{}, _ *[8]byte) error {
+	if v, ok := val.(*paymentFailureInfo); ok {
+		return lnwire.EncodeRecordsTo(
+			w, lnwire.ProduceRecordsSorted(
+				&v.sourceIdx, &v.msg,
+			),
+		)
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "routing.paymentFailureInfo")
+}
+
+func decodePaymentFailureInfo(r io.Reader, val interface{}, _ *[8]byte,
+	l uint64) error {
+
+	if v, ok := val.(*paymentFailureInfo); ok {
+		var h paymentFailureInfo
+
+		_, err := lnwire.DecodeRecords(
+			r,
+			lnwire.ProduceRecordsSorted(&h.sourceIdx, &h.msg)...,
+		)
+		if err != nil {
+			return err
+		}
+
+		*v = h
+
+		return nil
+	}
+
+	return tlv.NewTypeForDecodingErr(
+		val, "routing.paymentFailureInfo", l, l,
+	)
+}
+
+type failureMessage struct {
+	lnwire.FailureMessage
+}
+
+// Record returns a TLV record that can be used to encode/decode a list of
+// failureMessage to/from a TLV stream.
+func (r *failureMessage) Record() tlv.Record {
+	recordSize := func() uint64 {
+		var (
+			b   bytes.Buffer
+			buf [8]byte
+		)
+		if err := encodeFailureMessage(&b, r, &buf); err != nil {
+			panic(err)
+		}
+
+		return uint64(len(b.Bytes()))
+	}
+
+	return tlv.MakeDynamicRecord(
+		0, r, recordSize, encodeFailureMessage, decodeFailureMessage,
+	)
+}
+
+func encodeFailureMessage(w io.Writer, val interface{}, _ *[8]byte) error {
+	if v, ok := val.(*failureMessage); ok {
+		var b bytes.Buffer
+		err := lnwire.EncodeFailureMessage(&b, v.FailureMessage, 0)
+		if err != nil {
+			return err
+		}
+
+		_, err = w.Write(b.Bytes())
+
+		return err
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "routing.failureMessage")
+}
+
+func decodeFailureMessage(r io.Reader, val interface{}, _ *[8]byte,
+	l uint64) error {
+
+	if v, ok := val.(*failureMessage); ok {
+		msg, err := lnwire.DecodeFailureMessage(r, 0)
+		if err != nil {
+			return err
+		}
+
+		*v = failureMessage{
+			FailureMessage: msg,
+		}
+
+		return nil
+	}
+
+	return tlv.NewTypeForDecodingErr(val, "routing.failureMessage", l, l)
 }
 
 // extractMCRoute extracts the fields required by MC from the Route struct to
 // create the more minimal mcRoute struct.
-func extractMCRoute(route *Route) *mcRoute {
+func extractMCRoute(r *Route) *mcRoute {
 	return &mcRoute{
-		sourcePubKey: route.SourcePubKey,
-		totalAmount:  route.TotalAmount,
-		hops:         extractMCHops(route.Hops),
+		sourcePubKey: tlv.NewRecordT[tlv.TlvType0](r.SourcePubKey),
+		totalAmount:  tlv.NewRecordT[tlv.TlvType1](r.TotalAmount),
+		hops: tlv.NewRecordT[tlv.TlvType2](
+			extractMCHops(r.Hops),
+		),
 	}
 }
 
 // extractMCHops extracts the Hop fields that MC actually uses from a slice of
 // Hops.
-func extractMCHops(hops []*Hop) []*mcHop {
-	mcHops := make([]*mcHop, len(hops))
-	for i, hop := range hops {
-		mcHops[i] = extractMCHop(hop)
-	}
-
-	return mcHops
+func extractMCHops(hops []*Hop) mcHops {
+	return fn.Map(extractMCHop, hops)
 }
 
 // extractMCHop extracts the Hop fields that MC actually uses from a Hop.
 func extractMCHop(hop *Hop) *mcHop {
-	return &mcHop{
-		channelID:        hop.ChannelID,
-		pubKeyBytes:      hop.PubKeyBytes,
-		amtToFwd:         hop.AmtToForward,
-		hasBlindingPoint: hop.BlindingPoint != nil,
-		hasCustomRecords: len(hop.CustomRecords) > 0,
+	h := mcHop{
+		channelID: tlv.NewPrimitiveRecord[tlv.TlvType0, uint64](
+			hop.ChannelID,
+		),
+		pubKeyBytes: tlv.NewRecordT[tlv.TlvType1, Vertex](
+			hop.PubKeyBytes,
+		),
+		amtToFwd: tlv.NewRecordT[tlv.TlvType2, lnwire.MilliSatoshi](
+			hop.AmtToForward,
+		),
 	}
+
+	if hop.BlindingPoint != nil {
+		h.hasBlindingPoint = tlv.SomeRecordT(
+			tlv.NewRecordT[tlv.TlvType3, lnwire.TrueBoolean](
+				lnwire.TrueBoolean{},
+			),
+		)
+	}
+
+	if len(hop.CustomRecords) != 0 {
+		h.hasCustomRecords = tlv.SomeRecordT(
+			tlv.NewRecordT[tlv.TlvType4, lnwire.TrueBoolean](
+				lnwire.TrueBoolean{},
+			),
+		)
+	}
+
+	return &h
 }
 
 // mcRoute holds the bare minimum info about a payment attempt route that MC
 // requires.
 type mcRoute struct {
-	sourcePubKey Vertex
-	totalAmount  lnwire.MilliSatoshi
-	hops         []*mcHop
+	sourcePubKey tlv.RecordT[tlv.TlvType0, Vertex]
+	totalAmount  tlv.RecordT[tlv.TlvType1, lnwire.MilliSatoshi]
+	hops         tlv.RecordT[tlv.TlvType2, mcHops]
+}
+
+// Record returns a TLV record that can be used to encode/decode an mcRoute
+// to/from a TLV stream.
+func (r *mcRoute) Record() tlv.Record {
+	recordSize := func() uint64 {
+		var (
+			b   bytes.Buffer
+			buf [8]byte
+		)
+		if err := encodeMCRoute(&b, r, &buf); err != nil {
+			panic(err)
+		}
+
+		return uint64(len(b.Bytes()))
+	}
+
+	return tlv.MakeDynamicRecord(
+		0, r, recordSize, encodeMCRoute, decodeMCRoute,
+	)
+}
+
+func encodeMCRoute(w io.Writer, val interface{}, _ *[8]byte) error {
+	if v, ok := val.(*mcRoute); ok {
+		return serializeRoute(w, v)
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "routing.mcRoute")
+}
+
+func decodeMCRoute(r io.Reader, val interface{}, _ *[8]byte, l uint64) error {
+	if v, ok := val.(*mcRoute); ok {
+		route, err := deserializeRoute(io.LimitReader(r, int64(l)))
+		if err != nil {
+			return err
+		}
+
+		*v = *route
+
+		return nil
+	}
+
+	return tlv.NewTypeForDecodingErr(val, "routing.mcRoute", l, l)
+}
+
+// mcHops is a list of mcHop records.
+type mcHops []*mcHop
+
+// Record returns a TLV record that can be used to encode/decode a list of
+// mcHop to/from a TLV stream.
+func (h *mcHops) Record() tlv.Record {
+	recordSize := func() uint64 {
+		var (
+			b   bytes.Buffer
+			buf [8]byte
+		)
+		if err := encodeMCHops(&b, h, &buf); err != nil {
+			panic(err)
+		}
+
+		return uint64(len(b.Bytes()))
+	}
+
+	return tlv.MakeDynamicRecord(
+		0, h, recordSize, encodeMCHops, decodeMCHops,
+	)
+}
+
+func encodeMCHops(w io.Writer, val interface{}, buf *[8]byte) error {
+	if v, ok := val.(*mcHops); ok {
+		// Encode the number of hops as a var int.
+		if err := tlv.WriteVarInt(w, uint64(len(*v)), buf); err != nil {
+			return err
+		}
+
+		// With that written out, we'll now encode the entries
+		// themselves as a sub-TLV record, which includes its _own_
+		// inner length prefix.
+		for _, hop := range *v {
+			var hopBytes bytes.Buffer
+			if err := serializeNewHop(&hopBytes, hop); err != nil {
+				return err
+			}
+
+			// We encode the record with a varint length followed by
+			// the _raw_ TLV bytes.
+			tlvLen := uint64(len(hopBytes.Bytes()))
+			if err := tlv.WriteVarInt(w, tlvLen, buf); err != nil {
+				return err
+			}
+
+			if _, err := w.Write(hopBytes.Bytes()); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "routing.mcHops")
+}
+
+func decodeMCHops(r io.Reader, val interface{}, buf *[8]byte, l uint64) error {
+	if v, ok := val.(*mcHops); ok {
+		// First, we'll decode the varint that encodes how many hops
+		// are encoded in the stream.
+		numHops, err := tlv.ReadVarInt(r, buf)
+		if err != nil {
+			return err
+		}
+
+		// Now that we know how many records we'll need to read, we can
+		// iterate and read them all out in series.
+		for i := uint64(0); i < numHops; i++ {
+			// Read out the varint that encodes the size of this
+			// inner TLV record.
+			hopSize, err := tlv.ReadVarInt(r, buf)
+			if err != nil {
+				return err
+			}
+
+			// Using this information, we'll create a new limited
+			// reader that'll return an EOF once the end has been
+			// reached so the stream stops consuming bytes.
+			innerTlvReader := &io.LimitedReader{
+				R: r,
+				N: int64(hopSize),
+			}
+
+			hop, err := deserializeNewHop(innerTlvReader)
+			if err != nil {
+				return err
+			}
+
+			*v = append(*v, hop)
+		}
+
+		return nil
+	}
+
+	return tlv.NewTypeForDecodingErr(val, "routing.mcHops", l, l)
+}
+
+// serializeRoute serializes a mcRoute and writes the resulting bytes to the
+// given io.Writer.
+func serializeRoute(w io.Writer, r *mcRoute) error {
+	records := lnwire.ProduceRecordsSorted(
+		&r.sourcePubKey,
+		&r.totalAmount,
+		&r.hops,
+	)
+
+	return lnwire.EncodeRecordsTo(w, records)
+}
+
+// deserializeRoute deserializes the mcRoute from the given io.Reader.
+func deserializeRoute(r io.Reader) (*mcRoute, error) {
+	var rt mcRoute
+	records := lnwire.ProduceRecordsSorted(
+		&rt.sourcePubKey,
+		&rt.totalAmount,
+		&rt.hops,
+	)
+
+	_, err := lnwire.DecodeRecords(r, records...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &rt, nil
+}
+
+// deserializeNewHop deserializes the mcHop from the given io.Reader.
+func deserializeNewHop(r io.Reader) (*mcHop, error) {
+	var (
+		h        mcHop
+		blinding = tlv.ZeroRecordT[tlv.TlvType3, lnwire.TrueBoolean]()
+		custom   = tlv.ZeroRecordT[tlv.TlvType4, lnwire.TrueBoolean]()
+	)
+	records := lnwire.ProduceRecordsSorted(
+		&h.channelID,
+		&h.pubKeyBytes,
+		&h.amtToFwd,
+		&blinding,
+		&custom,
+	)
+
+	typeMap, err := lnwire.DecodeRecords(r, records...)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, ok := typeMap[h.hasBlindingPoint.TlvType()]; ok {
+		h.hasBlindingPoint = tlv.SomeRecordT(blinding)
+	}
+
+	if _, ok := typeMap[h.hasCustomRecords.TlvType()]; ok {
+		h.hasCustomRecords = tlv.SomeRecordT(custom)
+	}
+
+	return &h, nil
+}
+
+// serializeNewHop serializes a mcHop and writes the resulting bytes to the
+// given io.Writer.
+func serializeNewHop(w io.Writer, h *mcHop) error {
+	recordProducers := []tlv.RecordProducer{
+		&h.channelID,
+		&h.pubKeyBytes,
+		&h.amtToFwd,
+	}
+
+	h.hasBlindingPoint.WhenSome(func(
+		hasBlinding tlv.RecordT[tlv.TlvType3, lnwire.TrueBoolean]) {
+
+		recordProducers = append(recordProducers, &hasBlinding)
+	})
+
+	h.hasCustomRecords.WhenSome(func(
+		hasCustom tlv.RecordT[tlv.TlvType4, lnwire.TrueBoolean]) {
+
+		recordProducers = append(recordProducers, &hasCustom)
+	})
+
+	return lnwire.EncodeRecordsTo(
+		w, lnwire.ProduceRecordsSorted(recordProducers...),
+	)
 }
 
 // mcHop holds the bare minimum info about a payment attempt route hop that MC
 // requires.
 type mcHop struct {
-	channelID        uint64
-	pubKeyBytes      Vertex
-	amtToFwd         lnwire.MilliSatoshi
-	hasBlindingPoint bool
-	hasCustomRecords bool
+	channelID        tlv.RecordT[tlv.TlvType0, uint64]
+	pubKeyBytes      tlv.RecordT[tlv.TlvType1, Vertex]
+	amtToFwd         tlv.RecordT[tlv.TlvType2, lnwire.MilliSatoshi]
+	hasBlindingPoint tlv.OptionalRecordT[tlv.TlvType3, lnwire.TrueBoolean]
+	hasCustomRecords tlv.OptionalRecordT[tlv.TlvType4, lnwire.TrueBoolean]
 }
 
 // serializeOldResult serializes a payment result and returns a key and value
@@ -225,48 +715,30 @@ func getResultKeyOld(rp *paymentResultOld) []byte {
 // serializeNewResult serializes a payment result and returns a key and value
 // byte slice to insert into the bucket.
 func serializeNewResult(rp *paymentResultNew) ([]byte, []byte, error) {
-	// Write timestamps, success status, failure source index and route.
-	var b bytes.Buffer
-
-	var dbFailureSourceIdx int32
-	if rp.failureSourceIdx == nil {
-		dbFailureSourceIdx = unknownFailureSourceIdx
-	} else {
-		dbFailureSourceIdx = int32(*rp.failureSourceIdx)
+	recordProducers := []tlv.RecordProducer{
+		&rp.timeFwd,
+		&rp.timeReply,
+		&rp.route,
 	}
 
-	err := WriteElements(
-		&b,
-		uint64(rp.timeFwd.UnixNano()),
-		uint64(rp.timeReply.UnixNano()),
-		rp.success, dbFailureSourceIdx,
+	rp.failure.WhenSome(
+		func(failure tlv.RecordT[tlv.TlvType3, paymentFailure]) {
+			recordProducers = append(recordProducers, &failure)
+		},
+	)
+
+	// Compose key that identifies this result.
+	key := getResultKeyNew(rp)
+
+	var buff bytes.Buffer
+	err := lnwire.EncodeRecordsTo(
+		&buff, lnwire.ProduceRecordsSorted(recordProducers...),
 	)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	if err := serializeMCRoute(&b, rp.route); err != nil {
-		return nil, nil, err
-	}
-
-	// Write failure. If there is no failure message, write an empty
-	// byte slice.
-	var failureBytes bytes.Buffer
-	if rp.failure != nil {
-		err := lnwire.EncodeFailureMessage(&failureBytes, rp.failure, 0)
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-	err = wire.WriteVarBytes(&b, 0, failureBytes.Bytes())
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Compose key that identifies this result.
-	key := getResultKeyNew(rp)
-
-	return key, b.Bytes(), nil
+	return key, buff.Bytes(), err
 }
 
 // getResultKeyNew returns a byte slice representing a unique key for this
@@ -278,43 +750,9 @@ func getResultKeyNew(rp *paymentResultNew) []byte {
 	// key. This allows importing mission control data from an external
 	// source without key collisions and keeps the records sorted
 	// chronologically.
-	byteOrder.PutUint64(keyBytes[:], uint64(rp.timeReply.UnixNano()))
+	byteOrder.PutUint64(keyBytes[:], rp.timeReply.Val)
 	byteOrder.PutUint64(keyBytes[8:], rp.id)
-	copy(keyBytes[16:], rp.route.sourcePubKey[:])
+	copy(keyBytes[16:], rp.route.Val.sourcePubKey.Val[:])
 
 	return keyBytes[:]
-}
-
-// serializeMCRoute serializes an mcRoute and writes the bytes to the given
-// io.Writer.
-func serializeMCRoute(w io.Writer, r *mcRoute) error {
-	if err := WriteElements(
-		w, r.totalAmount, r.sourcePubKey[:],
-	); err != nil {
-		return err
-	}
-
-	if err := WriteElements(w, uint32(len(r.hops))); err != nil {
-		return err
-	}
-
-	for _, h := range r.hops {
-		if err := serializeNewHop(w, h); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// serializeMCRoute serializes an mcHop and writes the bytes to the given
-// io.Writer.
-func serializeNewHop(w io.Writer, h *mcHop) error {
-	return WriteElements(w,
-		h.pubKeyBytes[:],
-		h.channelID,
-		h.amtToFwd,
-		h.hasBlindingPoint,
-		h.hasCustomRecords,
-	)
 }

--- a/channeldb/migration32/route.go
+++ b/channeldb/migration32/route.go
@@ -29,6 +29,32 @@ const VertexSize = 33
 // public key.
 type Vertex [VertexSize]byte
 
+// Record returns a TLV record that can be used to encode/decode a Vertex
+// to/from a TLV stream.
+func (v *Vertex) Record() tlv.Record {
+	return tlv.MakeStaticRecord(
+		0, v, VertexSize, encodeVertex, decodeVertex,
+	)
+}
+
+func encodeVertex(w io.Writer, val interface{}, _ *[8]byte) error {
+	if b, ok := val.(*Vertex); ok {
+		_, err := w.Write(b[:])
+		return err
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "Vertex")
+}
+
+func decodeVertex(r io.Reader, val interface{}, _ *[8]byte, l uint64) error {
+	if b, ok := val.(*Vertex); ok {
+		_, err := io.ReadFull(r, b[:])
+		return err
+	}
+
+	return tlv.NewTypeForDecodingErr(val, "Vertex", l, VertexSize)
+}
+
 // Route represents a path through the channel graph which runs over one or
 // more channels in succession. This struct carries all the information
 // required to craft the Sphinx onion packet, and send the payment along the

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -122,7 +122,8 @@
 
 * [Migrate the mission control 
   store](https://github.com/lightningnetwork/lnd/pull/8911) to use a more 
-  minimal encoding for payment attempt routes.
+  minimal encoding for payment attempt routes as well as use [pure TLV 
+  encoding](https://github.com/lightningnetwork/lnd/pull/9167).
 
 * [Migrate the mission control 
   store](https://github.com/lightningnetwork/lnd/pull/9001) so that results are 

--- a/lnwire/channel_update_2.go
+++ b/lnwire/channel_update_2.go
@@ -411,7 +411,7 @@ func decodeDisableFlags(r io.Reader, val interface{}, buf *[8]byte,
 }
 
 // TrueBoolean is a record that indicates true or false using the presence of
-// the record. If the record is absent, it indicates false. If it is presence,
+// the record. If the record is absent, it indicates false. If it is present,
 // it indicates true.
 type TrueBoolean struct{}
 

--- a/routing/missioncontrol_store_test.go
+++ b/routing/missioncontrol_store_test.go
@@ -11,27 +11,25 @@ import (
 	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
+	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/stretchr/testify/require"
 )
 
 const testMaxRecords = 2
 
-var (
-	// mcStoreTestRoute is a test route for the mission control store tests.
-	mcStoreTestRoute = mcRoute{
-		totalAmount:  lnwire.MilliSatoshi(5),
-		sourcePubKey: route.Vertex{1},
-		hops: []*mcHop{
-			{
-				pubKeyBytes:      route.Vertex{2},
-				channelID:        4,
-				amtToFwd:         lnwire.MilliSatoshi(7),
-				hasCustomRecords: true,
-				hasBlindingPoint: false,
-			},
+// mcStoreTestRoute is a test route for the mission control store tests.
+var mcStoreTestRoute = extractMCRoute(&route.Route{
+	TotalAmount:  lnwire.MilliSatoshi(5),
+	SourcePubKey: route.Vertex{1},
+	Hops: []*route.Hop{
+		{
+			PubKeyBytes:   route.Vertex{2},
+			ChannelID:     4,
+			AmtToForward:  lnwire.MilliSatoshi(7),
+			CustomRecords: make(map[uint64][]byte),
 		},
-	}
-)
+	},
+})
 
 // mcStoreTestHarness is the harness for a MissonControlStore test.
 type mcStoreTestHarness struct {
@@ -84,28 +82,31 @@ func TestMissionControlStore(t *testing.T) {
 
 	failureSourceIdx := 1
 
-	result1 := paymentResult{
-		route:            &mcStoreTestRoute,
-		failure:          lnwire.NewFailIncorrectDetails(100, 1000),
-		failureSourceIdx: &failureSourceIdx,
-		id:               99,
-		timeReply:        testTime,
-		timeFwd:          testTime.Add(-time.Minute),
-	}
+	result1 := newPaymentResult(
+		99, mcStoreTestRoute, testTime, testTime,
+		newPaymentFailure(
+			&failureSourceIdx,
+			lnwire.NewFailIncorrectDetails(100, 1000),
+		),
+	)
 
-	result2 := result1
-	result2.timeReply = result1.timeReply.Add(time.Hour)
-	result2.timeFwd = result1.timeReply.Add(time.Hour)
-	result2.id = 2
+	result2 := newPaymentResult(
+		2, mcStoreTestRoute, testTime.Add(time.Hour),
+		testTime.Add(time.Hour),
+		newPaymentFailure(
+			&failureSourceIdx,
+			lnwire.NewFailIncorrectDetails(100, 1000),
+		),
+	)
 
 	// Store result.
-	store.AddResult(&result2)
+	store.AddResult(result2)
 
 	// Store again to test idempotency.
-	store.AddResult(&result2)
+	store.AddResult(result2)
 
 	// Store second result which has an earlier timestamp.
-	store.AddResult(&result1)
+	store.AddResult(result1)
 	require.NoError(t, store.storeResults())
 
 	results, err = store.fetchAll()
@@ -113,8 +114,8 @@ func TestMissionControlStore(t *testing.T) {
 	require.Len(t, results, 2)
 
 	// Check that results are stored in chronological order.
-	require.Equal(t, &result1, results[0])
-	require.Equal(t, &result2, results[1])
+	require.Equal(t, result1, results[0])
+	require.Equal(t, result2, results[1])
 
 	// Recreate store to test pruning.
 	store, err = newMissionControlStore(
@@ -124,12 +125,20 @@ func TestMissionControlStore(t *testing.T) {
 
 	// Add a newer result which failed due to mpp timeout.
 	result3 := result1
-	result3.timeReply = result1.timeReply.Add(2 * time.Hour)
-	result3.timeFwd = result1.timeReply.Add(2 * time.Hour)
+	result3.timeReply = tlv.NewPrimitiveRecord[tlv.TlvType1](
+		uint64(testTime.Add(2 * time.Hour).UnixNano()),
+	)
+	result3.timeFwd = tlv.NewPrimitiveRecord[tlv.TlvType0](
+		uint64(testTime.Add(2 * time.Hour).UnixNano()),
+	)
 	result3.id = 3
-	result3.failure = &lnwire.FailMPPTimeout{}
+	result3.failure = tlv.SomeRecordT(
+		tlv.NewRecordT[tlv.TlvType3](*newPaymentFailure(
+			&failureSourceIdx, &lnwire.FailMPPTimeout{},
+		)),
+	)
 
-	store.AddResult(&result3)
+	store.AddResult(result3)
 	require.NoError(t, store.storeResults())
 
 	// Check that results are pruned.
@@ -137,8 +146,25 @@ func TestMissionControlStore(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 
-	require.Equal(t, &result2, results[0])
-	require.Equal(t, &result3, results[1])
+	require.Equal(t, result2, results[0])
+	require.Equal(t, result3, results[1])
+
+	// Also demonstrate the persistence of a success result.
+	result4 := newPaymentResult(
+		5, mcStoreTestRoute, testTime.Add(3*time.Hour),
+		testTime.Add(3*time.Hour), nil,
+	)
+	store.AddResult(result4)
+	require.NoError(t, store.storeResults())
+
+	// We should still only have 2 results.
+	results, err = store.fetchAll()
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	// The two latest results should have been returned.
+	require.Equal(t, result3, results[0])
+	require.Equal(t, result4, results[1])
 }
 
 // TestMissionControlStoreFlushing asserts the periodic flushing of the store
@@ -156,14 +182,11 @@ func TestMissionControlStoreFlushing(t *testing.T) {
 	)
 	nextResult := func() *paymentResult {
 		lastID += 1
-		return &paymentResult{
-			route:            &mcStoreTestRoute,
-			failure:          failureDetails,
-			failureSourceIdx: &failureSourceIdx,
-			id:               lastID,
-			timeReply:        testTime,
-			timeFwd:          testTime.Add(-time.Minute),
-		}
+		return newPaymentResult(
+			lastID, mcStoreTestRoute, testTime.Add(-time.Hour),
+			testTime,
+			newPaymentFailure(&failureSourceIdx, failureDetails),
+		)
 	}
 
 	// Helper to assert the number of results is correct.
@@ -260,14 +283,14 @@ func BenchmarkMissionControlStoreFlushing(b *testing.B) {
 			var lastID uint64
 			for i := 0; i < testMaxRecords; i++ {
 				lastID++
-				result := &paymentResult{
-					route:            &mcStoreTestRoute,
-					failure:          failureDetails,
-					failureSourceIdx: &failureSourceIdx,
-					id:               lastID,
-					timeReply:        testTime,
-					timeFwd:          testTimeFwd,
-				}
+				result := newPaymentResult(
+					lastID, mcStoreTestRoute, testTimeFwd,
+					testTime,
+					newPaymentFailure(
+						&failureSourceIdx,
+						failureDetails,
+					),
+				)
 				store.AddResult(result)
 			}
 
@@ -278,13 +301,14 @@ func BenchmarkMissionControlStoreFlushing(b *testing.B) {
 			// Create the additional results.
 			results := make([]*paymentResult, tc)
 			for i := 0; i < len(results); i++ {
-				results[i] = &paymentResult{
-					route:            &mcStoreTestRoute,
-					failure:          failureDetails,
-					failureSourceIdx: &failureSourceIdx,
-					timeReply:        testTime,
-					timeFwd:          testTimeFwd,
-				}
+				results[i] = newPaymentResult(
+					0, mcStoreTestRoute, testTimeFwd,
+					testTime,
+					newPaymentFailure(
+						&failureSourceIdx,
+						failureDetails,
+					),
+				)
 			}
 
 			// Run the actual benchmark.

--- a/routing/route/route.go
+++ b/routing/route/route.go
@@ -94,6 +94,32 @@ func (v Vertex) String() string {
 	return fmt.Sprintf("%x", v[:])
 }
 
+// Record returns a TLV record that can be used to encode/decode a Vertex
+// to/from a TLV stream.
+func (v *Vertex) Record() tlv.Record {
+	return tlv.MakeStaticRecord(
+		0, v, VertexSize, encodeVertex, decodeVertex,
+	)
+}
+
+func encodeVertex(w io.Writer, val interface{}, _ *[8]byte) error {
+	if b, ok := val.(*Vertex); ok {
+		_, err := w.Write(b[:])
+		return err
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "Vertex")
+}
+
+func decodeVertex(r io.Reader, val interface{}, _ *[8]byte, l uint64) error {
+	if b, ok := val.(*Vertex); ok {
+		_, err := io.ReadFull(r, b[:])
+		return err
+	}
+
+	return tlv.NewTypeForDecodingErr(val, "Vertex", l, VertexSize)
+}
+
 // Hop represents an intermediate or final node of the route. This naming
 // is in line with the definition given in BOLT #4: Onion Routing Protocol.
 // The struct houses the channel along which this hop can be reached and


### PR DESCRIPTION
In this commit, we update an existing migration which at the time of
writing has not been included in a release. We update it so that it
converts the format used for MissionControl result encoding to use pure
TLV instead. The 3 structs that have been updated are: `mcHop`,
`mcRoute` and `paymentResult`.