### PR TITLE
 Beat itest [1/3]: remove the usage of standby nodes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -292,7 +292,7 @@ jobs:
         run: ./scripts/install_bitcoind.sh $BITCOIN_VERSION
 
       - name: run ${{ matrix.name }}
-        run: make itest-parallel tranches=${{ env.TRANCHES }} ${{ matrix.args }}
+        run: make itest-parallel tranches=${{ env.TRANCHES }} ${{ matrix.args }} shuffleseed=${{ github.run_id }}${{ strategy.job-index }}
 
       - name: Send coverage
         if: ${{ contains(matrix.args, 'cover=1') }}
@@ -340,7 +340,7 @@ jobs:
           key-prefix: integration-test
 
       - name: run itest
-        run: make itest-parallel tranches=${{ env.TRANCHES }} windows=1
+        run: make itest-parallel tranches=${{ env.TRANCHES }} windows=1 shuffleseed=${{ github.run_id }}
         
       - name: kill any remaining lnd processes
         if: ${{ failure() }}
@@ -390,7 +390,7 @@ jobs:
           mv bitcoin-${BITCOIN_VERSION}.0 /tmp/bitcoin
 
       - name: run itest
-        run: PATH=$PATH:/tmp/bitcoin/bin make itest-parallel tranches=${{ env.TRANCHES }} backend=bitcoind
+        run: PATH=$PATH:/tmp/bitcoin/bin make itest-parallel tranches=${{ env.TRANCHES }} backend=bitcoind shuffleseed=${{ github.run_id }}
 
       - name: Zip log files on failure
         if: ${{ failure() }}

--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ endif
 itest-only: db-instance
 	@$(call print, "Running integration tests with ${backend} backend.")
 	rm -rf itest/*.log itest/.logs-*; date
-	EXEC_SUFFIX=$(EXEC_SUFFIX) scripts/itest_part.sh 0 1 $(TEST_FLAGS) $(ITEST_FLAGS) -test.v
+	EXEC_SUFFIX=$(EXEC_SUFFIX) scripts/itest_part.sh 0 1 $(SHUFFLE_SEED) $(TEST_FLAGS) $(ITEST_FLAGS) -test.v
 	$(COLLECT_ITEST_COVERAGE)
 
 #? itest: Build and run integration tests
@@ -221,7 +221,7 @@ itest-race: build-itest-race itest-only
 itest-parallel: build-itest db-instance
 	@$(call print, "Running tests")
 	rm -rf itest/*.log itest/.logs-*; date
-	EXEC_SUFFIX=$(EXEC_SUFFIX) scripts/itest_parallel.sh $(ITEST_PARALLELISM) $(NUM_ITEST_TRANCHES) $(TEST_FLAGS) $(ITEST_FLAGS)
+	EXEC_SUFFIX=$(EXEC_SUFFIX) scripts/itest_parallel.sh $(ITEST_PARALLELISM) $(NUM_ITEST_TRANCHES) $(SHUFFLE_SEED) $(TEST_FLAGS) $(ITEST_FLAGS)
 	$(COLLECT_ITEST_COVERAGE)
 
 #? itest-clean: Kill all running itest processes

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -2,7 +2,9 @@
 
 package itest
 
-import "github.com/lightningnetwork/lnd/lntest"
+import (
+	"github.com/lightningnetwork/lnd/lntest"
+)
 
 var allTestCases = []*lntest.TestCase{
 	{

--- a/itest/lnd_channel_backup_test.go
+++ b/itest/lnd_channel_backup_test.go
@@ -844,7 +844,7 @@ func runChanRestoreScenarioForceClose(ht *lntest.HarnessTest, zeroConf bool) {
 // and the on-disk channel.backup are updated each time a channel is
 // opened/closed.
 func testChannelBackupUpdates(ht *lntest.HarnessTest) {
-	alice := ht.Alice
+	alice := ht.NewNodeWithCoins("Alice", nil)
 
 	// First, we'll make a temp directory that we'll use to store our
 	// backup file, so we can check in on it during the test easily.
@@ -1052,7 +1052,7 @@ func testExportChannelBackup(ht *lntest.HarnessTest) {
 
 	// With Carol up, we'll now connect her to Alice, and open a channel
 	// between them.
-	alice := ht.Alice
+	alice := ht.NewNodeWithCoins("Alice", nil)
 	ht.ConnectNodes(carol, alice)
 
 	// Next, we'll open two channels between Alice and Carol back to back.

--- a/itest/lnd_channel_balance_test.go
+++ b/itest/lnd_channel_balance_test.go
@@ -48,7 +48,8 @@ func testChannelBalance(ht *lntest.HarnessTest) {
 	}
 
 	// Before beginning, make sure alice and bob are connected.
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNode("Bob", nil)
 	ht.EnsureConnected(alice, bob)
 
 	chanPoint := ht.OpenChannel(
@@ -118,7 +119,7 @@ func testChannelUnsettledBalance(ht *lntest.HarnessTest) {
 	carol := ht.NewNode("Carol", []string{"--hodl.exit-settle"})
 
 	// Connect Alice to Carol.
-	alice := ht.Alice
+	alice := ht.NewNodeWithCoins("Alice", nil)
 	ht.ConnectNodes(alice, carol)
 
 	// Open a channel between Alice and Carol.

--- a/itest/lnd_channel_balance_test.go
+++ b/itest/lnd_channel_balance_test.go
@@ -63,10 +63,6 @@ func testChannelBalance(ht *lntest.HarnessTest) {
 
 	// Ensure Bob currently has no available balance within the channel.
 	checkChannelBalance(bob, 0, amount-lntest.CalcStaticFee(cType, 0))
-
-	// Finally close the channel between Alice and Bob, asserting that the
-	// channel has been properly closed on-chain.
-	ht.CloseChannel(alice, chanPoint)
 }
 
 // testChannelUnsettledBalance will test that the UnsettledBalance field
@@ -208,7 +204,4 @@ func testChannelUnsettledBalance(ht *lntest.HarnessTest) {
 	// balance that equals to the amount of invoices * payAmt. The local
 	// balance remains zero.
 	checkChannelBalance(carol, 0, aliceLocal, numInvoices*payAmt, 0)
-
-	// Force and assert the channel closure.
-	ht.ForceCloseChannel(alice, chanPointAlice)
 }

--- a/itest/lnd_channel_force_close_test.go
+++ b/itest/lnd_channel_force_close_test.go
@@ -771,7 +771,7 @@ func testFailingChannel(ht *lntest.HarnessTest) {
 	// totally unrelated preimage.
 	carol := ht.NewNode("Carol", []string{"--hodl.bogus-settle"})
 
-	alice := ht.Alice
+	alice := ht.NewNodeWithCoins("Alice", nil)
 	ht.ConnectNodes(alice, carol)
 
 	// Let Alice connect and open a channel to Carol,

--- a/itest/lnd_channel_funding_fund_max_test.go
+++ b/itest/lnd_channel_funding_fund_max_test.go
@@ -57,10 +57,7 @@ func testChannelFundMax(ht *lntest.HarnessTest) {
 	// tests.
 	args := lntest.NodeArgsForCommitType(lnrpc.CommitmentType_ANCHORS)
 	alice := ht.NewNode("Alice", args)
-	defer ht.Shutdown(alice)
-
 	bob := ht.NewNode("Bob", args)
-	defer ht.Shutdown(bob)
 
 	// Ensure both sides are connected so the funding flow can be properly
 	// executed.
@@ -229,12 +226,11 @@ func runFundMaxTestCase(ht *lntest.HarnessTest, alice, bob *node.HarnessNode,
 
 	// Otherwise, if we expect to open a channel use the helper function.
 	chanPoint := ht.OpenChannel(alice, bob, chanParams)
+	cType := ht.GetChannelCommitType(alice, chanPoint)
 
 	// Close the channel between Alice and Bob, asserting
 	// that the channel has been properly closed on-chain.
 	defer ht.CloseChannel(alice, chanPoint)
-
-	cType := ht.GetChannelCommitType(alice, chanPoint)
 
 	// Alice's balance should be her amount subtracted by the commitment
 	// transaction fee.

--- a/itest/lnd_channel_funding_utxo_selection_test.go
+++ b/itest/lnd_channel_funding_utxo_selection_test.go
@@ -64,10 +64,7 @@ func testChannelUtxoSelection(ht *lntest.HarnessTest) {
 	// tests.
 	args := lntest.NodeArgsForCommitType(lnrpc.CommitmentType_ANCHORS)
 	alice := ht.NewNode("Alice", args)
-	defer ht.Shutdown(alice)
-
 	bob := ht.NewNode("Bob", args)
-	defer ht.Shutdown(bob)
 
 	// Ensure both sides are connected so the funding flow can be properly
 	// executed.

--- a/itest/lnd_channel_graph_test.go
+++ b/itest/lnd_channel_graph_test.go
@@ -234,7 +234,7 @@ func testUnannouncedChannels(ht *lntest.HarnessTest) {
 
 	// One block is enough to make the channel ready for use, since the
 	// nodes have defaultNumConfs=1 set.
-	fundingChanPoint := ht.WaitForChannelOpenEvent(chanOpenUpdate)
+	ht.WaitForChannelOpenEvent(chanOpenUpdate)
 
 	// Alice should have 1 edge in her graph.
 	ht.AssertNumActiveEdges(alice, 1, true)
@@ -248,9 +248,6 @@ func testUnannouncedChannels(ht *lntest.HarnessTest) {
 
 	// Give the network a chance to learn that auth proof is confirmed.
 	ht.AssertNumActiveEdges(alice, 1, false)
-
-	// Close the channel used during the test.
-	ht.CloseChannel(alice, fundingChanPoint)
 }
 
 func testGraphTopologyNotifications(ht *lntest.HarnessTest) {
@@ -367,9 +364,6 @@ func testGraphTopologyNtfns(ht *lntest.HarnessTest, pinned bool) {
 	// Bob's new node announcement, and the channel between Bob and Carol.
 	ht.AssertNumChannelUpdates(alice, chanPoint, 2)
 	ht.AssertNumNodeAnns(alice, bob.PubKeyStr, 1)
-
-	// Close the channel between Bob and Carol.
-	ht.CloseChannel(bob, chanPoint)
 }
 
 // testNodeAnnouncement ensures that when a node is started with one or more
@@ -402,7 +396,7 @@ func testNodeAnnouncement(ht *lntest.HarnessTest) {
 	// We'll then go ahead and open a channel between Bob and Dave. This
 	// ensures that Alice receives the node announcement from Bob as part of
 	// the announcement broadcast.
-	chanPoint := ht.OpenChannel(
+	ht.OpenChannel(
 		bob, dave, lntest.OpenChannelParams{Amt: 1000000},
 	)
 
@@ -424,9 +418,6 @@ func testNodeAnnouncement(ht *lntest.HarnessTest) {
 	allUpdates := ht.AssertNumNodeAnns(alice, dave.PubKeyStr, 1)
 	nodeUpdate := allUpdates[len(allUpdates)-1]
 	assertAddrs(nodeUpdate.Addresses, advertisedAddrs...)
-
-	// Close the channel between Bob and Dave.
-	ht.CloseChannel(bob, chanPoint)
 }
 
 // testUpdateNodeAnnouncement ensures that the RPC endpoint validates
@@ -531,7 +522,7 @@ func testUpdateNodeAnnouncement(ht *lntest.HarnessTest) {
 	// Go ahead and open a channel between Bob and Dave. This
 	// ensures that Alice receives the node announcement from Bob as part of
 	// the announcement broadcast.
-	chanPoint := ht.OpenChannel(
+	ht.OpenChannel(
 		bob, dave, lntest.OpenChannelParams{
 			Amt: 1000000,
 		},
@@ -661,9 +652,6 @@ func testUpdateNodeAnnouncement(ht *lntest.HarnessTest) {
 		FeatureUpdates: updateFeatureActions,
 	}
 	dave.RPC.UpdateNodeAnnouncementErr(nodeAnnReq)
-
-	// Close the channel between Bob and Dave.
-	ht.CloseChannel(bob, chanPoint)
 }
 
 // assertSyncType asserts that the peer has an expected syncType.

--- a/itest/lnd_channel_graph_test.go
+++ b/itest/lnd_channel_graph_test.go
@@ -218,7 +218,9 @@ func testUpdateChanStatus(ht *lntest.HarnessTest) {
 // describeGraph RPC request unless explicitly asked for.
 func testUnannouncedChannels(ht *lntest.HarnessTest) {
 	amount := funding.MaxBtcFundingAmount
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNode("Bob", nil)
+	ht.EnsureConnected(alice, bob)
 
 	// Open a channel between Alice and Bob, ensuring the
 	// channel has been opened properly.
@@ -267,13 +269,9 @@ func testGraphTopologyNtfns(ht *lntest.HarnessTest, pinned bool) {
 
 	// Spin up Bob first, since we will need to grab his pubkey when
 	// starting Alice to test pinned syncing.
-	bob := ht.Bob
+	bob := ht.NewNodeWithCoins("Bob", nil)
 	bobInfo := bob.RPC.GetInfo()
 	bobPubkey := bobInfo.IdentityPubkey
-
-	// Restart Bob as he may have leftover announcements from previous
-	// tests, causing the graph to be unsynced.
-	ht.RestartNodeWithExtraArgs(bob, nil)
 
 	// For unpinned syncing, start Alice as usual. Otherwise grab Bob's
 	// pubkey to include in his pinned syncer set.
@@ -285,8 +283,7 @@ func testGraphTopologyNtfns(ht *lntest.HarnessTest, pinned bool) {
 		}
 	}
 
-	alice := ht.Alice
-	ht.RestartNodeWithExtraArgs(alice, aliceArgs)
+	alice := ht.NewNodeWithCoins("Alice", aliceArgs)
 
 	// Connect Alice and Bob.
 	ht.EnsureConnected(alice, bob)
@@ -379,7 +376,9 @@ func testGraphTopologyNtfns(ht *lntest.HarnessTest, pinned bool) {
 // external IP addresses specified on the command line, that those addresses
 // announced to the network and reported in the network graph.
 func testNodeAnnouncement(ht *lntest.HarnessTest) {
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNode("Alice", nil)
+	bob := ht.NewNodeWithCoins("Bob", nil)
+	ht.EnsureConnected(alice, bob)
 
 	advertisedAddrs := []string{
 		"192.168.1.1:8333",
@@ -434,7 +433,9 @@ func testNodeAnnouncement(ht *lntest.HarnessTest) {
 // the requests correctly and that the new node announcement is broadcast
 // with the right information after updating our node.
 func testUpdateNodeAnnouncement(ht *lntest.HarnessTest) {
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNode("Alice", nil)
+	bob := ht.NewNodeWithCoins("Bob", nil)
+	ht.EnsureConnected(alice, bob)
 
 	var lndArgs []string
 

--- a/itest/lnd_channel_policy_test.go
+++ b/itest/lnd_channel_policy_test.go
@@ -30,19 +30,16 @@ func testUpdateChannelPolicy(ht *lntest.HarnessTest) {
 	chanAmt := funding.MaxBtcFundingAmount
 	pushAmt := chanAmt / 2
 
-	alice, bob := ht.Alice, ht.Bob
-
 	// Create a channel Alice->Bob.
-	chanPoint := ht.OpenChannel(
-		alice, bob, lntest.OpenChannelParams{
+	chanPoints, nodes := ht.CreateSimpleNetwork(
+		[][]string{nil, nil}, lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,
 		},
 	)
 
-	// We add all the nodes' update channels to a slice, such that we can
-	// make sure they all receive the expected updates.
-	nodes := []*node.HarnessNode{alice, bob}
+	alice, bob := nodes[0], nodes[1]
+	chanPoint := chanPoints[0]
 
 	// Alice and Bob should see each other's ChannelUpdates, advertising the
 	// default routing policies. We do not currently set any inbound fees.
@@ -441,7 +438,8 @@ func testUpdateChannelPolicy(ht *lntest.HarnessTest) {
 func testSendUpdateDisableChannel(ht *lntest.HarnessTest) {
 	const chanAmt = 100000
 
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNode("Bob", nil)
 
 	// Create a new node Eve, which will be restarted later with a config
 	// that has an inactive channel timeout of just 6 seconds (down from
@@ -678,7 +676,9 @@ func testUpdateChannelPolicyForPrivateChannel(ht *lntest.HarnessTest) {
 
 	// We'll create the following topology first,
 	// Alice <--public:100k--> Bob <--private:100k--> Carol
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNodeWithCoins("Bob", nil)
+	ht.EnsureConnected(alice, bob)
 
 	// Open a channel with 100k satoshis between Alice and Bob.
 	chanPointAliceBob := ht.OpenChannel(
@@ -787,16 +787,14 @@ func testUpdateChannelPolicyFeeRateAccuracy(ht *lntest.HarnessTest) {
 	pushAmt := chanAmt / 2
 
 	// Create a channel Alice -> Bob.
-	alice, bob := ht.Alice, ht.Bob
-	chanPoint := ht.OpenChannel(
-		alice, bob, lntest.OpenChannelParams{
+	chanPoints, nodes := ht.CreateSimpleNetwork(
+		[][]string{nil, nil}, lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,
 		},
 	)
-
-	// Nodes that we need to make sure receive the channel updates.
-	nodes := []*node.HarnessNode{alice, bob}
+	alice := nodes[0]
+	chanPoint := chanPoints[0]
 
 	baseFee := int64(1500)
 	timeLockDelta := uint32(66)

--- a/itest/lnd_channel_policy_test.go
+++ b/itest/lnd_channel_policy_test.go
@@ -420,11 +420,6 @@ func testUpdateChannelPolicy(ht *lntest.HarnessTest) {
 	ht.AssertChannelPolicy(
 		carol, alice.PubKeyStr, expectedPolicy, chanPoint3,
 	)
-
-	// Close all channels.
-	ht.CloseChannel(alice, chanPoint)
-	ht.CloseChannel(bob, chanPoint2)
-	ht.CloseChannel(alice, chanPoint3)
 }
 
 // testSendUpdateDisableChannel ensures that a channel update with the disable
@@ -773,10 +768,6 @@ func testUpdateChannelPolicyForPrivateChannel(ht *lntest.HarnessTest) {
 	// Alice should have sent 20k satoshis + fee to Bob.
 	ht.AssertAmountPaid("Alice(local) => Bob(remote)",
 		alice, chanPointAliceBob, amtExpected, 0)
-
-	// Finally, close the channels.
-	ht.CloseChannel(alice, chanPointAliceBob)
-	ht.CloseChannel(bob, chanPointBobCarol)
 }
 
 // testUpdateChannelPolicyFeeRateAccuracy tests that updating the channel policy
@@ -845,8 +836,6 @@ func testUpdateChannelPolicyFeeRateAccuracy(ht *lntest.HarnessTest) {
 
 	// Make sure that both Alice and Bob sees the same policy after update.
 	assertNodesPolicyUpdate(ht, nodes, alice, expectedPolicy, chanPoint)
-
-	ht.CloseChannel(alice, chanPoint)
 }
 
 // assertNodesPolicyUpdate checks that a given policy update has been received

--- a/itest/lnd_coop_close_external_delivery_test.go
+++ b/itest/lnd_coop_close_external_delivery_test.go
@@ -58,7 +58,8 @@ func testCoopCloseWithExternalDelivery(ht *lntest.HarnessTest) {
 func testCoopCloseWithExternalDeliveryImpl(ht *lntest.HarnessTest,
 	upfrontShutdown bool, deliveryAddressType lnrpc.AddressType) {
 
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNodeWithCoins("bob", nil)
 	ht.ConnectNodes(alice, bob)
 
 	// Here we generate a final delivery address in bob's wallet but set by

--- a/itest/lnd_coop_close_with_htlcs_test.go
+++ b/itest/lnd_coop_close_with_htlcs_test.go
@@ -37,7 +37,8 @@ func testCoopCloseWithHtlcs(ht *lntest.HarnessTest) {
 // channel party initiates a channel shutdown while an HTLC is still pending on
 // the channel.
 func coopCloseWithHTLCs(ht *lntest.HarnessTest) {
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNodeWithCoins("bob", nil)
 	ht.ConnectNodes(alice, bob)
 
 	// Here we set up a channel between Alice and Bob, beginning with a
@@ -128,7 +129,8 @@ func coopCloseWithHTLCs(ht *lntest.HarnessTest) {
 // process continues as expected even if a channel re-establish happens after
 // one party has already initiated the shutdown.
 func coopCloseWithHTLCsWithRestart(ht *lntest.HarnessTest) {
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNodeWithCoins("bob", nil)
 	ht.ConnectNodes(alice, bob)
 
 	// Open a channel between Alice and Bob with the balance split equally.

--- a/itest/lnd_custom_features.go
+++ b/itest/lnd_custom_features.go
@@ -29,11 +29,10 @@ func testCustomFeatures(ht *lntest.HarnessTest) {
 	}
 	cfgs := [][]string{extraArgs, nil}
 
-	chanPoints, nodes := ht.CreateSimpleNetwork(
+	_, nodes := ht.CreateSimpleNetwork(
 		cfgs, lntest.OpenChannelParams{Amt: 1000000},
 	)
 	alice, bob := nodes[0], nodes[1]
-	chanPoint := chanPoints[0]
 
 	// Check that Alice's custom feature bit was sent to Bob in her init
 	// message.
@@ -79,8 +78,6 @@ func testCustomFeatures(ht *lntest.HarnessTest) {
 		},
 	}
 	alice.RPC.UpdateNodeAnnouncementErr(nodeAnnReq)
-
-	ht.CloseChannel(alice, chanPoint)
 }
 
 // assertFeatureNotInSet checks that the features provided aren't contained in

--- a/itest/lnd_custom_features.go
+++ b/itest/lnd_custom_features.go
@@ -13,8 +13,6 @@ import (
 // sets. For completeness, it also asserts that features aren't set in places
 // where they aren't intended to be.
 func testCustomFeatures(ht *lntest.HarnessTest) {
-	alice, bob := ht.Alice, ht.Bob
-
 	var (
 		// Odd custom features so that we don't need to worry about
 		// issues connecting to peers.
@@ -29,14 +27,13 @@ func testCustomFeatures(ht *lntest.HarnessTest) {
 		fmt.Sprintf("--protocol.custom-nodeann=%v", customNodeAnn),
 		fmt.Sprintf("--protocol.custom-invoice=%v", customInvoice),
 	}
-	ht.RestartNodeWithExtraArgs(alice, extraArgs)
+	cfgs := [][]string{extraArgs, nil}
 
-	// Connect nodes and open a channel so that Alice will be included
-	// in Bob's graph.
-	ht.ConnectNodes(alice, bob)
-	chanPoint := ht.OpenChannel(
-		alice, bob, lntest.OpenChannelParams{Amt: 1000000},
+	chanPoints, nodes := ht.CreateSimpleNetwork(
+		cfgs, lntest.OpenChannelParams{Amt: 1000000},
 	)
+	alice, bob := nodes[0], nodes[1]
+	chanPoint := chanPoints[0]
 
 	// Check that Alice's custom feature bit was sent to Bob in her init
 	// message.

--- a/itest/lnd_custom_message_test.go
+++ b/itest/lnd_custom_message_test.go
@@ -14,8 +14,6 @@ import (
 // types (within the message type range usually reserved for protocol messages)
 // via the send and subscribe custom message APIs.
 func testCustomMessage(ht *lntest.HarnessTest) {
-	alice, bob := ht.Alice, ht.Bob
-
 	var (
 		overrideType1  uint32 = 554
 		overrideType2  uint32 = 555
@@ -27,7 +25,8 @@ func testCustomMessage(ht *lntest.HarnessTest) {
 	extraArgs := []string{
 		fmt.Sprintf(msgOverrideArg, overrideType1),
 	}
-	ht.RestartNodeWithExtraArgs(alice, extraArgs)
+	alice := ht.NewNode("Alice", extraArgs)
+	bob := ht.NewNode("Bob", nil)
 
 	// Subscribe Alice to custom messages before we send any, so that we
 	// don't miss any.

--- a/itest/lnd_estimate_route_fee_test.go
+++ b/itest/lnd_estimate_route_fee_test.go
@@ -109,7 +109,7 @@ func testEstimateRouteFee(ht *lntest.HarnessTest) {
 		},
 	)
 
-	bobsPrivChannels := ht.Bob.RPC.ListChannels(&lnrpc.ListChannelsRequest{
+	bobsPrivChannels := mts.bob.RPC.ListChannels(&lnrpc.ListChannelsRequest{
 		PrivateOnly: true,
 	})
 	require.Len(ht, bobsPrivChannels.Channels, 1)

--- a/itest/lnd_experimental_endorsement.go
+++ b/itest/lnd_experimental_endorsement.go
@@ -49,7 +49,7 @@ func testEndorsement(ht *lntest.HarnessTest, aliceEndorse bool) {
 		{Local: dave, Remote: eve, Param: p},
 	}
 	resp := ht.OpenMultiChannelsAsync(reqs)
-	cpAB, cpBC, cpCD, cpDE := resp[0], resp[1], resp[2], resp[3]
+	_, cpBC, cpCD, cpDE := resp[0], resp[1], resp[2], resp[3]
 
 	// Make sure Alice is aware of Bob=>Carol=>Dave=>Eve channels.
 	ht.AssertChannelInGraph(alice, cpBC)
@@ -95,11 +95,6 @@ func testEndorsement(ht *lntest.HarnessTest, aliceEndorse bool) {
 	var preimage lntypes.Preimage
 	copy(preimage[:], invoice.RPreimage)
 	ht.AssertPaymentStatus(alice, preimage, lnrpc.Payment_SUCCEEDED)
-
-	ht.CloseChannel(alice, cpAB)
-	ht.CloseChannel(bob, cpBC)
-	ht.CloseChannel(carol, cpCD)
-	ht.CloseChannel(dave, cpDE)
 }
 
 func validateEndorsedAndResume(ht *lntest.HarnessTest,

--- a/itest/lnd_experimental_endorsement.go
+++ b/itest/lnd_experimental_endorsement.go
@@ -24,7 +24,8 @@ func testExperimentalEndorsement(ht *lntest.HarnessTest) {
 // testEndorsement sets up a 5 hop network and tests propagation of
 // experimental endorsement signals.
 func testEndorsement(ht *lntest.HarnessTest, aliceEndorse bool) {
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNodeWithCoins("Bob", nil)
 	carol := ht.NewNode(
 		"carol", []string{"--protocol.no-experimental-endorsement"},
 	)

--- a/itest/lnd_forward_interceptor_test.go
+++ b/itest/lnd_forward_interceptor_test.go
@@ -765,7 +765,9 @@ type interceptorTestScenario struct {
 func newInterceptorTestScenario(
 	ht *lntest.HarnessTest) *interceptorTestScenario {
 
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNodeWithCoins("bob", nil)
+
 	carol := ht.NewNode("carol", nil)
 	dave := ht.NewNode("dave", nil)
 

--- a/itest/lnd_forward_interceptor_test.go
+++ b/itest/lnd_forward_interceptor_test.go
@@ -177,10 +177,6 @@ func testForwardInterceptorDedupHtlc(ht *lntest.HarnessTest) {
 	case <-time.After(defaultTimeout):
 		require.Fail(ht, "timeout waiting for interceptor error")
 	}
-
-	// Finally, close channels.
-	ht.CloseChannel(alice, cpAB)
-	ht.CloseChannel(bob, cpBC)
 }
 
 // testForwardInterceptorBasic tests the forward interceptor RPC layer.
@@ -345,10 +341,6 @@ func testForwardInterceptorBasic(ht *lntest.HarnessTest) {
 	case <-time.After(defaultTimeout):
 		require.Fail(ht, "timeout waiting for interceptor error")
 	}
-
-	// Finally, close channels.
-	ht.CloseChannel(alice, cpAB)
-	ht.CloseChannel(bob, cpBC)
 }
 
 // testForwardInterceptorModifiedHtlc tests that the interceptor can modify the
@@ -367,7 +359,7 @@ func testForwardInterceptorModifiedHtlc(ht *lntest.HarnessTest) {
 		{Local: bob, Remote: carol, Param: p},
 	}
 	resp := ht.OpenMultiChannelsAsync(reqs)
-	cpAB, cpBC := resp[0], resp[1]
+	cpBC := resp[1]
 
 	// Make sure Alice is aware of channel Bob=>Carol.
 	ht.AssertChannelInGraph(alice, cpBC)
@@ -451,10 +443,6 @@ func testForwardInterceptorModifiedHtlc(ht *lntest.HarnessTest) {
 	var preimage lntypes.Preimage
 	copy(preimage[:], invoice.RPreimage)
 	ht.AssertPaymentStatus(alice, preimage, lnrpc.Payment_SUCCEEDED)
-
-	// Finally, close channels.
-	ht.CloseChannel(alice, cpAB)
-	ht.CloseChannel(bob, cpBC)
 }
 
 // testForwardInterceptorWireRecords tests that the interceptor can read any
@@ -475,7 +463,7 @@ func testForwardInterceptorWireRecords(ht *lntest.HarnessTest) {
 		{Local: carol, Remote: dave, Param: p},
 	}
 	resp := ht.OpenMultiChannelsAsync(reqs)
-	cpAB, cpBC, cpCD := resp[0], resp[1], resp[2]
+	cpBC := resp[1]
 
 	// Make sure Alice is aware of channel Bob=>Carol.
 	ht.AssertChannelInGraph(alice, cpBC)
@@ -579,11 +567,6 @@ func testForwardInterceptorWireRecords(ht *lntest.HarnessTest) {
 			return nil
 		},
 	)
-
-	// Finally, close channels.
-	ht.CloseChannel(alice, cpAB)
-	ht.CloseChannel(bob, cpBC)
-	ht.CloseChannel(carol, cpCD)
 }
 
 // testForwardInterceptorRestart tests that the interceptor can read any wire
@@ -605,7 +588,7 @@ func testForwardInterceptorRestart(ht *lntest.HarnessTest) {
 		{Local: carol, Remote: dave, Param: p},
 	}
 	resp := ht.OpenMultiChannelsAsync(reqs)
-	cpAB, cpBC, cpCD := resp[0], resp[1], resp[2]
+	cpBC, cpCD := resp[1], resp[2]
 
 	// Make sure Alice is aware of channels Bob=>Carol and Carol=>Dave.
 	ht.AssertChannelInGraph(alice, cpBC)
@@ -742,11 +725,6 @@ func testForwardInterceptorRestart(ht *lntest.HarnessTest) {
 			return nil
 		},
 	)
-
-	// Finally, close channels.
-	ht.CloseChannel(alice, cpAB)
-	ht.CloseChannel(bob, cpBC)
-	ht.CloseChannel(carol, cpCD)
 }
 
 // interceptorTestScenario is a helper struct to hold the test context and

--- a/itest/lnd_funding_test.go
+++ b/itest/lnd_funding_test.go
@@ -287,8 +287,7 @@ func testUnconfirmedChannelFunding(ht *lntest.HarnessTest) {
 
 	// We'll start off by creating a node for Carol.
 	carol := ht.NewNode("Carol", nil)
-
-	alice := ht.Alice
+	alice := ht.NewNode("Alice", nil)
 
 	// We'll send her some unconfirmed funds.
 	ht.FundCoinsUnconfirmed(2*chanAmt, carol)
@@ -407,7 +406,7 @@ func testUnconfirmedChannelFunding(ht *lntest.HarnessTest) {
 // testChannelFundingInputTypes tests that any type of supported input type can
 // be used to fund channels.
 func testChannelFundingInputTypes(ht *lntest.HarnessTest) {
-	alice := ht.Alice
+	alice := ht.NewNode("Alice", nil)
 
 	// We'll start off by creating a node for Carol.
 	carol := ht.NewNode("Carol", nil)
@@ -846,7 +845,7 @@ func testChannelFundingPersistence(ht *lntest.HarnessTest) {
 	}
 	carol := ht.NewNode("Carol", carolArgs)
 
-	alice := ht.Alice
+	alice := ht.NewNodeWithCoins("Alice", nil)
 	ht.ConnectNodes(alice, carol)
 
 	// Create a new channel that requires 5 confs before it's considered
@@ -962,8 +961,8 @@ func testBatchChanFunding(ht *lntest.HarnessTest) {
 	}
 	eve := ht.NewNode("eve", scidAliasArgs)
 
-	alice, bob := ht.Alice, ht.Bob
-	ht.RestartNodeWithExtraArgs(alice, scidAliasArgs)
+	alice := ht.NewNodeWithCoins("Alice", scidAliasArgs)
+	bob := ht.NewNodeWithCoins("Bob", nil)
 
 	// Before we start the test, we'll ensure Alice is connected to Carol
 	// and Dave, so she can open channels to both of them (and Bob).

--- a/itest/lnd_funding_test.go
+++ b/itest/lnd_funding_test.go
@@ -407,14 +407,16 @@ func testUnconfirmedChannelFunding(ht *lntest.HarnessTest) {
 // testChannelFundingInputTypes tests that any type of supported input type can
 // be used to fund channels.
 func testChannelFundingInputTypes(ht *lntest.HarnessTest) {
+	alice := ht.Alice
+
 	// We'll start off by creating a node for Carol.
 	carol := ht.NewNode("Carol", nil)
 
 	// Now, we'll connect her to Alice so that they can open a
 	// channel together.
-	ht.ConnectNodes(carol, ht.Alice)
+	ht.ConnectNodes(carol, alice)
 
-	runChannelFundingInputTypes(ht, ht.Alice, carol)
+	runChannelFundingInputTypes(ht, alice, carol)
 }
 
 // runChannelFundingInputTypes tests that any type of supported input type can

--- a/itest/lnd_hold_invoice_force_test.go
+++ b/itest/lnd_hold_invoice_force_test.go
@@ -17,10 +17,11 @@ import (
 // would otherwise trigger force closes when they expire.
 func testHoldInvoiceForceClose(ht *lntest.HarnessTest) {
 	// Open a channel between alice and bob.
-	alice, bob := ht.Alice, ht.Bob
-	chanPoint := ht.OpenChannel(
-		alice, bob, lntest.OpenChannelParams{Amt: 300000},
+	chanPoints, nodes := ht.CreateSimpleNetwork(
+		[][]string{nil, nil}, lntest.OpenChannelParams{Amt: 300000},
 	)
+	alice, bob := nodes[0], nodes[1]
+	chanPoint := chanPoints[0]
 
 	// Create a non-dust hold invoice for bob.
 	var (

--- a/itest/lnd_hold_invoice_force_test.go
+++ b/itest/lnd_hold_invoice_force_test.go
@@ -140,7 +140,4 @@ func testHoldInvoiceForceClose(ht *lntest.HarnessTest) {
 	// outgoing HTLCs in her channel as the only HTLC has already been
 	// canceled.
 	ht.AssertNumPendingForceClose(alice, 0)
-
-	// Clean up the channel.
-	ht.CloseChannel(alice, chanPoint)
 }

--- a/itest/lnd_hold_persistence_test.go
+++ b/itest/lnd_hold_persistence_test.go
@@ -28,7 +28,9 @@ func testHoldInvoicePersistence(ht *lntest.HarnessTest) {
 	carol := ht.NewNode("Carol", nil)
 
 	// Connect Alice to Carol.
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNode("Bob", nil)
+	ht.EnsureConnected(alice, bob)
 	ht.ConnectNodes(alice, carol)
 
 	// Open a channel between Alice and Carol which is private so that we

--- a/itest/lnd_hold_persistence_test.go
+++ b/itest/lnd_hold_persistence_test.go
@@ -35,7 +35,7 @@ func testHoldInvoicePersistence(ht *lntest.HarnessTest) {
 
 	// Open a channel between Alice and Carol which is private so that we
 	// cover the addition of hop hints for hold invoices.
-	chanPointAlice := ht.OpenChannel(
+	ht.OpenChannel(
 		alice, carol, lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			Private: true,
@@ -222,8 +222,4 @@ func testHoldInvoicePersistence(ht *lntest.HarnessTest) {
 				"wrong failure reason")
 		}
 	}
-
-	// Finally, close all channels.
-	ht.CloseChannel(alice, chanPointBob)
-	ht.CloseChannel(alice, chanPointAlice)
 }

--- a/itest/lnd_htlc_test.go
+++ b/itest/lnd_htlc_test.go
@@ -14,7 +14,7 @@ import (
 func testLookupHtlcResolution(ht *lntest.HarnessTest) {
 	const chanAmt = btcutil.Amount(1000000)
 
-	alice := ht.Alice
+	alice := ht.NewNodeWithCoins("Alice", nil)
 	carol := ht.NewNode("Carol", []string{
 		"--store-final-htlc-resolutions",
 	})

--- a/itest/lnd_htlc_test.go
+++ b/itest/lnd_htlc_test.go
@@ -24,7 +24,6 @@ func testLookupHtlcResolution(ht *lntest.HarnessTest) {
 	cp := ht.OpenChannel(
 		alice, carol, lntest.OpenChannelParams{Amt: chanAmt},
 	)
-	defer ht.CloseChannel(alice, cp)
 
 	// Channel should be ready for payments.
 	const payAmt = 100

--- a/itest/lnd_invoice_acceptor_test.go
+++ b/itest/lnd_invoice_acceptor_test.go
@@ -32,7 +32,7 @@ func testInvoiceHtlcModifierBasic(ht *lntest.HarnessTest) {
 		{Local: bob, Remote: carol, Param: p},
 	}
 	resp := ht.OpenMultiChannelsAsync(reqs)
-	cpAB, cpBC := resp[0], resp[1]
+	cpBC := resp[1]
 
 	// Make sure Alice is aware of channel Bob=>Carol.
 	ht.AssertChannelInGraph(alice, cpBC)
@@ -208,10 +208,6 @@ func testInvoiceHtlcModifierBasic(ht *lntest.HarnessTest) {
 	}
 
 	cancelModifier()
-
-	// Finally, close channels.
-	ht.CloseChannel(alice, cpAB)
-	ht.CloseChannel(bob, cpBC)
 }
 
 // acceptorTestCase is a helper struct to hold test case data.

--- a/itest/lnd_invoice_acceptor_test.go
+++ b/itest/lnd_invoice_acceptor_test.go
@@ -251,7 +251,8 @@ type acceptorTestScenario struct {
 //
 // Among them, Alice and Bob are standby nodes and Carol is a new node.
 func newAcceptorTestScenario(ht *lntest.HarnessTest) *acceptorTestScenario {
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNodeWithCoins("bob", nil)
 	carol := ht.NewNode("carol", nil)
 
 	ht.EnsureConnected(alice, bob)

--- a/itest/lnd_macaroons_test.go
+++ b/itest/lnd_macaroons_test.go
@@ -29,7 +29,7 @@ func testMacaroonAuthentication(ht *lntest.HarnessTest) {
 		newAddrReq = &lnrpc.NewAddressRequest{
 			Type: AddrTypeWitnessPubkeyHash,
 		}
-		testNode   = ht.Alice
+		testNode   = ht.NewNode("Alice", nil)
 		testClient = testNode.RPC.LN
 	)
 
@@ -295,7 +295,7 @@ func testMacaroonAuthentication(ht *lntest.HarnessTest) {
 // in the request must be set correctly, and the baked macaroon has the intended
 // permissions.
 func testBakeMacaroon(ht *lntest.HarnessTest) {
-	var testNode = ht.Alice
+	var testNode = ht.NewNode("Alice", nil)
 
 	testCases := []struct {
 		name string
@@ -521,7 +521,7 @@ func testBakeMacaroon(ht *lntest.HarnessTest) {
 func testDeleteMacaroonID(ht *lntest.HarnessTest) {
 	var (
 		ctxb     = ht.Context()
-		testNode = ht.Alice
+		testNode = ht.NewNode("Alice", nil)
 	)
 	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
 	defer cancel()

--- a/itest/lnd_max_channel_size_test.go
+++ b/itest/lnd_max_channel_size_test.go
@@ -56,9 +56,7 @@ func testMaxChannelSize(ht *lntest.HarnessTest) {
 
 	// Creating a wumbo channel between these two nodes should succeed.
 	ht.EnsureConnected(wumboNode, wumboNode3)
-	chanPoint := ht.OpenChannel(
+	ht.OpenChannel(
 		wumboNode, wumboNode3, lntest.OpenChannelParams{Amt: chanAmt},
 	)
-
-	ht.CloseChannel(wumboNode, chanPoint)
 }

--- a/itest/lnd_max_htlcs_test.go
+++ b/itest/lnd_max_htlcs_test.go
@@ -25,14 +25,13 @@ func testMaxHtlcPathfind(ht *lntest.HarnessTest) {
 	cfgs := [][]string{cfg, cfg}
 
 	// Create a channel Alice->Bob.
-	chanPoints, nodes := ht.CreateSimpleNetwork(
+	_, nodes := ht.CreateSimpleNetwork(
 		cfgs, lntest.OpenChannelParams{
 			Amt:            1000000,
 			PushAmt:        800000,
 			RemoteMaxHtlcs: uint16(maxHtlcs),
 		},
 	)
-	chanPoint := chanPoints[0]
 	alice, bob := nodes[0], nodes[1]
 
 	// Alice and bob should have one channel open with each other now.
@@ -78,8 +77,6 @@ func testMaxHtlcPathfind(ht *lntest.HarnessTest) {
 
 	ht.AssertNumActiveHtlcs(alice, 0)
 	ht.AssertNumActiveHtlcs(bob, 0)
-
-	ht.CloseChannel(alice, chanPoint)
 }
 
 type holdSubscription struct {

--- a/itest/lnd_max_htlcs_test.go
+++ b/itest/lnd_max_htlcs_test.go
@@ -19,25 +19,21 @@ func testMaxHtlcPathfind(ht *lntest.HarnessTest) {
 	// Bob to add a maximum of 5 htlcs to her commitment.
 	maxHtlcs := 5
 
-	alice, bob := ht.Alice, ht.Bob
-
-	// Restart nodes with the new flag so they understand the new payment
+	// Create nodes with the new flag so they understand the new payment
 	// status.
-	ht.RestartNodeWithExtraArgs(alice, []string{
-		"--routerrpc.usestatusinitiated",
-	})
-	ht.RestartNodeWithExtraArgs(bob, []string{
-		"--routerrpc.usestatusinitiated",
-	})
+	cfg := []string{"--routerrpc.usestatusinitiated"}
+	cfgs := [][]string{cfg, cfg}
 
-	ht.EnsureConnected(alice, bob)
-	chanPoint := ht.OpenChannel(
-		alice, bob, lntest.OpenChannelParams{
+	// Create a channel Alice->Bob.
+	chanPoints, nodes := ht.CreateSimpleNetwork(
+		cfgs, lntest.OpenChannelParams{
 			Amt:            1000000,
 			PushAmt:        800000,
 			RemoteMaxHtlcs: uint16(maxHtlcs),
 		},
 	)
+	chanPoint := chanPoints[0]
+	alice, bob := nodes[0], nodes[1]
 
 	// Alice and bob should have one channel open with each other now.
 	ht.AssertNodeNumChannels(alice, 1)

--- a/itest/lnd_misc_test.go
+++ b/itest/lnd_misc_test.go
@@ -763,6 +763,8 @@ func testAbandonChannel(ht *lntest.HarnessTest) {
 // testSendAllCoins tests that we're able to properly sweep all coins from the
 // wallet into a single target address at the specified fee rate.
 func testSendAllCoins(ht *lntest.HarnessTest) {
+	alice := ht.Alice
+
 	// First, we'll make a new node, Ainz who'll we'll use to test wallet
 	// sweeping.
 	//
@@ -789,7 +791,7 @@ func testSendAllCoins(ht *lntest.HarnessTest) {
 
 	// Ensure that we can't send coins to another user's Pubkey.
 	err = ainz.RPC.SendCoinsAssertErr(&lnrpc.SendCoinsRequest{
-		Addr:       ht.Alice.RPC.GetInfo().IdentityPubkey,
+		Addr:       alice.RPC.GetInfo().IdentityPubkey,
 		SendAll:    true,
 		Label:      sendCoinsLabel,
 		TargetConf: 6,

--- a/itest/lnd_mpp_test.go
+++ b/itest/lnd_mpp_test.go
@@ -180,8 +180,8 @@ type mppTestScenario struct {
 //	    \              /
 //	     \__ Dave ____/
 func newMppTestScenario(ht *lntest.HarnessTest) *mppTestScenario {
-	alice, bob := ht.Alice, ht.Bob
-	ht.RestartNodeWithExtraArgs(bob, []string{
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNodeWithCoins("Bob", []string{
 		"--maxpendingchannels=2",
 		"--accept-amp",
 	})

--- a/itest/lnd_multi-hop-error-propagation_test.go
+++ b/itest/lnd_multi-hop-error-propagation_test.go
@@ -365,12 +365,4 @@ func testHtlcErrorPropagation(ht *lntest.HarnessTest) {
 	ht.AssertHtlcEventTypes(
 		bobEvents, routerrpc.HtlcEvent_UNKNOWN, lntest.HtlcEventFinal,
 	)
-
-	// Finally, immediately close the channel. This function will also
-	// block until the channel is closed and will additionally assert the
-	// relevant channel closing post conditions.
-	ht.CloseChannel(alice, chanPointAlice)
-
-	// Force close Bob's final channel.
-	ht.ForceCloseChannel(bob, chanPointBob)
 }

--- a/itest/lnd_multi-hop-error-propagation_test.go
+++ b/itest/lnd_multi-hop-error-propagation_test.go
@@ -15,7 +15,9 @@ func testHtlcErrorPropagation(ht *lntest.HarnessTest) {
 	// multi-hop payment.
 	const chanAmt = funding.MaxBtcFundingAmount
 
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNodeWithCoins("Bob", nil)
+	ht.EnsureConnected(alice, bob)
 
 	// Since we'd like to test some multi-hop failure scenarios, we'll
 	// introduce another node into our test network: Carol.

--- a/itest/lnd_multi-hop-payments_test.go
+++ b/itest/lnd_multi-hop-payments_test.go
@@ -18,7 +18,8 @@ func testMultiHopPayments(ht *lntest.HarnessTest) {
 	// channel with Alice, and Carol with Dave. After this setup, the
 	// network topology should now look like:
 	//     Carol -> Dave -> Alice -> Bob
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNode("Bob", nil)
 
 	daveArgs := []string{"--protocol.legacy.onion"}
 	dave := ht.NewNode("Dave", daveArgs)
@@ -37,6 +38,7 @@ func testMultiHopPayments(ht *lntest.HarnessTest) {
 	ht.AssertHtlcEventType(daveEvents, routerrpc.HtlcEvent_UNKNOWN)
 
 	// Connect the nodes.
+	ht.ConnectNodes(alice, bob)
 	ht.ConnectNodes(dave, alice)
 	ht.ConnectNodes(carol, dave)
 

--- a/itest/lnd_multi-hop-payments_test.go
+++ b/itest/lnd_multi-hop-payments_test.go
@@ -235,11 +235,6 @@ func testMultiHopPayments(ht *lntest.HarnessTest) {
 	ht.AssertHtlcEvents(
 		bobEvents, 0, 0, numPayments, 0, routerrpc.HtlcEvent_RECEIVE,
 	)
-
-	// Finally, close all channels.
-	ht.CloseChannel(alice, chanPointAlice)
-	ht.CloseChannel(dave, chanPointDave)
-	ht.CloseChannel(carol, chanPointCarol)
 }
 
 // updateChannelPolicy updates the channel policy of node to the given fees and

--- a/itest/lnd_network_test.go
+++ b/itest/lnd_network_test.go
@@ -133,9 +133,7 @@ func testReconnectAfterIPChange(ht *lntest.HarnessTest) {
 	// We'll then go ahead and open a channel between Alice and Dave. This
 	// ensures that Charlie receives the node announcement from Alice as
 	// part of the announcement broadcast.
-	chanPoint := ht.OpenChannel(
-		alice, dave, lntest.OpenChannelParams{Amt: 1000000},
-	)
+	ht.OpenChannel(alice, dave, lntest.OpenChannelParams{Amt: 1000000})
 
 	// waitForNodeAnnouncement is a closure used to wait on the given graph
 	// subscription for a node announcement from a node with the given
@@ -210,9 +208,6 @@ func testReconnectAfterIPChange(ht *lntest.HarnessTest) {
 	// address to one not listed in Dave's original advertised list of
 	// addresses.
 	ht.AssertConnected(dave, charlie)
-
-	// Finally, close the channel.
-	ht.CloseChannel(alice, chanPoint)
 }
 
 // testAddPeerConfig tests that the "--addpeer" config flag successfully adds

--- a/itest/lnd_network_test.go
+++ b/itest/lnd_network_test.go
@@ -126,7 +126,7 @@ func testReconnectAfterIPChange(ht *lntest.HarnessTest) {
 	}
 
 	// Connect Alice to Dave and Charlie.
-	alice := ht.Alice
+	alice := ht.NewNodeWithCoins("Alice", nil)
 	ht.ConnectNodes(alice, dave)
 	ht.ConnectNodes(alice, charlie)
 
@@ -218,7 +218,7 @@ func testReconnectAfterIPChange(ht *lntest.HarnessTest) {
 // testAddPeerConfig tests that the "--addpeer" config flag successfully adds
 // a new peer.
 func testAddPeerConfig(ht *lntest.HarnessTest) {
-	alice := ht.Alice
+	alice := ht.NewNode("Alice", nil)
 	info := alice.RPC.GetInfo()
 
 	alicePeerAddress := info.Uris[0]

--- a/itest/lnd_neutrino_test.go
+++ b/itest/lnd_neutrino_test.go
@@ -13,7 +13,7 @@ func testNeutrino(ht *lntest.HarnessTest) {
 		ht.Skipf("skipping test for non neutrino backends")
 	}
 
-	alice := ht.Alice
+	alice := ht.NewNode("Alice", nil)
 
 	// Check if the neutrino sub server is running.
 	statusRes := alice.RPC.Status(nil)

--- a/itest/lnd_neutrino_test.go
+++ b/itest/lnd_neutrino_test.go
@@ -13,8 +13,10 @@ func testNeutrino(ht *lntest.HarnessTest) {
 		ht.Skipf("skipping test for non neutrino backends")
 	}
 
+	alice := ht.Alice
+
 	// Check if the neutrino sub server is running.
-	statusRes := ht.Alice.RPC.Status(nil)
+	statusRes := alice.RPC.Status(nil)
 	require.True(ht, statusRes.Active)
 	require.Len(ht, statusRes.Peers, 1, "unable to find a peer")
 
@@ -22,11 +24,11 @@ func testNeutrino(ht *lntest.HarnessTest) {
 	cFilterReq := &neutrinorpc.GetCFilterRequest{
 		Hash: statusRes.GetBlockHash(),
 	}
-	ht.Alice.RPC.GetCFilter(cFilterReq)
+	alice.RPC.GetCFilter(cFilterReq)
 
 	// Try to reconnect to a connected peer.
 	addPeerReq := &neutrinorpc.AddPeerRequest{
 		PeerAddrs: statusRes.Peers[0],
 	}
-	ht.Alice.RPC.AddPeer(addPeerReq)
+	alice.RPC.AddPeer(addPeerReq)
 }

--- a/itest/lnd_onchain_test.go
+++ b/itest/lnd_onchain_test.go
@@ -33,8 +33,10 @@ func testChainKit(ht *lntest.HarnessTest) {
 // testChainKitGetBlock ensures that given a block hash, the RPC endpoint
 // returns the correct target block.
 func testChainKitGetBlock(ht *lntest.HarnessTest) {
+	alice := ht.Alice
+
 	// Get best block hash.
-	bestBlockRes := ht.Alice.RPC.GetBestBlock(nil)
+	bestBlockRes := alice.RPC.GetBestBlock(nil)
 
 	var bestBlockHash chainhash.Hash
 	err := bestBlockHash.SetBytes(bestBlockRes.BlockHash)
@@ -44,7 +46,7 @@ func testChainKitGetBlock(ht *lntest.HarnessTest) {
 	getBlockReq := &chainrpc.GetBlockRequest{
 		BlockHash: bestBlockHash[:],
 	}
-	getBlockRes := ht.Alice.RPC.GetBlock(getBlockReq)
+	getBlockRes := alice.RPC.GetBlock(getBlockReq)
 
 	// Deserialize the block which was retrieved by hash.
 	msgBlock := &wire.MsgBlock{}
@@ -61,8 +63,10 @@ func testChainKitGetBlock(ht *lntest.HarnessTest) {
 // testChainKitGetBlockHeader ensures that given a block hash, the RPC endpoint
 // returns the correct target block header.
 func testChainKitGetBlockHeader(ht *lntest.HarnessTest) {
+	alice := ht.Alice
+
 	// Get best block hash.
-	bestBlockRes := ht.Alice.RPC.GetBestBlock(nil)
+	bestBlockRes := alice.RPC.GetBestBlock(nil)
 
 	var (
 		bestBlockHash   chainhash.Hash
@@ -76,7 +80,7 @@ func testChainKitGetBlockHeader(ht *lntest.HarnessTest) {
 	getBlockReq := &chainrpc.GetBlockRequest{
 		BlockHash: bestBlockHash[:],
 	}
-	getBlockRes := ht.Alice.RPC.GetBlock(getBlockReq)
+	getBlockRes := alice.RPC.GetBlock(getBlockReq)
 
 	// Deserialize the block which was retrieved by hash.
 	blockReader := bytes.NewReader(getBlockRes.RawBlock)
@@ -87,7 +91,7 @@ func testChainKitGetBlockHeader(ht *lntest.HarnessTest) {
 	getBlockHeaderReq := &chainrpc.GetBlockHeaderRequest{
 		BlockHash: bestBlockHash[:],
 	}
-	getBlockHeaderRes := ht.Alice.RPC.GetBlockHeader(getBlockHeaderReq)
+	getBlockHeaderRes := alice.RPC.GetBlockHeader(getBlockHeaderReq)
 
 	// Deserialize the block header which was retrieved by hash.
 	blockHeaderReader := bytes.NewReader(getBlockHeaderRes.RawBlockHeader)
@@ -104,14 +108,16 @@ func testChainKitGetBlockHeader(ht *lntest.HarnessTest) {
 // testChainKitGetBlockHash ensures that given a block height, the RPC endpoint
 // returns the correct target block hash.
 func testChainKitGetBlockHash(ht *lntest.HarnessTest) {
+	alice := ht.Alice
+
 	// Get best block hash.
-	bestBlockRes := ht.Alice.RPC.GetBestBlock(nil)
+	bestBlockRes := alice.RPC.GetBestBlock(nil)
 
 	// Retrieve the block hash at best block height.
 	req := &chainrpc.GetBlockHashRequest{
 		BlockHeight: int64(bestBlockRes.BlockHeight),
 	}
-	getBlockHashRes := ht.Alice.RPC.GetBlockHash(req)
+	getBlockHashRes := alice.RPC.GetBlockHash(req)
 
 	// Ensure best block hash is the same as retrieved block hash.
 	expected := bestBlockRes.BlockHash

--- a/itest/lnd_onchain_test.go
+++ b/itest/lnd_onchain_test.go
@@ -33,7 +33,7 @@ func testChainKit(ht *lntest.HarnessTest) {
 // testChainKitGetBlock ensures that given a block hash, the RPC endpoint
 // returns the correct target block.
 func testChainKitGetBlock(ht *lntest.HarnessTest) {
-	alice := ht.Alice
+	alice := ht.NewNode("Alice", nil)
 
 	// Get best block hash.
 	bestBlockRes := alice.RPC.GetBestBlock(nil)
@@ -63,7 +63,7 @@ func testChainKitGetBlock(ht *lntest.HarnessTest) {
 // testChainKitGetBlockHeader ensures that given a block hash, the RPC endpoint
 // returns the correct target block header.
 func testChainKitGetBlockHeader(ht *lntest.HarnessTest) {
-	alice := ht.Alice
+	alice := ht.NewNode("Alice", nil)
 
 	// Get best block hash.
 	bestBlockRes := alice.RPC.GetBestBlock(nil)
@@ -108,7 +108,7 @@ func testChainKitGetBlockHeader(ht *lntest.HarnessTest) {
 // testChainKitGetBlockHash ensures that given a block height, the RPC endpoint
 // returns the correct target block hash.
 func testChainKitGetBlockHash(ht *lntest.HarnessTest) {
-	alice := ht.Alice
+	alice := ht.NewNode("Alice", nil)
 
 	// Get best block hash.
 	bestBlockRes := alice.RPC.GetBestBlock(nil)
@@ -134,8 +134,7 @@ func testChainKitSendOutputsAnchorReserve(ht *lntest.HarnessTest) {
 	// NOTE: we cannot reuse the standby node here as the test requires the
 	// node to start with no UTXOs.
 	charlie := ht.NewNode("Charlie", args)
-	bob := ht.Bob
-	ht.RestartNodeWithExtraArgs(bob, args)
+	bob := ht.NewNode("Bob", args)
 
 	// We'll start the test by sending Charlie some coins.
 	fundingAmount := btcutil.Amount(100_000)
@@ -222,12 +221,8 @@ func testAnchorReservedValue(ht *lntest.HarnessTest) {
 	// Start two nodes supporting anchor channels.
 	args := lntest.NodeArgsForCommitType(lnrpc.CommitmentType_ANCHORS)
 
-	// NOTE: we cannot reuse the standby node here as the test requires the
-	// node to start with no UTXOs.
 	alice := ht.NewNode("Alice", args)
-	bob := ht.Bob
-	ht.RestartNodeWithExtraArgs(bob, args)
-
+	bob := ht.NewNode("Bob", args)
 	ht.ConnectNodes(alice, bob)
 
 	// Send just enough coins for Alice to open a channel without a change

--- a/itest/lnd_onchain_test.go
+++ b/itest/lnd_onchain_test.go
@@ -153,7 +153,7 @@ func testChainKitSendOutputsAnchorReserve(ht *lntest.HarnessTest) {
 	// Charlie opens an anchor channel and keeps twice the amount of the
 	// anchor reserve in her wallet.
 	chanAmt := fundingAmount - 2*btcutil.Amount(reserve.RequiredReserve)
-	outpoint := ht.OpenChannel(charlie, bob, lntest.OpenChannelParams{
+	ht.OpenChannel(charlie, bob, lntest.OpenChannelParams{
 		Amt:            chanAmt,
 		CommitmentType: lnrpc.CommitmentType_ANCHORS,
 		SatPerVByte:    1,
@@ -207,11 +207,7 @@ func testChainKitSendOutputsAnchorReserve(ht *lntest.HarnessTest) {
 
 	// This second transaction should be published correctly.
 	charlie.RPC.SendOutputs(req)
-
 	ht.MineBlocksAndAssertNumTxes(1, 1)
-
-	// Clean up our test setup.
-	ht.CloseChannel(charlie, outpoint)
 }
 
 // testAnchorReservedValue tests that we won't allow sending transactions when

--- a/itest/lnd_open_channel_test.go
+++ b/itest/lnd_open_channel_test.go
@@ -315,7 +315,9 @@ func testOpenChannelUpdateFeePolicy(ht *lntest.HarnessTest) {
 // closing, and ensures that if a node is subscribed to channel updates they
 // will be received correctly for both cooperative and force closed channels.
 func testBasicChannelCreationAndUpdates(ht *lntest.HarnessTest) {
-	runBasicChannelCreationAndUpdates(ht, ht.Alice, ht.Bob)
+	alice, bob := ht.Alice, ht.Bob
+
+	runBasicChannelCreationAndUpdates(ht, alice, bob)
 }
 
 // runBasicChannelCreationAndUpdates tests multiple channel opening and closing,

--- a/itest/lnd_open_channel_test.go
+++ b/itest/lnd_open_channel_test.go
@@ -34,7 +34,9 @@ func testOpenChannelAfterReorg(ht *lntest.HarnessTest) {
 	tempMiner := ht.SpawnTempMiner()
 
 	miner := ht.Miner()
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNode("Bob", nil)
+	ht.EnsureConnected(alice, bob)
 
 	// Create a new channel that requires 1 confs before it's considered
 	// open, then broadcast the funding transaction
@@ -242,9 +244,10 @@ func testOpenChannelUpdateFeePolicy(ht *lntest.HarnessTest) {
 	// In this basic test, we'll need a third node, Carol, so we can forward
 	// a payment through the channel we'll open with the different fee
 	// policies.
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNode("Bob", nil)
 	carol := ht.NewNode("Carol", nil)
 
-	alice, bob := ht.Alice, ht.Bob
 	nodes := []*node.HarnessNode{alice, bob, carol}
 
 	runTestCase := func(ht *lntest.HarnessTest,
@@ -301,7 +304,7 @@ func testOpenChannelUpdateFeePolicy(ht *lntest.HarnessTest) {
 
 			// Send Carol enough coins to be able to open a channel
 			// to Alice.
-			ht.FundCoins(btcutil.SatoshiPerBitcoin, carol)
+			st.FundCoins(btcutil.SatoshiPerBitcoin, carol)
 
 			runTestCase(
 				st, feeScenario,
@@ -315,7 +318,9 @@ func testOpenChannelUpdateFeePolicy(ht *lntest.HarnessTest) {
 // closing, and ensures that if a node is subscribed to channel updates they
 // will be received correctly for both cooperative and force closed channels.
 func testBasicChannelCreationAndUpdates(ht *lntest.HarnessTest) {
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNodeWithCoins("Bob", nil)
+	ht.EnsureConnected(alice, bob)
 
 	runBasicChannelCreationAndUpdates(ht, alice, bob)
 }
@@ -519,8 +524,8 @@ func testUpdateOnPendingOpenChannels(ht *lntest.HarnessTest) {
 // processing the fundee's `channel_ready`, the HTLC will be cached and
 // eventually settled.
 func testUpdateOnFunderPendingOpenChannels(ht *lntest.HarnessTest) {
-	// Grab the channel participants.
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNode("Bob", nil)
 
 	// Restart Alice with the config so she won't process Bob's
 	// channel_ready msg immediately.
@@ -603,8 +608,8 @@ func testUpdateOnFunderPendingOpenChannels(ht *lntest.HarnessTest) {
 // processing the funder's `channel_ready`, the HTLC will be cached and
 // eventually settled.
 func testUpdateOnFundeePendingOpenChannels(ht *lntest.HarnessTest) {
-	// Grab the channel participants.
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNode("Bob", nil)
 
 	// Restart Bob with the config so he won't process Alice's
 	// channel_ready msg immediately.
@@ -746,7 +751,10 @@ func verifyCloseUpdate(chanUpdate *lnrpc.ChannelEventUpdate,
 // before the funding transaction is confirmed, that the FundingExpiryBlocks
 // field of a PendingChannels decreases.
 func testFundingExpiryBlocksOnPending(ht *lntest.HarnessTest) {
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNode("Bob", nil)
+	ht.EnsureConnected(alice, bob)
+
 	param := lntest.OpenChannelParams{Amt: 100000}
 	update := ht.OpenChannelAssertPending(alice, bob, param)
 
@@ -844,7 +852,6 @@ func testSimpleTaprootChannelActivation(ht *lntest.HarnessTest) {
 // up as locked balance in the WalletBalance response.
 func testOpenChannelLockedBalance(ht *lntest.HarnessTest) {
 	var (
-		bob = ht.Bob
 		req *lnrpc.ChannelAcceptRequest
 		err error
 	)
@@ -852,6 +859,7 @@ func testOpenChannelLockedBalance(ht *lntest.HarnessTest) {
 	// Create a new node so we can assert exactly how much fund has been
 	// locked later.
 	alice := ht.NewNode("alice", nil)
+	bob := ht.NewNode("bob", nil)
 	ht.FundCoins(btcutil.SatoshiPerBitcoin, alice)
 
 	// Connect the nodes.

--- a/itest/lnd_payment_test.go
+++ b/itest/lnd_payment_test.go
@@ -449,6 +449,12 @@ func testSendDirectPayment(ht *lntest.HarnessTest) {
 			// Make sure they are connected.
 			st.EnsureConnected(alice, bob)
 
+			// There's a bug that causes the funding to be failed
+			// due to the `ListCoins` cannot find the utxos.
+			//
+			// TODO(yy): remove this line to fix the ListCoins bug.
+			st.FundCoins(btcutil.SatoshiPerBitcoin, alice)
+
 			// Open a channel with 100k satoshis between Alice and
 			// Bob with Alice being the sole funder of the channel.
 			params := lntest.OpenChannelParams{

--- a/itest/lnd_payment_test.go
+++ b/itest/lnd_payment_test.go
@@ -346,7 +346,8 @@ func runTestPaymentHTLCTimeout(ht *lntest.HarnessTest, restartAlice bool) {
 // to return floor fee rate(1 sat/vb).
 func testSendDirectPayment(ht *lntest.HarnessTest) {
 	// Grab Alice and Bob's nodes for convenience.
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNodeWithCoins("Bob", nil)
 
 	// Create a list of commitment types we want to test.
 	commitmentTypes := []lnrpc.CommitmentType{
@@ -466,7 +467,9 @@ func testSendDirectPayment(ht *lntest.HarnessTest) {
 }
 
 func testListPayments(ht *lntest.HarnessTest) {
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNode("Bob", nil)
+	ht.EnsureConnected(alice, bob)
 
 	// Check that there are no payments before test.
 	ht.AssertNumPayments(alice, 0)
@@ -658,7 +661,10 @@ func testPaymentFollowingChannelOpen(ht *lntest.HarnessTest) {
 	channelCapacity := paymentAmt * 1000
 
 	// We first establish a channel between Alice and Bob.
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNode("Bob", nil)
+	ht.EnsureConnected(alice, bob)
+
 	p := lntest.OpenChannelParams{
 		Amt: channelCapacity,
 	}
@@ -934,7 +940,9 @@ func testBidirectionalAsyncPayments(ht *lntest.HarnessTest) {
 func testInvoiceSubscriptions(ht *lntest.HarnessTest) {
 	const chanAmt = btcutil.Amount(500000)
 
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNode("Bob", nil)
+	ht.EnsureConnected(alice, bob)
 
 	// Create a new invoice subscription client for Bob, the notification
 	// should be dispatched shortly below.

--- a/itest/lnd_payment_test.go
+++ b/itest/lnd_payment_test.go
@@ -477,9 +477,7 @@ func testListPayments(ht *lntest.HarnessTest) {
 	// Open a channel with 100k satoshis between Alice and Bob with Alice
 	// being the sole funder of the channel.
 	chanAmt := btcutil.Amount(100000)
-	chanPoint := ht.OpenChannel(
-		alice, bob, lntest.OpenChannelParams{Amt: chanAmt},
-	)
+	ht.OpenChannel(alice, bob, lntest.OpenChannelParams{Amt: chanAmt})
 
 	// Now that the channel is open, create an invoice for Bob which
 	// expects a payment of 1000 satoshis from Alice paid via a particular
@@ -638,17 +636,6 @@ func testListPayments(ht *lntest.HarnessTest) {
 
 	// Check that there are no payments after test.
 	ht.AssertNumPayments(alice, 0)
-
-	// TODO(yy): remove the sleep once the following bug is fixed.
-	// When the invoice is reported settled, the commitment dance is not
-	// yet finished, which can cause an error when closing the channel,
-	// saying there's active HTLCs. We need to investigate this issue and
-	// reverse the order to, first finish the commitment dance, then report
-	// the invoice as settled.
-	time.Sleep(2 * time.Second)
-
-	// Close the channel.
-	ht.CloseChannel(alice, chanPoint)
 }
 
 // testPaymentFollowingChannelOpen tests that the channel transition from
@@ -698,19 +685,6 @@ func testPaymentFollowingChannelOpen(ht *lntest.HarnessTest) {
 	// Send payment to Bob so that a channel update to disk will be
 	// executed.
 	ht.CompletePaymentRequests(alice, []string{bobPayReqs[0]})
-
-	// TODO(yy): remove the sleep once the following bug is fixed.
-	// When the invoice is reported settled, the commitment dance is not
-	// yet finished, which can cause an error when closing the channel,
-	// saying there's active HTLCs. We need to investigate this issue and
-	// reverse the order to, first finish the commitment dance, then report
-	// the invoice as settled.
-	time.Sleep(2 * time.Second)
-
-	// Finally, immediately close the channel. This function will also
-	// block until the channel is closed and will additionally assert the
-	// relevant channel closing post conditions.
-	ht.CloseChannel(alice, chanPoint)
 }
 
 // testAsyncPayments tests the performance of the async payments.
@@ -818,11 +792,6 @@ func runAsyncPayments(ht *lntest.HarnessTest, alice, bob *node.HarnessNode,
 	ht.Log("\tBenchmark info: Elapsed time: ", timeTaken)
 	ht.Log("\tBenchmark info: TPS: ",
 		float64(numInvoices)/timeTaken.Seconds())
-
-	// Finally, immediately close the channel. This function will also
-	// block until the channel is closed and will additionally assert the
-	// relevant channel closing post conditions.
-	ht.CloseChannel(alice, chanPoint)
 }
 
 // testBidirectionalAsyncPayments tests that nodes are able to send the
@@ -930,11 +899,6 @@ func testBidirectionalAsyncPayments(ht *lntest.HarnessTest) {
 	// Next query for Bob's and Alice's channel states, in order to confirm
 	// that all payment have been successfully transmitted.
 	assertChannelState(ht, bob, chanPoint, bobAmt, aliceAmt)
-
-	// Finally, immediately close the channel. This function will also
-	// block until the channel is closed and will additionally assert the
-	// relevant channel closing post conditions.
-	ht.CloseChannel(alice, chanPoint)
 }
 
 func testInvoiceSubscriptions(ht *lntest.HarnessTest) {
@@ -951,9 +915,7 @@ func testInvoiceSubscriptions(ht *lntest.HarnessTest) {
 
 	// Open a channel with 500k satoshis between Alice and Bob with Alice
 	// being the sole funder of the channel.
-	chanPoint := ht.OpenChannel(
-		alice, bob, lntest.OpenChannelParams{Amt: chanAmt},
-	)
+	ht.OpenChannel(alice, bob, lntest.OpenChannelParams{Amt: chanAmt})
 
 	// Next create a new invoice for Bob requesting 1k satoshis.
 	const paymentAmt = 1000
@@ -1055,16 +1017,6 @@ func testInvoiceSubscriptions(ht *lntest.HarnessTest) {
 
 	// At this point, all the invoices should be fully settled.
 	require.Empty(ht, settledInvoices, "not all invoices settled")
-
-	// TODO(yy): remove the sleep once the following bug is fixed.
-	// When the invoice is reported settled, the commitment dance is not
-	// yet finished, which can cause an error when closing the channel,
-	// saying there's active HTLCs. We need to investigate this issue and
-	// reverse the order to, first finish the commitment dance, then report
-	// the invoice as settled.
-	time.Sleep(2 * time.Second)
-
-	ht.CloseChannel(alice, chanPoint)
 }
 
 // assertChannelState asserts the channel state by checking the values in
@@ -1151,10 +1103,6 @@ func testPaymentFailureReasonCanceled(ht *lntest.HarnessTest) {
 		ht, ts, cpAB, routerrpc.ResolveHoldForwardAction_FAIL,
 		lnrpc.Payment_FAILED, interceptor,
 	)
-
-	// Finally, close channels.
-	ht.CloseChannel(alice, cpAB)
-	ht.CloseChannel(bob, cpBC)
 }
 
 func sendPaymentInterceptAndCancel(ht *lntest.HarnessTest,

--- a/itest/lnd_psbt_test.go
+++ b/itest/lnd_psbt_test.go
@@ -324,13 +324,6 @@ func runPsbtChanFunding(ht *lntest.HarnessTest, carol, dave *node.HarnessNode,
 	}
 	resp := dave.RPC.AddInvoice(invoice)
 	ht.CompletePaymentRequests(carol, []string{resp.PaymentRequest})
-
-	// To conclude, we'll close the newly created channel between Carol and
-	// Dave. This function will also block until the channel is closed and
-	// will additionally assert the relevant channel closing post
-	// conditions.
-	ht.CloseChannel(carol, chanPoint)
-	ht.CloseChannel(carol, chanPoint2)
 }
 
 // runPsbtChanFundingExternal makes sure a channel can be opened between carol
@@ -499,13 +492,6 @@ func runPsbtChanFundingExternal(ht *lntest.HarnessTest, carol,
 	}
 	resp := dave.RPC.AddInvoice(invoice)
 	ht.CompletePaymentRequests(carol, []string{resp.PaymentRequest})
-
-	// To conclude, we'll close the newly created channel between Carol and
-	// Dave. This function will also block until the channels are closed and
-	// will additionally assert the relevant channel closing post
-	// conditions.
-	ht.CloseChannel(carol, chanPoint)
-	ht.CloseChannel(carol, chanPoint2)
 }
 
 // runPsbtChanFundingSingleStep checks whether PSBT funding works also when
@@ -649,12 +635,6 @@ func runPsbtChanFundingSingleStep(ht *lntest.HarnessTest, carol,
 	}
 	resp := dave.RPC.AddInvoice(invoice)
 	ht.CompletePaymentRequests(carol, []string{resp.PaymentRequest})
-
-	// To conclude, we'll close the newly created channel between Carol and
-	// Dave. This function will also block until the channel is closed and
-	// will additionally assert the relevant channel closing post
-	// conditions.
-	ht.CloseChannel(carol, chanPoint)
 }
 
 // testSignPsbt tests that the SignPsbt RPC works correctly.

--- a/itest/lnd_psbt_test.go
+++ b/itest/lnd_psbt_test.go
@@ -146,7 +146,7 @@ func runPsbtChanFunding(ht *lntest.HarnessTest, carol, dave *node.HarnessNode,
 
 	// Before we start the test, we'll ensure both sides are connected so
 	// the funding flow can be properly executed.
-	alice := ht.Alice
+	alice := ht.NewNodeWithCoins("Alice", nil)
 	ht.EnsureConnected(carol, dave)
 	ht.EnsureConnected(carol, alice)
 
@@ -344,7 +344,7 @@ func runPsbtChanFundingExternal(ht *lntest.HarnessTest, carol,
 
 	// Before we start the test, we'll ensure both sides are connected so
 	// the funding flow can be properly executed.
-	alice := ht.Alice
+	alice := ht.NewNodeWithCoins("Alice", nil)
 	ht.EnsureConnected(carol, dave)
 	ht.EnsureConnected(carol, alice)
 
@@ -517,8 +517,7 @@ func runPsbtChanFundingSingleStep(ht *lntest.HarnessTest, carol,
 
 	const chanSize = funding.MaxBtcFundingAmount
 
-	alice := ht.Alice
-	ht.FundCoins(btcutil.SatoshiPerBitcoin, alice)
+	alice := ht.NewNodeWithCoins("Alice", nil)
 
 	// Get new address for anchor reserve.
 	req := &lnrpc.NewAddressRequest{
@@ -697,7 +696,8 @@ func testSignPsbt(ht *lntest.HarnessTest) {
 	for _, tc := range psbtTestRunners {
 		succeed := ht.Run(tc.name, func(t *testing.T) {
 			st := ht.Subtest(t)
-			tc.runner(st, st.Alice)
+			alice := st.NewNodeWithCoins("Alice", nil)
+			tc.runner(st, alice)
 		})
 
 		// Abort the test if failed.
@@ -1088,7 +1088,8 @@ func runFundAndSignPsbt(ht *lntest.HarnessTest, alice *node.HarnessNode) {
 // a PSBT that already specifies an input but where the user still wants the
 // wallet to perform coin selection.
 func testFundPsbt(ht *lntest.HarnessTest) {
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNodeWithCoins("Bob", nil)
 
 	// We test a pay-join between Alice and Bob. Bob wants to send Alice
 	// 5 million Satoshis in a non-obvious way. So Bob selects a UTXO that's
@@ -1598,8 +1599,8 @@ func sendAllCoinsToAddrType(ht *lntest.HarnessTest,
 // the channel opening. The psbt funding flow is used to simulate this behavior
 // because we can easily let the remote peer run into the timeout.
 func testPsbtChanFundingFailFlow(ht *lntest.HarnessTest) {
-	alice := ht.Alice
-	bob := ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNodeWithCoins("Bob", nil)
 
 	const chanSize = funding.MaxBtcFundingAmount
 

--- a/itest/lnd_quiescence_test.go
+++ b/itest/lnd_quiescence_test.go
@@ -30,7 +30,7 @@ func testQuiescence(ht *lntest.HarnessTest) {
 	require.True(ht, res.Initiator)
 
 	req := &routerrpc.SendPaymentRequest{
-		Dest:           ht.Alice.PubKey[:],
+		Dest:           alice.PubKey[:],
 		Amt:            100,
 		PaymentHash:    ht.Random32Bytes(),
 		FinalCltvDelta: finalCltvDelta,
@@ -39,7 +39,7 @@ func testQuiescence(ht *lntest.HarnessTest) {
 	}
 
 	ht.SendPaymentAssertFail(
-		ht.Bob, req,
+		bob, req,
 		// This fails with insufficient balance because the bandwidth
 		// manager reports 0 bandwidth if a link is not eligible for
 		// forwarding, which is the case during quiescence.

--- a/itest/lnd_quiescence_test.go
+++ b/itest/lnd_quiescence_test.go
@@ -22,7 +22,6 @@ func testQuiescence(ht *lntest.HarnessTest) {
 	chanPoint := ht.OpenChannel(bob, alice, lntest.OpenChannelParams{
 		Amt: btcutil.Amount(1000000),
 	})
-	defer ht.CloseChannel(bob, chanPoint)
 
 	res := alice.RPC.Quiesce(&devrpc.QuiescenceRequest{
 		ChanId: chanPoint,

--- a/itest/lnd_quiescence_test.go
+++ b/itest/lnd_quiescence_test.go
@@ -16,7 +16,8 @@ import (
 // NOTE FOR REVIEW: this could be improved by blasting the channel with HTLC
 // traffic on both sides to increase the surface area of the change under test.
 func testQuiescence(ht *lntest.HarnessTest) {
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNode("Bob", nil)
 
 	chanPoint := ht.OpenChannel(bob, alice, lntest.OpenChannelParams{
 		Amt: btcutil.Amount(1000000),

--- a/itest/lnd_res_handoff_test.go
+++ b/itest/lnd_res_handoff_test.go
@@ -17,7 +17,8 @@ func testResHandoff(ht *lntest.HarnessTest) {
 		paymentAmt = 50000
 	)
 
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNodeWithCoins("Bob", nil)
 
 	// First we'll create a channel between Alice and Bob.
 	ht.EnsureConnected(alice, bob)

--- a/itest/lnd_res_handoff_test.go
+++ b/itest/lnd_res_handoff_test.go
@@ -94,6 +94,4 @@ func testResHandoff(ht *lntest.HarnessTest) {
 
 	// Assert that Alice's payment failed.
 	ht.AssertFirstHTLCError(alice, lnrpc.Failure_PERMANENT_CHANNEL_FAILURE)
-
-	ht.CloseChannel(alice, chanPointAlice)
 }

--- a/itest/lnd_rest_api_test.go
+++ b/itest/lnd_rest_api_test.go
@@ -237,6 +237,8 @@ func testRestAPI(ht *lntest.HarnessTest) {
 }
 
 func wsTestCaseSubscription(ht *lntest.HarnessTest) {
+	alice := ht.Alice
+
 	// Find out the current best block so we can subscribe to the next one.
 	hash, height := ht.GetBestBlock()
 
@@ -246,7 +248,7 @@ func wsTestCaseSubscription(ht *lntest.HarnessTest) {
 		Height: uint32(height),
 	}
 	url := "/v2/chainnotifier/register/blocks"
-	c, err := openWebSocket(ht.Alice, url, "POST", req, nil)
+	c, err := openWebSocket(alice, url, "POST", req, nil)
 	require.NoError(ht, err, "websocket")
 	defer func() {
 		err := c.WriteMessage(websocket.CloseMessage, closeMsg)

--- a/itest/lnd_rest_api_test.go
+++ b/itest/lnd_rest_api_test.go
@@ -212,13 +212,13 @@ func testRestAPI(ht *lntest.HarnessTest) {
 	// Make sure Alice allows all CORS origins. Bob will keep the default.
 	// We also make sure the ping/pong messages are sent very often, so we
 	// can test them without waiting half a minute.
-	alice, bob := ht.Alice, ht.Bob
-	alice.Cfg.ExtraArgs = append(
-		alice.Cfg.ExtraArgs, "--restcors=\"*\"",
+	bob := ht.NewNode("Bob", nil)
+	args := []string{
+		"--restcors=\"*\"",
 		fmt.Sprintf("--ws-ping-interval=%s", pingInterval),
 		fmt.Sprintf("--ws-pong-wait=%s", pongWait),
-	)
-	ht.RestartNode(alice)
+	}
+	alice := ht.NewNodeWithCoins("Alice", args)
 
 	for _, tc := range testCases {
 		tc := tc
@@ -237,7 +237,7 @@ func testRestAPI(ht *lntest.HarnessTest) {
 }
 
 func wsTestCaseSubscription(ht *lntest.HarnessTest) {
-	alice := ht.Alice
+	alice := ht.NewNode("Alice", nil)
 
 	// Find out the current best block so we can subscribe to the next one.
 	hash, height := ht.GetBestBlock()
@@ -328,7 +328,7 @@ func wsTestCaseSubscriptionMacaroon(ht *lntest.HarnessTest) {
 	// This time we send the macaroon in the special header
 	// Sec-Websocket-Protocol which is the only header field available to
 	// browsers when opening a WebSocket.
-	alice := ht.Alice
+	alice := ht.NewNode("Alice", nil)
 	mac, err := alice.ReadMacaroon(
 		alice.Cfg.AdminMacPath, defaultTimeout,
 	)
@@ -413,7 +413,7 @@ func wsTestCaseBiDirectionalSubscription(ht *lntest.HarnessTest) {
 	// This time we send the macaroon in the special header
 	// Sec-Websocket-Protocol which is the only header field available to
 	// browsers when opening a WebSocket.
-	alice := ht.Alice
+	alice := ht.NewNode("Alice", nil)
 	mac, err := alice.ReadMacaroon(
 		alice.Cfg.AdminMacPath, defaultTimeout,
 	)
@@ -522,7 +522,7 @@ func wsTestCaseBiDirectionalSubscription(ht *lntest.HarnessTest) {
 
 	// Before we start opening channels, make sure the two nodes are
 	// connected.
-	bob := ht.Bob
+	bob := ht.NewNodeWithCoins("Bob", nil)
 	ht.EnsureConnected(alice, bob)
 
 	// Open 3 channels to make sure multiple requests and responses can be
@@ -554,7 +554,7 @@ func wsTestPingPongTimeout(ht *lntest.HarnessTest) {
 	// This time we send the macaroon in the special header
 	// Sec-Websocket-Protocol which is the only header field available to
 	// browsers when opening a WebSocket.
-	alice := ht.Alice
+	alice := ht.NewNode("Alice", nil)
 	mac, err := alice.ReadMacaroon(
 		alice.Cfg.AdminMacPath, defaultTimeout,
 	)

--- a/itest/lnd_rest_api_test.go
+++ b/itest/lnd_rest_api_test.go
@@ -529,10 +529,9 @@ func wsTestCaseBiDirectionalSubscription(ht *lntest.HarnessTest) {
 	// sent over the web socket.
 	const numChannels = 3
 	for i := 0; i < numChannels; i++ {
-		chanPoint := ht.OpenChannel(
+		ht.OpenChannel(
 			bob, alice, lntest.OpenChannelParams{Amt: 500000},
 		)
-		defer ht.CloseChannel(bob, chanPoint)
 
 		select {
 		case <-msgChan:

--- a/itest/lnd_route_blinding_test.go
+++ b/itest/lnd_route_blinding_test.go
@@ -309,9 +309,6 @@ func testQueryBlindedRoutes(ht *lntest.HarnessTest) {
 	require.Len(ht, resp.Routes, 1)
 	require.Len(ht, resp.Routes[0].Hops, 2)
 	require.Equal(ht, resp.Routes[0].TotalTimeLock, sendToIntroTimelock)
-
-	ht.CloseChannel(alice, chanPointAliceBob)
-	ht.CloseChannel(bob, chanPointBobCarol)
 }
 
 type blindedForwardTest struct {
@@ -412,10 +409,6 @@ func (b *blindedForwardTest) buildBlindedPath() *lnrpc.BlindedPaymentPath {
 // cleanup tears down all channels created by the test and cancels the top
 // level context used in the test.
 func (b *blindedForwardTest) cleanup() {
-	b.ht.CloseChannel(b.alice, b.channels[0])
-	b.ht.CloseChannel(b.bob, b.channels[1])
-	b.ht.CloseChannel(b.carol, b.channels[2])
-
 	b.cancel()
 }
 
@@ -846,8 +839,6 @@ func testErrorHandlingOnChainFailure(ht *lntest.HarnessTest) {
 	// Manually close out the rest of our channels and cancel (don't use
 	// built in cleanup which will try close the already-force-closed
 	// channel).
-	ht.CloseChannel(alice, testCase.channels[0])
-	ht.CloseChannel(testCase.carol, testCase.channels[2])
 	testCase.cancel()
 }
 

--- a/itest/lnd_route_blinding_test.go
+++ b/itest/lnd_route_blinding_test.go
@@ -26,11 +26,9 @@ import (
 // expected. It also includes the edge case of a single-hop blinded route,
 // which indicates that the introduction node is the recipient.
 func testQueryBlindedRoutes(ht *lntest.HarnessTest) {
-	var (
-		// Convenience aliases.
-		alice = ht.Alice
-		bob   = ht.Bob
-	)
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNodeWithCoins("Bob", nil)
+	ht.EnsureConnected(alice, bob)
 
 	// Setup a two hop channel network: Alice -- Bob -- Carol.
 	// We set our proportional fee for these channels to zero, so that
@@ -318,6 +316,8 @@ func testQueryBlindedRoutes(ht *lntest.HarnessTest) {
 
 type blindedForwardTest struct {
 	ht       *lntest.HarnessTest
+	alice    *node.HarnessNode
+	bob      *node.HarnessNode
 	carol    *node.HarnessNode
 	dave     *node.HarnessNode
 	channels []*lnrpc.ChannelPoint
@@ -349,11 +349,24 @@ func newBlindedForwardTest(ht *lntest.HarnessTest) (context.Context,
 func (b *blindedForwardTest) setupNetwork(ctx context.Context,
 	withInterceptor bool) {
 
+	const chanAmt = btcutil.Amount(100_000)
+
 	carolArgs := []string{"--bitcoin.timelockdelta=18"}
 	if withInterceptor {
 		carolArgs = append(carolArgs, "--requireinterceptor")
 	}
-	b.carol = b.ht.NewNode("Carol", carolArgs)
+
+	daveArgs := []string{"--bitcoin.timelockdelta=18"}
+	cfgs := [][]string{nil, nil, carolArgs, daveArgs}
+	param := lntest.OpenChannelParams{
+		Amt: chanAmt,
+	}
+
+	// Creates a network with the following topology and liquidity:
+	// Alice (100k)----- Bob (100k) ----- Carol (100k) ----- Dave
+	chanPoints, nodes := b.ht.CreateSimpleNetwork(cfgs, param)
+	b.channels = chanPoints
+	b.alice, b.bob, b.carol, b.dave = nodes[0], nodes[1], nodes[2], nodes[3]
 
 	if withInterceptor {
 		var err error
@@ -362,10 +375,6 @@ func (b *blindedForwardTest) setupNetwork(ctx context.Context,
 		)
 		require.NoError(b.ht, err, "interceptor")
 	}
-
-	b.dave = b.ht.NewNode("Dave", []string{"--bitcoin.timelockdelta=18"})
-
-	b.channels = setupFourHopNetwork(b.ht, b.carol, b.dave)
 }
 
 // buildBlindedPath returns a blinded route from Bob -> Carol -> Dave, with Bob
@@ -395,7 +404,7 @@ func (b *blindedForwardTest) buildBlindedPath() *lnrpc.BlindedPaymentPath {
 	require.Len(b.ht, payReq.BlindedPaths, 1)
 	path := payReq.BlindedPaths[0].BlindedPath
 	require.Len(b.ht, path.BlindedHops, 3)
-	require.EqualValues(b.ht, path.IntroductionNode, b.ht.Bob.PubKey[:])
+	require.EqualValues(b.ht, path.IntroductionNode, b.bob.PubKey[:])
 
 	return payReq.BlindedPaths[0]
 }
@@ -403,8 +412,8 @@ func (b *blindedForwardTest) buildBlindedPath() *lnrpc.BlindedPaymentPath {
 // cleanup tears down all channels created by the test and cancels the top
 // level context used in the test.
 func (b *blindedForwardTest) cleanup() {
-	b.ht.CloseChannel(b.ht.Alice, b.channels[0])
-	b.ht.CloseChannel(b.ht.Bob, b.channels[1])
+	b.ht.CloseChannel(b.alice, b.channels[0])
+	b.ht.CloseChannel(b.bob, b.channels[1])
 	b.ht.CloseChannel(b.carol, b.channels[2])
 
 	b.cancel()
@@ -431,7 +440,7 @@ func (b *blindedForwardTest) createRouteToBlinded(paymentAmt int64,
 		},
 	}
 
-	resp := b.ht.Alice.RPC.QueryRoutes(req)
+	resp := b.alice.RPC.QueryRoutes(req)
 	require.Greater(b.ht, len(resp.Routes), 0, "no routes")
 	require.Len(b.ht, resp.Routes[0].Hops, 3, "unexpected route length")
 
@@ -452,7 +461,7 @@ func (b *blindedForwardTest) sendBlindedPayment(ctx context.Context,
 
 	ctx, cancel := context.WithTimeout(ctx, time.Hour)
 	go func() {
-		_, err := b.ht.Alice.RPC.Router.SendToRouteV2(ctx, sendReq)
+		_, err := b.alice.RPC.Router.SendToRouteV2(ctx, sendReq)
 
 		// We may get a context canceled error when the test is
 		// finished.
@@ -481,7 +490,7 @@ func (b *blindedForwardTest) sendToRoute(route *lnrpc.Route,
 
 	// Let Alice send to the blinded payment path and assert that it
 	// succeeds/fails.
-	htlcAttempt := b.ht.Alice.RPC.SendToRouteV2(sendReq)
+	htlcAttempt := b.alice.RPC.SendToRouteV2(sendReq)
 	if assertSuccess {
 		require.Nil(b.ht, htlcAttempt.Failure)
 		require.Equal(b.ht, htlcAttempt.Status,
@@ -498,7 +507,7 @@ func (b *blindedForwardTest) sendToRoute(route *lnrpc.Route,
 	require.NoError(b.ht, err)
 
 	pmt := b.ht.AssertPaymentStatus(
-		b.ht.Alice, preimage, lnrpc.Payment_FAILED,
+		b.alice, preimage, lnrpc.Payment_FAILED,
 	)
 	require.Len(b.ht, pmt.Htlcs, 1)
 
@@ -520,7 +529,7 @@ func (b *blindedForwardTest) drainCarolLiquidity(incoming bool) {
 	receivingNode := b.dave
 
 	if incoming {
-		sendingNode = b.ht.Bob
+		sendingNode = b.bob
 		receivingNode = b.carol
 	}
 
@@ -556,7 +565,8 @@ func (b *blindedForwardTest) drainCarolLiquidity(incoming bool) {
 func setupFourHopNetwork(ht *lntest.HarnessTest,
 	carol, dave *node.HarnessNode) []*lnrpc.ChannelPoint {
 
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNodeWithCoins("Bob", nil)
 
 	const chanAmt = btcutil.Amount(100000)
 	var networkChans []*lnrpc.ChannelPoint
@@ -611,14 +621,14 @@ func setupFourHopNetwork(ht *lntest.HarnessTest,
 // path and forward payments in a blinded route and finally, receiving the
 // payment.
 func testBlindedRouteInvoices(ht *lntest.HarnessTest) {
-	alice := ht.Alice
-
 	ctx, testCase := newBlindedForwardTest(ht)
 	defer testCase.cleanup()
 
 	// Set up the 4 hop network and let Dave create an invoice with a
 	// blinded path that uses Bob as an introduction node.
 	testCase.setupNetwork(ctx, false)
+
+	alice := testCase.alice
 
 	// Let Dave add a blinded invoice.
 	// Add restrictions so that he only ever creates a single blinded path
@@ -737,13 +747,13 @@ func testRelayingBlindedError(ht *lntest.HarnessTest) {
 // over Alice -- Bob -- Carol -- Dave, where Bob is the introduction node and
 // has insufficient outgoing liquidity to forward on to carol.
 func testIntroductionNodeError(ht *lntest.HarnessTest) {
-	bob := ht.Bob
-
 	ctx, testCase := newBlindedForwardTest(ht)
 	defer testCase.cleanup()
 	testCase.setupNetwork(ctx, false)
 	blindedPaymentPath := testCase.buildBlindedPath()
 	route := testCase.createRouteToBlinded(10_000_000, blindedPaymentPath)
+
+	bob := testCase.bob
 
 	// Before we send our payment, drain all of Carol's incoming liquidity
 	// so that she can't receive the forward from Bob, causing a failure
@@ -770,8 +780,6 @@ func testIntroductionNodeError(ht *lntest.HarnessTest) {
 // testDisableIntroductionNode tests disabling of blinded forwards for the
 // introduction node.
 func testDisableIntroductionNode(ht *lntest.HarnessTest) {
-	alice, bob := ht.Alice, ht.Bob
-
 	// First construct a blinded route while Bob is still advertising the
 	// route blinding feature bit to ensure that Bob is included in the
 	// blinded path that Dave selects.
@@ -780,6 +788,8 @@ func testDisableIntroductionNode(ht *lntest.HarnessTest) {
 	testCase.setupNetwork(ctx, false)
 	blindedPaymentPath := testCase.buildBlindedPath()
 	route := testCase.createRouteToBlinded(10_000_000, blindedPaymentPath)
+
+	alice, bob := testCase.alice, testCase.bob
 
 	// Now, disable route blinding for Bob, then re-connect to Alice.
 	ht.RestartNodeWithExtraArgs(bob, []string{
@@ -796,8 +806,6 @@ func testDisableIntroductionNode(ht *lntest.HarnessTest) {
 // to resolve blinded HTLCs on chain between restarts, as we've got all the
 // infrastructure in place already for error testing.
 func testErrorHandlingOnChainFailure(ht *lntest.HarnessTest) {
-	alice, bob := ht.Alice, ht.Bob
-
 	// Setup a test case, note that we don't use its built in clean up
 	// because we're going to close a channel, so we'll close out the
 	// rest manually.
@@ -810,6 +818,8 @@ func testErrorHandlingOnChainFailure(ht *lntest.HarnessTest) {
 	blindedRoute := testCase.createRouteToBlinded(
 		50_000_000, blindedPaymentPath,
 	)
+
+	alice, bob := testCase.alice, testCase.bob
 
 	// Once our interceptor is set up, we can send the blinded payment.
 	cancelPmt := testCase.sendBlindedPayment(ctx, blindedRoute)
@@ -917,8 +927,8 @@ func testErrorHandlingOnChainFailure(ht *lntest.HarnessTest) {
 func testMPPToSingleBlindedPath(ht *lntest.HarnessTest) {
 	// Create a five-node context consisting of Alice, Bob and three new
 	// nodes.
-	alice, bob := ht.Alice, ht.Bob
-
+	alice := ht.NewNode("Alice", nil)
+	bob := ht.NewNode("Bob", nil)
 	dave := ht.NewNode("dave", nil)
 	carol := ht.NewNode("carol", nil)
 	eve := ht.NewNode("eve", nil)
@@ -932,10 +942,12 @@ func testMPPToSingleBlindedPath(ht *lntest.HarnessTest) {
 
 	// Send coins to the nodes and mine 1 blocks to confirm them.
 	for i := 0; i < 2; i++ {
+		ht.FundCoinsUnconfirmed(btcutil.SatoshiPerBitcoin, alice)
+		ht.FundCoinsUnconfirmed(btcutil.SatoshiPerBitcoin, bob)
 		ht.FundCoinsUnconfirmed(btcutil.SatoshiPerBitcoin, carol)
 		ht.FundCoinsUnconfirmed(btcutil.SatoshiPerBitcoin, dave)
 		ht.FundCoinsUnconfirmed(btcutil.SatoshiPerBitcoin, eve)
-		ht.MineBlocksAndAssertNumTxes(1, 3)
+		ht.MineBlocksAndAssertNumTxes(1, 5)
 	}
 
 	const paymentAmt = btcutil.Amount(300000)
@@ -1107,11 +1119,11 @@ func testMPPToSingleBlindedPath(ht *lntest.HarnessTest) {
 // between him and the introduction node. So we expect that Carol is chosen as
 // the intro node and that one dummy hops is appended.
 func testBlindedRouteDummyHops(ht *lntest.HarnessTest) {
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
 
 	// Disable route blinding for Bob so that he is never chosen as the
 	// introduction node.
-	ht.RestartNodeWithExtraArgs(bob, []string{
+	bob := ht.NewNodeWithCoins("Bob", []string{
 		"--protocol.no-route-blinding",
 	})
 
@@ -1278,7 +1290,8 @@ func testBlindedRouteDummyHops(ht *lntest.HarnessTest) {
 //		  \	       /
 //		   --- Carol ---
 func testMPPToMultipleBlindedPaths(ht *lntest.HarnessTest) {
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNodeWithCoins("Bob", nil)
 
 	// Create a four-node context consisting of Alice, Bob and three new
 	// nodes.
@@ -1440,14 +1453,14 @@ func testMPPToMultipleBlindedPaths(ht *lntest.HarnessTest) {
 // UpdateAddHTLC which we need to ensure gets included in the message on
 // restart.
 func testBlindedPaymentHTLCReForward(ht *lntest.HarnessTest) {
-	alice, bob := ht.Alice, ht.Bob
-
 	// Setup a test case.
 	ctx, testCase := newBlindedForwardTest(ht)
 	defer testCase.cleanup()
 
 	// Set up network with carol interceptor.
 	testCase.setupNetwork(ctx, true)
+
+	alice, bob := testCase.alice, testCase.bob
 
 	// Let dave create invoice.
 	blindedPaymentPath := testCase.buildBlindedPath()
@@ -1465,7 +1478,7 @@ func testBlindedPaymentHTLCReForward(ht *lntest.HarnessTest) {
 	go func() {
 		defer close(done)
 
-		htlcAttempt, err := testCase.ht.Alice.RPC.Router.SendToRouteV2(
+		htlcAttempt, err := testCase.alice.RPC.Router.SendToRouteV2(
 			ctx, sendReq,
 		)
 		require.NoError(testCase.ht, err)

--- a/itest/lnd_routing_test.go
+++ b/itest/lnd_routing_test.go
@@ -317,9 +317,8 @@ func runMultiHopSendToRoute(ht *lntest.HarnessTest, useGraphCache bool) {
 		opts = append(opts, "--db.no-graph-cache")
 	}
 
-	alice, bob := ht.Alice, ht.Bob
-	ht.RestartNodeWithExtraArgs(alice, opts)
-
+	alice := ht.NewNodeWithCoins("Alice", opts)
+	bob := ht.NewNodeWithCoins("Bob", opts)
 	ht.EnsureConnected(alice, bob)
 
 	const chanAmt = btcutil.Amount(100000)
@@ -417,7 +416,10 @@ func testSendToRouteErrorPropagation(ht *lntest.HarnessTest) {
 
 	// Open a channel with 100k satoshis between Alice and Bob with Alice
 	// being the sole funder of the channel.
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNode("Bob", nil)
+	ht.EnsureConnected(alice, bob)
+
 	chanPointAlice := ht.OpenChannel(
 		alice, bob, lntest.OpenChannelParams{Amt: chanAmt},
 	)
@@ -496,7 +498,10 @@ func testPrivateChannels(ht *lntest.HarnessTest) {
 	// where the 100k channel between Carol and Alice is private.
 
 	// Open a channel with 200k satoshis between Alice and Bob.
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNode("Bob", nil)
+	ht.EnsureConnected(alice, bob)
+
 	chanPointAlice := ht.OpenChannel(
 		alice, bob, lntest.OpenChannelParams{Amt: chanAmt * 2},
 	)
@@ -618,7 +623,10 @@ func testInvoiceRoutingHints(ht *lntest.HarnessTest) {
 	// throughout this test. We'll include a push amount since we currently
 	// require channels to have enough remote balance to cover the
 	// invoice's payment.
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNodeWithCoins("Bob", nil)
+	ht.EnsureConnected(alice, bob)
+
 	chanPointBob := ht.OpenChannel(
 		alice, bob, lntest.OpenChannelParams{
 			Amt:     chanAmt,
@@ -750,7 +758,7 @@ func testInvoiceRoutingHints(ht *lntest.HarnessTest) {
 // testScidAliasRoutingHints tests that dynamically created aliases via the RPC
 // are properly used when routing.
 func testScidAliasRoutingHints(ht *lntest.HarnessTest) {
-	bob := ht.Bob
+	bob := ht.NewNodeWithCoins("Bob", nil)
 
 	const chanAmt = btcutil.Amount(800000)
 
@@ -948,7 +956,10 @@ func testMultiHopOverPrivateChannels(ht *lntest.HarnessTest) {
 
 	// First, we'll open a private channel between Alice and Bob with Alice
 	// being the funder.
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNodeWithCoins("Bob", nil)
+	ht.EnsureConnected(alice, bob)
+
 	chanPointAlice := ht.OpenChannel(
 		alice, bob, lntest.OpenChannelParams{
 			Amt:     chanAmt,
@@ -958,7 +969,7 @@ func testMultiHopOverPrivateChannels(ht *lntest.HarnessTest) {
 
 	// Next, we'll create Carol's node and open a public channel between
 	// her and Bob with Bob being the funder.
-	carol := ht.NewNode("Carol", nil)
+	carol := ht.NewNodeWithCoins("Carol", nil)
 	ht.ConnectNodes(bob, carol)
 	chanPointBob := ht.OpenChannel(
 		bob, carol, lntest.OpenChannelParams{
@@ -973,7 +984,6 @@ func testMultiHopOverPrivateChannels(ht *lntest.HarnessTest) {
 	// him and Carol with Carol being the funder.
 	dave := ht.NewNode("Dave", nil)
 	ht.ConnectNodes(carol, dave)
-	ht.FundCoins(btcutil.SatoshiPerBitcoin, carol)
 
 	chanPointCarol := ht.OpenChannel(
 		carol, dave, lntest.OpenChannelParams{
@@ -1050,7 +1060,9 @@ func testQueryRoutes(ht *lntest.HarnessTest) {
 	const chanAmt = btcutil.Amount(100000)
 
 	// Grab Alice and Bob from the standby nodes.
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNodeWithCoins("Bob", nil)
+	ht.EnsureConnected(alice, bob)
 
 	// Create Carol and connect her to Bob. We also send her some coins for
 	// channel opening.
@@ -1353,7 +1365,10 @@ func testRouteFeeCutoff(ht *lntest.HarnessTest) {
 	const chanAmt = btcutil.Amount(100000)
 
 	// Open a channel between Alice and Bob.
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNodeWithCoins("Bob", nil)
+	ht.EnsureConnected(alice, bob)
+
 	chanPointAliceBob := ht.OpenChannel(
 		alice, bob, lntest.OpenChannelParams{Amt: chanAmt},
 	)

--- a/itest/lnd_routing_test.go
+++ b/itest/lnd_routing_test.go
@@ -750,6 +750,8 @@ func testInvoiceRoutingHints(ht *lntest.HarnessTest) {
 // testScidAliasRoutingHints tests that dynamically created aliases via the RPC
 // are properly used when routing.
 func testScidAliasRoutingHints(ht *lntest.HarnessTest) {
+	bob := ht.Bob
+
 	const chanAmt = btcutil.Amount(800000)
 
 	// Option-scid-alias is opt-in, as is anchors.
@@ -866,8 +868,8 @@ func testScidAliasRoutingHints(ht *lntest.HarnessTest) {
 	})
 
 	// Connect the existing Bob node with Carol via a public channel.
-	ht.ConnectNodes(ht.Bob, carol)
-	chanPointBC := ht.OpenChannel(ht.Bob, carol, lntest.OpenChannelParams{
+	ht.ConnectNodes(bob, carol)
+	chanPointBC := ht.OpenChannel(bob, carol, lntest.OpenChannelParams{
 		Amt:     chanAmt,
 		PushAmt: chanAmt / 2,
 	})
@@ -902,7 +904,7 @@ func testScidAliasRoutingHints(ht *lntest.HarnessTest) {
 
 	// Now Alice will try to pay to that payment request.
 	timeout := time.Second * 15
-	stream := ht.Bob.RPC.SendPayment(&routerrpc.SendPaymentRequest{
+	stream := bob.RPC.SendPayment(&routerrpc.SendPaymentRequest{
 		PaymentRequest: payReq,
 		TimeoutSeconds: int32(timeout.Seconds()),
 		FeeLimitSat:    math.MaxInt64,
@@ -924,7 +926,7 @@ func testScidAliasRoutingHints(ht *lntest.HarnessTest) {
 		AliasMaps: ephemeralAliasMap,
 	})
 	payReq2 := dave.RPC.AddInvoice(invoice).PaymentRequest
-	stream2 := ht.Bob.RPC.SendPayment(&routerrpc.SendPaymentRequest{
+	stream2 := bob.RPC.SendPayment(&routerrpc.SendPaymentRequest{
 		PaymentRequest: payReq2,
 		TimeoutSeconds: int32(timeout.Seconds()),
 		FeeLimitSat:    math.MaxInt64,
@@ -932,7 +934,7 @@ func testScidAliasRoutingHints(ht *lntest.HarnessTest) {
 	ht.AssertPaymentStatusFromStream(stream2, lnrpc.Payment_FAILED)
 
 	ht.CloseChannel(carol, chanPointCD)
-	ht.CloseChannel(ht.Bob, chanPointBC)
+	ht.CloseChannel(bob, chanPointBC)
 }
 
 // testMultiHopOverPrivateChannels tests that private channels can be used as

--- a/itest/lnd_signer_test.go
+++ b/itest/lnd_signer_test.go
@@ -25,7 +25,9 @@ import (
 // the node's pubkey and a customized public key to check the validity of the
 // result.
 func testDeriveSharedKey(ht *lntest.HarnessTest) {
-	runDeriveSharedKey(ht, ht.Alice)
+	alice := ht.Alice
+
+	runDeriveSharedKey(ht, alice)
 }
 
 // runDeriveSharedKey checks the ECDH performed by the endpoint
@@ -197,7 +199,9 @@ func runDeriveSharedKey(ht *lntest.HarnessTest, alice *node.HarnessNode) {
 // testSignOutputRaw makes sure that the SignOutputRaw RPC can be used with all
 // custom ways of specifying the signing key in the key descriptor/locator.
 func testSignOutputRaw(ht *lntest.HarnessTest) {
-	runSignOutputRaw(ht, ht.Alice)
+	alice := ht.Alice
+
+	runSignOutputRaw(ht, alice)
 }
 
 // runSignOutputRaw makes sure that the SignOutputRaw RPC can be used with all
@@ -377,7 +381,9 @@ func assertSignOutputRaw(ht *lntest.HarnessTest,
 // all custom flags by verifying with VerifyMessage. Tests both ECDSA and
 // Schnorr signatures.
 func testSignVerifyMessage(ht *lntest.HarnessTest) {
-	runSignVerifyMessage(ht, ht.Alice)
+	alice := ht.Alice
+
+	runSignVerifyMessage(ht, alice)
 }
 
 // runSignVerifyMessage makes sure that the SignMessage RPC can be used with

--- a/itest/lnd_signer_test.go
+++ b/itest/lnd_signer_test.go
@@ -25,7 +25,7 @@ import (
 // the node's pubkey and a customized public key to check the validity of the
 // result.
 func testDeriveSharedKey(ht *lntest.HarnessTest) {
-	alice := ht.Alice
+	alice := ht.NewNode("Alice", nil)
 
 	runDeriveSharedKey(ht, alice)
 }
@@ -199,7 +199,7 @@ func runDeriveSharedKey(ht *lntest.HarnessTest, alice *node.HarnessNode) {
 // testSignOutputRaw makes sure that the SignOutputRaw RPC can be used with all
 // custom ways of specifying the signing key in the key descriptor/locator.
 func testSignOutputRaw(ht *lntest.HarnessTest) {
-	alice := ht.Alice
+	alice := ht.NewNodeWithCoins("Alice", nil)
 
 	runSignOutputRaw(ht, alice)
 }
@@ -381,7 +381,7 @@ func assertSignOutputRaw(ht *lntest.HarnessTest,
 // all custom flags by verifying with VerifyMessage. Tests both ECDSA and
 // Schnorr signatures.
 func testSignVerifyMessage(ht *lntest.HarnessTest) {
-	alice := ht.Alice
+	alice := ht.NewNode("Alice", nil)
 
 	runSignVerifyMessage(ht, alice)
 }

--- a/itest/lnd_single_hop_invoice_test.go
+++ b/itest/lnd_single_hop_invoice_test.go
@@ -18,10 +18,11 @@ func testSingleHopInvoice(ht *lntest.HarnessTest) {
 	// Open a channel with 100k satoshis between Alice and Bob with Alice
 	// being the sole funder of the channel.
 	chanAmt := btcutil.Amount(100000)
-	alice, bob := ht.Alice, ht.Bob
-	cp := ht.OpenChannel(
-		alice, bob, lntest.OpenChannelParams{Amt: chanAmt},
+	chanPoints, nodes := ht.CreateSimpleNetwork(
+		[][]string{nil, nil}, lntest.OpenChannelParams{Amt: chanAmt},
 	)
+	cp := chanPoints[0]
+	alice, bob := nodes[0], nodes[1]
 
 	// assertAmountPaid is a helper closure that asserts the amount paid by
 	// Alice and received by Bob are expected.

--- a/itest/lnd_single_hop_invoice_test.go
+++ b/itest/lnd_single_hop_invoice_test.go
@@ -137,6 +137,4 @@ func testSingleHopInvoice(ht *lntest.HarnessTest) {
 	require.EqualValues(ht, 1, hopHint.FeeBaseMsat, "wrong FeeBaseMsat")
 	require.EqualValues(ht, 20, hopHint.CltvExpiryDelta,
 		"wrong CltvExpiryDelta")
-
-	ht.CloseChannel(alice, cp)
 }

--- a/itest/lnd_sweep_test.go
+++ b/itest/lnd_sweep_test.go
@@ -1548,7 +1548,9 @@ func testSweepCommitOutputAndAnchor(ht *lntest.HarnessTest) {
 // CPFP, then RBF. Along the way, we check the `BumpFee` can properly update
 // the fee function used by supplying new params.
 func testBumpFee(ht *lntest.HarnessTest) {
-	runBumpFee(ht, ht.Alice)
+	alice := ht.Alice
+
+	runBumpFee(ht, alice)
 }
 
 // runBumpFee checks the `BumpFee` RPC can properly bump the fee of a given

--- a/itest/lnd_sweep_test.go
+++ b/itest/lnd_sweep_test.go
@@ -1548,7 +1548,7 @@ func testSweepCommitOutputAndAnchor(ht *lntest.HarnessTest) {
 // CPFP, then RBF. Along the way, we check the `BumpFee` can properly update
 // the fee function used by supplying new params.
 func testBumpFee(ht *lntest.HarnessTest) {
-	alice := ht.Alice
+	alice := ht.NewNodeWithCoins("Alice", nil)
 
 	runBumpFee(ht, alice)
 }

--- a/itest/lnd_switch_test.go
+++ b/itest/lnd_switch_test.go
@@ -29,7 +29,6 @@ func testSwitchCircuitPersistence(ht *lntest.HarnessTest) {
 	// Setup our test scenario. We should now have four nodes running with
 	// three channels.
 	s := setupScenarioFourNodes(ht)
-	defer s.cleanUp()
 
 	// Restart the intermediaries and the sender.
 	ht.RestartNode(s.dave)
@@ -99,7 +98,6 @@ func testSwitchOfflineDelivery(ht *lntest.HarnessTest) {
 	// Setup our test scenario. We should now have four nodes running with
 	// three channels.
 	s := setupScenarioFourNodes(ht)
-	defer s.cleanUp()
 
 	// First, disconnect Dave and Alice so that their link is broken.
 	ht.DisconnectNodes(s.dave, s.alice)
@@ -175,7 +173,6 @@ func testSwitchOfflineDeliveryPersistence(ht *lntest.HarnessTest) {
 	// Setup our test scenario. We should now have four nodes running with
 	// three channels.
 	s := setupScenarioFourNodes(ht)
-	defer s.cleanUp()
 
 	// Disconnect the two intermediaries, Alice and Dave, by shutting down
 	// Alice.
@@ -264,7 +261,6 @@ func testSwitchOfflineDeliveryOutgoingOffline(ht *lntest.HarnessTest) {
 	// three channels. Note that we won't call the cleanUp function here as
 	// we will manually stop the node Carol and her channel.
 	s := setupScenarioFourNodes(ht)
-	defer s.cleanUp()
 
 	// Disconnect the two intermediaries, Alice and Dave, so that when carol
 	// restarts, the response will be held by Dave.
@@ -355,8 +351,6 @@ type scenarioFourNodes struct {
 	chanPointAliceBob  *lnrpc.ChannelPoint
 	chanPointCarolDave *lnrpc.ChannelPoint
 	chanPointDaveAlice *lnrpc.ChannelPoint
-
-	cleanUp func()
 }
 
 // setupScenarioFourNodes creates a topology for switch tests. It will create
@@ -433,21 +427,9 @@ func setupScenarioFourNodes(ht *lntest.HarnessTest) *scenarioFourNodes {
 	// above.
 	ht.CompletePaymentRequestsNoWait(bob, payReqs, chanPointAliceBob)
 
-	// Create a cleanUp to wipe the states.
-	cleanUp := func() {
-		if ht.Failed() {
-			ht.Skip("Skipped cleanup for failed test")
-			return
-		}
-
-		ht.CloseChannel(alice, chanPointAliceBob)
-		ht.CloseChannel(dave, chanPointDaveAlice)
-		ht.CloseChannel(carol, chanPointCarolDave)
-	}
-
 	s := &scenarioFourNodes{
 		alice, bob, carol, dave, chanPointAliceBob,
-		chanPointCarolDave, chanPointDaveAlice, cleanUp,
+		chanPointCarolDave, chanPointDaveAlice,
 	}
 
 	// Wait until all nodes in the network have 5 outstanding htlcs.

--- a/itest/lnd_switch_test.go
+++ b/itest/lnd_switch_test.go
@@ -383,7 +383,9 @@ func setupScenarioFourNodes(ht *lntest.HarnessTest) *scenarioFourNodes {
 	}
 
 	// Grab the standby nodes.
-	alice, bob := ht.Alice, ht.Bob
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNodeWithCoins("bob", nil)
+	ht.ConnectNodes(alice, bob)
 
 	// As preliminary setup, we'll create two new nodes: Carol and Dave,
 	// such that we now have a 4 node, 3 channel topology. Dave will make

--- a/itest/lnd_taproot_test.go
+++ b/itest/lnd_taproot_test.go
@@ -49,7 +49,7 @@ var (
 // testTaproot ensures that the daemon can send to and spend from taproot (p2tr)
 // outputs.
 func testTaproot(ht *lntest.HarnessTest) {
-	alice := ht.Alice
+	alice := ht.NewNode("Alice", nil)
 
 	testTaprootSendCoinsKeySpendBip86(ht, alice)
 	testTaprootComputeInputScriptKeySpendBip86(ht, alice)

--- a/itest/lnd_taproot_test.go
+++ b/itest/lnd_taproot_test.go
@@ -49,34 +49,36 @@ var (
 // testTaproot ensures that the daemon can send to and spend from taproot (p2tr)
 // outputs.
 func testTaproot(ht *lntest.HarnessTest) {
-	testTaprootSendCoinsKeySpendBip86(ht, ht.Alice)
-	testTaprootComputeInputScriptKeySpendBip86(ht, ht.Alice)
-	testTaprootSignOutputRawScriptSpend(ht, ht.Alice)
+	alice := ht.Alice
+
+	testTaprootSendCoinsKeySpendBip86(ht, alice)
+	testTaprootComputeInputScriptKeySpendBip86(ht, alice)
+	testTaprootSignOutputRawScriptSpend(ht, alice)
 	testTaprootSignOutputRawScriptSpend(
-		ht, ht.Alice, txscript.SigHashSingle,
+		ht, alice, txscript.SigHashSingle,
 	)
-	testTaprootSignOutputRawKeySpendBip86(ht, ht.Alice)
+	testTaprootSignOutputRawKeySpendBip86(ht, alice)
 	testTaprootSignOutputRawKeySpendBip86(
-		ht, ht.Alice, txscript.SigHashSingle,
+		ht, alice, txscript.SigHashSingle,
 	)
-	testTaprootSignOutputRawKeySpendRootHash(ht, ht.Alice)
+	testTaprootSignOutputRawKeySpendRootHash(ht, alice)
 
 	muSig2Versions := []signrpc.MuSig2Version{
 		signrpc.MuSig2Version_MUSIG2_VERSION_V040,
 		signrpc.MuSig2Version_MUSIG2_VERSION_V100RC2,
 	}
 	for _, version := range muSig2Versions {
-		testTaprootMuSig2KeySpendBip86(ht, ht.Alice, version)
-		testTaprootMuSig2KeySpendRootHash(ht, ht.Alice, version)
-		testTaprootMuSig2ScriptSpend(ht, ht.Alice, version)
-		testTaprootMuSig2CombinedLeafKeySpend(ht, ht.Alice, version)
-		testMuSig2CombineKey(ht, ht.Alice, version)
+		testTaprootMuSig2KeySpendBip86(ht, alice, version)
+		testTaprootMuSig2KeySpendRootHash(ht, alice, version)
+		testTaprootMuSig2ScriptSpend(ht, alice, version)
+		testTaprootMuSig2CombinedLeafKeySpend(ht, alice, version)
+		testMuSig2CombineKey(ht, alice, version)
 	}
 
-	testTaprootImportTapscriptFullTree(ht, ht.Alice)
-	testTaprootImportTapscriptPartialReveal(ht, ht.Alice)
-	testTaprootImportTapscriptRootHashOnly(ht, ht.Alice)
-	testTaprootImportTapscriptFullKey(ht, ht.Alice)
+	testTaprootImportTapscriptFullTree(ht, alice)
+	testTaprootImportTapscriptPartialReveal(ht, alice)
+	testTaprootImportTapscriptRootHashOnly(ht, alice)
+	testTaprootImportTapscriptFullKey(ht, alice)
 }
 
 // testTaprootSendCoinsKeySpendBip86 tests sending to and spending from

--- a/itest/lnd_test.go
+++ b/itest/lnd_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
 
@@ -110,10 +109,6 @@ func TestLightningNetworkDaemon(t *testing.T) {
 	)
 	defer harnessTest.Stop()
 
-	// Setup standby nodes, Alice and Bob, which will be alive and shared
-	// among all the test cases.
-	harnessTest.SetupStandbyNodes()
-
 	// Get the current block height.
 	height := harnessTest.CurrentHeight()
 
@@ -130,22 +125,7 @@ func TestLightningNetworkDaemon(t *testing.T) {
 			// avoid overwriting the external harness test that is
 			// tied to the parent test.
 			ht := harnessTest.Subtest(t1)
-
-			// TODO(yy): split log files.
-			cleanTestCaseName := strings.ReplaceAll(
-				testCase.Name, " ", "_",
-			)
-			ht.SetTestName(cleanTestCaseName)
-
-			logLine := fmt.Sprintf(
-				"STARTING ============ %v ============\n",
-				testCase.Name,
-			)
-
-			ht.Alice.AddToLogf(logLine)
-			ht.Bob.AddToLogf(logLine)
-
-			ht.EnsureConnected(ht.Alice, ht.Bob)
+			ht.SetTestName(testCase.Name)
 
 			ht.RunTestCase(testCase)
 		})

--- a/itest/lnd_test.go
+++ b/itest/lnd_test.go
@@ -106,6 +106,9 @@ func TestLightningNetworkDaemon(t *testing.T) {
 	// among all the test cases.
 	harnessTest.SetupStandbyNodes()
 
+	// Get the current block height.
+	height := harnessTest.CurrentHeight()
+
 	// Run the subset of the test cases selected in this tranche.
 	for idx, testCase := range testCases {
 		testCase := testCase
@@ -151,9 +154,10 @@ func TestLightningNetworkDaemon(t *testing.T) {
 		}
 	}
 
-	height := harnessTest.CurrentHeight()
-	t.Logf("=========> tests finished for tranche: %v, tested %d "+
-		"cases, end height: %d\n", trancheIndex, len(testCases), height)
+	//nolint:forbidigo
+	fmt.Printf("=========> tranche %v finished, tested %d cases, mined "+
+		"blocks: %d\n", trancheIndex, len(testCases),
+		harnessTest.CurrentHeight()-height)
 }
 
 // getTestCaseSplitTranche returns the sub slice of the test cases that should

--- a/itest/lnd_trackpayments_test.go
+++ b/itest/lnd_trackpayments_test.go
@@ -14,21 +14,19 @@ import (
 // testTrackPayments tests whether a client that calls the TrackPayments api
 // receives payment updates.
 func testTrackPayments(ht *lntest.HarnessTest) {
-	alice, bob := ht.Alice, ht.Bob
-
-	// Restart Alice with the new flag so she understands the new payment
+	// Create Alice with the new flag so she understands the new payment
 	// status.
-	ht.RestartNodeWithExtraArgs(alice, []string{
-		"--routerrpc.usestatusinitiated",
-	})
+	cfgAlice := []string{"--routerrpc.usestatusinitiated"}
+	cfgs := [][]string{cfgAlice, nil}
 
-	// Open a channel between alice and bob.
-	ht.EnsureConnected(alice, bob)
-	channel := ht.OpenChannel(
-		alice, bob, lntest.OpenChannelParams{
+	// Create a channel Alice->Bob.
+	chanPoints, nodes := ht.CreateSimpleNetwork(
+		cfgs, lntest.OpenChannelParams{
 			Amt: btcutil.Amount(300000),
 		},
 	)
+	channel := chanPoints[0]
+	alice, bob := nodes[0], nodes[1]
 
 	// Call the TrackPayments api to listen for payment updates.
 	req := &routerrpc.TrackPaymentsRequest{
@@ -104,12 +102,13 @@ func testTrackPayments(ht *lntest.HarnessTest) {
 // is not set, the new Payment_INITIATED is replaced with Payment_IN_FLIGHT.
 func testTrackPaymentsCompatible(ht *lntest.HarnessTest) {
 	// Open a channel between alice and bob.
-	alice, bob := ht.Alice, ht.Bob
-	channel := ht.OpenChannel(
-		alice, bob, lntest.OpenChannelParams{
+	chanPoints, nodes := ht.CreateSimpleNetwork(
+		[][]string{nil, nil}, lntest.OpenChannelParams{
 			Amt: btcutil.Amount(300000),
 		},
 	)
+	channel := chanPoints[0]
+	alice, bob := nodes[0], nodes[1]
 
 	// Call the TrackPayments api to listen for payment updates.
 	req := &routerrpc.TrackPaymentsRequest{

--- a/itest/lnd_wallet_import_test.go
+++ b/itest/lnd_wallet_import_test.go
@@ -582,7 +582,7 @@ func runWalletImportAccountScenario(ht *lntest.HarnessTest,
 
 	// Send coins to Carol's address and confirm them, making sure the
 	// balance updates accordingly.
-	alice := ht.Alice
+	alice := ht.NewNodeWithCoins("Alice", nil)
 	req := &lnrpc.SendCoinsRequest{
 		Addr:       externalAddr,
 		Amount:     utxoAmt,
@@ -694,7 +694,7 @@ func testWalletImportPubKeyScenario(ht *lntest.HarnessTest,
 	addrType walletrpc.AddressType) {
 
 	const utxoAmt int64 = btcutil.SatoshiPerBitcoin
-	alice := ht.Alice
+	alice := ht.NewNodeWithCoins("Alice", nil)
 
 	// We'll start our test by having two nodes, Carol and Dave.
 	//

--- a/itest/lnd_watchtower_test.go
+++ b/itest/lnd_watchtower_test.go
@@ -39,6 +39,8 @@ var watchtowerTestCases = []*lntest.TestCase{
 // testTowerClientTowerAndSessionManagement tests the various control commands
 // that a user has over the client's set of active towers and sessions.
 func testTowerClientTowerAndSessionManagement(ht *lntest.HarnessTest) {
+	alice := ht.Alice
+
 	const (
 		chanAmt           = funding.MaxBtcFundingAmount
 		externalIP        = "1.2.3.4"
@@ -104,13 +106,13 @@ func testTowerClientTowerAndSessionManagement(ht *lntest.HarnessTest) {
 	ht.FundCoins(btcutil.SatoshiPerBitcoin, dave)
 
 	// Connect Dave and Alice.
-	ht.ConnectNodes(dave, ht.Alice)
+	ht.ConnectNodes(dave, alice)
 
 	// Open a channel between Dave and Alice.
 	params := lntest.OpenChannelParams{
 		Amt: chanAmt,
 	}
-	chanPoint := ht.OpenChannel(dave, ht.Alice, params)
+	chanPoint := ht.OpenChannel(dave, alice, params)
 
 	// Show that the Wallis tower is currently seen as an active session
 	// candidate.
@@ -122,7 +124,7 @@ func testTowerClientTowerAndSessionManagement(ht *lntest.HarnessTest) {
 
 	// Make some back-ups and assert that they are added to a session with
 	// the tower.
-	generateBackups(ht, dave, ht.Alice, 4)
+	generateBackups(ht, dave, alice, 4)
 
 	// Assert that one of the sessions now has 4 backups.
 	assertNumBackups(ht, dave.RPC, wallisPk, 4, false)
@@ -139,7 +141,7 @@ func testTowerClientTowerAndSessionManagement(ht *lntest.HarnessTest) {
 	require.False(ht, info.SessionInfo[0].ActiveSessionCandidate)
 
 	// Back up a few more states.
-	generateBackups(ht, dave, ht.Alice, 4)
+	generateBackups(ht, dave, alice, 4)
 
 	// These should _not_ be on the tower. Therefore, the number of
 	// back-ups on the tower should be the same as before.
@@ -163,7 +165,7 @@ func testTowerClientTowerAndSessionManagement(ht *lntest.HarnessTest) {
 	})
 
 	// Generate some more back-ups.
-	generateBackups(ht, dave, ht.Alice, 4)
+	generateBackups(ht, dave, alice, 4)
 
 	// Assert that they get added to the first tower (Wallis) and that the
 	// number of sessions with Wallis has not changed - in other words, the
@@ -205,7 +207,7 @@ func testTowerClientTowerAndSessionManagement(ht *lntest.HarnessTest) {
 	assertNumSessions(wallisPk, 4, false)
 
 	// Any new back-ups should now be backed up on a different session.
-	generateBackups(ht, dave, ht.Alice, 2)
+	generateBackups(ht, dave, alice, 2)
 	assertNumBackups(ht, dave.RPC, wallisPk, 10, false)
 	findSession(wallisPk, 2)
 
@@ -238,6 +240,8 @@ func testTowerClientTowerAndSessionManagement(ht *lntest.HarnessTest) {
 // testTowerClientSessionDeletion tests that sessions are correctly deleted
 // when they are deemed closable.
 func testTowerClientSessionDeletion(ht *lntest.HarnessTest) {
+	alice := ht.Alice
+
 	const (
 		chanAmt           = funding.MaxBtcFundingAmount
 		numInvoices       = 5
@@ -290,18 +294,18 @@ func testTowerClientSessionDeletion(ht *lntest.HarnessTest) {
 	ht.FundCoins(btcutil.SatoshiPerBitcoin, dave)
 
 	// Connect Dave and Alice.
-	ht.ConnectNodes(dave, ht.Alice)
+	ht.ConnectNodes(dave, alice)
 
 	// Open a channel between Dave and Alice.
 	params := lntest.OpenChannelParams{
 		Amt: chanAmt,
 	}
-	chanPoint := ht.OpenChannel(dave, ht.Alice, params)
+	chanPoint := ht.OpenChannel(dave, alice, params)
 
 	// Since there are 2 updates made for every payment and the maximum
 	// number of updates per session has been set to 10, make 5 payments
 	// between the pair so that the session is exhausted.
-	generateBackups(ht, dave, ht.Alice, maxUpdates)
+	generateBackups(ht, dave, alice, maxUpdates)
 
 	// Assert that one of the sessions now has 10 backups.
 	assertNumBackups(ht, dave.RPC, wallisPk, 10, false)

--- a/itest/lnd_watchtower_test.go
+++ b/itest/lnd_watchtower_test.go
@@ -39,7 +39,7 @@ var watchtowerTestCases = []*lntest.TestCase{
 // testTowerClientTowerAndSessionManagement tests the various control commands
 // that a user has over the client's set of active towers and sessions.
 func testTowerClientTowerAndSessionManagement(ht *lntest.HarnessTest) {
-	alice := ht.Alice
+	alice := ht.NewNode("Alice", nil)
 
 	const (
 		chanAmt           = funding.MaxBtcFundingAmount
@@ -240,7 +240,7 @@ func testTowerClientTowerAndSessionManagement(ht *lntest.HarnessTest) {
 // testTowerClientSessionDeletion tests that sessions are correctly deleted
 // when they are deemed closable.
 func testTowerClientSessionDeletion(ht *lntest.HarnessTest) {
-	alice := ht.Alice
+	alice := ht.NewNode("Alice", nil)
 
 	const (
 		chanAmt           = funding.MaxBtcFundingAmount
@@ -395,7 +395,7 @@ func testRevokedCloseRetributionAltruistWatchtowerCase(ht *lntest.HarnessTest,
 	// protection logic automatically.
 	daveArgs := lntest.NodeArgsForCommitType(commitType)
 	daveArgs = append(daveArgs, "--nolisten", "--wtclient.active")
-	dave := ht.NewNode("Dave", daveArgs)
+	dave := ht.NewNodeWithCoins("Dave", daveArgs)
 
 	addTowerReq := &wtclientrpc.AddTowerRequest{
 		Pubkey:  willyInfoPk,
@@ -406,10 +406,6 @@ func testRevokedCloseRetributionAltruistWatchtowerCase(ht *lntest.HarnessTest,
 	// We must let Dave have an open channel before she can send a node
 	// announcement, so we open a channel with Carol,
 	ht.ConnectNodes(dave, carol)
-
-	// Before we make a channel, we'll load up Dave with some coins sent
-	// directly from the miner.
-	ht.FundCoins(btcutil.SatoshiPerBitcoin, dave)
 
 	// Send one more UTXOs if this is a neutrino backend.
 	if ht.IsNeutrinoBackend() {

--- a/itest/lnd_wipe_fwdpkgs_test.go
+++ b/itest/lnd_wipe_fwdpkgs_test.go
@@ -27,25 +27,12 @@ func testWipeForwardingPackages(ht *lntest.HarnessTest) {
 		numInvoices    = 3
 	)
 
-	// Grab Alice and Bob from HarnessTest.
-	alice, bob := ht.Alice, ht.Bob
-
-	// Create a new node Carol, which will create invoices that require
-	// Alice to pay.
-	carol := ht.NewNode("Carol", nil)
-
-	// Connect Bob to Carol.
-	ht.ConnectNodes(bob, carol)
-
-	// Open a channel between Alice and Bob.
-	chanPointAB := ht.OpenChannel(
-		alice, bob, lntest.OpenChannelParams{Amt: chanAmt},
+	chanPoints, nodes := ht.CreateSimpleNetwork(
+		[][]string{nil, nil, nil},
+		lntest.OpenChannelParams{Amt: chanAmt},
 	)
-
-	// Open a channel between Bob and Carol.
-	chanPointBC := ht.OpenChannel(
-		bob, carol, lntest.OpenChannelParams{Amt: chanAmt},
-	)
+	chanPointAB, chanPointBC := chanPoints[0], chanPoints[1]
+	alice, bob, carol := nodes[0], nodes[1], nodes[2]
 
 	// Before we continue, make sure Alice has seen the channel between Bob
 	// and Carol.

--- a/itest/lnd_wumbo_channels_test.go
+++ b/itest/lnd_wumbo_channels_test.go
@@ -45,8 +45,7 @@ func testWumboChannels(ht *lntest.HarnessTest) {
 
 	// Creating a wumbo channel between these two nodes should succeed.
 	ht.EnsureConnected(wumboNode, wumboNode2)
-	chanPoint := ht.OpenChannel(
+	ht.OpenChannel(
 		wumboNode, wumboNode2, lntest.OpenChannelParams{Amt: chanAmt},
 	)
-	ht.CloseChannel(wumboNode, chanPoint)
 }

--- a/itest/lnd_zero_conf_test.go
+++ b/itest/lnd_zero_conf_test.go
@@ -854,9 +854,6 @@ func testOptionScidUpgrade(ht *lntest.HarnessTest) {
 
 	daveInvoice2 := dave.RPC.AddInvoice(daveParams)
 	ht.CompletePaymentRequests(bob, []string{daveInvoice2.PaymentRequest})
-
-	// Close standby node's channels.
-	ht.CloseChannel(bob, fundingPoint2)
 }
 
 // acceptChannel is used to accept a single channel that comes across. This

--- a/itest/lnd_zero_conf_test.go
+++ b/itest/lnd_zero_conf_test.go
@@ -753,7 +753,7 @@ func testPrivateUpdateAlias(ht *lntest.HarnessTest,
 // testOptionScidUpgrade tests that toggling the option-scid-alias feature bit
 // correctly upgrades existing channels.
 func testOptionScidUpgrade(ht *lntest.HarnessTest) {
-	bob := ht.Bob
+	bob := ht.NewNodeWithCoins("Bob", nil)
 
 	// Start carol with anchors only.
 	carolArgs := []string{

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -2165,6 +2165,13 @@ func acceptChannel(t *testing.T, zeroConf bool, stream rpc.AcceptorClient) {
 	require.NoError(t, err)
 }
 
+// nodeNames defines a slice of human-reable names for the nodes created in the
+// `createNodes` method. 8 nodes are defined here as by default we can only
+// create this many nodes in one test.
+var nodeNames = []string{
+	"Alice", "Bob", "Carol", "Dave", "Eve", "Frank", "Grace", "Heidi",
+}
+
 // createNodes creates the number of nodes specified by the number of configs.
 // Each node is created using the specified config, the neighbors are
 // connected.
@@ -2172,12 +2179,15 @@ func (h *HarnessTest) createNodes(nodeCfgs [][]string) []*node.HarnessNode {
 	// Get the number of nodes.
 	numNodes := len(nodeCfgs)
 
+	// Make sure we are creating a reasonable number of nodes.
+	require.LessOrEqual(h, numNodes, len(nodeNames), "too many nodes")
+
 	// Make a slice of nodes.
 	nodes := make([]*node.HarnessNode, numNodes)
 
 	// Create new nodes.
 	for i, nodeCfg := range nodeCfgs {
-		nodeName := fmt.Sprintf("Node%q", string(rune('A'+i)))
+		nodeName := nodeNames[i]
 		n := h.NewNode(nodeName, nodeCfg)
 		nodes[i] = n
 	}

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -67,23 +68,11 @@ type TestCase struct {
 	TestFunc func(t *HarnessTest)
 }
 
-// standbyNodes are a list of nodes which are created during the initialization
-// of the test and used across all test cases.
-type standbyNodes struct {
-	// Alice and Bob are the initial seeder nodes that are automatically
-	// created to be the initial participants of the test network.
-	Alice *node.HarnessNode
-	Bob   *node.HarnessNode
-}
-
 // HarnessTest builds on top of a testing.T with enhanced error detection. It
 // is responsible for managing the interactions among different nodes, and
 // providing easy-to-use assertions.
 type HarnessTest struct {
 	*testing.T
-
-	// Embed the standbyNodes so we can easily access them via `ht.Alice`.
-	standbyNodes
 
 	// miner is a reference to a running full node that can be used to
 	// create new blocks on the network.
@@ -271,97 +260,6 @@ func (h *HarnessTest) createAndSendOutput(target *node.HarnessNode,
 	h.miner.SendOutput(output, defaultMinerFeeRate)
 }
 
-// SetupRemoteSigningStandbyNodes starts the initial seeder nodes within the
-// test harness in a remote signing configuration. The initial node's wallets
-// will be funded wallets with 100x1 BTC outputs each.
-func (h *HarnessTest) SetupRemoteSigningStandbyNodes() {
-	h.Log("Setting up standby nodes Alice and Bob with remote " +
-		"signing configurations...")
-	defer h.Log("Finished the setup, now running tests...")
-
-	password := []byte("itestpassword")
-
-	// Setup remote signing nodes for Alice and Bob.
-	signerAlice := h.NewNode("SignerAlice", nil)
-	signerBob := h.NewNode("SignerBob", nil)
-
-	// Setup watch-only nodes for Alice and Bob, each configured with their
-	// own remote signing instance.
-	h.Alice = h.setupWatchOnlyNode("Alice", signerAlice, password)
-	h.Bob = h.setupWatchOnlyNode("Bob", signerBob, password)
-
-	// Fund each node with 100 BTC (using 100 separate transactions).
-	const fundAmount = 1 * btcutil.SatoshiPerBitcoin
-	const numOutputs = 100
-	const totalAmount = fundAmount * numOutputs
-	for _, node := range []*node.HarnessNode{h.Alice, h.Bob} {
-		h.manager.standbyNodes[node.Cfg.NodeID] = node
-		for i := 0; i < numOutputs; i++ {
-			h.createAndSendOutput(
-				node, fundAmount,
-				lnrpc.AddressType_WITNESS_PUBKEY_HASH,
-			)
-		}
-	}
-
-	// We generate several blocks in order to give the outputs created
-	// above a good number of confirmations.
-	const totalTxes = 200
-	h.MineBlocksAndAssertNumTxes(numBlocksSendOutput, totalTxes)
-
-	// Now we want to wait for the nodes to catch up.
-	h.WaitForBlockchainSync(h.Alice)
-	h.WaitForBlockchainSync(h.Bob)
-
-	// Now block until both wallets have fully synced up.
-	h.WaitForBalanceConfirmed(h.Alice, totalAmount)
-	h.WaitForBalanceConfirmed(h.Bob, totalAmount)
-}
-
-// SetUp starts the initial seeder nodes within the test harness. The initial
-// node's wallets will be funded wallets with 10x10 BTC outputs each.
-func (h *HarnessTest) SetupStandbyNodes() {
-	h.Log("Setting up standby nodes Alice and Bob...")
-	defer h.Log("Finished the setup, now running tests...")
-
-	lndArgs := []string{
-		"--default-remote-max-htlcs=483",
-		"--channel-max-fee-exposure=5000000",
-	}
-
-	// Start the initial seeder nodes within the test network.
-	h.Alice = h.NewNode("Alice", lndArgs)
-	h.Bob = h.NewNode("Bob", lndArgs)
-
-	// Load up the wallets of the seeder nodes with 100 outputs of 1 BTC
-	// each.
-	const fundAmount = 1 * btcutil.SatoshiPerBitcoin
-	const numOutputs = 100
-	const totalAmount = fundAmount * numOutputs
-	for _, node := range []*node.HarnessNode{h.Alice, h.Bob} {
-		h.manager.standbyNodes[node.Cfg.NodeID] = node
-		for i := 0; i < numOutputs; i++ {
-			h.createAndSendOutput(
-				node, fundAmount,
-				lnrpc.AddressType_WITNESS_PUBKEY_HASH,
-			)
-		}
-	}
-
-	// We generate several blocks in order to give the outputs created
-	// above a good number of confirmations.
-	const totalTxes = 200
-	h.MineBlocksAndAssertNumTxes(numBlocksSendOutput, totalTxes)
-
-	// Now we want to wait for the nodes to catch up.
-	h.WaitForBlockchainSync(h.Alice)
-	h.WaitForBlockchainSync(h.Bob)
-
-	// Now block until both wallets have fully synced up.
-	h.WaitForBalanceConfirmed(h.Alice, totalAmount)
-	h.WaitForBalanceConfirmed(h.Bob, totalAmount)
-}
-
 // Stop stops the test harness.
 func (h *HarnessTest) Stop() {
 	// Do nothing if it's not started.
@@ -399,24 +297,6 @@ func (h *HarnessTest) RunTestCase(testCase *TestCase) {
 	testCase.TestFunc(h)
 }
 
-// resetStandbyNodes resets all standby nodes by attaching the new testing.T
-// and restarting them with the original config.
-func (h *HarnessTest) resetStandbyNodes(t *testing.T) {
-	t.Helper()
-
-	for _, hn := range h.manager.standbyNodes {
-		// Inherit the testing.T.
-		h.T = t
-
-		// Reset the config so the node will be using the default
-		// config for the coming test. This will also inherit the
-		// test's running context.
-		h.RestartNodeWithExtraArgs(hn, hn.Cfg.OriginalExtraArgs)
-
-		hn.AddToLogf("Finished test case %v", h.manager.currentTestCase)
-	}
-}
-
 // Subtest creates a child HarnessTest, which inherits the harness net and
 // stand by nodes created by the parent test. It will return a cleanup function
 // which resets  all the standby nodes' configs back to its original state and
@@ -428,7 +308,6 @@ func (h *HarnessTest) Subtest(t *testing.T) *HarnessTest {
 		T:            t,
 		manager:      h.manager,
 		miner:        h.miner,
-		standbyNodes: h.standbyNodes,
 		feeService:   h.feeService,
 		lndErrorChan: make(chan error, lndErrorChanSize),
 	}
@@ -438,9 +317,6 @@ func (h *HarnessTest) Subtest(t *testing.T) *HarnessTest {
 
 	// Inherit the subtest for the miner.
 	st.miner.T = st.T
-
-	// Reset the standby nodes.
-	st.resetStandbyNodes(t)
 
 	// Reset fee estimator.
 	st.feeService.Reset()
@@ -471,14 +347,8 @@ func (h *HarnessTest) Subtest(t *testing.T) *HarnessTest {
 			return
 		}
 
-		// When we finish the test, reset the nodes' configs and take a
-		// snapshot of each of the nodes' internal states.
-		for _, node := range st.manager.standbyNodes {
-			st.cleanupStandbyNode(node)
-		}
-
 		// If found running nodes, shut them down.
-		st.shutdownNonStandbyNodes()
+		st.shutdownAllNodes()
 
 		// We require the mempool to be cleaned from the test.
 		require.Empty(st, st.miner.GetRawMempool(), "mempool not "+
@@ -498,26 +368,9 @@ func (h *HarnessTest) Subtest(t *testing.T) *HarnessTest {
 	return st
 }
 
-// shutdownNonStandbyNodes will shutdown any non-standby nodes.
-func (h *HarnessTest) shutdownNonStandbyNodes() {
-	h.shutdownNodes(true)
-}
-
 // shutdownAllNodes will shutdown all running nodes.
 func (h *HarnessTest) shutdownAllNodes() {
-	h.shutdownNodes(false)
-}
-
-// shutdownNodes will shutdown any non-standby nodes. If skipStandby is false,
-// all the standby nodes will be shutdown too.
-func (h *HarnessTest) shutdownNodes(skipStandby bool) {
-	for nid, node := range h.manager.activeNodes {
-		// If it's a standby node, skip.
-		_, ok := h.manager.standbyNodes[nid]
-		if ok && skipStandby {
-			continue
-		}
-
+	for _, node := range h.manager.activeNodes {
 		// The process may not be in a state to always shutdown
 		// immediately, so we'll retry up to a hard limit to ensure we
 		// eventually shutdown.
@@ -566,26 +419,14 @@ func (h *HarnessTest) cleanupStandbyNode(hn *node.HarnessNode) {
 func (h *HarnessTest) removeConnectionns(hn *node.HarnessNode) {
 	resp := hn.RPC.ListPeers()
 	for _, peer := range resp.Peers {
-		// Skip disconnecting Alice and Bob.
-		switch peer.PubKey {
-		case h.Alice.PubKeyStr:
-			continue
-		case h.Bob.PubKeyStr:
-			continue
-		}
-
 		hn.RPC.DisconnectPeer(peer.PubKey)
 	}
 }
 
 // SetTestName set the test case name.
 func (h *HarnessTest) SetTestName(name string) {
-	h.manager.currentTestCase = name
-
-	// Overwrite the old log filename so we can create new log files.
-	for _, node := range h.manager.standbyNodes {
-		node.Cfg.LogFilenamePrefix = name
-	}
+	cleanTestCaseName := strings.ReplaceAll(name, " ", "_")
+	h.manager.currentTestCase = cleanTestCaseName
 }
 
 // NewNode creates a new node and asserts its creation. The node is guaranteed
@@ -1507,7 +1348,7 @@ func (h *HarnessTest) fundCoins(amt btcutil.Amount, target *node.HarnessNode,
 }
 
 // FundCoins attempts to send amt satoshis from the internal mining node to the
-// targeted lightning node using a P2WKH address. 2 blocks are mined after in
+// targeted lightning node using a P2WKH address. 1 blocks are mined after in
 // order to confirm the transaction.
 func (h *HarnessTest) FundCoins(amt btcutil.Amount, hn *node.HarnessNode) {
 	h.fundCoins(amt, hn, lnrpc.AddressType_WITNESS_PUBKEY_HASH, true)
@@ -1783,9 +1624,9 @@ func (h *HarnessTest) RestartNodeAndRestoreDB(hn *node.HarnessNode) {
 // closures as the caller doesn't need to mine all the blocks to make sure the
 // mempool is empty.
 func (h *HarnessTest) CleanShutDown() {
-	// First, shutdown all non-standby nodes to prevent new transactions
-	// being created and fed into the mempool.
-	h.shutdownNonStandbyNodes()
+	// First, shutdown all nodes to prevent new transactions being created
+	// and fed into the mempool.
+	h.shutdownAllNodes()
 
 	// Now mine blocks till the mempool is empty.
 	h.cleanMempool()

--- a/lntest/harness_node_manager.go
+++ b/lntest/harness_node_manager.go
@@ -40,10 +40,6 @@ type nodeManager struct {
 	// {pubkey: *HarnessNode}.
 	activeNodes map[uint32]*node.HarnessNode
 
-	// standbyNodes is a map of all the standby nodes, format:
-	// {pubkey: *HarnessNode}.
-	standbyNodes map[uint32]*node.HarnessNode
-
 	// nodeCounter is a monotonically increasing counter that's used as the
 	// node's unique ID.
 	nodeCounter atomic.Uint32
@@ -57,11 +53,10 @@ func newNodeManager(lndBinary string, dbBackend node.DatabaseBackend,
 	nativeSQL bool) *nodeManager {
 
 	return &nodeManager{
-		lndBinary:    lndBinary,
-		dbBackend:    dbBackend,
-		nativeSQL:    nativeSQL,
-		activeNodes:  make(map[uint32]*node.HarnessNode),
-		standbyNodes: make(map[uint32]*node.HarnessNode),
+		lndBinary:   lndBinary,
+		dbBackend:   dbBackend,
+		nativeSQL:   nativeSQL,
+		activeNodes: make(map[uint32]*node.HarnessNode),
 	}
 }
 

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -10,6 +10,7 @@ COVER_PKG = $$(go list -deps -tags="$(DEV_TAGS)" ./... | grep '$(PKG)' | grep -v
 NUM_ITEST_TRANCHES = 4
 ITEST_PARALLELISM = $(NUM_ITEST_TRANCHES)
 POSTGRES_START_DELAY = 5
+SHUFFLE_SEED = 0
 
 # If rpc option is set also add all extra RPC tags to DEV_TAGS
 ifneq ($(with-rpc),)
@@ -25,6 +26,11 @@ endif
 # Give the ability to run the same tranche multiple times at the same time.
 ifneq ($(parallel),)
 ITEST_PARALLELISM = $(parallel)
+endif
+
+# Set the seed for shuffling the test cases.
+ifneq ($(shuffleseed),)
+SHUFFLE_SEED = $(shuffleseed)
 endif
 
 # Windows needs to append a .exe suffix to all executable files, otherwise it

--- a/scripts/itest_parallel.sh
+++ b/scripts/itest_parallel.sh
@@ -3,9 +3,10 @@
 # Get all the variables.
 PROCESSES=$1
 TRANCHES=$2
+SHUFFLE_SEED=$3
 
-# Here we also shift 2 times and get the rest of our flags to pass on in $@.
-shift 2
+# Here we also shift 3 times and get the rest of our flags to pass on in $@.
+shift 3
 
 # Create a variable to hold the final exit code.
 exit_code=0
@@ -13,7 +14,7 @@ exit_code=0
 # Run commands using xargs in parallel and capture their PIDs
 pids=()
 for ((i=0; i<PROCESSES; i++)); do 
-    scripts/itest_part.sh $i $TRANCHES $@ &
+    scripts/itest_part.sh $i $TRANCHES $SHUFFLE_SEED $@ &
     pids+=($!)
 done
 

--- a/scripts/itest_part.sh
+++ b/scripts/itest_part.sh
@@ -5,11 +5,11 @@ WORKDIR=$(pwd)/itest
 
 TRANCHE=$1
 NUM_TRANCHES=$2
+SHUFFLE_SEED_PARAM=$3
 
-# Shift the passed parameters by two, giving us all remaining testing flags in
+# Shift the passed parameters by three, giving us all remaining testing flags in
 # the $@ special variable.
-shift
-shift
+shift 3
 
 # Windows insists on having the .exe suffix for an executable, we need to add
 # that here if necessary.
@@ -18,9 +18,9 @@ LND_EXEC="$WORKDIR"/lnd-itest"$EXEC_SUFFIX"
 BTCD_EXEC="$WORKDIR"/btcd-itest"$EXEC_SUFFIX"
 export GOCOVERDIR="$WORKDIR/cover"
 mkdir -p "$GOCOVERDIR"
-echo $EXEC "$@" -logoutput -logdir=.logs-tranche$TRANCHE -lndexec=$LND_EXEC -btcdexec=$BTCD_EXEC -splittranches=$NUM_TRANCHES -runtranche=$TRANCHE
+echo $EXEC "$@" -logoutput -logdir=.logs-tranche$TRANCHE -lndexec=$LND_EXEC -btcdexec=$BTCD_EXEC -splittranches=$NUM_TRANCHES -runtranche=$TRANCHE -shuffleseed=$SHUFFLE_SEED_PARAM
 
 # Exit code 255 causes the parallel jobs to abort, so if one part fails the
 # other is aborted too.
 cd "$WORKDIR" || exit 255
-$EXEC "$@" -logoutput -logdir=.logs-tranche$TRANCHE -lndexec=$LND_EXEC -btcdexec=$BTCD_EXEC -splittranches=$NUM_TRANCHES -runtranche=$TRANCHE || exit 255
+$EXEC "$@" -logoutput -logdir=.logs-tranche$TRANCHE -lndexec=$LND_EXEC -btcdexec=$BTCD_EXEC -splittranches=$NUM_TRANCHES -runtranche=$TRANCHE -shuffleseed=$SHUFFLE_SEED_PARAM || exit 255


### PR DESCRIPTION
This PR is resulted from fixing the itest failures in `blockbeat`. Since it's a critical system, we need to make sure the CI is indicative of reporting failures.

Check #9260 for the final result.

### Improvements

This PR does the following,
1. All itest flakes are now documented and fixed.
2. A large decrease in the time taken to run the CI, e.g., for `btcd` itest, previously it takes 45m and now it takes around 18m.

### Changes

- standby nodes are removed. On one hand, this setup contributes to some of the flakes we've previously seen, e.g., checking num of edges. It creates quite a burden as all the tests are supposed to be independent, and this setup has created unnecessary states that need to be managed. On the other hand, this setup hides bugs, especially when it comes to how the wallet manages UTXOs since it always gives each standby node more than enough UTXOs to use, which is shown in one of the test failures found, in which the `ListCoins` gives incorrect result and is currently under investigation.

- tests are shuffled deterministically before running to maximize the tranche scheduler. Out of the 8 tranches in the CI, one of them takes much longer to run due to more blocks mined in this tranche. Since the time it takes to run the test is almost linear to the num of blocks mined, we now shuffle the test cases so it's more likely each tranche mines a similar num of blocks. This setup also gives a faster feedback loop during development, which was why I did it originally. Suppose one change caused 10 tests to fail, with shuffling, we are likely to catch all of them in one CI run, whereas we'd run the CI multiple times previously.

- most of the table-driven tests are now broken into independent tests, mostly because we want them to be more maintainable, but also contribute to speeding up the CI as the more tests we have, the more likely we get even tranches.

Aside from the above structural changes, all the flakes are now documented, including the ones in windows (windows is less stable, unfortunately). We also assert the shutdown is clean (which contributes to some of the nasty flakes).

### Dependent PRs
Issues fixed from this new itest setup, which are dependent PRs,

- #9303
- #9242

- #9338 
- #9292
- #9291
- #9275
- #9261
- #9259
- #9258
- #9249
- #9248
- #9228
