### PR TITLE
lnrpc: fix lncli documentation tags in walletkit.proto

### DIFF
--- a/lnrpc/walletrpc/walletkit.proto
+++ b/lnrpc/walletrpc/walletkit.proto
@@ -222,14 +222,14 @@ service WalletKit {
     */
     rpc SendOutputs (SendOutputsRequest) returns (SendOutputsResponse);
 
-    /*
+    /* lncli: `wallet estimatefeerate`
     EstimateFee attempts to query the internal fee estimator of the wallet to
     determine the fee (in sat/kw) to attach to a transaction in order to
     achieve the confirmation target.
     */
     rpc EstimateFee (EstimateFeeRequest) returns (EstimateFeeResponse);
 
-    /* lncli: `pendingsweeps`
+    /* lncli: `wallet pendingsweeps`
     PendingSweeps returns lists of on-chain outputs that lnd is currently
     attempting to sweep within its central batching engine. Outputs with similar
     fee rates are batched together in order to sweep them within a single

--- a/lnrpc/walletrpc/walletkit.swagger.json
+++ b/lnrpc/walletrpc/walletkit.swagger.json
@@ -306,7 +306,7 @@
     },
     "/v2/wallet/estimatefee/{conf_target}": {
       "get": {
-        "summary": "EstimateFee attempts to query the internal fee estimator of the wallet to\ndetermine the fee (in sat/kw) to attach to a transaction in order to\nachieve the confirmation target.",
+        "summary": "lncli: `wallet estimatefeerate`\nEstimateFee attempts to query the internal fee estimator of the wallet to\ndetermine the fee (in sat/kw) to attach to a transaction in order to\nachieve the confirmation target.",
         "operationId": "WalletKit_EstimateFee",
         "responses": {
           "200": {
@@ -680,7 +680,7 @@
     },
     "/v2/wallet/sweeps/pending": {
       "get": {
-        "summary": "lncli: `pendingsweeps`\nPendingSweeps returns lists of on-chain outputs that lnd is currently\nattempting to sweep within its central batching engine. Outputs with similar\nfee rates are batched together in order to sweep them within a single\ntransaction.",
+        "summary": "lncli: `wallet pendingsweeps`\nPendingSweeps returns lists of on-chain outputs that lnd is currently\nattempting to sweep within its central batching engine. Outputs with similar\nfee rates are batched together in order to sweep them within a single\ntransaction.",
         "description": "NOTE: Some of the fields within PendingSweepsRequest are not guaranteed to\nremain supported. This is an advanced API that depends on the internals of\nthe UtxoSweeper, so things may change.",
         "operationId": "WalletKit_PendingSweeps",
         "responses": {

--- a/lnrpc/walletrpc/walletkit_grpc.pb.go
+++ b/lnrpc/walletrpc/walletkit_grpc.pb.go
@@ -164,11 +164,12 @@ type WalletKitClient interface {
 	// allows the caller to create a transaction that sends to several outputs at
 	// once. This is ideal when wanting to batch create a set of transactions.
 	SendOutputs(ctx context.Context, in *SendOutputsRequest, opts ...grpc.CallOption) (*SendOutputsResponse, error)
+	// lncli: `wallet estimatefeerate`
 	// EstimateFee attempts to query the internal fee estimator of the wallet to
 	// determine the fee (in sat/kw) to attach to a transaction in order to
 	// achieve the confirmation target.
 	EstimateFee(ctx context.Context, in *EstimateFeeRequest, opts ...grpc.CallOption) (*EstimateFeeResponse, error)
-	// lncli: `pendingsweeps`
+	// lncli: `wallet pendingsweeps`
 	// PendingSweeps returns lists of on-chain outputs that lnd is currently
 	// attempting to sweep within its central batching engine. Outputs with similar
 	// fee rates are batched together in order to sweep them within a single
@@ -688,11 +689,12 @@ type WalletKitServer interface {
 	// allows the caller to create a transaction that sends to several outputs at
 	// once. This is ideal when wanting to batch create a set of transactions.
 	SendOutputs(context.Context, *SendOutputsRequest) (*SendOutputsResponse, error)
+	// lncli: `wallet estimatefeerate`
 	// EstimateFee attempts to query the internal fee estimator of the wallet to
 	// determine the fee (in sat/kw) to attach to a transaction in order to
 	// achieve the confirmation target.
 	EstimateFee(context.Context, *EstimateFeeRequest) (*EstimateFeeResponse, error)
-	// lncli: `pendingsweeps`
+	// lncli: `wallet pendingsweeps`
 	// PendingSweeps returns lists of on-chain outputs that lnd is currently
 	// attempting to sweep within its central batching engine. Outputs with similar
 	// fee rates are batched together in order to sweep them within a single


### PR DESCRIPTION
Fixes the tag for `wallet pendingsweeps` and adds the tag for `wallet estimatefeerate`.

## Change Description
fixes #9156 

I think no change log required. But CI should run for rpc check.


## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
