### PR TITLE
lnwire: add new fuzz targets

### DIFF
--- a/lnwire/fuzz_test.go
+++ b/lnwire/fuzz_test.go
@@ -995,6 +995,12 @@ func FuzzInvalidOnionPayload(f *testing.F) {
 	})
 }
 
+func FuzzFailInvalidBlinding(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		onionFailureHarness(t, data, CodeInvalidBlinding)
+	})
+}
+
 func FuzzClosingSig(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		// Prefix with ClosingSig.

--- a/lnwire/fuzz_test.go
+++ b/lnwire/fuzz_test.go
@@ -1053,3 +1053,30 @@ func FuzzClosingComplete(f *testing.F) {
 		harness(t, data)
 	})
 }
+
+// FuzzFee tests that decoding and re-encoding a Fee TLV does not mutate it.
+func FuzzFee(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 8 {
+			return
+		}
+
+		var fee Fee
+		var buf [8]byte
+		r := bytes.NewReader(data)
+
+		if err := feeDecoder(r, &fee, &buf, 8); err != nil {
+			return
+		}
+
+		var b bytes.Buffer
+		require.NoError(t, feeEncoder(&b, &fee, &buf))
+
+		// Use bytes.Equal instead of require.Equal so that nil and
+		// empty slices are considered equal.
+		require.True(
+			t, bytes.Equal(data, b.Bytes()), "%v != %v", data,
+			b.Bytes(),
+		)
+	})
+}


### PR DESCRIPTION
Add fuzz targets for:
- 3 new gossip 1.75 messages
- 1 new route blinding message
- Schnorr signature conversions
- the `Fee` TLV