### PR TITLE
multi: remote graph source

### DIFF
--- a/config.go
+++ b/config.go
@@ -475,6 +475,8 @@ type Config struct {
 
 	Gossip *lncfg.Gossip `group:"gossip" namespace:"gossip"`
 
+	RemoteGraph *lncfg.RemoteGraph `group:"remotegraph" namespace:"remotegraph"`
+
 	Workers *lncfg.Workers `group:"workers" namespace:"workers"`
 
 	Caches *lncfg.Caches `group:"caches" namespace:"caches"`
@@ -720,6 +722,9 @@ func DefaultConfig() Config {
 				Attempts: defaultLeaderCheckAttempts,
 				Backoff:  defaultLeaderCheckBackoff,
 			},
+		},
+		RemoteGraph: &lncfg.RemoteGraph{
+			Timeout: lncfg.DefaultRemoteGraphTimeout,
 		},
 		Gossip: &lncfg.Gossip{
 			MaxChannelUpdateBurst: discovery.DefaultMaxChannelUpdateBurst,
@@ -1806,6 +1811,16 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 		cfg.Routing,
 		cfg.Pprof,
 		cfg.Gossip,
+		cfg.RemoteGraph,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate that the remote graph feature is compatible with the
+	// current configuration.
+	err = lncfg.ValidateRemoteGraph(
+		cfg.RemoteGraph, cfg.DB.NoGraphCache, cfg.Gossip.NoSync,
 	)
 	if err != nil {
 		return nil, err

--- a/discovery/bootstrapper.go
+++ b/discovery/bootstrapper.go
@@ -249,7 +249,7 @@ func (c *ChannelGraphBootstrapper) SampleNodeAddrs(_ context.Context,
 
 			return errFound
 		}, func() {
-			clear(a)
+			a = a[:0]
 		})
 		if err != nil && !errors.Is(err, errFound) {
 			return nil, err

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -87,6 +87,12 @@ var (
 	// the remote peer.
 	ErrGossipSyncerNotFound = errors.New("gossip syncer not found")
 
+	// ErrUnexpectedGossipQueries is returned if we receive gossip queries
+	// from a peer when gossip syncing is disabled.
+	ErrUnexpectedGossipQueries = errors.New(
+		"unexpected gossip queries received",
+	)
+
 	// ErrNoFundingTransaction is returned when we are unable to find the
 	// funding transaction described by the short channel ID on chain.
 	ErrNoFundingTransaction = errors.New(
@@ -408,6 +414,11 @@ type Config struct {
 	// PeerMsgRateBytes is the rate limit for the number of bytes per second
 	// that we'll allocate to outbound gossip messages for a single peer.
 	PeerMsgRateBytes uint64
+
+	// NoGossipSync is true if gossip syncing has been disabled. It
+	// indicates that we have not advertised the gossip queries feature bit,
+	// and so we should not receive any gossip queries from our peers.
+	NoGossipSync bool
 }
 
 // processedNetworkMsg is a wrapper around networkMsg and a boolean. It is
@@ -887,6 +898,25 @@ func (d *AuthenticatedGossiper) ProcessRemoteAnnouncement(ctx context.Context,
 	// TODO(ziggie): Redesign this once the actor model pattern becomes
 	// available. See https://github.com/lightningnetwork/lnd/pull/9820.
 	errChan := make(chan error, 2)
+
+	// If gossip syncing has been disabled, reject any gossip queries from
+	// our peer since we have not advertised the gossip queries feature bit.
+	if d.cfg.NoGossipSync {
+		switch msg.(type) {
+		case *lnwire.QueryShortChanIDs,
+			*lnwire.QueryChannelRange,
+			*lnwire.ReplyChannelRange,
+			*lnwire.ReplyShortChanIDsEnd,
+			*lnwire.GossipTimestampRange:
+
+			log.Warnf("Gossip syncing was disabled, "+
+				"skipping message: %v", msg)
+			errChan <- ErrUnexpectedGossipQueries
+
+			return errChan
+		default:
+		}
+	}
 
 	// For messages in the known set of channel series queries, we'll
 	// dispatch the message directly to the GossipSyncer, and skip the main

--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -74,6 +74,16 @@
   non-wumbo channel size (~0.168 BTC), with wumbo channels always requiring
   6 confirmations.
 
+* [Added support for using a remote LND node as a graph data
+  source](https://github.com/lightningnetwork/lnd/pull/9265). This allows a
+  lightweight or mobile node to delegate graph queries to a trusted remote LND
+  node instead of syncing and storing the full network graph locally. The feature
+  introduces a new `GraphSource` interface, a `Mux` that combines local and
+  remote graph data, and an RPC client that connects to the remote node's gRPC
+  API. The local graph cache is kept in sync via a topology subscription. Enable
+  with `--remotegraph.enable` along with `--gossip.no-sync` to disable local
+  gossip syncing.
+
 ## RPC Additions
 
 * The `WaitingCloseChannel` response in `PendingChannels` now includes two

--- a/feature/manager.go
+++ b/feature/manager.go
@@ -81,6 +81,11 @@ type Config struct {
 	// messaging.
 	NoOnionMessages bool
 
+	// NoGossipQueries unsets the gossip queries feature bit. This is set
+	// when gossip syncing is disabled (e.g. when using a remote graph
+	// source).
+	NoGossipQueries bool
+
 	// CustomFeatures is a set of custom features to advertise in each
 	// set.
 	CustomFeatures map[Set][]lnwire.FeatureBit
@@ -228,6 +233,10 @@ func newManager(cfg Config, desc setDesc) (*Manager, error) {
 		if cfg.NoOnionMessages {
 			raw.Unset(lnwire.OnionMessagesOptional)
 			raw.Unset(lnwire.OnionMessagesRequired)
+		}
+		if cfg.NoGossipQueries {
+			raw.Unset(lnwire.GossipQueriesOptional)
+			raw.Unset(lnwire.GossipQueriesRequired)
 		}
 
 		for _, custom := range cfg.CustomFeatures[set] {

--- a/graph/builder.go
+++ b/graph/builder.go
@@ -115,6 +115,13 @@ type Config struct {
 	// updates for such channels are applied directly to the graph cache
 	// without a DB write.
 	GraphSource graphdb.GraphSource
+
+	// OnRemoteChannelUpdate is an optional callback invoked when a channel
+	// update is applied from the GraphSource (i.e. for a channel that only
+	// exists in the remote graph). This allows the update to be propagated
+	// back to the remote graph source so it can validate, apply, and
+	// re-broadcast it to its peers.
+	OnRemoteChannelUpdate func(msg *lnwire.ChannelUpdate1)
 }
 
 // Builder builds and maintains a view of the Lightning Network graph.
@@ -1129,6 +1136,13 @@ func (b *Builder) applyChannelUpdateFromSource(ctx context.Context,
 
 	log.Debugf("Applied channel update from graph source for "+
 		"chan_id=%v directly to graph cache", chanID)
+
+	// If a callback is registered, propagate the update back to the
+	// remote graph source so it can validate, apply, and re-broadcast
+	// it to its peers.
+	if b.cfg.OnRemoteChannelUpdate != nil {
+		b.cfg.OnRemoteChannelUpdate(msg)
+	}
 
 	return true
 }

--- a/graph/builder.go
+++ b/graph/builder.go
@@ -107,6 +107,14 @@ type Config struct {
 	// IsAlias returns whether a passed ShortChannelID is an alias. This is
 	// only used for our local channels.
 	IsAlias func(scid lnwire.ShortChannelID) bool
+
+	// GraphSource is an optional read-only graph source that may combine
+	// local and remote graph data. When set, ApplyChannelUpdate will fall
+	// back to this source to look up channels that don't exist in the
+	// local graph DB (e.g. channels only known via a remote graph). Policy
+	// updates for such channels are applied directly to the graph cache
+	// without a DB write.
+	GraphSource graphdb.GraphSource
 }
 
 // Builder builds and maintains a view of the Lightning Network graph.
@@ -980,7 +988,17 @@ func (b *Builder) ApplyChannelUpdate(msg *lnwire.ChannelUpdate1) bool {
 
 	ch, _, _, err := b.GetChannelByID(msg.ShortChannelID)
 	if err != nil {
+		// If the channel isn't found in the local DB but we have a
+		// GraphSource (e.g. a remote graph), try looking it up there
+		// and apply the update directly to the graph cache.
+		if errors.Is(err, graphdb.ErrEdgeNotFound) &&
+			b.cfg.GraphSource != nil {
+
+			return b.applyChannelUpdateFromSource(ctx, msg)
+		}
+
 		log.Errorf("Unable to retrieve channel by id: %v", err)
+
 		return false
 	}
 
@@ -1020,6 +1038,97 @@ func (b *Builder) ApplyChannelUpdate(msg *lnwire.ChannelUpdate1) bool {
 		log.Errorf("Unable to apply channel update: %v", err)
 		return false
 	}
+
+	return true
+}
+
+// applyChannelUpdateFromSource handles channel updates for channels that only
+// exist in the GraphSource (e.g. via a remote graph) and not in the local DB.
+// It looks up the channel from the GraphSource, validates the update signature,
+// and applies the policy change directly to the graph cache.
+func (b *Builder) applyChannelUpdateFromSource(ctx context.Context,
+	msg *lnwire.ChannelUpdate1) bool {
+
+	chanID := msg.ShortChannelID.ToUint64()
+
+	ch, p1, p2, err := b.cfg.GraphSource.FetchChannelEdgesByID(ctx, chanID)
+	if err != nil {
+		log.Errorf("Unable to retrieve channel %v from graph "+
+			"source: %v", chanID, err)
+
+		return false
+	}
+
+	var pubKey *btcec.PublicKey
+
+	switch msg.ChannelFlags & lnwire.ChanUpdateDirection {
+	case 0:
+		pubKey, _ = ch.NodeKey1()
+
+	case 1:
+		pubKey, _ = ch.NodeKey2()
+	}
+
+	if pubKey == nil {
+		log.Errorf("Unable to decide pubkey with ChannelFlags=%v",
+			msg.ChannelFlags)
+
+		return false
+	}
+
+	err = netann.ValidateChannelUpdateAnn(pubKey, ch.Capacity, msg)
+	if err != nil {
+		log.Errorf("Unable to validate channel update: %v", err)
+
+		return false
+	}
+
+	// Check timestamp monotonicity per BOLT #7: only accept the
+	// update if its timestamp is newer than the existing policy.
+	var existingPolicy *models.ChannelEdgePolicy
+	if msg.ChannelFlags&lnwire.ChanUpdateDirection == 0 {
+		existingPolicy = p1
+	} else {
+		existingPolicy = p2
+	}
+
+	if existingPolicy != nil &&
+		msg.Timestamp <= uint32(existingPolicy.LastUpdate.Unix()) {
+
+		log.Debugf("Ignoring stale channel update from graph "+
+			"source for chan_id=%v (timestamp %d <= %d)",
+			chanID, msg.Timestamp,
+			existingPolicy.LastUpdate.Unix())
+
+		return false
+	}
+
+	update, err := models.ChanEdgePolicyFromWire(chanID, msg)
+	if err != nil {
+		log.Errorf("Unable to parse channel update: %v", err)
+
+		return false
+	}
+
+	fromNode, _ := ch.NodeKey1()
+	toNode, _ := ch.NodeKey2()
+
+	if fromNode == nil || toNode == nil {
+		log.Errorf("Unable to get node keys for channel %v", chanID)
+
+		return false
+	}
+
+	b.cfg.Graph.ApplyCacheUpdate(func(cache *graphdb.GraphCache) {
+		cache.UpdatePolicy(
+			models.NewCachedPolicy(update),
+			route.NewVertex(fromNode),
+			route.NewVertex(toNode),
+		)
+	})
+
+	log.Debugf("Applied channel update from graph source for "+
+		"chan_id=%v directly to graph cache", chanID)
 
 	return true
 }

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -105,6 +105,19 @@ func (c *ChannelGraph) GraphCacheStatus() GraphCacheStatus {
 	}
 }
 
+// ApplyCacheUpdate applies an update function to the graph cache. If the
+// cache is still being populated, the update is buffered and replayed once
+// population completes. This is used by the remote graph subscription
+// handler to update the cache with topology changes from the remote graph
+// source.
+func (c *ChannelGraph) ApplyCacheUpdate(update func(cache *GraphCache)) {
+	if c.cache == nil {
+		return
+	}
+
+	c.cache.applyUpdate(update)
+}
+
 // Start kicks off any goroutines required for the ChannelGraph to function.
 // If the graph cache is enabled, then it will be populated with the contents of
 // the database.

--- a/graph/db/graph_cache.go
+++ b/graph/db/graph_cache.go
@@ -125,13 +125,13 @@ func (c *GraphCache) AddChannel(info *models.CachedEdgeInfo,
 	// structure to the cache, even if both policies are currently disabled,
 	// so that later policy updates can find and update the channel entry.
 	c.mtx.Lock()
-	c.updateOrAddEdge(info.NodeKey1Bytes, &DirectedChannel{
+	c.maybeAddEdge(info.NodeKey1Bytes, &DirectedChannel{
 		ChannelID: info.ChannelID,
 		IsNode1:   true,
 		OtherNode: info.NodeKey2Bytes,
 		Capacity:  info.Capacity,
 	})
-	c.updateOrAddEdge(info.NodeKey2Bytes, &DirectedChannel{
+	c.maybeAddEdge(info.NodeKey2Bytes, &DirectedChannel{
 		ChannelID: info.ChannelID,
 		IsNode1:   false,
 		OtherNode: info.NodeKey1Bytes,
@@ -170,11 +170,17 @@ func (c *GraphCache) AddChannel(info *models.CachedEdgeInfo,
 	}
 }
 
-// updateOrAddEdge makes sure the edge information for a node is either updated
-// if it already exists or is added to that node's list of channels.
-func (c *GraphCache) updateOrAddEdge(node route.Vertex, edge *DirectedChannel) {
+// maybeAddEdge adds the edge to the node's channel list only if it does not
+// already exist. This prevents overwriting policies that were set by previous
+// updates (e.g., from topology subscription updates where channel structure
+// and policy updates arrive separately).
+func (c *GraphCache) maybeAddEdge(node route.Vertex, edge *DirectedChannel) {
 	if len(c.nodeChannels[node]) == 0 {
 		c.nodeChannels[node] = make(map[uint64]*DirectedChannel)
+	}
+
+	if c.nodeChannels[node][edge.ChannelID] != nil {
+		return
 	}
 
 	c.nodeChannels[node][edge.ChannelID] = edge

--- a/graph/db/graph_cache.go
+++ b/graph/db/graph_cache.go
@@ -268,6 +268,18 @@ func (c *GraphCache) RemoveChannel(node1, node2 route.Vertex, chanID uint64) {
 	c.removeChannelIfFound(node2, chanID)
 }
 
+// RemoveChannelByID removes a channel by its ID. This is less efficient than
+// RemoveChannel since it needs to scan all nodes to find the channel, but is
+// useful when the channel's endpoint nodes are not known.
+func (c *GraphCache) RemoveChannelByID(chanID uint64) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	for node := range c.nodeChannels {
+		c.removeChannelIfFound(node, chanID)
+	}
+}
+
 // removeChannelIfFound removes a single channel from one side.
 func (c *GraphCache) removeChannelIfFound(node route.Vertex, chanID uint64) {
 	if len(c.nodeChannels[node]) == 0 {

--- a/graph/db/graph_source.go
+++ b/graph/db/graph_source.go
@@ -344,7 +344,7 @@ func (d *DBGraphSource) SourceNode(ctx context.Context) (*models.Node,
 		func(v lnwire.GossipVersion) (*models.Node, error) {
 			return d.cg.db.SourceNode(ctx, v)
 		},
-		ErrGraphNodeNotFound,
+		ErrSourceNodeNotSet,
 	)
 }
 

--- a/graph/db/graph_source.go
+++ b/graph/db/graph_source.go
@@ -18,6 +18,8 @@ import (
 // etc.) to work with a unified view of the network without caring about gossip
 // protocol versions or whether the data comes from a local database or a
 // remote source.
+//
+//nolint:interfacebloat
 type GraphSource interface {
 	NodeTraverser
 

--- a/graph/db/graph_source.go
+++ b/graph/db/graph_source.go
@@ -1,0 +1,397 @@
+package graphdb
+
+import (
+	"context"
+	"errors"
+	"net"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/graph/db/models"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/route"
+)
+
+// GraphSource is a read-only interface for accessing channel graph data. It is
+// version-agnostic: implementations return the best available data across all
+// gossip protocol versions. This allows consumers (routing, RPC, autopilot,
+// etc.) to work with a unified view of the network without caring about gossip
+// protocol versions or whether the data comes from a local database or a
+// remote source.
+type GraphSource interface {
+	NodeTraverser
+
+	// ForEachNode iterates through all the stored vertices/nodes in the
+	// graph, executing the passed callback with each node encountered. If
+	// the callback returns an error, then the transaction is aborted and
+	// the iteration stops early.
+	ForEachNode(ctx context.Context,
+		cb func(*models.Node) error, reset func()) error
+
+	// ForEachChannel iterates through all the channel edges stored within
+	// the graph and invokes the passed callback for each edge. The callback
+	// receives the edge info and both directed edge policies. If the
+	// callback returns an error, then the iteration is halted with the
+	// error propagated back up to the caller. Channels from all gossip
+	// versions are included.
+	ForEachChannel(ctx context.Context,
+		cb func(*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+			*models.ChannelEdgePolicy) error,
+		reset func()) error
+
+	// ForEachNodeChannel iterates through all channels of the given node,
+	// executing the passed callback with an edge info structure and the
+	// policies of each end of the channel. Channels from all gossip
+	// versions are included.
+	ForEachNodeChannel(ctx context.Context,
+		nodePub route.Vertex,
+		cb func(*models.ChannelEdgeInfo,
+			*models.ChannelEdgePolicy,
+			*models.ChannelEdgePolicy) error,
+		reset func()) error
+
+	// ForEachNodeCached is similar to ForEachNode, but it returns
+	// DirectedChannel data to the callback. Uses the graph cache if
+	// available.
+	ForEachNodeCached(ctx context.Context, withAddrs bool,
+		cb func(ctx context.Context, node route.Vertex,
+			addrs []net.Addr,
+			chans map[uint64]*DirectedChannel) error,
+		reset func()) error
+
+	// FetchChannelEdgesByID attempts to look up the two directed edges for
+	// the channel identified by the channel ID. If the channel can't be
+	// found, then ErrEdgeNotFound is returned.
+	FetchChannelEdgesByID(ctx context.Context, chanID uint64) (
+		*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+		*models.ChannelEdgePolicy, error)
+
+	// FetchChannelEdgesByOutpoint attempts to look up the two directed
+	// edges for the channel identified by the funding outpoint.
+	FetchChannelEdgesByOutpoint(ctx context.Context,
+		op *wire.OutPoint) (
+		*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+		*models.ChannelEdgePolicy, error)
+
+	// FetchNode looks up a target node by its identity public key. If the
+	// node isn't found in the database, then ErrGraphNodeNotFound is
+	// returned.
+	FetchNode(ctx context.Context,
+		nodePub route.Vertex) (*models.Node, error)
+
+	// LookupAlias attempts to return the alias as advertised by the target
+	// node.
+	LookupAlias(ctx context.Context,
+		pub *btcec.PublicKey) (string, error)
+
+	// IsPublicNode determines whether the node with the given public key
+	// is seen as a public node in the graph from the graph's source node's
+	// point of view.
+	IsPublicNode(ctx context.Context, pubKey [33]byte) (bool, error)
+
+	// AddrsForNode returns all known addresses for the target node public
+	// key. The returned boolean indicates if the given node is known to
+	// the graph.
+	AddrsForNode(ctx context.Context,
+		nodePub *btcec.PublicKey) (bool, []net.Addr, error)
+
+	// GraphSession provides the callback with access to a NodeTraverser
+	// which can be used to perform queries against the channel graph with
+	// read consistency.
+	GraphSession(ctx context.Context,
+		cb func(graph NodeTraverser) error, reset func()) error
+
+	// SourceNode returns the source node of the graph. The source node is
+	// treated as the center node within a star-graph.
+	SourceNode(ctx context.Context) (*models.Node, error)
+
+	// ForEachSourceNodeChannel iterates through all channels of the source
+	// node.
+	ForEachSourceNodeChannel(ctx context.Context,
+		cb func(chanPoint wire.OutPoint, havePolicy bool,
+			otherNode *models.Node) error,
+		reset func()) error
+}
+
+// Compile-time check that DBGraphSource implements GraphSource.
+var _ GraphSource = (*DBGraphSource)(nil)
+
+// DBGraphSource implements GraphSource backed by a ChannelGraph database. It
+// provides a version-agnostic view: single-item lookups prefer the highest
+// available gossip version, while iteration methods currently cover v1 with
+// cross-version iteration planned.
+type DBGraphSource struct {
+	cg *ChannelGraph
+}
+
+// NewDBGraphSource creates a new DBGraphSource backed by the given
+// ChannelGraph.
+func NewDBGraphSource(cg *ChannelGraph) *DBGraphSource {
+	return &DBGraphSource{cg: cg}
+}
+
+// ForEachNodeDirectedChannel calls the callback for every channel of the given
+// node, using the graph cache if available.
+//
+// NOTE: this is part of the NodeTraverser interface.
+func (d *DBGraphSource) ForEachNodeDirectedChannel(ctx context.Context,
+	nodePub route.Vertex,
+	cb func(channel *DirectedChannel) error, reset func()) error {
+
+	return d.cg.ForEachNodeDirectedChannel(ctx, nodePub, cb, reset)
+}
+
+// FetchNodeFeatures returns the features of the given node.
+//
+// NOTE: this is part of the NodeTraverser interface.
+func (d *DBGraphSource) FetchNodeFeatures(ctx context.Context,
+	nodePub route.Vertex) (*lnwire.FeatureVector, error) {
+
+	return d.cg.FetchNodeFeatures(ctx, nodePub)
+}
+
+// ForEachNode iterates through all the stored vertices/nodes in the graph.
+//
+// NOTE: this is part of the GraphSource interface.
+func (d *DBGraphSource) ForEachNode(ctx context.Context,
+	cb func(*models.Node) error, reset func()) error {
+
+	return d.cg.db.ForEachNode(ctx, lnwire.GossipVersion1, cb, reset)
+}
+
+// ForEachChannel iterates through all channel edges stored within the graph.
+//
+// NOTE: this is part of the GraphSource interface.
+func (d *DBGraphSource) ForEachChannel(ctx context.Context,
+	cb func(*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+		*models.ChannelEdgePolicy) error,
+	reset func()) error {
+
+	// TODO(elle): add cross-version iteration support once the store
+	// provides a unified API for iterating across gossip versions. For
+	// now we iterate v1 only, matching the existing behavior.
+	return d.cg.db.ForEachChannel(ctx, gossipV1, cb, reset)
+}
+
+// ForEachNodeChannel iterates through all channels of the given node.
+//
+// NOTE: this is part of the GraphSource interface.
+func (d *DBGraphSource) ForEachNodeChannel(ctx context.Context,
+	nodePub route.Vertex,
+	cb func(*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+		*models.ChannelEdgePolicy) error,
+	reset func()) error {
+
+	// TODO(elle): add cross-version iteration support once the store
+	// provides a unified API for iterating across gossip versions. For
+	// now we iterate v1 only, matching the existing behavior.
+	return d.cg.db.ForEachNodeChannel(ctx, gossipV1, nodePub, cb, reset)
+}
+
+// ForEachNodeCached iterates through all nodes using the cache if available.
+//
+// NOTE: this is part of the GraphSource interface.
+func (d *DBGraphSource) ForEachNodeCached(ctx context.Context, withAddrs bool,
+	cb func(ctx context.Context, node route.Vertex, addrs []net.Addr,
+		chans map[uint64]*DirectedChannel) error,
+	reset func()) error {
+
+	return d.cg.ForEachNodeCached(
+		ctx, lnwire.GossipVersion1, withAddrs, cb, reset,
+	)
+}
+
+// FetchChannelEdgesByID looks up the two directed edges for the channel
+// identified by channel ID, preferring the highest gossip version.
+//
+// NOTE: this is part of the GraphSource interface.
+func (d *DBGraphSource) FetchChannelEdgesByID(ctx context.Context,
+	chanID uint64) (
+	*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+	*models.ChannelEdgePolicy, error) {
+
+	return d.cg.FetchChannelEdgesByID(ctx, chanID)
+}
+
+// FetchChannelEdgesByOutpoint looks up the two directed edges for the channel
+// identified by the funding outpoint, preferring the highest gossip version.
+//
+// NOTE: this is part of the GraphSource interface.
+func (d *DBGraphSource) FetchChannelEdgesByOutpoint(ctx context.Context,
+	op *wire.OutPoint) (
+	*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+	*models.ChannelEdgePolicy, error) {
+
+	return d.cg.FetchChannelEdgesByOutpoint(ctx, op)
+}
+
+// FetchNode looks up a target node by its identity public key, preferring
+// the highest gossip version.
+//
+// NOTE: this is part of the GraphSource interface.
+func (d *DBGraphSource) FetchNode(ctx context.Context,
+	nodePub route.Vertex) (*models.Node, error) {
+
+	return fetchPreferHighest(
+		func(v lnwire.GossipVersion) (*models.Node, error) {
+			return d.cg.db.FetchNode(ctx, v, nodePub)
+		},
+		ErrGraphNodeNotFound,
+	)
+}
+
+// LookupAlias returns the alias as advertised by the target node, preferring
+// the highest gossip version.
+//
+// NOTE: this is part of the GraphSource interface.
+func (d *DBGraphSource) LookupAlias(ctx context.Context,
+	pub *btcec.PublicKey) (string, error) {
+
+	return fetchPreferHighest(
+		func(v lnwire.GossipVersion) (string, error) {
+			return d.cg.db.LookupAlias(ctx, v, pub)
+		},
+		ErrNodeAliasNotFound,
+	)
+}
+
+// IsPublicNode determines whether the node with the given public key is seen
+// as a public node in the graph. A node is considered public if it has
+// announced channels in any gossip version.
+//
+// NOTE: this is part of the GraphSource interface.
+func (d *DBGraphSource) IsPublicNode(ctx context.Context,
+	pubKey [33]byte) (bool, error) {
+
+	for _, v := range gossipVersionsDescending {
+		public, err := d.cg.db.IsPublicNode(ctx, v, pubKey)
+		if err != nil {
+			if errors.Is(err, ErrVersionNotSupportedForKVDB) {
+				continue
+			}
+
+			return false, err
+		}
+
+		if public {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// AddrsForNode returns all known addresses for the target node public key,
+// preferring the highest gossip version.
+//
+// NOTE: this is part of the GraphSource interface.
+func (d *DBGraphSource) AddrsForNode(ctx context.Context,
+	nodePub *btcec.PublicKey) (bool, []net.Addr, error) {
+
+	type result struct {
+		known bool
+		addrs []net.Addr
+	}
+
+	r, err := fetchPreferHighest(
+		func(v lnwire.GossipVersion) (result, error) {
+			known, addrs, err := d.cg.db.AddrsForNode(
+				ctx, v, nodePub,
+			)
+			if err != nil {
+				return result{}, err
+			}
+
+			if !known {
+				return result{}, ErrGraphNodeNotFound
+			}
+
+			return result{known: known, addrs: addrs}, nil
+		},
+		ErrGraphNodeNotFound,
+	)
+	if err != nil {
+		// If the node wasn't found in any version, return (false, nil)
+		// rather than an error, matching the original AddrsForNode
+		// semantics.
+		if errors.Is(err, ErrGraphNodeNotFound) {
+			return false, nil, nil
+		}
+
+		return false, nil, err
+	}
+
+	return r.known, r.addrs, nil
+}
+
+// GraphSession provides the callback with access to a NodeTraverser.
+//
+// NOTE: this is part of the GraphSource interface.
+func (d *DBGraphSource) GraphSession(ctx context.Context,
+	cb func(graph NodeTraverser) error, reset func()) error {
+
+	return d.cg.GraphSession(ctx, cb, reset)
+}
+
+// SourceNode returns the source node of the graph, preferring the highest
+// gossip version.
+//
+// NOTE: this is part of the GraphSource interface.
+func (d *DBGraphSource) SourceNode(ctx context.Context) (*models.Node,
+	error) {
+
+	return fetchPreferHighest(
+		func(v lnwire.GossipVersion) (*models.Node, error) {
+			return d.cg.db.SourceNode(ctx, v)
+		},
+		ErrGraphNodeNotFound,
+	)
+}
+
+// ForEachSourceNodeChannel iterates through all channels of the source node.
+//
+// NOTE: this is part of the GraphSource interface.
+func (d *DBGraphSource) ForEachSourceNodeChannel(ctx context.Context,
+	cb func(chanPoint wire.OutPoint, havePolicy bool,
+		otherNode *models.Node) error,
+	reset func()) error {
+
+	// TODO(elle): add cross-version iteration support once the store
+	// provides a unified API for iterating across gossip versions. For
+	// now we iterate v1 only, matching the existing behavior.
+	return d.cg.db.ForEachSourceNodeChannel(ctx, gossipV1, cb, reset)
+}
+
+// gossipVersionsDescending lists gossip versions in descending order so that
+// the highest (newest) version is tried first.
+var gossipVersionsDescending = []lnwire.GossipVersion{
+	gossipV2, gossipV1,
+}
+
+// fetchPreferHighest is a helper that tries a versioned fetch function against
+// gossip versions in descending order. It returns the result from the highest
+// version that succeeds. If a version returns the given notFoundErr (or
+// ErrVersionNotSupportedForKVDB), the next version is tried. Any other error
+// is returned immediately.
+func fetchPreferHighest[T any](fetch func(lnwire.GossipVersion) (T, error),
+	notFoundErr error) (T, error) {
+
+	var zero T
+
+	for _, v := range gossipVersionsDescending {
+		result, err := fetch(v)
+		if err == nil {
+			return result, nil
+		}
+
+		if errors.Is(err, notFoundErr) ||
+			errors.Is(err, ErrVersionNotSupportedForKVDB) {
+
+			continue
+		}
+
+		return zero, err
+	}
+
+	return zero, notFoundErr
+}

--- a/graph/db/graph_source_test.go
+++ b/graph/db/graph_source_test.go
@@ -1,0 +1,29 @@
+package graphdb
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDBGraphSourceSourceNodeFallback ensures the graph source falls back to
+// the next supported gossip version when the preferred version does not yet
+// have a source node persisted.
+func TestDBGraphSourceSourceNodeFallback(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	graph := MakeTestGraph(t)
+	source := NewDBGraphSource(graph)
+
+	_, err := source.SourceNode(ctx)
+	require.ErrorIs(t, err, ErrSourceNodeNotSet)
+
+	node := createTestVertex(t, lnwire.GossipVersion1)
+	require.NoError(t, graph.SetSourceNode(ctx, node))
+
+	sourceNode, err := source.SourceNode(ctx)
+	require.NoError(t, err)
+	compareNodes(t, node, sourceNode)
+}

--- a/graph/sources/interface.go
+++ b/graph/sources/interface.go
@@ -1,0 +1,68 @@
+package sources
+
+import (
+	"context"
+	"net"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/graph/db/models"
+	"github.com/lightningnetwork/lnd/routing/route"
+)
+
+// RemoteGraph defines the read-only methods that a remote graph source must
+// implement. These are the methods called by the Mux when it needs to query
+// the remote graph provider for network data.
+//
+// Cache-related methods (ForEachNodeDirectedChannel, FetchNodeFeatures,
+// ForEachNodeCached, GraphSession) and self-node methods (SourceNode,
+// ForEachSourceNodeChannel) are intentionally excluded. The Mux handles these
+// using the local graph cache and local DB respectively.
+type RemoteGraph interface {
+	// ForEachNode iterates through all nodes known to the remote source.
+	ForEachNode(ctx context.Context,
+		cb func(*models.Node) error, reset func()) error
+
+	// ForEachChannel iterates through all channel edges known to the
+	// remote source.
+	ForEachChannel(ctx context.Context,
+		cb func(*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+			*models.ChannelEdgePolicy) error,
+		reset func()) error
+
+	// ForEachNodeChannel iterates through all channels of the given node.
+	ForEachNodeChannel(ctx context.Context,
+		nodePub route.Vertex,
+		cb func(*models.ChannelEdgeInfo,
+			*models.ChannelEdgePolicy,
+			*models.ChannelEdgePolicy) error,
+		reset func()) error
+
+	// FetchChannelEdgesByID looks up directed edges by channel ID.
+	FetchChannelEdgesByID(ctx context.Context, chanID uint64) (
+		*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+		*models.ChannelEdgePolicy, error)
+
+	// FetchChannelEdgesByOutpoint looks up directed edges by funding
+	// outpoint.
+	FetchChannelEdgesByOutpoint(ctx context.Context,
+		op *wire.OutPoint) (
+		*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+		*models.ChannelEdgePolicy, error)
+
+	// FetchNode looks up a target node by its identity public key.
+	FetchNode(ctx context.Context,
+		nodePub route.Vertex) (*models.Node, error)
+
+	// IsPublicNode determines whether the given node is seen as a public
+	// node in the remote graph.
+	IsPublicNode(ctx context.Context, pubKey [33]byte) (bool, error)
+
+	// LookupAlias returns the alias as advertised by the target node.
+	LookupAlias(ctx context.Context,
+		pub *btcec.PublicKey) (string, error)
+
+	// AddrsForNode returns all known addresses for the target node.
+	AddrsForNode(ctx context.Context,
+		nodePub *btcec.PublicKey) (bool, []net.Addr, error)
+}

--- a/graph/sources/log.go
+++ b/graph/sources/log.go
@@ -1,0 +1,21 @@
+package sources
+
+import (
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightningnetwork/lnd/build"
+)
+
+// log is a logger that is initialized with no output filters.  This
+// means the package will not perform any logging by default until the caller
+// requests it.
+var log btclog.Logger
+
+// The default amount of logging is none.
+func init() {
+	UseLogger(build.NewSubLogger("GSRC", nil))
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/graph/sources/mux.go
+++ b/graph/sources/mux.go
@@ -1,0 +1,430 @@
+package sources
+
+import (
+	"context"
+	"maps"
+	"net"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/wire"
+	graphdb "github.com/lightningnetwork/lnd/graph/db"
+	"github.com/lightningnetwork/lnd/graph/db/models"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/route"
+)
+
+// Compile-time check that Mux implements graphdb.GraphSource.
+var _ graphdb.GraphSource = (*Mux)(nil)
+
+// Mux is a GraphSource implementation that multiplexes between a local
+// database source and a remote graph source. It provides a unified view of
+// the network by combining data from both sources with the following strategy:
+//
+//   - Own node/channels: always served from local (authoritative)
+//   - Other nodes/channels: remote first, supplemented by local
+//   - Pathfinding (NodeTraverser): uses the local graph cache
+//     (populated from both sources via subscription)
+//
+// The Mux deduplicates results when iterating both sources to avoid
+// presenting the same node or channel twice.
+type Mux struct {
+	local  graphdb.GraphSource
+	remote RemoteGraph
+
+	selfPub route.Vertex
+}
+
+// NewMux creates a new Mux that combines the local and remote graph sources.
+// The selfPub is the public key of this node, used to determine which data
+// should be served from the local source.
+func NewMux(local graphdb.GraphSource, remote RemoteGraph,
+	selfPub route.Vertex) *Mux {
+
+	return &Mux{
+		local:   local,
+		remote:  remote,
+		selfPub: selfPub,
+	}
+}
+
+// ForEachNodeDirectedChannel calls the callback for every channel of the given
+// node. This is delegated to the local source which uses the graph cache
+// (populated from both local and remote data via subscription).
+//
+// NOTE: this is part of the graphdb.NodeTraverser interface.
+func (m *Mux) ForEachNodeDirectedChannel(ctx context.Context,
+	nodePub route.Vertex,
+	cb func(channel *graphdb.DirectedChannel) error,
+	reset func()) error {
+
+	return m.local.ForEachNodeDirectedChannel(ctx, nodePub, cb, reset)
+}
+
+// FetchNodeFeatures returns the features of the given node. Delegated to local
+// which uses the graph cache.
+//
+// NOTE: this is part of the graphdb.NodeTraverser interface.
+func (m *Mux) FetchNodeFeatures(ctx context.Context,
+	nodePub route.Vertex) (*lnwire.FeatureVector, error) {
+
+	return m.local.FetchNodeFeatures(ctx, nodePub)
+}
+
+// ForEachNode iterates through all nodes, combining remote and local sources.
+// Remote nodes are iterated first, then local nodes not already seen.
+//
+// NOTE: this is part of the graphdb.GraphSource interface.
+func (m *Mux) ForEachNode(ctx context.Context,
+	cb func(*models.Node) error, reset func()) error {
+
+	seen := make(map[route.Vertex]struct{})
+
+	var cbErr error
+	err := m.remote.ForEachNode(ctx, func(node *models.Node) error {
+		seen[node.PubKeyBytes] = struct{}{}
+
+		if err := cb(node); err != nil {
+			// Tag callback errors so we can distinguish them
+			// from remote transport errors below.
+			cbErr = err
+
+			return err
+		}
+
+		return nil
+	}, func() {
+		clear(seen)
+		reset()
+	})
+	if err != nil {
+		// If the error came from the caller's callback, propagate
+		// it directly rather than falling back to local.
+		if cbErr != nil {
+			return cbErr
+		}
+
+		// If the remote source itself failed, fall back to
+		// local-only iteration. Reset accumulated state so the
+		// caller starts fresh.
+		log.Warnf("Remote ForEachNode failed, falling back to "+
+			"local: %v", err)
+
+		clear(seen)
+		reset()
+
+		return m.local.ForEachNode(ctx, cb, reset)
+	}
+
+	// Take a snapshot of the seen map after remote iteration. On SQL
+	// transaction retry during local iteration, we restore to this
+	// snapshot so that local-only entries from the failed attempt are
+	// cleared while remote entries are preserved.
+	remoteSeen := make(map[route.Vertex]struct{}, len(seen))
+	maps.Copy(remoteSeen, seen)
+
+	return m.local.ForEachNode(ctx, func(node *models.Node) error {
+		if _, ok := seen[node.PubKeyBytes]; ok {
+			return nil
+		}
+
+		seen[node.PubKeyBytes] = struct{}{}
+
+		return cb(node)
+	}, func() {
+		// Restore seen to only contain remote entries.
+		clear(seen)
+		maps.Copy(seen, remoteSeen)
+	})
+}
+
+// ForEachChannel iterates through all channel edges, combining remote and
+// local sources. Remote channels come first, then local channels not already
+// seen (e.g., private channels).
+//
+// NOTE: this is part of the graphdb.GraphSource interface.
+func (m *Mux) ForEachChannel(ctx context.Context,
+	cb func(*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+		*models.ChannelEdgePolicy) error,
+	reset func()) error {
+
+	seen := make(map[uint64]struct{})
+
+	var cbErr error
+	err := m.remote.ForEachChannel(ctx,
+		func(info *models.ChannelEdgeInfo,
+			p1, p2 *models.ChannelEdgePolicy) error {
+
+			seen[info.ChannelID] = struct{}{}
+
+			if err := cb(info, p1, p2); err != nil {
+				cbErr = err
+
+				return err
+			}
+
+			return nil
+		}, func() {
+			clear(seen)
+			reset()
+		},
+	)
+	if err != nil {
+		if cbErr != nil {
+			return cbErr
+		}
+
+		log.Warnf("Remote ForEachChannel failed, falling back to "+
+			"local: %v", err)
+
+		clear(seen)
+		reset()
+
+		return m.local.ForEachChannel(ctx, cb, reset)
+	}
+
+	// Take a snapshot of the seen map after remote iteration. On SQL
+	// transaction retry during local iteration, we restore to this
+	// snapshot so that local-only entries from the failed attempt are
+	// cleared while remote entries are preserved.
+	remoteSeen := make(map[uint64]struct{}, len(seen))
+	maps.Copy(remoteSeen, seen)
+
+	return m.local.ForEachChannel(ctx,
+		func(info *models.ChannelEdgeInfo,
+			p1, p2 *models.ChannelEdgePolicy) error {
+
+			if _, ok := seen[info.ChannelID]; ok {
+				return nil
+			}
+
+			seen[info.ChannelID] = struct{}{}
+
+			return cb(info, p1, p2)
+		}, func() {
+			clear(seen)
+			maps.Copy(seen, remoteSeen)
+		},
+	)
+}
+
+// ForEachNodeChannel iterates through all channels of the given node. For our
+// own node, only local is used (authoritative for private channels). For other
+// nodes, remote is queried first, then local supplements with any channels
+// the remote doesn't know about.
+//
+// NOTE: this is part of the graphdb.GraphSource interface.
+func (m *Mux) ForEachNodeChannel(ctx context.Context,
+	nodePub route.Vertex,
+	cb func(*models.ChannelEdgeInfo,
+		*models.ChannelEdgePolicy,
+		*models.ChannelEdgePolicy) error,
+	reset func()) error {
+
+	// For our own node, always use local (has private channels).
+	if nodePub == m.selfPub {
+		return m.local.ForEachNodeChannel(ctx, nodePub, cb, reset)
+	}
+
+	seen := make(map[uint64]struct{})
+
+	var cbErr error
+	err := m.remote.ForEachNodeChannel(ctx, nodePub,
+		func(info *models.ChannelEdgeInfo,
+			p1, p2 *models.ChannelEdgePolicy) error {
+
+			seen[info.ChannelID] = struct{}{}
+
+			if err := cb(info, p1, p2); err != nil {
+				cbErr = err
+
+				return err
+			}
+
+			return nil
+		}, func() {
+			clear(seen)
+			reset()
+		},
+	)
+	if err != nil {
+		if cbErr != nil {
+			return cbErr
+		}
+
+		log.Warnf("Remote ForEachNodeChannel failed, falling "+
+			"back to local: %v", err)
+
+		clear(seen)
+		reset()
+
+		return m.local.ForEachNodeChannel(
+			ctx, nodePub, cb, reset,
+		)
+	}
+
+	remoteSeen := make(map[uint64]struct{}, len(seen))
+	maps.Copy(remoteSeen, seen)
+
+	return m.local.ForEachNodeChannel(ctx, nodePub,
+		func(info *models.ChannelEdgeInfo,
+			p1, p2 *models.ChannelEdgePolicy) error {
+
+			if _, ok := seen[info.ChannelID]; ok {
+				return nil
+			}
+
+			seen[info.ChannelID] = struct{}{}
+
+			return cb(info, p1, p2)
+		}, func() {
+			clear(seen)
+			maps.Copy(seen, remoteSeen)
+		},
+	)
+}
+
+// ForEachNodeCached delegates to local since the graph cache is populated
+// from both local and remote data.
+//
+// NOTE: this is part of the graphdb.GraphSource interface.
+func (m *Mux) ForEachNodeCached(ctx context.Context, withAddrs bool,
+	cb func(ctx context.Context, node route.Vertex, addrs []net.Addr,
+		chans map[uint64]*graphdb.DirectedChannel) error,
+	reset func()) error {
+
+	return m.local.ForEachNodeCached(ctx, withAddrs, cb, reset)
+}
+
+// FetchChannelEdgesByID looks up a channel by ID. Tries remote first (broader
+// network view), falls back to local (has private channels).
+//
+// NOTE: this is part of the graphdb.GraphSource interface.
+func (m *Mux) FetchChannelEdgesByID(ctx context.Context, chanID uint64) (
+	*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+	*models.ChannelEdgePolicy, error) {
+
+	info, p1, p2, err := m.remote.FetchChannelEdgesByID(ctx, chanID)
+	if err == nil {
+		return info, p1, p2, nil
+	}
+
+	return m.local.FetchChannelEdgesByID(ctx, chanID)
+}
+
+// FetchChannelEdgesByOutpoint looks up a channel by funding outpoint. Tries
+// remote first, falls back to local.
+//
+// NOTE: this is part of the graphdb.GraphSource interface.
+func (m *Mux) FetchChannelEdgesByOutpoint(ctx context.Context,
+	op *wire.OutPoint) (
+	*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+	*models.ChannelEdgePolicy, error) {
+
+	info, p1, p2, err := m.remote.FetchChannelEdgesByOutpoint(ctx, op)
+	if err == nil {
+		return info, p1, p2, nil
+	}
+
+	return m.local.FetchChannelEdgesByOutpoint(ctx, op)
+}
+
+// FetchNode looks up a node. For self, uses local. Otherwise tries remote
+// first, falls back to local.
+//
+// NOTE: this is part of the graphdb.GraphSource interface.
+func (m *Mux) FetchNode(ctx context.Context,
+	nodePub route.Vertex) (*models.Node, error) {
+
+	if nodePub == m.selfPub {
+		return m.local.FetchNode(ctx, nodePub)
+	}
+
+	node, err := m.remote.FetchNode(ctx, nodePub)
+	if err == nil {
+		return node, nil
+	}
+
+	return m.local.FetchNode(ctx, nodePub)
+}
+
+// LookupAlias returns the alias for a node. Tries remote first for non-self
+// nodes.
+//
+// NOTE: this is part of the graphdb.GraphSource interface.
+func (m *Mux) LookupAlias(ctx context.Context,
+	pub *btcec.PublicKey) (string, error) {
+
+	if route.NewVertex(pub) == m.selfPub {
+		return m.local.LookupAlias(ctx, pub)
+	}
+
+	alias, err := m.remote.LookupAlias(ctx, pub)
+	if err == nil {
+		return alias, nil
+	}
+
+	return m.local.LookupAlias(ctx, pub)
+}
+
+// IsPublicNode checks whether a node is public. A node is public if either
+// the remote or local source considers it public.
+//
+// NOTE: this is part of the graphdb.GraphSource interface.
+func (m *Mux) IsPublicNode(ctx context.Context,
+	pubKey [33]byte) (bool, error) {
+
+	public, err := m.remote.IsPublicNode(ctx, pubKey)
+	if err == nil && public {
+		return true, nil
+	}
+
+	return m.local.IsPublicNode(ctx, pubKey)
+}
+
+// AddrsForNode returns addresses for a node. For non-self nodes, tries remote
+// first (may have more up-to-date addresses).
+//
+// NOTE: this is part of the graphdb.GraphSource interface.
+func (m *Mux) AddrsForNode(ctx context.Context,
+	nodePub *btcec.PublicKey) (bool, []net.Addr, error) {
+
+	if route.NewVertex(nodePub) == m.selfPub {
+		return m.local.AddrsForNode(ctx, nodePub)
+	}
+
+	known, addrs, err := m.remote.AddrsForNode(ctx, nodePub)
+	if err == nil && known {
+		return known, addrs, nil
+	}
+
+	return m.local.AddrsForNode(ctx, nodePub)
+}
+
+// GraphSession delegates to local since the graph cache handles pathfinding.
+//
+// NOTE: this is part of the graphdb.GraphSource interface.
+func (m *Mux) GraphSession(ctx context.Context,
+	cb func(graph graphdb.NodeTraverser) error, reset func()) error {
+
+	return m.local.GraphSession(ctx, cb, reset)
+}
+
+// SourceNode returns the local source node (always from local, we are the
+// authority on our own identity).
+//
+// NOTE: this is part of the graphdb.GraphSource interface.
+func (m *Mux) SourceNode(ctx context.Context) (*models.Node, error) {
+	return m.local.SourceNode(ctx)
+}
+
+// ForEachSourceNodeChannel iterates through our own channels (always from
+// local, has private channels).
+//
+// NOTE: this is part of the graphdb.GraphSource interface.
+func (m *Mux) ForEachSourceNodeChannel(ctx context.Context,
+	cb func(chanPoint wire.OutPoint, havePolicy bool,
+		otherNode *models.Node) error,
+	reset func()) error {
+
+	return m.local.ForEachSourceNodeChannel(ctx, cb, reset)
+}

--- a/graph/sources/mux_test.go
+++ b/graph/sources/mux_test.go
@@ -1,0 +1,674 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/wire"
+	graphdb "github.com/lightningnetwork/lnd/graph/db"
+	"github.com/lightningnetwork/lnd/graph/db/models"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/route"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	// Test vertices for use in tests.
+	pubSelf  = route.Vertex{0x01}
+	pubAlice = route.Vertex{0x02}
+	pubBob   = route.Vertex{0x03}
+	pubCarol = route.Vertex{0x04}
+)
+
+// mockLocal is a minimal mock of graphdb.GraphSource for testing the Mux.
+// Only the methods exercised by the tests are implemented.
+type mockLocal struct {
+	nodes    []*models.Node
+	channels []mockChannel
+	nodeMap  map[route.Vertex]*models.Node
+	chanMap  map[uint64]mockChannel
+	aliases  map[route.Vertex]string
+}
+
+type mockChannel struct {
+	info *models.ChannelEdgeInfo
+	p1   *models.ChannelEdgePolicy
+	p2   *models.ChannelEdgePolicy
+}
+
+func newMockLocal() *mockLocal {
+	return &mockLocal{
+		nodeMap: make(map[route.Vertex]*models.Node),
+		chanMap: make(map[uint64]mockChannel),
+		aliases: make(map[route.Vertex]string),
+	}
+}
+
+func (m *mockLocal) addNode(pub route.Vertex) {
+	n := &models.Node{PubKeyBytes: pub}
+	m.nodes = append(m.nodes, n)
+	m.nodeMap[pub] = n
+}
+
+func (m *mockLocal) addChannel(id uint64, node1, node2 route.Vertex) {
+	ch := mockChannel{
+		info: &models.ChannelEdgeInfo{
+			ChannelID:     id,
+			NodeKey1Bytes: node1,
+			NodeKey2Bytes: node2,
+		},
+	}
+	m.channels = append(m.channels, ch)
+	m.chanMap[id] = ch
+}
+
+func (m *mockLocal) ForEachNode(_ context.Context,
+	cb func(*models.Node) error, reset func()) error {
+
+	reset()
+	for _, n := range m.nodes {
+		if err := cb(n); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *mockLocal) ForEachChannel(_ context.Context,
+	cb func(*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+		*models.ChannelEdgePolicy) error,
+	reset func()) error {
+
+	reset()
+	for _, ch := range m.channels {
+		if err := cb(ch.info, ch.p1, ch.p2); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *mockLocal) ForEachNodeChannel(_ context.Context,
+	nodePub route.Vertex,
+	cb func(*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+		*models.ChannelEdgePolicy) error,
+	reset func()) error {
+
+	reset()
+	for _, ch := range m.channels {
+		if ch.info.NodeKey1Bytes == nodePub ||
+			ch.info.NodeKey2Bytes == nodePub {
+
+			if err := cb(ch.info, ch.p1, ch.p2); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (m *mockLocal) FetchNode(_ context.Context,
+	pub route.Vertex) (*models.Node, error) {
+
+	n, ok := m.nodeMap[pub]
+	if !ok {
+		return nil, graphdb.ErrGraphNodeNotFound
+	}
+
+	return n, nil
+}
+
+func (m *mockLocal) FetchChannelEdgesByID(_ context.Context,
+	chanID uint64) (*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+	*models.ChannelEdgePolicy, error) {
+
+	ch, ok := m.chanMap[chanID]
+	if !ok {
+		return nil, nil, nil, graphdb.ErrEdgeNotFound
+	}
+
+	return ch.info, ch.p1, ch.p2, nil
+}
+
+func (m *mockLocal) LookupAlias(_ context.Context,
+	pub *btcec.PublicKey) (string, error) {
+
+	v := route.NewVertex(pub)
+	alias, ok := m.aliases[v]
+	if !ok {
+		return "", graphdb.ErrGraphNodeNotFound
+	}
+
+	return alias, nil
+}
+
+func (m *mockLocal) IsPublicNode(_ context.Context,
+	pubKey [33]byte) (bool, error) {
+
+	_, ok := m.nodeMap[pubKey]
+	return ok, nil
+}
+
+func (m *mockLocal) AddrsForNode(_ context.Context,
+	pub *btcec.PublicKey) (bool, []net.Addr, error) {
+
+	v := route.NewVertex(pub)
+	_, ok := m.nodeMap[v]
+	if !ok {
+		return false, nil, nil
+	}
+
+	return true, nil, nil
+}
+
+// Stub methods that the Mux delegates directly to local.
+func (m *mockLocal) ForEachNodeDirectedChannel(
+	context.Context, route.Vertex,
+	func(*graphdb.DirectedChannel) error,
+	func(),
+) error {
+
+	return nil
+}
+
+func (m *mockLocal) FetchNodeFeatures(
+	context.Context, route.Vertex,
+) (*lnwire.FeatureVector, error) {
+
+	return lnwire.EmptyFeatureVector(), nil
+}
+
+func (m *mockLocal) ForEachNodeCached(
+	context.Context, bool,
+	func(context.Context, route.Vertex, []net.Addr,
+		map[uint64]*graphdb.DirectedChannel) error,
+	func(),
+) error {
+
+	return nil
+}
+
+func (m *mockLocal) FetchChannelEdgesByOutpoint(
+	context.Context, *wire.OutPoint,
+) (*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+	*models.ChannelEdgePolicy, error) {
+
+	return nil, nil, nil, graphdb.ErrEdgeNotFound
+}
+
+func (m *mockLocal) GraphSession(
+	_ context.Context,
+	cb func(graphdb.NodeTraverser) error, _ func(),
+) error {
+
+	return cb(nil)
+}
+
+func (m *mockLocal) SourceNode(
+	context.Context,
+) (*models.Node, error) {
+
+	return m.nodeMap[pubSelf], nil
+}
+
+func (m *mockLocal) ForEachSourceNodeChannel(
+	context.Context,
+	func(wire.OutPoint, bool, *models.Node) error,
+	func(),
+) error {
+
+	return nil
+}
+
+// mockRemote is a minimal mock of RemoteGraph for testing the Mux.
+type mockRemote struct {
+	nodes    []*models.Node
+	channels []mockChannel
+	nodeMap  map[route.Vertex]*models.Node
+	chanMap  map[uint64]mockChannel
+	aliases  map[route.Vertex]string
+
+	// forEachErr causes ForEachNode/ForEachChannel to return this error.
+	forEachErr error
+}
+
+func newMockRemote() *mockRemote {
+	return &mockRemote{
+		nodeMap: make(map[route.Vertex]*models.Node),
+		chanMap: make(map[uint64]mockChannel),
+		aliases: make(map[route.Vertex]string),
+	}
+}
+
+func (m *mockRemote) addNode(pub route.Vertex) {
+	n := &models.Node{PubKeyBytes: pub}
+	m.nodes = append(m.nodes, n)
+	m.nodeMap[pub] = n
+}
+
+func (m *mockRemote) addChannel(id uint64, node1, node2 route.Vertex) {
+	ch := mockChannel{
+		info: &models.ChannelEdgeInfo{
+			ChannelID:     id,
+			NodeKey1Bytes: node1,
+			NodeKey2Bytes: node2,
+		},
+	}
+	m.channels = append(m.channels, ch)
+	m.chanMap[id] = ch
+}
+
+func (m *mockRemote) ForEachNode(_ context.Context,
+	cb func(*models.Node) error, _ func()) error {
+
+	if m.forEachErr != nil {
+		return m.forEachErr
+	}
+	for _, n := range m.nodes {
+		if err := cb(n); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *mockRemote) ForEachChannel(_ context.Context,
+	cb func(*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+		*models.ChannelEdgePolicy) error,
+	_ func()) error {
+
+	if m.forEachErr != nil {
+		return m.forEachErr
+	}
+	for _, ch := range m.channels {
+		if err := cb(ch.info, ch.p1, ch.p2); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *mockRemote) ForEachNodeChannel(_ context.Context,
+	nodePub route.Vertex,
+	cb func(*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+		*models.ChannelEdgePolicy) error,
+	_ func()) error {
+
+	if m.forEachErr != nil {
+		return m.forEachErr
+	}
+	for _, ch := range m.channels {
+		if ch.info.NodeKey1Bytes == nodePub ||
+			ch.info.NodeKey2Bytes == nodePub {
+
+			if err := cb(ch.info, ch.p1, ch.p2); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (m *mockRemote) FetchChannelEdgesByID(_ context.Context,
+	chanID uint64) (*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+	*models.ChannelEdgePolicy, error) {
+
+	ch, ok := m.chanMap[chanID]
+	if !ok {
+		return nil, nil, nil, graphdb.ErrEdgeNotFound
+	}
+
+	return ch.info, ch.p1, ch.p2, nil
+}
+
+func (m *mockRemote) FetchChannelEdgesByOutpoint(context.Context,
+	*wire.OutPoint) (*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+	*models.ChannelEdgePolicy, error) {
+
+	return nil, nil, nil, graphdb.ErrEdgeNotFound
+}
+
+func (m *mockRemote) FetchNode(_ context.Context,
+	pub route.Vertex) (*models.Node, error) {
+
+	n, ok := m.nodeMap[pub]
+	if !ok {
+		return nil, graphdb.ErrGraphNodeNotFound
+	}
+
+	return n, nil
+}
+
+func (m *mockRemote) IsPublicNode(_ context.Context,
+	pubKey [33]byte) (bool, error) {
+
+	_, ok := m.nodeMap[pubKey]
+
+	return ok, nil
+}
+
+func (m *mockRemote) LookupAlias(_ context.Context,
+	pub *btcec.PublicKey) (string, error) {
+
+	v := route.NewVertex(pub)
+	alias, ok := m.aliases[v]
+	if !ok {
+		return "", graphdb.ErrGraphNodeNotFound
+	}
+
+	return alias, nil
+}
+
+func (m *mockRemote) AddrsForNode(_ context.Context,
+	pub *btcec.PublicKey) (bool, []net.Addr, error) {
+
+	v := route.NewVertex(pub)
+	_, ok := m.nodeMap[v]
+	if !ok {
+		return false, nil, nil
+	}
+
+	return true, nil, nil
+}
+
+// newTestMux creates a Mux with the given mocks and pubSelf as the self key.
+func newTestMux(local *mockLocal, remote *mockRemote) *Mux {
+	return NewMux(local, remote, pubSelf)
+}
+
+// TestMuxForEachNodeDedup verifies that nodes returned by both remote and local
+// are deduplicated — only the remote version is returned.
+func TestMuxForEachNodeDedup(t *testing.T) {
+	local := newMockLocal()
+	remote := newMockRemote()
+
+	// Alice exists on both; Bob only on remote; Carol only on local.
+	remote.addNode(pubAlice)
+	remote.addNode(pubBob)
+	local.addNode(pubAlice)
+	local.addNode(pubCarol)
+
+	mux := newTestMux(local, remote)
+
+	var got []route.Vertex
+	err := mux.ForEachNode(t.Context(),
+		func(n *models.Node) error {
+			got = append(got, n.PubKeyBytes)
+			return nil
+		}, func() { got = nil },
+	)
+	require.NoError(t, err)
+
+	// Should see Alice, Bob (from remote), Carol (from local). No dups.
+	require.Len(t, got, 3)
+	require.Contains(t, got, pubAlice)
+	require.Contains(t, got, pubBob)
+	require.Contains(t, got, pubCarol)
+}
+
+// TestMuxForEachChannelDedup verifies that channels from both sources are
+// deduplicated by channel ID.
+func TestMuxForEachChannelDedup(t *testing.T) {
+	local := newMockLocal()
+	remote := newMockRemote()
+
+	// Channel 1 on both; channel 2 only remote; channel 3 only local.
+	remote.addChannel(1, pubAlice, pubBob)
+	remote.addChannel(2, pubBob, pubCarol)
+	local.addChannel(1, pubAlice, pubBob)
+	local.addChannel(3, pubCarol, pubSelf)
+
+	mux := newTestMux(local, remote)
+
+	var got []uint64
+	err := mux.ForEachChannel(t.Context(),
+		func(info *models.ChannelEdgeInfo, _ *models.ChannelEdgePolicy,
+			_ *models.ChannelEdgePolicy) error {
+
+			got = append(got, info.ChannelID)
+			return nil
+		}, func() { got = nil },
+	)
+	require.NoError(t, err)
+
+	require.Len(t, got, 3)
+	require.Contains(t, got, uint64(1))
+	require.Contains(t, got, uint64(2))
+	require.Contains(t, got, uint64(3))
+}
+
+// TestMuxForEachNodeRemoteError verifies that when the remote fails,
+// ForEachNode falls back to local-only iteration.
+func TestMuxForEachNodeRemoteError(t *testing.T) {
+	local := newMockLocal()
+	remote := newMockRemote()
+
+	local.addNode(pubAlice)
+	local.addNode(pubBob)
+	remote.forEachErr = fmt.Errorf("connection refused")
+
+	mux := newTestMux(local, remote)
+
+	var got []route.Vertex
+	err := mux.ForEachNode(t.Context(),
+		func(n *models.Node) error {
+			got = append(got, n.PubKeyBytes)
+			return nil
+		}, func() { got = nil },
+	)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	require.Contains(t, got, pubAlice)
+	require.Contains(t, got, pubBob)
+}
+
+// TestMuxForEachChannelRemoteError verifies that ForEachChannel falls back to
+// local when remote fails.
+func TestMuxForEachChannelRemoteError(t *testing.T) {
+	local := newMockLocal()
+	remote := newMockRemote()
+
+	local.addChannel(1, pubAlice, pubBob)
+	remote.forEachErr = fmt.Errorf("connection refused")
+
+	mux := newTestMux(local, remote)
+
+	var got []uint64
+	err := mux.ForEachChannel(t.Context(),
+		func(info *models.ChannelEdgeInfo, _ *models.ChannelEdgePolicy,
+			_ *models.ChannelEdgePolicy) error {
+
+			got = append(got, info.ChannelID)
+			return nil
+		}, func() { got = nil },
+	)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, uint64(1), got[0])
+}
+
+// TestMuxForEachNodeChannelSelf verifies that ForEachNodeChannel uses
+// local-only when querying our own channels.
+func TestMuxForEachNodeChannelSelf(t *testing.T) {
+	local := newMockLocal()
+	remote := newMockRemote()
+
+	// Local has our private channel; remote does not.
+	local.addChannel(1, pubSelf, pubAlice)
+	remote.addChannel(2, pubBob, pubCarol)
+
+	mux := newTestMux(local, remote)
+
+	var got []uint64
+	err := mux.ForEachNodeChannel(t.Context(), pubSelf,
+		func(info *models.ChannelEdgeInfo, _ *models.ChannelEdgePolicy,
+			_ *models.ChannelEdgePolicy) error {
+
+			got = append(got, info.ChannelID)
+			return nil
+		}, func() { got = nil },
+	)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, uint64(1), got[0])
+}
+
+// TestMuxFetchNodeSelf verifies that FetchNode for our own pubkey goes to
+// local, even if remote has data.
+func TestMuxFetchNodeSelf(t *testing.T) {
+	local := newMockLocal()
+	remote := newMockRemote()
+
+	local.addNode(pubSelf)
+	remote.addNode(pubSelf)
+
+	mux := newTestMux(local, remote)
+
+	node, err := mux.FetchNode(t.Context(), pubSelf)
+	require.NoError(t, err)
+	require.Equal(t, pubSelf, route.Vertex(node.PubKeyBytes))
+}
+
+// TestMuxFetchNodeRemoteFirst verifies that FetchNode for non-self nodes
+// returns the remote result when available.
+func TestMuxFetchNodeRemoteFirst(t *testing.T) {
+	local := newMockLocal()
+	remote := newMockRemote()
+
+	local.addNode(pubAlice)
+	remote.addNode(pubAlice)
+
+	mux := newTestMux(local, remote)
+
+	node, err := mux.FetchNode(t.Context(), pubAlice)
+	require.NoError(t, err)
+	require.Equal(t, pubAlice, route.Vertex(node.PubKeyBytes))
+}
+
+// TestMuxFetchNodeFallback verifies that FetchNode falls back to local when
+// the remote doesn't have the node.
+func TestMuxFetchNodeFallback(t *testing.T) {
+	local := newMockLocal()
+	remote := newMockRemote()
+
+	local.addNode(pubAlice)
+	// Remote does not have Alice.
+
+	mux := newTestMux(local, remote)
+
+	node, err := mux.FetchNode(t.Context(), pubAlice)
+	require.NoError(t, err)
+	require.Equal(t, pubAlice, route.Vertex(node.PubKeyBytes))
+}
+
+// TestMuxFetchChannelEdgesByIDFallback verifies that channel lookups fall back
+// to local when remote doesn't have the channel.
+func TestMuxFetchChannelEdgesByIDFallback(t *testing.T) {
+	local := newMockLocal()
+	remote := newMockRemote()
+
+	// Private channel only on local.
+	local.addChannel(42, pubSelf, pubAlice)
+
+	mux := newTestMux(local, remote)
+
+	info, _, _, err := mux.FetchChannelEdgesByID(
+		t.Context(), 42,
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint64(42), info.ChannelID)
+}
+
+// TestMuxFetchChannelEdgesByIDRemoteFirst verifies that channel lookups prefer
+// the remote source.
+func TestMuxFetchChannelEdgesByIDRemoteFirst(t *testing.T) {
+	local := newMockLocal()
+	remote := newMockRemote()
+
+	remote.addChannel(100, pubAlice, pubBob)
+	local.addChannel(100, pubAlice, pubBob)
+
+	mux := newTestMux(local, remote)
+
+	info, _, _, err := mux.FetchChannelEdgesByID(
+		t.Context(), 100,
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), info.ChannelID)
+}
+
+// TestMuxLookupAliasSelf verifies that LookupAlias for our
+// own key uses local.
+func TestMuxLookupAliasSelf(t *testing.T) {
+	local := newMockLocal()
+	remote := newMockRemote()
+
+	// LookupAlias takes *btcec.PublicKey, so we need a
+	// real key to derive the vertex.
+	selfPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	selfPubKey := selfPriv.PubKey()
+	selfVertex := route.NewVertex(selfPubKey)
+
+	local.aliases[selfVertex] = "my-node"
+	remote.aliases[selfVertex] = "remote-version"
+	mux := NewMux(local, remote, selfVertex)
+
+	alias, err := mux.LookupAlias(t.Context(), selfPubKey)
+	require.NoError(t, err)
+	require.Equal(t, "my-node", alias)
+}
+
+// TestMuxAddrsForNodeSelf verifies that AddrsForNode for our own key uses
+// local.
+func TestMuxAddrsForNodeSelf(t *testing.T) {
+	local := newMockLocal()
+	remote := newMockRemote()
+
+	selfPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	selfPubKey := selfPriv.PubKey()
+	selfVertex := route.NewVertex(selfPubKey)
+
+	local.addNode(selfVertex)
+	remote.addNode(selfVertex)
+
+	mux := NewMux(local, remote, selfVertex)
+
+	known, _, err := mux.AddrsForNode(t.Context(), selfPubKey)
+	require.NoError(t, err)
+	require.True(t, known)
+}
+
+// TestMuxForEachNodeChannelRemoteError verifies that ForEachNodeChannel falls
+// back to local on remote error.
+func TestMuxForEachNodeChannelRemoteError(t *testing.T) {
+	local := newMockLocal()
+	remote := newMockRemote()
+
+	local.addChannel(1, pubAlice, pubBob)
+	remote.forEachErr = fmt.Errorf("timeout")
+
+	mux := newTestMux(local, remote)
+
+	var got []uint64
+	err := mux.ForEachNodeChannel(t.Context(), pubAlice,
+		func(info *models.ChannelEdgeInfo, _ *models.ChannelEdgePolicy,
+			_ *models.ChannelEdgePolicy) error {
+
+			got = append(got, info.ChannelID)
+			return nil
+		}, func() { got = nil },
+	)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+}

--- a/graph/sources/rpc_client.go
+++ b/graph/sources/rpc_client.go
@@ -1,0 +1,688 @@
+package sources
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+	"image/color"
+	"net"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/fn/v2"
+	graphdb "github.com/lightningnetwork/lnd/graph/db"
+	"github.com/lightningnetwork/lnd/graph/db/models"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/macaroons"
+	"github.com/lightningnetwork/lnd/routing/route"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
+	"gopkg.in/macaroon.v2"
+)
+
+// DefaultRPCTimeout is the default timeout for RPC calls to the remote graph
+// source.
+const DefaultRPCTimeout = 5 * time.Second
+
+// Compile-time check that RPCClient implements RemoteGraph.
+var _ RemoteGraph = (*RPCClient)(nil)
+
+// RPCConfig holds the configuration options for the remote graph RPC client.
+//
+//nolint:ll
+type RPCConfig struct {
+	RPCHost      string        `long:"rpchost" description:"The remote graph's RPC host:port"`
+	MacaroonPath string        `long:"macaroonpath" description:"The macaroon to use for authenticating with the remote graph source"`
+	TLSCertPath  string        `long:"tlscertpath" description:"The TLS certificate to use for establishing the remote graph's identity"`
+	Timeout      time.Duration `long:"timeout" description:"The timeout for connecting to the remote graph. Valid time units are {s, m, h}."`
+
+	// ParseAddress is a function that parses a string address (like
+	// "host:port") into a net.Addr. This is injected to avoid a
+	// dependency on lncfg from this package.
+	ParseAddress func(strAddress string) (net.Addr, error)
+}
+
+// RPCClient implements the RemoteGraph interface by querying a remote LND node
+// over gRPC.
+type RPCClient struct {
+	started atomic.Bool
+	stopped atomic.Bool
+
+	cfg *RPCConfig
+
+	grpcConn *grpc.ClientConn
+	conn     lnrpc.LightningClient
+
+	wg     sync.WaitGroup
+	cancel fn.Option[context.CancelFunc]
+}
+
+// NewRPCClient constructs a new RPCClient.
+func NewRPCClient(cfg *RPCConfig) *RPCClient {
+	return &RPCClient{
+		cfg: cfg,
+	}
+}
+
+// rpcCtx returns a context with the configured RPC timeout applied. The
+// returned cancel function must be called to release resources.
+func (c *RPCClient) rpcCtx(
+	ctx context.Context) (context.Context, context.CancelFunc) {
+
+	return context.WithTimeout(ctx, c.cfg.Timeout)
+}
+
+// Start connects the client to the remote graph server.
+func (c *RPCClient) Start(ctx context.Context) error {
+	if !c.started.CompareAndSwap(false, true) {
+		return nil
+	}
+
+	log.Info("Remote graph RPC client starting")
+
+	ctx, cancel := context.WithCancel(ctx)
+	c.cancel = fn.Some(cancel)
+
+	conn, err := connectRPC(
+		ctx, c.cfg.RPCHost, c.cfg.TLSCertPath, c.cfg.MacaroonPath,
+		c.cfg.Timeout,
+	)
+	if err != nil {
+		return err
+	}
+	c.grpcConn = conn
+	c.conn = lnrpc.NewLightningClient(conn)
+
+	return nil
+}
+
+// Stop cancels any goroutines and contexts created by the client.
+func (c *RPCClient) Stop() error {
+	if !c.stopped.CompareAndSwap(false, true) {
+		return nil
+	}
+
+	log.Info("Remote graph RPC client stopping...")
+	defer log.Info("Remote graph RPC client stopped")
+
+	c.cancel.WhenSome(func(cancel context.CancelFunc) { cancel() })
+	c.wg.Wait()
+
+	if c.grpcConn != nil {
+		if err := c.grpcConn.Close(); err != nil {
+			log.Errorf("Error closing gRPC connection: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// ForEachNode iterates over all nodes from the remote graph.
+//
+// NOTE: this is part of the RemoteGraph interface.
+func (c *RPCClient) ForEachNode(ctx context.Context,
+	cb func(*models.Node) error, reset func()) error {
+
+	ctx, cancel := c.rpcCtx(ctx)
+	defer cancel()
+
+	graph, err := c.conn.DescribeGraph(ctx, &lnrpc.ChannelGraphRequest{
+		IncludeUnannounced: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, rpcNode := range graph.Nodes {
+		node, err := c.unmarshalNode(rpcNode)
+		if err != nil {
+			return err
+		}
+
+		if err := cb(node); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ForEachChannel iterates over all channels from the remote graph.
+//
+// NOTE: this is part of the RemoteGraph interface.
+func (c *RPCClient) ForEachChannel(ctx context.Context,
+	cb func(*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+		*models.ChannelEdgePolicy) error,
+	reset func()) error {
+
+	ctx, cancel := c.rpcCtx(ctx)
+	defer cancel()
+
+	graph, err := c.conn.DescribeGraph(ctx, &lnrpc.ChannelGraphRequest{
+		IncludeUnannounced: true,
+		IncludeAuthProof:   true,
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, edge := range graph.Edges {
+		edgeInfo, p1, p2, err := unmarshalChannelEdge(edge)
+		if err != nil {
+			return err
+		}
+
+		if err := cb(edgeInfo, p1, p2); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ForEachNodeChannel iterates over all channels of the given node from the
+// remote graph.
+//
+// NOTE: this is part of the RemoteGraph interface.
+func (c *RPCClient) ForEachNodeChannel(ctx context.Context,
+	nodePub route.Vertex,
+	cb func(*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+		*models.ChannelEdgePolicy) error,
+	reset func()) error {
+
+	ctx, cancel := c.rpcCtx(ctx)
+	defer cancel()
+
+	info, err := c.conn.GetNodeInfo(ctx, &lnrpc.NodeInfoRequest{
+		PubKey:          hex.EncodeToString(nodePub[:]),
+		IncludeChannels: true,
+	})
+	if isNotFound(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	for _, channel := range info.Channels {
+		edge, p1, p2, err := unmarshalChannelEdge(channel)
+		if err != nil {
+			return err
+		}
+
+		if err := cb(edge, p1, p2); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// FetchChannelEdgesByID looks up a channel edge by channel ID.
+//
+// NOTE: this is part of the RemoteGraph interface.
+func (c *RPCClient) FetchChannelEdgesByID(ctx context.Context,
+	chanID uint64) (*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+	*models.ChannelEdgePolicy, error) {
+
+	ctx, cancel := c.rpcCtx(ctx)
+	defer cancel()
+
+	info, err := c.conn.GetChanInfo(ctx, &lnrpc.ChanInfoRequest{
+		ChanId: chanID,
+	})
+	if isNotFound(err) {
+		return nil, nil, nil, graphdb.ErrEdgeNotFound
+	} else if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return unmarshalChannelEdge(info)
+}
+
+// FetchChannelEdgesByOutpoint looks up a channel edge by funding outpoint.
+//
+// NOTE: this is part of the RemoteGraph interface.
+func (c *RPCClient) FetchChannelEdgesByOutpoint(ctx context.Context,
+	op *wire.OutPoint) (*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
+	*models.ChannelEdgePolicy, error) {
+
+	ctx, cancel := c.rpcCtx(ctx)
+	defer cancel()
+
+	info, err := c.conn.GetChanInfo(ctx, &lnrpc.ChanInfoRequest{
+		ChanPoint: op.String(),
+	})
+	if isNotFound(err) {
+		return nil, nil, nil, graphdb.ErrEdgeNotFound
+	} else if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return unmarshalChannelEdge(info)
+}
+
+// FetchNode looks up a node by its public key.
+//
+// NOTE: this is part of the RemoteGraph interface.
+func (c *RPCClient) FetchNode(ctx context.Context,
+	nodePub route.Vertex) (*models.Node, error) {
+
+	ctx, cancel := c.rpcCtx(ctx)
+	defer cancel()
+
+	resp, err := c.conn.GetNodeInfo(ctx, &lnrpc.NodeInfoRequest{
+		PubKey:          hex.EncodeToString(nodePub[:]),
+		IncludeChannels: false,
+	})
+	if isNotFound(err) {
+		return nil, graphdb.ErrGraphNodeNotFound
+	} else if err != nil {
+		return nil, err
+	}
+
+	return c.unmarshalNode(resp.Node)
+}
+
+// IsPublicNode checks whether the given node is known to the remote graph.
+//
+// NOTE: this is part of the RemoteGraph interface.
+func (c *RPCClient) IsPublicNode(ctx context.Context,
+	pubKey [33]byte) (bool, error) {
+
+	ctx, cancel := c.rpcCtx(ctx)
+	defer cancel()
+
+	_, err := c.conn.GetNodeInfo(ctx, &lnrpc.NodeInfoRequest{
+		PubKey:          hex.EncodeToString(pubKey[:]),
+		IncludeChannels: false,
+	})
+	if isNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// LookupAlias returns the alias for the given node.
+//
+// NOTE: this is part of the RemoteGraph interface.
+func (c *RPCClient) LookupAlias(ctx context.Context,
+	pub *btcec.PublicKey) (string, error) {
+
+	ctx, cancel := c.rpcCtx(ctx)
+	defer cancel()
+
+	pubBytes := route.NewVertex(pub)
+	resp, err := c.conn.GetNodeInfo(ctx, &lnrpc.NodeInfoRequest{
+		PubKey:          hex.EncodeToString(pubBytes[:]),
+		IncludeChannels: false,
+	})
+	if isNotFound(err) {
+		return "", graphdb.ErrGraphNodeNotFound
+	} else if err != nil {
+		return "", err
+	}
+
+	if resp.Node == nil {
+		return "", graphdb.ErrGraphNodeNotFound
+	}
+
+	return resp.Node.Alias, nil
+}
+
+// AddrsForNode returns the addresses for the given node.
+//
+// NOTE: this is part of the RemoteGraph interface.
+func (c *RPCClient) AddrsForNode(ctx context.Context,
+	nodePub *btcec.PublicKey) (bool, []net.Addr, error) {
+
+	ctx, cancel := c.rpcCtx(ctx)
+	defer cancel()
+
+	pubBytes := route.NewVertex(nodePub)
+	resp, err := c.conn.GetNodeInfo(ctx, &lnrpc.NodeInfoRequest{
+		PubKey:          hex.EncodeToString(pubBytes[:]),
+		IncludeChannels: false,
+	})
+	if isNotFound(err) {
+		return false, nil, nil
+	} else if err != nil {
+		return false, nil, err
+	}
+
+	if resp.Node == nil {
+		return false, nil, nil
+	}
+
+	addrs, err := c.unmarshalAddrs(resp.Node.Addresses)
+	if err != nil {
+		return false, nil, err
+	}
+
+	return true, addrs, nil
+}
+
+// connectRPC establishes a gRPC connection to the remote LND node.
+func connectRPC(ctx context.Context, hostPort, tlsCertPath, macaroonPath string,
+	timeout time.Duration) (*grpc.ClientConn, error) {
+
+	certBytes, err := os.ReadFile(tlsCertPath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading TLS cert file %v: %w",
+			tlsCertPath, err)
+	}
+
+	cp := x509.NewCertPool()
+	if !cp.AppendCertsFromPEM(certBytes) {
+		return nil, fmt.Errorf("credentials: failed to append " +
+			"certificate")
+	}
+
+	macBytes, err := os.ReadFile(macaroonPath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading macaroon file %v: %w",
+			macaroonPath, err)
+	}
+	mac := &macaroon.Macaroon{}
+	if err := mac.UnmarshalBinary(macBytes); err != nil {
+		return nil, fmt.Errorf("error decoding macaroon: %w", err)
+	}
+
+	macCred, err := macaroons.NewMacaroonCredential(mac)
+	if err != nil {
+		return nil, fmt.Errorf("error creating creds: %w", err)
+	}
+
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(
+			cp, "",
+		)),
+		grpc.WithPerRPCCredentials(macCred),
+		grpc.WithBlock(),
+	}
+
+	ctxt, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	conn, err := grpc.DialContext(ctxt, hostPort, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("unable to connect to RPC server: %w",
+			err)
+	}
+
+	return conn, nil
+}
+
+// unmarshalNode converts an lnrpc.LightningNode to a models.Node.
+func (c *RPCClient) unmarshalNode(node *lnrpc.LightningNode) (
+	*models.Node, error) {
+
+	if node == nil {
+		return nil, fmt.Errorf("nil node received from remote")
+	}
+
+	pubKey, err := hex.DecodeString(node.PubKey)
+	if err != nil {
+		return nil, err
+	}
+
+	var pubKeyBytes [33]byte
+	copy(pubKeyBytes[:], pubKey)
+
+	extra, err := lnwire.CustomRecords(node.CustomRecords).Serialize()
+	if err != nil {
+		return nil, err
+	}
+
+	addrs, err := c.unmarshalAddrs(node.Addresses)
+	if err != nil {
+		return nil, err
+	}
+
+	nodeColor, err := parseColor(node.Color)
+	if err != nil {
+		return nil, err
+	}
+
+	features := unmarshalFeatures(node.Features)
+
+	// Build the node model. We treat nodes from the remote as v1 since
+	// the RPC doesn't currently convey gossip version info.
+	result := &models.Node{
+		Version:         lnwire.GossipVersion1,
+		PubKeyBytes:     pubKeyBytes,
+		LastUpdate:      time.Unix(int64(node.LastUpdate), 0),
+		Addresses:       addrs,
+		Alias:           fn.Some(node.Alias),
+		Color:           fn.Some(nodeColor),
+		Features:        features,
+		ExtraOpaqueData: extra,
+	}
+
+	return result, nil
+}
+
+// unmarshalAddrs converts lnrpc.NodeAddress slice to net.Addr slice.
+func (c *RPCClient) unmarshalAddrs(addrs []*lnrpc.NodeAddress) ([]net.Addr,
+	error) {
+
+	if c.cfg.ParseAddress == nil {
+		return nil, fmt.Errorf("no address parser configured")
+	}
+
+	netAddrs := make([]net.Addr, 0, len(addrs))
+	for _, addr := range addrs {
+		netAddr, err := c.cfg.ParseAddress(addr.Addr)
+		if err != nil {
+			return nil, err
+		}
+		netAddrs = append(netAddrs, netAddr)
+	}
+
+	return netAddrs, nil
+}
+
+// unmarshalChannelEdge converts an lnrpc.ChannelEdge to internal model types.
+func unmarshalChannelEdge(info *lnrpc.ChannelEdge) (*models.ChannelEdgeInfo,
+	*models.ChannelEdgePolicy, *models.ChannelEdgePolicy, error) {
+
+	chanPoint, err := wire.NewOutPointFromString(info.ChanPoint)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	var (
+		node1Bytes [33]byte
+		node2Bytes [33]byte
+	)
+	node1, err := hex.DecodeString(info.Node1Pub)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	copy(node1Bytes[:], node1)
+
+	node2, err := hex.DecodeString(info.Node2Pub)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	copy(node2Bytes[:], node2)
+
+	extra, err := lnwire.CustomRecords(info.CustomRecords).Serialize()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Build the edge. We treat edges from the remote as v1 since the RPC
+	// doesn't currently convey gossip version info.
+	edge := &models.ChannelEdgeInfo{
+		Version:         lnwire.GossipVersion1,
+		ChannelID:       info.ChannelId,
+		ChannelPoint:    *chanPoint,
+		NodeKey1Bytes:   node1Bytes,
+		NodeKey2Bytes:   node2Bytes,
+		Capacity:        btcutil.Amount(info.Capacity),
+		Features:        lnwire.EmptyFeatureVector(),
+		ExtraOpaqueData: extra,
+	}
+
+	if info.AuthProof != nil {
+		edge.AuthProof = models.NewV1ChannelAuthProof(
+			info.AuthProof.NodeSig1,
+			info.AuthProof.NodeSig2,
+			info.AuthProof.BitcoinSig1,
+			info.AuthProof.BitcoinSig2,
+		)
+	}
+
+	var (
+		policy1 *models.ChannelEdgePolicy
+		policy2 *models.ChannelEdgePolicy
+	)
+	if info.Node1Policy != nil {
+		policy1, err = unmarshalPolicy(
+			info.ChannelId, info.Node1Policy, true, info.Node2Pub,
+		)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	}
+	if info.Node2Policy != nil {
+		policy2, err = unmarshalPolicy(
+			info.ChannelId, info.Node2Policy, false, info.Node1Pub,
+		)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	}
+
+	return edge, policy1, policy2, nil
+}
+
+// unmarshalPolicy converts an lnrpc.RoutingPolicy to a
+// models.ChannelEdgePolicy.
+func unmarshalPolicy(channelID uint64, rpcPolicy *lnrpc.RoutingPolicy,
+	node1 bool, toNodeStr string) (*models.ChannelEdgePolicy, error) {
+
+	var chanFlags lnwire.ChanUpdateChanFlags
+	if !node1 {
+		chanFlags |= lnwire.ChanUpdateDirection
+	}
+	if rpcPolicy.Disabled {
+		chanFlags |= lnwire.ChanUpdateDisabled
+	}
+
+	var msgFlags lnwire.ChanUpdateMsgFlags
+	if rpcPolicy.MaxHtlcMsat > 0 {
+		msgFlags |= lnwire.ChanUpdateRequiredMaxHtlc
+	}
+
+	extra, err := lnwire.CustomRecords(rpcPolicy.CustomRecords).Serialize()
+	if err != nil {
+		return nil, err
+	}
+
+	toNodeB, err := hex.DecodeString(toNodeStr)
+	if err != nil {
+		return nil, err
+	}
+	toNode, err := route.NewVertexFromBytes(toNodeB)
+	if err != nil {
+		return nil, err
+	}
+
+	policy := &models.ChannelEdgePolicy{
+		Version:       lnwire.GossipVersion1,
+		ChannelID:     channelID,
+		LastUpdate:    time.Unix(int64(rpcPolicy.LastUpdate), 0),
+		MessageFlags:  msgFlags,
+		ChannelFlags:  chanFlags,
+		TimeLockDelta: uint16(rpcPolicy.TimeLockDelta),
+		MinHTLC:       lnwire.MilliSatoshi(rpcPolicy.MinHtlc),
+		MaxHTLC:       lnwire.MilliSatoshi(rpcPolicy.MaxHtlcMsat),
+		FeeBaseMSat:   lnwire.MilliSatoshi(rpcPolicy.FeeBaseMsat),
+		FeeProportionalMillionths: lnwire.MilliSatoshi(
+			rpcPolicy.FeeRateMilliMsat,
+		),
+		ToNode:          toNode,
+		ExtraOpaqueData: extra,
+	}
+
+	if rpcPolicy.InboundFeeRateMilliMsat != 0 ||
+		rpcPolicy.InboundFeeBaseMsat != 0 {
+
+		policy.InboundFee = fn.Some(lnwire.Fee{
+			BaseFee: rpcPolicy.InboundFeeBaseMsat,
+			FeeRate: rpcPolicy.InboundFeeRateMilliMsat,
+		})
+	}
+
+	return policy, nil
+}
+
+// unmarshalFeatures converts an lnrpc feature map to a lnwire.FeatureVector.
+func unmarshalFeatures(
+	features map[uint32]*lnrpc.Feature) *lnwire.FeatureVector {
+
+	featureBits := make([]lnwire.FeatureBit, 0, len(features))
+	featureNames := make(map[lnwire.FeatureBit]string)
+	for bit, feature := range features {
+		featureBits = append(featureBits, lnwire.FeatureBit(bit))
+		featureNames[lnwire.FeatureBit(bit)] = feature.Name
+	}
+
+	return lnwire.NewFeatureVector(
+		lnwire.NewRawFeatureVector(featureBits...), featureNames,
+	)
+}
+
+// parseColor parses a hex color string (e.g. "#3399ff") into a color.RGBA.
+func parseColor(hexColor string) (color.RGBA, error) {
+	if len(hexColor) == 0 {
+		return color.RGBA{}, nil
+	}
+
+	// Strip leading '#' if present.
+	if hexColor[0] == '#' {
+		hexColor = hexColor[1:]
+	}
+
+	if len(hexColor) != 6 {
+		return color.RGBA{}, fmt.Errorf("invalid color: %s", hexColor)
+	}
+
+	colorBytes, err := hex.DecodeString(hexColor)
+	if err != nil {
+		return color.RGBA{}, err
+	}
+
+	return color.RGBA{
+		R: colorBytes[0],
+		G: colorBytes[1],
+		B: colorBytes[2],
+	}, nil
+}
+
+// isNotFound returns true if the error is a gRPC NotFound status error.
+func isNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+
+	return st.Code() == codes.NotFound
+}

--- a/graph/sources/rpc_client.go
+++ b/graph/sources/rpc_client.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"bytes"
 	"context"
 	"crypto/x509"
 	"encoding/hex"
@@ -51,6 +52,26 @@ type RPCConfig struct {
 	ParseAddress func(strAddress string) (net.Addr, error)
 }
 
+// TopologyCallbacks defines callbacks invoked when the remote graph's topology
+// changes. These allow the caller (typically the server) to keep the local
+// graph cache in sync with the remote graph.
+type TopologyCallbacks struct {
+	// OnChannel is called when a new channel is discovered or an existing
+	// channel's edge info is received.
+	OnChannel func(info *models.CachedEdgeInfo)
+
+	// OnChannelUpdate is called when a channel policy update is received.
+	OnChannelUpdate func(policy *models.CachedEdgePolicy,
+		fromNode, toNode route.Vertex)
+
+	// OnNodeUpdate is called when a node announcement is received.
+	OnNodeUpdate func(node route.Vertex,
+		features *lnwire.FeatureVector)
+
+	// OnChannelClosed is called when a channel close is detected.
+	OnChannelClosed func(chanID uint64)
+}
+
 // RPCClient implements the RemoteGraph interface by querying a remote LND node
 // over gRPC.
 type RPCClient struct {
@@ -58,6 +79,7 @@ type RPCClient struct {
 	stopped atomic.Bool
 
 	cfg *RPCConfig
+	cb  *TopologyCallbacks
 
 	grpcConn *grpc.ClientConn
 	conn     lnrpc.LightningClient
@@ -67,9 +89,10 @@ type RPCClient struct {
 }
 
 // NewRPCClient constructs a new RPCClient.
-func NewRPCClient(cfg *RPCConfig) *RPCClient {
+func NewRPCClient(cfg *RPCConfig, cb *TopologyCallbacks) *RPCClient {
 	return &RPCClient{
 		cfg: cfg,
+		cb:  cb,
 	}
 }
 
@@ -124,6 +147,278 @@ func (c *RPCClient) Stop() error {
 	}
 
 	return nil
+}
+
+// StartSubscription launches the topology subscription goroutine that keeps
+// the local cache in sync with the remote graph. This should be called after
+// PopulateCache to avoid the subscription overwriting the initial snapshot
+// with stale data.
+func (c *RPCClient) StartSubscription(ctx context.Context) {
+	if c.cb == nil {
+		return
+	}
+
+	c.wg.Add(1)
+	go c.handleNetworkUpdates(ctx)
+}
+
+// PopulateCache performs an initial full fetch of the remote graph and feeds
+// all nodes and channels into the registered topology callbacks. This must be
+// called after Start to seed the local graph cache before relying on the
+// incremental subscription for updates.
+func (c *RPCClient) PopulateCache(ctx context.Context) error {
+	if c.cb == nil {
+		return nil
+	}
+
+	log.Info("Populating graph cache from remote graph...")
+	startTime := time.Now()
+
+	graph, err := c.conn.DescribeGraph(ctx, &lnrpc.ChannelGraphRequest{
+		IncludeUnannounced: true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to fetch remote graph: %w", err)
+	}
+
+	// First, add all node features.
+	if c.cb.OnNodeUpdate != nil {
+		for _, rpcNode := range graph.Nodes {
+			pub, err := route.NewVertexFromStr(rpcNode.PubKey)
+			if err != nil {
+				return err
+			}
+
+			c.cb.OnNodeUpdate(
+				pub, unmarshalFeatures(rpcNode.Features),
+			)
+		}
+	}
+
+	// Then add all channels and their policies.
+	for _, edge := range graph.Edges {
+		node1, err := route.NewVertexFromStr(edge.Node1Pub)
+		if err != nil {
+			return err
+		}
+		node2, err := route.NewVertexFromStr(edge.Node2Pub)
+		if err != nil {
+			return err
+		}
+
+		if c.cb.OnChannel != nil {
+			c.cb.OnChannel(&models.CachedEdgeInfo{
+				ChannelID:     edge.ChannelId,
+				Capacity:      btcutil.Amount(edge.Capacity),
+				NodeKey1Bytes: node1,
+				NodeKey2Bytes: node2,
+			})
+		}
+
+		if c.cb.OnChannelUpdate != nil {
+			if edge.Node1Policy != nil {
+				policy := makeCachedPolicy(
+					edge.ChannelId,
+					edge.Node1Policy,
+					node2, true,
+				)
+				c.cb.OnChannelUpdate(
+					policy, node1, node2,
+				)
+			}
+			if edge.Node2Policy != nil {
+				policy := makeCachedPolicy(
+					edge.ChannelId,
+					edge.Node2Policy,
+					node1, false,
+				)
+				c.cb.OnChannelUpdate(
+					policy, node2, node1,
+				)
+			}
+		}
+	}
+
+	log.Infof("Remote graph cache populated with %d nodes and %d "+
+		"channels in %v", len(graph.Nodes), len(graph.Edges),
+		time.Since(startTime))
+
+	return nil
+}
+// handleNetworkUpdates subscribes to topology updates from the remote LND
+// node and forwards them to the registered callbacks. If the subscription
+// drops, it reconnects with exponential backoff.
+//
+// NOTE: this MUST be run as a goroutine.
+func (c *RPCClient) handleNetworkUpdates(ctx context.Context) {
+	defer c.wg.Done()
+
+	backoff := time.Second
+	const maxBackoff = time.Minute
+
+	for {
+		err := c.subscribeAndProcess(ctx)
+
+		// If the context was cancelled, we're shutting down.
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		log.Errorf("Remote graph subscription error (retrying in "+
+			"%v): %v", backoff, err)
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+	}
+}
+
+// subscribeAndProcess opens a topology subscription and processes updates
+// until an error occurs or the context is cancelled.
+func (c *RPCClient) subscribeAndProcess(
+	ctx context.Context) error {
+
+	client, err := c.conn.SubscribeChannelGraph(
+		ctx, &lnrpc.GraphTopologySubscription{},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to subscribe: %w", err)
+	}
+
+	log.Info("Subscribed to remote graph topology updates")
+
+	for {
+		updates, err := client.Recv()
+		if err != nil {
+			return fmt.Errorf("recv error: %w", err)
+		}
+
+		for _, update := range updates.ChannelUpdates {
+			if err := c.handleChannelUpdate(update); err != nil {
+				log.Errorf("Error handling channel update: %v",
+					err)
+			}
+		}
+
+		for _, update := range updates.NodeUpdates {
+			if err := c.handleNodeUpdate(update); err != nil {
+				log.Errorf("Error handling node update: %v",
+					err)
+			}
+		}
+
+		for _, update := range updates.ClosedChans {
+			if c.cb.OnChannelClosed != nil {
+				c.cb.OnChannelClosed(update.ChanId)
+			}
+		}
+	}
+}
+
+// handleNodeUpdate converts an lnrpc.NodeUpdate and invokes the OnNodeUpdate
+// callback.
+func (c *RPCClient) handleNodeUpdate(update *lnrpc.NodeUpdate) error {
+	if c.cb.OnNodeUpdate == nil {
+		return nil
+	}
+
+	pub, err := route.NewVertexFromStr(update.IdentityKey)
+	if err != nil {
+		return err
+	}
+
+	c.cb.OnNodeUpdate(pub, unmarshalFeatures(update.Features))
+
+	return nil
+}
+
+// handleChannelUpdate converts an lnrpc.ChannelEdgeUpdate and invokes the
+// OnChannel and OnChannelUpdate callbacks.
+func (c *RPCClient) handleChannelUpdate(
+	update *lnrpc.ChannelEdgeUpdate) error {
+
+	fromNode, err := route.NewVertexFromStr(update.AdvertisingNode)
+	if err != nil {
+		return err
+	}
+
+	toNode, err := route.NewVertexFromStr(update.ConnectingNode)
+	if err != nil {
+		return err
+	}
+
+	// Lexicographically sort the pubkeys to determine node1/node2.
+	var node1, node2 route.Vertex
+	if bytes.Compare(fromNode[:], toNode[:]) == -1 {
+		node1 = fromNode
+		node2 = toNode
+	} else {
+		node1 = toNode
+		node2 = fromNode
+	}
+
+	if c.cb.OnChannel != nil {
+		edge := &models.CachedEdgeInfo{
+			ChannelID:     update.ChanId,
+			Capacity:      btcutil.Amount(update.Capacity),
+			NodeKey1Bytes: node1,
+			NodeKey2Bytes: node2,
+		}
+		c.cb.OnChannel(edge)
+	}
+
+	if update.RoutingPolicy != nil && c.cb.OnChannelUpdate != nil {
+		policy := makeCachedPolicy(
+			update.ChanId, update.RoutingPolicy, toNode,
+			fromNode == node1,
+		)
+		c.cb.OnChannelUpdate(policy, fromNode, toNode)
+	}
+
+	return nil
+}
+
+// makeCachedPolicy converts an lnrpc.RoutingPolicy to a CachedEdgePolicy
+// suitable for use with the graph cache.
+func makeCachedPolicy(chanID uint64, rpcPolicy *lnrpc.RoutingPolicy,
+	toNode [33]byte, isNode1 bool) *models.CachedEdgePolicy {
+
+	policy := &models.CachedEdgePolicy{
+		ChannelID:     chanID,
+		IsNode1:       isNode1,
+		IsDisabled:    rpcPolicy.Disabled,
+		HasMaxHTLC:    rpcPolicy.MaxHtlcMsat > 0,
+		TimeLockDelta: uint16(rpcPolicy.TimeLockDelta),
+		MinHTLC:       lnwire.MilliSatoshi(rpcPolicy.MinHtlc),
+		MaxHTLC:       lnwire.MilliSatoshi(rpcPolicy.MaxHtlcMsat),
+		FeeBaseMSat:   lnwire.MilliSatoshi(rpcPolicy.FeeBaseMsat),
+		FeeProportionalMillionths: lnwire.MilliSatoshi(
+			rpcPolicy.FeeRateMilliMsat,
+		),
+		ToNodePubKey: func() route.Vertex {
+			return toNode
+		},
+	}
+
+	if rpcPolicy.InboundFeeRateMilliMsat != 0 ||
+		rpcPolicy.InboundFeeBaseMsat != 0 {
+
+		policy.InboundFee = fn.Some(lnwire.Fee{
+			BaseFee: rpcPolicy.InboundFeeBaseMsat,
+			FeeRate: rpcPolicy.InboundFeeRateMilliMsat,
+		})
+	}
+
+	return policy
 }
 
 // ForEachNode iterates over all nodes from the remote graph.

--- a/graph/sources/rpc_client.go
+++ b/graph/sources/rpc_client.go
@@ -104,15 +104,17 @@ func (c *RPCClient) rpcCtx(
 	return context.WithTimeout(ctx, c.cfg.Timeout)
 }
 
-// Start connects the client to the remote graph server.
-func (c *RPCClient) Start(ctx context.Context) error {
+// Start connects the client to the remote graph server, populates the graph
+// cache from a full snapshot, and launches the topology subscription goroutine
+// to keep the cache in sync with incremental updates.
+func (c *RPCClient) Start() error {
 	if !c.started.CompareAndSwap(false, true) {
 		return nil
 	}
 
 	log.Info("Remote graph RPC client starting")
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(context.Background())
 	c.cancel = fn.Some(cancel)
 
 	conn, err := connectRPC(
@@ -124,6 +126,11 @@ func (c *RPCClient) Start(ctx context.Context) error {
 	}
 	c.grpcConn = conn
 	c.conn = lnrpc.NewLightningClient(conn)
+
+	if c.cb != nil {
+		c.wg.Add(1)
+		go c.populateAndSubscribe(ctx)
+	}
 
 	return nil
 }
@@ -149,24 +156,53 @@ func (c *RPCClient) Stop() error {
 	return nil
 }
 
-// StartSubscription launches the topology subscription goroutine that keeps
-// the local cache in sync with the remote graph. This should be called after
-// PopulateCache to avoid the subscription overwriting the initial snapshot
-// with stale data.
-func (c *RPCClient) StartSubscription(ctx context.Context) {
-	if c.cb == nil {
-		return
+// populateAndSubscribe runs the initial cache population with retry logic,
+// then hands off to the topology subscription loop. Both phases run in a
+// single goroutine to avoid wg.Add races with Stop().
+//
+// NOTE: this MUST be run as a goroutine.
+func (c *RPCClient) populateAndSubscribe(ctx context.Context) {
+	defer c.wg.Done()
+
+	backoff := time.Second
+	const maxBackoff = time.Minute
+
+	for {
+		err := c.populateCache(ctx)
+		if err == nil {
+			break
+		}
+
+		// If the context was cancelled, we're shutting down.
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		log.Warnf("Failed to populate cache from remote graph "+
+			"(retrying in %v): %v", backoff, err)
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
 	}
 
-	c.wg.Add(1)
-	go c.handleNetworkUpdates(ctx)
+	c.handleNetworkUpdates(ctx)
 }
 
-// PopulateCache performs an initial full fetch of the remote graph and feeds
-// all nodes and channels into the registered topology callbacks. This must be
-// called after Start to seed the local graph cache before relying on the
-// incremental subscription for updates.
-func (c *RPCClient) PopulateCache(ctx context.Context) error {
+// populateCache performs an initial full fetch of the remote graph and feeds
+// all nodes and channels into the registered topology callbacks. Once the
+// cache is populated, it launches the topology subscription goroutine to keep
+// the cache in sync with incremental updates.
+func (c *RPCClient) populateCache(ctx context.Context) error {
 	if c.cb == nil {
 		return nil
 	}
@@ -245,19 +281,22 @@ func (c *RPCClient) PopulateCache(ctx context.Context) error {
 
 	return nil
 }
+
 // handleNetworkUpdates subscribes to topology updates from the remote LND
 // node and forwards them to the registered callbacks. If the subscription
-// drops, it reconnects with exponential backoff.
-//
-// NOTE: this MUST be run as a goroutine.
+// drops, it reconnects with exponential backoff. The backoff resets after
+// each successful subscription period.
 func (c *RPCClient) handleNetworkUpdates(ctx context.Context) {
-	defer c.wg.Done()
-
 	backoff := time.Second
 	const maxBackoff = time.Minute
 
 	for {
 		err := c.subscribeAndProcess(ctx)
+
+		// Reset backoff after a successful subscription period so
+		// that transient failures after long stable runs don't
+		// start at the max delay.
+		backoff = time.Second
 
 		// If the context was cancelled, we're shutting down.
 		select {
@@ -266,7 +305,7 @@ func (c *RPCClient) handleNetworkUpdates(ctx context.Context) {
 		default:
 		}
 
-		log.Errorf("Remote graph subscription error (retrying in "+
+		log.Warnf("Remote graph subscription error (retrying in "+
 			"%v): %v", backoff, err)
 
 		select {
@@ -358,7 +397,7 @@ func (c *RPCClient) handleChannelUpdate(
 
 	// Lexicographically sort the pubkeys to determine node1/node2.
 	var node1, node2 route.Vertex
-	if bytes.Compare(fromNode[:], toNode[:]) == -1 {
+	if bytes.Compare(fromNode[:], toNode[:]) < 0 {
 		node1 = fromNode
 		node2 = toNode
 	} else {

--- a/graph/sources/rpc_client.go
+++ b/graph/sources/rpc_client.go
@@ -707,6 +707,30 @@ func (c *RPCClient) AddrsForNode(ctx context.Context,
 	return true, addrs, nil
 }
 
+// InjectGossipMessage sends a raw gossip message to the remote graph source
+// for validation and processing. This is used to push channel updates
+// discovered through payment failures back to the graph source so that other
+// lightweight nodes using the same source can benefit.
+func (c *RPCClient) InjectGossipMessage(ctx context.Context,
+	msg lnwire.Message) error {
+
+	ctx, cancel := c.rpcCtx(ctx)
+	defer cancel()
+
+	var buf bytes.Buffer
+	if _, err := lnwire.WriteMessage(&buf, msg, 0); err != nil {
+		return fmt.Errorf("unable to serialize gossip message: %w", err)
+	}
+
+	_, err := c.conn.InjectGossipMessage(ctx,
+		&lnrpc.InjectGossipMessageRequest{
+			Msg: buf.Bytes(),
+		},
+	)
+
+	return err
+}
+
 // connectRPC establishes a gRPC connection to the remote LND node.
 func connectRPC(ctx context.Context, hostPort, tlsCertPath, macaroonPath string,
 	timeout time.Duration) (*grpc.ClientConn, error) {

--- a/graph/sources/rpc_client_test.go
+++ b/graph/sources/rpc_client_test.go
@@ -1,0 +1,270 @@
+package sources
+
+import (
+	"fmt"
+	"image/color"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/route"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	testPub1 = "02000000000000000000000000000000" +
+		"0000000000000000000000000000000001"
+	testPub2 = "03000000000000000000000000000000" +
+		"0000000000000000000000000000000001"
+	testChanPoint = "abc123abc123abc123abc123abc123" +
+		"abc123abc123abc123abc123abc123abcd"
+)
+
+// TestUnmarshalFeatures verifies that lnrpc feature maps are correctly
+// converted to lnwire.FeatureVector.
+func TestUnmarshalFeatures(t *testing.T) {
+	rpcFeatures := map[uint32]*lnrpc.Feature{
+		0:  {Name: "data-loss-protect", IsRequired: true},
+		5:  {Name: "upfront-shutdown-script", IsKnown: true},
+		9:  {Name: "tlv-onion", IsKnown: true},
+		15: {Name: "payment-addr", IsKnown: true},
+	}
+
+	fv := unmarshalFeatures(rpcFeatures)
+	require.NotNil(t, fv)
+	require.True(t, fv.HasFeature(lnwire.FeatureBit(0)))
+	require.True(t, fv.HasFeature(lnwire.FeatureBit(5)))
+	require.True(t, fv.HasFeature(lnwire.FeatureBit(9)))
+	require.True(t, fv.HasFeature(lnwire.FeatureBit(15)))
+	require.False(t, fv.HasFeature(lnwire.FeatureBit(99)))
+}
+
+// TestUnmarshalFeaturesEmpty verifies that an empty feature map produces an
+// empty (but non-nil) feature vector.
+func TestUnmarshalFeaturesEmpty(t *testing.T) {
+	fv := unmarshalFeatures(nil)
+	require.NotNil(t, fv)
+	require.False(t, fv.HasFeature(lnwire.FeatureBit(0)))
+}
+
+// TestParseColor verifies hex color string parsing.
+func TestParseColor(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    color.RGBA
+		wantErr bool
+	}{
+		{
+			name:  "with hash",
+			input: "#3399ff",
+			want:  color.RGBA{R: 0x33, G: 0x99, B: 0xff},
+		},
+		{
+			name:  "without hash",
+			input: "ff0000",
+			want:  color.RGBA{R: 0xff, G: 0x00, B: 0x00},
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  color.RGBA{},
+		},
+		{
+			name:    "invalid length",
+			input:   "#fff",
+			wantErr: true,
+		},
+		{
+			name:    "invalid hex",
+			input:   "zzzzzz",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseColor(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestMakeCachedPolicy verifies that lnrpc.RoutingPolicy is correctly
+// converted to a CachedEdgePolicy.
+func TestMakeCachedPolicy(t *testing.T) {
+	toNode := route.Vertex{0xaa}
+	rpcPolicy := &lnrpc.RoutingPolicy{
+		TimeLockDelta:           40,
+		MinHtlc:                 1000,
+		MaxHtlcMsat:             1_000_000_000,
+		FeeBaseMsat:             1000,
+		FeeRateMilliMsat:        100,
+		Disabled:                false,
+		InboundFeeBaseMsat:      -10,
+		InboundFeeRateMilliMsat: -5,
+	}
+
+	policy := makeCachedPolicy(42, rpcPolicy, toNode, true)
+
+	require.Equal(t, uint64(42), policy.ChannelID)
+	require.True(t, policy.IsNode1)
+	require.False(t, policy.IsDisabled)
+	require.True(t, policy.HasMaxHTLC)
+	require.Equal(t, uint16(40), policy.TimeLockDelta)
+	require.Equal(t, lnwire.MilliSatoshi(1000), policy.MinHTLC)
+	require.Equal(t, lnwire.MilliSatoshi(1_000_000_000), policy.MaxHTLC)
+	require.Equal(t, lnwire.MilliSatoshi(1000), policy.FeeBaseMSat)
+	require.Equal(t, lnwire.MilliSatoshi(100),
+		policy.FeeProportionalMillionths)
+
+	// Check ToNodePubKey callback.
+	require.Equal(t, toNode, policy.ToNodePubKey())
+
+	// Check inbound fee.
+	policy.InboundFee.WhenSome(func(fee lnwire.Fee) {
+		require.Equal(t, int32(-10), fee.BaseFee)
+		require.Equal(t, int32(-5), fee.FeeRate)
+	})
+}
+
+// TestMakeCachedPolicyNoInboundFee verifies that when inbound fees are zero,
+// the InboundFee option is None.
+func TestMakeCachedPolicyNoInboundFee(t *testing.T) {
+	rpcPolicy := &lnrpc.RoutingPolicy{
+		TimeLockDelta:           40,
+		MaxHtlcMsat:             1000,
+		InboundFeeBaseMsat:      0,
+		InboundFeeRateMilliMsat: 0,
+	}
+
+	policy := makeCachedPolicy(1, rpcPolicy, route.Vertex{}, true)
+	require.True(t, policy.InboundFee.IsNone())
+}
+
+// TestMakeCachedPolicyDisabled verifies that a disabled policy is correctly
+// flagged.
+func TestMakeCachedPolicyDisabled(t *testing.T) {
+	rpcPolicy := &lnrpc.RoutingPolicy{
+		Disabled: true,
+	}
+
+	policy := makeCachedPolicy(1, rpcPolicy, route.Vertex{}, false)
+	require.True(t, policy.IsDisabled)
+	require.False(t, policy.IsNode1)
+	require.False(t, policy.HasMaxHTLC)
+}
+
+// TestUnmarshalChannelEdge verifies full channel edge unmarshalling including
+// both policies.
+func TestUnmarshalChannelEdge(t *testing.T) {
+	edge := &lnrpc.ChannelEdge{
+		ChannelId: 123,
+		ChanPoint: testChanPoint + ":0",
+		Node1Pub:  testPub1,
+		Node2Pub:  testPub2,
+		Capacity:  1_000_000,
+		Node1Policy: &lnrpc.RoutingPolicy{
+			TimeLockDelta:    40,
+			MinHtlc:          1000,
+			MaxHtlcMsat:      500_000_000,
+			FeeBaseMsat:      1000,
+			FeeRateMilliMsat: 1,
+			LastUpdate:       1700000000,
+		},
+		Node2Policy: &lnrpc.RoutingPolicy{
+			TimeLockDelta:    80,
+			MinHtlc:          2000,
+			MaxHtlcMsat:      900_000_000,
+			FeeBaseMsat:      2000,
+			FeeRateMilliMsat: 2,
+			LastUpdate:       1700000001,
+			Disabled:         true,
+		},
+	}
+
+	info, p1, p2, err := unmarshalChannelEdge(edge)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(123), info.ChannelID)
+	require.Equal(t, int64(1_000_000), int64(info.Capacity))
+
+	// Policy 1.
+	require.NotNil(t, p1)
+	require.Equal(t, uint16(40), p1.TimeLockDelta)
+	require.Equal(t, lnwire.MilliSatoshi(1000), p1.FeeBaseMSat)
+
+	// Policy 2.
+	require.NotNil(t, p2)
+	require.Equal(t, uint16(80), p2.TimeLockDelta)
+	require.Equal(t, lnwire.MilliSatoshi(2000), p2.FeeBaseMSat)
+
+	// Verify channel flags for disabled policy.
+	require.True(t, p2.ChannelFlags.IsDisabled())
+}
+
+// TestUnmarshalChannelEdgeNilPolicies verifies that nil policies are handled.
+func TestUnmarshalChannelEdgeNilPolicies(t *testing.T) {
+	edge := &lnrpc.ChannelEdge{
+		ChannelId: 456,
+		ChanPoint: testChanPoint + ":1",
+		Node1Pub:  testPub1,
+		Node2Pub:  testPub2,
+		Capacity:  500_000,
+	}
+
+	info, p1, p2, err := unmarshalChannelEdge(edge)
+	require.NoError(t, err)
+	require.Equal(t, uint64(456), info.ChannelID)
+	require.Nil(t, p1)
+	require.Nil(t, p2)
+}
+
+// TestUnmarshalPolicy verifies the full ChannelEdgePolicy unmarshalling
+// including message flags and channel flags.
+func TestUnmarshalPolicy(t *testing.T) {
+	rpc := &lnrpc.RoutingPolicy{
+		TimeLockDelta:    144,
+		MinHtlc:          1000,
+		MaxHtlcMsat:      100_000_000,
+		FeeBaseMsat:      1000,
+		FeeRateMilliMsat: 1,
+		Disabled:         true,
+		LastUpdate:       1700000000,
+	}
+
+	// Node 2 policy (not node1).
+	policy, err := unmarshalPolicy(
+		42, rpc, false, testPub1,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(42), policy.ChannelID)
+	require.True(t, policy.ChannelFlags.IsDisabled())
+	require.True(t, policy.MessageFlags.HasMaxHtlc())
+
+	// Direction bit should be set for node2.
+	require.Equal(t, lnwire.ChanUpdateDirection|lnwire.ChanUpdateDisabled,
+		policy.ChannelFlags)
+}
+
+// TestIsNotFound verifies the gRPC not-found detection helper.
+func TestIsNotFound(t *testing.T) {
+	require.False(t, isNotFound(nil))
+	require.False(t, isNotFound(fmt.Errorf("random error")))
+
+	// gRPC NotFound status error.
+	err := status.Error(codes.NotFound, "not found")
+	require.True(t, isNotFound(err))
+
+	// Non-NotFound gRPC error.
+	err = status.Error(codes.Internal, "internal")
+	require.False(t, isNotFound(err))
+}

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -787,6 +787,10 @@ var allTestCases = []*lntest.TestCase{
 		Name:     "estimate on chain fee auto selected inputs",
 		TestFunc: testEstimateOnChainFeeAutoSelectedInputs,
 	},
+	{
+		Name:     "remote graph",
+		TestFunc: testRemoteGraph,
+	},
 }
 
 // appendPrefixed is used to add a prefix to each test name in the subtests

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -795,6 +795,10 @@ var allTestCases = []*lntest.TestCase{
 		Name:     "remote graph policy update",
 		TestFunc: testRemoteGraphPolicyUpdate,
 	},
+	{
+		Name:     "remote graph policy propagation",
+		TestFunc: testRemoteGraphPolicyPropagation,
+	},
 }
 
 // appendPrefixed is used to add a prefix to each test name in the subtests

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -791,6 +791,10 @@ var allTestCases = []*lntest.TestCase{
 		Name:     "remote graph",
 		TestFunc: testRemoteGraph,
 	},
+	{
+		Name:     "remote graph policy update",
+		TestFunc: testRemoteGraphPolicyUpdate,
+	},
 }
 
 // appendPrefixed is used to add a prefix to each test name in the subtests

--- a/itest/lnd_remote_graph_test.go
+++ b/itest/lnd_remote_graph_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lntest"
 	"github.com/lightningnetwork/lnd/lntest/node"
 	"github.com/lightningnetwork/lnd/lntest/wait"
@@ -200,4 +201,232 @@ func testRemoteGraph(ht *lntest.HarnessTest) {
 		return nil
 	}, wait.DefaultTimeout)
 	require.NoError(ht.T, err)
+}
+
+// testRemoteGraphPolicyUpdate tests that when a payment fails because of a
+// stale fee policy (FeeInsufficient), the updated ChannelUpdate from the
+// failure message is applied to the sender's graph cache — even when the
+// channel only exists in the remote graph and not in the sender's local DB.
+func testRemoteGraphPolicyUpdate(ht *lntest.HarnessTest) {
+	var (
+		ctx          = context.Background()
+		descGraphReq = &lnrpc.ChannelGraphRequest{
+			IncludeUnannounced: true,
+		}
+	)
+
+	// Set up a network:
+	// Alice <- Bob <- Carol
+	_, nodes := ht.CreateSimpleNetwork(
+		[][]string{nil, nil, nil}, lntest.OpenChannelParams{
+			Amt: btcutil.Amount(100000),
+		},
+	)
+	carol, bob, alice := nodes[0], nodes[1], nodes[2]
+
+	// Create graph provider node, Greg. Connect it to Bob so it syncs the
+	// public graph.
+	greg := ht.NewNode("Greg", nil)
+	ht.EnsureConnected(greg, bob)
+
+	// Wait until Greg has synced the public graph.
+	err := wait.NoError(func() error {
+		resp := greg.RPC.DescribeGraph(descGraphReq)
+		if len(resp.Edges) != 2 {
+			return fmt.Errorf("greg has %d edges, want 2",
+				len(resp.Edges))
+		}
+
+		return nil
+	}, wait.DefaultTimeout)
+	require.NoError(ht.T, err)
+
+	// Create Zane, using Greg as its remote graph source with gossip
+	// sync disabled.
+	zane := ht.NewNode("Zane", []string{
+		"--gossip.no-sync",
+		"--remotegraph.enable",
+		"--caches.rpc-graph-cache-duration=0",
+		fmt.Sprintf(
+			"--remotegraph.rpchost=localhost:%d",
+			greg.Cfg.RPCPort,
+		),
+		fmt.Sprintf(
+			"--remotegraph.tlscertpath=%s",
+			greg.Cfg.TLSCertPath,
+		),
+		fmt.Sprintf(
+			"--remotegraph.macaroonpath=%s",
+			greg.Cfg.AdminMacPath,
+		),
+	})
+
+	// Fund Zane, connect to Carol, and open a private channel.
+	ht.FundCoins(btcutil.SatoshiPerBitcoin, zane)
+	ht.EnsureConnected(zane, carol)
+	chanPointZane := ht.OpenChannel(
+		zane, carol, lntest.OpenChannelParams{
+			Private: true,
+			Amt:     btcutil.Amount(100000),
+		},
+	)
+
+	// Wait until Zane sees the full graph (2 public + 1 private = 3
+	// edges).
+	err = wait.NoError(func() error {
+		resp := zane.RPC.DescribeGraph(descGraphReq)
+		if len(resp.Edges) != 3 {
+			return fmt.Errorf("zane has %d edges, want 3",
+				len(resp.Edges))
+		}
+
+		return nil
+	}, wait.DefaultTimeout)
+	require.NoError(ht.T, err)
+
+	// Verify Zane can route a payment through the remote graph.
+	invoice := alice.RPC.AddInvoice(&lnrpc.Invoice{Value: 100})
+	ht.CompletePaymentRequests(zane, []string{invoice.PaymentRequest})
+
+	// Record the Bob->Alice channel ID so we can query its policy later.
+	bobGraph := bob.RPC.DescribeGraph(descGraphReq)
+	var bobAliceChanID uint64
+	for _, edge := range bobGraph.Edges {
+		isBA := edge.Node1Pub == bob.PubKeyStr &&
+			edge.Node2Pub == alice.PubKeyStr
+		isAB := edge.Node1Pub == alice.PubKeyStr &&
+			edge.Node2Pub == bob.PubKeyStr
+
+		if isBA || isAB {
+			bobAliceChanID = edge.ChannelId
+
+			break
+		}
+	}
+	require.NotZero(ht.T, bobAliceChanID,
+		"bob-alice channel not found")
+
+	// Disconnect Greg from Bob so Greg won't receive the upcoming fee
+	// update through gossip. This means Zane's remote graph subscription
+	// won't deliver the update either.
+	ht.DisconnectNodes(greg, bob)
+
+	// Query Zane's current view of the Bob->Alice channel's fee policy
+	// so we know the "old" value.
+	zaneChanInfo, err := zane.RPC.LN.GetChanInfo(
+		ctx, &lnrpc.ChanInfoRequest{ChanId: bobAliceChanID},
+	)
+	require.NoError(ht.T, err)
+
+	// Determine which policy is Bob's. Bob is the node that charges fees
+	// for forwarding on this channel.
+	var oldBobFeeRate int64
+	if zaneChanInfo.Node1Pub == bob.PubKeyStr {
+		oldBobFeeRate = zaneChanInfo.Node1Policy.FeeRateMilliMsat
+	} else {
+		oldBobFeeRate = zaneChanInfo.Node2Policy.FeeRateMilliMsat
+	}
+
+	// Bob dramatically increases his fee on the Bob->Alice channel.
+	newFeeRate := oldBobFeeRate + 500_000
+	bob.RPC.UpdateChannelPolicy(&lnrpc.PolicyUpdateRequest{
+		Scope: &lnrpc.PolicyUpdateRequest_Global{
+			Global: true,
+		},
+		BaseFeeMsat:   1000,
+		FeeRate:       float64(newFeeRate) / 1_000_000,
+		TimeLockDelta: 80,
+	})
+
+	// Give Alice a moment to receive the update from Bob (they're
+	// connected), but Greg is disconnected so neither Greg nor Zane
+	// will learn of the update through gossip/subscription.
+	err = wait.NoError(func() error {
+		info, err := alice.RPC.LN.GetChanInfo(
+			ctx,
+			&lnrpc.ChanInfoRequest{ChanId: bobAliceChanID},
+		)
+		if err != nil {
+			return err
+		}
+
+		var feeRate int64
+		if info.Node1Pub == bob.PubKeyStr {
+			feeRate = info.Node1Policy.FeeRateMilliMsat
+		} else {
+			feeRate = info.Node2Policy.FeeRateMilliMsat
+		}
+		if feeRate != newFeeRate {
+			return fmt.Errorf("alice sees fee rate %d, "+
+				"want %d", feeRate, newFeeRate)
+		}
+
+		return nil
+	}, wait.DefaultTimeout)
+	require.NoError(ht.T, err)
+
+	// Zane should still have the OLD fee policy for Bob since Greg is
+	// disconnected and can't forward the update.
+	zaneChanInfo, err = zane.RPC.LN.GetChanInfo(
+		ctx, &lnrpc.ChanInfoRequest{ChanId: bobAliceChanID},
+	)
+	require.NoError(ht.T, err)
+
+	var zaneBobFeeRate int64
+	if zaneChanInfo.Node1Pub == bob.PubKeyStr {
+		zaneBobFeeRate = zaneChanInfo.Node1Policy.FeeRateMilliMsat
+	} else {
+		zaneBobFeeRate = zaneChanInfo.Node2Policy.FeeRateMilliMsat
+	}
+	require.Equal(ht.T, oldBobFeeRate, zaneBobFeeRate,
+		"zane should still see old fee rate")
+
+	// Now Zane tries to pay Alice again. The payment will be attempted
+	// with the stale fee policy. Bob will reject it with FeeInsufficient
+	// and include the updated ChannelUpdate in the failure message.
+	//
+	// The router will extract the ChannelUpdate and call
+	// ApplyChannelUpdate. Currently, this fails silently because the
+	// channel only exists in the remote graph (via Greg), not in Zane's
+	// local DB.
+	//
+	// We use a high fee limit to ensure the payment would succeed if
+	// Zane had the correct fee info.
+	invoice2 := alice.RPC.AddInvoice(&lnrpc.Invoice{Value: 100})
+
+	// TODO(elle): Once the fix is applied, this payment should succeed
+	// because ApplyChannelUpdate will update the graph cache from the
+	// failure message, and the router will retry with the correct fees.
+	// For now, we assert the BROKEN behavior: the payment fails because
+	// Zane can't learn the updated fee from the failure message.
+	ht.SendPaymentAssertFail(
+		zane,
+		&routerrpc.SendPaymentRequest{
+			PaymentRequest: invoice2.PaymentRequest,
+			TimeoutSeconds: 30,
+			FeeLimitMsat:   10_000_000,
+			MaxParts:       1,
+		},
+		lnrpc.PaymentFailureReason_FAILURE_REASON_NO_ROUTE,
+	)
+
+	// Verify Zane's cached policy for Bob->Alice is still the OLD fee.
+	// This confirms that ApplyChannelUpdate did NOT update the cache
+	// from the failure message (the bug).
+	zaneChanInfo, err = zane.RPC.LN.GetChanInfo(
+		ctx, &lnrpc.ChanInfoRequest{ChanId: bobAliceChanID},
+	)
+	require.NoError(ht.T, err)
+
+	if zaneChanInfo.Node1Pub == bob.PubKeyStr {
+		zaneBobFeeRate = zaneChanInfo.Node1Policy.FeeRateMilliMsat
+	} else {
+		zaneBobFeeRate = zaneChanInfo.Node2Policy.FeeRateMilliMsat
+	}
+	require.Equal(ht.T, oldBobFeeRate, zaneBobFeeRate,
+		"bug confirmed: zane's cache was NOT updated from "+
+			"the payment failure message")
+
+	// Clean up.
+	ht.CloseChannel(zane, chanPointZane)
 }

--- a/itest/lnd_remote_graph_test.go
+++ b/itest/lnd_remote_graph_test.go
@@ -1,0 +1,203 @@
+//go:build integration
+
+package itest
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lntest"
+	"github.com/lightningnetwork/lnd/lntest/node"
+	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/stretchr/testify/require"
+)
+
+// testRemoteGraph verifies that a node configured with a remote graph source
+// can discover channels and nodes via that remote source, maintain its own
+// private channels independently, and route payments using the combined graph
+// view.
+func testRemoteGraph(ht *lntest.HarnessTest) {
+	var (
+		ctx          = context.Background()
+		descGraphReq = &lnrpc.ChannelGraphRequest{
+			IncludeUnannounced: true,
+		}
+	)
+
+	// Set up a network:
+	// Alice <- Bob <- Carol
+	_, nodes := ht.CreateSimpleNetwork(
+		[][]string{nil, nil, nil}, lntest.OpenChannelParams{
+			Amt: btcutil.Amount(100000),
+		},
+	)
+	carol, bob, alice := nodes[0], nodes[1], nodes[2]
+
+	// assertDescGraph is a helper that asserts a node's graph contains the
+	// expected number of edges and the expected set of nodes.
+	assertDescGraph := func(node *node.HarnessNode, numEdges int,
+		nodes ...*node.HarnessNode) {
+
+		err := wait.NoError(func() error {
+			resp := node.RPC.DescribeGraph(descGraphReq)
+			if len(resp.Edges) != numEdges {
+				return fmt.Errorf("expected %d edges, got "+
+					"%d", numEdges, len(resp.Edges))
+			}
+
+			knownNodes := map[string]bool{
+				// A node always knows about itself.
+				node.PubKeyStr: true,
+			}
+			for _, n := range resp.Nodes {
+				knownNodes[n.PubKey] = true
+			}
+
+			expectedCount := len(nodes) + 1
+			if len(knownNodes) != expectedCount {
+				return fmt.Errorf("expected %d nodes, "+
+					"got %d", expectedCount,
+					len(knownNodes))
+			}
+
+			for _, n := range nodes {
+				if !knownNodes[n.PubKeyStr] {
+					return fmt.Errorf("node %s not "+
+						"found in graph",
+						n.PubKeyStr)
+				}
+			}
+
+			return nil
+		}, wait.DefaultTimeout)
+		require.NoError(ht.T, err)
+	}
+
+	// Alice should know about Alice, Bob and Carol along with the 2 public
+	// channels.
+	assertDescGraph(alice, 2, bob, carol)
+
+	// Create graph provider node, Greg. Don't connect it to any nodes yet.
+	greg := ht.NewNode("Greg", nil)
+
+	// Greg should just know about himself. No channels yet.
+	assertDescGraph(greg, 0)
+
+	// Create Zane, a node that uses Greg as its remote graph source.
+	// Gossip sync is disabled so Zane relies entirely on Greg for network
+	// topology.
+	zane := ht.NewNode("Zane", []string{
+		"--gossip.no-sync",
+		"--remotegraph.enable",
+		"--caches.rpc-graph-cache-duration=0",
+		fmt.Sprintf(
+			"--remotegraph.rpchost=localhost:%d",
+			greg.Cfg.RPCPort,
+		),
+		fmt.Sprintf(
+			"--remotegraph.tlscertpath=%s",
+			greg.Cfg.TLSCertPath,
+		),
+		fmt.Sprintf(
+			"--remotegraph.macaroonpath=%s",
+			greg.Cfg.AdminMacPath,
+		),
+	})
+
+	// Zane should know about itself and Greg (from the remote graph) but
+	// no channels yet.
+	assertDescGraph(zane, 0, greg)
+
+	// Connect Zane to Carol. Even though they're now peers, Zane should
+	// not sync gossip from Carol (--gossip.no-sync), so its graph view
+	// should not change.
+	ht.FundCoins(btcutil.SatoshiPerBitcoin, zane)
+	ht.EnsureConnected(zane, carol)
+	assertDescGraph(zane, 0, greg)
+
+	// Open a private channel between Zane and Carol. This channel is only
+	// known locally to Zane and Carol and should not appear in Greg's
+	// graph.
+	chanPointZane := ht.OpenChannel(
+		zane, carol, lntest.OpenChannelParams{
+			Private: true,
+			Amt:     btcutil.Amount(100000),
+		},
+	)
+
+	// Zane should now know about itself, Greg, and Carol along with the
+	// one private channel.
+	assertDescGraph(zane, 1, greg, carol)
+
+	// Connect Greg to Bob so Greg can sync the public network topology.
+	ht.EnsureConnected(greg, bob)
+
+	// Wait until Greg has discovered Carol (meaning gossip sync completed).
+	err := wait.NoError(func() error {
+		info, err := greg.RPC.LN.GetNodeInfo(
+			ctx, &lnrpc.NodeInfoRequest{
+				PubKey: carol.PubKeyStr,
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		if len(info.Node.Addresses) == 0 {
+			return fmt.Errorf("greg has not yet synced carol's " +
+				"node announcement")
+		}
+
+		return nil
+	}, wait.DefaultTimeout)
+	require.NoError(ht.T, err)
+
+	// Greg should know about the 2 public channels and all public nodes.
+	// It does NOT know about Zane since Zane's only channel is private.
+	assertDescGraph(greg, 2, alice, bob, carol)
+
+	// Zane uses Greg as its remote graph source, so it should see
+	// everything Greg sees PLUS its own private channel with Carol.
+	assertDescGraph(zane, 3, alice, bob, carol, greg)
+
+	// Verify Zane can route a payment through the remote graph. Alice
+	// creates an invoice, and Zane pays it via Carol -> Bob -> Alice.
+	invoice := alice.RPC.AddInvoice(&lnrpc.Invoice{Value: 100})
+	ht.CompletePaymentRequests(zane, []string{invoice.PaymentRequest})
+
+	// Clean up: close Zane's private channel and mine blocks so both
+	// sides clear the link node.
+	ht.CloseChannel(zane, chanPointZane)
+	ht.MineBlocks(6)
+
+	// Disconnect Zane from Carol so Carol won't auto-reconnect.
+	ht.DisconnectNodes(carol, zane)
+
+	// Restart Zane (bootstrap disabled by default in test harness). It
+	// should have no peers since it has no channels and no bootstrap.
+	ht.RestartNode(zane)
+	err = wait.Invariant(func() bool {
+		peerResp := zane.RPC.ListPeers()
+
+		return len(peerResp.Peers) == 0
+	}, time.Second*5)
+	require.NoError(ht.T, err)
+
+	// Now enable peer bootstrapping and restart. Zane should discover
+	// peers from the remote graph and connect to them.
+	zane.Cfg.WithPeerBootstrap = true
+	ht.RestartNode(zane)
+
+	err = wait.NoError(func() error {
+		peerResp := zane.RPC.ListPeers()
+		if len(peerResp.Peers) == 0 {
+			return fmt.Errorf("zane has no peers yet")
+		}
+
+		return nil
+	}, wait.DefaultTimeout)
+	require.NoError(ht.T, err)
+}

--- a/itest/lnd_remote_graph_test.go
+++ b/itest/lnd_remote_graph_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/lightningnetwork/lnd/lnrpc"
-	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lntest"
 	"github.com/lightningnetwork/lnd/lntest/node"
 	"github.com/lightningnetwork/lnd/lntest/wait"
@@ -381,51 +380,14 @@ func testRemoteGraphPolicyUpdate(ht *lntest.HarnessTest) {
 	require.Equal(ht.T, oldBobFeeRate, zaneBobFeeRate,
 		"zane should still see old fee rate")
 
-	// Now Zane tries to pay Alice again. The payment will be attempted
-	// with the stale fee policy. Bob will reject it with FeeInsufficient
-	// and include the updated ChannelUpdate in the failure message.
-	//
-	// The router will extract the ChannelUpdate and call
-	// ApplyChannelUpdate. Currently, this fails silently because the
-	// channel only exists in the remote graph (via Greg), not in Zane's
-	// local DB.
-	//
-	// We use a high fee limit to ensure the payment would succeed if
-	// Zane had the correct fee info.
+	// Now Zane tries to pay Alice again. The first attempt uses the stale
+	// fee policy, so Bob rejects it with FeeInsufficient and includes the
+	// updated ChannelUpdate in the failure message. ApplyChannelUpdate
+	// falls back to the GraphSource (since the channel isn't in Zane's
+	// local DB), updates the graph cache, and the router retries with
+	// the correct fees.
 	invoice2 := alice.RPC.AddInvoice(&lnrpc.Invoice{Value: 100})
-
-	// TODO(elle): Once the fix is applied, this payment should succeed
-	// because ApplyChannelUpdate will update the graph cache from the
-	// failure message, and the router will retry with the correct fees.
-	// For now, we assert the BROKEN behavior: the payment fails because
-	// Zane can't learn the updated fee from the failure message.
-	ht.SendPaymentAssertFail(
-		zane,
-		&routerrpc.SendPaymentRequest{
-			PaymentRequest: invoice2.PaymentRequest,
-			TimeoutSeconds: 30,
-			FeeLimitMsat:   10_000_000,
-			MaxParts:       1,
-		},
-		lnrpc.PaymentFailureReason_FAILURE_REASON_NO_ROUTE,
-	)
-
-	// Verify Zane's cached policy for Bob->Alice is still the OLD fee.
-	// This confirms that ApplyChannelUpdate did NOT update the cache
-	// from the failure message (the bug).
-	zaneChanInfo, err = zane.RPC.LN.GetChanInfo(
-		ctx, &lnrpc.ChanInfoRequest{ChanId: bobAliceChanID},
-	)
-	require.NoError(ht.T, err)
-
-	if zaneChanInfo.Node1Pub == bob.PubKeyStr {
-		zaneBobFeeRate = zaneChanInfo.Node1Policy.FeeRateMilliMsat
-	} else {
-		zaneBobFeeRate = zaneChanInfo.Node2Policy.FeeRateMilliMsat
-	}
-	require.Equal(ht.T, oldBobFeeRate, zaneBobFeeRate,
-		"bug confirmed: zane's cache was NOT updated from "+
-			"the payment failure message")
+	ht.CompletePaymentRequests(zane, []string{invoice2.PaymentRequest})
 
 	// Clean up.
 	ht.CloseChannel(zane, chanPointZane)

--- a/itest/lnd_remote_graph_test.go
+++ b/itest/lnd_remote_graph_test.go
@@ -392,3 +392,212 @@ func testRemoteGraphPolicyUpdate(ht *lntest.HarnessTest) {
 	// Clean up.
 	ht.CloseChannel(zane, chanPointZane)
 }
+
+// testRemoteGraphPolicyPropagation tests that when a lightweight node (Zane)
+// receives an updated channel policy from a payment failure, that update is
+// propagated back to the graph source (Greg) so that other lightweight nodes
+// (Yara) that also use Greg benefit from it.
+//
+// This test first asserts the current limitation: after Zane learns about an
+// updated policy via a payment failure, Greg still has the stale policy, so
+// Yara also encounters the same stale policy on its first payment attempt.
+//
+// TODO: Once policy propagation back to the graph source is implemented,
+// update this test to assert that Greg and Yara see the new policy after
+// Zane's payment, and Yara's payment succeeds without hitting stale fees.
+func testRemoteGraphPolicyPropagation(ht *lntest.HarnessTest) {
+	var (
+		ctx          = context.Background()
+		descGraphReq = &lnrpc.ChannelGraphRequest{
+			IncludeUnannounced: true,
+		}
+	)
+
+	// Set up a public network: Alice <- Bob <- Carol.
+	_, nodes := ht.CreateSimpleNetwork(
+		[][]string{nil, nil, nil}, lntest.OpenChannelParams{
+			Amt: btcutil.Amount(100000),
+		},
+	)
+	carol, bob, alice := nodes[0], nodes[1], nodes[2]
+
+	// Create graph provider node, Greg. Connect it to Bob so it syncs the
+	// public graph.
+	greg := ht.NewNode("Greg", nil)
+	ht.EnsureConnected(greg, bob)
+
+	// Wait until Greg has synced the public graph (2 public channels).
+	err := wait.NoError(func() error {
+		resp := greg.RPC.DescribeGraph(descGraphReq)
+		if len(resp.Edges) != 2 {
+			return fmt.Errorf("greg has %d edges, want 2",
+				len(resp.Edges))
+		}
+
+		return nil
+	}, wait.DefaultTimeout)
+	require.NoError(ht.T, err)
+
+	// Restart Greg with --gossip.no-sync so he won't learn about any
+	// future policy updates via gossip from his peers. This simulates
+	// the scenario where Greg has a snapshot of the graph but doesn't
+	// receive real-time gossip updates for some channels.
+	ht.RestartNodeWithExtraArgs(greg, []string{
+		"--gossip.no-sync",
+	})
+
+	// remoteGraphArgs returns the arguments for a node that uses Greg
+	// as its remote graph source.
+	remoteGraphArgs := func() []string {
+		return []string{
+			"--gossip.no-sync",
+			"--remotegraph.enable",
+			"--caches.rpc-graph-cache-duration=0",
+			fmt.Sprintf(
+				"--remotegraph.rpchost=localhost:%d",
+				greg.Cfg.RPCPort,
+			),
+			fmt.Sprintf(
+				"--remotegraph.tlscertpath=%s",
+				greg.Cfg.TLSCertPath,
+			),
+			fmt.Sprintf(
+				"--remotegraph.macaroonpath=%s",
+				greg.Cfg.AdminMacPath,
+			),
+		}
+	}
+
+	// Create Zane and Yara, both using Greg as their remote graph source.
+	zane := ht.NewNode("Zane", remoteGraphArgs())
+	yara := ht.NewNode("Yara", remoteGraphArgs())
+
+	// Fund both, connect to Carol, and open private channels.
+	ht.FundCoins(btcutil.SatoshiPerBitcoin, zane)
+	ht.FundCoins(btcutil.SatoshiPerBitcoin, yara)
+	ht.EnsureConnected(zane, carol)
+	ht.EnsureConnected(yara, carol)
+
+	chanPointZane := ht.OpenChannel(
+		zane, carol, lntest.OpenChannelParams{
+			Private: true,
+			Amt:     btcutil.Amount(100000),
+		},
+	)
+	chanPointYara := ht.OpenChannel(
+		yara, carol, lntest.OpenChannelParams{
+			Private: true,
+			Amt:     btcutil.Amount(100000),
+		},
+	)
+
+	// Wait until both Zane and Yara see the full graph
+	// (2 public + 1 private = 3 edges each).
+	for _, n := range []*node.HarnessNode{zane, yara} {
+		nodeName := n.Cfg.Name
+		err = wait.NoError(func() error {
+			resp := n.RPC.DescribeGraph(descGraphReq)
+			if len(resp.Edges) != 3 {
+				return fmt.Errorf("%s has %d edges, want 3",
+					nodeName, len(resp.Edges))
+			}
+
+			return nil
+		}, wait.DefaultTimeout)
+		require.NoError(ht.T, err)
+	}
+
+	// Verify Zane can route a payment to Alice through the remote graph.
+	invoice := alice.RPC.AddInvoice(&lnrpc.Invoice{Value: 100})
+	ht.CompletePaymentRequests(zane, []string{invoice.PaymentRequest})
+
+	// Record the Bob->Alice channel ID.
+	bobGraph := bob.RPC.DescribeGraph(descGraphReq)
+	var bobAliceChanID uint64
+	for _, edge := range bobGraph.Edges {
+		isBA := edge.Node1Pub == bob.PubKeyStr &&
+			edge.Node2Pub == alice.PubKeyStr
+		isAB := edge.Node1Pub == alice.PubKeyStr &&
+			edge.Node2Pub == bob.PubKeyStr
+
+		if isBA || isAB {
+			bobAliceChanID = edge.ChannelId
+
+			break
+		}
+	}
+	require.NotZero(ht.T, bobAliceChanID,
+		"bob-alice channel not found")
+
+	// getBobFeeRate queries a node's view of Bob's fee rate on the
+	// Bob<->Alice channel.
+	getBobFeeRate := func(n *node.HarnessNode) int64 {
+		info, err := n.RPC.LN.GetChanInfo(
+			ctx,
+			&lnrpc.ChanInfoRequest{ChanId: bobAliceChanID},
+		)
+		require.NoError(ht.T, err)
+
+		if info.Node1Pub == bob.PubKeyStr {
+			return info.Node1Policy.FeeRateMilliMsat
+		}
+
+		return info.Node2Policy.FeeRateMilliMsat
+	}
+
+	oldBobFeeRate := getBobFeeRate(greg)
+
+	// Bob dramatically increases his fee on the Bob->Alice channel.
+	newFeeRate := oldBobFeeRate + 500_000
+	bob.RPC.UpdateChannelPolicy(&lnrpc.PolicyUpdateRequest{
+		Scope: &lnrpc.PolicyUpdateRequest_Global{
+			Global: true,
+		},
+		BaseFeeMsat:   1000,
+		FeeRate:       float64(newFeeRate) / 1_000_000,
+		TimeLockDelta: 80,
+	})
+
+	// Wait for Alice to learn about the new fee (she's connected to Bob
+	// directly via gossip).
+	err = wait.NoError(func() error {
+		rate := getBobFeeRate(alice)
+		if rate != newFeeRate {
+			return fmt.Errorf("alice sees fee rate %d, "+
+				"want %d", rate, newFeeRate)
+		}
+
+		return nil
+	}, wait.DefaultTimeout)
+	require.NoError(ht.T, err)
+
+	// Greg should still have the old fee rate since --gossip.no-sync
+	// prevents him from learning about the update.
+	require.Equal(ht.T, oldBobFeeRate, getBobFeeRate(greg),
+		"greg should still see old fee rate")
+
+	// Zane pays Alice. The first attempt will use the stale fee policy
+	// from Greg, causing Bob to reject with FeeInsufficient. The router
+	// applies the updated ChannelUpdate from the failure and retries
+	// successfully.
+	invoice2 := alice.RPC.AddInvoice(&lnrpc.Invoice{Value: 100})
+	ht.CompletePaymentRequests(zane, []string{invoice2.PaymentRequest})
+
+	// Greg should still have the old fee rate — Zane only updated its
+	// own local cache; the update was not propagated back to Greg.
+	require.Equal(ht.T, oldBobFeeRate, getBobFeeRate(greg),
+		"greg should still see old fee rate after zane's payment")
+
+	// Yara now tries to pay Alice. Because Greg still has stale policy
+	// data, Yara also hits FeeInsufficient on the first attempt and has
+	// to do the same retry dance. The payment still succeeds, but each
+	// remote graph user independently discovers the updated policy
+	// through their own payment failures — this is the problem we want
+	// to fix.
+	invoice3 := alice.RPC.AddInvoice(&lnrpc.Invoice{Value: 100})
+	ht.CompletePaymentRequests(yara, []string{invoice3.PaymentRequest})
+
+	// Clean up.
+	ht.CloseChannel(zane, chanPointZane)
+	ht.CloseChannel(yara, chanPointYara)
+}

--- a/itest/lnd_remote_graph_test.go
+++ b/itest/lnd_remote_graph_test.go
@@ -398,13 +398,10 @@ func testRemoteGraphPolicyUpdate(ht *lntest.HarnessTest) {
 // propagated back to the graph source (Greg) so that other lightweight nodes
 // (Yara) that also use Greg benefit from it.
 //
-// This test first asserts the current limitation: after Zane learns about an
-// updated policy via a payment failure, Greg still has the stale policy, so
-// Yara also encounters the same stale policy on its first payment attempt.
-//
-// TODO: Once policy propagation back to the graph source is implemented,
-// update this test to assert that Greg and Yara see the new policy after
-// Zane's payment, and Yara's payment succeeds without hitting stale fees.
+// The test verifies that after Zane's payment failure triggers a policy
+// update, Zane pushes the update back to Greg via InjectGossipMessage.
+// Greg validates and applies it, so Yara (who also uses Greg) sees the
+// updated policy and can pay without hitting stale fees.
 func testRemoteGraphPolicyPropagation(ht *lntest.HarnessTest) {
 	var (
 		ctx          = context.Background()
@@ -583,17 +580,35 @@ func testRemoteGraphPolicyPropagation(ht *lntest.HarnessTest) {
 	invoice2 := alice.RPC.AddInvoice(&lnrpc.Invoice{Value: 100})
 	ht.CompletePaymentRequests(zane, []string{invoice2.PaymentRequest})
 
-	// Greg should still have the old fee rate — Zane only updated its
-	// own local cache; the update was not propagated back to Greg.
-	require.Equal(ht.T, oldBobFeeRate, getBobFeeRate(greg),
-		"greg should still see old fee rate after zane's payment")
+	// Greg should now have the updated fee rate — Zane's payment failure
+	// triggered an InjectGossipMessage call back to Greg, who validated
+	// and applied the update.
+	err = wait.NoError(func() error {
+		rate := getBobFeeRate(greg)
+		if rate != newFeeRate {
+			return fmt.Errorf("greg sees fee rate %d, want %d",
+				rate, newFeeRate)
+		}
 
-	// Yara now tries to pay Alice. Because Greg still has stale policy
-	// data, Yara also hits FeeInsufficient on the first attempt and has
-	// to do the same retry dance. The payment still succeeds, but each
-	// remote graph user independently discovers the updated policy
-	// through their own payment failures — this is the problem we want
-	// to fix.
+		return nil
+	}, wait.DefaultTimeout)
+	require.NoError(ht.T, err)
+
+	// Since Greg now has the updated fee, Yara should also see it
+	// (via her remote graph subscription or next RPC query). This means
+	// Yara's payment should succeed without needing to discover the
+	// updated policy through her own payment failure.
+	err = wait.NoError(func() error {
+		rate := getBobFeeRate(yara)
+		if rate != newFeeRate {
+			return fmt.Errorf("yara sees fee rate %d, want %d",
+				rate, newFeeRate)
+		}
+
+		return nil
+	}, wait.DefaultTimeout)
+	require.NoError(ht.T, err)
+
 	invoice3 := alice.RPC.AddInvoice(&lnrpc.Invoice{Value: 100})
 	ht.CompletePaymentRequests(yara, []string{invoice3.PaymentRequest})
 

--- a/lncfg/gossip.go
+++ b/lncfg/gossip.go
@@ -43,6 +43,8 @@ type Gossip struct {
 	BanThreshold uint64 `long:"ban-threshold" description:"The score at which a peer is banned. A peer's ban score is incremented for each invalid gossip message. Invalid messages include those with bad signatures, stale timestamps, excessive updates, or invalid chain data. Once the score reaches this threshold, the peer is banned. Set to 0 to disable banning."`
 
 	PeerMsgRateBytes uint64 `long:"peer-msg-rate-bytes" description:"The peer-specific rate of outbound gossip messages, expressed in bytes per second. This setting controls the long-term average speed of gossip traffic sent from your node. The rate limit is applied to each peer. If the rate of outgoing messages exceeds this value, lnd will start to queue and delay messages sending to that peer to stay within the limit."`
+
+	NoSync bool `long:"no-sync" description:"If set, lnd will not request graph updates from its peers and won't advertise the gossip queries feature bit. This is useful if LND has been provided with an external graph source that it may use for pathfinding."`
 }
 
 // Parse the pubkeys for the pinned syncers.

--- a/lncfg/remote_graph.go
+++ b/lncfg/remote_graph.go
@@ -1,0 +1,81 @@
+package lncfg
+
+import (
+	"fmt"
+	"time"
+)
+
+// DefaultRemoteGraphTimeout is the default timeout for connecting to the remote
+// graph source.
+const DefaultRemoteGraphTimeout = 5 * time.Second
+
+// RemoteGraph holds the configuration options for using a remote LND node as
+// a graph source.
+//
+//nolint:ll
+type RemoteGraph struct {
+	Enable       bool          `long:"enable" description:"Use an external LND node as a remote graph source"`
+	RPCHost      string        `long:"rpchost" description:"The remote LND node's RPC host:port"`
+	MacaroonPath string        `long:"macaroonpath" description:"The macaroon to use for authenticating with the remote LND node"`
+	TLSCertPath  string        `long:"tlscertpath" description:"The TLS certificate to use for establishing the remote LND node's identity"`
+	Timeout      time.Duration `long:"timeout" description:"The timeout for connecting to the remote graph. Valid time units are {s, m, h}."`
+}
+
+// Validate checks the remote graph configuration.
+func (r *RemoteGraph) Validate() error {
+	if !r.Enable {
+		return nil
+	}
+
+	if r.RPCHost == "" {
+		return fmt.Errorf("remote graph: rpchost must be set when " +
+			"remote graph is enabled")
+	}
+
+	if r.MacaroonPath == "" {
+		return fmt.Errorf("remote graph: macaroonpath must be set " +
+			"when remote graph is enabled")
+	}
+
+	if r.TLSCertPath == "" {
+		return fmt.Errorf("remote graph: tlscertpath must be set " +
+			"when remote graph is enabled")
+	}
+
+	if r.Timeout < time.Millisecond {
+		return fmt.Errorf("remote graph: timeout of %v is invalid, "+
+			"cannot be smaller than %v", r.Timeout,
+			time.Millisecond)
+	}
+
+	return nil
+}
+
+// ValidateRemoteGraph performs cross-config validation for the remote graph
+// feature. This is called separately from Validate because it needs access to
+// other config values.
+func ValidateRemoteGraph(remoteGraph *RemoteGraph, noGraphCache,
+	gossipNoSync bool) error {
+
+	if !remoteGraph.Enable {
+		return nil
+	}
+
+	if noGraphCache {
+		return fmt.Errorf("remote graph requires the graph cache " +
+			"to be enabled (do not set db.no-graph-cache when " +
+			"using remotegraph.enable)")
+	}
+
+	if !gossipNoSync {
+		log.Warnf("remotegraph.enable is set without " +
+			"gossip.no-sync=true; the node will sync gossip " +
+			"from peers AND use the remote graph, which wastes " +
+			"bandwidth. Consider setting gossip.no-sync=true.")
+	}
+
+	return nil
+}
+
+// Compile-time constraint to ensure RemoteGraph implements Validator.
+var _ Validator = (*RemoteGraph)(nil)

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -18188,6 +18188,89 @@ func (x *InterceptFeedback) GetReplacementSerialized() []byte {
 	return nil
 }
 
+type InjectGossipMessageRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The raw gossip message serialized in the Lightning wire format (as
+	// defined in BOLT #7). Currently only ChannelUpdate messages are
+	// supported.
+	Msg           []byte `protobuf:"bytes,1,opt,name=msg,proto3" json:"msg,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InjectGossipMessageRequest) Reset() {
+	*x = InjectGossipMessageRequest{}
+	mi := &file_lightning_proto_msgTypes[209]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InjectGossipMessageRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InjectGossipMessageRequest) ProtoMessage() {}
+
+func (x *InjectGossipMessageRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_lightning_proto_msgTypes[209]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InjectGossipMessageRequest.ProtoReflect.Descriptor instead.
+func (*InjectGossipMessageRequest) Descriptor() ([]byte, []int) {
+	return file_lightning_proto_rawDescGZIP(), []int{209}
+}
+
+func (x *InjectGossipMessageRequest) GetMsg() []byte {
+	if x != nil {
+		return x.Msg
+	}
+	return nil
+}
+
+type InjectGossipMessageResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InjectGossipMessageResponse) Reset() {
+	*x = InjectGossipMessageResponse{}
+	mi := &file_lightning_proto_msgTypes[210]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InjectGossipMessageResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InjectGossipMessageResponse) ProtoMessage() {}
+
+func (x *InjectGossipMessageResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_lightning_proto_msgTypes[210]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InjectGossipMessageResponse.ProtoReflect.Descriptor instead.
+func (*InjectGossipMessageResponse) Descriptor() ([]byte, []int) {
+	return file_lightning_proto_rawDescGZIP(), []int{210}
+}
+
 type PendingChannelsResponse_PendingChannel struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	RemoteNodePub string                 `protobuf:"bytes,1,opt,name=remote_node_pub,json=remoteNodePub,proto3" json:"remote_node_pub,omitempty"`
@@ -18223,7 +18306,7 @@ type PendingChannelsResponse_PendingChannel struct {
 
 func (x *PendingChannelsResponse_PendingChannel) Reset() {
 	*x = PendingChannelsResponse_PendingChannel{}
-	mi := &file_lightning_proto_msgTypes[216]
+	mi := &file_lightning_proto_msgTypes[218]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -18235,7 +18318,7 @@ func (x *PendingChannelsResponse_PendingChannel) String() string {
 func (*PendingChannelsResponse_PendingChannel) ProtoMessage() {}
 
 func (x *PendingChannelsResponse_PendingChannel) ProtoReflect() protoreflect.Message {
-	mi := &file_lightning_proto_msgTypes[216]
+	mi := &file_lightning_proto_msgTypes[218]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -18398,7 +18481,7 @@ type PendingChannelsResponse_PendingOpenChannel struct {
 
 func (x *PendingChannelsResponse_PendingOpenChannel) Reset() {
 	*x = PendingChannelsResponse_PendingOpenChannel{}
-	mi := &file_lightning_proto_msgTypes[217]
+	mi := &file_lightning_proto_msgTypes[219]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -18410,7 +18493,7 @@ func (x *PendingChannelsResponse_PendingOpenChannel) String() string {
 func (*PendingChannelsResponse_PendingOpenChannel) ProtoMessage() {}
 
 func (x *PendingChannelsResponse_PendingOpenChannel) ProtoReflect() protoreflect.Message {
-	mi := &file_lightning_proto_msgTypes[217]
+	mi := &file_lightning_proto_msgTypes[219]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -18507,7 +18590,7 @@ type PendingChannelsResponse_WaitingCloseChannel struct {
 
 func (x *PendingChannelsResponse_WaitingCloseChannel) Reset() {
 	*x = PendingChannelsResponse_WaitingCloseChannel{}
-	mi := &file_lightning_proto_msgTypes[218]
+	mi := &file_lightning_proto_msgTypes[220]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -18519,7 +18602,7 @@ func (x *PendingChannelsResponse_WaitingCloseChannel) String() string {
 func (*PendingChannelsResponse_WaitingCloseChannel) ProtoMessage() {}
 
 func (x *PendingChannelsResponse_WaitingCloseChannel) ProtoReflect() protoreflect.Message {
-	mi := &file_lightning_proto_msgTypes[218]
+	mi := &file_lightning_proto_msgTypes[220]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -18607,7 +18690,7 @@ type PendingChannelsResponse_Commitments struct {
 
 func (x *PendingChannelsResponse_Commitments) Reset() {
 	*x = PendingChannelsResponse_Commitments{}
-	mi := &file_lightning_proto_msgTypes[219]
+	mi := &file_lightning_proto_msgTypes[221]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -18619,7 +18702,7 @@ func (x *PendingChannelsResponse_Commitments) String() string {
 func (*PendingChannelsResponse_Commitments) ProtoMessage() {}
 
 func (x *PendingChannelsResponse_Commitments) ProtoReflect() protoreflect.Message {
-	mi := &file_lightning_proto_msgTypes[219]
+	mi := &file_lightning_proto_msgTypes[221]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -18689,7 +18772,7 @@ type PendingChannelsResponse_ClosedChannel struct {
 
 func (x *PendingChannelsResponse_ClosedChannel) Reset() {
 	*x = PendingChannelsResponse_ClosedChannel{}
-	mi := &file_lightning_proto_msgTypes[220]
+	mi := &file_lightning_proto_msgTypes[222]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -18701,7 +18784,7 @@ func (x *PendingChannelsResponse_ClosedChannel) String() string {
 func (*PendingChannelsResponse_ClosedChannel) ProtoMessage() {}
 
 func (x *PendingChannelsResponse_ClosedChannel) ProtoReflect() protoreflect.Message {
-	mi := &file_lightning_proto_msgTypes[220]
+	mi := &file_lightning_proto_msgTypes[222]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -18755,7 +18838,7 @@ type PendingChannelsResponse_ForceClosedChannel struct {
 
 func (x *PendingChannelsResponse_ForceClosedChannel) Reset() {
 	*x = PendingChannelsResponse_ForceClosedChannel{}
-	mi := &file_lightning_proto_msgTypes[221]
+	mi := &file_lightning_proto_msgTypes[223]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -18767,7 +18850,7 @@ func (x *PendingChannelsResponse_ForceClosedChannel) String() string {
 func (*PendingChannelsResponse_ForceClosedChannel) ProtoMessage() {}
 
 func (x *PendingChannelsResponse_ForceClosedChannel) ProtoReflect() protoreflect.Message {
-	mi := &file_lightning_proto_msgTypes[221]
+	mi := &file_lightning_proto_msgTypes[223]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -20334,7 +20417,10 @@ const file_lightning_proto_rawDesc = "" +
 	"\x11InterceptFeedback\x12\x14\n" +
 	"\x05error\x18\x01 \x01(\tR\x05error\x12)\n" +
 	"\x10replace_response\x18\x02 \x01(\bR\x0freplaceResponse\x125\n" +
-	"\x16replacement_serialized\x18\x03 \x01(\fR\x15replacementSerialized*\xcb\x02\n" +
+	"\x16replacement_serialized\x18\x03 \x01(\fR\x15replacementSerialized\".\n" +
+	"\x1aInjectGossipMessageRequest\x12\x10\n" +
+	"\x03msg\x18\x01 \x01(\fR\x03msg\"\x1d\n" +
+	"\x1bInjectGossipMessageResponse*\xcb\x02\n" +
 	"\x10OutputScriptType\x12\x1b\n" +
 	"\x17SCRIPT_TYPE_PUBKEY_HASH\x10\x00\x12\x1b\n" +
 	"\x17SCRIPT_TYPE_SCRIPT_HASH\x10\x01\x12&\n" +
@@ -20441,7 +20527,7 @@ const file_lightning_proto_rawDesc = "" +
 	"\x16UPDATE_FAILURE_PENDING\x10\x01\x12\x1c\n" +
 	"\x18UPDATE_FAILURE_NOT_FOUND\x10\x02\x12\x1f\n" +
 	"\x1bUPDATE_FAILURE_INTERNAL_ERR\x10\x03\x12$\n" +
-	" UPDATE_FAILURE_INVALID_PARAMETER\x10\x042\xcb)\n" +
+	" UPDATE_FAILURE_INVALID_PARAMETER\x10\x042\xa9*\n" +
 	"\tLightning\x12J\n" +
 	"\rWalletBalance\x12\x1b.lnrpc.WalletBalanceRequest\x1a\x1c.lnrpc.WalletBalanceResponse\x12M\n" +
 	"\x0eChannelBalance\x12\x1c.lnrpc.ChannelBalanceRequest\x1a\x1d.lnrpc.ChannelBalanceResponse\x12K\n" +
@@ -20517,7 +20603,8 @@ const file_lightning_proto_rawDesc = "" +
 	"\x10SendOnionMessage\x12\x1e.lnrpc.SendOnionMessageRequest\x1a\x1f.lnrpc.SendOnionMessageResponse\x12[\n" +
 	"\x16SubscribeOnionMessages\x12$.lnrpc.SubscribeOnionMessagesRequest\x1a\x19.lnrpc.OnionMessageUpdate0\x01\x12D\n" +
 	"\vListAliases\x12\x19.lnrpc.ListAliasesRequest\x1a\x1a.lnrpc.ListAliasesResponse\x12_\n" +
-	"\x14LookupHtlcResolution\x12\".lnrpc.LookupHtlcResolutionRequest\x1a#.lnrpc.LookupHtlcResolutionResponseB'Z%github.com/lightningnetwork/lnd/lnrpcb\x06proto3"
+	"\x14LookupHtlcResolution\x12\".lnrpc.LookupHtlcResolutionRequest\x1a#.lnrpc.LookupHtlcResolutionResponse\x12\\\n" +
+	"\x13InjectGossipMessage\x12!.lnrpc.InjectGossipMessageRequest\x1a\".lnrpc.InjectGossipMessageResponseB'Z%github.com/lightningnetwork/lnd/lnrpcb\x06proto3"
 
 var (
 	file_lightning_proto_rawDescOnce sync.Once
@@ -20532,7 +20619,7 @@ func file_lightning_proto_rawDescGZIP() []byte {
 }
 
 var file_lightning_proto_enumTypes = make([]protoimpl.EnumInfo, 22)
-var file_lightning_proto_msgTypes = make([]protoimpl.MessageInfo, 238)
+var file_lightning_proto_msgTypes = make([]protoimpl.MessageInfo, 240)
 var file_lightning_proto_goTypes = []any{
 	(OutputScriptType)(0),                // 0: lnrpc.OutputScriptType
 	(CoinSelectionStrategy)(0),           // 1: lnrpc.CoinSelectionStrategy
@@ -20765,39 +20852,41 @@ var file_lightning_proto_goTypes = []any{
 	(*RPCMiddlewareResponse)(nil),                               // 228: lnrpc.RPCMiddlewareResponse
 	(*MiddlewareRegistration)(nil),                              // 229: lnrpc.MiddlewareRegistration
 	(*InterceptFeedback)(nil),                                   // 230: lnrpc.InterceptFeedback
-	nil,                                                         // 231: lnrpc.OnionMessageUpdate.CustomRecordsEntry
-	nil,                                                         // 232: lnrpc.SendRequest.DestCustomRecordsEntry
-	nil,                                                         // 233: lnrpc.EstimateFeeRequest.AddrToAmountEntry
-	nil,                                                         // 234: lnrpc.SendManyRequest.AddrToAmountEntry
-	nil,                                                         // 235: lnrpc.Peer.FeaturesEntry
-	nil,                                                         // 236: lnrpc.GetInfoResponse.FeaturesEntry
-	nil,                                                         // 237: lnrpc.GetDebugInfoResponse.ConfigEntry
-	(*PendingChannelsResponse_PendingChannel)(nil),              // 238: lnrpc.PendingChannelsResponse.PendingChannel
-	(*PendingChannelsResponse_PendingOpenChannel)(nil),          // 239: lnrpc.PendingChannelsResponse.PendingOpenChannel
-	(*PendingChannelsResponse_WaitingCloseChannel)(nil),         // 240: lnrpc.PendingChannelsResponse.WaitingCloseChannel
-	(*PendingChannelsResponse_Commitments)(nil),                 // 241: lnrpc.PendingChannelsResponse.Commitments
-	(*PendingChannelsResponse_ClosedChannel)(nil),               // 242: lnrpc.PendingChannelsResponse.ClosedChannel
-	(*PendingChannelsResponse_ForceClosedChannel)(nil),          // 243: lnrpc.PendingChannelsResponse.ForceClosedChannel
-	nil, // 244: lnrpc.WalletBalanceResponse.AccountBalanceEntry
-	nil, // 245: lnrpc.QueryRoutesRequest.DestCustomRecordsEntry
-	nil, // 246: lnrpc.Hop.CustomRecordsEntry
-	nil, // 247: lnrpc.LightningNode.FeaturesEntry
-	nil, // 248: lnrpc.LightningNode.CustomRecordsEntry
-	nil, // 249: lnrpc.RoutingPolicy.CustomRecordsEntry
-	nil, // 250: lnrpc.ChannelEdge.CustomRecordsEntry
-	nil, // 251: lnrpc.NodeMetricsResponse.BetweennessCentralityEntry
-	nil, // 252: lnrpc.NodeUpdate.FeaturesEntry
-	nil, // 253: lnrpc.Invoice.FeaturesEntry
-	nil, // 254: lnrpc.Invoice.AmpInvoiceStateEntry
-	nil, // 255: lnrpc.InvoiceHTLC.CustomRecordsEntry
-	nil, // 256: lnrpc.Payment.FirstHopCustomRecordsEntry
-	nil, // 257: lnrpc.PayReq.FeaturesEntry
-	nil, // 258: lnrpc.ListPermissionsResponse.MethodPermissionsEntry
-	nil, // 259: lnrpc.RPCMiddlewareRequest.MetadataPairsEntry
+	(*InjectGossipMessageRequest)(nil),                          // 231: lnrpc.InjectGossipMessageRequest
+	(*InjectGossipMessageResponse)(nil),                         // 232: lnrpc.InjectGossipMessageResponse
+	nil,                                                         // 233: lnrpc.OnionMessageUpdate.CustomRecordsEntry
+	nil,                                                         // 234: lnrpc.SendRequest.DestCustomRecordsEntry
+	nil,                                                         // 235: lnrpc.EstimateFeeRequest.AddrToAmountEntry
+	nil,                                                         // 236: lnrpc.SendManyRequest.AddrToAmountEntry
+	nil,                                                         // 237: lnrpc.Peer.FeaturesEntry
+	nil,                                                         // 238: lnrpc.GetInfoResponse.FeaturesEntry
+	nil,                                                         // 239: lnrpc.GetDebugInfoResponse.ConfigEntry
+	(*PendingChannelsResponse_PendingChannel)(nil),              // 240: lnrpc.PendingChannelsResponse.PendingChannel
+	(*PendingChannelsResponse_PendingOpenChannel)(nil),          // 241: lnrpc.PendingChannelsResponse.PendingOpenChannel
+	(*PendingChannelsResponse_WaitingCloseChannel)(nil),         // 242: lnrpc.PendingChannelsResponse.WaitingCloseChannel
+	(*PendingChannelsResponse_Commitments)(nil),                 // 243: lnrpc.PendingChannelsResponse.Commitments
+	(*PendingChannelsResponse_ClosedChannel)(nil),               // 244: lnrpc.PendingChannelsResponse.ClosedChannel
+	(*PendingChannelsResponse_ForceClosedChannel)(nil),          // 245: lnrpc.PendingChannelsResponse.ForceClosedChannel
+	nil, // 246: lnrpc.WalletBalanceResponse.AccountBalanceEntry
+	nil, // 247: lnrpc.QueryRoutesRequest.DestCustomRecordsEntry
+	nil, // 248: lnrpc.Hop.CustomRecordsEntry
+	nil, // 249: lnrpc.LightningNode.FeaturesEntry
+	nil, // 250: lnrpc.LightningNode.CustomRecordsEntry
+	nil, // 251: lnrpc.RoutingPolicy.CustomRecordsEntry
+	nil, // 252: lnrpc.ChannelEdge.CustomRecordsEntry
+	nil, // 253: lnrpc.NodeMetricsResponse.BetweennessCentralityEntry
+	nil, // 254: lnrpc.NodeUpdate.FeaturesEntry
+	nil, // 255: lnrpc.Invoice.FeaturesEntry
+	nil, // 256: lnrpc.Invoice.AmpInvoiceStateEntry
+	nil, // 257: lnrpc.InvoiceHTLC.CustomRecordsEntry
+	nil, // 258: lnrpc.Payment.FirstHopCustomRecordsEntry
+	nil, // 259: lnrpc.PayReq.FeaturesEntry
+	nil, // 260: lnrpc.ListPermissionsResponse.MethodPermissionsEntry
+	nil, // 261: lnrpc.RPCMiddlewareRequest.MetadataPairsEntry
 }
 var file_lightning_proto_depIdxs = []int32{
 	159, // 0: lnrpc.OnionMessageUpdate.reply_path:type_name -> lnrpc.BlindedPath
-	231, // 1: lnrpc.OnionMessageUpdate.custom_records:type_name -> lnrpc.OnionMessageUpdate.CustomRecordsEntry
+	233, // 1: lnrpc.OnionMessageUpdate.custom_records:type_name -> lnrpc.OnionMessageUpdate.CustomRecordsEntry
 	2,   // 2: lnrpc.Utxo.address_type:type_name -> lnrpc.AddressType
 	44,  // 3: lnrpc.Utxo.outpoint:type_name -> lnrpc.OutPoint
 	0,   // 4: lnrpc.OutputDetail.output_type:type_name -> lnrpc.OutputScriptType
@@ -20805,16 +20894,16 @@ var file_lightning_proto_depIdxs = []int32{
 	45,  // 6: lnrpc.Transaction.previous_outpoints:type_name -> lnrpc.PreviousOutPoint
 	34,  // 7: lnrpc.TransactionDetails.transactions:type_name -> lnrpc.Transaction
 	37,  // 8: lnrpc.SendRequest.fee_limit:type_name -> lnrpc.FeeLimit
-	232, // 9: lnrpc.SendRequest.dest_custom_records:type_name -> lnrpc.SendRequest.DestCustomRecordsEntry
+	234, // 9: lnrpc.SendRequest.dest_custom_records:type_name -> lnrpc.SendRequest.DestCustomRecordsEntry
 	11,  // 10: lnrpc.SendRequest.dest_features:type_name -> lnrpc.FeatureBit
 	132, // 11: lnrpc.SendResponse.payment_route:type_name -> lnrpc.Route
 	132, // 12: lnrpc.SendToRouteRequest.route:type_name -> lnrpc.Route
 	3,   // 13: lnrpc.ChannelAcceptRequest.commitment_type:type_name -> lnrpc.CommitmentType
-	233, // 14: lnrpc.EstimateFeeRequest.AddrToAmount:type_name -> lnrpc.EstimateFeeRequest.AddrToAmountEntry
+	235, // 14: lnrpc.EstimateFeeRequest.AddrToAmount:type_name -> lnrpc.EstimateFeeRequest.AddrToAmountEntry
 	1,   // 15: lnrpc.EstimateFeeRequest.coin_selection_strategy:type_name -> lnrpc.CoinSelectionStrategy
 	44,  // 16: lnrpc.EstimateFeeRequest.inputs:type_name -> lnrpc.OutPoint
 	44,  // 17: lnrpc.EstimateFeeResponse.inputs:type_name -> lnrpc.OutPoint
-	234, // 18: lnrpc.SendManyRequest.AddrToAmount:type_name -> lnrpc.SendManyRequest.AddrToAmountEntry
+	236, // 18: lnrpc.SendManyRequest.AddrToAmount:type_name -> lnrpc.SendManyRequest.AddrToAmountEntry
 	1,   // 19: lnrpc.SendManyRequest.coin_selection_strategy:type_name -> lnrpc.CoinSelectionStrategy
 	1,   // 20: lnrpc.SendCoinsRequest.coin_selection_strategy:type_name -> lnrpc.CoinSelectionStrategy
 	44,  // 21: lnrpc.SendCoinsRequest.outpoints:type_name -> lnrpc.OutPoint
@@ -20836,14 +20925,14 @@ var file_lightning_proto_depIdxs = []int32{
 	44,  // 37: lnrpc.Resolution.outpoint:type_name -> lnrpc.OutPoint
 	73,  // 38: lnrpc.ClosedChannelsResponse.channels:type_name -> lnrpc.ChannelCloseSummary
 	14,  // 39: lnrpc.Peer.sync_type:type_name -> lnrpc.Peer.SyncType
-	235, // 40: lnrpc.Peer.features:type_name -> lnrpc.Peer.FeaturesEntry
+	237, // 40: lnrpc.Peer.features:type_name -> lnrpc.Peer.FeaturesEntry
 	78,  // 41: lnrpc.Peer.errors:type_name -> lnrpc.TimestampedError
 	77,  // 42: lnrpc.ListPeersResponse.peers:type_name -> lnrpc.Peer
 	15,  // 43: lnrpc.PeerEvent.type:type_name -> lnrpc.PeerEvent.EventType
 	89,  // 44: lnrpc.GetInfoResponse.chains:type_name -> lnrpc.Chain
-	236, // 45: lnrpc.GetInfoResponse.features:type_name -> lnrpc.GetInfoResponse.FeaturesEntry
+	238, // 45: lnrpc.GetInfoResponse.features:type_name -> lnrpc.GetInfoResponse.FeaturesEntry
 	7,   // 46: lnrpc.GetInfoResponse.graph_cache_status:type_name -> lnrpc.GraphCacheStatus
-	237, // 47: lnrpc.GetDebugInfoResponse.config:type_name -> lnrpc.GetDebugInfoResponse.ConfigEntry
+	239, // 47: lnrpc.GetDebugInfoResponse.config:type_name -> lnrpc.GetDebugInfoResponse.ConfigEntry
 	43,  // 48: lnrpc.ChannelOpenUpdate.channel_point:type_name -> lnrpc.ChannelPoint
 	91,  // 49: lnrpc.ChannelCloseUpdate.local_close_output:type_name -> lnrpc.CloseOutput
 	91,  // 50: lnrpc.ChannelCloseUpdate.remote_close_output:type_name -> lnrpc.CloseOutput
@@ -20871,10 +20960,10 @@ var file_lightning_proto_depIdxs = []int32{
 	108, // 72: lnrpc.FundingTransitionMsg.shim_cancel:type_name -> lnrpc.FundingShimCancel
 	109, // 73: lnrpc.FundingTransitionMsg.psbt_verify:type_name -> lnrpc.FundingPsbtVerify
 	110, // 74: lnrpc.FundingTransitionMsg.psbt_finalize:type_name -> lnrpc.FundingPsbtFinalize
-	239, // 75: lnrpc.PendingChannelsResponse.pending_open_channels:type_name -> lnrpc.PendingChannelsResponse.PendingOpenChannel
-	242, // 76: lnrpc.PendingChannelsResponse.pending_closing_channels:type_name -> lnrpc.PendingChannelsResponse.ClosedChannel
-	243, // 77: lnrpc.PendingChannelsResponse.pending_force_closing_channels:type_name -> lnrpc.PendingChannelsResponse.ForceClosedChannel
-	240, // 78: lnrpc.PendingChannelsResponse.waiting_close_channels:type_name -> lnrpc.PendingChannelsResponse.WaitingCloseChannel
+	241, // 75: lnrpc.PendingChannelsResponse.pending_open_channels:type_name -> lnrpc.PendingChannelsResponse.PendingOpenChannel
+	244, // 76: lnrpc.PendingChannelsResponse.pending_closing_channels:type_name -> lnrpc.PendingChannelsResponse.ClosedChannel
+	245, // 77: lnrpc.PendingChannelsResponse.pending_force_closing_channels:type_name -> lnrpc.PendingChannelsResponse.ForceClosedChannel
+	242, // 78: lnrpc.PendingChannelsResponse.waiting_close_channels:type_name -> lnrpc.PendingChannelsResponse.WaitingCloseChannel
 	67,  // 79: lnrpc.ChannelCommitUpdate.channel:type_name -> lnrpc.Channel
 	67,  // 80: lnrpc.ChannelEventUpdate.open_channel:type_name -> lnrpc.Channel
 	73,  // 81: lnrpc.ChannelEventUpdate.closed_channel:type_name -> lnrpc.ChannelCloseSummary
@@ -20885,7 +20974,7 @@ var file_lightning_proto_depIdxs = []int32{
 	43,  // 86: lnrpc.ChannelEventUpdate.channel_funding_timeout:type_name -> lnrpc.ChannelPoint
 	117, // 87: lnrpc.ChannelEventUpdate.updated_channel:type_name -> lnrpc.ChannelCommitUpdate
 	17,  // 88: lnrpc.ChannelEventUpdate.type:type_name -> lnrpc.ChannelEventUpdate.UpdateType
-	244, // 89: lnrpc.WalletBalanceResponse.account_balance:type_name -> lnrpc.WalletBalanceResponse.AccountBalanceEntry
+	246, // 89: lnrpc.WalletBalanceResponse.account_balance:type_name -> lnrpc.WalletBalanceResponse.AccountBalanceEntry
 	122, // 90: lnrpc.ChannelBalanceResponse.local_balance:type_name -> lnrpc.Amount
 	122, // 91: lnrpc.ChannelBalanceResponse.remote_balance:type_name -> lnrpc.Amount
 	122, // 92: lnrpc.ChannelBalanceResponse.unsettled_local_balance:type_name -> lnrpc.Amount
@@ -20895,34 +20984,34 @@ var file_lightning_proto_depIdxs = []int32{
 	37,  // 96: lnrpc.QueryRoutesRequest.fee_limit:type_name -> lnrpc.FeeLimit
 	127, // 97: lnrpc.QueryRoutesRequest.ignored_edges:type_name -> lnrpc.EdgeLocator
 	126, // 98: lnrpc.QueryRoutesRequest.ignored_pairs:type_name -> lnrpc.NodePair
-	245, // 99: lnrpc.QueryRoutesRequest.dest_custom_records:type_name -> lnrpc.QueryRoutesRequest.DestCustomRecordsEntry
+	247, // 99: lnrpc.QueryRoutesRequest.dest_custom_records:type_name -> lnrpc.QueryRoutesRequest.DestCustomRecordsEntry
 	157, // 100: lnrpc.QueryRoutesRequest.route_hints:type_name -> lnrpc.RouteHint
 	158, // 101: lnrpc.QueryRoutesRequest.blinded_payment_paths:type_name -> lnrpc.BlindedPaymentPath
 	11,  // 102: lnrpc.QueryRoutesRequest.dest_features:type_name -> lnrpc.FeatureBit
 	132, // 103: lnrpc.QueryRoutesResponse.routes:type_name -> lnrpc.Route
 	130, // 104: lnrpc.Hop.mpp_record:type_name -> lnrpc.MPPRecord
 	131, // 105: lnrpc.Hop.amp_record:type_name -> lnrpc.AMPRecord
-	246, // 106: lnrpc.Hop.custom_records:type_name -> lnrpc.Hop.CustomRecordsEntry
+	248, // 106: lnrpc.Hop.custom_records:type_name -> lnrpc.Hop.CustomRecordsEntry
 	129, // 107: lnrpc.Route.hops:type_name -> lnrpc.Hop
 	135, // 108: lnrpc.NodeInfo.node:type_name -> lnrpc.LightningNode
 	139, // 109: lnrpc.NodeInfo.channels:type_name -> lnrpc.ChannelEdge
 	136, // 110: lnrpc.LightningNode.addresses:type_name -> lnrpc.NodeAddress
-	247, // 111: lnrpc.LightningNode.features:type_name -> lnrpc.LightningNode.FeaturesEntry
-	248, // 112: lnrpc.LightningNode.custom_records:type_name -> lnrpc.LightningNode.CustomRecordsEntry
-	249, // 113: lnrpc.RoutingPolicy.custom_records:type_name -> lnrpc.RoutingPolicy.CustomRecordsEntry
+	249, // 111: lnrpc.LightningNode.features:type_name -> lnrpc.LightningNode.FeaturesEntry
+	250, // 112: lnrpc.LightningNode.custom_records:type_name -> lnrpc.LightningNode.CustomRecordsEntry
+	251, // 113: lnrpc.RoutingPolicy.custom_records:type_name -> lnrpc.RoutingPolicy.CustomRecordsEntry
 	137, // 114: lnrpc.ChannelEdge.node1_policy:type_name -> lnrpc.RoutingPolicy
 	137, // 115: lnrpc.ChannelEdge.node2_policy:type_name -> lnrpc.RoutingPolicy
-	250, // 116: lnrpc.ChannelEdge.custom_records:type_name -> lnrpc.ChannelEdge.CustomRecordsEntry
+	252, // 116: lnrpc.ChannelEdge.custom_records:type_name -> lnrpc.ChannelEdge.CustomRecordsEntry
 	138, // 117: lnrpc.ChannelEdge.auth_proof:type_name -> lnrpc.ChannelAuthProof
 	135, // 118: lnrpc.ChannelGraph.nodes:type_name -> lnrpc.LightningNode
 	139, // 119: lnrpc.ChannelGraph.edges:type_name -> lnrpc.ChannelEdge
 	8,   // 120: lnrpc.NodeMetricsRequest.types:type_name -> lnrpc.NodeMetricType
-	251, // 121: lnrpc.NodeMetricsResponse.betweenness_centrality:type_name -> lnrpc.NodeMetricsResponse.BetweennessCentralityEntry
+	253, // 121: lnrpc.NodeMetricsResponse.betweenness_centrality:type_name -> lnrpc.NodeMetricsResponse.BetweennessCentralityEntry
 	152, // 122: lnrpc.GraphTopologyUpdate.node_updates:type_name -> lnrpc.NodeUpdate
 	153, // 123: lnrpc.GraphTopologyUpdate.channel_updates:type_name -> lnrpc.ChannelEdgeUpdate
 	154, // 124: lnrpc.GraphTopologyUpdate.closed_chans:type_name -> lnrpc.ClosedChannelUpdate
 	136, // 125: lnrpc.NodeUpdate.node_addresses:type_name -> lnrpc.NodeAddress
-	252, // 126: lnrpc.NodeUpdate.features:type_name -> lnrpc.NodeUpdate.FeaturesEntry
+	254, // 126: lnrpc.NodeUpdate.features:type_name -> lnrpc.NodeUpdate.FeaturesEntry
 	43,  // 127: lnrpc.ChannelEdgeUpdate.chan_point:type_name -> lnrpc.ChannelPoint
 	137, // 128: lnrpc.ChannelEdgeUpdate.routing_policy:type_name -> lnrpc.RoutingPolicy
 	43,  // 129: lnrpc.ClosedChannelUpdate.chan_point:type_name -> lnrpc.ChannelPoint
@@ -20934,24 +21023,24 @@ var file_lightning_proto_depIdxs = []int32{
 	157, // 135: lnrpc.Invoice.route_hints:type_name -> lnrpc.RouteHint
 	18,  // 136: lnrpc.Invoice.state:type_name -> lnrpc.Invoice.InvoiceState
 	164, // 137: lnrpc.Invoice.htlcs:type_name -> lnrpc.InvoiceHTLC
-	253, // 138: lnrpc.Invoice.features:type_name -> lnrpc.Invoice.FeaturesEntry
-	254, // 139: lnrpc.Invoice.amp_invoice_state:type_name -> lnrpc.Invoice.AmpInvoiceStateEntry
+	255, // 138: lnrpc.Invoice.features:type_name -> lnrpc.Invoice.FeaturesEntry
+	256, // 139: lnrpc.Invoice.amp_invoice_state:type_name -> lnrpc.Invoice.AmpInvoiceStateEntry
 	163, // 140: lnrpc.Invoice.blinded_path_config:type_name -> lnrpc.BlindedPathConfig
 	9,   // 141: lnrpc.InvoiceHTLC.state:type_name -> lnrpc.InvoiceHTLCState
-	255, // 142: lnrpc.InvoiceHTLC.custom_records:type_name -> lnrpc.InvoiceHTLC.CustomRecordsEntry
+	257, // 142: lnrpc.InvoiceHTLC.custom_records:type_name -> lnrpc.InvoiceHTLC.CustomRecordsEntry
 	165, // 143: lnrpc.InvoiceHTLC.amp:type_name -> lnrpc.AMP
 	162, // 144: lnrpc.ListInvoiceResponse.invoices:type_name -> lnrpc.Invoice
 	19,  // 145: lnrpc.Payment.status:type_name -> lnrpc.Payment.PaymentStatus
 	174, // 146: lnrpc.Payment.htlcs:type_name -> lnrpc.HTLCAttempt
 	10,  // 147: lnrpc.Payment.failure_reason:type_name -> lnrpc.PaymentFailureReason
-	256, // 148: lnrpc.Payment.first_hop_custom_records:type_name -> lnrpc.Payment.FirstHopCustomRecordsEntry
+	258, // 148: lnrpc.Payment.first_hop_custom_records:type_name -> lnrpc.Payment.FirstHopCustomRecordsEntry
 	20,  // 149: lnrpc.HTLCAttempt.status:type_name -> lnrpc.HTLCAttempt.HTLCStatus
 	132, // 150: lnrpc.HTLCAttempt.route:type_name -> lnrpc.Route
 	218, // 151: lnrpc.HTLCAttempt.failure:type_name -> lnrpc.Failure
 	173, // 152: lnrpc.ListPaymentsResponse.payments:type_name -> lnrpc.Payment
 	43,  // 153: lnrpc.AbandonChannelRequest.channel_point:type_name -> lnrpc.ChannelPoint
 	157, // 154: lnrpc.PayReq.route_hints:type_name -> lnrpc.RouteHint
-	257, // 155: lnrpc.PayReq.features:type_name -> lnrpc.PayReq.FeaturesEntry
+	259, // 155: lnrpc.PayReq.features:type_name -> lnrpc.PayReq.FeaturesEntry
 	158, // 156: lnrpc.PayReq.blinded_paths:type_name -> lnrpc.BlindedPaymentPath
 	189, // 157: lnrpc.FeeReportResponse.channel_fees:type_name -> lnrpc.ChannelFeeReport
 	43,  // 158: lnrpc.PolicyUpdateRequest.chan_point:type_name -> lnrpc.ChannelPoint
@@ -20969,7 +21058,7 @@ var file_lightning_proto_depIdxs = []int32{
 	203, // 170: lnrpc.RestoreChanBackupRequest.chan_backups:type_name -> lnrpc.ChannelBackups
 	208, // 171: lnrpc.BakeMacaroonRequest.permissions:type_name -> lnrpc.MacaroonPermission
 	208, // 172: lnrpc.MacaroonPermissionList.permissions:type_name -> lnrpc.MacaroonPermission
-	258, // 173: lnrpc.ListPermissionsResponse.method_permissions:type_name -> lnrpc.ListPermissionsResponse.MethodPermissionsEntry
+	260, // 173: lnrpc.ListPermissionsResponse.method_permissions:type_name -> lnrpc.ListPermissionsResponse.MethodPermissionsEntry
 	21,  // 174: lnrpc.Failure.code:type_name -> lnrpc.Failure.FailureCode
 	219, // 175: lnrpc.Failure.channel_update:type_name -> lnrpc.ChannelUpdate
 	221, // 176: lnrpc.MacaroonId.ops:type_name -> lnrpc.Op
@@ -20977,18 +21066,18 @@ var file_lightning_proto_depIdxs = []int32{
 	226, // 178: lnrpc.RPCMiddlewareRequest.stream_auth:type_name -> lnrpc.StreamAuth
 	227, // 179: lnrpc.RPCMiddlewareRequest.request:type_name -> lnrpc.RPCMessage
 	227, // 180: lnrpc.RPCMiddlewareRequest.response:type_name -> lnrpc.RPCMessage
-	259, // 181: lnrpc.RPCMiddlewareRequest.metadata_pairs:type_name -> lnrpc.RPCMiddlewareRequest.MetadataPairsEntry
+	261, // 181: lnrpc.RPCMiddlewareRequest.metadata_pairs:type_name -> lnrpc.RPCMiddlewareRequest.MetadataPairsEntry
 	229, // 182: lnrpc.RPCMiddlewareResponse.register:type_name -> lnrpc.MiddlewareRegistration
 	230, // 183: lnrpc.RPCMiddlewareResponse.feedback:type_name -> lnrpc.InterceptFeedback
 	187, // 184: lnrpc.Peer.FeaturesEntry.value:type_name -> lnrpc.Feature
 	187, // 185: lnrpc.GetInfoResponse.FeaturesEntry.value:type_name -> lnrpc.Feature
 	4,   // 186: lnrpc.PendingChannelsResponse.PendingChannel.initiator:type_name -> lnrpc.Initiator
 	3,   // 187: lnrpc.PendingChannelsResponse.PendingChannel.commitment_type:type_name -> lnrpc.CommitmentType
-	238, // 188: lnrpc.PendingChannelsResponse.PendingOpenChannel.channel:type_name -> lnrpc.PendingChannelsResponse.PendingChannel
-	238, // 189: lnrpc.PendingChannelsResponse.WaitingCloseChannel.channel:type_name -> lnrpc.PendingChannelsResponse.PendingChannel
-	241, // 190: lnrpc.PendingChannelsResponse.WaitingCloseChannel.commitments:type_name -> lnrpc.PendingChannelsResponse.Commitments
-	238, // 191: lnrpc.PendingChannelsResponse.ClosedChannel.channel:type_name -> lnrpc.PendingChannelsResponse.PendingChannel
-	238, // 192: lnrpc.PendingChannelsResponse.ForceClosedChannel.channel:type_name -> lnrpc.PendingChannelsResponse.PendingChannel
+	240, // 188: lnrpc.PendingChannelsResponse.PendingOpenChannel.channel:type_name -> lnrpc.PendingChannelsResponse.PendingChannel
+	240, // 189: lnrpc.PendingChannelsResponse.WaitingCloseChannel.channel:type_name -> lnrpc.PendingChannelsResponse.PendingChannel
+	243, // 190: lnrpc.PendingChannelsResponse.WaitingCloseChannel.commitments:type_name -> lnrpc.PendingChannelsResponse.Commitments
+	240, // 191: lnrpc.PendingChannelsResponse.ClosedChannel.channel:type_name -> lnrpc.PendingChannelsResponse.PendingChannel
+	240, // 192: lnrpc.PendingChannelsResponse.ForceClosedChannel.channel:type_name -> lnrpc.PendingChannelsResponse.PendingChannel
 	113, // 193: lnrpc.PendingChannelsResponse.ForceClosedChannel.pending_htlcs:type_name -> lnrpc.PendingHTLC
 	16,  // 194: lnrpc.PendingChannelsResponse.ForceClosedChannel.anchor:type_name -> lnrpc.PendingChannelsResponse.ForceClosedChannel.AnchorState
 	119, // 195: lnrpc.WalletBalanceResponse.AccountBalanceEntry.value:type_name -> lnrpc.WalletAccountBalance
@@ -21071,79 +21160,81 @@ var file_lightning_proto_depIdxs = []int32{
 	28,  // 272: lnrpc.Lightning.SubscribeOnionMessages:input_type -> lnrpc.SubscribeOnionMessagesRequest
 	71,  // 273: lnrpc.Lightning.ListAliases:input_type -> lnrpc.ListAliasesRequest
 	22,  // 274: lnrpc.Lightning.LookupHtlcResolution:input_type -> lnrpc.LookupHtlcResolutionRequest
-	121, // 275: lnrpc.Lightning.WalletBalance:output_type -> lnrpc.WalletBalanceResponse
-	124, // 276: lnrpc.Lightning.ChannelBalance:output_type -> lnrpc.ChannelBalanceResponse
-	36,  // 277: lnrpc.Lightning.GetTransactions:output_type -> lnrpc.TransactionDetails
-	48,  // 278: lnrpc.Lightning.EstimateFee:output_type -> lnrpc.EstimateFeeResponse
-	52,  // 279: lnrpc.Lightning.SendCoins:output_type -> lnrpc.SendCoinsResponse
-	54,  // 280: lnrpc.Lightning.ListUnspent:output_type -> lnrpc.ListUnspentResponse
-	34,  // 281: lnrpc.Lightning.SubscribeTransactions:output_type -> lnrpc.Transaction
-	50,  // 282: lnrpc.Lightning.SendMany:output_type -> lnrpc.SendManyResponse
-	56,  // 283: lnrpc.Lightning.NewAddress:output_type -> lnrpc.NewAddressResponse
-	58,  // 284: lnrpc.Lightning.SignMessage:output_type -> lnrpc.SignMessageResponse
-	60,  // 285: lnrpc.Lightning.VerifyMessage:output_type -> lnrpc.VerifyMessageResponse
-	62,  // 286: lnrpc.Lightning.ConnectPeer:output_type -> lnrpc.ConnectPeerResponse
-	64,  // 287: lnrpc.Lightning.DisconnectPeer:output_type -> lnrpc.DisconnectPeerResponse
-	80,  // 288: lnrpc.Lightning.ListPeers:output_type -> lnrpc.ListPeersResponse
-	82,  // 289: lnrpc.Lightning.SubscribePeerEvents:output_type -> lnrpc.PeerEvent
-	84,  // 290: lnrpc.Lightning.GetInfo:output_type -> lnrpc.GetInfoResponse
-	86,  // 291: lnrpc.Lightning.GetDebugInfo:output_type -> lnrpc.GetDebugInfoResponse
-	88,  // 292: lnrpc.Lightning.GetRecoveryInfo:output_type -> lnrpc.GetRecoveryInfoResponse
-	115, // 293: lnrpc.Lightning.PendingChannels:output_type -> lnrpc.PendingChannelsResponse
-	69,  // 294: lnrpc.Lightning.ListChannels:output_type -> lnrpc.ListChannelsResponse
-	118, // 295: lnrpc.Lightning.SubscribeChannelEvents:output_type -> lnrpc.ChannelEventUpdate
-	76,  // 296: lnrpc.Lightning.ClosedChannels:output_type -> lnrpc.ClosedChannelsResponse
-	43,  // 297: lnrpc.Lightning.OpenChannelSync:output_type -> lnrpc.ChannelPoint
-	102, // 298: lnrpc.Lightning.OpenChannel:output_type -> lnrpc.OpenStatusUpdate
-	100, // 299: lnrpc.Lightning.BatchOpenChannel:output_type -> lnrpc.BatchOpenChannelResponse
-	112, // 300: lnrpc.Lightning.FundingStateStep:output_type -> lnrpc.FundingStateStepResp
-	41,  // 301: lnrpc.Lightning.ChannelAcceptor:output_type -> lnrpc.ChannelAcceptRequest
-	94,  // 302: lnrpc.Lightning.CloseChannel:output_type -> lnrpc.CloseStatusUpdate
-	182, // 303: lnrpc.Lightning.AbandonChannel:output_type -> lnrpc.AbandonChannelResponse
-	39,  // 304: lnrpc.Lightning.SendPayment:output_type -> lnrpc.SendResponse
-	39,  // 305: lnrpc.Lightning.SendPaymentSync:output_type -> lnrpc.SendResponse
-	39,  // 306: lnrpc.Lightning.SendToRoute:output_type -> lnrpc.SendResponse
-	39,  // 307: lnrpc.Lightning.SendToRouteSync:output_type -> lnrpc.SendResponse
-	166, // 308: lnrpc.Lightning.AddInvoice:output_type -> lnrpc.AddInvoiceResponse
-	169, // 309: lnrpc.Lightning.ListInvoices:output_type -> lnrpc.ListInvoiceResponse
-	162, // 310: lnrpc.Lightning.LookupInvoice:output_type -> lnrpc.Invoice
-	162, // 311: lnrpc.Lightning.SubscribeInvoices:output_type -> lnrpc.Invoice
-	172, // 312: lnrpc.Lightning.DeleteCanceledInvoice:output_type -> lnrpc.DelCanceledInvoiceResp
-	186, // 313: lnrpc.Lightning.DecodePayReq:output_type -> lnrpc.PayReq
-	176, // 314: lnrpc.Lightning.ListPayments:output_type -> lnrpc.ListPaymentsResponse
-	179, // 315: lnrpc.Lightning.DeletePayment:output_type -> lnrpc.DeletePaymentResponse
-	180, // 316: lnrpc.Lightning.DeleteAllPayments:output_type -> lnrpc.DeleteAllPaymentsResponse
-	141, // 317: lnrpc.Lightning.DescribeGraph:output_type -> lnrpc.ChannelGraph
-	143, // 318: lnrpc.Lightning.GetNodeMetrics:output_type -> lnrpc.NodeMetricsResponse
-	139, // 319: lnrpc.Lightning.GetChanInfo:output_type -> lnrpc.ChannelEdge
-	134, // 320: lnrpc.Lightning.GetNodeInfo:output_type -> lnrpc.NodeInfo
-	128, // 321: lnrpc.Lightning.QueryRoutes:output_type -> lnrpc.QueryRoutesResponse
-	147, // 322: lnrpc.Lightning.GetNetworkInfo:output_type -> lnrpc.NetworkInfo
-	149, // 323: lnrpc.Lightning.StopDaemon:output_type -> lnrpc.StopResponse
-	151, // 324: lnrpc.Lightning.SubscribeChannelGraph:output_type -> lnrpc.GraphTopologyUpdate
-	184, // 325: lnrpc.Lightning.DebugLevel:output_type -> lnrpc.DebugLevelResponse
-	190, // 326: lnrpc.Lightning.FeeReport:output_type -> lnrpc.FeeReportResponse
-	194, // 327: lnrpc.Lightning.UpdateChannelPolicy:output_type -> lnrpc.PolicyUpdateResponse
-	197, // 328: lnrpc.Lightning.ForwardingHistory:output_type -> lnrpc.ForwardingHistoryResponse
-	199, // 329: lnrpc.Lightning.ExportChannelBackup:output_type -> lnrpc.ChannelBackup
-	202, // 330: lnrpc.Lightning.ExportAllChannelBackups:output_type -> lnrpc.ChanBackupSnapshot
-	207, // 331: lnrpc.Lightning.VerifyChanBackup:output_type -> lnrpc.VerifyChanBackupResponse
-	205, // 332: lnrpc.Lightning.RestoreChannelBackups:output_type -> lnrpc.RestoreBackupResponse
-	202, // 333: lnrpc.Lightning.SubscribeChannelBackups:output_type -> lnrpc.ChanBackupSnapshot
-	210, // 334: lnrpc.Lightning.BakeMacaroon:output_type -> lnrpc.BakeMacaroonResponse
-	212, // 335: lnrpc.Lightning.ListMacaroonIDs:output_type -> lnrpc.ListMacaroonIDsResponse
-	214, // 336: lnrpc.Lightning.DeleteMacaroonID:output_type -> lnrpc.DeleteMacaroonIDResponse
-	217, // 337: lnrpc.Lightning.ListPermissions:output_type -> lnrpc.ListPermissionsResponse
-	223, // 338: lnrpc.Lightning.CheckMacaroonPermissions:output_type -> lnrpc.CheckMacPermResponse
-	224, // 339: lnrpc.Lightning.RegisterRPCMiddleware:output_type -> lnrpc.RPCMiddlewareRequest
-	27,  // 340: lnrpc.Lightning.SendCustomMessage:output_type -> lnrpc.SendCustomMessageResponse
-	25,  // 341: lnrpc.Lightning.SubscribeCustomMessages:output_type -> lnrpc.CustomMessage
-	31,  // 342: lnrpc.Lightning.SendOnionMessage:output_type -> lnrpc.SendOnionMessageResponse
-	29,  // 343: lnrpc.Lightning.SubscribeOnionMessages:output_type -> lnrpc.OnionMessageUpdate
-	72,  // 344: lnrpc.Lightning.ListAliases:output_type -> lnrpc.ListAliasesResponse
-	23,  // 345: lnrpc.Lightning.LookupHtlcResolution:output_type -> lnrpc.LookupHtlcResolutionResponse
-	275, // [275:346] is the sub-list for method output_type
-	204, // [204:275] is the sub-list for method input_type
+	231, // 275: lnrpc.Lightning.InjectGossipMessage:input_type -> lnrpc.InjectGossipMessageRequest
+	121, // 276: lnrpc.Lightning.WalletBalance:output_type -> lnrpc.WalletBalanceResponse
+	124, // 277: lnrpc.Lightning.ChannelBalance:output_type -> lnrpc.ChannelBalanceResponse
+	36,  // 278: lnrpc.Lightning.GetTransactions:output_type -> lnrpc.TransactionDetails
+	48,  // 279: lnrpc.Lightning.EstimateFee:output_type -> lnrpc.EstimateFeeResponse
+	52,  // 280: lnrpc.Lightning.SendCoins:output_type -> lnrpc.SendCoinsResponse
+	54,  // 281: lnrpc.Lightning.ListUnspent:output_type -> lnrpc.ListUnspentResponse
+	34,  // 282: lnrpc.Lightning.SubscribeTransactions:output_type -> lnrpc.Transaction
+	50,  // 283: lnrpc.Lightning.SendMany:output_type -> lnrpc.SendManyResponse
+	56,  // 284: lnrpc.Lightning.NewAddress:output_type -> lnrpc.NewAddressResponse
+	58,  // 285: lnrpc.Lightning.SignMessage:output_type -> lnrpc.SignMessageResponse
+	60,  // 286: lnrpc.Lightning.VerifyMessage:output_type -> lnrpc.VerifyMessageResponse
+	62,  // 287: lnrpc.Lightning.ConnectPeer:output_type -> lnrpc.ConnectPeerResponse
+	64,  // 288: lnrpc.Lightning.DisconnectPeer:output_type -> lnrpc.DisconnectPeerResponse
+	80,  // 289: lnrpc.Lightning.ListPeers:output_type -> lnrpc.ListPeersResponse
+	82,  // 290: lnrpc.Lightning.SubscribePeerEvents:output_type -> lnrpc.PeerEvent
+	84,  // 291: lnrpc.Lightning.GetInfo:output_type -> lnrpc.GetInfoResponse
+	86,  // 292: lnrpc.Lightning.GetDebugInfo:output_type -> lnrpc.GetDebugInfoResponse
+	88,  // 293: lnrpc.Lightning.GetRecoveryInfo:output_type -> lnrpc.GetRecoveryInfoResponse
+	115, // 294: lnrpc.Lightning.PendingChannels:output_type -> lnrpc.PendingChannelsResponse
+	69,  // 295: lnrpc.Lightning.ListChannels:output_type -> lnrpc.ListChannelsResponse
+	118, // 296: lnrpc.Lightning.SubscribeChannelEvents:output_type -> lnrpc.ChannelEventUpdate
+	76,  // 297: lnrpc.Lightning.ClosedChannels:output_type -> lnrpc.ClosedChannelsResponse
+	43,  // 298: lnrpc.Lightning.OpenChannelSync:output_type -> lnrpc.ChannelPoint
+	102, // 299: lnrpc.Lightning.OpenChannel:output_type -> lnrpc.OpenStatusUpdate
+	100, // 300: lnrpc.Lightning.BatchOpenChannel:output_type -> lnrpc.BatchOpenChannelResponse
+	112, // 301: lnrpc.Lightning.FundingStateStep:output_type -> lnrpc.FundingStateStepResp
+	41,  // 302: lnrpc.Lightning.ChannelAcceptor:output_type -> lnrpc.ChannelAcceptRequest
+	94,  // 303: lnrpc.Lightning.CloseChannel:output_type -> lnrpc.CloseStatusUpdate
+	182, // 304: lnrpc.Lightning.AbandonChannel:output_type -> lnrpc.AbandonChannelResponse
+	39,  // 305: lnrpc.Lightning.SendPayment:output_type -> lnrpc.SendResponse
+	39,  // 306: lnrpc.Lightning.SendPaymentSync:output_type -> lnrpc.SendResponse
+	39,  // 307: lnrpc.Lightning.SendToRoute:output_type -> lnrpc.SendResponse
+	39,  // 308: lnrpc.Lightning.SendToRouteSync:output_type -> lnrpc.SendResponse
+	166, // 309: lnrpc.Lightning.AddInvoice:output_type -> lnrpc.AddInvoiceResponse
+	169, // 310: lnrpc.Lightning.ListInvoices:output_type -> lnrpc.ListInvoiceResponse
+	162, // 311: lnrpc.Lightning.LookupInvoice:output_type -> lnrpc.Invoice
+	162, // 312: lnrpc.Lightning.SubscribeInvoices:output_type -> lnrpc.Invoice
+	172, // 313: lnrpc.Lightning.DeleteCanceledInvoice:output_type -> lnrpc.DelCanceledInvoiceResp
+	186, // 314: lnrpc.Lightning.DecodePayReq:output_type -> lnrpc.PayReq
+	176, // 315: lnrpc.Lightning.ListPayments:output_type -> lnrpc.ListPaymentsResponse
+	179, // 316: lnrpc.Lightning.DeletePayment:output_type -> lnrpc.DeletePaymentResponse
+	180, // 317: lnrpc.Lightning.DeleteAllPayments:output_type -> lnrpc.DeleteAllPaymentsResponse
+	141, // 318: lnrpc.Lightning.DescribeGraph:output_type -> lnrpc.ChannelGraph
+	143, // 319: lnrpc.Lightning.GetNodeMetrics:output_type -> lnrpc.NodeMetricsResponse
+	139, // 320: lnrpc.Lightning.GetChanInfo:output_type -> lnrpc.ChannelEdge
+	134, // 321: lnrpc.Lightning.GetNodeInfo:output_type -> lnrpc.NodeInfo
+	128, // 322: lnrpc.Lightning.QueryRoutes:output_type -> lnrpc.QueryRoutesResponse
+	147, // 323: lnrpc.Lightning.GetNetworkInfo:output_type -> lnrpc.NetworkInfo
+	149, // 324: lnrpc.Lightning.StopDaemon:output_type -> lnrpc.StopResponse
+	151, // 325: lnrpc.Lightning.SubscribeChannelGraph:output_type -> lnrpc.GraphTopologyUpdate
+	184, // 326: lnrpc.Lightning.DebugLevel:output_type -> lnrpc.DebugLevelResponse
+	190, // 327: lnrpc.Lightning.FeeReport:output_type -> lnrpc.FeeReportResponse
+	194, // 328: lnrpc.Lightning.UpdateChannelPolicy:output_type -> lnrpc.PolicyUpdateResponse
+	197, // 329: lnrpc.Lightning.ForwardingHistory:output_type -> lnrpc.ForwardingHistoryResponse
+	199, // 330: lnrpc.Lightning.ExportChannelBackup:output_type -> lnrpc.ChannelBackup
+	202, // 331: lnrpc.Lightning.ExportAllChannelBackups:output_type -> lnrpc.ChanBackupSnapshot
+	207, // 332: lnrpc.Lightning.VerifyChanBackup:output_type -> lnrpc.VerifyChanBackupResponse
+	205, // 333: lnrpc.Lightning.RestoreChannelBackups:output_type -> lnrpc.RestoreBackupResponse
+	202, // 334: lnrpc.Lightning.SubscribeChannelBackups:output_type -> lnrpc.ChanBackupSnapshot
+	210, // 335: lnrpc.Lightning.BakeMacaroon:output_type -> lnrpc.BakeMacaroonResponse
+	212, // 336: lnrpc.Lightning.ListMacaroonIDs:output_type -> lnrpc.ListMacaroonIDsResponse
+	214, // 337: lnrpc.Lightning.DeleteMacaroonID:output_type -> lnrpc.DeleteMacaroonIDResponse
+	217, // 338: lnrpc.Lightning.ListPermissions:output_type -> lnrpc.ListPermissionsResponse
+	223, // 339: lnrpc.Lightning.CheckMacaroonPermissions:output_type -> lnrpc.CheckMacPermResponse
+	224, // 340: lnrpc.Lightning.RegisterRPCMiddleware:output_type -> lnrpc.RPCMiddlewareRequest
+	27,  // 341: lnrpc.Lightning.SendCustomMessage:output_type -> lnrpc.SendCustomMessageResponse
+	25,  // 342: lnrpc.Lightning.SubscribeCustomMessages:output_type -> lnrpc.CustomMessage
+	31,  // 343: lnrpc.Lightning.SendOnionMessage:output_type -> lnrpc.SendOnionMessageResponse
+	29,  // 344: lnrpc.Lightning.SubscribeOnionMessages:output_type -> lnrpc.OnionMessageUpdate
+	72,  // 345: lnrpc.Lightning.ListAliases:output_type -> lnrpc.ListAliasesResponse
+	23,  // 346: lnrpc.Lightning.LookupHtlcResolution:output_type -> lnrpc.LookupHtlcResolutionResponse
+	232, // 347: lnrpc.Lightning.InjectGossipMessage:output_type -> lnrpc.InjectGossipMessageResponse
+	276, // [276:348] is the sub-list for method output_type
+	204, // [204:276] is the sub-list for method input_type
 	204, // [204:204] is the sub-list for extension type_name
 	204, // [204:204] is the sub-list for extension extendee
 	0,   // [0:204] is the sub-list for field type_name
@@ -21219,7 +21310,7 @@ func file_lightning_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_lightning_proto_rawDesc), len(file_lightning_proto_rawDesc)),
 			NumEnums:      22,
-			NumMessages:   238,
+			NumMessages:   240,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/lnrpc/lightning.pb.gw.go
+++ b/lnrpc/lightning.pb.gw.go
@@ -2682,6 +2682,40 @@ func local_request_Lightning_LookupHtlcResolution_0(ctx context.Context, marshal
 
 }
 
+func request_Lightning_InjectGossipMessage_0(ctx context.Context, marshaler runtime.Marshaler, client LightningClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq InjectGossipMessageRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.InjectGossipMessage(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Lightning_InjectGossipMessage_0(ctx context.Context, marshaler runtime.Marshaler, server LightningServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq InjectGossipMessageRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.InjectGossipMessage(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 // RegisterLightningHandlerServer registers the http handlers for service Lightning to "mux".
 // UnaryRPC     :call LightningServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -4226,6 +4260,31 @@ func RegisterLightningHandlerServer(ctx context.Context, mux *runtime.ServeMux, 
 		}
 
 		forward_Lightning_LookupHtlcResolution_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_Lightning_InjectGossipMessage_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/lnrpc.Lightning/InjectGossipMessage", runtime.WithHTTPPathPattern("/v1/graph/inject"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Lightning_InjectGossipMessage_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Lightning_InjectGossipMessage_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -5832,6 +5891,28 @@ func RegisterLightningHandlerClient(ctx context.Context, mux *runtime.ServeMux, 
 
 	})
 
+	mux.Handle("POST", pattern_Lightning_InjectGossipMessage_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/lnrpc.Lightning/InjectGossipMessage", runtime.WithHTTPPathPattern("/v1/graph/inject"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Lightning_InjectGossipMessage_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Lightning_InjectGossipMessage_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
@@ -5977,6 +6058,8 @@ var (
 	pattern_Lightning_ListAliases_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "aliases", "list"}, ""))
 
 	pattern_Lightning_LookupHtlcResolution_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "htlc-resolution", "chan_id", "htlc_index"}, ""))
+
+	pattern_Lightning_InjectGossipMessage_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "graph", "inject"}, ""))
 )
 
 var (
@@ -6121,4 +6204,6 @@ var (
 	forward_Lightning_ListAliases_0 = runtime.ForwardResponseMessage
 
 	forward_Lightning_LookupHtlcResolution_0 = runtime.ForwardResponseMessage
+
+	forward_Lightning_InjectGossipMessage_0 = runtime.ForwardResponseMessage
 )

--- a/lnrpc/lightning.pb.json.go
+++ b/lnrpc/lightning.pb.json.go
@@ -1865,4 +1865,29 @@ func RegisterLightningJSONCallbacks(registry map[string]func(ctx context.Context
 		}
 		callback(string(respBytes), nil)
 	}
+
+	registry["lnrpc.Lightning.InjectGossipMessage"] = func(ctx context.Context,
+		conn *grpc.ClientConn, reqJSON string, callback func(string, error)) {
+
+		req := &InjectGossipMessageRequest{}
+		err := marshaler.Unmarshal([]byte(reqJSON), req)
+		if err != nil {
+			callback("", err)
+			return
+		}
+
+		client := NewLightningClient(conn)
+		resp, err := client.InjectGossipMessage(ctx, req)
+		if err != nil {
+			callback("", err)
+			return
+		}
+
+		respBytes, err := marshaler.Marshal(resp)
+		if err != nil {
+			callback("", err)
+			return
+		}
+		callback(string(respBytes), nil)
+	}
 }

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -623,6 +623,17 @@ service Lightning {
     */
     rpc LookupHtlcResolution (LookupHtlcResolutionRequest)
         returns (LookupHtlcResolutionResponse);
+
+    /*
+    InjectGossipMessage injects a raw gossip message (e.g. a ChannelUpdate)
+    into this node's gossiper for validation and processing. This is used by
+    lightweight nodes that use this node as a remote graph source: when they
+    learn about updated channel policies through payment failures, they push
+    those updates back so the graph source can validate, apply, and
+    re-broadcast them to its peers.
+    */
+    rpc InjectGossipMessage (InjectGossipMessageRequest)
+        returns (InjectGossipMessageResponse);
 }
 
 message LookupHtlcResolutionRequest {
@@ -5533,4 +5544,14 @@ message InterceptFeedback {
     binary serialized gRPC message in the protobuf format.
     */
     bytes replacement_serialized = 3;
+}
+
+message InjectGossipMessageRequest {
+    // The raw gossip message serialized in the Lightning wire format (as
+    // defined in BOLT #7). Currently only ChannelUpdate messages are
+    // supported.
+    bytes msg = 1;
+}
+
+message InjectGossipMessageResponse {
 }

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -1264,6 +1264,39 @@
         ]
       }
     },
+    "/v1/graph/inject": {
+      "post": {
+        "summary": "InjectGossipMessage injects a raw gossip message (e.g. a ChannelUpdate)\ninto this node's gossiper for validation and processing. This is used by\nlightweight nodes that use this node as a remote graph source: when they\nlearn about updated channel policies through payment failures, they push\nthose updates back so the graph source can validate, apply, and\nre-broadcast them to its peers.",
+        "operationId": "Lightning_InjectGossipMessage",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/lnrpcInjectGossipMessageResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/lnrpcInjectGossipMessageRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Lightning"
+        ]
+      }
+    },
     "/v1/graph/node/{pub_key}": {
       "get": {
         "summary": "lncli: `getnodeinfo`\nGetNodeInfo returns the latest advertised, aggregated, and authenticated\nchannel information for the specified node identified by its public key.",
@@ -5866,6 +5899,19 @@
         "INITIATOR_BOTH"
       ],
       "default": "INITIATOR_UNKNOWN"
+    },
+    "lnrpcInjectGossipMessageRequest": {
+      "type": "object",
+      "properties": {
+        "msg": {
+          "type": "string",
+          "format": "byte",
+          "description": "The raw gossip message serialized in the Lightning wire format (as\ndefined in BOLT #7). Currently only ChannelUpdate messages are\nsupported."
+        }
+      }
+    },
+    "lnrpcInjectGossipMessageResponse": {
+      "type": "object"
     },
     "lnrpcInstantUpdate": {
       "type": "object",

--- a/lnrpc/lightning.yaml
+++ b/lnrpc/lightning.yaml
@@ -176,3 +176,6 @@ http:
       get: "/v1/aliases/list"
     - selector: lnrpc.Lightning.LookupHtlcResolution
       get: "/v1/htlc-resolution/{chan_id}/{htlc_index}"
+    - selector: lnrpc.Lightning.InjectGossipMessage
+      post: "/v1/graph/inject"
+      body: "*"

--- a/lnrpc/lightning_grpc.pb.go
+++ b/lnrpc/lightning_grpc.pb.go
@@ -432,6 +432,13 @@ type LightningClient interface {
 	// If the htlc has no final resolution yet, a NotFound grpc status code is
 	// returned.
 	LookupHtlcResolution(ctx context.Context, in *LookupHtlcResolutionRequest, opts ...grpc.CallOption) (*LookupHtlcResolutionResponse, error)
+	// InjectGossipMessage injects a raw gossip message (e.g. a ChannelUpdate)
+	// into this node's gossiper for validation and processing. This is used by
+	// lightweight nodes that use this node as a remote graph source: when they
+	// learn about updated channel policies through payment failures, they push
+	// those updates back so the graph source can validate, apply, and
+	// re-broadcast them to its peers.
+	InjectGossipMessage(ctx context.Context, in *InjectGossipMessageRequest, opts ...grpc.CallOption) (*InjectGossipMessageResponse, error)
 }
 
 type lightningClient struct {
@@ -1403,6 +1410,15 @@ func (c *lightningClient) LookupHtlcResolution(ctx context.Context, in *LookupHt
 	return out, nil
 }
 
+func (c *lightningClient) InjectGossipMessage(ctx context.Context, in *InjectGossipMessageRequest, opts ...grpc.CallOption) (*InjectGossipMessageResponse, error) {
+	out := new(InjectGossipMessageResponse)
+	err := c.cc.Invoke(ctx, "/lnrpc.Lightning/InjectGossipMessage", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // LightningServer is the server API for Lightning service.
 // All implementations must embed UnimplementedLightningServer
 // for forward compatibility
@@ -1821,6 +1837,13 @@ type LightningServer interface {
 	// If the htlc has no final resolution yet, a NotFound grpc status code is
 	// returned.
 	LookupHtlcResolution(context.Context, *LookupHtlcResolutionRequest) (*LookupHtlcResolutionResponse, error)
+	// InjectGossipMessage injects a raw gossip message (e.g. a ChannelUpdate)
+	// into this node's gossiper for validation and processing. This is used by
+	// lightweight nodes that use this node as a remote graph source: when they
+	// learn about updated channel policies through payment failures, they push
+	// those updates back so the graph source can validate, apply, and
+	// re-broadcast them to its peers.
+	InjectGossipMessage(context.Context, *InjectGossipMessageRequest) (*InjectGossipMessageResponse, error)
 	mustEmbedUnimplementedLightningServer()
 }
 
@@ -2040,6 +2063,9 @@ func (UnimplementedLightningServer) ListAliases(context.Context, *ListAliasesReq
 }
 func (UnimplementedLightningServer) LookupHtlcResolution(context.Context, *LookupHtlcResolutionRequest) (*LookupHtlcResolutionResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method LookupHtlcResolution not implemented")
+}
+func (UnimplementedLightningServer) InjectGossipMessage(context.Context, *InjectGossipMessageRequest) (*InjectGossipMessageResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method InjectGossipMessage not implemented")
 }
 func (UnimplementedLightningServer) mustEmbedUnimplementedLightningServer() {}
 
@@ -3394,6 +3420,24 @@ func _Lightning_LookupHtlcResolution_Handler(srv interface{}, ctx context.Contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Lightning_InjectGossipMessage_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(InjectGossipMessageRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LightningServer).InjectGossipMessage(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/lnrpc.Lightning/InjectGossipMessage",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LightningServer).InjectGossipMessage(ctx, req.(*InjectGossipMessageRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // Lightning_ServiceDesc is the grpc.ServiceDesc for Lightning service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -3628,6 +3672,10 @@ var Lightning_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "LookupHtlcResolution",
 			Handler:    _Lightning_LookupHtlcResolution_Handler,
+		},
+		{
+			MethodName: "InjectGossipMessage",
+			Handler:    _Lightning_InjectGossipMessage_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/log.go
+++ b/log.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lightningnetwork/lnd/funding"
 	"github.com/lightningnetwork/lnd/graph"
 	graphdb "github.com/lightningnetwork/lnd/graph/db"
+	"github.com/lightningnetwork/lnd/graph/sources"
 	"github.com/lightningnetwork/lnd/healthcheck"
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/invoices"
@@ -206,6 +207,7 @@ func SetupLoggers(root *build.SubLoggerManager, interceptor signal.Interceptor) 
 		root, blindedpath.Subsystem, interceptor, blindedpath.UseLogger,
 	)
 	AddSubLogger(root, graphdb.Subsystem, interceptor, graphdb.UseLogger)
+	AddSubLogger(root, "GSRC", interceptor, sources.UseLogger)
 	AddSubLogger(root, chainio.Subsystem, interceptor, chainio.UseLogger)
 	AddSubLogger(root, msgmux.Subsystem, interceptor, msgmux.UseLogger)
 	AddSubLogger(root, sqldb.Subsystem, interceptor, sqldb.UseLogger)

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -258,9 +258,9 @@ type Config struct {
 	// ChannelDB is used to fetch opened channels, and closed channels.
 	ChannelDB *channeldb.ChannelStateDB
 
-	// ChannelGraph is a pointer to the channel graph which is used to
-	// query information about the set of known active channels.
-	ChannelGraph *graphdb.ChannelGraph
+	// ChannelGraph is used to query information about the set of known
+	// active channels.
+	ChannelGraph graphdb.GraphSource
 
 	// ChainArb is used to subscribe to channel events, update contract signals,
 	// and force close channels.

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -270,6 +270,10 @@ type Config struct {
 	// gossiper and process remote channel announcements.
 	AuthGossiper *discovery.AuthenticatedGossiper
 
+	// NoGossipSync indicates that gossip syncing has been disabled. When
+	// set, we will not initiate gossip sync with our peers.
+	NoGossipSync bool
+
 	// ChanStatusMgr is used to set or un-set the disabled bit in channel
 	// updates.
 	ChanStatusMgr *netann.ChanStatusManager
@@ -995,6 +999,13 @@ func (p *Brontide) Start() error {
 // initGossipSync initializes either a gossip syncer or an initial routing
 // dump, depending on the negotiated synchronization method.
 func (p *Brontide) initGossipSync() {
+	// If gossip syncing has been disabled, we don't need to initialize a
+	// gossip syncer.
+	if p.cfg.NoGossipSync {
+		p.log.Info("Gossip syncing disabled, skipping init")
+		return
+	}
+
 	// If the remote peer knows of the new gossip queries feature, then
 	// we'll create a new gossipSyncer in the AuthenticatedGossiper for it.
 	if p.remoteFeatures.HasFeature(lnwire.GossipQueriesOptional) {

--- a/pilot.go
+++ b/pilot.go
@@ -185,7 +185,9 @@ func initAutoPilot(svr *server, cfg *lncfg.AutoPilot,
 				cfg.MinConfs, lnwallet.DefaultAccountName,
 			)
 		},
-		Graph:       autopilot.ChannelGraphFromDatabase(svr.v1Graph),
+		Graph: autopilot.ChannelGraphFromDatabase(
+			svr.graphSource,
+		),
 		Constraints: atplConstraints,
 		ConnectToPeer: func(target *btcec.PublicKey, addrs []net.Addr) (bool, error) {
 			// First, we'll check if we're already connected to the

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -588,6 +588,10 @@ func MainRPCServerPermissions() map[string][]bakery.Op {
 			Entity: "offchain",
 			Action: "read",
 		}},
+		"/lnrpc.Lightning/InjectGossipMessage": {{
+			Entity: "info",
+			Action: "write",
+		}},
 		"/lnrpc.Lightning/ListAliases": {{
 			Entity: "offchain",
 			Action: "read",
@@ -4789,6 +4793,55 @@ func (r *rpcServer) LookupHtlcResolution(
 		Settled:  info.Settled,
 		Offchain: info.Offchain,
 	}, nil
+}
+
+// InjectGossipMessage accepts a raw Lightning gossip message (wire format) and
+// feeds it into this node's gossiper for validation and processing. This
+// allows lightweight nodes using this node as a remote graph source to push
+// back channel updates they discover through payment failures.
+func (r *rpcServer) InjectGossipMessage(ctx context.Context,
+	in *lnrpc.InjectGossipMessageRequest) (
+	*lnrpc.InjectGossipMessageResponse, error) {
+
+	if len(in.Msg) == 0 {
+		return nil, status.Error(codes.InvalidArgument,
+			"gossip message bytes required")
+	}
+
+	// Deserialize the wire message.
+	msg, err := lnwire.ReadMessage(bytes.NewReader(in.Msg), 0)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"unable to decode gossip message: %v", err)
+	}
+
+	// Only ChannelUpdate messages are currently supported.
+	switch msg.(type) {
+	case *lnwire.ChannelUpdate1:
+	default:
+		return nil, status.Errorf(codes.InvalidArgument,
+			"unsupported gossip message type: %T", msg)
+	}
+
+	// Feed the message to the gossiper as if it came from a remote peer.
+	// We use ProcessLocalAnnouncement which does not require a peer
+	// reference. The gossiper will validate the message (checking the
+	// signature, timestamp, etc.) and if valid, apply it to the graph
+	// and broadcast it to peers.
+	errChan := r.server.authGossiper.ProcessLocalAnnouncement(msg)
+
+	select {
+	case err := <-errChan:
+		if err != nil {
+			return nil, status.Errorf(codes.Internal,
+				"gossiper rejected message: %v", err)
+		}
+
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	return &lnrpc.InjectGossipMessageResponse{}, nil
 }
 
 // ListChannels returns a description of all the open channels that this node

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -704,11 +704,11 @@ func (r *rpcServer) addDeps(ctx context.Context, s *server,
 	invoiceHtlcModifier *invoices.HtlcModificationInterceptor) error {
 
 	// Set up router rpc backend.
-	selfNode, err := s.v1Graph.SourceNode(ctx)
+	selfNode, err := s.graphSource.SourceNode(ctx)
 	if err != nil {
 		return err
 	}
-	graph := s.v1Graph
+	graph := s.graphSource
 
 	routerBackend := &routerrpc.RouterBackend{
 		SelfNode: selfNode.PubKeyBytes,
@@ -5071,7 +5071,7 @@ func createRPCOpenChannel(ctx context.Context, r *rpcServer,
 
 	// Look up our channel peer's node alias if the caller requests it.
 	if peerAliasLookup {
-		peerAlias, err := r.server.v1Graph.LookupAlias(ctx, nodePub)
+		peerAlias, err := r.server.graphSource.LookupAlias(ctx, nodePub)
 		if err != nil {
 			peerAlias = fmt.Sprintf("unable to lookup "+
 				"peer alias: %v", err)
@@ -6525,7 +6525,7 @@ func (r *rpcServer) AddInvoice(ctx context.Context,
 		NodeSigner:        r.server.nodeSigner,
 		DefaultCLTVExpiry: defaultDelta,
 		ChanDB:            r.server.chanStateDB,
-		Graph:             r.server.v1Graph,
+		Graph:             r.server.graphSource,
 		GenInvoiceFeatures: func() *lnwire.FeatureVector {
 			v := r.server.featureMgr.Get(feature.SetInvoice)
 
@@ -6957,11 +6957,7 @@ func (r *rpcServer) DescribeGraph(ctx context.Context,
 		}
 	}
 
-	// Obtain the pointer to the V1 channel graph. This will provide a
-	// consistent view of the graph due to bolt db's transactional model.
-	//
-	// TODO(elle): switch to a cross-version graph view when available.
-	graph := r.server.v1Graph
+	graph := r.server.graphSource
 
 	// First iterate through all the known nodes (connected or unconnected
 	// within the graph), collating their current state into the RPC
@@ -7152,15 +7148,14 @@ func (r *rpcServer) GetNodeMetrics(ctx context.Context,
 		BetweennessCentrality: make(map[string]*lnrpc.FloatMetric),
 	}
 
-	// Obtain the pointer to the V1 channel graph, this will provide a
-	// consistent view of the graph due to bolt db's transactional model.
-	//
-	// TODO(elle): switch to a cross-version graph view when available.
-	graph := r.server.v1Graph
-
+	// Obtain the pointer to the global singleton channel graph, this will
+	// provide a consistent view of the graph due to bolt db's
+	// transactional model.
 	// Calculate betweenness centrality if requested. Note that depending on the
 	// graph size, this may take up to a few minutes.
-	channelGraph := autopilot.ChannelGraphFromDatabase(graph)
+	channelGraph := autopilot.ChannelGraphFromDatabase(
+		r.server.graphSource,
+	)
 	centralityMetric, err := autopilot.NewBetweennessCentralityMetric(
 		runtime.NumCPU(),
 	)
@@ -7196,13 +7191,13 @@ func (r *rpcServer) GetNodeMetrics(ctx context.Context,
 func (r *rpcServer) GetChanInfo(ctx context.Context,
 	in *lnrpc.ChanInfoRequest) (*lnrpc.ChannelEdge, error) {
 
-	graph := r.server.graphDB
-
 	var (
 		edgeInfo     *models.ChannelEdgeInfo
 		edge1, edge2 *models.ChannelEdgePolicy
 		err          error
 	)
+
+	graph := r.server.graphSource
 
 	switch {
 	case in.ChanId != 0:
@@ -7250,8 +7245,6 @@ func (r *rpcServer) GetNodeInfo(ctx context.Context,
 			"include_channels")
 	}
 
-	graph := r.server.v1Graph
-
 	// First, parse the hex-encoded public key into a full in-memory public
 	// key object we can work with for querying.
 	pubKey, err := route.NewVertexFromStr(in.PubKey)
@@ -7262,6 +7255,7 @@ func (r *rpcServer) GetNodeInfo(ctx context.Context,
 	// With the public key decoded, attempt to fetch the node corresponding
 	// to this public key. If the node cannot be found, then an error will
 	// be returned.
+	graph := r.server.graphSource
 	node, err := graph.FetchNode(ctx, pubKey)
 	switch {
 	case errors.Is(err, graphdb.ErrGraphNodeNotFound):
@@ -7370,8 +7364,7 @@ func (r *rpcServer) QueryRoutes(ctx context.Context,
 func (r *rpcServer) GetNetworkInfo(ctx context.Context,
 	_ *lnrpc.NetworkInfoRequest) (*lnrpc.NetworkInfo, error) {
 
-	// TODO(elle): switch to a cross-version graph view when available.
-	graph := r.server.v1Graph
+	graph := r.server.graphSource
 
 	var (
 		numNodes             uint32
@@ -7464,7 +7457,7 @@ func (r *rpcServer) GetNetworkInfo(ctx context.Context,
 	}
 
 	// Query the graph for the current number of zombie channels.
-	numZombies, err := graph.NumZombies(ctx)
+	numZombies, err := r.server.v1Graph.NumZombies(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -8018,14 +8011,13 @@ const feeBase float64 = 1000000
 func (r *rpcServer) FeeReport(ctx context.Context,
 	_ *lnrpc.FeeReportRequest) (*lnrpc.FeeReportResponse, error) {
 
-	channelGraph := r.server.v1Graph
-	selfNode, err := channelGraph.SourceNode(ctx)
+	selfNode, err := r.server.graphSource.SourceNode(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	var feeReports []*lnrpc.ChannelFeeReport
-	err = channelGraph.ForEachNodeChannel(
+	err = r.server.graphSource.ForEachNodeChannel(
 		ctx, selfNode.PubKeyBytes,
 		func(chanInfo *models.ChannelEdgeInfo,
 			edgePolicy, _ *models.ChannelEdgePolicy) error {
@@ -8407,7 +8399,7 @@ func (r *rpcServer) ForwardingHistory(ctx context.Context,
 			return "", err
 		}
 
-		peer, err := r.server.v1Graph.FetchNode(ctx, vertex)
+		peer, err := r.server.graphSource.FetchNode(ctx, vertex)
 		if err != nil {
 			return "", err
 		}

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1869,6 +1869,39 @@
 ; messages sending to that peer to stay within the limit.
 ; gossip.peer-msg-rate-bytes=51200
 
+; If set, lnd will not request graph updates from its peers and won't advertise
+; the gossip queries feature bit. This is useful if lnd has been provided with
+; an external graph source that it may use for pathfinding.
+; gossip.no-sync=false
+
+[remotegraph]
+
+; Use an external LND node as a remote graph source. When enabled, lnd will
+; query the remote node for graph data instead of syncing the full graph
+; locally. This is useful for lightweight nodes that don't need to maintain
+; their own graph. It is recommended to also set gossip.no-sync=true when
+; using a remote graph source.
+;
+; NOTE: This feature trusts the remote node to provide accurate graph data.
+; The remote graph data is NOT independently verified (no signature checks,
+; no on-chain funding transaction validation). Only use a remote node that
+; you control or fully trust.
+; remotegraph.enable=false
+
+; The remote LND node's RPC host:port.
+; remotegraph.rpchost=
+
+; The macaroon to use for authenticating with the remote LND node. For
+; security, use a readonly.macaroon from the remote node — only read
+; access to the graph is needed.
+; remotegraph.macaroonpath=
+
+; The TLS certificate to use for establishing the remote LND node's identity.
+; remotegraph.tlscertpath=
+
+; The timeout for connecting to the remote graph. Valid time units are {s,m,h}.
+; remotegraph.timeout=5s
+
 [invoices]
 
 ; If a hold invoice has accepted htlcs that reach their expiry height and are

--- a/server.go
+++ b/server.go
@@ -708,11 +708,13 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 	if cfg.RemoteGraph.Enable {
 		selfPub := route.NewVertex(nodeKeyECDH.PubKey())
 
-		if dbs.GraphDB.GraphCacheStatus() == graphdb.GraphCacheStatusDisabled {
+		status := dbs.GraphDB.GraphCacheStatus()
+		if status == graphdb.GraphCacheStatusDisabled {
 			return nil, fmt.Errorf("remote graph requires the " +
 				"graph cache to be enabled")
 		}
 
+		graphDB := dbs.GraphDB
 		remoteGraphClient = sources.NewRPCClient(
 			&sources.RPCConfig{
 				RPCHost:      cfg.RemoteGraph.RPCHost,
@@ -725,6 +727,52 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 
 					return parseAddr(
 						addr, cfg.net,
+					)
+				},
+			},
+			&sources.TopologyCallbacks{
+				OnChannel: func(info *models.CachedEdgeInfo) {
+					graphDB.ApplyCacheUpdate(
+						func(c *graphdb.GraphCache) {
+							c.AddChannel(
+								info, nil, nil,
+							)
+						},
+					)
+				},
+				OnChannelUpdate: func(
+					policy *models.CachedEdgePolicy,
+					fromNode, toNode route.Vertex) {
+
+					graphDB.ApplyCacheUpdate(
+						func(c *graphdb.GraphCache) {
+							c.UpdatePolicy(
+								policy,
+								fromNode,
+								toNode,
+							)
+						},
+					)
+				},
+				OnNodeUpdate: func(
+					node route.Vertex,
+					features *lnwire.FeatureVector) {
+
+					graphDB.ApplyCacheUpdate(
+						func(c *graphdb.GraphCache) {
+							c.AddNodeFeatures(
+								node, features,
+							)
+						},
+					)
+				},
+				OnChannelClosed: func(chanID uint64) {
+					graphDB.ApplyCacheUpdate(
+						func(c *graphdb.GraphCache) {
+							c.RemoveChannelByID(
+								chanID,
+							)
+						},
 					)
 				},
 			},
@@ -2218,14 +2266,6 @@ func (s *server) Start(ctx context.Context) error {
 			return
 		}
 
-		if s.remoteGraphClient != nil {
-			cleanup = cleanup.add(s.remoteGraphClient.Stop)
-			if err := s.remoteGraphClient.Start(ctx); err != nil {
-				startErr = err
-				return
-			}
-		}
-
 		cleanup = cleanup.add(s.customMessageServer.Stop)
 		if err := s.customMessageServer.Start(); err != nil {
 			startErr = err
@@ -2384,6 +2424,14 @@ func (s *server) Start(ctx context.Context) error {
 		if err := s.graphDB.Start(); err != nil {
 			startErr = err
 			return
+		}
+
+		if s.remoteGraphClient != nil {
+			cleanup = cleanup.add(s.remoteGraphClient.Stop)
+			if err := s.remoteGraphClient.Start(ctx); err != nil {
+				startErr = err
+				return
+			}
 		}
 
 		cleanup = cleanup.add(s.graphBuilder.Stop)

--- a/server.go
+++ b/server.go
@@ -322,8 +322,9 @@ type server struct {
 
 	fundingMgr *funding.Manager
 
-	graphDB *graphdb.ChannelGraph
-	v1Graph *graphdb.VersionedGraph
+	graphDB     *graphdb.ChannelGraph
+	graphSource graphdb.GraphSource
+	v1Graph     *graphdb.VersionedGraph
 
 	chanStateDB *channeldb.ChannelStateDB
 
@@ -693,13 +694,15 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 	v1Graph := graphdb.NewVersionedGraph(
 		dbs.GraphDB, lnwire.GossipVersion1,
 	)
+	graphSource := graphdb.NewDBGraphSource(dbs.GraphDB)
 
-	addrSource := channeldb.NewMultiAddrSource(dbs.ChanStateDB, v1Graph)
+	addrSource := channeldb.NewMultiAddrSource(dbs.ChanStateDB, graphSource)
 
 	s := &server{
 		cfg:            cfg,
 		implCfg:        implCfg,
 		graphDB:        dbs.GraphDB,
+		graphSource:    graphSource,
 		v1Graph:        v1Graph,
 		chanStateDB:    dbs.ChanStateDB.ChannelStateDB(),
 		addrSource:     addrSource,
@@ -863,7 +866,7 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 		IsChannelActive:          s.htlcSwitch.HasActiveLink,
 		ApplyChannelUpdate:       s.applyChannelUpdate,
 		DB:                       s.chanStateDB,
-		Graph:                    dbs.GraphDB,
+		Graph:                    s.graphSource,
 	}
 
 	chanStatusMgr, err := netann.NewChanStatusManager(chanStatusMgrCfg)
@@ -1011,12 +1014,12 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 		MinProbability: routingConfig.MinRouteProbability,
 	}
 
-	sourceNode, err := s.v1Graph.SourceNode(ctx)
+	sourceNode, err := s.graphSource.SourceNode(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error getting source node: %w", err)
 	}
 	paymentSessionSource := &routing.SessionSource{
-		GraphSessionFactory: s.v1Graph,
+		GraphSessionFactory: s.graphSource,
 		SourceNode:          sourceNode,
 		MissionControl:      s.defaultMC,
 		GetLink:             s.htlcSwitch.GetLinkByShortID,
@@ -1157,7 +1160,7 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 				*models.ChannelEdgePolicy) error,
 			reset func()) error {
 
-			return s.v1Graph.ForEachNodeChannel(
+			return s.graphSource.ForEachNodeChannel(
 				ctx, selfVertex,
 				func(c *models.ChannelEdgeInfo,
 					e *models.ChannelEdgePolicy,
@@ -1420,7 +1423,7 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 	deleteAliasEdge := func(scid lnwire.ShortChannelID) (
 		*models.ChannelEdgePolicy, error) {
 
-		info, e1, e2, err := s.graphDB.FetchChannelEdgesByID(
+		info, e1, e2, err := s.graphSource.FetchChannelEdgesByID(
 			context.TODO(), scid.ToUint64(),
 		)
 		if errors.Is(err, graphdb.ErrEdgeNotFound) {
@@ -2991,7 +2994,7 @@ func initNetworkBootstrappers(s *server) ([]discovery.NetworkPeerBootstrapper, e
 	// First, we'll create an instance of the ChannelGraphBootstrapper as
 	// this can be used by default if we've already partially seeded the
 	// network.
-	chanGraph := autopilot.ChannelGraphFromDatabase(s.v1Graph)
+	chanGraph := autopilot.ChannelGraphFromDatabase(s.graphSource)
 	graphBootstrapper, err := discovery.NewGraphBootstrapper(
 		chanGraph, s.cfg.Bitcoin.IsLocalNetwork(),
 	)
@@ -3492,7 +3495,7 @@ func (s *server) updateAndBroadcastSelfNode(ctx context.Context,
 	// Update the on-disk version of our announcement.
 	// Load and modify self node istead of creating anew instance so we
 	// don't risk overwriting any existing values.
-	selfNode, err := s.v1Graph.SourceNode(ctx)
+	selfNode, err := s.graphSource.SourceNode(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to get current source node: %w", err)
 	}
@@ -3628,9 +3631,7 @@ func (s *server) establishPersistentConnections(ctx context.Context) error {
 		return nil
 	}
 
-	// TODO(elle): for now, we only fetch our V1 channels. This should be
-	//  updated to fetch channels across all versions.
-	err = s.v1Graph.ForEachSourceNodeChannel(
+	err = s.graphSource.ForEachSourceNodeChannel(
 		ctx, forEachSrcNodeChan, func() {
 			clear(graphAddrs)
 		},
@@ -4436,7 +4437,7 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 		Switch:                  s.htlcSwitch,
 		InterceptSwitch:         s.interceptableSwitch,
 		ChannelDB:               s.chanStateDB,
-		ChannelGraph:            s.graphDB,
+		ChannelGraph:            s.graphSource,
 		ChainArb:                s.chainArb,
 		AuthGossiper:            s.authGossiper,
 		ChanStatusMgr:           s.chanStatusMgr,
@@ -5273,7 +5274,7 @@ func (s *server) fetchNodeAdvertisedAddrs(ctx context.Context,
 		return nil, err
 	}
 
-	node, err := s.v1Graph.FetchNode(ctx, vertex)
+	node, err := s.graphSource.FetchNode(ctx, vertex)
 	if err != nil {
 		return nil, err
 	}
@@ -5698,7 +5699,7 @@ func (s *server) setSelfNode(ctx context.Context, nodePub route.Vertex,
 		nodeLastUpdate = time.Now()
 	)
 
-	srcNode, err := s.v1Graph.SourceNode(ctx)
+	srcNode, err := s.graphSource.SourceNode(ctx)
 	switch {
 	case err == nil:
 		// If we have a source node persisted in the DB already, then we

--- a/server.go
+++ b/server.go
@@ -673,6 +673,7 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 		NoExperimentalAccountability: cfg.ProtocolOptions.NoExpAccountability(),
 		NoQuiescence:                 cfg.ProtocolOptions.NoQuiescence(),
 		NoRbfCoopClose:               !cfg.ProtocolOptions.RbfCoopClose,
+		NoGossipQueries:              cfg.Gossip.NoSync,
 	})
 	if err != nil {
 		return nil, err
@@ -1128,6 +1129,7 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 		FilterConcurrency:       cfg.Gossip.FilterConcurrency,
 		BanThreshold:            cfg.Gossip.BanThreshold,
 		PeerMsgRateBytes:        cfg.Gossip.PeerMsgRateBytes,
+		NoGossipSync:            cfg.Gossip.NoSync,
 	}, nodeKeyDesc)
 
 	accessCfg := &accessManConfig{
@@ -4440,6 +4442,7 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 		ChannelGraph:            s.graphSource,
 		ChainArb:                s.chainArb,
 		AuthGossiper:            s.authGossiper,
+		NoGossipSync:            s.cfg.Gossip.NoSync,
 		ChanStatusMgr:           s.chanStatusMgr,
 		ChainIO:                 s.cc.ChainIO,
 		FeeEstimator:            s.cc.FeeEstimator,

--- a/server.go
+++ b/server.go
@@ -48,6 +48,7 @@ import (
 	"github.com/lightningnetwork/lnd/graph"
 	graphdb "github.com/lightningnetwork/lnd/graph/db"
 	"github.com/lightningnetwork/lnd/graph/db/models"
+	"github.com/lightningnetwork/lnd/graph/sources"
 	"github.com/lightningnetwork/lnd/healthcheck"
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
@@ -322,9 +323,10 @@ type server struct {
 
 	fundingMgr *funding.Manager
 
-	graphDB     *graphdb.ChannelGraph
-	graphSource graphdb.GraphSource
-	v1Graph     *graphdb.VersionedGraph
+	graphDB           *graphdb.ChannelGraph
+	graphSource       graphdb.GraphSource
+	v1Graph           *graphdb.VersionedGraph
+	remoteGraphClient *sources.RPCClient
 
 	chanStateDB *channeldb.ChannelStateDB
 
@@ -695,23 +697,64 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 	v1Graph := graphdb.NewVersionedGraph(
 		dbs.GraphDB, lnwire.GossipVersion1,
 	)
-	graphSource := graphdb.NewDBGraphSource(dbs.GraphDB)
+
+	var (
+		graphSource       graphdb.GraphSource
+		remoteGraphClient *sources.RPCClient
+	)
+
+	localSource := graphdb.NewDBGraphSource(dbs.GraphDB)
+
+	if cfg.RemoteGraph.Enable {
+		selfPub := route.NewVertex(nodeKeyECDH.PubKey())
+
+		if dbs.GraphDB.GraphCacheStatus() == graphdb.GraphCacheStatusDisabled {
+			return nil, fmt.Errorf("remote graph requires the " +
+				"graph cache to be enabled")
+		}
+
+		remoteGraphClient = sources.NewRPCClient(
+			&sources.RPCConfig{
+				RPCHost:      cfg.RemoteGraph.RPCHost,
+				MacaroonPath: cfg.RemoteGraph.MacaroonPath,
+				TLSCertPath:  cfg.RemoteGraph.TLSCertPath,
+				Timeout:      cfg.RemoteGraph.Timeout,
+				ParseAddress: func(
+					addr string,
+				) (net.Addr, error) {
+
+					return parseAddr(
+						addr, cfg.net,
+					)
+				},
+			},
+		)
+
+		graphSource = sources.NewMux(
+			localSource, remoteGraphClient, selfPub,
+		)
+	} else {
+		graphSource = localSource
+	}
 
 	addrSource := channeldb.NewMultiAddrSource(dbs.ChanStateDB, graphSource)
 
 	s := &server{
-		cfg:            cfg,
-		implCfg:        implCfg,
-		graphDB:        dbs.GraphDB,
-		graphSource:    graphSource,
-		v1Graph:        v1Graph,
-		chanStateDB:    dbs.ChanStateDB.ChannelStateDB(),
-		addrSource:     addrSource,
-		miscDB:         dbs.ChanStateDB,
-		invoicesDB:     dbs.InvoiceDB,
-		paymentsDB:     dbs.PaymentsDB,
-		cc:             cc,
-		sigPool:        lnwallet.NewSigPool(cfg.Workers.Sig, cc.Signer),
+		cfg:               cfg,
+		implCfg:           implCfg,
+		graphDB:           dbs.GraphDB,
+		graphSource:       graphSource,
+		v1Graph:           v1Graph,
+		remoteGraphClient: remoteGraphClient,
+		chanStateDB:       dbs.ChanStateDB.ChannelStateDB(),
+		addrSource:        addrSource,
+		miscDB:            dbs.ChanStateDB,
+		invoicesDB:        dbs.InvoiceDB,
+		paymentsDB:        dbs.PaymentsDB,
+		cc:                cc,
+		sigPool: lnwallet.NewSigPool(
+			cfg.Workers.Sig, cc.Signer,
+		),
 		writePool:      writePool,
 		readPool:       readPool,
 		chansToRestore: chansToRestore,
@@ -2175,6 +2218,14 @@ func (s *server) Start(ctx context.Context) error {
 			return
 		}
 
+		if s.remoteGraphClient != nil {
+			cleanup = cleanup.add(s.remoteGraphClient.Stop)
+			if err := s.remoteGraphClient.Start(ctx); err != nil {
+				startErr = err
+				return
+			}
+		}
+
 		cleanup = cleanup.add(s.customMessageServer.Stop)
 		if err := s.customMessageServer.Start(); err != nil {
 			startErr = err
@@ -2687,6 +2738,12 @@ func (s *server) Stop() error {
 		}
 		if err := s.graphDB.Stop(); err != nil {
 			srvrLog.Warnf("failed to stop graphDB %v", err)
+		}
+		if s.remoteGraphClient != nil {
+			if err := s.remoteGraphClient.Stop(); err != nil {
+				srvrLog.Warnf("failed to stop remote graph "+
+					"client: %v", err)
+			}
 		}
 		if err := s.chainArb.Stop(); err != nil {
 			srvrLog.Warnf("failed to stop chainArb: %v", err)

--- a/server.go
+++ b/server.go
@@ -1135,6 +1135,7 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 		AssumeChannelValid:  cfg.Routing.AssumeChannelValid,
 		StrictZombiePruning: strictPruning,
 		IsAlias:             aliasmgr.IsAlias,
+		GraphSource:         s.graphSource,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("can't create graph builder: %w", err)

--- a/server.go
+++ b/server.go
@@ -1136,6 +1136,27 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 		StrictZombiePruning: strictPruning,
 		IsAlias:             aliasmgr.IsAlias,
 		GraphSource:         s.graphSource,
+		OnRemoteChannelUpdate: func(
+			msg *lnwire.ChannelUpdate1) {
+
+			if s.remoteGraphClient == nil {
+				return
+			}
+
+			ctx, cancel := context.WithTimeout(
+				context.Background(), 5*time.Second,
+			)
+			defer cancel()
+
+			err := s.remoteGraphClient.InjectGossipMessage(
+				ctx, msg,
+			)
+			if err != nil {
+				srvrLog.Warnf("Failed to propagate "+
+					"channel update to remote "+
+					"graph source: %v", err)
+			}
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("can't create graph builder: %w", err)

--- a/server.go
+++ b/server.go
@@ -2428,7 +2428,7 @@ func (s *server) Start(ctx context.Context) error {
 
 		if s.remoteGraphClient != nil {
 			cleanup = cleanup.add(s.remoteGraphClient.Stop)
-			if err := s.remoteGraphClient.Start(ctx); err != nil {
+			if err := s.remoteGraphClient.Start(); err != nil {
 				startErr = err
 				return
 			}


### PR DESCRIPTION
## Summary

This PR adds support for using a remote LND node as a graph data source. A lightweight or mobile node can delegate graph queries to a trusted remote LND node instead of syncing and storing the full network graph locally.

```
┌─────────────────────────────────────────────────────────┐
│                     Lightweight Node                    │
│                                                         │
│  ┌──────────┐    ┌──────────────────────────────────┐   │
│  │ Routing  │    │          GraphSource (Mux)       │   │
│  │ Autopilot│───▶│                                  │   │
│  │ RPC      │    │  ┌────────────┐  ┌────────────┐  │   │
│  │ Invoices │    │  │   Local    │  │  Remote    │  │   │
│  └──────────┘    │  │ DBGraph    │  │ RPCClient  │──┼───┼──▶ Trusted LND Node
│                  │  │ Source     │  │            │  │   │    (full graph)
│                  │  └────────────┘  └────────────┘  │   │
│                  └──────────────────────────────────┘   │
│                           │                             │
│                  ┌────────▼────────┐                    │
│                  │   Graph Cache   │◀── topology sub    │
│                  │  (pathfinding)  │    (kept in sync)  │
│                  └─────────────────┘                    │
└─────────────────────────────────────────────────────────┘
```

### Architecture

The implementation introduces three layers:

```
                    ┌─────────────────────┐
                    │    GraphSource      │  ◀── read-only interface
                    │   (15 methods)      │      used by all consumers
                    └──────────┬──────────┘
                               │
              ┌────────────────┼────────────────┐
              │                │                │
     ┌────────▼───────┐  ┌────▼────┐  ┌────────▼─────────┐
     │ DBGraphSource  │  │   Mux   │  │   (future        │
     │ (local only)   │  │         │  │  implementations)│
     └────────────────┘  └────┬────┘  └──────────────────┘
                              │
                    ┌─────────┴──────────┐
                    │                    │
           ┌────────▼──────┐   ┌────────▼───────┐
           │ DBGraphSource │   │  RPCClient     │
           │   (local)     │   │  (RemoteGraph) │
           └───────────────┘   └────────────────┘
```

**`GraphSource` interface** (`graph/db/graph_source.go`) -- A read-only, version-agnostic abstraction for accessing graph data. All consumers (routing, RPC, autopilot, invoices, etc.) use this single interface. `DBGraphSource` wraps the local `ChannelGraph` database.

**`RemoteGraph` interface** (`graph/sources/interface.go`) -- A subset of `GraphSource` covering only the methods relevant for a remote source. Excludes cache-based and self-node methods which are always local.

**`Mux`** (`graph/sources/mux.go`) -- Combines local + remote with the strategy:
- **Own node/channels**: always local (authoritative for private channels)
- **Other nodes/channels**: remote first, local supplements
- **Pathfinding**: local graph cache (populated from both sources)

**`RPCClient`** (`graph/sources/rpc_client.go`) -- Implements `RemoteGraph` over gRPC using existing LND RPCs (`DescribeGraph`, `GetNodeInfo`, `GetChanInfo`, `SubscribeChannelGraph`).

### Data flow

```
Startup:
  1. Connect to remote LND (TLS + macaroon auth)
  2. PopulateCache: single DescribeGraph call seeds local graph cache (async)
  3. StartSubscription: SubscribeChannelGraph stream for incremental updates

Runtime:
  ┌──────────────┐   channel/policy/node updates     ┌──────────────────┐
  │ Remote LND   │ ─────────────────────────────────▶│ Local Graph      │
  │              │   (SubscribeChannelGraph stream)  │ Cache            │
  └──────────────┘                                   └──────────────────┘
         ▲                                                   │
         │                                          used by pathfinding
         │                                          (ForEachNodeDirectedChannel)
         │
  InjectGossipMessage (channel updates from payment failures)
         │
  ┌──────┴───────┐
  │ Lightweight  │
  │ Node         │
  └──────────────┘

  Point queries (FetchNode, GetChanInfo, etc.):
    remote ──▶ success? return : fallback to local
```

The subscription reconnects automatically with exponential backoff (1s -> 60s) if the stream drops.

### Async graph cache population

Graph cache updates from the remote source (both the initial `DescribeGraph` snapshot and incremental topology subscription updates) are routed through `ChannelGraph.ApplyCacheUpdate()`, which delegates to `graphCacheState.applyUpdate()`. This ensures that writes are properly buffered if the local DB cache population is still in progress (from #10065), and replayed once it completes. Both the local DB and remote graph populate the same cache without blocking startup.

### Channel update propagation

When a lightweight node discovers an updated channel policy through a payment failure (e.g. `FeeInsufficient`), it pushes the update back to the remote graph source via the new `InjectGossipMessage` RPC. The graph source validates the update through its gossiper (signature checks, timestamp checks, etc.) and if valid, applies it to its graph DB and re-broadcasts it to peers.

This solves the problem where multiple lightweight nodes using the same graph source each had to independently discover stale policies through their own payment failures. Now the first node to discover the update propagates it back, benefiting all other users.

### Configuration

```ini
[remotegraph]
remotegraph.enable=true
remotegraph.rpchost=trusted-node:10009
remotegraph.macaroonpath=/path/to/readonly.macaroon
remotegraph.tlscertpath=/path/to/tls.cert
remotegraph.timeout=5s

[gossip]
gossip.no-sync=true
```

When `gossip.no-sync=true`, the node does not advertise the gossip queries feature bit and does not initiate gossip syncing with peers, avoiding redundant bandwidth usage.

### Trust model

> **Important:** The remote graph data is NOT independently verified -- no signature checks, no on-chain funding transaction validation. This feature trusts the remote node to provide accurate graph data. Only connect to a remote node that you control or fully trust.

## Test plan

- [x] Integration test covers: graph discovery, gossip sync disabled, private channel isolation, combined Mux view, payment routing through remote graph, peer bootstrapping, node restart
- [x] Integration test for stale policy handling: payment failure with outdated fee policy triggers cache update from GraphSource fallback
- [x] Integration test for policy propagation: channel update from payment failure is pushed back to graph source via `InjectGossipMessage`, other lightweight nodes benefit
- [x] Unit tests cover: Mux deduplication and fallback logic, RPCClient unmarshal functions, feature parsing, color parsing, gRPC error mapping
- [ ] Manual test: run lightweight node against a mainnet LND with `readonly.macaroon`, verify graph queries and payment routing work