### PR TITLE
routerrpc: fix sendpayment_v2 negative fee limit

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -28,9 +28,13 @@
   does not contain a payment address.
   
 * [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/9033) where we
-  would not signal an error when trying to bump an non-anchor channel but
+  would not signal an error when trying to bump a non-anchor channel but
   instead report a successful cpfp registration although no fee bumping is
   possible for non-anchor channels anyways.
+
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/9269) where a
+  negative fee limit for `SendPaymentV2` would lead to omitting the fee limit
+  check.
 
 * [Use the required route blinding 
   feature-bit](https://github.com/lightningnetwork/lnd/pull/9143) for invoices 
@@ -196,6 +200,7 @@ The underlying functionality between those two options remain the same.
 * CharlieZKSmith
 * Elle Mouton
 * George Tsagkarelis
+* hieblmi
 * Oliver Gugger
 * Pins
 * Viktor Tigerström

--- a/lnrpc/marshall_utils.go
+++ b/lnrpc/marshall_utils.go
@@ -23,6 +23,9 @@ var (
 	ErrSatMsatMutualExclusive = errors.New(
 		"sat and msat arguments are mutually exclusive",
 	)
+
+	// ErrNegativeAmt is returned when a negative amount is specified.
+	ErrNegativeAmt = errors.New("amount cannot be negative")
 )
 
 // CalculateFeeLimit returns the fee limit in millisatoshis. If a percentage
@@ -54,6 +57,10 @@ func CalculateFeeLimit(feeLimit *FeeLimit,
 func UnmarshallAmt(amtSat, amtMsat int64) (lnwire.MilliSatoshi, error) {
 	if amtSat != 0 && amtMsat != 0 {
 		return 0, ErrSatMsatMutualExclusive
+	}
+
+	if amtSat < 0 || amtMsat < 0 {
+		return 0, ErrNegativeAmt
 	}
 
 	if amtSat != 0 {


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/9268

This PR intends to fix the handling of a negative fee limit in the `SendPayment_V2` rpc.