### PR TITLE
cmd: fix default timeout for estimateroutefee

### DIFF
--- a/cmd/commands/cmd_payments.go
+++ b/cmd/commands/cmd_payments.go
@@ -1920,9 +1920,7 @@ func estimateRouteFee(ctx *cli.Context) error {
 
 	case ctx.IsSet("pay_req"):
 		req.PaymentRequest = StripPrefix(ctx.String("pay_req"))
-		if ctx.IsSet("timeout") {
-			req.Timeout = uint32(ctx.Duration("timeout").Seconds())
-		}
+		req.Timeout = uint32(ctx.Duration("timeout").Seconds())
 
 	default:
 		return fmt.Errorf("fee estimation arguments missing")

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -60,6 +60,9 @@
 * [Make the contract resolutions for the channel arbitrator optional](
   https://github.com/lightningnetwork/lnd/pull/9253)
 
+  * [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/9322) that caused
+    estimateroutefee to ignore the default payment timeout.
+
 # New Features
 
 * [Support](https://github.com/lightningnetwork/lnd/pull/8390) for 


### PR DESCRIPTION
`lncli estimateroutefee --pay_req=...` would error in `router_backend.go` with
```
[lncli] rpc error: code = Unknown desc = timeout_seconds must be specified
```
because the cmd default param, which is `60s`, wasn't properly passed on.