### PR TITLE
rpcserver+lncli: fix custom channel data encoding issue

### DIFF
--- a/cmd/commands/commands.go
+++ b/cmd/commands/commands.go
@@ -54,10 +54,10 @@ var (
 
 // replaceCustomData replaces the custom channel data hex string with the
 // decoded custom channel data in the JSON response.
-func replaceCustomData(jsonBytes []byte) ([]byte, error) {
+func replaceCustomData(jsonBytes []byte) []byte {
 	// If there's nothing to replace, return the original JSON.
 	if !customDataPattern.Match(jsonBytes) {
-		return jsonBytes, nil
+		return jsonBytes
 	}
 
 	replacedBytes := customDataPattern.ReplaceAllFunc(
@@ -78,10 +78,12 @@ func replaceCustomData(jsonBytes []byte) ([]byte, error) {
 	var buf bytes.Buffer
 	err := json.Indent(&buf, replacedBytes, "", "    ")
 	if err != nil {
-		return nil, err
+		// If we can't indent the JSON, it likely means the replacement
+		// data wasn't correct, so we return the original JSON.
+		return jsonBytes
 	}
 
-	return buf.Bytes(), nil
+	return buf.Bytes()
 }
 
 func getContext() context.Context {
@@ -118,11 +120,7 @@ func printRespJSON(resp proto.Message) {
 		return
 	}
 
-	jsonBytesReplaced, err := replaceCustomData(jsonBytes)
-	if err != nil {
-		fmt.Println("unable to replace custom data: ", err)
-		jsonBytesReplaced = jsonBytes
-	}
+	jsonBytesReplaced := replaceCustomData(jsonBytes)
 
 	fmt.Printf("%s\n", jsonBytesReplaced)
 }

--- a/cmd/commands/commands_test.go
+++ b/cmd/commands/commands_test.go
@@ -131,7 +131,6 @@ func TestReplaceCustomData(t *testing.T) {
 		data        string
 		replaceData string
 		expected    string
-		expectedErr string
 	}{
 		{
 			name:     "no replacement necessary",
@@ -175,7 +174,8 @@ func TestReplaceCustomData(t *testing.T) {
 			name: "invalid json",
 			data: "this ain't json, " +
 				"\"custom_channel_data\":\"a\"",
-			expectedErr: "invalid character 'h' in literal true",
+			expected: "this ain't json, " +
+				"\"custom_channel_data\":\"a\"",
 		},
 		{
 			name:     "valid json, invalid hex, just formatted",
@@ -186,15 +186,7 @@ func TestReplaceCustomData(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := replaceCustomData([]byte(tc.data))
-
-			if tc.expectedErr != "" {
-				require.ErrorContains(t, err, tc.expectedErr)
-				return
-			}
-
-			require.NoError(t, err)
-
+			result := replaceCustomData([]byte(tc.data))
 			require.Equal(t, tc.expected, string(result))
 		})
 	}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4606,6 +4606,11 @@ func encodeCustomChanData(lnChan *channeldb.OpenChannel) ([]byte, error) {
 	customOpenChanData := lnChan.CustomBlob.UnwrapOr(nil)
 	customLocalCommitData := lnChan.LocalCommitment.CustomBlob.UnwrapOr(nil)
 
+	// Don't write any custom data if both blobs are empty.
+	if len(customOpenChanData) == 0 && len(customLocalCommitData) == 0 {
+		return nil, nil
+	}
+
 	// We'll encode our custom channel data as two blobs. The first is a
 	// set of var bytes encoding of the open chan data, the second is an
 	// encoding of the local commitment data.


### PR DESCRIPTION
Fixes an error that occurred in `lncli listchannels` for non-custom channels.