### PR TITLE
chainntnfs: fix missing notifications

### DIFF
--- a/chainntnfs/bitcoindnotify/bitcoind.go
+++ b/chainntnfs/bitcoindnotify/bitcoind.go
@@ -665,8 +665,14 @@ func (b *BitcoindNotifier) handleBlockConnected(block chainntnfs.BlockEpoch) err
 	// satisfy any client requests based upon the new block.
 	b.bestBlock = block
 
+	err = b.txNotifier.NotifyHeight(uint32(block.Height))
+	if err != nil {
+		return fmt.Errorf("unable to notify height: %w", err)
+	}
+
 	b.notifyBlockEpochs(block.Height, block.Hash, block.BlockHeader)
-	return b.txNotifier.NotifyHeight(uint32(block.Height))
+
+	return nil
 }
 
 // notifyBlockEpochs notifies all registered block epoch clients of the newly

--- a/chainntnfs/btcdnotify/btcd.go
+++ b/chainntnfs/btcdnotify/btcd.go
@@ -725,11 +725,16 @@ func (b *BtcdNotifier) handleBlockConnected(epoch chainntnfs.BlockEpoch) error {
 	// satisfy any client requests based upon the new block.
 	b.bestBlock = epoch
 
+	err = b.txNotifier.NotifyHeight(uint32(epoch.Height))
+	if err != nil {
+		return fmt.Errorf("unable to notify height: %w", err)
+	}
+
 	b.notifyBlockEpochs(
 		epoch.Height, epoch.Hash, epoch.BlockHeader,
 	)
 
-	return b.txNotifier.NotifyHeight(uint32(epoch.Height))
+	return nil
 }
 
 // notifyBlockEpochs notifies all registered block epoch clients of the newly

--- a/chainntnfs/interface.go
+++ b/chainntnfs/interface.go
@@ -258,6 +258,9 @@ type ConfirmationEvent struct {
 // channels.
 func NewConfirmationEvent(numConfs uint32, cancel func()) *ConfirmationEvent {
 	return &ConfirmationEvent{
+		// We cannot rely on the subscriber to immediately read from
+		// the channel so we need to create a larger buffer to avoid
+		// blocking the notifier.
 		Confirmed:    make(chan *TxConfirmation, 1),
 		Updates:      make(chan uint32, numConfs),
 		NegativeConf: make(chan int32, 1),

--- a/chainntnfs/neutrinonotify/neutrino.go
+++ b/chainntnfs/neutrinonotify/neutrino.go
@@ -689,10 +689,16 @@ func (n *NeutrinoNotifier) handleBlockConnected(newBlock *filteredBlock) error {
 	n.bestBlock.Height = int32(newBlock.height)
 	n.bestBlock.BlockHeader = newBlock.header
 
+	err = n.txNotifier.NotifyHeight(newBlock.height)
+	if err != nil {
+		return fmt.Errorf("unable to notify height: %w", err)
+	}
+
 	n.notifyBlockEpochs(
 		int32(newBlock.height), &newBlock.hash, newBlock.header,
 	)
-	return n.txNotifier.NotifyHeight(newBlock.height)
+
+	return nil
 }
 
 // getFilteredBlock is a utility to retrieve the full filtered block from a block epoch.

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -54,6 +54,9 @@
 * [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/9275) where the
   peer may block the shutdown process of lnd.
 
+* [Fixed a case](https://github.com/lightningnetwork/lnd/pull/9258) where the
+  confirmation notification may be missed.
+
 # New Features
 ## Functional Enhancements
 ## RPC Additions
@@ -199,6 +202,10 @@ The underlying functionality between those two options remain the same.
 * Oliver Gugger
 * Pins
 * Viktor Tigerström
+<<<<<<< HEAD
 * Yong Yu
 * Ziggie
 
+=======
+* Ziggie
+>>>>>>> 5a6264b6a (docs: update release notes)


### PR DESCRIPTION
Cherry-picked commits from the final `blockbeat` to reduce the PR size.

This PR made two minor changes,
1. we now always notify the txns first before the block, such that when the block arrives the relevant txn notification is also arrived.
2. make sure the conf notification is non-blocking and always sent.