### PR TITLE
chanbackup: archive old channel backup files

### DIFF
--- a/config.go
+++ b/config.go
@@ -360,6 +360,8 @@ type Config struct {
 	MaxPendingChannels int    `long:"maxpendingchannels" description:"The maximum number of incoming pending channels permitted per peer."`
 	BackupFilePath     string `long:"backupfilepath" description:"The target location of the channel backup file"`
 
+	NoBackupArchive bool `long:"no-backup-archive" description:"If set to true, channel backups will be deleted or replaced rather than being archived to a separate location."`
+
 	FeeURL string `long:"feeurl" description:"DEPRECATED: Use 'fee.url' option. Optional URL for external fee estimation. If no URL is specified, the method for fee estimation will depend on the chosen backend and network. Must be set for neutrino on mainnet." hidden:"true"`
 
 	Bitcoin      *lncfg.Chain    `group:"Bitcoin" namespace:"bitcoin"`

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -78,6 +78,11 @@
   initial historical sync may be blocked due to a race condition in handling the
   syncer's internal state.
 
+* Add support for [archiving channel backup](https://github.com/lightningnetwork/lnd/pull/9232)
+ in a designated folder which allows for easy referencing in the future. A new 
+ config is added `disable-backup-archive`, with default set to false, to 
+ determine if previous channel backups should be archived or not.
+
 ## Functional Enhancements
 * [Add ability](https://github.com/lightningnetwork/lnd/pull/8998) to paginate 
  wallet transactions.

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -309,6 +309,10 @@
 ; Example:
 ;   backupfilepath=~/.lnd/data/chain/bitcoin/mainnet/channel.backup
 
+; When false (default), old channel backups are archived to a designated location.
+; When true, old backups are simply replaced.
+; no-backup-archive=false
+
 ; The maximum capacity of the block cache in bytes. Increasing this will result
 ; in more blocks being kept in memory but will increase performance when the
 ; same block is required multiple times.

--- a/server.go
+++ b/server.go
@@ -1648,7 +1648,9 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		chanNotifier: s.channelNotifier,
 		addrs:        s.addrSource,
 	}
-	backupFile := chanbackup.NewMultiFile(cfg.BackupFilePath)
+	backupFile := chanbackup.NewMultiFile(
+		cfg.BackupFilePath, cfg.NoBackupArchive,
+	)
 	startingChans, err := chanbackup.FetchStaticChanBackups(
 		s.chanStateDB, s.addrSource,
 	)


### PR DESCRIPTION
Closes #8906 

## Change Description
From the [feature description](https://github.com/lightningnetwork/lnd/issues/8906):
> To ensure that certain classes of recovery are always possible, we should considering adding a mode to never delete channel backups, and only rename or move them to a special folder that stores archived channels. They're relatively small (~300 bytes or so), so it shouldn't take up a significant amount of disk space.


This PR allows for the archiving of channel backups, enabling users to choose whether to permanently delete previous backup files or archive them by moving them to a designated archives folder.

**Problem**:
LND currently overwrites old channel backup files when creating new ones. This means:

- If a user accidentally deletes a channel backup file, the backup is irretrievably lost.
- If a newly created backup file becomes corrupted and no older backups are preserved, recovering the channel through the file becomes impossible.
- In certain cases, users may want to compare older and newer backups to verify that the evolution of the channel states was valid.

**Solution**:
We modify the current flow of creating `channel.backup`. We start by creating a folder in the same directory where we store the `channel.backup` file (chan-backup-archives). We ensure that the `channel.backup` file is copied to the archive directory and timestamped before finally replacing it with the new file.

We set the LND's default behavior to archive old channel backups, but we provide a configuration option that can be passed as an argument or specified in `lnd.conf` to disable this behavior. This option allows LND to delete `channel.backup` files instead of archiving them. This can be achieved by setting `no-backup-archive=true` in `lnd.conf` or passed as argument:
```bash
lnd --no-backup-archive
```

## Steps to Test
1. Start LND (make sure `no-backup-archive=true` is not set in `lnd.conf`):
```bash
lnd
```
2. Trigger the channel backup process. This can be achieved by generating some blocks. If you're using BTCD backend: 
```bash
btcctl generate 6
```
3. Stop LND and check the directory where the `channel.backup` file is stored. You will find a new folder called `chan-backup-archives`, where the backup files are archived.

**To test disabling this feature**
- Start LND
```bash
lnd # if no-backup-archive=true is set in lnd.conf

# or

lnd --no-backup-archive # pass as arg

``` 
- Repeat 2 & 3. This time the `chan-backup-archives` directory will not be created (if it does not already exist). If it already exists a new archive will not be created.




## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
