### PR TITLE
lnd: stop `graphBuilder` during shutdown

### DIFF
--- a/server.go
+++ b/server.go
@@ -2481,6 +2481,9 @@ func (s *server) Stop() error {
 		if err := s.chanRouter.Stop(); err != nil {
 			srvrLog.Warnf("failed to stop chanRouter: %v", err)
 		}
+		if err := s.graphBuilder.Stop(); err != nil {
+			srvrLog.Warnf("failed to stop graphBuilder %v", err)
+		}
 		if err := s.chainArb.Stop(); err != nil {
 			srvrLog.Warnf("failed to stop chainArb: %v", err)
 		}


### PR DESCRIPTION
Cherry-picked commits from the final blockbeat to reduce the PR size.

Looks like we forgot to call the `graphBuilder.Stop` during the shutdown process - since we start the `graphBuilder` after the `chainArb`, we stop it before `chainArb`.