### PR TITLE
fn: add method GoBlocking to GoroutineManager

### DIFF
--- a/fn/goroutine_manager.go
+++ b/fn/goroutine_manager.go
@@ -17,20 +17,27 @@ type GoroutineManager struct {
 	// map. The key is the id of the goroutine.
 	cancelFns map[uint32]context.CancelFunc
 
-	mu sync.Mutex
+	mu   sync.Mutex
+	cond *sync.Cond
 
 	stopped sync.Once
 	quit    chan struct{}
-	wg      sync.WaitGroup
+
+	// count is the number of goroutines currently running. Must be accessed
+	// holding mu.
+	count int
 }
 
 // NewGoroutineManager constructs and returns a new instance of
 // GoroutineManager.
 func NewGoroutineManager() *GoroutineManager {
-	return &GoroutineManager{
+	gm := &GoroutineManager{
 		cancelFns: make(map[uint32]context.CancelFunc),
 		quit:      make(chan struct{}),
 	}
+	gm.cond = sync.NewCond(&gm.mu)
+
+	return gm
 }
 
 // addCancelFn adds a context cancel function to the manager and returns an id
@@ -82,15 +89,8 @@ func (g *GoroutineManager) Go(ctx context.Context,
 	ctx, cancel := context.WithCancel(ctx)
 	id := g.addCancelFn(cancel)
 
-	// Calling wg.Add(1) and wg.Wait() when the wg's counter is 0 is a race
-	// condition, since it is not clear if Wait() should block or not. This
-	// kind of race condition is detected by Go runtime and results in a
-	// crash if running with `-race`. To prevent this, we protect the calls
-	// to wg.Add(1) and wg.Wait() with a mutex. If we block here because
-	// Stop is running first, then Stop will close the quit channel which
-	// will cause the context to be cancelled, and we will exit before
-	// calling wg.Add(1). If we grab the mutex here before Stop does, then
-	// Stop will block until after we call wg.Add(1).
+	// Protect the remaining part of the method with the mutex, because we
+	// access quit and count.
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
@@ -112,11 +112,16 @@ func (g *GoroutineManager) Go(ctx context.Context,
 	default:
 	}
 
-	g.wg.Add(1)
+	g.count++
 	go func() {
 		defer func() {
 			g.cancel(id)
-			g.wg.Done()
+
+			g.mu.Lock()
+			g.count--
+			g.mu.Unlock()
+
+			g.cond.Signal()
 		}()
 
 		f(ctx)
@@ -129,22 +134,22 @@ func (g *GoroutineManager) Go(ctx context.Context,
 // goroutines to finish.
 func (g *GoroutineManager) Stop() {
 	g.stopped.Do(func() {
+		g.mu.Lock()
+		defer g.mu.Unlock()
+
 		// Closing the quit channel will prevent any new goroutines from
 		// starting.
-		g.mu.Lock()
 		close(g.quit)
+
+		// Cancelling contexts of all launched goroutines.
 		for _, cancel := range g.cancelFns {
 			cancel()
 		}
-		g.mu.Unlock()
 
-		// Wait for all goroutines to finish. Note that this wg.Wait()
-		// call is safe, since it can't run in parallel with wg.Add(1)
-		// call in Go, since we just cancelled the context and even if
-		// Go call starts running here after acquiring the mutex, it
-		// would see that the context has expired and return false
-		// instead of calling wg.Add(1).
-		g.wg.Wait()
+		// Wait for all goroutines to finish.
+		for g.count != 0 {
+			g.cond.Wait()
+		}
 	})
 }
 

--- a/fn/goroutine_manager_test.go
+++ b/fn/goroutine_manager_test.go
@@ -106,6 +106,62 @@ func TestGoroutineManager(t *testing.T) {
 		m.Stop()
 	})
 
+	t.Run("GoBlocking", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			ctx = context.Background()
+			m   = NewGoroutineManager()
+		)
+
+		// Start a blocking task.
+		taskChan := make(chan struct{})
+		require.True(t, m.GoBlocking(func() {
+			<-taskChan
+		}))
+
+		// Start stopping GoroutineManager.
+		stopped := make(chan struct{})
+		go func() {
+			m.Stop()
+			close(stopped)
+		}()
+
+		// Make sure Stop() is waiting.
+		select {
+		case <-stopped:
+			t.Fatalf("The Stop() method must be waiting")
+		case <-time.After(time.Millisecond * 200):
+		}
+
+		// Since the first goroutine is still running, we can launch
+		// another blocking goroutine.
+		secondBlockingTaskDone := make(chan struct{})
+		require.True(t, m.GoBlocking(func() {
+			close(secondBlockingTaskDone)
+		}))
+
+		// Make sure the second blocking goroutine has started and
+		// executed.
+		<-secondBlockingTaskDone
+
+		// However we can't start a non-blocking goroutine.
+		require.False(t, m.Go(ctx, func(ctx context.Context) {
+			t.Fatalf("The goroutine should not have started")
+		}))
+
+		// Now let the first goroutine finish.
+		close(taskChan)
+
+		// And make sure Stop() unblocked.
+		<-stopped
+
+		// Now we can't start a goroutine even if it is blocking.
+		require.False(t, m.GoBlocking(func() {
+			t.Fatalf("The goroutine should not have started")
+		}))
+	})
+
 	// Start many goroutines while calling Stop. We do this to make sure
 	// that the GoroutineManager does not crash when these calls are done in
 	// parallel because of the potential race between Go() and Stop() when
@@ -124,13 +180,23 @@ func TestGoroutineManager(t *testing.T) {
 			close(stopChan)
 		})
 
-		// Start 100 goroutines sequentially. Sequential order is needed
-		// to keep counter low (0 or 1) to increase probability of the
-		// race condition triggered if it exists. If mutex is removed in
+		// Start 100 goroutines sequentially, both with Go() and
+		// GoBlocking(). Sequential order is needed to keep counter low
+		// (0 or 1) to increase probability of the race condition
+		// triggered if it exists. If mutex is removed in
 		// the implementation, this test crashes under `-race`.
-		for i := 0; i < 100; i++ {
+		for i := 0; i < 50; i++ {
 			taskChan := make(chan struct{})
 			ok := m.Go(ctx, func(ctx context.Context) {
+				close(taskChan)
+			})
+			// If goroutine was started, wait for its completion.
+			if ok {
+				<-taskChan
+			}
+
+			taskChan = make(chan struct{})
+			ok = m.GoBlocking(func() {
 				close(taskChan)
 			})
 			// If goroutine was started, wait for its completion.

--- a/fn/goroutine_manager_test.go
+++ b/fn/goroutine_manager_test.go
@@ -108,8 +108,8 @@ func TestGoroutineManager(t *testing.T) {
 
 	// Start many goroutines while calling Stop. We do this to make sure
 	// that the GoroutineManager does not crash when these calls are done in
-	// parallel because of the potential race between wg.Add() and
-	// wg.Done() when the wg counter is 0.
+	// parallel because of the potential race between Go() and Stop() when
+	// the counter is 0.
 	t.Run("Stress test", func(t *testing.T) {
 		t.Parallel()
 
@@ -124,11 +124,10 @@ func TestGoroutineManager(t *testing.T) {
 			close(stopChan)
 		})
 
-		// Start 100 goroutines sequentially. Sequential order is
-		// needed to keep wg.counter low (0 or 1) to increase
-		// probability of the race condition to triggered if it exists.
-		// If mutex is removed in the implementation, this test crashes
-		// under `-race`.
+		// Start 100 goroutines sequentially. Sequential order is needed
+		// to keep counter low (0 or 1) to increase probability of the
+		// race condition triggered if it exists. If mutex is removed in
+		// the implementation, this test crashes under `-race`.
 		for i := 0; i < 100; i++ {
 			taskChan := make(chan struct{})
 			ok := m.Go(ctx, func(ctx context.Context) {


### PR DESCRIPTION
## Change Description

Switch `fn.GoroutineManager` from `sync.WaitGroup` to `sync.Cond`.

Add method `GoBlocking` to `GoroutineManager`. This method is intended to perform shutdown of important tasks, where
interruption is not desirable.

This change makes `GoroutineManager` a replacement for fn.ContextGuard in use cases where a context is passed to a goroutine.

See https://github.com/lightningnetwork/lnd/issues/9412

## Steps to Test

```
cd fn/
go test -race -run GoroutineManager
```

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
