### PR TITLE
chainreg: use feerate estimator in regtest and simnet

### DIFF
--- a/chainreg/chainregistry.go
+++ b/chainreg/chainregistry.go
@@ -385,8 +385,7 @@ func NewPartialChainControl(cfg *Config) (*PartialChainControl, func(), error) {
 		)
 		cc.ChainSource = bitcoindConn.NewBitcoindClient()
 
-		// If we're not in regtest mode, then we'll attempt to use a
-		// proper fee estimator for testnet.
+		// Initialize config to connect to bitcoind RPC.
 		rpcConfig := &rpcclient.ConnConfig{
 			Host:                 bitcoindHost,
 			User:                 bitcoindMode.RPCUser,
@@ -396,7 +395,9 @@ func NewPartialChainControl(cfg *Config) (*PartialChainControl, func(), error) {
 			DisableTLS:           true,
 			HTTPPostMode:         true,
 		}
-		if !cfg.Bitcoin.RegTest {
+
+		// If feeurl is not provided, use bitcoind's fee estimator.
+		if cfg.Fee.URL == "" {
 			log.Infof("Initializing bitcoind backed fee estimator "+
 				"in %s mode", bitcoindMode.EstimateMode)
 
@@ -660,9 +661,8 @@ func NewPartialChainControl(cfg *Config) (*PartialChainControl, func(), error) {
 			return checkOutboundPeers(chainRPC.Client)
 		}
 
-		// If we're not in simnet or regtest mode, then we'll attempt
-		// to use a proper fee estimator for testnet.
-		if !cfg.Bitcoin.SimNet && !cfg.Bitcoin.RegTest {
+		// If feeurl is not provided, use btcd's fee estimator.
+		if cfg.Fee.URL == "" {
 			log.Info("Initializing btcd backed fee estimator")
 
 			// Finally, we'll re-initialize the fee estimator, as

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -187,6 +187,11 @@ The underlying functionality between those two options remain the same.
   for the Gossip 1.75 protocol.
 
 ## Testing
+
+* LND [uses](https://github.com/lightningnetwork/lnd/pull/9257) the feerate
+  estimator provided by bitcoind or btcd in regtest and simnet modes instead of
+  static fee estimator if feeurl is not provided.
+
 ## Database
 
 * [Migrate the mission control 


### PR DESCRIPTION
## Change Description

If feeurl is not provided and LND is running in bitcoind or btcd mode, use fee estimator provided by bitcoind or btcd instead of using static fee estimator (which always returns 50 sats/vbyte).
    
This enables simulating high feerate environment in regtest and simnet not only via feeurl, but also by filling mempool with high feerate transactions, which is closer to what happens in mainnet.
    
Also skip creating bitcoind or btcd fee estimator, if feeurl is provided. Before LND logged both "Initializing bitcoind backed fee estimator" and "Using external fee estimator" if running in bitcoind mode with feeurl provided, but actually feeurl was used, so this is not a change of behavior.

## Steps to Test

 - Setup regtest/simnet network with LND, e.g. [in docker](https://github.com/lightningnetwork/lnd/blob/master/docker/README.md). Deploy LND from this branch.
 - Run `lncli wallet estimatefeerate 2` and make sure that `sat_per_vbyte` in response is 1. If you see value `50`, this means that the deployed LND is not from this branch (previous behavior was to always return 50).
 - Fill mempool with high feerate transactions, e.g. using [mempool-filler tool](https://github.com/lightninglabs/dev-resources/pull/98)
 - Run `lncli wallet estimatefeerate 2` again and make sure sat_per_vbyte is higher than 1.

I tested bitcoind/regtest and btcd/simnet modes.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
