### PR TITLE
lnwallet: fix closechannel for P2TR external addr

### DIFF
--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -636,6 +636,19 @@ func InternalKeyForAddr(wallet WalletController, netParams *chaincfg.Params,
 
 	walletAddr, err := wallet.AddressInfo(addr)
 	if err != nil {
+		// If the error is that the address can't be found, it is not
+		// an error. This happens when any channel which is not a custom
+		// taproot channel is cooperatively closed to an external P2TR
+		// address. In this case there is no internal key associated
+		// with the address. Callers can use the .Option() method to get
+		// an option value.
+		var managerErr waddrmgr.ManagerError
+		if errors.As(err, &managerErr) &&
+			managerErr.ErrorCode == waddrmgr.ErrAddressNotFound {
+
+			return none, nil
+		}
+
 		return none, err
 	}
 


### PR DESCRIPTION
## Change Description

Customize the itest with the type of external delivery address. Test with P2TR address type in addition to P2WKPH.

## Steps to Test

```
make itest icase='coop close with external delivery'
```

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
