### PR TITLE
[custom channels]: add taproot overlay channel type to channel acceptor

### DIFF
--- a/chanacceptor/rpcacceptor.go
+++ b/chanacceptor/rpcacceptor.go
@@ -357,6 +357,30 @@ func (r *RPCAcceptor) sendAcceptRequests(errChan chan error,
 					commitmentType = lnrpc.CommitmentType_SIMPLE_TAPROOT
 
 				case channelFeatures.OnlyContains(
+					lnwire.SimpleTaprootOverlayChansRequired,
+					lnwire.ZeroConfRequired,
+					lnwire.ScidAliasRequired,
+				):
+					commitmentType = lnrpc.CommitmentType_SIMPLE_TAPROOT_OVERLAY
+
+				case channelFeatures.OnlyContains(
+					lnwire.SimpleTaprootOverlayChansRequired,
+					lnwire.ZeroConfRequired,
+				):
+					commitmentType = lnrpc.CommitmentType_SIMPLE_TAPROOT_OVERLAY
+
+				case channelFeatures.OnlyContains(
+					lnwire.SimpleTaprootOverlayChansRequired,
+					lnwire.ScidAliasRequired,
+				):
+					commitmentType = lnrpc.CommitmentType_SIMPLE_TAPROOT_OVERLAY
+
+				case channelFeatures.OnlyContains(
+					lnwire.SimpleTaprootOverlayChansRequired,
+				):
+					commitmentType = lnrpc.CommitmentType_SIMPLE_TAPROOT_OVERLAY
+
+				case channelFeatures.OnlyContains(
 					lnwire.StaticRemoteKeyRequired,
 				):
 					commitmentType = lnrpc.CommitmentType_STATIC_REMOTE_KEY

--- a/docs/release-notes/release-notes-0.18.4.md
+++ b/docs/release-notes/release-notes-0.18.4.md
@@ -35,6 +35,7 @@ types in a series of changes:
   * https://github.com/lightningnetwork/lnd/pull/9095
   * https://github.com/lightningnetwork/lnd/pull/8960
   * https://github.com/lightningnetwork/lnd/pull/9194
+  * https://github.com/lightningnetwork/lnd/pull/9288
 
 ## Functional Enhancements
 


### PR DESCRIPTION
We forgot to add the new commitment type to the channel acceptor. Noticed in https://github.com/lightninglabs/taproot-assets/pull/1132.