### PR TITLE
chore: change 'register' to 'registered' in lnrpc starting debug logs [skip ci]

### DIFF
--- a/lnrpc/autopilotrpc/autopilot_server.go
+++ b/lnrpc/autopilotrpc/autopilot_server.go
@@ -137,7 +137,7 @@ func (r *ServerShell) RegisterWithRootServer(grpcServer *grpc.Server) error {
 	// all our methods are routed properly.
 	RegisterAutopilotServer(grpcServer, r)
 
-	log.Debugf("Autopilot RPC server successfully register with root " +
+	log.Debugf("Autopilot RPC server successfully registered with root " +
 		"gRPC server")
 
 	return nil

--- a/lnrpc/chainrpc/chain_server.go
+++ b/lnrpc/chainrpc/chain_server.go
@@ -207,12 +207,12 @@ func (r *ServerShell) RegisterWithRootServer(grpcServer *grpc.Server) error {
 	// We make sure that we register it with the main gRPC server to ensure
 	// all our methods are routed properly.
 	RegisterChainNotifierServer(grpcServer, r)
-	log.Debug("ChainNotifier RPC server successfully register with root " +
-		"gRPC server")
+	log.Debug("ChainNotifier RPC server successfully registered with " +
+		"root gRPC server")
 
 	RegisterChainKitServer(grpcServer, r)
-	log.Debug("ChainKit RPC server successfully register with root gRPC " +
-		"server")
+	log.Debug("ChainKit RPC server successfully registered with root " +
+		"gRPC server")
 
 	return nil
 }

--- a/lnrpc/devrpc/dev_server.go
+++ b/lnrpc/devrpc/dev_server.go
@@ -134,7 +134,7 @@ func (r *ServerShell) RegisterWithRootServer(grpcServer *grpc.Server) error {
 	// all our methods are routed properly.
 	RegisterDevServer(grpcServer, r)
 
-	log.Debugf("DEV RPC server successfully register with root the " +
+	log.Debugf("DEV RPC server successfully registered with root the " +
 		"gRPC server")
 
 	return nil

--- a/lnrpc/neutrinorpc/neutrino_server.go
+++ b/lnrpc/neutrinorpc/neutrino_server.go
@@ -138,7 +138,7 @@ func (r *ServerShell) RegisterWithRootServer(grpcServer *grpc.Server) error {
 	// all our methods are routed properly.
 	RegisterNeutrinoKitServer(grpcServer, r)
 
-	log.Debugf("Neutrino RPC server successfully register with root " +
+	log.Debugf("Neutrino RPC server successfully registered with root " +
 		"gRPC server")
 
 	return nil

--- a/lnrpc/peersrpc/peers_server.go
+++ b/lnrpc/peersrpc/peers_server.go
@@ -116,7 +116,7 @@ func (r *ServerShell) RegisterWithRootServer(grpcServer *grpc.Server) error {
 	// all our methods are routed properly.
 	RegisterPeersServer(grpcServer, r)
 
-	log.Debugf("Peers RPC server successfully register with root " +
+	log.Debugf("Peers RPC server successfully registered with root " +
 		"gRPC server")
 
 	return nil

--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -289,7 +289,7 @@ func (r *ServerShell) RegisterWithRootServer(grpcServer *grpc.Server) error {
 	// all our methods are routed properly.
 	RegisterRouterServer(grpcServer, r)
 
-	log.Debugf("Router RPC server successfully register with root gRPC " +
+	log.Debugf("Router RPC server successfully registered with root gRPC " +
 		"server")
 
 	return nil

--- a/lnrpc/signrpc/signer_server.go
+++ b/lnrpc/signrpc/signer_server.go
@@ -213,7 +213,7 @@ func (r *ServerShell) RegisterWithRootServer(grpcServer *grpc.Server) error {
 	// all our methods are routed properly.
 	RegisterSignerServer(grpcServer, r)
 
-	log.Debugf("Signer RPC server successfully register with root gRPC " +
+	log.Debugf("Signer RPC server successfully registered with root gRPC " +
 		"server")
 
 	return nil

--- a/lnrpc/watchtowerrpc/handler.go
+++ b/lnrpc/watchtowerrpc/handler.go
@@ -97,7 +97,7 @@ func (r *ServerShell) RegisterWithRootServer(grpcServer *grpc.Server) error {
 	// all our methods are routed properly.
 	RegisterWatchtowerServer(grpcServer, r)
 
-	log.Debugf("Watchtower RPC server successfully register with root " +
+	log.Debugf("Watchtower RPC server successfully registered with root " +
 		"gRPC server")
 
 	return nil


### PR DESCRIPTION
## Change Description

chore: change 'register' to 'registered' in lnrpc starting debug logs [skip ci]

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
