### PR TITLE
channeldb+lnd: set invoice bucket tombstone after migration

### DIFF
--- a/channeldb/invoice_test.go
+++ b/channeldb/invoice_test.go
@@ -103,3 +103,28 @@ func TestEncodeDecodeAmpInvoiceState(t *testing.T) {
 	// The two states should match.
 	require.Equal(t, ampState, ampState2)
 }
+
+// TestInvoiceBucketTombstone tests the behavior of setting and checking the
+// invoice bucket tombstone. It verifies that the tombstone can be set correctly
+// and detected when present in the database.
+func TestInvoiceBucketTombstone(t *testing.T) {
+	t.Parallel()
+
+	// Initialize a test database.
+	db, err := MakeTestDB(t)
+	require.NoError(t, err, "unable to initialize db")
+
+	// Ensure the tombstone doesn't exist initially.
+	tombstoneExists, err := db.GetInvoiceBucketTombstone()
+	require.NoError(t, err)
+	require.False(t, tombstoneExists)
+
+	// Set the tombstone.
+	err = db.SetInvoiceBucketTombstone()
+	require.NoError(t, err)
+
+	// Verify that the tombstone exists after setting it.
+	tombstoneExists, err = db.GetInvoiceBucketTombstone()
+	require.NoError(t, err)
+	require.True(t, tombstoneExists)
+}

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -268,6 +268,9 @@ The underlying functionality between those two options remain the same.
   SQL](https://github.com/lightningnetwork/lnd/pull/8831) as part of a larger
   effort to support SQL databases natively in LND.
 
+* [Set invoice bucket
+  ](https://github.com/lightningnetwork/lnd/pull/9438) tombstone after native 
+  SQL migration.
 
 ## Code Health
 

--- a/itest/lnd_invoice_migration_test.go
+++ b/itest/lnd_invoice_migration_test.go
@@ -298,6 +298,16 @@ func testInvoiceMigration(ht *lntest.HarnessTest) {
 		}
 	}
 
+	// Now restart Bob without the --db.use-native-sql flag so we can check
+	// that the KV tombstone was set and that Bob will fail to start.
+	require.NoError(ht, bob.Stop())
+	bob.SetExtraArgs(nil)
+
+	// Bob should now fail to start due to the tombstone being set.
+	require.NoError(ht, bob.StartLndCmd(ht.Context()))
+	require.Error(ht, bob.WaitForProcessExit())
+
 	// Start Bob again so the test can complete.
+	bob.SetExtraArgs([]string{"--db.use-native-sql"})
 	require.NoError(ht, bob.Start(ht.Context()))
 }


### PR DESCRIPTION
This commit introduces the functionality to set a tombstone key in the invoice bucket after the migration to the native SQL database. The tombstone prevents the user from switching back to the KV invoice database, ensuring data consistency and avoiding potential issues like lingering invoices or partial state in KV tables. The tombstone is checked on startup to block any manual overrides that attempt to revert the migration.

Fixes https://github.com/lightningnetwork/lnd/issues/9434