### PR TITLE
contractcourt: include custom records on replayed htlc

### DIFF
--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -308,7 +308,8 @@ func (h *htlcIncomingContestResolver) Resolve(
 
 		resolution, err := h.Registry.NotifyExitHopHtlc(
 			h.htlc.RHash, h.htlc.Amt, h.htlcExpiry, currentHeight,
-			circuitKey, hodlQueue.ChanIn(), nil, payload,
+			circuitKey, hodlQueue.ChanIn(), h.htlc.CustomRecords,
+			payload,
 		)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Description

When notifying the invoice registry for an exit hop htlc we also want to
include its custom records. The channelLink, the other caller of this
method, already populates this field. So we make sure the contest
resolver does so too.