### PR TITLE
lntest: print node PID when launching in itests

### DIFF
--- a/lntest/node/harness_node.go
+++ b/lntest/node/harness_node.go
@@ -399,6 +399,9 @@ func (hn *HarnessNode) StartLndCmd(ctxb context.Context) error {
 		return err
 	}
 
+	pid := hn.cmd.Process.Pid
+	hn.T.Logf("Starting node (name=%v) with PID=%v", hn.Cfg.Name, pid)
+
 	return nil
 }
 


### PR DESCRIPTION
In this commit, we start to print the PID of node's we created within an itest. This is useful when debugging itests with `dlv` by attaching to a given node. By printing out the PID, we facilitate such debugging attempts.


Example run: 
```
    harness_node.go:403: Starting node (name=Alice) with PID=72474
```