### PR TITLE
chainntnfs/btcdnotify: remove redundant config params re-assignment

### DIFF
--- a/chainntnfs/btcdnotify/btcd.go
+++ b/chainntnfs/btcdnotify/btcd.go
@@ -129,11 +129,6 @@ func New(config *rpcclient.ConnConfig, chainParams *chaincfg.Params,
 		quit: make(chan struct{}),
 	}
 
-	// Disable connecting to btcd within the rpcclient.New method. We
-	// defer establishing the connection to our .Start() method.
-	config.DisableConnectOnNew = true
-	config.DisableAutoReconnect = false
-
 	ntfnCallbacks := &rpcclient.NotificationHandlers{
 		OnBlockConnected:    notifier.onBlockConnected,
 		OnBlockDisconnected: notifier.onBlockDisconnected,


### PR DESCRIPTION
Fix a race case found [here](https://github.com/lightningnetwork/lnd/actions/runs/11575782146/job/32223203058?pr=8893),
```
==================
WARNING: DATA RACE
Write at 0x00c000340110 by goroutine 11:
  github.com/lightningnetwork/lnd/chainntnfs/btcdnotify.New()
      /home/runner/work/lnd/lnd/chainntnfs/btcdnotify/btcd.go:135 +0xa2d
  github.com/lightningnetwork/lnd/chainntnfs/test.TestInterfaces.func3()
      /home/runner/work/lnd/lnd/chainntnfs/test/test_interface.go:1954 +0x70
  github.com/lightningnetwork/lnd/chainntnfs/test.TestInterfaces()
      /home/runner/work/lnd/lnd/chainntnfs/test/test_interface.go:2021 +0x[161](https://github.com/lightningnetwork/lnd/actions/runs/11575782146/job/32223203058?pr=8893#step:8:162)c
  github.com/lightningnetwork/lnd/chainntnfs/test/btcd_test.TestInterfaces()
      /home/runner/work/lnd/lnd/chainntnfs/test/btcd/btcd_test.go:15 +0x32
  testing.tRunner()
      /opt/hostedtoolcache/go/1.22.6/x64/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.22.6/x64/src/testing/testing.go:1742 +0x44

Previous read at 0x00c000340110 by goroutine 454:
  github.com/btcsuite/btcd/rpcclient.(*Client).Disconnect()
      /home/runner/go/pkg/mod/github.com/btcsuite/btcd@v0.24.3-0.20240921052913-67b8efd3ba53/rpcclient/infrastructure.go:1135 +0x104
  github.com/btcsuite/btcd/rpcclient.(*Client).wsInHandler()
      /home/runner/go/pkg/mod/github.com/btcsuite/btcd@v0.24.3-0.20240921052913-67b8efd3ba53/rpcclient/infrastructure.go:484 +0x1fe
  github.com/btcsuite/btcd/rpcclient.(*Client).start.gowrap2()
      /home/runner/go/pkg/mod/github.com/btcsuite/btcd@v0.24.3-0.20240921052913-67b8efd3ba53/rpcclient/infrastructure.go:1196 +0x33

Goroutine 11 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.22.6/x64/src/testing/testing.go:1742 +0x825
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.22.6/x64/src/testing/testing.go:2161 +0x85
  testing.tRunner()
      /opt/hostedtoolcache/go/1.22.6/x64/src/testing/testing.go:1689 +0x21e
  testing.runTests()
      /opt/hostedtoolcache/go/1.22.6/x64/src/testing/testing.go:2159 +0x8be
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.22.6/x64/src/testing/testing.go:2027 +0xf17
  main.main()
      _testmain.go:47 +0x2bd

Goroutine 454 (finished) created at:
  github.com/btcsuite/btcd/rpcclient.(*Client).start()
      /home/runner/go/pkg/mod/github.com/btcsuite/btcd@v0.24.3-0.20240921052913-67b8efd3ba53/rpcclient/infrastructure.go:1196 +0x2c7
  github.com/btcsuite/btcd/rpcclient.(*Client).Connect()
      /home/runner/go/pkg/mod/github.com/btcsuite/btcd@v0.24.3-0.20240921052913-67b8efd3ba53/rpcclient/infrastructure.go:1590 +0x496
  github.com/lightningnetwork/lnd/chainntnfs/btcdnotify.(*BtcdNotifier).startNotifier()
      /home/runner/work/lnd/lnd/chainntnfs/btcdnotify/btcd.go:221 +0x184
  github.com/lightningnetwork/lnd/chainntnfs/btcdnotify.(*BtcdNotifier).Start.func1()
      /home/runner/work/lnd/lnd/chainntnfs/btcdnotify/btcd.go:165 +0x37
  sync.(*Once).doSlow()
      /opt/hostedtoolcache/go/1.22.6/x64/src/sync/once.go:74 +0xf0
  sync.(*Once).Do()
      /opt/hostedtoolcache/go/1.22.6/x64/src/sync/once.go:65 +0x44
  github.com/lightningnetwork/lnd/chainntnfs/btcdnotify.(*BtcdNotifier).Start()
      /home/runner/work/lnd/lnd/chainntnfs/btcdnotify/btcd.go:[164](https://github.com/lightningnetwork/lnd/actions/runs/11575782146/job/32223203058?pr=8893#step:8:165) +0x88
  github.com/lightningnetwork/lnd/chainntnfs/test.TestInterfaces()
      /home/runner/work/lnd/lnd/chainntnfs/test/test_interface.go:1981 +0x104f
  github.com/lightningnetwork/lnd/chainntnfs/test/btcd_test.TestInterfaces()
      /home/runner/work/lnd/lnd/chainntnfs/test/btcd/btcd_test.go:15 +0x32
  testing.tRunner()
      /opt/hostedtoolcache/go/1.22.6/x64/src/testing/testing.go:[168](https://github.com/lightningnetwork/lnd/actions/runs/11575782146/job/32223203058?pr=8893#step:8:169)9 +0x21e
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.22.6/x64/src/testing/testing.go:1742 +0x44
==================
--- FAIL: TestInterfaces (39.96s)
    testing.go:1398: race detected during execution of test
FAIL
FAIL	github.com/lightningnetwork/lnd/chainntnfs/test/btcd	40.129s
FAIL
```

Turns out there is a race in the `config` file, and the fix is to remove the assignment in this `New` since it's redundant anyway,
https://github.com/lightningnetwork/lnd/blob/4778b146cc91dd4873988c6933b6fc2b0ba73499/chainreg/chainregistry.go#L584-L598