### PR TITLE
Update docs/grpc/python.md and ruby.md

### DIFF
--- a/docs/grpc/python.md
+++ b/docs/grpc/python.md
@@ -17,25 +17,20 @@ file in Python before you can use it to communicate with lnd.
     ```shell
     $  source lnd/bin/activate
     ```
-3. Install dependencies (googleapis-common-protos is required due to the use of
-  google/api/annotations.proto)
+3. Install dependencies 
     ```shell
-    lnd $  pip install grpcio grpcio-tools googleapis-common-protos mypy-protobuf
+    lnd $  pip install  grpcio-tools 
     ```
-4. Clone the google api's repository (required due to the use of
-  google/api/annotations.proto)
-    ```shell
-    lnd $  git clone https://github.com/googleapis/googleapis.git
-    ```
-5. Copy the lnd lightning.proto file (you'll find this at
+
+4. Copy the lnd lightning.proto file (you'll find this at
   [lnrpc/lightning.proto](https://github.com/lightningnetwork/lnd/blob/master/lnrpc/lightning.proto))
   or just download it
     ```shell
     lnd $  curl -o lightning.proto -s https://raw.githubusercontent.com/lightningnetwork/lnd/master/lnrpc/lightning.proto
     ```
-6. Compile the proto file
+5. Compile the proto file
     ```shell
-    lnd $  python -m grpc_tools.protoc --proto_path=googleapis:. --mypy_out=. --python_out=. --grpc_python_out=. lightning.proto
+    lnd $  python -m grpc_tools.protoc --proto_path=.  --python_out=. --grpc_python_out=. lightning.proto
     ```
 
 After following these steps, three files `lightning_pb2.py`,
@@ -53,7 +48,7 @@ extra steps (after completing all 6 step described above) to get the
 
 ```shell
 lnd $  curl -o router.proto -s https://raw.githubusercontent.com/lightningnetwork/lnd/master/lnrpc/routerrpc/router.proto
-lnd $  python -m grpc_tools.protoc --proto_path=googleapis:. --mypy_out=. --python_out=. --grpc_python_out=. router.proto
+lnd $  python -m grpc_tools.protoc --proto_path=.  --python_out=. --grpc_python_out=. router.proto
 ```
 
 ### Imports and Client

--- a/docs/grpc/ruby.md
+++ b/docs/grpc/ruby.md
@@ -19,11 +19,7 @@ $  gem install grpc
 $  gem install grpc-tools
 ```
 
-Clone the Google APIs repository:
 
-```shell
-$  git clone https://github.com/googleapis/googleapis.git
-```
 
 Fetch the `lightning.proto` file (or copy it from your local source directory):
 
@@ -34,7 +30,7 @@ $  curl -o lightning.proto -s https://raw.githubusercontent.com/lightningnetwork
 Compile the proto file:
 
 ```shell
-$  grpc_tools_ruby_protoc --proto_path googleapis:. --ruby_out=. --grpc_out=. lightning.proto
+$  grpc_tools_ruby_protoc --ruby_out=. --grpc_out=. lightning.proto
 ```
 
 Two files will be generated in the current directory: 


### PR DESCRIPTION
## Change Description
Updated docs for python and ruby. Removed ``` grpcio googleapis-common-protos mypy-protobuf ``` and ``` google api ``` refernce  from python file.Also removed --mypy_out=. from line 38 and 56.

Removed references of googleapis from ruby docs.

**FIXES #9285** 

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
