### PR TITLE
trivial: prepare itest for `blockbeat`

### DIFF
--- a/itest/lnd_channel_backup_test.go
+++ b/itest/lnd_channel_backup_test.go
@@ -1435,8 +1435,8 @@ func createLegacyRevocationChannel(ht *lntest.HarnessTest,
 	}
 
 	ht.MineBlocksAndAssertNumTxes(6, 1)
-	ht.AssertTopologyChannelOpen(from, chanPoint)
-	ht.AssertTopologyChannelOpen(to, chanPoint)
+	ht.AssertChannelInGraph(from, chanPoint)
+	ht.AssertChannelInGraph(to, chanPoint)
 }
 
 // chanRestoreViaRPC is a helper test method that returns a nodeRestorer

--- a/itest/lnd_channel_policy_test.go
+++ b/itest/lnd_channel_policy_test.go
@@ -127,8 +127,8 @@ func testUpdateChannelPolicy(ht *lntest.HarnessTest) {
 	}
 
 	// Make sure Alice and Carol have seen each other's channels.
-	ht.AssertTopologyChannelOpen(alice, chanPoint2)
-	ht.AssertTopologyChannelOpen(carol, chanPoint)
+	ht.AssertChannelInGraph(alice, chanPoint2)
+	ht.AssertChannelInGraph(carol, chanPoint)
 
 	// First we'll try to send a payment from Alice to Carol with an amount
 	// less than the min_htlc value required by Carol. This payment should
@@ -292,7 +292,7 @@ func testUpdateChannelPolicy(ht *lntest.HarnessTest) {
 	)
 
 	// Make sure Bob knows this channel.
-	ht.AssertTopologyChannelOpen(bob, chanPoint3)
+	ht.AssertChannelInGraph(bob, chanPoint3)
 
 	// Make a global update, and check that both channels' new policies get
 	// propagated.
@@ -515,9 +515,9 @@ func testSendUpdateDisableChannel(ht *lntest.HarnessTest) {
 	ht.RestartNodeWithExtraArgs(eve, nodeCfg)
 
 	// Dave should know all the channels.
-	ht.AssertTopologyChannelOpen(dave, chanPointAliceBob)
-	ht.AssertTopologyChannelOpen(dave, chanPointAliceCarol)
-	ht.AssertTopologyChannelOpen(dave, chanPointEveCarol)
+	ht.AssertChannelInGraph(dave, chanPointAliceBob)
+	ht.AssertChannelInGraph(dave, chanPointAliceCarol)
+	ht.AssertChannelInGraph(dave, chanPointEveCarol)
 
 	// We should expect to see a channel update with the default routing
 	// policy, except that it should indicate the channel is disabled.
@@ -701,7 +701,7 @@ func testUpdateChannelPolicyForPrivateChannel(ht *lntest.HarnessTest) {
 	)
 
 	// Carol should be aware of the channel between Alice and Bob.
-	ht.AssertTopologyChannelOpen(carol, chanPointAliceBob)
+	ht.AssertChannelInGraph(carol, chanPointAliceBob)
 
 	// We should have the following topology now,
 	// Alice <--public:100k--> Bob <--private:100k--> Carol

--- a/itest/lnd_coop_close_with_htlcs_test.go
+++ b/itest/lnd_coop_close_with_htlcs_test.go
@@ -47,7 +47,7 @@ func coopCloseWithHTLCs(ht *lntest.HarnessTest) {
 	})
 
 	// Wait for Bob to understand that the channel is ready to use.
-	ht.AssertTopologyChannelOpen(bob, chanPoint)
+	ht.AssertChannelInGraph(bob, chanPoint)
 
 	// Here we set things up so that Alice generates a HODL invoice so we
 	// can test whether the shutdown is deferred until the settlement of
@@ -141,7 +141,7 @@ func coopCloseWithHTLCsWithRestart(ht *lntest.HarnessTest) {
 	})
 
 	// Wait for Bob to understand that the channel is ready to use.
-	ht.AssertTopologyChannelOpen(bob, chanPoint)
+	ht.AssertChannelInGraph(bob, chanPoint)
 
 	// Set up a HODL invoice so that we can be sure that an HTLC is pending
 	// on the channel at the time that shutdown is requested.

--- a/itest/lnd_forward_interceptor_test.go
+++ b/itest/lnd_forward_interceptor_test.go
@@ -58,7 +58,7 @@ func testForwardInterceptorDedupHtlc(ht *lntest.HarnessTest) {
 	cpAB, cpBC := resp[0], resp[1]
 
 	// Make sure Alice is aware of channel Bob=>Carol.
-	ht.AssertTopologyChannelOpen(alice, cpBC)
+	ht.AssertChannelInGraph(alice, cpBC)
 
 	// Connect the interceptor.
 	interceptor, cancelInterceptor := bob.RPC.HtlcInterceptor()
@@ -209,7 +209,7 @@ func testForwardInterceptorBasic(ht *lntest.HarnessTest) {
 	cpAB, cpBC := resp[0], resp[1]
 
 	// Make sure Alice is aware of channel Bob=>Carol.
-	ht.AssertTopologyChannelOpen(alice, cpBC)
+	ht.AssertChannelInGraph(alice, cpBC)
 
 	// Connect the interceptor.
 	interceptor, cancelInterceptor := bob.RPC.HtlcInterceptor()
@@ -370,7 +370,7 @@ func testForwardInterceptorModifiedHtlc(ht *lntest.HarnessTest) {
 	cpAB, cpBC := resp[0], resp[1]
 
 	// Make sure Alice is aware of channel Bob=>Carol.
-	ht.AssertTopologyChannelOpen(alice, cpBC)
+	ht.AssertChannelInGraph(alice, cpBC)
 
 	// Connect an interceptor to Bob's node.
 	bobInterceptor, cancelBobInterceptor := bob.RPC.HtlcInterceptor()
@@ -478,7 +478,7 @@ func testForwardInterceptorWireRecords(ht *lntest.HarnessTest) {
 	cpAB, cpBC, cpCD := resp[0], resp[1], resp[2]
 
 	// Make sure Alice is aware of channel Bob=>Carol.
-	ht.AssertTopologyChannelOpen(alice, cpBC)
+	ht.AssertChannelInGraph(alice, cpBC)
 
 	// Connect an interceptor to Bob's node.
 	bobInterceptor, cancelBobInterceptor := bob.RPC.HtlcInterceptor()
@@ -609,8 +609,8 @@ func testForwardInterceptorRestart(ht *lntest.HarnessTest) {
 	cpAB, cpBC, cpCD := resp[0], resp[1], resp[2]
 
 	// Make sure Alice is aware of channels Bob=>Carol and Carol=>Dave.
-	ht.AssertTopologyChannelOpen(alice, cpBC)
-	ht.AssertTopologyChannelOpen(alice, cpCD)
+	ht.AssertChannelInGraph(alice, cpBC)
+	ht.AssertChannelInGraph(alice, cpCD)
 
 	// Connect an interceptor to Bob's node.
 	bobInterceptor, cancelBobInterceptor := bob.RPC.HtlcInterceptor()

--- a/itest/lnd_funding_test.go
+++ b/itest/lnd_funding_test.go
@@ -927,8 +927,8 @@ func testChannelFundingPersistence(ht *lntest.HarnessTest) {
 
 	// Make sure Alice and Carol have seen the channel in their network
 	// topology.
-	ht.AssertTopologyChannelOpen(alice, chanPoint)
-	ht.AssertTopologyChannelOpen(carol, chanPoint)
+	ht.AssertChannelInGraph(alice, chanPoint)
+	ht.AssertChannelInGraph(carol, chanPoint)
 
 	// Create an additional check for our channel assertion that will
 	// check that our label is as expected.
@@ -1055,7 +1055,7 @@ func testBatchChanFunding(ht *lntest.HarnessTest) {
 
 	// Ensure that Alice can send funds to Eve via the zero-conf channel
 	// before the batch transaction was mined.
-	ht.AssertTopologyChannelOpen(alice, chanPoint4)
+	ht.AssertChannelInGraph(alice, chanPoint4)
 	eveInvoiceParams := &lnrpc.Invoice{
 		Value:   int64(10_000),
 		Private: true,
@@ -1068,9 +1068,9 @@ func testBatchChanFunding(ht *lntest.HarnessTest) {
 	// Mine the batch transaction and check the network topology.
 	block := ht.MineBlocksAndAssertNumTxes(6, 1)[0]
 	ht.AssertTxInBlock(block, *txHash)
-	ht.AssertTopologyChannelOpen(alice, chanPoint1)
-	ht.AssertTopologyChannelOpen(alice, chanPoint2)
-	ht.AssertTopologyChannelOpen(alice, chanPoint3)
+	ht.AssertChannelInGraph(alice, chanPoint1)
+	ht.AssertChannelInGraph(alice, chanPoint2)
+	ht.AssertChannelInGraph(alice, chanPoint3)
 
 	// Check if the change type from the batch_open_channel funding is P2TR.
 	rawTx := ht.GetRawTransaction(*txHash)

--- a/itest/lnd_hold_persistence_test.go
+++ b/itest/lnd_hold_persistence_test.go
@@ -51,7 +51,7 @@ func testHoldInvoicePersistence(ht *lntest.HarnessTest) {
 	)
 
 	// Wait for Carol to see the open channel Alice-Bob.
-	ht.AssertTopologyChannelOpen(carol, chanPointBob)
+	ht.AssertChannelInGraph(carol, chanPointBob)
 
 	// Create preimages for all payments we are going to initiate.
 	var preimages []lntypes.Preimage

--- a/itest/lnd_invoice_acceptor_test.go
+++ b/itest/lnd_invoice_acceptor_test.go
@@ -35,7 +35,7 @@ func testInvoiceHtlcModifierBasic(ht *lntest.HarnessTest) {
 	cpAB, cpBC := resp[0], resp[1]
 
 	// Make sure Alice is aware of channel Bob=>Carol.
-	ht.AssertTopologyChannelOpen(alice, cpBC)
+	ht.AssertChannelInGraph(alice, cpBC)
 
 	// Initiate Carol's invoice HTLC modifier.
 	invoiceModifier, cancelModifier := carol.RPC.InvoiceHtlcModifier()

--- a/itest/lnd_misc_test.go
+++ b/itest/lnd_misc_test.go
@@ -172,10 +172,10 @@ func testSphinxReplayPersistence(ht *lntest.HarnessTest) {
 	invoiceResp := dave.RPC.AddInvoice(invoice)
 
 	// Wait for all channels to be recognized and advertized.
-	ht.AssertTopologyChannelOpen(carol, chanPoint)
-	ht.AssertTopologyChannelOpen(dave, chanPoint)
-	ht.AssertTopologyChannelOpen(carol, chanPointFC)
-	ht.AssertTopologyChannelOpen(fred, chanPointFC)
+	ht.AssertChannelInGraph(carol, chanPoint)
+	ht.AssertChannelInGraph(dave, chanPoint)
+	ht.AssertChannelInGraph(carol, chanPointFC)
+	ht.AssertChannelInGraph(fred, chanPointFC)
 
 	// With the invoice for Dave added, send a payment from Fred paying
 	// to the above generated invoice.
@@ -417,7 +417,7 @@ func testMaxPendingChannels(ht *lntest.HarnessTest) {
 		// Ensure that the funding transaction enters a block, and is
 		// properly advertised by Alice.
 		ht.AssertTxInBlock(block, fundingTxID)
-		ht.AssertTopologyChannelOpen(alice, fundingChanPoint)
+		ht.AssertChannelInGraph(alice, fundingChanPoint)
 
 		// The channel should be listed in the peer information
 		// returned by both peers.

--- a/itest/lnd_mpp_test.go
+++ b/itest/lnd_mpp_test.go
@@ -295,7 +295,7 @@ func (m *mppTestScenario) openChannels(r *mppOpenChannelRequest) {
 	// Make sure every node has heard every channel.
 	for _, hn := range m.nodes {
 		for _, cp := range m.channelPoints {
-			m.ht.AssertTopologyChannelOpen(hn, cp)
+			m.ht.AssertChannelInGraph(hn, cp)
 		}
 
 		// Each node should have exactly 6 edges.

--- a/itest/lnd_multi-hop-error-propagation_test.go
+++ b/itest/lnd_multi-hop-error-propagation_test.go
@@ -49,7 +49,7 @@ func testHtlcErrorPropagation(ht *lntest.HarnessTest) {
 	)
 
 	// Ensure that Alice has Carol in her routing table before proceeding.
-	ht.AssertTopologyChannelOpen(alice, chanPointBob)
+	ht.AssertChannelInGraph(alice, chanPointBob)
 
 	cType := ht.GetChannelCommitType(alice, chanPointAlice)
 	commitFee := lntest.CalcStaticFee(cType, 0)

--- a/itest/lnd_multi-hop_test.go
+++ b/itest/lnd_multi-hop_test.go
@@ -2295,8 +2295,8 @@ func createThreeHopNetwork(ht *lntest.HarnessTest,
 	// We'll only do this though if it wasn't a private channel we opened
 	// earlier.
 	if !privateChan {
-		ht.AssertTopologyChannelOpen(alice, bobChanPoint)
-		ht.AssertTopologyChannelOpen(carol, aliceChanPoint)
+		ht.AssertChannelInGraph(alice, bobChanPoint)
+		ht.AssertChannelInGraph(carol, aliceChanPoint)
 	} else {
 		// Otherwise, we want to wait for all the channels to be shown
 		// as active before we proceed.

--- a/itest/lnd_open_channel_test.go
+++ b/itest/lnd_open_channel_test.go
@@ -80,8 +80,8 @@ func testOpenChannelAfterReorg(ht *lntest.HarnessTest) {
 
 	// Wait for Alice and Bob to recognize and advertise the new channel
 	// generated above.
-	ht.AssertTopologyChannelOpen(alice, chanPoint)
-	ht.AssertTopologyChannelOpen(bob, chanPoint)
+	ht.AssertChannelInGraph(alice, chanPoint)
+	ht.AssertChannelInGraph(bob, chanPoint)
 
 	// Alice should now have 1 edge in her graph.
 	ht.AssertNumActiveEdges(alice, 1, true)

--- a/itest/lnd_payment_test.go
+++ b/itest/lnd_payment_test.go
@@ -1113,7 +1113,7 @@ func testPaymentFailureReasonCanceled(ht *lntest.HarnessTest) {
 	cpAB, cpBC := resp[0], resp[1]
 
 	// Make sure Alice is aware of channel Bob=>Carol.
-	ht.AssertTopologyChannelOpen(alice, cpBC)
+	ht.AssertChannelInGraph(alice, cpBC)
 
 	// Connect the interceptor.
 	interceptor, cancelInterceptor := bob.RPC.HtlcInterceptor()

--- a/itest/lnd_psbt_test.go
+++ b/itest/lnd_psbt_test.go
@@ -307,8 +307,8 @@ func runPsbtChanFunding(ht *lntest.HarnessTest, carol, dave *node.HarnessNode,
 	txHash := finalTx.TxHash()
 	block := ht.MineBlocksAndAssertNumTxes(6, 1)[0]
 	ht.AssertTxInBlock(block, txHash)
-	ht.AssertTopologyChannelOpen(carol, chanPoint)
-	ht.AssertTopologyChannelOpen(carol, chanPoint2)
+	ht.AssertChannelInGraph(carol, chanPoint)
+	ht.AssertChannelInGraph(carol, chanPoint2)
 
 	// With the channel open, ensure that it is counted towards Carol's
 	// total channel balance.
@@ -482,8 +482,8 @@ func runPsbtChanFundingExternal(ht *lntest.HarnessTest, carol,
 	// for the new channel to be propagated through the network.
 	block := ht.MineBlocksAndAssertNumTxes(6, 1)[0]
 	ht.AssertTxInBlock(block, txHash)
-	ht.AssertTopologyChannelOpen(carol, chanPoint)
-	ht.AssertTopologyChannelOpen(carol, chanPoint2)
+	ht.AssertChannelInGraph(carol, chanPoint)
+	ht.AssertChannelInGraph(carol, chanPoint2)
 
 	// With the channel open, ensure that it is counted towards Carol's
 	// total channel balance.
@@ -639,7 +639,7 @@ func runPsbtChanFundingSingleStep(ht *lntest.HarnessTest, carol,
 	txHash := finalTx.TxHash()
 	block := ht.MineBlocksAndAssertNumTxes(6, 1)[0]
 	ht.AssertTxInBlock(block, txHash)
-	ht.AssertTopologyChannelOpen(carol, chanPoint)
+	ht.AssertChannelInGraph(carol, chanPoint)
 
 	// Next, to make sure the channel functions as normal, we'll make some
 	// payments within the channel.

--- a/itest/lnd_res_handoff_test.go
+++ b/itest/lnd_res_handoff_test.go
@@ -37,7 +37,7 @@ func testResHandoff(ht *lntest.HarnessTest) {
 	chanPointCarol := ht.OpenChannel(bob, carol, params)
 
 	// Wait for Alice to see the channel edge in the graph.
-	ht.AssertTopologyChannelOpen(alice, chanPointCarol)
+	ht.AssertChannelInGraph(alice, chanPointCarol)
 
 	// We'll create an invoice for Carol that Alice will attempt to pay.
 	// Since Carol is in hodl.commit mode, she won't send back any commit

--- a/itest/lnd_revocation_test.go
+++ b/itest/lnd_revocation_test.go
@@ -276,7 +276,7 @@ func revokedCloseRetributionZeroValueRemoteOutputCase(ht *lntest.HarnessTest,
 	ht.EnsureConnected(dave, carol)
 
 	// Once connected, give Dave some time to enable the channel again.
-	ht.AssertTopologyChannelOpen(dave, chanPoint)
+	ht.AssertChannelInGraph(dave, chanPoint)
 
 	// Finally, send payments from Dave to Carol, consuming Carol's
 	// remaining payment hashes.
@@ -502,7 +502,7 @@ func revokedCloseRetributionRemoteHodlCase(ht *lntest.HarnessTest,
 	ht.EnsureConnected(dave, carol)
 
 	// Once connected, give Dave some time to enable the channel again.
-	ht.AssertTopologyChannelOpen(dave, chanPoint)
+	ht.AssertChannelInGraph(dave, chanPoint)
 
 	// Finally, send payments from Dave to Carol, consuming Carol's
 	// remaining payment hashes.

--- a/itest/lnd_route_blinding_test.go
+++ b/itest/lnd_route_blinding_test.go
@@ -63,7 +63,7 @@ func testQueryBlindedRoutes(ht *lntest.HarnessTest) {
 
 	// Wait for Alice to see Bob/Carol's channel because she'll need it for
 	// pathfinding.
-	ht.AssertTopologyChannelOpen(alice, chanPointBobCarol)
+	ht.AssertChannelInGraph(alice, chanPointBobCarol)
 
 	// Lookup full channel info so that we have channel ids for our route.
 	aliceBobChan := ht.GetChannelByChanPoint(alice, chanPointAliceBob)
@@ -593,7 +593,7 @@ func setupFourHopNetwork(ht *lntest.HarnessTest,
 	nodes := []*node.HarnessNode{ht.Alice, ht.Bob, carol, dave}
 	for _, chanPoint := range networkChans {
 		for _, node := range nodes {
-			ht.AssertTopologyChannelOpen(node, chanPoint)
+			ht.AssertChannelInGraph(node, chanPoint)
 		}
 	}
 
@@ -981,7 +981,7 @@ func testMPPToSingleBlindedPath(ht *lntest.HarnessTest) {
 			}
 
 			numPublic++
-			ht.AssertTopologyChannelOpen(hn, cp)
+			ht.AssertChannelInGraph(hn, cp)
 		}
 
 		// Each node should have exactly numPublic edges.
@@ -1152,7 +1152,7 @@ func testBlindedRouteDummyHops(ht *lntest.HarnessTest) {
 	// Make sure every node has heard about every channel.
 	for _, hn := range nodes {
 		for _, cp := range channelPoints {
-			ht.AssertTopologyChannelOpen(hn, cp)
+			ht.AssertChannelInGraph(hn, cp)
 		}
 
 		// Each node should have exactly 5 edges.
@@ -1321,7 +1321,7 @@ func testMPPToMultipleBlindedPaths(ht *lntest.HarnessTest) {
 	// Make sure every node has heard every channel.
 	for _, hn := range nodes {
 		for _, cp := range channelPoints {
-			ht.AssertTopologyChannelOpen(hn, cp)
+			ht.AssertChannelInGraph(hn, cp)
 		}
 
 		// Each node should have exactly 5 edges.

--- a/itest/lnd_routing_test.go
+++ b/itest/lnd_routing_test.go
@@ -344,7 +344,7 @@ func runMultiHopSendToRoute(ht *lntest.HarnessTest, useGraphCache bool) {
 	defer ht.CloseChannel(carol, chanPointBob)
 
 	// Make sure Alice knows the channel between Bob and Carol.
-	ht.AssertTopologyChannelOpen(alice, chanPointBob)
+	ht.AssertChannelInGraph(alice, chanPointBob)
 
 	// Create 5 invoices for Carol, which expect a payment from Alice for
 	// 1k satoshis with a different preimage each time.
@@ -965,7 +965,7 @@ func testMultiHopOverPrivateChannels(ht *lntest.HarnessTest) {
 	)
 
 	// Alice should know the new channel from Bob.
-	ht.AssertTopologyChannelOpen(alice, chanPointBob)
+	ht.AssertChannelInGraph(alice, chanPointBob)
 
 	// Next, we'll create Dave's node and open a private channel between
 	// him and Carol with Carol being the funder.
@@ -981,7 +981,7 @@ func testMultiHopOverPrivateChannels(ht *lntest.HarnessTest) {
 	)
 
 	// Dave should know the channel[Bob<->Carol] from Carol.
-	ht.AssertTopologyChannelOpen(dave, chanPointBob)
+	ht.AssertChannelInGraph(dave, chanPointBob)
 
 	// Now that all the channels are set up according to the topology from
 	// above, we can proceed to test payments. We'll create an invoice for
@@ -1077,8 +1077,8 @@ func testQueryRoutes(ht *lntest.HarnessTest) {
 
 	// Before we continue, give Alice some time to catch up with the newly
 	// opened channels.
-	ht.AssertTopologyChannelOpen(alice, chanPointBob)
-	ht.AssertTopologyChannelOpen(alice, chanPointCarol)
+	ht.AssertChannelInGraph(alice, chanPointBob)
+	ht.AssertChannelInGraph(alice, chanPointCarol)
 
 	// Query for routes to pay from Alice to Dave.
 	const paymentAmt = 1000
@@ -1389,7 +1389,7 @@ func testRouteFeeCutoff(ht *lntest.HarnessTest) {
 	}
 	for _, chanPoint := range networkChans {
 		for _, node := range nodes {
-			ht.AssertTopologyChannelOpen(node, chanPoint)
+			ht.AssertChannelInGraph(node, chanPoint)
 		}
 	}
 

--- a/itest/lnd_rpc_middleware_interceptor_test.go
+++ b/itest/lnd_rpc_middleware_interceptor_test.go
@@ -153,9 +153,13 @@ func testRPCMiddlewareInterceptor(ht *lntest.HarnessTest) {
 	// And finally make sure mandatory middleware is always checked for any
 	// RPC request.
 	ht.Run("mandatory middleware", func(tt *testing.T) {
-		st := ht.Subtest(tt)
-		middlewareMandatoryTest(st, alice)
+		middlewareMandatoryTest(ht, alice)
 	})
+
+	// We now shut down the node manually to prevent the test from failing
+	// because we can't call the stop RPC if we unregister the middleware
+	// in the defer statement above.
+	ht.KillNode(alice)
 }
 
 // middlewareRegistrationRestrictionTests tests all restrictions that apply to
@@ -593,11 +597,6 @@ func middlewareMandatoryTest(ht *lntest.HarnessTest, node *node.HarnessNode) {
 	time.Sleep(500 * time.Millisecond)
 	node.RPC.ListChannels(&lnrpc.ListChannelsRequest{})
 	node.RPC.SubscribeInvoices(&lnrpc.InvoiceSubscription{})
-
-	// We now shut down the node manually to prevent the test from failing
-	// because we can't call the stop RPC if we unregister the middleware
-	// in the defer statement above.
-	ht.KillNode(node)
 }
 
 // assertInterceptedType makes sure that the intercept message sent by the RPC

--- a/itest/lnd_switch_test.go
+++ b/itest/lnd_switch_test.go
@@ -415,7 +415,7 @@ func setupScenarioFourNodes(ht *lntest.HarnessTest) *scenarioFourNodes {
 	nodes := []*node.HarnessNode{alice, bob, carol, dave}
 	for _, chanPoint := range resp {
 		for _, node := range nodes {
-			ht.AssertTopologyChannelOpen(node, chanPoint)
+			ht.AssertChannelInGraph(node, chanPoint)
 		}
 	}
 

--- a/itest/lnd_wallet_import_test.go
+++ b/itest/lnd_wallet_import_test.go
@@ -413,8 +413,8 @@ func fundChanAndCloseFromImportedAccount(ht *lntest.HarnessTest, srcNode,
 		},
 		OutputIndex: upd.ChanPending.OutputIndex,
 	}
-	ht.AssertTopologyChannelOpen(srcNode, chanPoint)
-	ht.AssertTopologyChannelOpen(destNode, chanPoint)
+	ht.AssertChannelInGraph(srcNode, chanPoint)
+	ht.AssertChannelInGraph(destNode, chanPoint)
 
 	// Send a test payment to ensure the channel is operating as normal.
 	const invoiceAmt = 100000

--- a/itest/lnd_watchtower_test.go
+++ b/itest/lnd_watchtower_test.go
@@ -450,7 +450,7 @@ func testRevokedCloseRetributionAltruistWatchtowerCase(ht *lntest.HarnessTest,
 	ht.EnsureConnected(dave, carol)
 
 	// Once connected, give Dave some time to enable the channel again.
-	ht.AssertTopologyChannelOpen(dave, chanPoint)
+	ht.AssertChannelInGraph(dave, chanPoint)
 
 	// Finally, send payments from Dave to Carol, consuming Carol's
 	// remaining payment hashes.

--- a/itest/lnd_wipe_fwdpkgs_test.go
+++ b/itest/lnd_wipe_fwdpkgs_test.go
@@ -49,7 +49,7 @@ func testWipeForwardingPackages(ht *lntest.HarnessTest) {
 
 	// Before we continue, make sure Alice has seen the channel between Bob
 	// and Carol.
-	ht.AssertTopologyChannelOpen(alice, chanPointBC)
+	ht.AssertChannelInGraph(alice, chanPointBC)
 
 	// Alice sends several payments to Carol through Bob, which triggers
 	// Bob to create forwarding packages.

--- a/itest/lnd_zero_conf_test.go
+++ b/itest/lnd_zero_conf_test.go
@@ -75,8 +75,8 @@ func testZeroConfChannelOpen(ht *lntest.HarnessTest) {
 	// having to mine any blocks.
 	fundingPoint2 := ht.WaitForChannelOpenEvent(stream)
 
-	ht.AssertTopologyChannelOpen(carol, fundingPoint2)
-	ht.AssertTopologyChannelOpen(dave, fundingPoint2)
+	ht.AssertChannelInGraph(carol, fundingPoint2)
+	ht.AssertChannelInGraph(dave, fundingPoint2)
 
 	// Attempt to send a 10K satoshi payment from Carol to Dave.
 	daveInvoiceParams := &lnrpc.Invoice{
@@ -144,8 +144,8 @@ func testZeroConfChannelOpen(ht *lntest.HarnessTest) {
 	// Wait to receive the OpenStatusUpdate_ChanOpen update.
 	fundingPoint3 := ht.WaitForChannelOpenEvent(stream)
 
-	ht.AssertTopologyChannelOpen(eve, fundingPoint3)
-	ht.AssertTopologyChannelOpen(carol, fundingPoint3)
+	ht.AssertChannelInGraph(eve, fundingPoint3)
+	ht.AssertChannelInGraph(carol, fundingPoint3)
 
 	// Attempt to send a 20K satoshi payment from Eve to Dave.
 	daveInvoiceParams.Value = int64(20_000)
@@ -182,7 +182,7 @@ func testZeroConfChannelOpen(ht *lntest.HarnessTest) {
 	require.Len(ht, payReq.RouteHints, 0)
 
 	// Make sure Dave is aware of this channel and send the payment.
-	ht.AssertTopologyChannelOpen(dave, fundingPoint3)
+	ht.AssertChannelInGraph(dave, fundingPoint3)
 	ht.CompletePaymentRequests(
 		dave, []string{eveInvoiceResp.PaymentRequest},
 	)
@@ -269,7 +269,7 @@ func optionScidAliasScenario(ht *lntest.HarnessTest, chantype, private bool) {
 
 	// Make sure Bob knows this channel if it's public.
 	if !private {
-		ht.AssertTopologyChannelOpen(bob, fundingPoint)
+		ht.AssertChannelInGraph(bob, fundingPoint)
 	}
 
 	// Assert that a payment from Carol to Dave works as expected.
@@ -291,7 +291,7 @@ func optionScidAliasScenario(ht *lntest.HarnessTest, chantype, private bool) {
 	fundingPoint2 := ht.OpenChannel(bob, carol, p)
 
 	// Wait until Dave receives the Bob<->Carol channel.
-	ht.AssertTopologyChannelOpen(dave, fundingPoint2)
+	ht.AssertChannelInGraph(dave, fundingPoint2)
 
 	daveInvoiceResp2 := dave.RPC.AddInvoice(daveInvoiceParams)
 	decodedReq := dave.RPC.DecodePayReq(daveInvoiceResp2.PaymentRequest)
@@ -490,7 +490,7 @@ func testPrivateUpdateAlias(ht *lntest.HarnessTest,
 	fundingPoint := ht.OpenChannel(eve, carol, p)
 
 	// Make sure Dave has seen this public channel.
-	ht.AssertTopologyChannelOpen(dave, fundingPoint)
+	ht.AssertChannelInGraph(dave, fundingPoint)
 
 	// Setup a ChannelAcceptor for Dave.
 	acceptStream, cancel := dave.RPC.ChannelAcceptor()
@@ -792,7 +792,7 @@ func testOptionScidUpgrade(ht *lntest.HarnessTest) {
 	fundingPoint2 := ht.OpenChannel(bob, carol, p)
 
 	// Make sure Dave knows this channel.
-	ht.AssertTopologyChannelOpen(dave, fundingPoint2)
+	ht.AssertChannelInGraph(dave, fundingPoint2)
 
 	// Carol will now set the option-scid-alias feature bit and restart.
 	carolArgs = append(carolArgs, "--protocol.option-scid-alias")

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -841,9 +841,10 @@ func (h *HarnessTest) NewNodeRemoteSigner(name string, extraArgs []string,
 	return hn
 }
 
-// KillNode kills the node (but won't wait for the node process to stop).
+// KillNode kills the node and waits for the node process to stop.
 func (h *HarnessTest) KillNode(hn *node.HarnessNode) {
-	require.NoErrorf(h, hn.Kill(), "%s: kill got error", hn.Name())
+	h.Logf("Manually killing the node %s", hn.Name())
+	require.NoErrorf(h, hn.KillAndWait(), "%s: kill got error", hn.Name())
 	delete(h.manager.activeNodes, hn.Cfg.NodeID)
 }
 

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -193,6 +193,9 @@ func (h *HarnessTest) Start(chain node.BackendConfig,
 
 	// Assemble the miner.
 	h.miner = miner
+
+	// Update block height.
+	h.updateCurrentHeight()
 }
 
 // ChainBackendName returns the chain backend name used in the test.

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -1223,8 +1223,8 @@ func (h *HarnessTest) openChannel(alice, bob *node.HarnessNode,
 
 	// Check that both alice and bob have seen the channel from their
 	// network topology.
-	h.AssertTopologyChannelOpen(alice, fundingChanPoint)
-	h.AssertTopologyChannelOpen(bob, fundingChanPoint)
+	h.AssertChannelInGraph(alice, fundingChanPoint)
+	h.AssertChannelInGraph(bob, fundingChanPoint)
 
 	// Check that the channel can be seen in their ListChannels.
 	h.AssertChannelExists(alice, fundingChanPoint)
@@ -1245,8 +1245,8 @@ func (h *HarnessTest) openChannelZeroConf(alice, bob *node.HarnessNode,
 
 	// Check that both alice and bob have seen the channel from their
 	// network topology.
-	h.AssertTopologyChannelOpen(alice, fundingChanPoint)
-	h.AssertTopologyChannelOpen(bob, fundingChanPoint)
+	h.AssertChannelInGraph(alice, fundingChanPoint)
+	h.AssertChannelInGraph(bob, fundingChanPoint)
 
 	// Finally, check that the channel can be seen in their ListChannels.
 	h.AssertChannelExists(alice, fundingChanPoint)
@@ -1830,8 +1830,8 @@ func (h *HarnessTest) OpenMultiChannelsAsync(
 		if !req.Param.Private {
 			// Check that both alice and bob have seen the channel
 			// from their channel watch request.
-			h.AssertTopologyChannelOpen(req.Local, cp)
-			h.AssertTopologyChannelOpen(req.Remote, cp)
+			h.AssertChannelInGraph(req.Local, cp)
+			h.AssertChannelInGraph(req.Remote, cp)
 		}
 
 		// Finally, check that the channel can be seen in their
@@ -2327,7 +2327,7 @@ func (h *HarnessTest) openChannelsForNodes(nodes []*node.HarnessNode,
 	if !p.Private {
 		for _, node := range nodes {
 			for _, chanPoint := range resp {
-				h.AssertTopologyChannelOpen(node, chanPoint)
+				h.AssertChannelInGraph(node, chanPoint)
 			}
 		}
 	}

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -2302,7 +2302,6 @@ func (h *HarnessTest) openChannelsForNodes(nodes []*node.HarnessNode,
 	p OpenChannelParams) []*lnrpc.ChannelPoint {
 
 	// Sanity check the params.
-	require.False(h, p.ZeroConf, "zero-conf channels must be disabled")
 	require.Greater(h, len(nodes), 1, "need at least 2 nodes")
 
 	// Open channels in batch to save blocks mined.

--- a/lntest/harness_assertion.go
+++ b/lntest/harness_assertion.go
@@ -403,15 +403,6 @@ func (h HarnessTest) WaitForChannelOpenEvent(
 	return resp.ChanOpen.ChannelPoint
 }
 
-// AssertTopologyChannelOpen asserts that a given channel outpoint is seen by
-// the passed node's network topology.
-func (h *HarnessTest) AssertTopologyChannelOpen(hn *node.HarnessNode,
-	chanPoint *lnrpc.ChannelPoint) {
-
-	err := hn.Watcher.WaitForChannelOpen(chanPoint)
-	require.NoErrorf(h, err, "%s didn't report channel", hn.Name())
-}
-
 // AssertChannelExists asserts that an active channel identified by the
 // specified channel point exists from the point-of-view of the node.
 func (h *HarnessTest) AssertChannelExists(hn *node.HarnessNode,
@@ -506,7 +497,8 @@ func (h *HarnessTest) findChannel(hn *node.HarnessNode,
 		}
 	}
 
-	return nil, fmt.Errorf("channel not found using %s", chanPoint)
+	return nil, fmt.Errorf("%s: channel not found using %s", hn.Name(),
+		fp.String())
 }
 
 // ReceiveCloseChannelUpdate waits until a message or an error is received on
@@ -1943,6 +1935,37 @@ func (h *HarnessTest) AssertNotInGraph(hn *node.HarnessNode, chanID uint64) {
 	}, DefaultTimeout)
 	require.NoError(h, err, "timeout while checking that channel is not "+
 		"found in graph")
+}
+
+// AssertChannelInGraph asserts that a given channel is found in the graph.
+func (h *HarnessTest) AssertChannelInGraph(hn *node.HarnessNode,
+	chanPoint *lnrpc.ChannelPoint) *lnrpc.ChannelEdge {
+
+	ctxt, cancel := context.WithCancel(h.runCtx)
+	defer cancel()
+
+	var edge *lnrpc.ChannelEdge
+
+	op := h.OutPointFromChannelPoint(chanPoint)
+	err := wait.NoError(func() error {
+		resp, err := hn.RPC.LN.GetChanInfo(
+			ctxt, &lnrpc.ChanInfoRequest{
+				ChanPoint: op.String(),
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("channel %s not found in graph: %w",
+				op, err)
+		}
+
+		edge = resp
+
+		return nil
+	}, DefaultTimeout)
+	require.NoError(h, err, "%s: timeout finding channel in graph",
+		hn.Name())
+
+	return edge
 }
 
 // AssertTxAtHeight gets all of the transactions that a node's wallet has a

--- a/lntest/harness_node_manager.go
+++ b/lntest/harness_node_manager.go
@@ -46,7 +46,7 @@ type nodeManager struct {
 
 	// nodeCounter is a monotonically increasing counter that's used as the
 	// node's unique ID.
-	nodeCounter uint32
+	nodeCounter atomic.Uint32
 
 	// feeServiceURL is the url of the fee service.
 	feeServiceURL string
@@ -67,8 +67,8 @@ func newNodeManager(lndBinary string, dbBackend node.DatabaseBackend,
 
 // nextNodeID generates a unique sequence to be used as the node's ID.
 func (nm *nodeManager) nextNodeID() uint32 {
-	nodeID := atomic.AddUint32(&nm.nodeCounter, 1)
-	return nodeID - 1
+	nodeID := nm.nodeCounter.Add(1)
+	return nodeID
 }
 
 // newNode initializes a new HarnessNode, supporting the ability to initialize

--- a/lntest/node/config.go
+++ b/lntest/node/config.go
@@ -215,7 +215,6 @@ func (cfg *BaseNodeConfig) GenArgs() []string {
 		fmt.Sprintf("--readonlymacaroonpath=%v", cfg.ReadMacPath),
 		fmt.Sprintf("--invoicemacaroonpath=%v", cfg.InvoiceMacPath),
 		fmt.Sprintf("--trickledelay=%v", trickleDelay),
-		fmt.Sprintf("--profile=%d", cfg.ProfilePort),
 
 		// Use a small batch delay so we can broadcast the
 		// announcements quickly in the tests.

--- a/lntest/node/harness_node.go
+++ b/lntest/node/harness_node.go
@@ -796,6 +796,18 @@ func (hn *HarnessNode) Kill() error {
 	return hn.cmd.Process.Kill()
 }
 
+// KillAndWait kills the lnd process and waits for it to finish.
+func (hn *HarnessNode) KillAndWait() error {
+	err := hn.cmd.Process.Kill()
+	if err != nil {
+		return err
+	}
+
+	_, err = hn.cmd.Process.Wait()
+
+	return err
+}
+
 // printErrf prints an error to the console.
 func (hn *HarnessNode) printErrf(format string, a ...interface{}) {
 	fmt.Printf("itest error from [%s:%s]: %s\n", //nolint:forbidigo


### PR DESCRIPTION
Cherry-picked commits from the final `blockbeat` to reduce the PR size.

This PR makes a few trivial changes to fix the flakes found in the blockbeat itest.
