### PR TITLE
multi: unify RPC connection creations for `btcd` & `bitcoind`

### DIFF
--- a/chainntnfs/btcdnotify/btcd.go
+++ b/chainntnfs/btcdnotify/btcd.go
@@ -60,7 +60,7 @@ type BtcdNotifier struct {
 	active  int32 // To be used atomically.
 	stopped int32 // To be used atomically.
 
-	chainConn   *chain.RPCClient
+	chainConn   *chain.BtcdClient
 	chainParams *chaincfg.Params
 
 	notificationCancels  chan interface{}
@@ -135,14 +135,14 @@ func New(config *rpcclient.ConnConfig, chainParams *chaincfg.Params,
 		OnRedeemingTx:       notifier.onRedeemingTx,
 	}
 
-	rpcCfg := &chain.RPCClientConfig{
+	rpcCfg := &chain.BtcdConfig{
 		ReconnectAttempts:    20,
 		Conn:                 config,
 		Chain:                chainParams,
 		NotificationHandlers: ntfnCallbacks,
 	}
 
-	chainRPC, err := chain.NewRPCClientWithConfig(rpcCfg)
+	chainRPC, err := chain.NewBtcdClientWithConfig(rpcCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/chainreg/no_chain_backend.go
+++ b/chainreg/no_chain_backend.go
@@ -1,6 +1,7 @@
 package chainreg
 
 import (
+	"encoding/json"
 	"errors"
 	"time"
 
@@ -147,6 +148,10 @@ func (n *NoChainSource) Stop() {
 func (n *NoChainSource) WaitForShutdown() {
 }
 
+func (n *NoChainSource) GetPeerInfo() ([]btcjson.GetPeerInfoResult, error) {
+	return nil, errNotImplemented
+}
+
 func (n *NoChainSource) GetBestBlock() (*chainhash.Hash, int32, error) {
 	return noChainBackendBestHash, noChainBackendBestHeight, nil
 }
@@ -172,6 +177,12 @@ func (n *NoChainSource) GetBlockHeader(*chainhash.Hash) (*wire.BlockHeader,
 	}, nil
 }
 
+func (n *NoChainSource) GetBlockChainInfo() (*btcjson.GetBlockChainInfoResult,
+	error) {
+
+	return nil, errNotImplemented
+}
+
 func (n *NoChainSource) IsCurrent() bool {
 	return true
 }
@@ -188,6 +199,12 @@ func (n *NoChainSource) BlockStamp() (*waddrmgr.BlockStamp, error) {
 
 func (n *NoChainSource) SendRawTransaction(*wire.MsgTx, bool) (*chainhash.Hash,
 	error) {
+
+	return nil, errNotImplemented
+}
+
+func (n *NoChainSource) RawRequest(method string,
+	params []json.RawMessage) (json.RawMessage, error) {
 
 	return nil, errNotImplemented
 }

--- a/chainreg/taproot_check.go
+++ b/chainreg/taproot_check.go
@@ -3,14 +3,14 @@ package chainreg
 import (
 	"encoding/json"
 
-	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/btcsuite/btcwallet/chain"
 )
 
 // backendSupportsTaproot returns true if the backend understands the taproot
 // soft fork.
-func backendSupportsTaproot(rpc *rpcclient.Client) bool {
+func backendSupportsTaproot(client chain.Interface) bool {
 	// First, we'll try to access the normal getblockchaininfo call.
-	chainInfo, err := rpc.GetBlockChainInfo()
+	chainInfo, err := client.GetBlockChainInfo()
 	if err == nil {
 		// If this call worked, then we'll check that the taproot
 		// deployment is defined.
@@ -41,7 +41,7 @@ func backendSupportsTaproot(rpc *rpcclient.Client) bool {
 	// running a newer version of bitcoind that still has the
 	// getblockchaininfo call, but doesn't populate the data, so we'll hit
 	// the new getdeploymentinfo call.
-	resp, err := rpc.RawRequest("getdeploymentinfo", nil)
+	resp, err := client.RawRequest("getdeploymentinfo", nil)
 	if err != nil {
 		log.Warnf("unable to make getdeploymentinfo request: %v", err)
 		return false

--- a/lnmock/chain.go
+++ b/lnmock/chain.go
@@ -1,6 +1,8 @@
 package lnmock
 
 import (
+	"encoding/json"
+
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -30,6 +32,28 @@ func (m *MockChain) Stop() {
 
 func (m *MockChain) WaitForShutdown() {
 	m.Called()
+}
+
+func (m *MockChain) GetPeerInfo() ([]btcjson.GetPeerInfoResult, error) {
+	args := m.Called()
+
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).([]btcjson.GetPeerInfoResult), args.Error(1)
+}
+
+func (m *MockChain) GetBlockChainInfo() (*btcjson.GetBlockChainInfoResult,
+	error) {
+
+	args := m.Called()
+
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*btcjson.GetBlockChainInfoResult), args.Error(1)
 }
 
 func (m *MockChain) GetBestBlock() (*chainhash.Hash, int32, error) {
@@ -112,6 +136,18 @@ func (m *MockChain) SendRawTransaction(tx *wire.MsgTx, allowHighFees bool) (
 	}
 
 	return args.Get(0).(*chainhash.Hash), args.Error(1)
+}
+
+func (m *MockChain) RawRequest(method string,
+	params []json.RawMessage) (json.RawMessage, error) {
+
+	args := m.Called(method, params)
+
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(json.RawMessage), args.Error(1)
 }
 
 func (m *MockChain) Rescan(startHash *chainhash.Hash, addrs []btcutil.Address,

--- a/lnwallet/btcwallet/blockchain.go
+++ b/lnwallet/btcwallet/blockchain.go
@@ -72,7 +72,7 @@ func (b *BtcWallet) GetUtxo(op *wire.OutPoint, pkScript []byte,
 		// Otherwise, the output is assumed to be in the UTXO.
 		return spendReport.Output, nil
 
-	case *chain.RPCClient:
+	case *chain.BtcdClient:
 		txout, err := backend.GetTxOut(&op.Hash, op.Index, false)
 		if err != nil {
 			return nil, err

--- a/lnwallet/btcwallet/signer_test.go
+++ b/lnwallet/btcwallet/signer_test.go
@@ -337,7 +337,7 @@ func getChainBackend(t *testing.T, netParams *chaincfg.Params) (chain.Interface,
 	require.NoError(t, err)
 
 	rpcConfig := miningNode.RPCConfig()
-	chainClient, err := chain.NewRPCClient(
+	chainClient, err := chain.NewBtcdClient(
 		netParams, rpcConfig.Host, rpcConfig.User, rpcConfig.Pass,
 		rpcConfig.Certificates, false, 20,
 	)

--- a/lnwallet/chainfee/filtermanager.go
+++ b/lnwallet/chainfee/filtermanager.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
-	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/btcsuite/btcwallet/chain"
 	"github.com/lightningnetwork/lnd/fn/v2"
 )
 
@@ -107,7 +107,7 @@ type bitcoindPeerInfoResp struct {
 	MinFeeFilter float64 `json:"minfeefilter"`
 }
 
-func fetchBitcoindFilters(client *rpcclient.Client) ([]SatPerKWeight, error) {
+func fetchBitcoindFilters(client *chain.BitcoindClient) ([]SatPerKWeight, error) {
 	resp, err := client.RawRequest("getpeerinfo", nil)
 	if err != nil {
 		return nil, err
@@ -159,7 +159,7 @@ func fetchBitcoindFilters(client *rpcclient.Client) ([]SatPerKWeight, error) {
 	return outboundPeerFilters, nil
 }
 
-func fetchBtcdFilters(client *rpcclient.Client) ([]SatPerKWeight, error) {
+func fetchBtcdFilters(client *chain.BtcdClient) ([]SatPerKWeight, error) {
 	resp, err := client.GetPeerInfo()
 	if err != nil {
 		return nil, err

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -3267,7 +3267,7 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 		var aliceClient, bobClient chain.Interface
 		switch backEnd {
 		case "btcd":
-			aliceClient, err = chain.NewRPCClient(
+			aliceClient, err = chain.NewBtcdClient(
 				netParams, rpcConfig.Host, rpcConfig.User,
 				rpcConfig.Pass, rpcConfig.Certificates, false,
 				20,
@@ -3275,7 +3275,7 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 			if err != nil {
 				t.Fatalf("unable to make chain rpc: %v", err)
 			}
-			bobClient, err = chain.NewRPCClient(
+			bobClient, err = chain.NewBtcdClient(
 				netParams, rpcConfig.Host, rpcConfig.User,
 				rpcConfig.Pass, rpcConfig.Certificates, false,
 				20,


### PR DESCRIPTION
## Change Description

In this commit, we unify rpc connection creations for `btcd` & `bitcoind`.

Closes #7951.
Depends on https://github.com/btcsuite/btcwallet/pull/973.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
