### PR TITLE
chainntnfs: fix `TestHistoricalConfDetailsTxIndex`

### DIFF
--- a/chainntnfs/bitcoindnotify/bitcoind_test.go
+++ b/chainntnfs/bitcoindnotify/bitcoind_test.go
@@ -109,10 +109,14 @@ func syncNotifierWithMiner(t *testing.T, notifier *BitcoindNotifier,
 // TestHistoricalConfDetailsTxIndex ensures that we correctly retrieve
 // historical confirmation details using the backend node's txindex.
 func TestHistoricalConfDetailsTxIndex(t *testing.T) {
-	t.Run("rpc polling enabled", func(st *testing.T) {
+	success := t.Run("rpc polling enabled", func(st *testing.T) {
 		st.Parallel()
 		testHistoricalConfDetailsTxIndex(st, true)
 	})
+
+	if !success {
+		return
+	}
 
 	t.Run("rpc polling disabled", func(st *testing.T) {
 		st.Parallel()
@@ -207,10 +211,14 @@ func testHistoricalConfDetailsTxIndex(t *testing.T, rpcPolling bool) {
 // historical confirmation details using the set of fallback methods when the
 // backend node's txindex is disabled.
 func TestHistoricalConfDetailsNoTxIndex(t *testing.T) {
-	t.Run("rpc polling enabled", func(st *testing.T) {
+	success := t.Run("rpc polling enabled", func(st *testing.T) {
 		st.Parallel()
 		testHistoricalConfDetailsNoTxIndex(st, true)
 	})
+
+	if !success {
+		return
+	}
 
 	t.Run("rpc polling disabled", func(st *testing.T) {
 		st.Parallel()

--- a/chainntnfs/test/bitcoind/bitcoind_test.go
+++ b/chainntnfs/test/bitcoind/bitcoind_test.go
@@ -12,10 +12,14 @@ import (
 // TestInterfaces executes the generic notifier test suite against a bitcoind
 // powered chain notifier.
 func TestInterfaces(t *testing.T) {
-	t.Run("bitcoind", func(st *testing.T) {
+	success := t.Run("bitcoind", func(st *testing.T) {
 		st.Parallel()
 		chainntnfstest.TestInterfaces(st, "bitcoind")
 	})
+
+	if !success {
+		return
+	}
 
 	t.Run("bitcoind rpc polling", func(st *testing.T) {
 		st.Parallel()

--- a/chainntnfs/txnotifier_test.go
+++ b/chainntnfs/txnotifier_test.go
@@ -173,7 +173,7 @@ func TestTxNotifierRegistrationValidation(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testCase := testCase
-		t.Run(testCase.name, func(t *testing.T) {
+		success := t.Run(testCase.name, func(t *testing.T) {
 			hintCache := newMockHintCache()
 			n := chainntnfs.NewTxNotifier(
 				10, chainntnfs.ReorgSafetyLimit, hintCache, hintCache,
@@ -201,6 +201,10 @@ func TestTxNotifierRegistrationValidation(t *testing.T) {
 					"\"%v\", got \"%v\"", testCase.err, err)
 			}
 		})
+
+		if !success {
+			return
+		}
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/NebulousLabs/go-upnp v0.0.0-20180202185039-29b680b06c82
 	github.com/Yawning/aez v0.0.0-20211027044916-e49e68abd344
 	github.com/andybalholm/brotli v1.0.4
-	github.com/btcsuite/btcd v0.24.3-0.20240921052913-67b8efd3ba53
+	github.com/btcsuite/btcd v0.24.3-0.20241210095828-e646d437e95b
 	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/btcsuite/btcd/btcutil v1.1.5
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.8

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=
-github.com/btcsuite/btcd v0.24.3-0.20240921052913-67b8efd3ba53 h1:XOZ/wRGHkKv0AqxfDks5IkzaQ1Ge6fq322ZOOG5VIkU=
-github.com/btcsuite/btcd v0.24.3-0.20240921052913-67b8efd3ba53/go.mod h1:zHK7t7sw8XbsCkD64WePHE3r3k9/XoGAcf6mXV14c64=
+github.com/btcsuite/btcd v0.24.3-0.20241210095828-e646d437e95b h1:VQoobSrWdxICuqFU3tKVu/Lzk7BTk9SsCgRr5dUvC70=
+github.com/btcsuite/btcd v0.24.3-0.20241210095828-e646d437e95b/go.mod h1:zHK7t7sw8XbsCkD64WePHE3r3k9/XoGAcf6mXV14c64=
 github.com/btcsuite/btcd/btcec/v2 v2.1.0/go.mod h1:2VzYrv4Gm4apmbVVsSq5bqf1Ec8v56E48Vt0Y/umPgA=
 github.com/btcsuite/btcd/btcec/v2 v2.1.3/go.mod h1:ctjw4H1kknNJmRN4iP1R7bTQ+v3GJkZBd6mui8ZsAZE=
 github.com/btcsuite/btcd/btcec/v2 v2.3.4 h1:3EJjcN70HCu/mwqlUsGK8GcNVyLVxFDlWurTXGPFfiQ=


### PR DESCRIPTION
Depends on https://github.com/btcsuite/btcd/pull/2277

Fix the following unit test. From a local observation, it looks like a previous node is still shutting down, causing the following test to fail.
```
--- FAIL: TestHistoricalConfDetailsTxIndex (0.00s)
    --- FAIL: TestHistoricalConfDetailsTxIndex/rpc_polling_disabled (11.65s)
        bitcoind_test.go:143: miner height=430, bitcoind height=0
        ...
        bitcoind_test.go:143: miner height=430, bitcoind height=0
        bitcoind_test.go:143: timed out in syncNotifierWithMiner, got err=<nil>, minerHeight=430, bitcoindHeight=0
FAIL
FAIL	github.com/lightningnetwork/lnd/chainntnfs/bitcoindnotify	13.323s
FAIL
```