### PR TITLE
htlcswitch: merge htlc custom records on modify

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -100,6 +100,10 @@
     * `lncli abandonchannel` (`Lightning.AbandonChannel` RPC)
     * `lncli restorechanbackup` (`Lightning.RestoreChannelBackups` RPC)
     * `lncli verifychanbackup` (`Lightning.VerifyChanBackup` RPC)
+* The `ForwardInterceptor`'s `MODIFY` option will
+  [merge](https://github.com/lightningnetwork/lnd/pull/9240) any custom
+  range TLVs provided with the existing set of records on the HTLC,
+  overwriting any conflicting values with those supplied by the API.
 
 ## lncli Updates
 

--- a/htlcswitch/interceptable_switch.go
+++ b/htlcswitch/interceptable_switch.go
@@ -715,9 +715,12 @@ func (f *interceptedForward) ResumeModified(
 			htlc.Amount = amount
 		})
 
-		if len(validatedRecords) > 0 {
-			htlc.CustomRecords = validatedRecords
-		}
+		// Merge custom records with any validated records that were
+		// added in the modify request, overwriting any existing values
+		// with those supplied in the modifier API.
+		htlc.CustomRecords = htlc.CustomRecords.MergedCopy(
+			validatedRecords,
+		)
 
 	case *lnwire.UpdateFulfillHTLC:
 		if len(validatedRecords) > 0 {

--- a/lnrpc/routerrpc/router.pb.go
+++ b/lnrpc/routerrpc/router.pb.go
@@ -3254,13 +3254,9 @@ type ForwardHtlcInterceptResponse struct {
 	// the resumed HTLC. This field is ignored if the action is not
 	// RESUME_MODIFIED.
 	//
-	// If this map is populated, it will overwrite any of the wire custom
-	// records set by LND. It is the caller's responsibility to copy any desired
-	// records across. If the map is empty, no action will be taken and existing
-	// custom records will be propagated.
-	//
-	// The API does not currently support deleting custom records, unless they
-	// are overwritten by a new set.
+	// This map will merge with the existing set of custom records (if any),
+	// replacing any conflicting types. Note that there currently is no support
+	// for deleting existing custom records (they can only be replaced).
 	OutWireCustomRecords map[uint64][]byte `protobuf:"bytes,8,rep,name=out_wire_custom_records,json=outWireCustomRecords,proto3" json:"out_wire_custom_records,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }
 

--- a/lnrpc/routerrpc/router.proto
+++ b/lnrpc/routerrpc/router.proto
@@ -1064,13 +1064,9 @@ message ForwardHtlcInterceptResponse {
     // the resumed HTLC. This field is ignored if the action is not
     // RESUME_MODIFIED.
     //
-    // If this map is populated, it will overwrite any of the wire custom
-    // records set by LND. It is the caller's responsibility to copy any desired
-    // records across. If the map is empty, no action will be taken and existing
-    // custom records will be propagated.
-    //
-    // The API does not currently support deleting custom records, unless they
-    // are overwritten by a new set.
+    // This map will merge with the existing set of custom records (if any),
+    // replacing any conflicting types. Note that there currently is no support
+    // for deleting existing custom records (they can only be replaced).
     map<uint64, bytes> out_wire_custom_records = 8;
 }
 

--- a/lnrpc/routerrpc/router.swagger.json
+++ b/lnrpc/routerrpc/router.swagger.json
@@ -1525,7 +1525,7 @@
             "type": "string",
             "format": "byte"
           },
-          "description": "Any custom records that should be set on the p2p wire message message of\nthe resumed HTLC. This field is ignored if the action is not\nRESUME_MODIFIED.\n\nIf this map is populated, it will overwrite any of the wire custom\nrecords set by LND. It is the caller's responsibility to copy any desired\nrecords across. If the map is empty, no action will be taken and existing\ncustom records will be propagated.\n\nThe API does not currently support deleting custom records, unless they\nare overwritten by a new set."
+          "description": "Any custom records that should be set on the p2p wire message message of\nthe resumed HTLC. This field is ignored if the action is not\nRESUME_MODIFIED.\n\nThis map will merge with the existing set of custom records (if any),\nreplacing any conflicting types. Note that there currently is no support\nfor deleting existing custom records (they can only be replaced)."
         }
       },
       "description": "*\nForwardHtlcInterceptResponse enables the caller to resolve a previously hold\nforward. The caller can choose either to:\n- `Resume`: Execute the default behavior (usually forward).\n- `ResumeModified`: Execute the default behavior (usually forward) with HTLC\nfield modifications.\n- `Reject`: Fail the htlc backwards.\n- `Settle`: Settle this htlc with a given preimage."


### PR DESCRIPTION
Update forward interceptor `MODIFY` to consistently merge custom records supplied by the interceptor with those already in LND (previously it would overwrite if set and merge if empty).

Note that this change does not provide the ability to clear any custom records (only overwrite them). If a use cases emerges for the ability to delete records, the API can be extended accordingly. 

See #9166 for further discussion.