### PR TITLE
peer: fix logging (missing argument) [skip ci]

### DIFF
--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -1812,7 +1812,7 @@ func newChanMsgStream(p *Brontide, cid lnwire.ChannelID) *msgStream {
 			// If the link is still not active and the calling function
 			// errored out, just return.
 			if chanLink == nil {
-				p.log.Warnf("Link=%v is not active")
+				p.log.Warnf("Link=%v is not active", cid)
 				return
 			}
 		}


### PR DESCRIPTION
## Change Description

Previously, LND log used to have such records:

```
[WRN] PEER: Peer(...): Link=%!v(MISSING) is not active
```

Now the short channel ID is printed there instead of "%!v(MISSING)".

## Steps to Test

I got this message when opened a channel from a node using neutrino. I had to restart the node multiple times until the channel become active and I got this message after the first restart.

Also I found this message in the log of another node running with full bitcoin node.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] ~~Tests covering the positive and negative (error paths) are included.~~(irrelevant)
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] ~~Any new logging statements use an appropriate subsystem and logging level.~~ (irrelevant)
- [ ] ~~Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.~~ (irrelevant)
- [x] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
