### PR TITLE
wtclientrpc: prevent watchtower connections to local addresses

### DIFF
--- a/lnrpc/wtclientrpc/wtclient.go
+++ b/lnrpc/wtclientrpc/wtclient.go
@@ -212,6 +212,9 @@ func (c *WatchtowerClient) AddTower(ctx context.Context,
 			err)
 	}
 
+	if lncfg.IsLocalAddress(addr) {
+		return nil, fmt.Errorf("cannot connect to local network address %v", addr)
+	}
 	towerAddr := &lnwire.NetAddress{
 		IdentityKey: pubKey,
 		Address:     addr,


### PR DESCRIPTION
## Change Description
Fixes [5522](https://github.com/lightningnetwork/lnd/issues/5522)

Adds validation to prevent watchtower client connections to local addresses by:
- Implementing IsLocalAddress() to detect localhost/local network addresses
- Adding check in AddTower RPC to reject local tower connections
- Including unit tests for address validation

This helps prevent security issues from misconfigured watchtower setups that accidentally expose local addresses.


## Steps to Test
Steps for reviewers to follow to test the change.
<img width="1466" alt="image" src="https://github.com/user-attachments/assets/e3746851-60e4-4c31-b7ff-5225615db349">

