### PR TITLE
Introducing lnd Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Irc](https://img.shields.io/badge/chat-on%20libera-brightgreen.svg)](https://web.libera.chat/#lnd)
 [![Godoc](https://godoc.org/github.com/lightningnetwork/lnd?status.svg)](https://godoc.org/github.com/lightningnetwork/lnd)
 [![Go Report Card](https://goreportcard.com/badge/github.com/lightningnetwork/lnd)](https://goreportcard.com/report/github.com/lightningnetwork/lnd)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20lnd%20Guru-006BFF)](https://gurubase.io/g/lnd)
 
 <img src="logo.png">
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [lnd Guru](https://gurubase.io/g/lnd) to Gurubase. lnd Guru uses the data from this repo and data from the [docs](https://docs.lightning.engineering/) to answer questions by leveraging the LLM.

In this PR, I showcased the "lnd Guru", which highlights that lnd now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable lnd Guru in Gurubase, just let me know that's totally fine.