### PR TITLE
lnrpc: sort `Invoice.HTLCs` based on `HtlcIndex`

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -90,6 +90,10 @@
 * [The `walletrpc.FundPsbt` method now has a new option to specify the maximum
   fee to output amounts ratio.](https://github.com/lightningnetwork/lnd/pull/8600)
 
+* When returning the response from list invoices RPC, the `lnrpc.Invoice.Htlcs`
+  are now [sorted](https://github.com/lightningnetwork/lnd/pull/9337) based on
+  the `InvoiceHTLC.HtlcIndex`.
+
 ## lncli Additions
 
 * [A pre-generated macaroon root key can now be specified in `lncli create` and

--- a/lnrpc/invoicesrpc/utils.go
+++ b/lnrpc/invoicesrpc/utils.go
@@ -1,8 +1,10 @@
 package invoicesrpc
 
 import (
+	"cmp"
 	"encoding/hex"
 	"fmt"
+	"slices"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -159,6 +161,11 @@ func CreateRPCInvoice(invoice *invoices.Invoice,
 
 		rpcHtlcs = append(rpcHtlcs, &rpcHtlc)
 	}
+
+	// Perform an inplace sort of the HTLCs to ensure they are ordered.
+	slices.SortFunc(rpcHtlcs, func(i, j *lnrpc.InvoiceHTLC) int {
+		return cmp.Compare(i.HtlcIndex, j.HtlcIndex)
+	})
 
 	rpcInvoice := &lnrpc.Invoice{
 		Memo:            string(invoice.Memo),


### PR DESCRIPTION
Cherry-picked from #9260, we need this to have deterministic results from the RPC response.