### PR TITLE
itest: fix flake in `testSweepHTLCs`

### DIFF
--- a/itest/lnd_sweep_test.go
+++ b/itest/lnd_sweep_test.go
@@ -864,12 +864,12 @@ func testSweepHTLCs(ht *lntest.HarnessTest) {
 	// Carol settles the first invoice.
 	carol.RPC.SettleInvoice(preimageSettled[:])
 
+	// Bob should have settled his outgoing HTLC with Carol.
+	ht.AssertHTLCNotActive(bob, bcChanPoint, payHashSettled[:])
+
 	// Let Carol go offline so we can focus on testing Bob's sweeping
 	// behavior.
 	ht.Shutdown(carol)
-
-	// Bob should have settled his outgoing HTLC with Carol.
-	ht.AssertHTLCNotActive(bob, bcChanPoint, payHashSettled[:])
 
 	// We'll now mine enough blocks to trigger Bob to force close channel
 	// Bob->Carol due to his outgoing HTLC is about to timeout. With the


### PR DESCRIPTION
Fix the following flake found in this [build](https://github.com/lightningnetwork/lnd/actions/runs/12830273599/job/35778121044?pr=9405),
```
--- FAIL: TestLightningNetworkDaemon (891.26s)
    harness_setup.go:25: Setting up HarnessTest...
    harness_setup.go:38: Prepare the miner and mine blocks to activate segwit...
    harness_setup.go:46: Connecting the miner at 127.0.0.1:10023 with the chain backend...
    --- FAIL: TestLightningNetworkDaemon/tranche00/12-of-269/bitcoind/sweep_htlcs (176.54s)
        harness_node.go:403: Starting node (name=Alice) with PID=21999
        harness_node.go:403: Starting node (name=Bob) with PID=22733
        harness_node.go:403: Starting node (name=Carol) with PID=23043
        harness_assertion.go:1363: 
            	Error Trace:	/home/runner/work/lnd/lnd/lntest/harness_assertion.go:1363
            	            				/home/runner/work/lnd/lnd/itest/lnd_sweep_test.go:872
            	            				/home/runner/work/lnd/lnd/lntest/harness.go:297
            	            				/home/runner/work/lnd/lnd/itest/lnd_test.go:130
            	Error:      	Received unexpected error:
            	            	node [Bob:038c60d4da2abce1965884f68fd4c60206b5bb397d35780d6b015c98ed3e48f2be] still has: the payHash 65c6b77c1cd2ee5271ecd23aa8e2bead8bdd18172f402a7a628751c97d1f3357
            	Test:       	TestLightningNetworkDaemon/tranche00/12-of-269/bitcoind/sweep_htlcs
            	Messages:   	timeout checking pending HTLC
        harness.go:375: finished test: sweep_htlcs, start height=655, end height=663, mined blocks=8
```