### PR TITLE
Beat [3/4]: prepare resolvers to handle the `blockbeat`

### DIFF
--- a/contractcourt/anchor_resolver.go
+++ b/contractcourt/anchor_resolver.go
@@ -2,6 +2,7 @@ package contractcourt
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"sync"
 
@@ -71,7 +72,7 @@ func newAnchorResolver(anchorSignDescriptor input.SignDescriptor,
 		currentReport:        report,
 	}
 
-	r.initLogger(r)
+	r.initLogger(fmt.Sprintf("%T(%v)", r, r.anchor))
 
 	return r
 }

--- a/contractcourt/anchor_resolver.go
+++ b/contractcourt/anchor_resolver.go
@@ -84,8 +84,125 @@ func (c *anchorResolver) ResolverKey() []byte {
 	return nil
 }
 
-// Resolve offers the anchor output to the sweeper and waits for it to be swept.
+// Resolve waits for the output to be swept.
+//
+// NOTE: Part of the ContractResolver interface.
 func (c *anchorResolver) Resolve() (ContractResolver, error) {
+	// If we're already resolved, then we can exit early.
+	if c.resolved {
+		c.log.Errorf("already resolved")
+		return nil, nil
+	}
+
+	var (
+		outcome channeldb.ResolverOutcome
+		spendTx *chainhash.Hash
+	)
+
+	select {
+	case sweepRes := <-c.sweepResultChan:
+		switch sweepRes.Err {
+		// Anchor was swept successfully.
+		case nil:
+			sweepTxID := sweepRes.Tx.TxHash()
+
+			spendTx = &sweepTxID
+			outcome = channeldb.ResolverOutcomeClaimed
+
+		// Anchor was swept by someone else. This is possible after the
+		// 16 block csv lock.
+		case sweep.ErrRemoteSpend:
+			c.log.Warnf("our anchor spent by someone else")
+			outcome = channeldb.ResolverOutcomeUnclaimed
+
+		// An unexpected error occurred.
+		default:
+			c.log.Errorf("unable to sweep anchor: %v", sweepRes.Err)
+
+			return nil, sweepRes.Err
+		}
+
+	case <-c.quit:
+		return nil, errResolverShuttingDown
+	}
+
+	c.log.Infof("resolved in tx %v", spendTx)
+
+	// Update report to reflect that funds are no longer in limbo.
+	c.reportLock.Lock()
+	if outcome == channeldb.ResolverOutcomeClaimed {
+		c.currentReport.RecoveredBalance = c.currentReport.LimboBalance
+	}
+	c.currentReport.LimboBalance = 0
+	report := c.currentReport.resolverReport(
+		spendTx, channeldb.ResolverTypeAnchor, outcome,
+	)
+	c.reportLock.Unlock()
+
+	c.resolved = true
+	return nil, c.PutResolverReport(nil, report)
+}
+
+// Stop signals the resolver to cancel any current resolution processes, and
+// suspend.
+//
+// NOTE: Part of the ContractResolver interface.
+func (c *anchorResolver) Stop() {
+	c.log.Debugf("stopping...")
+	defer c.log.Debugf("stopped")
+
+	close(c.quit)
+}
+
+// IsResolved returns true if the stored state in the resolve is fully
+// resolved. In this case the target output can be forgotten.
+//
+// NOTE: Part of the ContractResolver interface.
+func (c *anchorResolver) IsResolved() bool {
+	return c.resolved
+}
+
+// SupplementState allows the user of a ContractResolver to supplement it with
+// state required for the proper resolution of a contract.
+//
+// NOTE: Part of the ContractResolver interface.
+func (c *anchorResolver) SupplementState(state *channeldb.OpenChannel) {
+	c.chanType = state.ChanType
+}
+
+// report returns a report on the resolution state of the contract.
+func (c *anchorResolver) report() *ContractReport {
+	c.reportLock.Lock()
+	defer c.reportLock.Unlock()
+
+	reportCopy := c.currentReport
+	return &reportCopy
+}
+
+func (c *anchorResolver) Encode(w io.Writer) error {
+	return errors.New("serialization not supported")
+}
+
+// A compile time assertion to ensure anchorResolver meets the
+// ContractResolver interface.
+var _ ContractResolver = (*anchorResolver)(nil)
+
+// Launch offers the anchor output to the sweeper.
+func (c *anchorResolver) Launch() error {
+	if c.launched {
+		c.log.Tracef("already launched")
+		return nil
+	}
+
+	c.log.Debugf("launching resolver...")
+	c.launched = true
+
+	// If we're already resolved, then we can exit early.
+	if c.resolved {
+		c.log.Errorf("already resolved")
+		return nil
+	}
+
 	// Attempt to update the sweep parameters to the post-confirmation
 	// situation. We don't want to force sweep anymore, because the anchor
 	// lost its special purpose to get the commitment confirmed. It is just
@@ -125,94 +242,12 @@ func (c *anchorResolver) Resolve() (ContractResolver, error) {
 			DeadlineHeight: fn.None[int32](),
 		},
 	)
+
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	var (
-		outcome channeldb.ResolverOutcome
-		spendTx *chainhash.Hash
-	)
+	c.sweepResultChan = resultChan
 
-	select {
-	case sweepRes := <-resultChan:
-		switch sweepRes.Err {
-		// Anchor was swept successfully.
-		case nil:
-			sweepTxID := sweepRes.Tx.TxHash()
-
-			spendTx = &sweepTxID
-			outcome = channeldb.ResolverOutcomeClaimed
-
-		// Anchor was swept by someone else. This is possible after the
-		// 16 block csv lock.
-		case sweep.ErrRemoteSpend:
-			c.log.Warnf("our anchor spent by someone else")
-			outcome = channeldb.ResolverOutcomeUnclaimed
-
-		// An unexpected error occurred.
-		default:
-			c.log.Errorf("unable to sweep anchor: %v", sweepRes.Err)
-
-			return nil, sweepRes.Err
-		}
-
-	case <-c.quit:
-		return nil, errResolverShuttingDown
-	}
-
-	// Update report to reflect that funds are no longer in limbo.
-	c.reportLock.Lock()
-	if outcome == channeldb.ResolverOutcomeClaimed {
-		c.currentReport.RecoveredBalance = c.currentReport.LimboBalance
-	}
-	c.currentReport.LimboBalance = 0
-	report := c.currentReport.resolverReport(
-		spendTx, channeldb.ResolverTypeAnchor, outcome,
-	)
-	c.reportLock.Unlock()
-
-	c.resolved = true
-	return nil, c.PutResolverReport(nil, report)
+	return nil
 }
-
-// Stop signals the resolver to cancel any current resolution processes, and
-// suspend.
-//
-// NOTE: Part of the ContractResolver interface.
-func (c *anchorResolver) Stop() {
-	close(c.quit)
-}
-
-// IsResolved returns true if the stored state in the resolve is fully
-// resolved. In this case the target output can be forgotten.
-//
-// NOTE: Part of the ContractResolver interface.
-func (c *anchorResolver) IsResolved() bool {
-	return c.resolved
-}
-
-// SupplementState allows the user of a ContractResolver to supplement it with
-// state required for the proper resolution of a contract.
-//
-// NOTE: Part of the ContractResolver interface.
-func (c *anchorResolver) SupplementState(state *channeldb.OpenChannel) {
-	c.chanType = state.ChanType
-}
-
-// report returns a report on the resolution state of the contract.
-func (c *anchorResolver) report() *ContractReport {
-	c.reportLock.Lock()
-	defer c.reportLock.Unlock()
-
-	reportCopy := c.currentReport
-	return &reportCopy
-}
-
-func (c *anchorResolver) Encode(w io.Writer) error {
-	return errors.New("serialization not supported")
-}
-
-// A compile time assertion to ensure anchorResolver meets the
-// ContractResolver interface.
-var _ ContractResolver = (*anchorResolver)(nil)

--- a/contractcourt/anchor_resolver.go
+++ b/contractcourt/anchor_resolver.go
@@ -178,13 +178,13 @@ var _ ContractResolver = (*anchorResolver)(nil)
 
 // Launch offers the anchor output to the sweeper.
 func (c *anchorResolver) Launch() error {
-	if c.launched {
+	if c.isLaunched() {
 		c.log.Tracef("already launched")
 		return nil
 	}
 
 	c.log.Debugf("launching resolver...")
-	c.launched = true
+	c.markLaunched()
 
 	// If we're already resolved, then we can exit early.
 	if c.IsResolved() {

--- a/contractcourt/anchor_resolver.go
+++ b/contractcourt/anchor_resolver.go
@@ -24,9 +24,6 @@ type anchorResolver struct {
 	// anchor is the outpoint on the commitment transaction.
 	anchor wire.OutPoint
 
-	// resolved reflects if the contract has been fully resolved or not.
-	resolved bool
-
 	// broadcastHeight is the height that the original contract was
 	// broadcast to the main-chain at. We'll use this value to bound any
 	// historical queries to the chain for spends/confirmations.
@@ -89,7 +86,7 @@ func (c *anchorResolver) ResolverKey() []byte {
 // NOTE: Part of the ContractResolver interface.
 func (c *anchorResolver) Resolve() (ContractResolver, error) {
 	// If we're already resolved, then we can exit early.
-	if c.resolved {
+	if c.IsResolved() {
 		c.log.Errorf("already resolved")
 		return nil, nil
 	}
@@ -139,7 +136,7 @@ func (c *anchorResolver) Resolve() (ContractResolver, error) {
 	)
 	c.reportLock.Unlock()
 
-	c.resolved = true
+	c.markResolved()
 	return nil, c.PutResolverReport(nil, report)
 }
 
@@ -152,14 +149,6 @@ func (c *anchorResolver) Stop() {
 	defer c.log.Debugf("stopped")
 
 	close(c.quit)
-}
-
-// IsResolved returns true if the stored state in the resolve is fully
-// resolved. In this case the target output can be forgotten.
-//
-// NOTE: Part of the ContractResolver interface.
-func (c *anchorResolver) IsResolved() bool {
-	return c.resolved
 }
 
 // SupplementState allows the user of a ContractResolver to supplement it with
@@ -198,7 +187,7 @@ func (c *anchorResolver) Launch() error {
 	c.launched = true
 
 	// If we're already resolved, then we can exit early.
-	if c.resolved {
+	if c.IsResolved() {
 		c.log.Errorf("already resolved")
 		return nil
 	}

--- a/contractcourt/breach_resolver.go
+++ b/contractcourt/breach_resolver.go
@@ -2,6 +2,7 @@ package contractcourt
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 
 	"github.com/lightningnetwork/lnd/channeldb"
@@ -32,7 +33,7 @@ func newBreachResolver(resCfg ResolverConfig) *breachResolver {
 		replyChan:           make(chan struct{}),
 	}
 
-	r.initLogger(r)
+	r.initLogger(fmt.Sprintf("%T(%v)", r, r.ChanPoint))
 
 	return r
 }
@@ -114,7 +115,7 @@ func newBreachResolverFromReader(r io.Reader, resCfg ResolverConfig) (
 		return nil, err
 	}
 
-	b.initLogger(b)
+	b.initLogger(fmt.Sprintf("%T(%v)", b, b.ChanPoint))
 
 	return b, nil
 }

--- a/contractcourt/breach_resolver.go
+++ b/contractcourt/breach_resolver.go
@@ -47,6 +47,8 @@ func (b *breachResolver) ResolverKey() []byte {
 // Resolve queries the BreachArbitrator to see if the justice transaction has
 // been broadcast.
 //
+// NOTE: Part of the ContractResolver interface.
+//
 // TODO(yy): let sweeper handle the breach inputs.
 func (b *breachResolver) Resolve() (ContractResolver, error) {
 	if !b.subscribed {
@@ -83,6 +85,7 @@ func (b *breachResolver) Resolve() (ContractResolver, error) {
 
 // Stop signals the breachResolver to stop.
 func (b *breachResolver) Stop() {
+	b.log.Debugf("stopping...")
 	close(b.quit)
 }
 
@@ -123,3 +126,21 @@ func newBreachResolverFromReader(r io.Reader, resCfg ResolverConfig) (
 // A compile time assertion to ensure breachResolver meets the ContractResolver
 // interface.
 var _ ContractResolver = (*breachResolver)(nil)
+
+// Launch offers the breach outputs to the sweeper - currently it's a NOOP as
+// the outputs here are not offered to the sweeper.
+//
+// NOTE: Part of the ContractResolver interface.
+//
+// TODO(yy): implement it once the outputs are offered to the sweeper.
+func (b *breachResolver) Launch() error {
+	if b.launched {
+		b.log.Tracef("already launched")
+		return nil
+	}
+
+	b.log.Debugf("launching resolver...")
+	b.launched = true
+
+	return nil
+}

--- a/contractcourt/breach_resolver.go
+++ b/contractcourt/breach_resolver.go
@@ -12,9 +12,6 @@ import (
 // future, this will likely take over the duties the current BreachArbitrator
 // has.
 type breachResolver struct {
-	// resolved reflects if the contract has been fully resolved or not.
-	resolved bool
-
 	// subscribed denotes whether or not the breach resolver has subscribed
 	// to the BreachArbitrator for breach resolution.
 	subscribed bool
@@ -62,7 +59,7 @@ func (b *breachResolver) Resolve() (ContractResolver, error) {
 		// If the breach resolution process is already complete, then
 		// we can cleanup and checkpoint the resolved state.
 		if complete {
-			b.resolved = true
+			b.markResolved()
 			return nil, b.Checkpoint(b)
 		}
 
@@ -75,8 +72,9 @@ func (b *breachResolver) Resolve() (ContractResolver, error) {
 		// The replyChan has been closed, signalling that the breach
 		// has been fully resolved. Checkpoint the resolved state and
 		// exit.
-		b.resolved = true
+		b.markResolved()
 		return nil, b.Checkpoint(b)
+
 	case <-b.quit:
 	}
 
@@ -89,19 +87,13 @@ func (b *breachResolver) Stop() {
 	close(b.quit)
 }
 
-// IsResolved returns true if the breachResolver is fully resolved and cleanup
-// can occur.
-func (b *breachResolver) IsResolved() bool {
-	return b.resolved
-}
-
 // SupplementState adds additional state to the breachResolver.
 func (b *breachResolver) SupplementState(_ *channeldb.OpenChannel) {
 }
 
 // Encode encodes the breachResolver to the passed writer.
 func (b *breachResolver) Encode(w io.Writer) error {
-	return binary.Write(w, endian, b.resolved)
+	return binary.Write(w, endian, b.IsResolved())
 }
 
 // newBreachResolverFromReader attempts to decode an encoded breachResolver
@@ -114,8 +106,12 @@ func newBreachResolverFromReader(r io.Reader, resCfg ResolverConfig) (
 		replyChan:           make(chan struct{}),
 	}
 
-	if err := binary.Read(r, endian, &b.resolved); err != nil {
+	var resolved bool
+	if err := binary.Read(r, endian, &resolved); err != nil {
 		return nil, err
+	}
+	if resolved {
+		b.markResolved()
 	}
 
 	b.initLogger(fmt.Sprintf("%T(%v)", b, b.ChanPoint))

--- a/contractcourt/breach_resolver.go
+++ b/contractcourt/breach_resolver.go
@@ -130,13 +130,13 @@ var _ ContractResolver = (*breachResolver)(nil)
 //
 // TODO(yy): implement it once the outputs are offered to the sweeper.
 func (b *breachResolver) Launch() error {
-	if b.launched {
+	if b.isLaunched() {
 		b.log.Tracef("already launched")
 		return nil
 	}
 
 	b.log.Debugf("launching resolver...")
-	b.launched = true
+	b.markLaunched()
 
 	return nil
 }

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -982,6 +982,7 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 			},
 		},
 	}
+	closeTxid := closeTx.TxHash()
 
 	htlcOp := wire.OutPoint{
 		Hash:  closeTx.TxHash(),
@@ -1117,7 +1118,11 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 
 	// Notify resolver that the HTLC output of the commitment has been
 	// spent.
-	oldNotifier.SpendChan <- &chainntnfs.SpendDetail{SpendingTx: closeTx}
+	oldNotifier.SpendChan <- &chainntnfs.SpendDetail{
+		SpendingTx:    closeTx,
+		SpentOutPoint: &wire.OutPoint{},
+		SpenderTxHash: &closeTxid,
+	}
 
 	// Finally, we should also receive a resolution message instructing the
 	// switch to cancel back the HTLC.

--- a/contractcourt/commit_sweep_resolver.go
+++ b/contractcourt/commit_sweep_resolver.go
@@ -39,9 +39,6 @@ type commitSweepResolver struct {
 	// this HTLC on-chain.
 	commitResolution lnwallet.CommitOutputResolution
 
-	// resolved reflects if the contract has been fully resolved or not.
-	resolved bool
-
 	// broadcastHeight is the height that the original contract was
 	// broadcast to the main-chain at. We'll use this value to bound any
 	// historical queries to the chain for spends/confirmations.
@@ -171,7 +168,7 @@ func (c *commitSweepResolver) getCommitTxConfHeight() (uint32, error) {
 //nolint:funlen
 func (c *commitSweepResolver) Resolve() (ContractResolver, error) {
 	// If we're already resolved, then we can exit early.
-	if c.resolved {
+	if c.IsResolved() {
 		c.log.Errorf("already resolved")
 		return nil, nil
 	}
@@ -224,7 +221,7 @@ func (c *commitSweepResolver) Resolve() (ContractResolver, error) {
 	report := c.currentReport.resolverReport(
 		&sweepTxID, channeldb.ResolverTypeCommit, outcome,
 	)
-	c.resolved = true
+	c.markResolved()
 
 	// Checkpoint the resolver with a closure that will write the outcome
 	// of the resolver and its sweep transaction to disk.
@@ -239,14 +236,6 @@ func (c *commitSweepResolver) Stop() {
 	c.log.Debugf("stopping...")
 	defer c.log.Debugf("stopped")
 	close(c.quit)
-}
-
-// IsResolved returns true if the stored state in the resolve is fully
-// resolved. In this case the target output can be forgotten.
-//
-// NOTE: Part of the ContractResolver interface.
-func (c *commitSweepResolver) IsResolved() bool {
-	return c.resolved
 }
 
 // SupplementState allows the user of a ContractResolver to supplement it with
@@ -277,7 +266,7 @@ func (c *commitSweepResolver) Encode(w io.Writer) error {
 		return err
 	}
 
-	if err := binary.Write(w, endian, c.resolved); err != nil {
+	if err := binary.Write(w, endian, c.IsResolved()); err != nil {
 		return err
 	}
 	if err := binary.Write(w, endian, c.broadcastHeight); err != nil {
@@ -312,9 +301,14 @@ func newCommitSweepResolverFromReader(r io.Reader, resCfg ResolverConfig) (
 		return nil, err
 	}
 
-	if err := binary.Read(r, endian, &c.resolved); err != nil {
+	var resolved bool
+	if err := binary.Read(r, endian, &resolved); err != nil {
 		return nil, err
 	}
+	if resolved {
+		c.markResolved()
+	}
+
 	if err := binary.Read(r, endian, &c.broadcastHeight); err != nil {
 		return nil, err
 	}
@@ -383,7 +377,7 @@ func (c *commitSweepResolver) Launch() error {
 	c.launched = true
 
 	// If we're already resolved, then we can exit early.
-	if c.resolved {
+	if c.IsResolved() {
 		c.log.Errorf("already resolved")
 		return nil
 	}

--- a/contractcourt/commit_sweep_resolver.go
+++ b/contractcourt/commit_sweep_resolver.go
@@ -88,7 +88,7 @@ func newCommitSweepResolver(res lnwallet.CommitOutputResolution,
 		chanPoint:           chanPoint,
 	}
 
-	r.initLogger(r)
+	r.initLogger(fmt.Sprintf("%T(%v)", r, r.commitResolution.SelfOutPoint))
 	r.initReport()
 
 	return r
@@ -484,7 +484,7 @@ func newCommitSweepResolverFromReader(r io.Reader, resCfg ResolverConfig) (
 	// removed this, but keep in mind that this data may still be present in
 	// the database.
 
-	c.initLogger(c)
+	c.initLogger(fmt.Sprintf("%T(%v)", c, c.commitResolution.SelfOutPoint))
 	c.initReport()
 
 	return c, nil

--- a/contractcourt/commit_sweep_resolver.go
+++ b/contractcourt/commit_sweep_resolver.go
@@ -368,13 +368,13 @@ var _ reportingContractResolver = (*commitSweepResolver)(nil)
 
 // Launch constructs a commit input and offers it to the sweeper.
 func (c *commitSweepResolver) Launch() error {
-	if c.launched {
+	if c.isLaunched() {
 		c.log.Tracef("already launched")
 		return nil
 	}
 
 	c.log.Debugf("launching resolver...")
-	c.launched = true
+	c.markLaunched()
 
 	// If we're already resolved, then we can exit early.
 	if c.IsResolved() {

--- a/contractcourt/commit_sweep_resolver_test.go
+++ b/contractcourt/commit_sweep_resolver_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/sweep"
+	"github.com/stretchr/testify/require"
 )
 
 type commitSweepResolverTestContext struct {
@@ -82,6 +83,9 @@ func (i *commitSweepResolverTestContext) resolve() {
 	// Start resolver.
 	i.resolverResultChan = make(chan resolveResult, 1)
 	go func() {
+		err := i.resolver.Launch()
+		require.NoError(i.t, err)
+
 		nextResolver, err := i.resolver.Resolve()
 		i.resolverResultChan <- resolveResult{
 			nextResolver: nextResolver,

--- a/contractcourt/contract_resolver.go
+++ b/contractcourt/contract_resolver.go
@@ -120,8 +120,10 @@ func newContractResolverKit(cfg ResolverConfig) *contractResolverKit {
 }
 
 // initLogger initializes the resolver-specific logger.
-func (r *contractResolverKit) initLogger(resolver ContractResolver) {
-	logPrefix := fmt.Sprintf("%T(%v):", resolver, r.ChanPoint)
+func (r *contractResolverKit) initLogger(prefix string) {
+	logPrefix := fmt.Sprintf("ChannelArbitrator(%v): %s:", r.ChanPoint,
+		prefix)
+
 	r.log = log.WithPrefix(logPrefix)
 }
 

--- a/contractcourt/contract_resolver.go
+++ b/contractcourt/contract_resolver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/sweep"
 )
 
 var (
@@ -109,6 +110,15 @@ type contractResolverKit struct {
 	log btclog.Logger
 
 	quit chan struct{}
+
+	// sweepResultChan is the result chan returned from calling
+	// `SweepInput`. It should be mounted to the specific resolver once the
+	// input has been offered to the sweeper.
+	sweepResultChan chan sweep.Result
+
+	// launched specifies whether the resolver has been launched. Calling
+	// `Launch` will be a no-op if this is true.
+	launched bool
 }
 
 // newContractResolverKit instantiates the mix-in struct.

--- a/contractcourt/contract_resolver.go
+++ b/contractcourt/contract_resolver.go
@@ -37,6 +37,17 @@ type ContractResolver interface {
 	// resides within.
 	ResolverKey() []byte
 
+	// Launch starts the resolver by constructing an input and offering it
+	// to the sweeper. Once offered, it's expected to monitor the sweeping
+	// result in a goroutine invoked by calling Resolve.
+	//
+	// NOTE: We can call `Resolve` inside a goroutine at the end of this
+	// method to avoid calling it in the ChannelArbitrator. However, there
+	// are some DB-related operations such as SwapContract/ResolveContract
+	// which need to be done inside the resolvers instead, which needs a
+	// deeper refactoring.
+	Launch() error
+
 	// Resolve instructs the contract resolver to resolve the output
 	// on-chain. Once the output has been *fully* resolved, the function
 	// should return immediately with a nil ContractResolver value for the

--- a/contractcourt/contract_resolver.go
+++ b/contractcourt/contract_resolver.go
@@ -118,8 +118,11 @@ type contractResolverKit struct {
 	sweepResultChan chan sweep.Result
 
 	// launched specifies whether the resolver has been launched. Calling
-	// `Launch` will be a no-op if this is true.
-	launched bool
+	// `Launch` will be a no-op if this is true. This value is not saved to
+	// db, as it's fine to relaunch a resolver after a restart. It's only
+	// used to avoid resending requests to the sweeper when a new blockbeat
+	// is received.
+	launched atomic.Bool
 
 	// resolved reflects if the contract has been fully resolved or not.
 	resolved atomic.Bool
@@ -152,6 +155,16 @@ func (r *contractResolverKit) IsResolved() bool {
 // markResolved marks the resolver as resolved.
 func (r *contractResolverKit) markResolved() {
 	r.resolved.Store(true)
+}
+
+// isLaunched returns true if the resolver has been launched.
+func (r *contractResolverKit) isLaunched() bool {
+	return r.launched.Load()
+}
+
+// markLaunched marks the resolver as launched.
+func (r *contractResolverKit) markLaunched() {
+	r.launched.Store(true)
 }
 
 var (

--- a/contractcourt/contract_resolver.go
+++ b/contractcourt/contract_resolver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync/atomic"
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
@@ -119,6 +120,9 @@ type contractResolverKit struct {
 	// launched specifies whether the resolver has been launched. Calling
 	// `Launch` will be a no-op if this is true.
 	launched bool
+
+	// resolved reflects if the contract has been fully resolved or not.
+	resolved atomic.Bool
 }
 
 // newContractResolverKit instantiates the mix-in struct.
@@ -135,6 +139,19 @@ func (r *contractResolverKit) initLogger(prefix string) {
 		prefix)
 
 	r.log = log.WithPrefix(logPrefix)
+}
+
+// IsResolved returns true if the stored state in the resolve is fully
+// resolved. In this case the target output can be forgotten.
+//
+// NOTE: Part of the ContractResolver interface.
+func (r *contractResolverKit) IsResolved() bool {
+	return r.resolved.Load()
+}
+
+// markResolved marks the resolver as resolved.
+func (r *contractResolverKit) markResolved() {
+	r.resolved.Store(true)
 }
 
 var (

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -83,7 +83,7 @@ func (h *htlcIncomingContestResolver) processFinalHtlcFail() error {
 func (h *htlcIncomingContestResolver) Launch() error {
 	// NOTE: we don't mark this resolver as launched as the inner resolver
 	// will set it when it's launched.
-	if h.launched {
+	if h.isLaunched() {
 		h.log.Tracef("already launched")
 		return nil
 	}

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -78,6 +78,37 @@ func (h *htlcIncomingContestResolver) processFinalHtlcFail() error {
 	return nil
 }
 
+// Launch will call the inner resolver's launch method if the preimage can be
+// found, otherwise it's a no-op.
+func (h *htlcIncomingContestResolver) Launch() error {
+	// NOTE: we don't mark this resolver as launched as the inner resolver
+	// will set it when it's launched.
+	if h.launched {
+		h.log.Tracef("already launched")
+		return nil
+	}
+
+	h.log.Debugf("launching contest resolver...")
+
+	// Query the preimage and apply it if we already know it.
+	applied, err := h.findAndapplyPreimage()
+	if err != nil {
+		return err
+	}
+
+	// No preimage found, leave it to be handled by the resolver.
+	if !applied {
+		return nil
+	}
+
+	h.log.Debugf("found preimage for htlc=%x,  transforming into success "+
+		"resolver and launching it", h.htlc.RHash)
+
+	// Once we've applied the preimage, we'll launch the inner resolver to
+	// attempt to claim the HTLC.
+	return h.htlcSuccessResolver.Launch()
+}
+
 // Resolve attempts to resolve this contract. As we don't yet know of the
 // preimage for the contract, we'll wait for one of two things to happen:
 //
@@ -94,6 +125,7 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 	// If we're already full resolved, then we don't have anything further
 	// to do.
 	if h.resolved {
+		h.log.Errorf("already resolved")
 		return nil, nil
 	}
 
@@ -101,8 +133,7 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 	// now.
 	payload, nextHopOnionBlob, err := h.decodePayload()
 	if err != nil {
-		log.Debugf("ChannelArbitrator(%v): cannot decode payload of "+
-			"htlc %v", h.ChanPoint, h.HtlcPoint())
+		h.log.Debugf("cannot decode payload of htlc %v", h.HtlcPoint())
 
 		// If we've locked in an htlc with an invalid payload on our
 		// commitment tx, we don't need to resolve it. The other party
@@ -177,65 +208,6 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 		return nil, h.Checkpoint(h, report)
 	}
 
-	// applyPreimage is a helper function that will populate our internal
-	// resolver with the preimage we learn of. This should be called once
-	// the preimage is revealed so the inner resolver can properly complete
-	// its duties. The error return value indicates whether the preimage
-	// was properly applied.
-	applyPreimage := func(preimage lntypes.Preimage) error {
-		// Sanity check to see if this preimage matches our htlc. At
-		// this point it should never happen that it does not match.
-		if !preimage.Matches(h.htlc.RHash) {
-			return errors.New("preimage does not match hash")
-		}
-
-		// Update htlcResolution with the matching preimage.
-		h.htlcResolution.Preimage = preimage
-
-		log.Infof("%T(%v): applied preimage=%v", h,
-			h.htlcResolution.ClaimOutpoint, preimage)
-
-		isSecondLevel := h.htlcResolution.SignedSuccessTx != nil
-
-		// If we didn't have to go to the second level to claim (this
-		// is the remote commitment transaction), then we don't need to
-		// modify our canned witness.
-		if !isSecondLevel {
-			return nil
-		}
-
-		isTaproot := txscript.IsPayToTaproot(
-			h.htlcResolution.SignedSuccessTx.TxOut[0].PkScript,
-		)
-
-		// If this is our commitment transaction, then we'll need to
-		// populate the witness for the second-level HTLC transaction.
-		switch {
-		// For taproot channels, the witness for sweeping with success
-		// looks like:
-		//   - <sender sig> <receiver sig> <preimage> <success_script>
-		//     <control_block>
-		//
-		// So we'll insert it at the 3rd index of the witness.
-		case isTaproot:
-			//nolint:ll
-			h.htlcResolution.SignedSuccessTx.TxIn[0].Witness[2] = preimage[:]
-
-		// Within the witness for the success transaction, the
-		// preimage is the 4th element as it looks like:
-		//
-		//  * <0> <sender sig> <recvr sig> <preimage> <witness script>
-		//
-		// We'll populate it within the witness, as since this
-		// was a "contest" resolver, we didn't yet know of the
-		// preimage.
-		case !isTaproot:
-			h.htlcResolution.SignedSuccessTx.TxIn[0].Witness[3] = preimage[:]
-		}
-
-		return nil
-	}
-
 	// Define a closure to process htlc resolutions either directly or
 	// triggered by future notifications.
 	processHtlcResolution := func(e invoices.HtlcResolution) (
@@ -247,7 +219,7 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 		// If the htlc resolution was a settle, apply the
 		// preimage and return a success resolver.
 		case *invoices.HtlcSettleResolution:
-			err := applyPreimage(resolution.Preimage)
+			err := h.applyPreimage(resolution.Preimage)
 			if err != nil {
 				return nil, err
 			}
@@ -312,6 +284,9 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 			return nil, err
 		}
 
+		h.log.Debugf("received resolution from registry: %v",
+			resolution)
+
 		defer func() {
 			h.Registry.HodlUnsubscribeAll(hodlQueue.ChanIn())
 
@@ -369,7 +344,9 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 			// However, we don't know how to ourselves, so we'll
 			// return our inner resolver which has the knowledge to
 			// do so.
-			if err := applyPreimage(preimage); err != nil {
+			h.log.Debugf("Found preimage for htlc=%x", h.htlc.RHash)
+
+			if err := h.applyPreimage(preimage); err != nil {
 				return nil, err
 			}
 
@@ -388,7 +365,10 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 				continue
 			}
 
-			if err := applyPreimage(preimage); err != nil {
+			h.log.Debugf("Received preimage for htlc=%x",
+				h.htlc.RHash)
+
+			if err := h.applyPreimage(preimage); err != nil {
 				return nil, err
 			}
 
@@ -435,6 +415,76 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 	}
 }
 
+// applyPreimage is a helper function that will populate our internal resolver
+// with the preimage we learn of. This should be called once the preimage is
+// revealed so the inner resolver can properly complete its duties. The error
+// return value indicates whether the preimage was properly applied.
+func (h *htlcIncomingContestResolver) applyPreimage(
+	preimage lntypes.Preimage) error {
+
+	// Sanity check to see if this preimage matches our htlc. At this point
+	// it should never happen that it does not match.
+	if !preimage.Matches(h.htlc.RHash) {
+		return errors.New("preimage does not match hash")
+	}
+
+	// We may already have the preimage since both the `Launch` and
+	// `Resolve` methods will look for it.
+	if h.htlcResolution.Preimage != lntypes.ZeroHash {
+		h.log.Debugf("already applied preimage for htlc=%x",
+			h.htlc.RHash)
+
+		return nil
+	}
+
+	// Update htlcResolution with the matching preimage.
+	h.htlcResolution.Preimage = preimage
+
+	log.Infof("%T(%v): applied preimage=%v", h,
+		h.htlcResolution.ClaimOutpoint, preimage)
+
+	isSecondLevel := h.htlcResolution.SignedSuccessTx != nil
+
+	// If we didn't have to go to the second level to claim (this
+	// is the remote commitment transaction), then we don't need to
+	// modify our canned witness.
+	if !isSecondLevel {
+		return nil
+	}
+
+	isTaproot := txscript.IsPayToTaproot(
+		h.htlcResolution.SignedSuccessTx.TxOut[0].PkScript,
+	)
+
+	// If this is our commitment transaction, then we'll need to
+	// populate the witness for the second-level HTLC transaction.
+	switch {
+	// For taproot channels, the witness for sweeping with success
+	// looks like:
+	//   - <sender sig> <receiver sig> <preimage> <success_script>
+	//     <control_block>
+	//
+	// So we'll insert it at the 3rd index of the witness.
+	case isTaproot:
+		//nolint:ll
+		h.htlcResolution.SignedSuccessTx.TxIn[0].Witness[2] = preimage[:]
+
+	// Within the witness for the success transaction, the
+	// preimage is the 4th element as it looks like:
+	//
+	//  * <0> <sender sig> <recvr sig> <preimage> <witness script>
+	//
+	// We'll populate it within the witness, as since this
+	// was a "contest" resolver, we didn't yet know of the
+	// preimage.
+	case !isTaproot:
+		//nolint:ll
+		h.htlcResolution.SignedSuccessTx.TxIn[0].Witness[3] = preimage[:]
+	}
+
+	return nil
+}
+
 // report returns a report on the resolution state of the contract.
 func (h *htlcIncomingContestResolver) report() *ContractReport {
 	// No locking needed as these values are read-only.
@@ -461,6 +511,8 @@ func (h *htlcIncomingContestResolver) report() *ContractReport {
 //
 // NOTE: Part of the ContractResolver interface.
 func (h *htlcIncomingContestResolver) Stop() {
+	h.log.Debugf("stopping...")
+	defer h.log.Debugf("stopped")
 	close(h.quit)
 }
 
@@ -560,3 +612,82 @@ func (h *htlcIncomingContestResolver) decodePayload() (*hop.Payload,
 // A compile time assertion to ensure htlcIncomingContestResolver meets the
 // ContractResolver interface.
 var _ htlcContractResolver = (*htlcIncomingContestResolver)(nil)
+
+// findAndapplyPreimage performs a non-blocking read to find the preimage for
+// the incoming HTLC. If found, it will be applied to the resolver. This method
+// is used for the resolver to decide whether it wants to transform into a
+// success resolver during launching.
+//
+// NOTE: Since we have two places to query the preimage, we need to check both
+// the preimage db and the invoice db to look up the preimage.
+func (h *htlcIncomingContestResolver) findAndapplyPreimage() (bool, error) {
+	// Query to see if we already know the preimage.
+	preimage, ok := h.PreimageDB.LookupPreimage(h.htlc.RHash)
+
+	// If the preimage is known, we'll apply it.
+	if ok {
+		if err := h.applyPreimage(preimage); err != nil {
+			return false, err
+		}
+
+		// Successfully applied the preimage, we can now return.
+		return true, nil
+	}
+
+	// First try to parse the payload.
+	payload, _, err := h.decodePayload()
+	if err != nil {
+		h.log.Errorf("Cannot decode payload of htlc %v", h.HtlcPoint())
+
+		// If we cannot decode the payload, we will return a nil error
+		// and let it to be handled in `Resolve`.
+		return false, nil
+	}
+
+	// Exit early if this is not the exit hop, which means we are not the
+	// payment receiver and don't have preimage.
+	if payload.FwdInfo.NextHop != hop.Exit {
+		return false, nil
+	}
+
+	// Notify registry that we are potentially resolving as an exit hop
+	// on-chain. If this HTLC indeed pays to an existing invoice, the
+	// invoice registry will tell us what to do with the HTLC. This is
+	// identical to HTLC resolution in the link.
+	circuitKey := models.CircuitKey{
+		ChanID: h.ShortChanID,
+		HtlcID: h.htlc.HtlcIndex,
+	}
+
+	// Try get the resolution - if it doesn't give us a resolution
+	// immediately, we'll assume we don't know it yet and let the `Resolve`
+	// handle the waiting.
+	//
+	// NOTE: we use a nil subscriber here and a zero current height as we
+	// are only interested in the settle resolution.
+	//
+	// TODO(yy): move this logic to link and let the preimage be accessed
+	// via the preimage beacon.
+	resolution, err := h.Registry.NotifyExitHopHtlc(
+		h.htlc.RHash, h.htlc.Amt, h.htlcExpiry, 0,
+		circuitKey, nil, nil, payload,
+	)
+	if err != nil {
+		return false, err
+	}
+
+	res, ok := resolution.(*invoices.HtlcSettleResolution)
+
+	// Exit early if it's not a settle resolution.
+	if !ok {
+		return false, nil
+	}
+
+	// Otherwise we have a settle resolution, apply the preimage.
+	err = h.applyPreimage(res.Preimage)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -124,7 +124,7 @@ func (h *htlcIncomingContestResolver) Launch() error {
 func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 	// If we're already full resolved, then we don't have anything further
 	// to do.
-	if h.resolved {
+	if h.IsResolved() {
 		h.log.Errorf("already resolved")
 		return nil, nil
 	}
@@ -140,7 +140,7 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 		// will time it out and get their funds back. This situation
 		// can present itself when we crash before processRemoteAdds in
 		// the link has ran.
-		h.resolved = true
+		h.markResolved()
 
 		if err := h.processFinalHtlcFail(); err != nil {
 			return nil, err
@@ -193,7 +193,7 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 		log.Infof("%T(%v): HTLC has timed out (expiry=%v, height=%v), "+
 			"abandoning", h, h.htlcResolution.ClaimOutpoint,
 			h.htlcExpiry, currentHeight)
-		h.resolved = true
+		h.markResolved()
 
 		if err := h.processFinalHtlcFail(); err != nil {
 			return nil, err
@@ -234,7 +234,7 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 				h.htlcResolution.ClaimOutpoint,
 				h.htlcExpiry, currentHeight)
 
-			h.resolved = true
+			h.markResolved()
 
 			if err := h.processFinalHtlcFail(); err != nil {
 				return nil, err
@@ -395,7 +395,8 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 					"(expiry=%v, height=%v), abandoning", h,
 					h.htlcResolution.ClaimOutpoint,
 					h.htlcExpiry, currentHeight)
-				h.resolved = true
+
+				h.markResolved()
 
 				if err := h.processFinalHtlcFail(); err != nil {
 					return nil, err
@@ -514,14 +515,6 @@ func (h *htlcIncomingContestResolver) Stop() {
 	h.log.Debugf("stopping...")
 	defer h.log.Debugf("stopped")
 	close(h.quit)
-}
-
-// IsResolved returns true if the stored state in the resolve is fully
-// resolved. In this case the target output can be forgotten.
-//
-// NOTE: Part of the ContractResolver interface.
-func (h *htlcIncomingContestResolver) IsResolved() bool {
-	return h.resolved
 }
 
 // Encode writes an encoded version of the ContractResolver into the passed

--- a/contractcourt/htlc_outgoing_contest_resolver.go
+++ b/contractcourt/htlc_outgoing_contest_resolver.go
@@ -155,7 +155,14 @@ func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 			// fail.
 			newHeight := uint32(newBlock.Height)
 			expiry := h.htlcResolution.Expiry
-			if newHeight >= expiry {
+
+			// Check if the expiry height is about to be reached.
+			// We offer this HTLC one block earlier to make sure
+			// when the next block arrives, the sweeper will pick
+			// up this input and sweep it immediately. The sweeper
+			// will handle the waiting for the one last block till
+			// expiry.
+			if newHeight >= expiry-1 {
 				h.log.Infof("HTLC about to expire "+
 					"(height=%v, expiry=%v), transforming "+
 					"into timeout resolver", h,

--- a/contractcourt/htlc_outgoing_contest_resolver.go
+++ b/contractcourt/htlc_outgoing_contest_resolver.go
@@ -40,7 +40,7 @@ func newOutgoingContestResolver(res lnwallet.OutgoingHtlcResolution,
 func (h *htlcOutgoingContestResolver) Launch() error {
 	// NOTE: we don't mark this resolver as launched as the inner resolver
 	// will set it when it's launched.
-	if h.launched {
+	if h.isLaunched() {
 		h.log.Tracef("already launched")
 		return nil
 	}

--- a/contractcourt/htlc_outgoing_contest_resolver.go
+++ b/contractcourt/htlc_outgoing_contest_resolver.go
@@ -1,7 +1,6 @@
 package contractcourt
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -36,6 +35,37 @@ func newOutgoingContestResolver(res lnwallet.OutgoingHtlcResolution,
 	}
 }
 
+// Launch will call the inner resolver's launch method if the expiry height has
+// been reached, otherwise it's a no-op.
+func (h *htlcOutgoingContestResolver) Launch() error {
+	// NOTE: we don't mark this resolver as launched as the inner resolver
+	// will set it when it's launched.
+	if h.launched {
+		h.log.Tracef("already launched")
+		return nil
+	}
+
+	h.log.Debugf("launching contest resolver...")
+
+	_, bestHeight, err := h.ChainIO.GetBestBlock()
+	if err != nil {
+		return err
+	}
+
+	if uint32(bestHeight) < h.htlcResolution.Expiry {
+		return nil
+	}
+
+	// If the current height is >= expiry, then a timeout path spend will
+	// be valid to be included in the next block, and we can immediately
+	// return the resolver.
+	h.log.Infof("expired (height=%v, expiry=%v), transforming into "+
+		"timeout resolver and launching it", bestHeight,
+		h.htlcResolution.Expiry)
+
+	return h.htlcTimeoutResolver.Launch()
+}
+
 // Resolve commences the resolution of this contract. As this contract hasn't
 // yet timed out, we'll wait for one of two things to happen
 //
@@ -53,6 +83,7 @@ func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 	// If we're already full resolved, then we don't have anything further
 	// to do.
 	if h.resolved {
+		h.log.Errorf("already resolved")
 		return nil, nil
 	}
 
@@ -86,7 +117,6 @@ func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 			return nil, errResolverShuttingDown
 		}
 
-		// TODO(roasbeef): Checkpoint?
 		return nil, h.claimCleanUp(commitSpend)
 
 	// If it hasn't, then we'll watch for both the expiration, and the
@@ -124,12 +154,14 @@ func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 			// finalized` will be returned and the broadcast will
 			// fail.
 			newHeight := uint32(newBlock.Height)
-			if newHeight >= h.htlcResolution.Expiry {
-				log.Infof("%T(%v): HTLC has expired "+
+			expiry := h.htlcResolution.Expiry
+			if newHeight >= expiry {
+				h.log.Infof("HTLC about to expire "+
 					"(height=%v, expiry=%v), transforming "+
 					"into timeout resolver", h,
 					h.htlcResolution.ClaimOutpoint,
 					newHeight, h.htlcResolution.Expiry)
+
 				return h.htlcTimeoutResolver, nil
 			}
 
@@ -147,7 +179,7 @@ func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 			return nil, h.claimCleanUp(commitSpend)
 
 		case <-h.quit:
-			return nil, fmt.Errorf("resolver canceled")
+			return nil, errResolverShuttingDown
 		}
 	}
 }
@@ -178,6 +210,8 @@ func (h *htlcOutgoingContestResolver) report() *ContractReport {
 //
 // NOTE: Part of the ContractResolver interface.
 func (h *htlcOutgoingContestResolver) Stop() {
+	h.log.Debugf("stopping...")
+	defer h.log.Debugf("stopped")
 	close(h.quit)
 }
 

--- a/contractcourt/htlc_outgoing_contest_resolver.go
+++ b/contractcourt/htlc_outgoing_contest_resolver.go
@@ -82,7 +82,7 @@ func (h *htlcOutgoingContestResolver) Launch() error {
 func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 	// If we're already full resolved, then we don't have anything further
 	// to do.
-	if h.resolved {
+	if h.IsResolved() {
 		h.log.Errorf("already resolved")
 		return nil, nil
 	}
@@ -213,14 +213,6 @@ func (h *htlcOutgoingContestResolver) Stop() {
 	h.log.Debugf("stopping...")
 	defer h.log.Debugf("stopped")
 	close(h.quit)
-}
-
-// IsResolved returns true if the stored state in the resolve is fully
-// resolved. In this case the target output can be forgotten.
-//
-// NOTE: Part of the ContractResolver interface.
-func (h *htlcOutgoingContestResolver) IsResolved() bool {
-	return h.resolved
 }
 
 // Encode writes an encoded version of the ContractResolver into the passed

--- a/contractcourt/htlc_outgoing_contest_resolver.go
+++ b/contractcourt/htlc_outgoing_contest_resolver.go
@@ -87,7 +87,7 @@ func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 		}
 
 		// TODO(roasbeef): Checkpoint?
-		return h.claimCleanUp(commitSpend)
+		return nil, h.claimCleanUp(commitSpend)
 
 	// If it hasn't, then we'll watch for both the expiration, and the
 	// sweeping out this output.
@@ -144,7 +144,7 @@ func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 			// party is by revealing the preimage. So we'll perform
 			// our duties to clean up the contract once it has been
 			// claimed.
-			return h.claimCleanUp(commitSpend)
+			return nil, h.claimCleanUp(commitSpend)
 
 		case <-h.quit:
 			return nil, fmt.Errorf("resolver canceled")

--- a/contractcourt/htlc_outgoing_contest_resolver_test.go
+++ b/contractcourt/htlc_outgoing_contest_resolver_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -159,6 +160,7 @@ func newOutgoingResolverTestContext(t *testing.T) *outgoingResolverTestContext {
 
 				return nil
 			},
+			ChainIO: &mock.ChainIO{},
 		},
 		PutResolverReport: func(_ kvdb.RwTx,
 			_ *channeldb.ResolverReport) error {
@@ -195,6 +197,7 @@ func newOutgoingResolverTestContext(t *testing.T) *outgoingResolverTestContext {
 			},
 		},
 	}
+	resolver.initLogger("htlcOutgoingContestResolver")
 
 	return &outgoingResolverTestContext{
 		resolver:       resolver,
@@ -209,6 +212,9 @@ func (i *outgoingResolverTestContext) resolve() {
 	// Start resolver.
 	i.resolverResultChan = make(chan resolveResult, 1)
 	go func() {
+		err := i.resolver.Launch()
+		require.NoError(i.t, err)
+
 		nextResolver, err := i.resolver.Resolve()
 		i.resolverResultChan <- resolveResult{
 			nextResolver: nextResolver,

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -140,27 +140,7 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 
 	// To wrap this up, we'll wait until the second-level transaction has
 	// been spent, then fully resolve the contract.
-	log.Infof("%T(%x): waiting for second-level HTLC output to be spent "+
-		"after csv_delay=%v", h, h.htlc.RHash[:], h.htlcResolution.CsvDelay)
-
-	spend, err := waitForSpend(
-		secondLevelOutpoint,
-		h.htlcResolution.SweepSignDesc.Output.PkScript,
-		h.broadcastHeight, h.Notifier, h.quit,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	h.reportLock.Lock()
-	h.currentReport.RecoveredBalance = h.currentReport.LimboBalance
-	h.currentReport.LimboBalance = 0
-	h.reportLock.Unlock()
-
-	h.resolved = true
-	return nil, h.checkpointClaim(
-		spend.SpenderTxHash, channeldb.ResolverOutcomeClaimed,
-	)
+	return nil, h.resolveSuccessTxOutput(*secondLevelOutpoint)
 }
 
 // broadcastSuccessTx handles an HTLC output on our local commitment by
@@ -187,38 +167,9 @@ func (h *htlcSuccessResolver) broadcastSuccessTx() (
 
 	// We'll now broadcast the second layer transaction so we can kick off
 	// the claiming process.
-	//
-	// TODO(roasbeef): after changing sighashes send to tx bundler
-	label := labels.MakeLabel(
-		labels.LabelTypeChannelClose, &h.ShortChanID,
-	)
-	err := h.PublishTx(h.htlcResolution.SignedSuccessTx, label)
+	err := h.resolveLegacySuccessTx()
 	if err != nil {
 		return nil, err
-	}
-
-	// Otherwise, this is an output on our commitment transaction. In this
-	// case, we'll send it to the incubator, but only if we haven't already
-	// done so.
-	if !h.outputIncubating {
-		log.Infof("%T(%x): incubating incoming htlc output",
-			h, h.htlc.RHash[:])
-
-		err := h.IncubateOutputs(
-			h.ChanPoint, fn.None[lnwallet.OutgoingHtlcResolution](),
-			fn.Some(h.htlcResolution),
-			h.broadcastHeight, fn.Some(int32(h.htlc.RefundTimeout)),
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		h.outputIncubating = true
-
-		if err := h.Checkpoint(h); err != nil {
-			log.Errorf("unable to Checkpoint: %v", err)
-			return nil, err
-		}
 	}
 
 	return &h.htlcResolution.ClaimOutpoint, nil
@@ -242,33 +193,25 @@ func (h *htlcSuccessResolver) broadcastReSignedSuccessTx() (*wire.OutPoint,
 			return nil, err
 		}
 
-		log.Infof("%T(%x): waiting for second-level HTLC success "+
-			"transaction to confirm", h, h.htlc.RHash[:])
-
-		// Wait for the second level transaction to confirm.
-		commitSpend, err = waitForSpend(
-			&h.htlcResolution.SignedSuccessTx.TxIn[0].PreviousOutPoint,
-			h.htlcResolution.SignDetails.SignDesc.Output.PkScript,
-			h.broadcastHeight, h.Notifier, h.quit,
-		)
+		err = h.resolveSuccessTx()
 		if err != nil {
 			return nil, err
 		}
-
-		// Now that the second-level transaction has confirmed, we
-		// checkpoint the state so we'll go to the next stage in case
-		// of restarts.
-		h.outputIncubating = true
-		if err := h.Checkpoint(h); err != nil {
-			log.Errorf("unable to Checkpoint: %v", err)
-			return nil, err
-		}
-
-		log.Infof("%T(%x): second-level HTLC success transaction "+
-			"confirmed!", h, h.htlc.RHash[:])
 	}
 
-	err := h.sweepSuccessTxOutput()
+	// This should be non-blocking as we will only attempt to sweep the
+	// output when the second level tx has already been confirmed. In other
+	// words, waitForSpend will return immediately.
+	commitSpend, err := waitForSpend(
+		&h.htlcResolution.SignedSuccessTx.TxIn[0].PreviousOutPoint,
+		h.htlcResolution.SignDetails.SignDesc.Output.PkScript,
+		h.broadcastHeight, h.Notifier, h.quit,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	err = h.sweepSuccessTxOutput()
 	if err != nil {
 		return nil, err
 	}
@@ -304,23 +247,14 @@ func (h *htlcSuccessResolver) resolveRemoteCommitOutput() (
 		return nil, err
 	}
 
-	// Once the transaction has received a sufficient number of
-	// confirmations, we'll mark ourselves as fully resolved and exit.
-	h.resolved = true
-
 	// Checkpoint the resolver, and write the outcome to disk.
-	return nil, h.checkpointClaim(
-		sweepTxDetails.SpenderTxHash,
-		channeldb.ResolverOutcomeClaimed,
-	)
+	return nil, h.checkpointClaim(sweepTxDetails.SpenderTxHash)
 }
 
 // checkpointClaim checkpoints the success resolver with the reports it needs.
 // If this htlc was claimed two stages, it will write reports for both stages,
 // otherwise it will just write for the single htlc claim.
-func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash,
-	outcome channeldb.ResolverOutcome) error {
-
+func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash) error {
 	// Mark the htlc as final settled.
 	err := h.ChainArbitratorConfig.PutFinalHtlcOutcome(
 		h.ChannelArbitratorConfig.ShortChanID, h.htlc.HtlcIndex, true,
@@ -348,7 +282,7 @@ func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash,
 			OutPoint:        h.htlcResolution.ClaimOutpoint,
 			Amount:          amt,
 			ResolverType:    channeldb.ResolverTypeIncomingHtlc,
-			ResolverOutcome: outcome,
+			ResolverOutcome: channeldb.ResolverOutcomeClaimed,
 			SpendTxID:       spendTx,
 		},
 	}
@@ -373,6 +307,7 @@ func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash,
 	}
 
 	// Finally, we checkpoint the resolver with our report(s).
+	h.resolved = true
 	return h.Checkpoint(h, reports...)
 }
 
@@ -747,4 +682,130 @@ func (h *htlcSuccessResolver) sweepSuccessTxOutput() error {
 	)
 
 	return err
+}
+
+// resolveLegacySuccessTx handles an HTLC output from a pre-anchor type channel
+// by broadcasting the second-level success transaction.
+func (h *htlcSuccessResolver) resolveLegacySuccessTx() error {
+	// Otherwise we'll publish the second-level transaction directly and
+	// offer the resolution to the nursery to handle.
+	h.log.Infof("broadcasting legacy second-level success tx: %v",
+		h.htlcResolution.SignedSuccessTx.TxHash())
+
+	// We'll now broadcast the second layer transaction so we can kick off
+	// the claiming process.
+	//
+	// TODO(yy): offer it to the sweeper instead.
+	label := labels.MakeLabel(
+		labels.LabelTypeChannelClose, &h.ShortChanID,
+	)
+	err := h.PublishTx(h.htlcResolution.SignedSuccessTx, label)
+	if err != nil {
+		return err
+	}
+
+	// Fast-forward to resolve the output from the success tx if the it has
+	// already been sent to the UtxoNursery.
+	if h.outputIncubating {
+		return h.resolveSuccessTxOutput(h.htlcResolution.ClaimOutpoint)
+	}
+
+	h.log.Infof("incubating incoming htlc output")
+
+	// Send the output to the incubator.
+	err = h.IncubateOutputs(
+		h.ChanPoint, fn.None[lnwallet.OutgoingHtlcResolution](),
+		fn.Some(h.htlcResolution),
+		h.broadcastHeight, fn.Some(int32(h.htlc.RefundTimeout)),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Mark the output as incubating and checkpoint it.
+	h.outputIncubating = true
+	if err := h.Checkpoint(h); err != nil {
+		return err
+	}
+
+	// Move to resolve the output.
+	return h.resolveSuccessTxOutput(h.htlcResolution.ClaimOutpoint)
+}
+
+// resolveSuccessTx waits for the sweeping tx of the second-level success tx to
+// confirm and offers the output from the success tx to the sweeper.
+func (h *htlcSuccessResolver) resolveSuccessTx() error {
+	h.log.Infof("waiting for 2nd-level HTLC success transaction to confirm")
+
+	// Create aliases to make the code more readable.
+	outpoint := h.htlcResolution.SignedSuccessTx.TxIn[0].PreviousOutPoint
+	pkScript := h.htlcResolution.SignDetails.SignDesc.Output.PkScript
+
+	// Wait for the second level transaction to confirm.
+	commitSpend, err := waitForSpend(
+		&outpoint, pkScript, h.broadcastHeight, h.Notifier, h.quit,
+	)
+	if err != nil {
+		return err
+	}
+
+	// We'll use this input index to determine the second-level output
+	// index on the transaction, as the signatures requires the indexes to
+	// be the same. We don't look for the second-level output script
+	// directly, as there might be more than one HTLC output to the same
+	// pkScript.
+	op := wire.OutPoint{
+		Hash:  *commitSpend.SpenderTxHash,
+		Index: commitSpend.SpenderInputIndex,
+	}
+
+	// If the 2nd-stage sweeping has already been started, we can
+	// fast-forward to start the resolving process for the stage two
+	// output.
+	if h.outputIncubating {
+		return h.resolveSuccessTxOutput(op)
+	}
+
+	// Now that the second-level transaction has confirmed, we checkpoint
+	// the state so we'll go to the next stage in case of restarts.
+	h.outputIncubating = true
+	if err := h.Checkpoint(h); err != nil {
+		log.Errorf("unable to Checkpoint: %v", err)
+		return err
+	}
+
+	h.log.Infof("2nd-level HTLC success tx=%v confirmed",
+		commitSpend.SpenderTxHash)
+
+	// Send the sweep request for the output from the success tx.
+	if err := h.sweepSuccessTxOutput(); err != nil {
+		return err
+	}
+
+	return h.resolveSuccessTxOutput(op)
+}
+
+// resolveSuccessTxOutput waits for the spend of the output from the 2nd-level
+// success tx.
+func (h *htlcSuccessResolver) resolveSuccessTxOutput(op wire.OutPoint) error {
+	// To wrap this up, we'll wait until the second-level transaction has
+	// been spent, then fully resolve the contract.
+	log.Infof("%T(%x): waiting for second-level HTLC output to be spent "+
+		"after csv_delay=%v", h, h.htlc.RHash[:],
+		h.htlcResolution.CsvDelay)
+
+	spend, err := waitForSpend(
+		&op, h.htlcResolution.SweepSignDesc.Output.PkScript,
+		h.broadcastHeight, h.Notifier, h.quit,
+	)
+	if err != nil {
+		return err
+	}
+
+	h.reportLock.Lock()
+	h.currentReport.RecoveredBalance = h.currentReport.LimboBalance
+	h.currentReport.LimboBalance = 0
+	h.reportLock.Unlock()
+
+	return h.checkpointClaim(spend.SpenderTxHash)
 }

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -730,13 +730,13 @@ func (h *htlcSuccessResolver) resolveSuccessTxOutput(op wire.OutPoint) error {
 // Launch creates an input based on the details of the incoming htlc resolution
 // and offers it to the sweeper.
 func (h *htlcSuccessResolver) Launch() error {
-	if h.launched {
+	if h.isLaunched() {
 		h.log.Tracef("already launched")
 		return nil
 	}
 
 	h.log.Debugf("launching resolver...")
-	h.launched = true
+	h.markLaunched()
 
 	switch {
 	// If we're already resolved, then we can exit early.

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -237,55 +237,7 @@ func (h *htlcSuccessResolver) broadcastReSignedSuccessTx() (*wire.OutPoint,
 	// We will have to let the sweeper re-sign the success tx and wait for
 	// it to confirm, if we haven't already.
 	if !h.outputIncubating {
-		var secondLevelInput input.HtlcSecondLevelAnchorInput
-		if h.isTaproot() {
-			//nolint:ll
-			secondLevelInput = input.MakeHtlcSecondLevelSuccessTaprootInput(
-				h.htlcResolution.SignedSuccessTx,
-				h.htlcResolution.SignDetails, h.htlcResolution.Preimage,
-				h.broadcastHeight,
-				input.WithResolutionBlob(
-					h.htlcResolution.ResolutionBlob,
-				),
-			)
-		} else {
-			//nolint:ll
-			secondLevelInput = input.MakeHtlcSecondLevelSuccessAnchorInput(
-				h.htlcResolution.SignedSuccessTx,
-				h.htlcResolution.SignDetails, h.htlcResolution.Preimage,
-				h.broadcastHeight,
-			)
-		}
-
-		// Calculate the budget for this sweep.
-		value := btcutil.Amount(
-			secondLevelInput.SignDesc().Output.Value,
-		)
-		budget := calculateBudget(
-			value, h.Budget.DeadlineHTLCRatio,
-			h.Budget.DeadlineHTLC,
-		)
-
-		// The deadline would be the CLTV in this HTLC output. If we
-		// are the initiator of this force close, with the default
-		// `IncomingBroadcastDelta`, it means we have 10 blocks left
-		// when going onchain. Given we need to mine one block to
-		// confirm the force close tx, and one more block to trigger
-		// the sweep, we have 8 blocks left to sweep the HTLC.
-		deadline := fn.Some(int32(h.htlc.RefundTimeout))
-
-		log.Infof("%T(%x): offering second-level HTLC success tx to "+
-			"sweeper with deadline=%v, budget=%v", h,
-			h.htlc.RHash[:], h.htlc.RefundTimeout, budget)
-
-		// We'll now offer the second-level transaction to the sweeper.
-		_, err := h.Sweeper.SweepInput(
-			&secondLevelInput,
-			sweep.Params{
-				Budget:         budget,
-				DeadlineHeight: deadline,
-			},
-		)
+		err := h.sweepSuccessTx()
 		if err != nil {
 			return nil, err
 		}
@@ -316,99 +268,18 @@ func (h *htlcSuccessResolver) broadcastReSignedSuccessTx() (*wire.OutPoint,
 			"confirmed!", h, h.htlc.RHash[:])
 	}
 
-	// If we ended up here after a restart, we must again get the
-	// spend notification.
-	if commitSpend == nil {
-		var err error
-		commitSpend, err = waitForSpend(
-			&h.htlcResolution.SignedSuccessTx.TxIn[0].PreviousOutPoint,
-			h.htlcResolution.SignDetails.SignDesc.Output.PkScript,
-			h.broadcastHeight, h.Notifier, h.quit,
-		)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// The HTLC success tx has a CSV lock that we must wait for, and if
-	// this is a lease enforced channel and we're the imitator, we may need
-	// to wait for longer.
-	waitHeight := h.deriveWaitHeight(
-		h.htlcResolution.CsvDelay, commitSpend,
-	)
-
-	// Now that the sweeper has broadcasted the second-level transaction,
-	// it has confirmed, and we have checkpointed our state, we'll sweep
-	// the second level output. We report the resolver has moved the next
-	// stage.
-	h.reportLock.Lock()
-	h.currentReport.Stage = 2
-	h.currentReport.MaturityHeight = waitHeight
-	h.reportLock.Unlock()
-
-	if h.hasCLTV() {
-		log.Infof("%T(%x): waiting for CSV and CLTV lock to "+
-			"expire at height %v", h, h.htlc.RHash[:],
-			waitHeight)
-	} else {
-		log.Infof("%T(%x): waiting for CSV lock to expire at "+
-			"height %v", h, h.htlc.RHash[:], waitHeight)
-	}
-
-	// We'll use this input index to determine the second-level output
-	// index on the transaction, as the signatures requires the indexes to
-	// be the same. We don't look for the second-level output script
-	// directly, as there might be more than one HTLC output to the same
-	// pkScript.
-	op := &wire.OutPoint{
-		Hash:  *commitSpend.SpenderTxHash,
-		Index: commitSpend.SpenderInputIndex,
-	}
-
-	// Let the sweeper sweep the second-level output now that the
-	// CSV/CLTV locks have expired.
-	var witType input.StandardWitnessType
-	if h.isTaproot() {
-		witType = input.TaprootHtlcAcceptedSuccessSecondLevel
-	} else {
-		witType = input.HtlcAcceptedSuccessSecondLevel
-	}
-	inp := h.makeSweepInput(
-		op, witType,
-		input.LeaseHtlcAcceptedSuccessSecondLevel,
-		&h.htlcResolution.SweepSignDesc,
-		h.htlcResolution.CsvDelay, uint32(commitSpend.SpendingHeight),
-		h.htlc.RHash, h.htlcResolution.ResolutionBlob,
-	)
-
-	// Calculate the budget for this sweep.
-	budget := calculateBudget(
-		btcutil.Amount(inp.SignDesc().Output.Value),
-		h.Budget.NoDeadlineHTLCRatio,
-		h.Budget.NoDeadlineHTLC,
-	)
-
-	log.Infof("%T(%x): offering second-level success tx output to sweeper "+
-		"with no deadline and budget=%v at height=%v", h,
-		h.htlc.RHash[:], budget, waitHeight)
-
-	// TODO(roasbeef): need to update above for leased types
-	_, err := h.Sweeper.SweepInput(
-		inp,
-		sweep.Params{
-			Budget: budget,
-
-			// For second level success tx, there's no rush to get
-			// it confirmed, so we use a nil deadline.
-			DeadlineHeight: fn.None[int32](),
-		},
-	)
+	err := h.sweepSuccessTxOutput()
 	if err != nil {
 		return nil, err
 	}
 
 	// Will return this outpoint, when this is spent the resolver is fully
 	// resolved.
+	op := &wire.OutPoint{
+		Hash:  *commitSpend.SpenderTxHash,
+		Index: commitSpend.SpenderInputIndex,
+	}
+
 	return op, nil
 }
 
@@ -418,53 +289,7 @@ func (h *htlcSuccessResolver) broadcastReSignedSuccessTx() (*wire.OutPoint,
 func (h *htlcSuccessResolver) resolveRemoteCommitOutput() (
 	ContractResolver, error) {
 
-	// Before we can craft out sweeping transaction, we need to
-	// create an input which contains all the items required to add
-	// this input to a sweeping transaction, and generate a
-	// witness.
-	var inp input.Input
-	if h.isTaproot() {
-		inp = lnutils.Ptr(input.MakeTaprootHtlcSucceedInput(
-			&h.htlcResolution.ClaimOutpoint,
-			&h.htlcResolution.SweepSignDesc,
-			h.htlcResolution.Preimage[:],
-			h.broadcastHeight,
-			h.htlcResolution.CsvDelay,
-			input.WithResolutionBlob(
-				h.htlcResolution.ResolutionBlob,
-			),
-		))
-	} else {
-		inp = lnutils.Ptr(input.MakeHtlcSucceedInput(
-			&h.htlcResolution.ClaimOutpoint,
-			&h.htlcResolution.SweepSignDesc,
-			h.htlcResolution.Preimage[:],
-			h.broadcastHeight,
-			h.htlcResolution.CsvDelay,
-		))
-	}
-
-	// Calculate the budget for this sweep.
-	budget := calculateBudget(
-		btcutil.Amount(inp.SignDesc().Output.Value),
-		h.Budget.DeadlineHTLCRatio,
-		h.Budget.DeadlineHTLC,
-	)
-
-	deadline := fn.Some(int32(h.htlc.RefundTimeout))
-
-	log.Infof("%T(%x): offering direct-preimage HTLC output to sweeper "+
-		"with deadline=%v, budget=%v", h, h.htlc.RHash[:],
-		h.htlc.RefundTimeout, budget)
-
-	// We'll now offer the direct preimage HTLC to the sweeper.
-	_, err := h.Sweeper.SweepInput(
-		inp,
-		sweep.Params{
-			Budget:         budget,
-			DeadlineHeight: deadline,
-		},
-	)
+	err := h.sweepRemoteCommitOutput()
 	if err != nil {
 		return nil, err
 	}
@@ -730,4 +555,196 @@ func (h *htlcSuccessResolver) isTaproot() bool {
 	return txscript.IsPayToTaproot(
 		h.htlcResolution.SweepSignDesc.Output.PkScript,
 	)
+}
+
+// sweepRemoteCommitOutput creates a sweep request to sweep the HTLC output on
+// the remote commitment via the direct preimage-spend.
+func (h *htlcSuccessResolver) sweepRemoteCommitOutput() error {
+	// Before we can craft out sweeping transaction, we need to create an
+	// input which contains all the items required to add this input to a
+	// sweeping transaction, and generate a witness.
+	var inp input.Input
+
+	if h.isTaproot() {
+		inp = lnutils.Ptr(input.MakeTaprootHtlcSucceedInput(
+			&h.htlcResolution.ClaimOutpoint,
+			&h.htlcResolution.SweepSignDesc,
+			h.htlcResolution.Preimage[:],
+			h.broadcastHeight,
+			h.htlcResolution.CsvDelay,
+			input.WithResolutionBlob(
+				h.htlcResolution.ResolutionBlob,
+			),
+		))
+	} else {
+		inp = lnutils.Ptr(input.MakeHtlcSucceedInput(
+			&h.htlcResolution.ClaimOutpoint,
+			&h.htlcResolution.SweepSignDesc,
+			h.htlcResolution.Preimage[:],
+			h.broadcastHeight,
+			h.htlcResolution.CsvDelay,
+		))
+	}
+
+	// Calculate the budget for this sweep.
+	budget := calculateBudget(
+		btcutil.Amount(inp.SignDesc().Output.Value),
+		h.Budget.DeadlineHTLCRatio,
+		h.Budget.DeadlineHTLC,
+	)
+
+	deadline := fn.Some(int32(h.htlc.RefundTimeout))
+
+	log.Infof("%T(%x): offering direct-preimage HTLC output to sweeper "+
+		"with deadline=%v, budget=%v", h, h.htlc.RHash[:],
+		h.htlc.RefundTimeout, budget)
+
+	// We'll now offer the direct preimage HTLC to the sweeper.
+	_, err := h.Sweeper.SweepInput(
+		inp,
+		sweep.Params{
+			Budget:         budget,
+			DeadlineHeight: deadline,
+		},
+	)
+
+	return err
+}
+
+// sweepSuccessTx attempts to sweep the second level success tx.
+func (h *htlcSuccessResolver) sweepSuccessTx() error {
+	var secondLevelInput input.HtlcSecondLevelAnchorInput
+	if h.isTaproot() {
+		secondLevelInput = input.MakeHtlcSecondLevelSuccessTaprootInput(
+			h.htlcResolution.SignedSuccessTx,
+			h.htlcResolution.SignDetails, h.htlcResolution.Preimage,
+			h.broadcastHeight, input.WithResolutionBlob(
+				h.htlcResolution.ResolutionBlob,
+			),
+		)
+	} else {
+		secondLevelInput = input.MakeHtlcSecondLevelSuccessAnchorInput(
+			h.htlcResolution.SignedSuccessTx,
+			h.htlcResolution.SignDetails, h.htlcResolution.Preimage,
+			h.broadcastHeight,
+		)
+	}
+
+	// Calculate the budget for this sweep.
+	value := btcutil.Amount(secondLevelInput.SignDesc().Output.Value)
+	budget := calculateBudget(
+		value, h.Budget.DeadlineHTLCRatio, h.Budget.DeadlineHTLC,
+	)
+
+	// The deadline would be the CLTV in this HTLC output. If we are the
+	// initiator of this force close, with the default
+	// `IncomingBroadcastDelta`, it means we have 10 blocks left when going
+	// onchain.
+	deadline := fn.Some(int32(h.htlc.RefundTimeout))
+
+	h.log.Infof("offering second-level HTLC success tx to sweeper with "+
+		"deadline=%v, budget=%v", h.htlc.RefundTimeout, budget)
+
+	// We'll now offer the second-level transaction to the sweeper.
+	_, err := h.Sweeper.SweepInput(
+		&secondLevelInput,
+		sweep.Params{
+			Budget:         budget,
+			DeadlineHeight: deadline,
+		},
+	)
+
+	return err
+}
+
+// sweepSuccessTxOutput attempts to sweep the output of the second level
+// success tx.
+func (h *htlcSuccessResolver) sweepSuccessTxOutput() error {
+	h.log.Debugf("sweeping output %v from 2nd-level HTLC success tx",
+		h.htlcResolution.ClaimOutpoint)
+
+	// This should be non-blocking as we will only attempt to sweep the
+	// output when the second level tx has already been confirmed. In other
+	// words, waitForSpend will return immediately.
+	commitSpend, err := waitForSpend(
+		&h.htlcResolution.SignedSuccessTx.TxIn[0].PreviousOutPoint,
+		h.htlcResolution.SignDetails.SignDesc.Output.PkScript,
+		h.broadcastHeight, h.Notifier, h.quit,
+	)
+	if err != nil {
+		return err
+	}
+
+	// The HTLC success tx has a CSV lock that we must wait for, and if
+	// this is a lease enforced channel and we're the imitator, we may need
+	// to wait for longer.
+	waitHeight := h.deriveWaitHeight(h.htlcResolution.CsvDelay, commitSpend)
+
+	// Now that the sweeper has broadcasted the second-level transaction,
+	// it has confirmed, and we have checkpointed our state, we'll sweep
+	// the second level output. We report the resolver has moved the next
+	// stage.
+	h.reportLock.Lock()
+	h.currentReport.Stage = 2
+	h.currentReport.MaturityHeight = waitHeight
+	h.reportLock.Unlock()
+
+	if h.hasCLTV() {
+		log.Infof("%T(%x): waiting for CSV and CLTV lock to expire at "+
+			"height %v", h, h.htlc.RHash[:], waitHeight)
+	} else {
+		log.Infof("%T(%x): waiting for CSV lock to expire at height %v",
+			h, h.htlc.RHash[:], waitHeight)
+	}
+
+	// We'll use this input index to determine the second-level output
+	// index on the transaction, as the signatures requires the indexes to
+	// be the same. We don't look for the second-level output script
+	// directly, as there might be more than one HTLC output to the same
+	// pkScript.
+	op := &wire.OutPoint{
+		Hash:  *commitSpend.SpenderTxHash,
+		Index: commitSpend.SpenderInputIndex,
+	}
+
+	// Let the sweeper sweep the second-level output now that the
+	// CSV/CLTV locks have expired.
+	var witType input.StandardWitnessType
+	if h.isTaproot() {
+		witType = input.TaprootHtlcAcceptedSuccessSecondLevel
+	} else {
+		witType = input.HtlcAcceptedSuccessSecondLevel
+	}
+	inp := h.makeSweepInput(
+		op, witType,
+		input.LeaseHtlcAcceptedSuccessSecondLevel,
+		&h.htlcResolution.SweepSignDesc,
+		h.htlcResolution.CsvDelay, uint32(commitSpend.SpendingHeight),
+		h.htlc.RHash, h.htlcResolution.ResolutionBlob,
+	)
+
+	// Calculate the budget for this sweep.
+	budget := calculateBudget(
+		btcutil.Amount(inp.SignDesc().Output.Value),
+		h.Budget.NoDeadlineHTLCRatio,
+		h.Budget.NoDeadlineHTLC,
+	)
+
+	log.Infof("%T(%x): offering second-level success tx output to sweeper "+
+		"with no deadline and budget=%v at height=%v", h,
+		h.htlc.RHash[:], budget, waitHeight)
+
+	// TODO(yy): use the result chan returned from SweepInput.
+	_, err = h.Sweeper.SweepInput(
+		inp,
+		sweep.Params{
+			Budget: budget,
+
+			// For second level success tx, there's no rush to get
+			// it confirmed, so we use a nil deadline.
+			DeadlineHeight: fn.None[int32](),
+		},
+	)
+
+	return err
 }

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -616,11 +616,11 @@ func runFromCheckpoint(t *testing.T, ctx *htlcResolverTestContext,
 
 		var resolved, incubating bool
 		if h, ok := resolver.(*htlcSuccessResolver); ok {
-			resolved = h.resolved
+			resolved = h.resolved.Load()
 			incubating = h.outputIncubating
 		}
 		if h, ok := resolver.(*htlcTimeoutResolver); ok {
-			resolved = h.resolved
+			resolved = h.resolved.Load()
 			incubating = h.outputIncubating
 		}
 

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -20,6 +21,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntest/mock"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
 )
 
 var testHtlcAmt = lnwire.MilliSatoshi(200000)
@@ -37,6 +39,15 @@ type htlcResolverTestContext struct {
 	finalHtlcOutcomeStored bool
 
 	t *testing.T
+}
+
+func newHtlcResolverTestContextFromReader(t *testing.T,
+	newResolver func(htlc channeldb.HTLC,
+		cfg ResolverConfig) ContractResolver) *htlcResolverTestContext {
+
+	ctx := newHtlcResolverTestContext(t, newResolver)
+
+	return ctx
 }
 
 func newHtlcResolverTestContext(t *testing.T,
@@ -133,6 +144,7 @@ func newHtlcResolverTestContext(t *testing.T,
 func (i *htlcResolverTestContext) resolve() {
 	// Start resolver.
 	i.resolverResultChan = make(chan resolveResult, 1)
+
 	go func() {
 		nextResolver, err := i.resolver.Resolve()
 		i.resolverResultChan <- resolveResult{
@@ -192,6 +204,7 @@ func TestHtlcSuccessSingleStage(t *testing.T) {
 				// sweeper.
 				details := &chainntnfs.SpendDetail{
 					SpendingTx:    sweepTx,
+					SpentOutPoint: &htlcOutpoint,
 					SpenderTxHash: &sweepTxid,
 				}
 				ctx.notifier.SpendChan <- details
@@ -215,8 +228,8 @@ func TestHtlcSuccessSingleStage(t *testing.T) {
 	)
 }
 
-// TestSecondStageResolution tests successful sweep of a second stage htlc
-// claim, going through the Nursery.
+// TestHtlcSuccessSecondStageResolution tests successful sweep of a second
+// stage htlc claim, going through the Nursery.
 func TestHtlcSuccessSecondStageResolution(t *testing.T) {
 	commitOutpoint := wire.OutPoint{Index: 2}
 	htlcOutpoint := wire.OutPoint{Index: 3}
@@ -279,6 +292,7 @@ func TestHtlcSuccessSecondStageResolution(t *testing.T) {
 
 				ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
 					SpendingTx:    sweepTx,
+					SpentOutPoint: &htlcOutpoint,
 					SpenderTxHash: &sweepHash,
 				}
 
@@ -302,6 +316,8 @@ func TestHtlcSuccessSecondStageResolution(t *testing.T) {
 // TestHtlcSuccessSecondStageResolutionSweeper test that a resolver with
 // non-nil SignDetails will offer the second-level transaction to the sweeper
 // for re-signing.
+//
+//nolint:ll
 func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 	commitOutpoint := wire.OutPoint{Index: 2}
 	htlcOutpoint := wire.OutPoint{Index: 3}
@@ -399,7 +415,20 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 				_ bool) error {
 
 				resolver := ctx.resolver.(*htlcSuccessResolver)
-				inp := <-resolver.Sweeper.(*mockSweeper).sweptInputs
+
+				var (
+					inp input.Input
+					ok  bool
+				)
+
+				select {
+				case inp, ok = <-resolver.Sweeper.(*mockSweeper).sweptInputs:
+					require.True(t, ok)
+
+				case <-time.After(1 * time.Second):
+					t.Fatal("expected input to be swept")
+				}
+
 				op := inp.OutPoint()
 				if op != commitOutpoint {
 					return fmt.Errorf("outpoint %v swept, "+
@@ -412,6 +441,7 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 					SpenderTxHash:     &reSignedHash,
 					SpenderInputIndex: 1,
 					SpendingHeight:    10,
+					SpentOutPoint:     &commitOutpoint,
 				}
 				return nil
 			},
@@ -434,13 +464,37 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 						SpenderTxHash:     &reSignedHash,
 						SpenderInputIndex: 1,
 						SpendingHeight:    10,
+						SpentOutPoint:     &commitOutpoint,
 					}
 				}
 
 				// We expect it to sweep the second-level
 				// transaction we notfied about above.
 				resolver := ctx.resolver.(*htlcSuccessResolver)
-				inp := <-resolver.Sweeper.(*mockSweeper).sweptInputs
+
+				// Mock `waitForSpend` to return the commit
+				// spend.
+				ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
+					SpendingTx:        reSignedSuccessTx,
+					SpenderTxHash:     &reSignedHash,
+					SpenderInputIndex: 1,
+					SpendingHeight:    10,
+					SpentOutPoint:     &commitOutpoint,
+				}
+
+				var (
+					inp input.Input
+					ok  bool
+				)
+
+				select {
+				case inp, ok = <-resolver.Sweeper.(*mockSweeper).sweptInputs:
+					require.True(t, ok)
+
+				case <-time.After(1 * time.Second):
+					t.Fatal("expected input to be swept")
+				}
+
 				op := inp.OutPoint()
 				exp := wire.OutPoint{
 					Hash:  reSignedHash,
@@ -457,6 +511,7 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 					SpendingTx:     sweepTx,
 					SpenderTxHash:  &sweepHash,
 					SpendingHeight: 14,
+					SpentOutPoint:  &op,
 				}
 
 				return nil
@@ -504,11 +559,14 @@ func testHtlcSuccess(t *testing.T, resolution lnwallet.IncomingHtlcResolution,
 	// for the next portion of the test.
 	ctx := newHtlcResolverTestContext(t,
 		func(htlc channeldb.HTLC, cfg ResolverConfig) ContractResolver {
-			return &htlcSuccessResolver{
+			r := &htlcSuccessResolver{
 				contractResolverKit: *newContractResolverKit(cfg),
 				htlc:                htlc,
 				htlcResolution:      resolution,
 			}
+			r.initLogger("htlcSuccessResolver")
+
+			return r
 		},
 	)
 
@@ -606,7 +664,12 @@ func runFromCheckpoint(t *testing.T, ctx *htlcResolverTestContext,
 
 		checkpointedState = append(checkpointedState, b.Bytes())
 		nextCheckpoint++
-		checkpointChan <- struct{}{}
+		select {
+		case checkpointChan <- struct{}{}:
+		case <-time.After(1 * time.Second):
+			t.Fatal("checkpoint timeout")
+		}
+
 		return nil
 	}
 
@@ -617,6 +680,8 @@ func runFromCheckpoint(t *testing.T, ctx *htlcResolverTestContext,
 	// preCheckpoint logic if needed.
 	resumed := true
 	for i, cp := range expectedCheckpoints {
+		t.Logf("Running checkpoint %d", i)
+
 		if cp.preCheckpoint != nil {
 			if err := cp.preCheckpoint(ctx, resumed); err != nil {
 				t.Fatalf("failure at stage %d: %v", i, err)
@@ -625,15 +690,15 @@ func runFromCheckpoint(t *testing.T, ctx *htlcResolverTestContext,
 		resumed = false
 
 		// Wait for the resolver to have checkpointed its state.
-		<-checkpointChan
+		select {
+		case <-checkpointChan:
+		case <-time.After(1 * time.Second):
+			t.Fatalf("resolver did not checkpoint at stage %d", i)
+		}
 	}
 
 	// Wait for the resolver to fully complete.
 	ctx.waitForResult()
-
-	if nextCheckpoint < len(expectedCheckpoints) {
-		t.Fatalf("not all checkpoints hit")
-	}
 
 	return checkpointedState
 }

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -146,6 +146,9 @@ func (i *htlcResolverTestContext) resolve() {
 	i.resolverResultChan = make(chan resolveResult, 1)
 
 	go func() {
+		err := i.resolver.Launch()
+		require.NoError(i.t, err)
+
 		nextResolver, err := i.resolver.Resolve()
 		i.resolverResultChan <- resolveResult{
 			nextResolver: nextResolver,

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -425,40 +425,25 @@ func checkSizeAndIndex(witness wire.TxWitness, size, index int) bool {
 func (h *htlcTimeoutResolver) Resolve() (ContractResolver, error) {
 	// If we're already resolved, then we can exit early.
 	if h.resolved {
+		h.log.Errorf("already resolved")
 		return nil, nil
 	}
 
-	// Start by spending the HTLC output, either by broadcasting the
-	// second-level timeout transaction, or directly if this is the remote
-	// commitment.
-	commitSpend, err := h.spendHtlcOutput()
-	if err != nil {
-		return nil, err
-	}
-
-	// If the spend reveals the pre-image, then we'll enter the clean up
-	// workflow to pass the pre-image back to the incoming link, add it to
-	// the witness cache, and exit.
-	if isPreimageSpend(
-		h.isTaproot(), commitSpend,
-		h.htlcResolution.SignedTimeoutTx != nil,
-	) {
-
-		log.Infof("%T(%v): HTLC has been swept with pre-image by "+
-			"remote party during timeout flow! Adding pre-image to "+
-			"witness cache", h, h.htlc.RHash[:],
-			h.htlcResolution.ClaimOutpoint)
-
-		return nil, h.claimCleanUp(commitSpend)
-	}
-
-	// Depending on whether this was a local or remote commit, we must
-	// handle the spending transaction accordingly.
+	// If this is an output on the remote party's commitment transaction,
+	// use the direct-spend path to sweep the htlc.
 	if h.isRemoteCommitOutput() {
 		return nil, h.resolveRemoteCommitOutput()
 	}
 
-	return nil, h.resolveTimeoutTx()
+	// If this is a zero-fee HTLC, we now handle the spend from our
+	// commitment transaction.
+	if h.isZeroFeeOutput() {
+		return nil, h.resolveTimeoutTx()
+	}
+
+	// If this is an output on our own commitment using pre-anchor channel
+	// type, we will let the utxo nursery handle it.
+	return nil, h.resolveSecondLevelTxLegacy()
 }
 
 // sweepTimeoutTx sends a second level timeout transaction to the sweeper.
@@ -521,11 +506,16 @@ func (h *htlcTimeoutResolver) resolveSecondLevelTxLegacy() error {
 
 	// The utxo nursery will take care of broadcasting the second-level
 	// timeout tx and sweeping its output once it confirms.
-	return h.IncubateOutputs(
+	err := h.IncubateOutputs(
 		h.ChanPoint, fn.Some(h.htlcResolution),
 		fn.None[lnwallet.IncomingHtlcResolution](),
 		h.broadcastHeight, h.incomingHTLCExpiryHeight,
 	)
+	if err != nil {
+		return err
+	}
+
+	return h.resolveTimeoutTx()
 }
 
 // sweepDirectHtlcOutput sends the direct spend of the HTLC output to the
@@ -581,53 +571,6 @@ func (h *htlcTimeoutResolver) sweepDirectHtlcOutput() error {
 	return nil
 }
 
-// spendHtlcOutput handles the initial spend of an HTLC output via the timeout
-// clause. If this is our local commitment, the second-level timeout TX will be
-// used to spend the output into the next stage. If this is the remote
-// commitment, the output will be swept directly without the timeout
-// transaction.
-func (h *htlcTimeoutResolver) spendHtlcOutput() (
-	*chainntnfs.SpendDetail, error) {
-
-	switch {
-	// If we have non-nil SignDetails, this means that have a 2nd level
-	// HTLC transaction that is signed using sighash SINGLE|ANYONECANPAY
-	// (the case for anchor type channels). In this case we can re-sign it
-	// and attach fees at will. We let the sweeper handle this job.
-	case h.isZeroFeeOutput() && !h.outputIncubating:
-		if err := h.sweepTimeoutTx(); err != nil {
-			log.Errorf("Sending timeout tx to sweeper: %v", err)
-
-			return nil, err
-		}
-
-	// If this is a remote commitment there's no second level timeout txn,
-	// and we can just send this directly to the sweeper.
-	case h.isRemoteCommitOutput() && !h.outputIncubating:
-		if err := h.sweepDirectHtlcOutput(); err != nil {
-			log.Errorf("Sending direct spend to sweeper: %v", err)
-
-			return nil, err
-		}
-
-	// If we have a SignedTimeoutTx but no SignDetails, this is a local
-	// commitment for a non-anchor channel, so we'll send it to the utxo
-	// nursery.
-	case h.isLegacyOutput() && !h.outputIncubating:
-		if err := h.resolveSecondLevelTxLegacy(); err != nil {
-			log.Errorf("Sending timeout tx to nursery: %v", err)
-
-			return nil, err
-		}
-	}
-
-	// Now that we've handed off the HTLC to the nursery or sweeper, we'll
-	// watch for a spend of the output, and make our next move off of that.
-	// Depending on if this is our commitment, or the remote party's
-	// commitment, we'll be watching a different outpoint and script.
-	return h.watchHtlcSpend()
-}
-
 // watchHtlcSpend watches for a spend of the HTLC output. For neutrino backend,
 // it will check blocks for the confirmed spend. For btcd and bitcoind, it will
 // check both the mempool and the blocks.
@@ -673,6 +616,9 @@ func (h *htlcTimeoutResolver) waitForConfirmedSpend(op *wire.OutPoint,
 //
 // NOTE: Part of the ContractResolver interface.
 func (h *htlcTimeoutResolver) Stop() {
+	h.log.Debugf("stopping...")
+	defer h.log.Debugf("stopped")
+
 	close(h.quit)
 }
 
@@ -1018,15 +964,6 @@ func (h *htlcTimeoutResolver) isZeroFeeOutput() bool {
 		h.htlcResolution.SignDetails != nil
 }
 
-// isLegacyOutput returns a boolean indicating whether the htlc output is from
-// a non-anchor-enabled channel.
-func (h *htlcTimeoutResolver) isLegacyOutput() bool {
-	// If we have a SignedTimeoutTx but no SignDetails, this is a local
-	// commitment for a non-anchor channel.
-	return h.htlcResolution.SignedTimeoutTx != nil &&
-		h.htlcResolution.SignDetails == nil
-}
-
 // waitHtlcSpendAndCheckPreimage waits for the htlc output to be spent and
 // checks whether the spending reveals the preimage. If the preimage is found,
 // it will be added to the preimage beacon to settle the incoming link, and a
@@ -1296,9 +1233,11 @@ func (h *htlcTimeoutResolver) resolveTimeoutTx() error {
 	h.log.Infof("2nd-level HTLC timeout tx=%v confirmed", spenderTxid)
 
 	// Start the process to sweep the output from the timeout tx.
-	err = h.sweepTimeoutTxOutput()
-	if err != nil {
-		return err
+	if h.isZeroFeeOutput() {
+		err = h.sweepTimeoutTxOutput()
+		if err != nil {
+			return err
+		}
 	}
 
 	// Create a checkpoint since the timeout tx is confirmed and the sweep
@@ -1331,4 +1270,53 @@ func (h *htlcTimeoutResolver) resolveTimeoutTxOutput(op wire.OutPoint) error {
 	h.reportLock.Unlock()
 
 	return h.checkpointClaim(spend)
+}
+
+// Launch creates an input based on the details of the outgoing htlc resolution
+// and offers it to the sweeper.
+func (h *htlcTimeoutResolver) Launch() error {
+	if h.launched {
+		h.log.Tracef("already launched")
+		return nil
+	}
+
+	h.log.Debugf("launching resolver...")
+	h.launched = true
+
+	switch {
+	// If we're already resolved, then we can exit early.
+	case h.resolved:
+		h.log.Errorf("already resolved")
+		return nil
+
+	// If this is an output on the remote party's commitment transaction,
+	// use the direct timeout spend path.
+	//
+	// NOTE: When the outputIncubating is false, it means that the output
+	// has been offered to the utxo nursery as starting in 0.18.4, we
+	// stopped marking this flag for direct timeout spends (#9062). In that
+	// case, we will do nothing and let the utxo nursery handle it.
+	case h.isRemoteCommitOutput() && !h.outputIncubating:
+		return h.sweepDirectHtlcOutput()
+
+	// If this is an anchor type channel, we now sweep either the
+	// second-level timeout tx or the output from the second-level timeout
+	// tx.
+	case h.isZeroFeeOutput():
+		// If the second-level timeout tx has already been swept, we
+		// can go ahead and sweep its output.
+		if h.outputIncubating {
+			return h.sweepTimeoutTxOutput()
+		}
+
+		// Otherwise, sweep the second level tx.
+		return h.sweepTimeoutTx()
+
+	// If this is an output on our own commitment using pre-anchor channel
+	// type, we will let the utxo nursery handle it via Resolve.
+	//
+	// TODO(yy): handle the legacy output by offering it to the sweeper.
+	default:
+		return nil
+	}
 }

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -548,9 +548,9 @@ func (h *htlcTimeoutResolver) sweepSecondLevelTx() error {
 	return err
 }
 
-// sendSecondLevelTxLegacy sends a second level timeout transaction to the utxo
-// nursery. This transaction uses the legacy SIGHASH_ALL flag.
-func (h *htlcTimeoutResolver) sendSecondLevelTxLegacy() error {
+// resolveSecondLevelTxLegacy sends a second level timeout transaction to the
+// utxo nursery. This transaction uses the legacy SIGHASH_ALL flag.
+func (h *htlcTimeoutResolver) resolveSecondLevelTxLegacy() error {
 	log.Debugf("%T(%v): incubating htlc output", h,
 		h.htlcResolution.ClaimOutpoint)
 
@@ -654,7 +654,7 @@ func (h *htlcTimeoutResolver) spendHtlcOutput() (
 	// commitment for a non-anchor channel, so we'll send it to the utxo
 	// nursery.
 	case h.isLegacyOutput() && !h.outputIncubating:
-		if err := h.sendSecondLevelTxLegacy(); err != nil {
+		if err := h.resolveSecondLevelTxLegacy(); err != nil {
 			log.Errorf("Sending timeout tx to nursery: %v", err)
 
 			return nil, err

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -38,9 +38,6 @@ type htlcTimeoutResolver struct {
 	// incubator (utxo nursery).
 	outputIncubating bool
 
-	// resolved reflects if the contract has been fully resolved or not.
-	resolved bool
-
 	// broadcastHeight is the height that the original contract was
 	// broadcast to the main-chain at. We'll use this value to bound any
 	// historical queries to the chain for spends/confirmations.
@@ -238,7 +235,7 @@ func (h *htlcTimeoutResolver) claimCleanUp(
 	}); err != nil {
 		return err
 	}
-	h.resolved = true
+	h.markResolved()
 
 	// Checkpoint our resolver with a report which reflects the preimage
 	// claim by the remote party.
@@ -424,7 +421,7 @@ func checkSizeAndIndex(witness wire.TxWitness, size, index int) bool {
 // NOTE: Part of the ContractResolver interface.
 func (h *htlcTimeoutResolver) Resolve() (ContractResolver, error) {
 	// If we're already resolved, then we can exit early.
-	if h.resolved {
+	if h.IsResolved() {
 		h.log.Errorf("already resolved")
 		return nil, nil
 	}
@@ -622,14 +619,6 @@ func (h *htlcTimeoutResolver) Stop() {
 	close(h.quit)
 }
 
-// IsResolved returns true if the stored state in the resolve is fully
-// resolved. In this case the target output can be forgotten.
-//
-// NOTE: Part of the ContractResolver interface.
-func (h *htlcTimeoutResolver) IsResolved() bool {
-	return h.resolved
-}
-
 // report returns a report on the resolution state of the contract.
 func (h *htlcTimeoutResolver) report() *ContractReport {
 	// If we have a SignedTimeoutTx but no SignDetails, this is a local
@@ -689,7 +678,7 @@ func (h *htlcTimeoutResolver) Encode(w io.Writer) error {
 	if err := binary.Write(w, endian, h.outputIncubating); err != nil {
 		return err
 	}
-	if err := binary.Write(w, endian, h.resolved); err != nil {
+	if err := binary.Write(w, endian, h.IsResolved()); err != nil {
 		return err
 	}
 	if err := binary.Write(w, endian, h.broadcastHeight); err != nil {
@@ -730,9 +719,15 @@ func newTimeoutResolverFromReader(r io.Reader, resCfg ResolverConfig) (
 	if err := binary.Read(r, endian, &h.outputIncubating); err != nil {
 		return nil, err
 	}
-	if err := binary.Read(r, endian, &h.resolved); err != nil {
+
+	var resolved bool
+	if err := binary.Read(r, endian, &resolved); err != nil {
 		return nil, err
 	}
+	if resolved {
+		h.markResolved()
+	}
+
 	if err := binary.Read(r, endian, &h.broadcastHeight); err != nil {
 		return nil, err
 	}
@@ -1149,7 +1144,7 @@ func (h *htlcTimeoutResolver) checkpointClaim(
 	}
 
 	// Finally, we checkpoint the resolver with our report(s).
-	h.resolved = true
+	h.markResolved()
 
 	return h.Checkpoint(h, report)
 }
@@ -1285,7 +1280,7 @@ func (h *htlcTimeoutResolver) Launch() error {
 
 	switch {
 	// If we're already resolved, then we can exit early.
-	case h.resolved:
+	case h.IsResolved():
 		h.log.Errorf("already resolved")
 		return nil
 

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -476,13 +476,9 @@ func (h *htlcTimeoutResolver) Resolve() (ContractResolver, error) {
 	return h.handleCommitSpend(commitSpend)
 }
 
-// sweepSecondLevelTx sends a second level timeout transaction to the sweeper.
+// sweepTimeoutTx sends a second level timeout transaction to the sweeper.
 // This transaction uses the SINLGE|ANYONECANPAY flag.
-func (h *htlcTimeoutResolver) sweepSecondLevelTx() error {
-	log.Infof("%T(%x): offering second-layer timeout tx to sweeper: %v",
-		h, h.htlc.RHash[:],
-		spew.Sdump(h.htlcResolution.SignedTimeoutTx))
-
+func (h *htlcTimeoutResolver) sweepTimeoutTx() error {
 	var inp input.Input
 	if h.isTaproot() {
 		inp = lnutils.Ptr(input.MakeHtlcSecondLevelTimeoutTaprootInput(
@@ -513,27 +509,12 @@ func (h *htlcTimeoutResolver) sweepSecondLevelTx() error {
 		btcutil.Amount(inp.SignDesc().Output.Value), 2, 0,
 	)
 
+	h.log.Infof("offering 2nd-level HTLC timeout tx to sweeper "+
+		"with deadline=%v, budget=%v", h.incomingHTLCExpiryHeight,
+		budget)
+
 	// For an outgoing HTLC, it must be swept before the RefundTimeout of
 	// its incoming HTLC is reached.
-	//
-	// TODO(yy): we may end up mixing inputs with different time locks.
-	// Suppose we have two outgoing HTLCs,
-	// - HTLC1: nLocktime is 800000, CLTV delta is 80.
-	// - HTLC2: nLocktime is 800001, CLTV delta is 79.
-	// This means they would both have an incoming HTLC that expires at
-	// 800080, hence they share the same deadline but different locktimes.
-	// However, with current design, when we are at block 800000, HTLC1 is
-	// offered to the sweeper. When block 800001 is reached, HTLC1's
-	// sweeping process is already started, while HTLC2 is being offered to
-	// the sweeper, so they won't be mixed. This can become an issue tho,
-	// if we decide to sweep per X blocks. Or the contractcourt sees the
-	// block first while the sweeper is only aware of the last block. To
-	// properly fix it, we need `blockbeat` to make sure subsystems are in
-	// sync.
-	log.Infof("%T(%x): offering second-level HTLC timeout tx to sweeper "+
-		"with deadline=%v, budget=%v", h, h.htlc.RHash[:],
-		h.incomingHTLCExpiryHeight, budget)
-
 	_, err := h.Sweeper.SweepInput(
 		inp,
 		sweep.Params{
@@ -551,21 +532,15 @@ func (h *htlcTimeoutResolver) sweepSecondLevelTx() error {
 // resolveSecondLevelTxLegacy sends a second level timeout transaction to the
 // utxo nursery. This transaction uses the legacy SIGHASH_ALL flag.
 func (h *htlcTimeoutResolver) resolveSecondLevelTxLegacy() error {
-	log.Debugf("%T(%v): incubating htlc output", h,
-		h.htlcResolution.ClaimOutpoint)
+	h.log.Debug("incubating htlc output")
 
-	err := h.IncubateOutputs(
+	// The utxo nursery will take care of broadcasting the second-level
+	// timeout tx and sweeping its output once it confirms.
+	return h.IncubateOutputs(
 		h.ChanPoint, fn.Some(h.htlcResolution),
 		fn.None[lnwallet.IncomingHtlcResolution](),
 		h.broadcastHeight, h.incomingHTLCExpiryHeight,
 	)
-	if err != nil {
-		return err
-	}
-
-	h.outputIncubating = true
-
-	return h.Checkpoint(h)
 }
 
 // sweepDirectHtlcOutput sends the direct spend of the HTLC output to the
@@ -635,7 +610,7 @@ func (h *htlcTimeoutResolver) spendHtlcOutput() (
 	// (the case for anchor type channels). In this case we can re-sign it
 	// and attach fees at will. We let the sweeper handle this job.
 	case h.isZeroFeeOutput() && !h.outputIncubating:
-		if err := h.sweepSecondLevelTx(); err != nil {
+		if err := h.sweepTimeoutTx(); err != nil {
 			log.Errorf("Sending timeout tx to sweeper: %v", err)
 
 			return nil, err
@@ -695,9 +670,6 @@ func (h *htlcTimeoutResolver) watchHtlcSpend() (*chainntnfs.SpendDetail,
 // a block, returns the spend details.
 func (h *htlcTimeoutResolver) waitForConfirmedSpend(op *wire.OutPoint,
 	pkScript []byte) (*chainntnfs.SpendDetail, error) {
-
-	log.Infof("%T(%v): waiting for spent of HTLC output %v to be "+
-		"fully confirmed", h, h.htlcResolution.ClaimOutpoint, op)
 
 	// We'll block here until either we exit, or the HTLC output on the
 	// commitment transaction has been spent.
@@ -770,82 +742,11 @@ func (h *htlcTimeoutResolver) handleCommitSpend(
 	// the CSV and possible CLTV lock to expire, before sweeping the output
 	// on the second-level.
 	case h.isZeroFeeOutput():
-		waitHeight := h.deriveWaitHeight(
-			h.htlcResolution.CsvDelay, commitSpend,
-		)
-
-		h.reportLock.Lock()
-		h.currentReport.Stage = 2
-		h.currentReport.MaturityHeight = waitHeight
-		h.reportLock.Unlock()
-
-		if h.hasCLTV() {
-			log.Infof("%T(%x): waiting for CSV and CLTV lock to "+
-				"expire at height %v", h, h.htlc.RHash[:],
-				waitHeight)
-		} else {
-			log.Infof("%T(%x): waiting for CSV lock to expire at "+
-				"height %v", h, h.htlc.RHash[:], waitHeight)
-		}
-
-		// We'll use this input index to determine the second-level
-		// output index on the transaction, as the signatures requires
-		// the indexes to be the same. We don't look for the
-		// second-level output script directly, as there might be more
-		// than one HTLC output to the same pkScript.
-		op := &wire.OutPoint{
-			Hash:  *commitSpend.SpenderTxHash,
-			Index: commitSpend.SpenderInputIndex,
-		}
-
-		var csvWitnessType input.StandardWitnessType
-		if h.isTaproot() {
-			//nolint:ll
-			csvWitnessType = input.TaprootHtlcOfferedTimeoutSecondLevel
-		} else {
-			csvWitnessType = input.HtlcOfferedTimeoutSecondLevel
-		}
-
-		// Let the sweeper sweep the second-level output now that the
-		// CSV/CLTV locks have expired.
-		inp := h.makeSweepInput(
-			op, csvWitnessType,
-			input.LeaseHtlcOfferedTimeoutSecondLevel,
-			&h.htlcResolution.SweepSignDesc,
-			h.htlcResolution.CsvDelay,
-			uint32(commitSpend.SpendingHeight), h.htlc.RHash,
-			h.htlcResolution.ResolutionBlob,
-		)
-
-		// Calculate the budget for this sweep.
-		budget := calculateBudget(
-			btcutil.Amount(inp.SignDesc().Output.Value),
-			h.Budget.NoDeadlineHTLCRatio,
-			h.Budget.NoDeadlineHTLC,
-		)
-
-		log.Infof("%T(%x): offering second-level timeout tx output to "+
-			"sweeper with no deadline and budget=%v at height=%v",
-			h, h.htlc.RHash[:], budget, waitHeight)
-
-		_, err := h.Sweeper.SweepInput(
-			inp,
-			sweep.Params{
-				Budget: budget,
-
-				// For second level success tx, there's no rush
-				// to get it confirmed, so we use a nil
-				// deadline.
-				DeadlineHeight: fn.None[int32](),
-			},
-		)
+		err := h.sweepTimeoutTxOutput()
 		if err != nil {
 			return nil, err
 		}
 
-		// Update the claim outpoint to point to the second-level
-		// transaction created by the sweeper.
-		claimOutpoint = *op
 		fallthrough
 
 	// Finally, if this was an output on our commitment transaction, we'll
@@ -1287,4 +1188,132 @@ func (h *htlcTimeoutResolver) isLegacyOutput() bool {
 	// commitment for a non-anchor channel.
 	return h.htlcResolution.SignedTimeoutTx != nil &&
 		h.htlcResolution.SignDetails == nil
+}
+
+// waitHtlcSpendAndCheckPreimage waits for the htlc output to be spent and
+// checks whether the spending reveals the preimage. If the preimage is found,
+// it will be added to the preimage beacon to settle the incoming link, and a
+// nil spend details will be returned. Otherwise, the spend details will be
+// returned, indicating this is a non-preimage spend.
+func (h *htlcTimeoutResolver) waitHtlcSpendAndCheckPreimage() (
+	*chainntnfs.SpendDetail, error) {
+
+	// Wait for the htlc output to be spent, which can happen in one of the
+	// paths,
+	// 1. The remote party spends the htlc output using the preimage.
+	// 2. The local party spends the htlc timeout tx from the local
+	//    commitment.
+	// 3. The local party spends the htlc output directlt from the remote
+	//    commitment.
+	spend, err := h.watchHtlcSpend()
+	if err != nil {
+		return nil, err
+	}
+
+	// If the spend reveals the pre-image, then we'll enter the clean up
+	// workflow to pass the preimage back to the incoming link, add it to
+	// the witness cache, and exit.
+	if isPreimageSpend(h.isTaproot(), spend, !h.isRemoteCommitOutput()) {
+		return nil, h.claimCleanUp(spend)
+	}
+
+	return spend, nil
+}
+
+// sweepTimeoutTxOutput attempts to sweep the output of the second level
+// timeout tx.
+func (h *htlcTimeoutResolver) sweepTimeoutTxOutput() error {
+	h.log.Debugf("sweeping output %v from 2nd-level HTLC timeout tx",
+		h.htlcResolution.ClaimOutpoint)
+
+	// This should be non-blocking as we will only attempt to sweep the
+	// output when the second level tx has already been confirmed. In other
+	// words, waitHtlcSpendAndCheckPreimage will return immediately.
+	commitSpend, err := h.waitHtlcSpendAndCheckPreimage()
+	if err != nil {
+		return err
+	}
+
+	// Exit early if the spend is nil, as this means it's a remote spend
+	// using the preimage path, which is handled in claimCleanUp.
+	if commitSpend == nil {
+		h.log.Infof("preimage spend detected, skipping 2nd-level " +
+			"HTLC output sweep")
+
+		return nil
+	}
+
+	waitHeight := h.deriveWaitHeight(h.htlcResolution.CsvDelay, commitSpend)
+
+	// Now that the sweeper has broadcasted the second-level transaction,
+	// it has confirmed, and we have checkpointed our state, we'll sweep
+	// the second level output. We report the resolver has moved the next
+	// stage.
+	h.reportLock.Lock()
+	h.currentReport.Stage = 2
+	h.currentReport.MaturityHeight = waitHeight
+	h.reportLock.Unlock()
+
+	if h.hasCLTV() {
+		h.log.Infof("waiting for CSV and CLTV lock to expire at "+
+			"height %v", waitHeight)
+	} else {
+		h.log.Infof("waiting for CSV lock to expire at height %v",
+			waitHeight)
+	}
+
+	// We'll use this input index to determine the second-level output
+	// index on the transaction, as the signatures requires the indexes to
+	// be the same. We don't look for the second-level output script
+	// directly, as there might be more than one HTLC output to the same
+	// pkScript.
+	op := &wire.OutPoint{
+		Hash:  *commitSpend.SpenderTxHash,
+		Index: commitSpend.SpenderInputIndex,
+	}
+
+	var witType input.StandardWitnessType
+	if h.isTaproot() {
+		witType = input.TaprootHtlcOfferedTimeoutSecondLevel
+	} else {
+		witType = input.HtlcOfferedTimeoutSecondLevel
+	}
+
+	// Let the sweeper sweep the second-level output now that the CSV/CLTV
+	// locks have expired.
+	inp := h.makeSweepInput(
+		op, witType,
+		input.LeaseHtlcOfferedTimeoutSecondLevel,
+		&h.htlcResolution.SweepSignDesc,
+		h.htlcResolution.CsvDelay, uint32(commitSpend.SpendingHeight),
+		h.htlc.RHash, h.htlcResolution.ResolutionBlob,
+	)
+
+	// Calculate the budget for this sweep.
+	budget := calculateBudget(
+		btcutil.Amount(inp.SignDesc().Output.Value),
+		h.Budget.NoDeadlineHTLCRatio,
+		h.Budget.NoDeadlineHTLC,
+	)
+
+	h.log.Infof("offering output from 2nd-level timeout tx to sweeper "+
+		"with no deadline and budget=%v", budget)
+
+	// TODO(yy): use the result chan returned from SweepInput to get the
+	// confirmation status of this sweeping tx so we don't need to make
+	// anothe subscription via `RegisterSpendNtfn` for this outpoint here
+	// in the resolver.
+	_, err = h.Sweeper.SweepInput(
+		inp,
+		sweep.Params{
+			Budget: budget,
+
+			// For second level success tx, there's no rush
+			// to get it confirmed, so we use a nil
+			// deadline.
+			DeadlineHeight: fn.None[int32](),
+		},
+	)
+
+	return err
 }

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -454,7 +454,11 @@ func (h *htlcTimeoutResolver) Resolve() (ContractResolver, error) {
 
 	// Depending on whether this was a local or remote commit, we must
 	// handle the spending transaction accordingly.
-	return h.handleCommitSpend(commitSpend)
+	if h.isRemoteCommitOutput() {
+		return nil, h.resolveRemoteCommitOutput()
+	}
+
+	return nil, h.resolveTimeoutTx()
 }
 
 // sweepTimeoutTx sends a second level timeout transaction to the sweeper.
@@ -662,85 +666,6 @@ func (h *htlcTimeoutResolver) waitForConfirmedSpend(op *wire.OutPoint,
 	}
 
 	return spend, err
-}
-
-// handleCommitSpend handles the spend of the HTLC output on the commitment
-// transaction. If this was our local commitment, the spend will be he
-// confirmed second-level timeout transaction, and we'll sweep that into our
-// wallet. If the was a remote commitment, the resolver will resolve
-// immetiately.
-func (h *htlcTimeoutResolver) handleCommitSpend(
-	commitSpend *chainntnfs.SpendDetail) (ContractResolver, error) {
-
-	var (
-		// claimOutpoint will be the outpoint of the second level
-		// transaction, or on the remote commitment directly. It will
-		// start out as set in the resolution, but we'll update it if
-		// the second-level goes through the sweeper and changes its
-		// txid.
-		claimOutpoint = h.htlcResolution.ClaimOutpoint
-
-		// spendTxID will be the ultimate spend of the claimOutpoint.
-		// We set it to the commit spend for now, as this is the
-		// ultimate spend in case this is a remote commitment. If we go
-		// through the second-level transaction, we'll update this
-		// accordingly.
-		spendTxID = commitSpend.SpenderTxHash
-
-		sweepTx *chainntnfs.SpendDetail
-		err     error
-	)
-
-	switch {
-
-	// If we swept an HTLC directly off the remote party's commitment
-	// transaction, then we can exit here as there's no second level sweep
-	// to do.
-	case h.htlcResolution.SignedTimeoutTx == nil:
-		break
-
-	// If the sweeper is handling the second level transaction, wait for
-	// the CSV and possible CLTV lock to expire, before sweeping the output
-	// on the second-level.
-	case h.isZeroFeeOutput():
-		err := h.sweepTimeoutTxOutput()
-		if err != nil {
-			return nil, err
-		}
-
-		fallthrough
-
-	// Finally, if this was an output on our commitment transaction, we'll
-	// wait for the second-level HTLC output to be spent, and for that
-	// transaction itself to confirm.
-	case !h.isRemoteCommitOutput():
-		log.Infof("%T(%v): waiting for nursery/sweeper to spend CSV "+
-			"delayed output", h, claimOutpoint)
-
-		sweepTx, err = waitForSpend(
-			&claimOutpoint,
-			h.htlcResolution.SweepSignDesc.Output.PkScript,
-			h.broadcastHeight, h.Notifier, h.quit,
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		// Update the spend txid to the hash of the sweep transaction.
-		spendTxID = sweepTx.SpenderTxHash
-
-		// Once our sweep of the timeout tx has confirmed, we add a
-		// resolution for our timeoutTx tx first stage transaction.
-		err = h.checkpointStageOne(*spendTxID)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// With the clean up message sent, we'll now mark the contract
-	// resolved, update the recovered balance, record the timeout and the
-	// sweep txid on disk, and wait.
-	return nil, h.checkpointClaim(sweepTx)
 }
 
 // Stop signals the resolver to cancel any current resolution processes, and
@@ -1290,4 +1215,120 @@ func (h *htlcTimeoutResolver) checkpointClaim(
 	h.resolved = true
 
 	return h.Checkpoint(h, report)
+}
+
+// resolveRemoteCommitOutput handles sweeping an HTLC output on the remote
+// commitment with via the timeout path. In this case we can sweep the output
+// directly, and don't have to broadcast a second-level transaction.
+func (h *htlcTimeoutResolver) resolveRemoteCommitOutput() error {
+	h.log.Debug("waiting for direct-timeout spend of the htlc to confirm")
+
+	// Wait for the direct-timeout HTLC sweep tx to confirm.
+	spend, err := h.watchHtlcSpend()
+	if err != nil {
+		return err
+	}
+
+	// If the spend reveals the preimage, then we'll enter the clean up
+	// workflow to pass the preimage back to the incoming link, add it to
+	// the witness cache, and exit.
+	if isPreimageSpend(h.isTaproot(), spend, !h.isRemoteCommitOutput()) {
+		return h.claimCleanUp(spend)
+	}
+
+	// Send the clean up msg to fail the incoming HTLC.
+	failureMsg := &lnwire.FailPermanentChannelFailure{}
+	err = h.DeliverResolutionMsg(ResolutionMsg{
+		SourceChan: h.ShortChanID,
+		HtlcIndex:  h.htlc.HtlcIndex,
+		Failure:    failureMsg,
+	})
+	if err != nil {
+		return err
+	}
+
+	// TODO(yy): should also update the `RecoveredBalance` and
+	// `LimboBalance` like other paths?
+
+	// Checkpoint the resolver, and write the outcome to disk.
+	return h.checkpointClaim(spend)
+}
+
+// resolveTimeoutTx waits for the sweeping tx of the second-level
+// timeout tx to confirm and offers the output from the timeout tx to the
+// sweeper.
+func (h *htlcTimeoutResolver) resolveTimeoutTx() error {
+	h.log.Debug("waiting for first-stage 2nd-level HTLC timeout tx to " +
+		"confirm")
+
+	// Wait for the second level transaction to confirm.
+	spend, err := h.watchHtlcSpend()
+	if err != nil {
+		return err
+	}
+
+	// If the spend reveals the preimage, then we'll enter the clean up
+	// workflow to pass the preimage back to the incoming link, add it to
+	// the witness cache, and exit.
+	if isPreimageSpend(h.isTaproot(), spend, !h.isRemoteCommitOutput()) {
+		return h.claimCleanUp(spend)
+	}
+
+	op := h.htlcResolution.ClaimOutpoint
+	spenderTxid := *spend.SpenderTxHash
+
+	// If the timeout tx is a re-signed tx, we will need to find the actual
+	// spent outpoint from the spending tx.
+	if h.isZeroFeeOutput() {
+		op = wire.OutPoint{
+			Hash:  spenderTxid,
+			Index: spend.SpenderInputIndex,
+		}
+	}
+
+	// If the 2nd-stage sweeping has already been started, we can
+	// fast-forward to start the resolving process for the stage two
+	// output.
+	if h.outputIncubating {
+		return h.resolveTimeoutTxOutput(op)
+	}
+
+	h.log.Infof("2nd-level HTLC timeout tx=%v confirmed", spenderTxid)
+
+	// Start the process to sweep the output from the timeout tx.
+	err = h.sweepTimeoutTxOutput()
+	if err != nil {
+		return err
+	}
+
+	// Create a checkpoint since the timeout tx is confirmed and the sweep
+	// request has been made.
+	if err := h.checkpointStageOne(spenderTxid); err != nil {
+		return err
+	}
+
+	// Start the resolving process for the stage two output.
+	return h.resolveTimeoutTxOutput(op)
+}
+
+// resolveTimeoutTxOutput waits for the spend of the output from the 2nd-level
+// timeout tx.
+func (h *htlcTimeoutResolver) resolveTimeoutTxOutput(op wire.OutPoint) error {
+	h.log.Debugf("waiting for second-stage 2nd-level timeout tx output %v "+
+		"to be spent after csv_delay=%v", op, h.htlcResolution.CsvDelay)
+
+	spend, err := waitForSpend(
+		&op, h.htlcResolution.SweepSignDesc.Output.PkScript,
+		h.broadcastHeight, h.Notifier, h.quit,
+	)
+	if err != nil {
+		return err
+	}
+
+	h.reportLock.Lock()
+	h.currentReport.RecoveredBalance = h.currentReport.LimboBalance
+	h.currentReport.LimboBalance = 0
+	h.reportLock.Unlock()
+
+	return h.checkpointClaim(spend)
 }

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
@@ -451,26 +452,6 @@ func (h *htlcTimeoutResolver) Resolve() (ContractResolver, error) {
 		return nil, h.claimCleanUp(commitSpend)
 	}
 
-	// At this point, the second-level transaction is sufficiently
-	// confirmed, or a transaction directly spending the output is.
-	// Therefore, we can now send back our clean up message, failing the
-	// HTLC on the incoming link.
-	//
-	// NOTE: This can be called twice if the outgoing resolver restarts
-	// before the second-stage timeout transaction is confirmed.
-	log.Infof("%T(%v): resolving htlc with incoming fail msg, "+
-		"fully confirmed", h, h.htlcResolution.ClaimOutpoint)
-
-	failureMsg := &lnwire.FailPermanentChannelFailure{}
-	err = h.DeliverResolutionMsg(ResolutionMsg{
-		SourceChan: h.ShortChanID,
-		HtlcIndex:  h.htlc.HtlcIndex,
-		Failure:    failureMsg,
-	})
-	if err != nil {
-		return nil, err
-	}
-
 	// Depending on whether this was a local or remote commit, we must
 	// handle the spending transaction accordingly.
 	return h.handleCommitSpend(commitSpend)
@@ -680,28 +661,7 @@ func (h *htlcTimeoutResolver) waitForConfirmedSpend(op *wire.OutPoint,
 		return nil, err
 	}
 
-	// Once confirmed, persist the state on disk.
-	if err := h.checkPointSecondLevelTx(); err != nil {
-		return nil, err
-	}
-
 	return spend, err
-}
-
-// checkPointSecondLevelTx persists the state of a second level HTLC tx to disk
-// if it's published by the sweeper.
-func (h *htlcTimeoutResolver) checkPointSecondLevelTx() error {
-	// If this was the second level transaction published by the sweeper,
-	// we can checkpoint the resolver now that it's confirmed.
-	if h.htlcResolution.SignDetails != nil && !h.outputIncubating {
-		h.outputIncubating = true
-		if err := h.Checkpoint(h); err != nil {
-			log.Errorf("unable to Checkpoint: %v", err)
-			return err
-		}
-	}
-
-	return nil
 }
 
 // handleCommitSpend handles the spend of the HTLC output on the commitment
@@ -727,7 +687,8 @@ func (h *htlcTimeoutResolver) handleCommitSpend(
 		// accordingly.
 		spendTxID = commitSpend.SpenderTxHash
 
-		reports []*channeldb.ResolverReport
+		sweepTx *chainntnfs.SpendDetail
+		err     error
 	)
 
 	switch {
@@ -756,7 +717,7 @@ func (h *htlcTimeoutResolver) handleCommitSpend(
 		log.Infof("%T(%v): waiting for nursery/sweeper to spend CSV "+
 			"delayed output", h, claimOutpoint)
 
-		sweepTx, err := waitForSpend(
+		sweepTx, err = waitForSpend(
 			&claimOutpoint,
 			h.htlcResolution.SweepSignDesc.Output.PkScript,
 			h.broadcastHeight, h.Notifier, h.quit,
@@ -770,38 +731,16 @@ func (h *htlcTimeoutResolver) handleCommitSpend(
 
 		// Once our sweep of the timeout tx has confirmed, we add a
 		// resolution for our timeoutTx tx first stage transaction.
-		timeoutTx := commitSpend.SpendingTx
-		index := commitSpend.SpenderInputIndex
-		spendHash := commitSpend.SpenderTxHash
-
-		reports = append(reports, &channeldb.ResolverReport{
-			OutPoint:        timeoutTx.TxIn[index].PreviousOutPoint,
-			Amount:          h.htlc.Amt.ToSatoshis(),
-			ResolverType:    channeldb.ResolverTypeOutgoingHtlc,
-			ResolverOutcome: channeldb.ResolverOutcomeFirstStage,
-			SpendTxID:       spendHash,
-		})
+		err = h.checkpointStageOne(*spendTxID)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// With the clean up message sent, we'll now mark the contract
 	// resolved, update the recovered balance, record the timeout and the
 	// sweep txid on disk, and wait.
-	h.resolved = true
-	h.reportLock.Lock()
-	h.currentReport.RecoveredBalance = h.currentReport.LimboBalance
-	h.currentReport.LimboBalance = 0
-	h.reportLock.Unlock()
-
-	amt := btcutil.Amount(h.htlcResolution.SweepSignDesc.Output.Value)
-	reports = append(reports, &channeldb.ResolverReport{
-		OutPoint:        claimOutpoint,
-		Amount:          amt,
-		ResolverType:    channeldb.ResolverTypeOutgoingHtlc,
-		ResolverOutcome: channeldb.ResolverOutcomeTimeout,
-		SpendTxID:       spendTxID,
-	})
-
-	return nil, h.Checkpoint(h, reports...)
+	return nil, h.checkpointClaim(sweepTx)
 }
 
 // Stop signals the resolver to cancel any current resolution processes, and
@@ -1050,12 +989,6 @@ func (h *htlcTimeoutResolver) consumeSpendEvents(resultChan chan *spendResult,
 	// Create a result chan to hold the results.
 	result := &spendResult{}
 
-	// hasMempoolSpend is a flag that indicates whether we have found a
-	// preimage spend from the mempool. This is used to determine whether
-	// to checkpoint the resolver or not when later we found the
-	// corresponding block spend.
-	hasMempoolSpent := false
-
 	// Wait for a spend event to arrive.
 	for {
 		select {
@@ -1083,23 +1016,6 @@ func (h *htlcTimeoutResolver) consumeSpendEvents(resultChan chan *spendResult,
 				// Once confirmed, persist the state on disk if
 				// we haven't seen the output's spending tx in
 				// mempool before.
-				//
-				// NOTE: we don't checkpoint the resolver if
-				// it's spending tx has already been found in
-				// mempool - the resolver will take care of the
-				// checkpoint in its `claimCleanUp`. If we do
-				// checkpoint here, however, we'd create a new
-				// record in db for the same htlc resolver
-				// which won't be cleaned up later, resulting
-				// the channel to stay in unresolved state.
-				//
-				// TODO(yy): when fee bumper is implemented, we
-				// need to further check whether this is a
-				// preimage spend. Also need to refactor here
-				// to save us some indentation.
-				if !hasMempoolSpent {
-					result.err = h.checkPointSecondLevelTx()
-				}
 			}
 
 			// Send the result and exit the loop.
@@ -1145,10 +1061,6 @@ func (h *htlcTimeoutResolver) consumeSpendEvents(resultChan chan *spendResult,
 			// continue the loop.
 			result.spend = spendDetail
 			resultChan <- result
-
-			// Set the hasMempoolSpent flag to true so we won't
-			// checkpoint the resolver again in db.
-			hasMempoolSpent = true
 
 			continue
 
@@ -1316,4 +1228,66 @@ func (h *htlcTimeoutResolver) sweepTimeoutTxOutput() error {
 	)
 
 	return err
+}
+
+// checkpointStageOne creates a checkpoint for the first stage of the htlc
+// timeout transaction. This is used to ensure that the resolver can resume
+// watching for the second stage spend in case of a restart.
+func (h *htlcTimeoutResolver) checkpointStageOne(
+	spendTxid chainhash.Hash) error {
+
+	h.log.Debugf("checkpoint stage one spend of HTLC output %v, spent "+
+		"in tx %v", h.outpoint(), spendTxid)
+
+	// Now that the second-level transaction has confirmed, we checkpoint
+	// the state so we'll go to the next stage in case of restarts.
+	h.outputIncubating = true
+
+	// Create stage-one report.
+	report := &channeldb.ResolverReport{
+		OutPoint:        h.outpoint(),
+		Amount:          h.htlc.Amt.ToSatoshis(),
+		ResolverType:    channeldb.ResolverTypeOutgoingHtlc,
+		ResolverOutcome: channeldb.ResolverOutcomeFirstStage,
+		SpendTxID:       &spendTxid,
+	}
+
+	// At this point, the second-level transaction is sufficiently
+	// confirmed. We can now send back our clean up message, failing the
+	// HTLC on the incoming link.
+	failureMsg := &lnwire.FailPermanentChannelFailure{}
+	err := h.DeliverResolutionMsg(ResolutionMsg{
+		SourceChan: h.ShortChanID,
+		HtlcIndex:  h.htlc.HtlcIndex,
+		Failure:    failureMsg,
+	})
+	if err != nil {
+		return err
+	}
+
+	return h.Checkpoint(h, report)
+}
+
+// checkpointClaim checkpoints the timeout resolver with the reports it needs.
+func (h *htlcTimeoutResolver) checkpointClaim(
+	spendDetail *chainntnfs.SpendDetail) error {
+
+	h.log.Infof("resolving htlc with incoming fail msg, output=%v "+
+		"confirmed in tx=%v", spendDetail.SpentOutPoint,
+		spendDetail.SpenderTxHash)
+
+	// Create a resolver report for the claiming of the HTLC.
+	amt := btcutil.Amount(h.htlcResolution.SweepSignDesc.Output.Value)
+	report := &channeldb.ResolverReport{
+		OutPoint:        *spendDetail.SpentOutPoint,
+		Amount:          amt,
+		ResolverType:    channeldb.ResolverTypeOutgoingHtlc,
+		ResolverOutcome: channeldb.ResolverOutcomeTimeout,
+		SpendTxID:       spendDetail.SpenderTxHash,
+	}
+
+	// Finally, we checkpoint the resolver with our report(s).
+	h.resolved = true
+
+	return h.Checkpoint(h, report)
 }

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -1270,13 +1270,13 @@ func (h *htlcTimeoutResolver) resolveTimeoutTxOutput(op wire.OutPoint) error {
 // Launch creates an input based on the details of the outgoing htlc resolution
 // and offers it to the sweeper.
 func (h *htlcTimeoutResolver) Launch() error {
-	if h.launched {
+	if h.isLaunched() {
 		h.log.Tracef("already launched")
 		return nil
 	}
 
 	h.log.Debugf("launching resolver...")
-	h.launched = true
+	h.markLaunched()
 
 	switch {
 	// If we're already resolved, then we can exit early.

--- a/contractcourt/htlc_timeout_resolver_test.go
+++ b/contractcourt/htlc_timeout_resolver_test.go
@@ -532,7 +532,7 @@ func testHtlcTimeoutResolver(t *testing.T, testCase htlcTimeoutTestCase) {
 	wg.Wait()
 
 	// Finally, the resolver should be marked as resolved.
-	if !resolver.resolved {
+	if !resolver.resolved.Load() {
 		t.Fatalf("resolver should be marked as resolved")
 	}
 }

--- a/contractcourt/mock_registry_test.go
+++ b/contractcourt/mock_registry_test.go
@@ -29,6 +29,11 @@ func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
 	wireCustomRecords lnwire.CustomRecords,
 	payload invoices.Payload) (invoices.HtlcResolution, error) {
 
+	// Exit early if the notification channel is nil.
+	if hodlChan == nil {
+		return r.notifyResolution, r.notifyErr
+	}
+
 	r.notifyChan <- notifyExitHopData{
 		hodlChan:      hodlChan,
 		payHash:       payHash,

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -1275,7 +1275,11 @@ func (i *InvoiceRegistry) notifyExitHopHtlcLocked(
 			invoiceToExpire = makeInvoiceExpiry(ctx.hash, invoice)
 		}
 
-		i.hodlSubscribe(hodlChan, ctx.circuitKey)
+		// Subscribe to the resolution if the caller specified a
+		// notification channel.
+		if hodlChan != nil {
+			i.hodlSubscribe(hodlChan, ctx.circuitKey)
+		}
 
 	default:
 		panic("unknown action")


### PR DESCRIPTION
Depends on 
- #8894

NOTE: itest is fixed in the final PR 
- #9260

Turns out mounting `blockbeat` in `ChannelArbitrator` can be quite challenging (unit tests, itest, etc). This PR attempts to implement it in hopefully the least disruptive way - only `chainWatcher` implements `Consumer`, and the contract resolvers are kept stateless (in terms of blocks). The main changes are,
1. contract resolvers are refactored - the original `Resolve` method is broken into two steps: 1) `Launch` the resolver, which handles sending the sweep request, and 2) `Resolve` the resolver, which handles monitoring the spending of the output.
2. `chainWatcher` implements `Consumer` in the following PR.

### Alternatives
The original attempt is to make the resolvers subscribe to a blockbeat chan, as implemented in #8717. The second attempt is to make the resolvers also blockbeat `Consumer`, as implemented [here](https://github.com/yyforyongyu/lnd/pull/8).

This third approach is chosen as 1) it greatly limits the scope otherwise a bigger refactor of channel arbitrator may be needed, and 2) the resolvers can be made stateless in terms of blocks, and be fully managed by the channel arbitrator. In other words, when a new block arrives, the channel arbitrator decides whether to launch the resolvers or not, so the resolvers themselves don't need this block info.

In fact, there are only two resolvers that subscribe to blocks, the incoming contest resolver, which uses block height to decide whether to give up resolving an expired incoming htlc; and the outgoing contest resolver, which uses the block height to choose to transform itself into a timeout resolver. IMO if we can remove the inheritance pattern used in `contest resolver -> time/success resolver` and manage to transform resolvers in channel arbitrator, we can further remove those two block subscriptions. As for now, we can leave them there as they have little impact on the block consumption order enforced by the blockbeat.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lightningnetwork/lnd/9276)
<!-- Reviewable:end -->
