### PR TITLE
peer+lnd: fix peer blocking on node shutdown

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -51,6 +51,9 @@
 * Make sure the RPC clients used to access the chain backend are [properly
   shutdown](https://github.com/lightningnetwork/lnd/pull/9261).
 
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/9275) where the
+  peer may block the shutdown process of lnd.
+
 # New Features
 ## Functional Enhancements
 ## RPC Additions
@@ -196,5 +199,6 @@ The underlying functionality between those two options remain the same.
 * Oliver Gugger
 * Pins
 * Viktor Tigerström
+* Yong Yu
 * Ziggie
 


### PR DESCRIPTION
Cherry-picked commits from the final `blockbeat` to reduce the PR size.

This commit fixes a case where the peer blocks the shutdown process. During the shutdown, the server will call `s.DisconnectPeer`, which calls `peer.Disconnect`. Because the peer never enters `peer.Start` via `s.peerInitializer`, the `startReady` chan will not be closed, causing `peer.Disconnect` to hang forever. We now fix it by only block on `startReady` when the peer is started.