### PR TITLE
misc: nil checks and remove deprecated default values

### DIFF
--- a/config.go
+++ b/config.go
@@ -562,8 +562,6 @@ func DefaultConfig() Config {
 		LetsEncryptDir:    defaultLetsEncryptDir,
 		LetsEncryptListen: defaultLetsEncryptListen,
 		LogDir:            defaultLogDir,
-		MaxLogFiles:       build.DefaultMaxLogFiles,
-		MaxLogFileSize:    build.DefaultMaxLogFileSize,
 		AcceptorTimeout:   defaultAcceptorTimeout,
 		WSPingInterval:    lnrpc.DefaultPingInterval,
 		WSPongWait:        lnrpc.DefaultPongWait,
@@ -1417,7 +1415,7 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 		os.Exit(0)
 	}
 
-	if cfg.MaxLogFiles != build.DefaultMaxLogFiles {
+	if cfg.MaxLogFiles != 0 {
 		if cfg.LogConfig.File.MaxLogFiles !=
 			build.DefaultMaxLogFiles {
 
@@ -1427,7 +1425,7 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 
 		cfg.LogConfig.File.MaxLogFiles = cfg.MaxLogFiles
 	}
-	if cfg.MaxLogFileSize != build.DefaultMaxLogFileSize {
+	if cfg.MaxLogFileSize != 0 {
 		if cfg.LogConfig.File.MaxLogFileSize !=
 			build.DefaultMaxLogFileSize {
 

--- a/lntest/harness_assertion.go
+++ b/lntest/harness_assertion.go
@@ -255,10 +255,10 @@ func (h *HarnessTest) AssertNumActiveEdges(hn *node.HarnessNode,
 	// filterDisabled is a helper closure that filters out disabled
 	// channels.
 	filterDisabled := func(edge *lnrpc.ChannelEdge) bool {
-		if edge.Node1Policy.Disabled {
+		if edge.Node1Policy != nil && edge.Node1Policy.Disabled {
 			return false
 		}
-		if edge.Node2Policy.Disabled {
+		if edge.Node2Policy != nil && edge.Node2Policy.Disabled {
 			return false
 		}
 

--- a/lntest/node/state.go
+++ b/lntest/node/state.go
@@ -312,10 +312,10 @@ func (s *State) updateEdgeStats() {
 	// filterDisabled is a helper closure that filters out disabled
 	// channels.
 	filterDisabled := func(edge *lnrpc.ChannelEdge) bool {
-		if edge.Node1Policy.Disabled {
+		if edge.Node1Policy != nil && edge.Node1Policy.Disabled {
 			return false
 		}
-		if edge.Node2Policy.Disabled {
+		if edge.Node2Policy != nil && edge.Node2Policy.Disabled {
 			return false
 		}
 


### PR DESCRIPTION
1) The `Node1Policy` and `Node2Policy` members of the `lnrpc.ChannelEdge` struct can be nil 
and so we should check for this before dereferencing.  ran into panics [here](https://github.com/lightningnetwork/lnd/actions/runs/11898396588/job/33154809901)

2) remove default values for some deprecated log config options