### PR TITLE
config: fix "lnd --debuglevel show" command

### DIFF
--- a/config.go
+++ b/config.go
@@ -1261,7 +1261,7 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 	// The target network must be provided, otherwise, we won't
 	// know how to initialize the daemon.
 	if numNets == 0 {
-		str := "either --bitcoin.mainnet, or bitcoin.testnet," +
+		str := "either --bitcoin.mainnet, or bitcoin.testnet, " +
 			"bitcoin.simnet, bitcoin.regtest or bitcoin.signet " +
 			"must be specified"
 

--- a/config.go
+++ b/config.go
@@ -860,6 +860,18 @@ func LoadConfig(interceptor signal.Interceptor) (*Config, error) {
 func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 	flagParser *flags.Parser) (*Config, error) {
 
+	// Special show command to list supported subsystems and exit.
+	if cfg.DebugLevel == "show" {
+		subLogMgr := build.NewSubLoggerManager()
+
+		// Initialize logging at the default logging level.
+		SetupLoggers(subLogMgr, interceptor)
+
+		fmt.Println("Supported subsystems",
+			subLogMgr.SupportedSubsystems())
+		os.Exit(0)
+	}
+
 	// If the provided lnd directory is not the default, we'll modify the
 	// path to all of the files and directories that will live within it.
 	lndDir := CleanAndExpandPath(cfg.LndDir)
@@ -1407,13 +1419,6 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 
 	// Initialize logging at the default logging level.
 	SetupLoggers(cfg.SubLogMgr, interceptor)
-
-	// Special show command to list supported subsystems and exit.
-	if cfg.DebugLevel == "show" {
-		fmt.Println("Supported subsystems",
-			cfg.SubLogMgr.SupportedSubsystems())
-		os.Exit(0)
-	}
 
 	if cfg.MaxLogFiles != 0 {
 		if cfg.LogConfig.File.MaxLogFiles !=

--- a/itest/config.go
+++ b/itest/config.go
@@ -1,0 +1,28 @@
+//go:build integration
+
+package itest
+
+import (
+	"os/exec"
+
+	"github.com/lightningnetwork/lnd/lntest"
+	"github.com/stretchr/testify/require"
+)
+
+// testDebuglevelShow tests that "lnd --debuglevel=show" command works and
+// prints the list of supported subsystems.
+func testDebuglevelShow(ht *lntest.HarnessTest) {
+	// We can't use ht.NewNode, because it adds more arguments to the
+	// command line (e.g. flags configuring bitcoin backend), but we want to
+	// make sure that "lnd --debuglevel=show" works without any other flags.
+	lndBinary := getLndBinary(ht.T)
+	cmd := exec.Command(lndBinary, "--debuglevel=show")
+	stdoutStderrBytes, err := cmd.CombinedOutput()
+	require.NoError(ht, err, "failed to run 'lnd --debuglevel=show'")
+
+	// Make sure that the output contains the list of supported subsystems
+	// and that the list is not empty. We search PEER subsystem.
+	stdoutStderr := string(stdoutStderrBytes)
+	require.Contains(ht, stdoutStderr, "Supported subsystems")
+	require.Contains(ht, stdoutStderr, "PEER")
+}

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -702,4 +702,8 @@ var allTestCases = []*lntest.TestCase{
 		Name:     "send to route failed htlc timeout",
 		TestFunc: testSendToRouteFailHTLCTimeout,
 	},
+	{
+		Name:     "debuglevel show",
+		TestFunc: testDebuglevelShow,
+	},
 }


### PR DESCRIPTION
## Change Description

Previously, "lnd --debuglevel show" complained that bitcoin backend is not configured:

```
$ lnd --debuglevel show
failed to load config: ValidateConfig: either --bitcoin.mainnet, or bitcoin.testnet,bitcoin.simnet, bitcoin.regtest or bitcoin.signet must be specified
```

The command above is documented in [LND documentation](https://github.com/lightningnetwork/lnd/blob/bd36f765304f736391b752199aa9281b2e2ca5a7/docs/debugging_lnd.md#L38) and is expected to work without additional arguments.

To make it working, the user had to specify `--bitcoin.mainnet` and configure one of the backends, e.g. `--bitcoin.node neutrino`.
    
With this fix, the command works without any additional flags:

```
$ lnd --debuglevel show
Supported subsystems [ARPC ATPL BLPT BRAR BTCN BTWL CHAC CHBU CHCL CHDB CHFD CHFT CHNF CHRE CLUS CMGR CNCT CNFG CRTR DISC DRPC FNDG GRPH HLCK HSWC INVC IRPC LNWL LTND NANN NRPC NTFN NTFR PEER PRNF PROM PRPC RPCC RPCP RPCS RPWL RRPC SGNR SPHX SRVR SWPR TORC UTXN VRPC WLKT WTCL WTWR]
```

I also added missing space in the error message ("bitcoin.testnet,bitcoin.simnet" -> "bitcoin.testnet, bitcoin.simnet").

Also added an itest to prevent regressions in the future.

## Technical details

`cfg.SubLogMgr` depends on logging file path, which depends on bitcoin backed choice. To overcome this, I moved the "debuglevel show" logic to the beginning of `ValidateConfig` function and created a throw-away `subLogMgr` not depending on logging file path, just to use it for `SetupLoggers()` and `SupportedSubsystems()` calls.

## Steps to Test

Run `lnd --debuglevel show`, make sure it prints the list of subsystems and the list is full and correct.

I compared the list with the list provided by `lnd --bitcoin.active --bitcoin.mainnet --bitcoin.node neutrino --debuglevel show` before my fix. The lists match!

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
