### PR TITLE
makefile+scripts: add Go version check to release command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ release-install:
 release: clean-mobile
 	@$(call print, "Releasing lnd and lncli binaries.")
 	$(VERSION_CHECK)
-	./scripts/release.sh build-release "$(VERSION_TAG)" "$(BUILD_SYSTEM)" "$(RELEASE_TAGS)" "$(RELEASE_LDFLAGS)"
+	./scripts/release.sh build-release "$(VERSION_TAG)" "$(BUILD_SYSTEM)" "$(RELEASE_TAGS)" "$(RELEASE_LDFLAGS)" "$(GO_VERSION)"
 
 #? docker-release: Same as release but within a docker container to support reproducible builds on BSD/MacOS platforms
 docker-release:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -129,11 +129,23 @@ function check_tag_correct() {
 
 # build_release builds the actual release binaries.
 #   arguments: <version-tag> <build-system(s)> <build-tags> <ldflags>
+#              <go-version>
 function build_release() {
   local tag=$1
   local sys=$2
   local buildtags=$3
   local ldflags=$4
+  local goversion=$5
+
+  # Check if the active Go version matches the specified Go version.
+  active_go_version=$(go version | awk '{print $3}' | sed 's/go//')
+  if [ "$active_go_version" != "$goversion" ]; then
+    echo "Error: active Go version ($active_go_version) does not match \
+required Go version ($goversion)."
+    exit 1
+  fi
+
+  echo "Building release for tag $tag with Go version $goversion"
 
   green " - Packaging vendor"
   go mod vendor
@@ -202,7 +214,7 @@ function build_release() {
 function usage() {
   red "Usage: "
   red "release.sh check-tag <version-tag>"
-  red "release.sh build-release <version-tag> <build-system(s)> <build-tags> <ldflags>"
+  red "release.sh build-release <version-tag> <build-system(s)> <build-tags> <ldflags> <go-version>"
 }
 
 # Whatever sub command is passed in, we need at least 2 arguments.


### PR DESCRIPTION
This commit updates `scripts/release.sh` to include a check for the correct Go version before executing the release build. This ensures that the release binaries are built with the specified Go version, maintaining consistency and integrity for developer signatures.
