### PR TITLE
lnwallet: log the amounts in the same unit

### DIFF
--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -10299,6 +10299,7 @@ func TestApplyCommitmentFee(t *testing.T) {
 		balance           lnwire.MilliSatoshi
 		expectedBalance   lnwire.MilliSatoshi
 		expectedBufferAmt lnwire.MilliSatoshi
+		expectedCommitFee lnwire.MilliSatoshi
 		bufferAmt         lnwire.MilliSatoshi
 		expectedErr       error
 	}{
@@ -10309,6 +10310,7 @@ func TestApplyCommitmentFee(t *testing.T) {
 			balance:           balance,
 			expectedBalance:   balance - feeBuffer,
 			expectedBufferAmt: feeBuffer - commitFee,
+			expectedCommitFee: commitFee,
 		},
 		{
 			name:        "apply feebuffer remote initiator",
@@ -10324,6 +10326,7 @@ func TestApplyCommitmentFee(t *testing.T) {
 			balance:           balance,
 			expectedBalance:   balance - commitFee - additionalHtlc,
 			expectedBufferAmt: additionalHtlc,
+			expectedCommitFee: commitFee,
 		},
 		{
 			name:              "apply NoBuffer",
@@ -10332,6 +10335,7 @@ func TestApplyCommitmentFee(t *testing.T) {
 			balance:           balance,
 			expectedBalance:   balance - commitFee,
 			expectedBufferAmt: 0,
+			expectedCommitFee: commitFee,
 		},
 		{
 			name:              "apply FeeBuffer balance negative",
@@ -10341,18 +10345,22 @@ func TestApplyCommitmentFee(t *testing.T) {
 			expectedBalance:   balanceBelowReserve,
 			expectedErr:       ErrBelowChanReserve,
 			expectedBufferAmt: feeBuffer,
+			expectedCommitFee: commitFee,
 		},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			balance, bufferAmt, err := tc.channel.applyCommitFee(
-				tc.balance, commitWeight, feePerKw, tc.buffer)
+			//nolint:lll
+			balance, bufferAmt, commitFee, err := tc.channel.applyCommitFee(
+				tc.balance, commitWeight, feePerKw, tc.buffer,
+			)
 
 			require.ErrorIs(t, err, tc.expectedErr)
 			require.Equal(t, tc.expectedBalance, balance)
 			require.Equal(t, tc.expectedBufferAmt, bufferAmt)
+			require.Equal(t, tc.expectedCommitFee, commitFee)
 		})
 	}
 }


### PR DESCRIPTION
Cherry-picked commits from the final blockbeat to reduce the PR size.

This PR makes sure we log the amounts in the same unit so it's easier to debug.

Before,
```
2024-11-20 06:30:24.312 [ERR] LNWL prefix_log.go:69: ChannelPoint(882a35d69a86c6c9dd753b94086c899df5ec42b15d2e2038e7bf4fcd3ae6ebdb:0): Cannot pay for the CommitmentFee of the ChannelState: ourBalance is negative after applying the fee: ourBalance=3850000, commitFee=0.00013350 BTC, feeBuffer=31000000 mSAT (type=feebuffer) local_chan_initiator
```

After,
```
2024-11-20 12:55:14.386 [ERR] LNWL prefix_log.go:69: ChannelPoint([ChanPoint: Alice=>dave]): Cannot pay for the CommitmentFee of the ChannelState: ourBalance is negative after applying the fee: ourBalance=3850000 mSAT, commitFee=13350000 mSAT, feeBuffer=31000000 mSAT (type=feebuffer) local_chan_initiator
```