### PR TITLE
.github: bump upload-artifact action to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -327,7 +327,7 @@ jobs:
         run: 7z a logs-itest-${{ matrix.name }}.zip itest/**/*.log itest/postgres.log
 
       - name: Upload log files on failure
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: logs-itest-${{ matrix.name }}
@@ -394,7 +394,7 @@ jobs:
         run: 7z a logs-itest-${{ matrix.name }}.zip itest/**/*.log
 
       - name: Upload log files on failure
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: logs-itest-${{ matrix.name }}
@@ -439,7 +439,7 @@ jobs:
         run: 7z a logs-itest-windows.zip itest/**/*.log
 
       - name: Upload log files on failure
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: logs-itest-windows
@@ -478,7 +478,7 @@ jobs:
         run: 7z a logs-itest-macos.zip itest/**/*.log
 
       - name: Upload log files on failure
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: logs-itest-macos


### PR DESCRIPTION
the `actions/upload-artifact@v3` is (or it seems might already be) [deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). 

As per the [migration notes](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md), the only thing to be aware of is that we need to take care to namespace artifacts correctly so that jobs in the same CI run dont overwrite the artifacts of other jobs with the same name. Luckily though it seems we already namespace all our jobs. So It seems that only the version bump is required :)