### PR TITLE
itest+lntest: make sure to assert edge in both graph db and cache

### DIFF
--- a/itest/lnd_multi-hop_force_close_test.go
+++ b/itest/lnd_multi-hop_force_close_test.go
@@ -1588,7 +1588,8 @@ func testLocalClaimIncomingHTLCSimpleTaprootZeroConf(ht *lntest.HarnessTest) {
 		Private:        true,
 	}
 
-	// Prepare Carol's node config to enable zero-conf and leased channel.
+	// Prepare Carol's node config to enable zero-conf and simple taproot
+	// channel.
 	cfg := node.CfgSimpleTaproot
 	cfg = append(cfg, node.CfgZeroConf...)
 	cfgs := [][]string{cfg, cfg, cfg}


### PR DESCRIPTION
Fix a flake found in this [build](https://github.com/yyforyongyu/lnd/actions/runs/12789819648/job/35654165173?pr=22),
```
 --- FAIL: TestLightningNetworkDaemon/tranche07/248-of-269/bitcoind/graph_topology_notifications (93.80s)
        --- FAIL: TestLightningNetworkDaemon/tranche07/248-of-269/bitcoind/graph_topology_notifications/unpinned (37.65s)
            harness_node.go:403: Starting node (name=Bob) with PID=19372
            harness_node.go:403: Starting node (name=Alice) with PID=19574
            lnd_channel_graph_test.go:669: 
                	Error Trace:	/home/runner/work/lnd/lnd/itest/lnd_channel_graph_test.go:669
                	            				/home/runner/work/lnd/lnd/itest/lnd_channel_graph_test.go:292
                	            				/home/runner/work/lnd/lnd/itest/lnd_channel_graph_test.go:260
                	Error:      	Not equal: 
                	            	expected: 1
                	            	actual  : 2
                	Test:       	TestLightningNetworkDaemon/tranche07/248-of-269/bitcoind/graph_topology_notifications/unpinned
            harness.go:375: finished test: graph_topology_notifications, start height=621, end height=623, mined blocks=2
            harness.go:334: test failed, skipped cleanup
        harness.go:375: finished test: graph_topology_notifications, start height=606, end height=623, mined blocks=17
        harness.go:334: test failed, skipped cleanup
    lnd_test.go:138: Failure time: 2025-01-15 14:35:05.182
FAIL
```

And another flake, which looks like payment-related, but actually it's due to edge not being updated in the graph cache yet,
```
--- FAIL: TestLightningNetworkDaemon/tranche05/178-of-269/bitcoind/multihop-local_claim_incoming_htlc_anchor_zero_conf (126.76s)
        harness_node.go:403: Starting node (name=Alice) with PID=8140
        harness_node.go:403: Starting node (name=Bob) with PID=8203
        harness_node.go:403: Starting node (name=Carol) with PID=8237
        harness_assertion.go:1259: 
            	Error Trace:	/home/runner/work/lnd/lnd/lntest/harness_assertion.go:1259
            	            				/home/runner/work/lnd/lnd/itest/lnd_multi-hop_force_close_test.go:1698
            	            				/home/runner/work/lnd/lnd/itest/lnd_multi-hop_force_close_test.go:1557
            	            				/home/runner/work/lnd/lnd/lntest/harness.go:297
            	            				/home/runner/work/lnd/lnd/itest/lnd_test.go:130
            	Error:      	Received unexpected error:
            	            	Alice: assert active HTLCs failed: want 1, got: 0, total: 0, previously had: 0
            	Test:       	TestLightningNetworkDaemon/tranche05/178-of-269/bitcoind/multihop-local_claim_incoming_htlc_anchor_zero_conf
            	Messages:   	Alice timeout checking num active htlcs
        harness.go:375: finished test: multihop-local_claim_incoming_htlc_anchor_zero_conf, start height=621, end height=631, mined blocks=10
        harness.go:334: test failed, skipped cleanup
```