### PR TITLE
fn: optimize context guard

### DIFF
--- a/fn/context_guard.go
+++ b/fn/context_guard.go
@@ -51,6 +51,10 @@ func (g *ContextGuard) Quit() {
 			cancel()
 		}
 
+		// Clear cancelFns. It is safe to use nil, because no write
+		// operations to it can happen after g.quit is closed.
+		g.cancelFns = nil
+
 		close(g.quit)
 	})
 }

--- a/fn/context_guard.go
+++ b/fn/context_guard.go
@@ -149,7 +149,7 @@ func (g *ContextGuard) Create(ctx context.Context,
 	}
 
 	if opts.blocking {
-		g.ctxBlocking(ctx, cancel)
+		g.ctxBlocking(ctx)
 
 		return ctx, cancel
 	}
@@ -196,14 +196,10 @@ func (g *ContextGuard) ctxQuitUnsafe(ctx context.Context,
 }
 
 // ctxBlocking spins off a goroutine that will block until the passed context
-// is cancelled after which it will call the passed cancel function and
-// decrement the wait group.
-func (g *ContextGuard) ctxBlocking(ctx context.Context,
-	cancel context.CancelFunc) {
-
+// is cancelled after which it will decrement the wait group.
+func (g *ContextGuard) ctxBlocking(ctx context.Context) {
 	g.wg.Add(1)
 	go func() {
-		defer cancel()
 		defer g.wg.Done()
 
 		select {

--- a/fn/context_guard_test.go
+++ b/fn/context_guard_test.go
@@ -298,6 +298,12 @@ func TestContextGuard(t *testing.T) {
 		case <-time.After(time.Second):
 			t.Fatalf("timeout")
 		}
+
+		// Cancel the context.
+		cancel()
+
+		// Make sure wg's counter gets to 0 eventually.
+		g.WgWait()
 	})
 
 	// Test that if we add the CustomTimeoutCGOpt option, then the context


### PR DESCRIPTION
## Change Description

Simplifies context cancellation handling by using context.AfterFunc instead of a goroutine to wait for context cancellation. This approach avoids the overhead of a goroutine during the waiting period.

Additional changes:
 - added test of blocking context cancelling
 - removed unneeded argument `cancel` of ctxBlocking
 - clear store of cancel funcs after quitting
 - test that the Create method does not launch any goroutines

## Steps to Test

```
cd fn
go test -race
```

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
