### PR TITLE
make: remove exotic build targets from release list

### DIFF
--- a/make/release_flags.mk
+++ b/make/release_flags.mk
@@ -21,12 +21,6 @@ linux-amd64 \
 linux-armv6 \
 linux-armv7 \
 linux-arm64 \
-linux-ppc64 \
-linux-ppc64le \
-linux-mips \
-linux-mipsle \
-linux-mips64 \
-linux-s390x \
 netbsd-amd64 \
 openbsd-amd64 \
 windows-386 \


### PR DESCRIPTION
With this commit we remove build targets from our list of release build OS/architecture pairs to reduce the overhead of building for them with [every pull request](https://github.com/lightningnetwork/lnd/actions/runs/12051378606/job/33602271830?pr=9257) and every release.

According to https://tooomm.github.io/github-release-stats/?username=lightningnetwork&repository=lnd those targets are rarely used, compared to the most popular ones:

| Release File                          | Absolute DL | Relative DL |
|---------------------------------------|-------------|-------------|
| lnd-darwin-amd64-v0.18.3-beta.tar.gz  | 1,930       | 72          |
| lnd-darwin-arm64-v0.18.3-beta.tar.gz  | 2,020       | 162         |
| lnd-freebsd-386-v0.18.3-beta.tar.gz   | 1,864       | 6           |
| lnd-freebsd-amd64-v0.18.3-beta.tar.gz | 1,874       | 16          |
| lnd-freebsd-arm-v0.18.3-beta.tar.gz   | 1,865       | 7           |
| lnd-linux-386-v0.18.3-beta.tar.gz     | 1,873       | 15          |
| lnd-linux-amd64-v0.18.3-beta.tar.gz   | 3,355       | 1,497       |
| lnd-linux-arm64-v0.18.3-beta.tar.gz   | 3,053       | 1,195       |
| lnd-linux-armv6-v0.18.3-beta.tar.gz   | 1,868       | 10          |
| lnd-linux-armv7-v0.18.3-beta.tar.gz   | 1,893       | 35          |
| **lnd-linux-mips-v0.18.3-beta.tar.gz**    | 1,859       | 1           |
| **lnd-linux-mips64-v0.18.3-beta.tar.gz**  | 1,860       | 2           |
| **lnd-linux-mipsle-v0.18.3-beta.tar.gz**  | 1,859       | 1           |
| **lnd-linux-ppc64-v0.18.3-beta.tar.gz**   | 1,858       | 0           |
| **lnd-linux-ppc64le-v0.18.3-beta.tar.gz** | 1,859       | 1           |
| **lnd-linux-s390x-v0.18.3-beta.tar.gz**   | 1,859       | 1           |
| lnd-netbsd-amd64-v0.18.3-beta.tar.gz  | 1,859       | 1           |
| lnd-openbsd-amd64-v0.18.3-beta.tar.gz | 1,861       | 3           |
| lnd-source-v0.18.3-beta.tar.gz        | 1,863       | 5           |
| lnd-windows-386-v0.18.3-beta.zip      | 1,895       | 37          |
| lnd-windows-amd64-v0.18.3-beta.zip    | 1,997       | 139         |
| lnd-windows-arm-v0.18.3-beta.zip      | 1,868       | 10          |

Users of those more exotic systems will still be able to compile `lnd` from source.

Anyone not in agreement with the removal of these systems from the release binary target list, please speak up now!