### PR TITLE
routerrpc: add a default value for timeout_seconds in SendPaymentV2

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -94,6 +94,10 @@
   are now [sorted](https://github.com/lightningnetwork/lnd/pull/9337) based on
   the `InvoiceHTLC.HtlcIndex`.
 
+* [routerrpc.SendPaymentV2](https://github.com/lightningnetwork/lnd/pull/9359)
+  RPC method now applies a default timeout of 60 seconds when the
+  `timeout_seconds` field is not set or is explicitly set to 0.
+
 ## lncli Additions
 
 * [A pre-generated macaroon root key can now be specified in `lncli create` and

--- a/itest/lnd_amp_test.go
+++ b/itest/lnd_amp_test.go
@@ -118,7 +118,6 @@ func testSendPaymentAMPInvoiceCase(ht *lntest.HarnessTest,
 	sendReq := &routerrpc.SendPaymentRequest{
 		PaymentRequest: addInvoiceResp.PaymentRequest,
 		PaymentAddr:    externalPayAddr,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 		Amp:            true,
 	}
@@ -400,7 +399,6 @@ func testSendPaymentAMP(ht *lntest.HarnessTest) {
 		Dest:           mts.bob.PubKey[:],
 		Amt:            int64(paymentAmt),
 		FinalCltvDelta: chainreg.DefaultBitcoinTimeLockDelta,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 		Amp:            true,
 	}

--- a/itest/lnd_channel_balance_test.go
+++ b/itest/lnd_channel_balance_test.go
@@ -150,7 +150,6 @@ func testChannelUnsettledBalance(ht *lntest.HarnessTest) {
 				Amt:            int64(payAmt),
 				PaymentHash:    ht.Random32Bytes(),
 				FinalCltvDelta: finalCltvDelta,
-				TimeoutSeconds: 60,
 				FeeLimitMsat:   noFeeLimitMsat,
 			}
 			ht.SendPaymentAssertInflight(alice, req)

--- a/itest/lnd_channel_force_close_test.go
+++ b/itest/lnd_channel_force_close_test.go
@@ -111,7 +111,6 @@ func runChannelForceClosureTest(ht *lntest.HarnessTest,
 			Amt:            int64(paymentAmt),
 			PaymentHash:    ht.Random32Bytes(),
 			FinalCltvDelta: finalCltvDelta,
-			TimeoutSeconds: 60,
 			FeeLimitMsat:   noFeeLimitMsat,
 		}
 		ht.SendPaymentAssertInflight(alice, req)
@@ -811,7 +810,6 @@ func testFailingChannel(ht *lntest.HarnessTest) {
 	// won't work as the channel cannot be found.
 	req := &routerrpc.SendPaymentRequest{
 		PaymentRequest: resp.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 	ht.SendPaymentAndAssertStatus(alice, req, lnrpc.Payment_IN_FLIGHT)

--- a/itest/lnd_channel_policy_test.go
+++ b/itest/lnd_channel_policy_test.go
@@ -141,7 +141,6 @@ func testUpdateChannelPolicy(ht *lntest.HarnessTest) {
 	// not be able to find a path during routing.
 	payReq := &routerrpc.SendPaymentRequest{
 		PaymentRequest: resp.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 	ht.SendPaymentAssertFail(

--- a/itest/lnd_coop_close_with_htlcs_test.go
+++ b/itest/lnd_coop_close_with_htlcs_test.go
@@ -73,7 +73,6 @@ func coopCloseWithHTLCs(ht *lntest.HarnessTest) {
 	// HTLC for it.
 	req := &routerrpc.SendPaymentRequest{
 		PaymentRequest: resp.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitSat:    1000000,
 	}
 	ht.SendPaymentAndAssertStatus(bob, req, lnrpc.Payment_IN_FLIGHT)
@@ -166,7 +165,6 @@ func coopCloseWithHTLCsWithRestart(ht *lntest.HarnessTest) {
 	// for it.
 	req := &routerrpc.SendPaymentRequest{
 		PaymentRequest: resp.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitSat:    1000000,
 	}
 	ht.SendPaymentAndAssertStatus(bob, req, lnrpc.Payment_IN_FLIGHT)

--- a/itest/lnd_hold_invoice_force_test.go
+++ b/itest/lnd_hold_invoice_force_test.go
@@ -42,7 +42,6 @@ func testHoldInvoiceForceClose(ht *lntest.HarnessTest) {
 	// single htlc.
 	req := &routerrpc.SendPaymentRequest{
 		PaymentRequest: bobInvoice.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 	ht.SendPaymentAssertInflight(alice, req)

--- a/itest/lnd_hold_persistence_test.go
+++ b/itest/lnd_hold_persistence_test.go
@@ -108,7 +108,6 @@ func testHoldInvoicePersistence(ht *lntest.HarnessTest) {
 	for _, payReq := range payReqs {
 		req := &routerrpc.SendPaymentRequest{
 			PaymentRequest: payReq,
-			TimeoutSeconds: 60,
 			FeeLimitSat:    1000000,
 		}
 

--- a/itest/lnd_htlc_timeout_resolver_test.go
+++ b/itest/lnd_htlc_timeout_resolver_test.go
@@ -128,7 +128,6 @@ func testHtlcTimeoutResolverExtractPreimageRemote(ht *lntest.HarnessTest) {
 	// will not immediately settle the payment.
 	req := &routerrpc.SendPaymentRequest{
 		PaymentRequest: eveInvoice.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 	ht.SendPaymentAssertInflight(alice, req)
@@ -267,7 +266,6 @@ func testHtlcTimeoutResolverExtractPreimageLocal(ht *lntest.HarnessTest) {
 	// will not immediately settle the payment.
 	req := &routerrpc.SendPaymentRequest{
 		PaymentRequest: carolInvoice.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 	ht.SendPaymentAssertInflight(alice, req)

--- a/itest/lnd_max_htlcs_test.go
+++ b/itest/lnd_max_htlcs_test.go
@@ -59,12 +59,11 @@ func testMaxHtlcPathfind(ht *lntest.HarnessTest) {
 	// We've hit our max remote htlcs, so we expect this payment to spin
 	// out dramatically with pathfinding.
 	sendReq := &routerrpc.SendPaymentRequest{
-		Amt:            1000,
-		Dest:           alice.PubKey[:],
-		TimeoutSeconds: 60,
-		FeeLimitSat:    1000000,
-		MaxParts:       10,
-		Amp:            true,
+		Amt:         1000,
+		Dest:        alice.PubKey[:],
+		FeeLimitSat: 1000000,
+		MaxParts:    10,
+		Amp:         true,
 	}
 	ht.SendPaymentAndAssertStatus(bob, sendReq, lnrpc.Payment_FAILED)
 
@@ -130,7 +129,6 @@ func acceptHoldInvoice(ht *lntest.HarnessTest, idx int, sender,
 
 	sendReq := &routerrpc.SendPaymentRequest{
 		PaymentRequest: invoice.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitSat:    1000000,
 	}
 	payStream := sender.RPC.SendPayment(sendReq)

--- a/itest/lnd_misc_test.go
+++ b/itest/lnd_misc_test.go
@@ -178,7 +178,6 @@ func testSphinxReplayPersistence(ht *lntest.HarnessTest) {
 	// to the above generated invoice.
 	req := &routerrpc.SendPaymentRequest{
 		PaymentRequest: invoiceResp.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 	payStream := fred.RPC.SendPayment(req)
@@ -607,7 +606,6 @@ func testRejectHTLC(ht *lntest.HarnessTest) {
 	// lnd with --rejecthtlc.
 	paymentReq := &routerrpc.SendPaymentRequest{
 		PaymentRequest: resp.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 	ht.SendPaymentAssertFail(

--- a/itest/lnd_mpp_test.go
+++ b/itest/lnd_mpp_test.go
@@ -63,7 +63,6 @@ func testSendMultiPathPayment(ht *lntest.HarnessTest) {
 	sendReq := &routerrpc.SendPaymentRequest{
 		PaymentRequest: payReq,
 		MaxParts:       10,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 	payment := ht.SendPaymentAssertSettled(mts.alice, sendReq)

--- a/itest/lnd_multi-hop-error-propagation_test.go
+++ b/itest/lnd_multi-hop-error-propagation_test.go
@@ -134,7 +134,6 @@ func testHtlcErrorPropagation(ht *lntest.HarnessTest) {
 		Dest:           carol.PubKey[:],
 		Amt:            payAmt,
 		FinalCltvDelta: int32(carolPayReq.CltvExpiry),
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 		MaxParts:       1,
 	}
@@ -203,7 +202,6 @@ func testHtlcErrorPropagation(ht *lntest.HarnessTest) {
 		// 10k satoshis are expected.
 		Amt:            int64(htlcAmt.ToSatoshis()),
 		FinalCltvDelta: int32(carolPayReq.CltvExpiry),
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 		MaxParts:       1,
 	}
@@ -251,7 +249,6 @@ func testHtlcErrorPropagation(ht *lntest.HarnessTest) {
 
 	req := &routerrpc.SendPaymentRequest{
 		PaymentRequest: carolInvoice2.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 		MaxParts:       1,
 	}
@@ -287,7 +284,6 @@ func testHtlcErrorPropagation(ht *lntest.HarnessTest) {
 
 	sendReq = &routerrpc.SendPaymentRequest{
 		PaymentRequest: carolInvoice3.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 		MaxParts:       1,
 	}
@@ -336,7 +332,6 @@ func testHtlcErrorPropagation(ht *lntest.HarnessTest) {
 
 	req = &routerrpc.SendPaymentRequest{
 		PaymentRequest: carolInvoice.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 		MaxParts:       1,
 	}

--- a/itest/lnd_multi-hop_force_close_test.go
+++ b/itest/lnd_multi-hop_force_close_test.go
@@ -372,7 +372,6 @@ func runLocalClaimOutgoingHTLC(ht *lntest.HarnessTest,
 		Amt:            int64(dustHtlcAmt),
 		PaymentHash:    dustPayHash,
 		FinalCltvDelta: finalCltvDelta,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 		RouteHints:     routeHints,
 	}
@@ -383,7 +382,6 @@ func runLocalClaimOutgoingHTLC(ht *lntest.HarnessTest,
 		Amt:            int64(htlcAmt),
 		PaymentHash:    payHash,
 		FinalCltvDelta: finalCltvDelta,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 		RouteHints:     routeHints,
 	}
@@ -726,7 +724,6 @@ func runMultiHopReceiverPreimageClaim(ht *lntest.HarnessTest,
 	// will not immediately settle the payment.
 	req := &routerrpc.SendPaymentRequest{
 		PaymentRequest: carolInvoice.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 	ht.SendPaymentAssertInflight(alice, req)
@@ -1093,7 +1090,6 @@ func runLocalForceCloseBeforeHtlcTimeout(ht *lntest.HarnessTest,
 		Amt:            int64(htlcAmt),
 		PaymentHash:    payHash,
 		FinalCltvDelta: finalCltvDelta,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 		RouteHints:     routeHints,
 	}
@@ -1415,7 +1411,6 @@ func runRemoteForceCloseBeforeHtlcTimeout(ht *lntest.HarnessTest,
 
 	req := &routerrpc.SendPaymentRequest{
 		PaymentRequest: carolInvoice.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 	ht.SendPaymentAssertInflight(alice, req)
@@ -1684,7 +1679,6 @@ func runLocalClaimIncomingHTLC(ht *lntest.HarnessTest,
 	// will not immediately settle the payment.
 	req := &routerrpc.SendPaymentRequest{
 		PaymentRequest: carolInvoice.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 	ht.SendPaymentAssertInflight(alice, req)
@@ -1997,7 +1991,6 @@ func runLocalClaimIncomingHTLCLeased(ht *lntest.HarnessTest,
 	// will not immediately settle the payment.
 	req := &routerrpc.SendPaymentRequest{
 		PaymentRequest: carolInvoice.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 	ht.SendPaymentAssertInflight(alice, req)
@@ -2348,7 +2341,6 @@ func runLocalPreimageClaim(ht *lntest.HarnessTest,
 	// will not immediately settle the payment.
 	req := &routerrpc.SendPaymentRequest{
 		PaymentRequest: carolInvoice.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 	ht.SendPaymentAssertInflight(alice, req)
@@ -2654,7 +2646,6 @@ func runLocalPreimageClaimLeased(ht *lntest.HarnessTest,
 	// will not immediately settle the payment.
 	req := &routerrpc.SendPaymentRequest{
 		PaymentRequest: carolInvoice.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 	ht.SendPaymentAssertInflight(alice, req)
@@ -3103,7 +3094,6 @@ func runHtlcAggregation(ht *lntest.HarnessTest,
 	for _, carolInvoice := range carolInvoices {
 		req := &routerrpc.SendPaymentRequest{
 			PaymentRequest: carolInvoice.PaymentRequest,
-			TimeoutSeconds: 60,
 			FeeLimitMsat:   noFeeLimitMsat,
 		}
 		ht.SendPaymentAssertInflight(alice, req)
@@ -3113,7 +3103,6 @@ func runHtlcAggregation(ht *lntest.HarnessTest,
 	for _, aliceInvoice := range aliceInvoices {
 		req := &routerrpc.SendPaymentRequest{
 			PaymentRequest: aliceInvoice.PaymentRequest,
-			TimeoutSeconds: 60,
 			FeeLimitMsat:   noFeeLimitMsat,
 		}
 		ht.SendPaymentAssertInflight(carol, req)

--- a/itest/lnd_open_channel_test.go
+++ b/itest/lnd_open_channel_test.go
@@ -674,7 +674,6 @@ func testUpdateOnFunderPendingOpenChannels(ht *lntest.HarnessTest) {
 	// in-flight instead of being failed by Alice.
 	bobReq := &routerrpc.SendPaymentRequest{
 		PaymentRequest: invoice.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 	bobStream := bob.RPC.SendPayment(bobReq)
@@ -750,7 +749,6 @@ func testUpdateOnFundeePendingOpenChannels(ht *lntest.HarnessTest) {
 	// in-flight instead of being failed by Bob.
 	aliceReq := &routerrpc.SendPaymentRequest{
 		PaymentRequest: bobInvoice.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 	aliceStream := alice.RPC.SendPayment(aliceReq)

--- a/itest/lnd_payment_test.go
+++ b/itest/lnd_payment_test.go
@@ -1086,7 +1086,6 @@ func sendPaymentInterceptAndCancel(ht *lntest.HarnessTest,
 	go func() {
 		req := &routerrpc.SendPaymentRequest{
 			PaymentRequest: invoice.PaymentRequest,
-			TimeoutSeconds: 60,
 			FeeLimitSat:    100000,
 			Cancelable:     true,
 		}

--- a/itest/lnd_quiescence_test.go
+++ b/itest/lnd_quiescence_test.go
@@ -37,7 +37,6 @@ func testQuiescence(ht *lntest.HarnessTest) {
 		Amt:            100,
 		PaymentHash:    ht.Random32Bytes(),
 		FinalCltvDelta: finalCltvDelta,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 

--- a/itest/lnd_route_blinding_test.go
+++ b/itest/lnd_route_blinding_test.go
@@ -552,7 +552,6 @@ func (b *blindedForwardTest) drainCarolLiquidity(incoming bool) {
 	pmtClient := sendingNode.RPC.SendPayment(
 		&routerrpc.SendPaymentRequest{
 			PaymentRequest: invoice.PaymentRequest,
-			TimeoutSeconds: 60,
 		},
 	)
 
@@ -957,7 +956,6 @@ func testMPPToSingleBlindedPath(ht *lntest.HarnessTest) {
 	sendReq := &routerrpc.SendPaymentRequest{
 		PaymentRequest: invoiceResp.PaymentRequest,
 		MaxParts:       10,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 	payment := ht.SendPaymentAssertSettled(alice, sendReq)
@@ -1302,7 +1300,6 @@ func testMPPToMultipleBlindedPaths(ht *lntest.HarnessTest) {
 	sendReq := &routerrpc.SendPaymentRequest{
 		PaymentRequest: invoiceResp.PaymentRequest,
 		MaxParts:       10,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 	payment := ht.SendPaymentAssertSettled(alice, sendReq)

--- a/itest/lnd_routing_test.go
+++ b/itest/lnd_routing_test.go
@@ -1429,7 +1429,6 @@ func testRouteFeeCutoff(ht *lntest.HarnessTest) {
 
 		sendReq := &routerrpc.SendPaymentRequest{
 			PaymentRequest: invoiceResp.PaymentRequest,
-			TimeoutSeconds: 60,
 			FeeLimitMsat:   noFeeLimitMsat,
 		}
 		switch limit := feeLimit.Limit.(type) {
@@ -1529,7 +1528,6 @@ func testFeeLimitAfterQueryRoutes(ht *lntest.HarnessTest) {
 	invoiceResp := carol.RPC.AddInvoice(invoice)
 	sendReq := &routerrpc.SendPaymentRequest{
 		PaymentRequest: invoiceResp.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   0,
 	}
 

--- a/itest/lnd_single_hop_invoice_test.go
+++ b/itest/lnd_single_hop_invoice_test.go
@@ -85,8 +85,7 @@ func testSingleHopInvoice(ht *lntest.HarnessTest) {
 		DestCustomRecords: map[uint64][]byte{
 			record.KeySendType: keySendPreimage[:],
 		},
-		TimeoutSeconds: 60,
-		FeeLimitMsat:   noFeeLimitMsat,
+		FeeLimitMsat: noFeeLimitMsat,
 	}
 	ht.SendPaymentAssertSettled(alice, req)
 

--- a/itest/lnd_sweep_test.go
+++ b/itest/lnd_sweep_test.go
@@ -136,7 +136,6 @@ func testSweepCPFPAnchorOutgoingTimeout(ht *lntest.HarnessTest) {
 	// Let Alice pay the invoices.
 	req := &routerrpc.SendPaymentRequest{
 		PaymentRequest: invoice.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 
@@ -463,7 +462,6 @@ func testSweepCPFPAnchorIncomingTimeout(ht *lntest.HarnessTest) {
 	// Let Alice pay the invoices.
 	req := &routerrpc.SendPaymentRequest{
 		PaymentRequest: invoice.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 
@@ -820,12 +818,10 @@ func testSweepHTLCs(ht *lntest.HarnessTest) {
 	// Let Alice pay the invoices.
 	req1 := &routerrpc.SendPaymentRequest{
 		PaymentRequest: invoiceSettle.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 	req2 := &routerrpc.SendPaymentRequest{
 		PaymentRequest: invoiceHold.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 
@@ -1318,7 +1314,6 @@ func testSweepCommitOutputAndAnchor(ht *lntest.HarnessTest) {
 	// succeeded.
 	req := &routerrpc.SendPaymentRequest{
 		PaymentRequest: resp.PaymentRequest,
-		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
 	}
 	ht.SendPaymentAssertSettled(alice, req)

--- a/itest/lnd_trackpayments_test.go
+++ b/itest/lnd_trackpayments_test.go
@@ -45,7 +45,6 @@ func testTrackPayments(ht *lntest.HarnessTest) {
 	paymentClient := alice.RPC.SendPayment(
 		&routerrpc.SendPaymentRequest{
 			PaymentRequest: invoice.PaymentRequest,
-			TimeoutSeconds: 60,
 		},
 	)
 
@@ -116,7 +115,6 @@ func testTrackPaymentsCompatible(ht *lntest.HarnessTest) {
 	paymentClient := alice.RPC.SendPayment(
 		&routerrpc.SendPaymentRequest{
 			PaymentRequest: invoice.PaymentRequest,
-			TimeoutSeconds: 60,
 		},
 	)
 

--- a/itest/lnd_watchtower_test.go
+++ b/itest/lnd_watchtower_test.go
@@ -657,7 +657,6 @@ func generateBackups(ht *lntest.HarnessTest, srcNode,
 	send := func(node *node.HarnessNode, payReq string) {
 		req := &routerrpc.SendPaymentRequest{
 			PaymentRequest: payReq,
-			TimeoutSeconds: 60,
 			FeeLimitMsat:   noFeeLimitMsat,
 		}
 		ht.SendPaymentAssertSettled(node, req)

--- a/lnrpc/routerrpc/router.pb.go
+++ b/lnrpc/routerrpc/router.pb.go
@@ -427,10 +427,11 @@ type SendPaymentRequest struct {
 	// that case it is required to set the amt field as well. If no payment request
 	// is specified, the following fields are required: dest, amt and payment_hash.
 	PaymentRequest string `protobuf:"bytes,5,opt,name=payment_request,json=paymentRequest,proto3" json:"payment_request,omitempty"`
-	// An upper limit on the amount of time we should spend when attempting to
-	// fulfill the payment. This is expressed in seconds. If we cannot make a
-	// successful payment within this time frame, an error will be returned.
-	// This field must be non-zero.
+	// An optional limit, expressed in seconds, on the time to wait before
+	// attempting the first HTLC. Once HTLCs are in flight, the payment will
+	// not be aborted until the HTLCs are either settled or failed. If the field
+	// is not set or is explicitly set to zero, the default value of 60 seconds
+	// will be applied.
 	TimeoutSeconds int32 `protobuf:"varint,6,opt,name=timeout_seconds,json=timeoutSeconds,proto3" json:"timeout_seconds,omitempty"`
 	// The maximum number of satoshis that will be paid as a fee of the payment.
 	// If this field is left to the default value of 0, only zero-fee routes will

--- a/lnrpc/routerrpc/router.proto
+++ b/lnrpc/routerrpc/router.proto
@@ -227,10 +227,11 @@ message SendPaymentRequest {
     string payment_request = 5;
 
     /*
-    An upper limit on the amount of time we should spend when attempting to
-    fulfill the payment. This is expressed in seconds. If we cannot make a
-    successful payment within this time frame, an error will be returned.
-    This field must be non-zero.
+    An optional limit, expressed in seconds, on the time to wait before
+    attempting the first HTLC. Once HTLCs are in flight, the payment will
+    not be aborted until the HTLCs are either settled or failed. If the field
+    is not set or is explicitly set to zero, the default value of 60 seconds
+    will be applied.
     */
     int32 timeout_seconds = 6;
 

--- a/lnrpc/routerrpc/router.swagger.json
+++ b/lnrpc/routerrpc/router.swagger.json
@@ -1894,7 +1894,7 @@
         "timeout_seconds": {
           "type": "integer",
           "format": "int32",
-          "description": "An upper limit on the amount of time we should spend when attempting to\nfulfill the payment. This is expressed in seconds. If we cannot make a\nsuccessful payment within this time frame, an error will be returned.\nThis field must be non-zero."
+          "description": "An optional limit, expressed in seconds, on the time to wait before\nattempting the first HTLC. Once HTLCs are in flight, the payment will\nnot be aborted until the HTLCs are either settled or failed. If the field\nis not set or is explicitly set to zero, the default value of 60 seconds\nwill be applied."
         },
         "fee_limit_sat": {
           "type": "string",

--- a/lnrpc/routerrpc/router_backend.go
+++ b/lnrpc/routerrpc/router_backend.go
@@ -878,11 +878,6 @@ func (r *RouterBackend) extractIntentFromSendRequest(
 		return nil, err
 	}
 
-	// Set payment attempt timeout.
-	if rpcPayReq.TimeoutSeconds == 0 {
-		return nil, errors.New("timeout_seconds must be specified")
-	}
-
 	customRecords := record.CustomSet(rpcPayReq.DestCustomRecords)
 	if err := customRecords.Validate(); err != nil {
 		return nil, err

--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -40,6 +40,10 @@ const (
 	// routeFeeLimitSat is the maximum routing fee that we allow to occur
 	// when estimating a routing fee.
 	routeFeeLimitSat = 100_000_000
+
+	// DefaultPaymentTimeout is the default value of time we should spend
+	// when attempting to fulfill the payment.
+	DefaultPaymentTimeout int32 = 60
 )
 
 var (
@@ -343,6 +347,11 @@ func (r *ServerShell) CreateSubServer(configRegistry lnrpc.SubServerConfigDispat
 // pre-image, along with the final route will be returned.
 func (s *Server) SendPaymentV2(req *SendPaymentRequest,
 	stream Router_SendPaymentV2Server) error {
+
+	// Set payment request attempt timeout.
+	if req.TimeoutSeconds == 0 {
+		req.TimeoutSeconds = DefaultPaymentTimeout
+	}
 
 	payment, err := s.cfg.RouterBackend.extractIntentFromSendRequest(req)
 	if err != nil {


### PR DESCRIPTION
## Change Description
Description of change / link to associated issue.
This PR introduces a default value of 60 seconds for the `timeout_seconds` field in the `SendPaymentV2` RPC call in the `routerrpc.SendPaymentRequest`.

Fixes: #9282 
## Steps to Test
### Test with explicit timeout_seconds values:
- Make an RPC call to SendPaymentV2 with a valid non-zero value for timeout_seconds.
- Verify that the request behaves as expected and uses the provided value.
### Test without timeout_seconds:
- Make an RPC call to SendPaymentV2 without including the timeout_seconds field.
- Verify that the default value of 60 seconds is applied and used during the request.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
