### PR TITLE
docker+docs: update documentation around Golang minimum version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,12 +25,8 @@ env:
   
   TRANCHES: 8
 
-  # If you change this value, please change it in the following files as well:
-  # /.travis.yml
-  # /Dockerfile
-  # /dev.Dockerfile
-  # /make/builder.Dockerfile
-  # /.github/workflows/release.yml
+  # If you change this please also update GO_VERSION in Makefile (then run
+  # `make lint` to see where else it needs to be updated as well).
   GO_VERSION: 1.22.6
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,11 +10,8 @@ defaults:
     shell: bash
 
 env:
-  # If you change this value, please change it in the following files as well:
-  # /Dockerfile
-  # /dev.Dockerfile
-  # /make/builder.Dockerfile
-  # /.github/workflows/main.yml
+  # If you change this please also update GO_VERSION in Makefile (then run
+  # `make lint` to see where else it needs to be updated as well).
   GO_VERSION: 1.22.6
 
 jobs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,6 @@
 run:
+  # If you change this please also update GO_VERSION in Makefile (then run
+  # `make lint` to see where else it needs to be updated as well).
   go: "1.22.6"
 
   # Abort after 10 minutes.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
-# If you change this value, please change it in the following files as well:
-# /dev.Dockerfile
-# /make/builder.Dockerfile
-# /.github/workflows/main.yml
-# /.github/workflows/release.yml
+# If you change this please also update GO_VERSION in Makefile (then run
+# `make lint` to see where else it needs to be updated as well).
 FROM golang:1.22.6-alpine as builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,8 +1,5 @@
-# If you change this value, please change it in the following files as well:
-# /Dockerfile
-# /make/builder.Dockerfile
-# /.github/workflows/main.yml
-# /.github/workflows/release.yml
+# If you change this please also update GO_VERSION in Makefile (then run
+# `make lint` to see where else it needs to be updated as well).
 FROM golang:1.22.6-alpine as builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"

--- a/docker/btcd/Dockerfile
+++ b/docker/btcd/Dockerfile
@@ -1,3 +1,5 @@
+# If you change this please also update GO_VERSION in Makefile (then run
+# `make lint` to see where else it needs to be updated as well).
 FROM golang:1.22.6-alpine as builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -93,15 +93,16 @@ following build dependencies are required:
 
 ### Installing Go
 
-`lnd` is written in Go, with a minimum version of 1.19. To install, run one of
-the following commands for your OS:
+`lnd` is written in Go, with a minimum version of `1.22.6` (or, in case this
+document gets out of date, whatever the Go version in the main `go.mod` file
+requires). To install, run one of the following commands for your OS:
 
 <details>
   <summary>Linux (x86-64)</summary>
   
   ```
   wget https://dl.google.com/go/go1.22.6.linux-amd64.tar.gz
-  sha256sum go1.22.5.linux-amd64.tar.gz | awk -F " " '{ print $1 }'
+  sha256sum go1.22.6.linux-amd64.tar.gz | awk -F " " '{ print $1 }'
   ```
 
   The final output of the command above should be
@@ -109,7 +110,7 @@ the following commands for your OS:
   isn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
   this version of Go. If it matches, then proceed to install Go:
   ```
-  sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.22.5.linux-amd64.tar.gz
+  sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.22.6.linux-amd64.tar.gz
   export PATH=$PATH:/usr/local/go/bin
   ```
 </details>
@@ -118,8 +119,8 @@ the following commands for your OS:
   <summary>Linux (ARMv6)</summary>
   
   ```
-  wget https://dl.google.com/go/go1.22.5.linux-armv6l.tar.gz
-  sha256sum go1.22.5.linux-armv6l.tar.gz | awk -F " " '{ print $1 }'
+  wget https://dl.google.com/go/go1.22.6.linux-armv6l.tar.gz
+  sha256sum go1.22.6.linux-armv6l.tar.gz | awk -F " " '{ print $1 }'
   ```
 
   The final output of the command above should be
@@ -127,7 +128,7 @@ the following commands for your OS:
   isn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
   this version of Go. If it matches, then proceed to install Go:
   ```
-  sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.22.5.linux-armv6l.tar.gz
+  sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.22.6.linux-armv6l.tar.gz
   export PATH=$PATH:/usr/local/go/bin
   ```  
   

--- a/go.mod
+++ b/go.mod
@@ -207,8 +207,9 @@ replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 // allows us to specify that as an option.
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display
 
-// If you change this please also update .github/pull_request_template.md,
-// docs/INSTALL.md and GO_IMAGE in lnrpc/gen_protos_docker.sh.
+// If you change this please also update docs/INSTALL.md and GO_VERSION in
+// Makefile (then run `make lint` to see where else it needs to be updated as
+// well).
 go 1.22.6
 
 retract v0.0.2

--- a/lnrpc/Dockerfile
+++ b/lnrpc/Dockerfile
@@ -1,3 +1,5 @@
+# If you change this please also update GO_VERSION in Makefile (then run
+# `make lint` to see where else it needs to be updated as well).
 FROM golang:1.22.6-bookworm
 
 RUN apt-get update && apt-get install -y \

--- a/make/builder.Dockerfile
+++ b/make/builder.Dockerfile
@@ -1,8 +1,5 @@
-# If you change this value, please change it in the following files as well:
-# /Dockerfile
-# /dev.Dockerfile
-# /.github/workflows/main.yml
-# /.github/workflows/release.yml
+# If you change this please also update GO_VERSION in Makefile (then run
+# `make lint` to see where else it needs to be updated as well).
 FROM golang:1.22.6-bookworm
 
 MAINTAINER Olaoluwa Osuntokun <laolu@lightning.engineering>


### PR DESCRIPTION
As discovered in https://github.com/lightningnetwork/lnd/discussions/9327, the `docs/INSTALL.md` referenced an old version of Go that needs to be used.