### PR TITLE
release: create branch for v0.18.4-beta

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -47,7 +47,7 @@ const (
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.
-	AppPreRelease = "beta.rc2"
+	AppPreRelease = "beta"
 )
 
 func init() {

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -308,7 +308,8 @@ func (h *htlcIncomingContestResolver) Resolve(
 
 		resolution, err := h.Registry.NotifyExitHopHtlc(
 			h.htlc.RHash, h.htlc.Amt, h.htlcExpiry, currentHeight,
-			circuitKey, hodlQueue.ChanIn(), nil, payload,
+			circuitKey, hodlQueue.ChanIn(), h.htlc.CustomRecords,
+			payload,
 		)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Preparation PR to kick off the v0.18.4-beta.rc3 release.

This PR includes rebased versions of the following PRs (in order):

- #9357