### PR TITLE
The sweeper subsystem uses now also the configured budget values for HTLCs

### DIFF
--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -465,15 +465,9 @@ func (h *htlcTimeoutResolver) sweepTimeoutTx() error {
 	}
 
 	// Calculate the budget.
-	//
-	// TODO(yy): the budget is twice the output's value, which is needed as
-	// we don't force sweep the output now. To prevent cascading force
-	// closes, we use all its output value plus a wallet input as the
-	// budget. This is a temporary solution until we can optionally cancel
-	// the incoming HTLC, more details in,
-	// - https://github.com/lightningnetwork/lnd/issues/7969
 	budget := calculateBudget(
-		btcutil.Amount(inp.SignDesc().Output.Value), 2, 0,
+		btcutil.Amount(inp.SignDesc().Output.Value),
+		h.Budget.DeadlineHTLCRatio, h.Budget.DeadlineHTLC,
 	)
 
 	h.log.Infof("offering 2nd-level HTLC timeout tx to sweeper "+
@@ -535,15 +529,9 @@ func (h *htlcTimeoutResolver) sweepDirectHtlcOutput() error {
 	)
 
 	// Calculate the budget.
-	//
-	// TODO(yy): the budget is twice the output's value, which is needed as
-	// we don't force sweep the output now. To prevent cascading force
-	// closes, we use all its output value plus a wallet input as the
-	// budget. This is a temporary solution until we can optionally cancel
-	// the incoming HTLC, more details in,
-	// - https://github.com/lightningnetwork/lnd/issues/7969
 	budget := calculateBudget(
-		btcutil.Amount(sweepInput.SignDesc().Output.Value), 2, 0,
+		btcutil.Amount(sweepInput.SignDesc().Output.Value),
+		h.Budget.DeadlineHTLCRatio, h.Budget.DeadlineHTLC,
 	)
 
 	log.Infof("%T(%x): offering offered remote timeout HTLC output to "+

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -135,6 +135,10 @@
   block. Check
   [here](https://github.com/lightningnetwork/lnd/blob/master/chainio/README.md)
   to learn more.
+  
+* [The sweeper](https://github.com/lightningnetwork/lnd/pull/9274) does now also
+ use the configured budget values for HTLCs (first level sweep) in parcticular
+ `--sweeper.budget.deadlinehtlcratio` and `--sweeper.budget.deadlinehtlc`.
 
 ## RPC Updates
 

--- a/itest/lnd_sweep_test.go
+++ b/itest/lnd_sweep_test.go
@@ -928,12 +928,7 @@ func testSweepHTLCs(ht *lntest.HarnessTest) {
 	require.Len(ht, outgoingSweep.TxOut, 2)
 
 	// Calculate the ending fee rate.
-	//
-	// TODO(yy): the budget we use to sweep the first-level outgoing HTLC
-	// is twice its value. This is a temporary mitigation to prevent
-	// cascading FCs and the test should be updated once it's properly
-	// fixed.
-	outgoingBudget := 2 * invoiceAmt
+	outgoingBudget := invoiceAmt.MulF64(contractcourt.DefaultBudgetRatio)
 	outgoingTxSize := ht.CalculateTxWeight(outgoingSweep)
 	outgoingEndFeeRate := chainfee.NewSatPerKWeight(
 		outgoingBudget, outgoingTxSize,


### PR DESCRIPTION
Now since we are abandoning forwards early for dust htlcs, we can decrease this value.