### PR TITLE
htlcswitch+routing: handle nil pointer dereference properly

### DIFF
--- a/htlcswitch/packet.go
+++ b/htlcswitch/packet.go
@@ -1,6 +1,8 @@
 package htlcswitch
 
 import (
+	"fmt"
+
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/graph/db/models"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
@@ -135,4 +137,13 @@ func (p *htlcPacket) keystone() Keystone {
 		InKey:  p.inKey(),
 		OutKey: p.outKey(),
 	}
+}
+
+// String returns a human-readable description of the packet.
+func (p *htlcPacket) String() string {
+	return fmt.Sprintf("keystone=%v, sourceRef=%v, destRef=%v, "+
+		"incomingAmount=%v, amount=%v, localFailure=%v, hasSource=%v "+
+		"isResolution=%v", p.keystone(), p.sourceRef, p.destRef,
+		p.incomingAmount, p.amount, p.localFailure, p.hasSource,
+		p.isResolution)
 }

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -1710,7 +1710,7 @@ func (lc *LightningChannel) restorePendingRemoteUpdates(
 	localCommitmentHeight uint64,
 	pendingRemoteCommit *commitment) error {
 
-	lc.log.Debugf("Restoring %v dangling remote updates",
+	lc.log.Debugf("Restoring %v dangling remote updates pending our sig",
 		len(unsignedAckedUpdates))
 
 	for _, logUpdate := range unsignedAckedUpdates {
@@ -1828,6 +1828,9 @@ func (lc *LightningChannel) restorePendingLocalUpdates(
 
 	pendingCommit := pendingRemoteCommitDiff.Commitment
 	pendingHeight := pendingCommit.CommitHeight
+
+	lc.log.Debugf("Restoring pending remote commitment %v at commit "+
+		"height %v", pendingCommit.CommitTx.TxHash(), pendingHeight)
 
 	auxResult, err := fn.MapOptionZ(
 		lc.leafStore,


### PR DESCRIPTION
This is the final cherry-picking from the blockbeat series PR #9260, which fixes the case on how we handle a closing circuit and a nil pointer dereference in the payment lifecycle:

```
2024-11-07 18:05:26.293 [CRT] CHDB log_shutdown.go:31: Caught unhandled error: ERROR: could not access status of transaction 330367 (SQLSTATE 58P01)
2024-11-07 18:05:26.293 [INF] CHDB log_shutdown.go:32: Sending request for shutdown
2024-11-07 18:05:26.293 [INF] LTND signal.go:181: Received shutdown request.
2024-11-07 18:05:26.293 [INF] LTND signal.go:166: Shutting down...
2024-11-07 18:05:26.293 [INF] LTND signal.go:185: Gracefully shutting down.
2024-11-07 18:05:26.294 [DBG] HSWC payment_result.go:166: Subscribing to result for attemptID=266
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x1193220]

goroutine 69854 [running]:
github.com/lightningnetwork/lnd/channeldb.(*MPPayment).GetStatus(0xc000464320?)
	/home/runner/work/lnd/lnd/channeldb/mp_payment.go:459
github.com/lightningnetwork/lnd/routing.(*paymentLifecycle).resumePayment.func1({0x220afa0, 0xc000b23a80})
	/home/runner/work/lnd/lnd/routing/payment_lifecycle.go:195 +0x48
github.com/lightningnetwork/lnd/routing.(*paymentLifecycle).resumePayment(0xc00288d700, {0x2223108, 0xc0002c27e0})
	/home/runner/work/lnd/lnd/routing/payment_lifecycle.go:210 +0xf22
github.com/lightningnetwork/lnd/routing.(*ChannelRouter).sendPayment(0xc0004ef080, {0x2222410?, 0x337d480?}, 0x7fffffffffffffff, {0xb6, 0x7f, 0xd, 0xe2, 0xc4, 0x48, ...}, ...)
	/home/runner/work/lnd/lnd/routing/router.go:1328 +0x2ec
github.com/lightningnetwork/lnd/routing.(*ChannelRouter).SendPaymentAsync.func1()
	/home/runner/work/lnd/lnd/routing/router.go:983 +0x24c
created by github.com/lightningnetwork/lnd/routing.(*ChannelRouter).SendPaymentAsync in goroutine 42117
	/home/runner/work/lnd/lnd/routing/router.go:977 +0xec
```