### PR TITLE
multi: use more efficient key to avoid hashing the blob.

### DIFF
--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -5403,7 +5403,7 @@ func (lc *LightningChannel) IsChannelClean() bool {
 
 	// We call ActiveHtlcs to ensure there are no HTLCs on either
 	// commitment.
-	if len(lc.channelState.ActiveHtlcs()) != 0 {
+	if len(lc.channelState.LocalAndRemoteHtlcs()) != 0 {
 		return false
 	}
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2811,7 +2811,7 @@ func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 		// If the user hasn't specified NoWait, then before we attempt
 		// to close the channel we ensure there are no active HTLCs on
 		// the link.
-		if !in.NoWait && len(channel.ActiveHtlcs()) != 0 {
+		if !in.NoWait && len(channel.LocalAndRemoteHtlcs()) != 0 {
 			return fmt.Errorf("cannot co-op close channel " +
 				"with active htlcs")
 		}


### PR DESCRIPTION
This PR does 2 things (let's see whether the CI passes)

- adds a more efficient key to not hash the big onion-blob each time
- adds a new function which reports whether no HTLCs are on the channel state at all. Prior to this we would only look at the htlcs which were on both commitment transactions however to really have a clean state we need to make sure no HTLCs are on either of them.