### PR TITLE
lntest: shutdown all nodes at end of test

### DIFF
--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -361,6 +361,8 @@ func (h *HarnessTest) Stop() {
 		return
 	}
 
+	h.shutdownAllNodes()
+
 	close(h.lndErrorChan)
 
 	// Stop the fee service.


### PR DESCRIPTION
Fixes an issue where the standby nodes would keep running even after the test finished (successfully or with a failure).
