### PR TITLE
itest: fix flake in `payment_failure_reason_canceled`

### DIFF
--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -342,7 +342,6 @@ func (h *HarnessTest) SetupStandbyNodes() {
 	// above a good number of confirmations.
 	const totalTxes = 200
 	h.MineBlocksAndAssertNumTxes(numBlocksSendOutput, totalTxes)
-	h.MineBlocks(numBlocksSendOutput)
 
 	// Now we want to wait for the nodes to catch up.
 	h.WaitForBlockchainSync(h.Alice)


### PR DESCRIPTION
Peel off some commits from #9227, fix the case,
```
--- FAIL: TestLightningNetworkDaemon/tranche01/46-of-191/bitcoind/payment_failure_reason_canceled (20.86s)
        harness.go:2113:
            	Error Trace:	/home/runner/work/lnd/lnd/lntest/harness.go:2113
            	            				/home/runner/work/lnd/lnd/itest/lnd_payment_test.go:1183
            	            				/home/runner/work/lnd/lnd/itest/lnd_payment_test.go:1138
            	            				/home/runner/work/lnd/lnd/lntest/harness.go:396
            	            				/home/runner/work/lnd/lnd/itest/lnd_test.go:139
            	Error:      	err from HTLC interceptor stream
            	Test:       	TestLightningNetworkDaemon/tranche01/46-of-191/bitcoind/payment_failure_reason_canceled
            	Messages:   	received err from HTLC interceptor stream: rpc error: code = Unknown desc = interceptor already exists
```