### PR TITLE
 Use all valid routes during blinded path construction

### DIFF
--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -600,6 +600,10 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testQueryBlindedRoutes,
 	},
 	{
+		Name:     "blinding invoices maxnumpaths",
+		TestFunc: testBlindedPathsMaxNumPaths,
+	},
+	{
 		Name:     "route blinding invoices",
 		TestFunc: testBlindedRouteInvoices,
 	},

--- a/lnrpc/invoicesrpc/addinvoice.go
+++ b/lnrpc/invoicesrpc/addinvoice.go
@@ -183,6 +183,9 @@ type BlindedPathConfig struct {
 	// dummy hops in a blinded path in the case where they cant be derived
 	// through other means.
 	DefaultDummyHopPolicy *blindedpath.BlindedHopPolicy
+
+	// MaxNumPaths is the maximum number of blinded paths to select.
+	MaxNumPaths uint8
 }
 
 // paymentHashAndPreimage returns the payment hash and preimage for this invoice
@@ -542,6 +545,7 @@ func AddInvoice(ctx context.Context, cfg *AddInvoiceConfig,
 				},
 				MinNumHops:            blindCfg.MinNumPathHops,
 				DefaultDummyHopPolicy: blindCfg.DefaultDummyHopPolicy,
+				MaxNumPaths:           blindCfg.MaxNumPaths,
 			},
 		)
 		if err != nil {

--- a/routing/blindedpath/blinded_path_test.go
+++ b/routing/blindedpath/blinded_path_test.go
@@ -623,6 +623,7 @@ func TestBuildBlindedPath(t *testing.T) {
 		ValueMsat:               1000,
 		MinFinalCLTVExpiryDelta: 12,
 		BlocksUntilExpiry:       200,
+		MaxNumPaths:             3,
 	})
 	require.NoError(t, err)
 	require.Len(t, paths, 1)
@@ -797,6 +798,7 @@ func TestBuildBlindedPathWithDummyHops(t *testing.T) {
 		ValueMsat:               1000,
 		MinFinalCLTVExpiryDelta: 12,
 		BlocksUntilExpiry:       200,
+		MaxNumPaths:             3,
 
 		// By setting the minimum number of hops to 4, we force 2 dummy
 		// hops to be added to the real route.
@@ -976,6 +978,7 @@ func TestBuildBlindedPathWithDummyHops(t *testing.T) {
 		ValueMsat:               1000,
 		MinFinalCLTVExpiryDelta: 12,
 		BlocksUntilExpiry:       200,
+		MaxNumPaths:             3,
 
 		// By setting the minimum number of hops to 4, we force 2 dummy
 		// hops to be added to the real route.
@@ -1022,6 +1025,7 @@ func TestSingleHopBlindedPath(t *testing.T) {
 		ValueMsat:               1000,
 		MinFinalCLTVExpiryDelta: 12,
 		BlocksUntilExpiry:       200,
+		MaxNumPaths:             3,
 	})
 	require.NoError(t, err)
 	require.Len(t, paths, 1)

--- a/routing/router.go
+++ b/routing/router.go
@@ -603,9 +603,6 @@ type BlindedPathRestrictions struct {
 	// our node along with an introduction node hop.
 	NumHops uint8
 
-	// MaxNumPaths is the maximum number of blinded paths to select.
-	MaxNumPaths uint8
-
 	// NodeOmissionSet is a set of nodes that should not be used within any
 	// of the blinded paths that we generate.
 	NodeOmissionSet fn.Set[route.Vertex]
@@ -711,18 +708,13 @@ func (r *ChannelRouter) FindBlindedPaths(destination route.Vertex,
 		return routes[i].probability > routes[j].probability
 	})
 
-	// Now just choose the best paths up until the maximum number of allowed
-	// paths.
-	bestRoutes := make([]*route.Route, 0, restrictions.MaxNumPaths)
+	// Now just get all paths ordered by probability.
+	allRoutes := make([]*route.Route, 0, len(routes))
 	for _, route := range routes {
-		if len(bestRoutes) >= int(restrictions.MaxNumPaths) {
-			break
-		}
-
-		bestRoutes = append(bestRoutes, route.route)
+		allRoutes = append(allRoutes, route.route)
 	}
 
-	return bestRoutes, nil
+	return allRoutes, nil
 }
 
 // generateNewSessionKey generates a new ephemeral private key to be used for a

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -3135,12 +3135,11 @@ func TestFindBlindedPathsWithMC(t *testing.T) {
 	}
 
 	// All the probabilities are set to 1. So if we restrict the path length
-	// to 2 and allow a max of 3 routes, then we expect three paths here.
+	// to 2, then we expect three paths here.
 	routes, err := ctx.router.FindBlindedPaths(
 		dave, 1000, probabilitySrc, &BlindedPathRestrictions{
 			MinDistanceFromIntroNode: 2,
 			NumHops:                  2,
-			MaxNumPaths:              3,
 		},
 	)
 	require.NoError(t, err)
@@ -3174,8 +3173,7 @@ func TestFindBlindedPathsWithMC(t *testing.T) {
 	}
 
 	// Now, let's lower the MC probability of the B-D to 0.5 and F-D link to
-	// 0.25. We will leave the MaxNumPaths as 3 and so all paths should
-	// still be returned but the order should be:
+	// 0.25. All paths should still be returned but the order should be:
 	// 1) A -> C -> D
 	// 2) A -> B -> D
 	// 3) A -> F -> D
@@ -3185,7 +3183,6 @@ func TestFindBlindedPathsWithMC(t *testing.T) {
 		dave, 1000, probabilitySrc, &BlindedPathRestrictions{
 			MinDistanceFromIntroNode: 2,
 			NumHops:                  2,
-			MaxNumPaths:              3,
 		},
 	)
 	require.NoError(t, err)
@@ -3202,7 +3199,6 @@ func TestFindBlindedPathsWithMC(t *testing.T) {
 		dave, 1000, probabilitySrc, &BlindedPathRestrictions{
 			MinDistanceFromIntroNode: 2,
 			NumHops:                  2,
-			MaxNumPaths:              3,
 		},
 	)
 	require.NoError(t, err)
@@ -3212,27 +3208,12 @@ func TestFindBlindedPathsWithMC(t *testing.T) {
 		"alice,charlie,dave",
 	})
 
-	// Change the MaxNumPaths to 1 to assert that only the best route is
-	// returned.
-	routes, err = ctx.router.FindBlindedPaths(
-		dave, 1000, probabilitySrc, &BlindedPathRestrictions{
-			MinDistanceFromIntroNode: 2,
-			NumHops:                  2,
-			MaxNumPaths:              1,
-		},
-	)
-	require.NoError(t, err)
-	assertPaths(routes, []string{
-		"alice,bob,dave",
-	})
-
 	// Test the edge case where Dave, the recipient, is also the
 	// introduction node.
 	routes, err = ctx.router.FindBlindedPaths(
 		dave, 1000, probabilitySrc, &BlindedPathRestrictions{
 			MinDistanceFromIntroNode: 0,
 			NumHops:                  0,
-			MaxNumPaths:              1,
 		},
 	)
 	require.NoError(t, err)
@@ -3247,7 +3228,6 @@ func TestFindBlindedPathsWithMC(t *testing.T) {
 		dave, 1000, probabilitySrc, &BlindedPathRestrictions{
 			MinDistanceFromIntroNode: 2,
 			NumHops:                  2,
-			MaxNumPaths:              3,
 		},
 	)
 	require.NoError(t, err)
@@ -3262,7 +3242,6 @@ func TestFindBlindedPathsWithMC(t *testing.T) {
 		dave, 1000, probabilitySrc, &BlindedPathRestrictions{
 			MinDistanceFromIntroNode: 2,
 			NumHops:                  2,
-			MaxNumPaths:              3,
 			NodeOmissionSet:          fn.NewSet(frank),
 		},
 	)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -6322,10 +6322,10 @@ func (r *rpcServer) AddInvoice(ctx context.Context,
 	)
 
 	globalBlindCfg := r.server.cfg.Routing.BlindedPaths
+	maxNumPaths := globalBlindCfg.MaxNumPaths
 	blindingRestrictions := &routing.BlindedPathRestrictions{
 		MinDistanceFromIntroNode: globalBlindCfg.MinNumRealHops,
 		NumHops:                  globalBlindCfg.NumHops,
-		MaxNumPaths:              globalBlindCfg.MaxNumPaths,
 		NodeOmissionSet:          fn.NewSet[route.Vertex](),
 	}
 
@@ -6347,8 +6347,8 @@ func (r *rpcServer) AddInvoice(ctx context.Context,
 				return nil, fmt.Errorf("blinded max num " +
 					"paths cannot be 0")
 			}
-			blindingRestrictions.MaxNumPaths =
-				uint8(*blindCfg.MaxNumPaths)
+			maxNumPaths = uint8(*blindCfg.MaxNumPaths)
+
 		}
 
 		for _, nodeIDBytes := range blindCfg.NodeOmissionList {
@@ -6485,6 +6485,7 @@ func (r *rpcServer) AddInvoice(ctx context.Context,
 				MaxHTLCMsat: 0,
 			},
 			MinNumPathHops: blindingRestrictions.NumHops,
+			MaxNumPaths:    maxNumPaths,
 		}
 	}
 


### PR DESCRIPTION
Fixes #9076

MaxNumPaths restriction moved from `FindBlindedPaths` to `BuildBlindedPaymentPaths` this way we can interact  through all possibly routes.

If the reviewers agreed to this approach we will have to modify the `TestFindBlindedPathsWithMC` because it is considering that MaxNumPaths retriction is applied on `FindBlindedPaths` function.