### PR TITLE
multi: rename `lll` to `ll` and remove unused `nolint`

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -526,7 +526,7 @@ func New(cfg Config, selfKeyDesc *keychain.KeyDescriptor) *AuthenticatedGossiper
 		futureMsgs:        newFutureMsgCache(maxFutureMessages),
 		quit:              make(chan struct{}),
 		chanPolicyUpdates: make(chan *chanPolicyUpdateRequest),
-		prematureChannelUpdates: lru.NewCache[uint64, *cachedNetworkMsg]( //nolint: lll
+		prematureChannelUpdates: lru.NewCache[uint64, *cachedNetworkMsg]( //nolint: ll
 			maxPrematureUpdates,
 		),
 		channelMtx: multimutex.NewMutex[uint64](),

--- a/invoices/sql_store.go
+++ b/invoices/sql_store.go
@@ -616,7 +616,7 @@ func fetchAmpState(ctx context.Context, db SQLInvoiceQueries, invoiceID int64,
 
 				invoiceKeys[key] = struct{}{}
 
-				if htlc.State != HtlcStateCanceled { //nolint: lll
+				if htlc.State != HtlcStateCanceled { //nolint: ll
 					amtPaid += htlc.Amt
 				}
 			}

--- a/lnwire/typed_fee.go
+++ b/lnwire/typed_fee.go
@@ -46,10 +46,10 @@ func feeDecoder(r io.Reader, val interface{}, buf *[8]byte, l uint64) error {
 	}
 
 	var baseFee, feeRate uint32
-	if err := tlv.DUint32(r, &baseFee, buf, 4); err != nil { //nolint: gomnd,lll
+	if err := tlv.DUint32(r, &baseFee, buf, 4); err != nil {
 		return err
 	}
-	if err := tlv.DUint32(r, &feeRate, buf, 4); err != nil { //nolint: gomnd,lll
+	if err := tlv.DUint32(r, &feeRate, buf, 4); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Looks like there are a few more occurrences of `lll` which need to be fixed.