### PR TITLE
misc: fix incorrect inclusion of nil err in various formatted strings

### DIFF
--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -1343,12 +1343,17 @@ func (s *Server) trackPayment(subscription routing.ControlTowerSubscriber,
 	err := s.trackPaymentStream(
 		stream.Context(), subscription, noInflightUpdates, stream.Send,
 	)
+	switch {
+	case err == nil:
+		return nil
 
 	// If the context is canceled, we don't return an error.
-	if errors.Is(err, context.Canceled) {
+	case errors.Is(err, context.Canceled):
 		log.Infof("Payment stream %v canceled", identifier)
 
 		return nil
+
+	default:
 	}
 
 	// Otherwise, we will log and return the error as the stream has

--- a/lntest/harness_assertion.go
+++ b/lntest/harness_assertion.go
@@ -1862,13 +1862,11 @@ func (h *HarnessTest) AssertChannelInGraphDB(hn *node.HarnessNode,
 		// Make sure the policies are populated, otherwise this edge
 		// cannot be used for routing.
 		if resp.Node1Policy == nil {
-			return fmt.Errorf("channel %s has no policy1: %w",
-				op, err)
+			return fmt.Errorf("channel %s has no policy1", op)
 		}
 
 		if resp.Node2Policy == nil {
-			return fmt.Errorf("channel %s has no policy2: %w",
-				op, err)
+			return fmt.Errorf("channel %s has no policy2", op)
 		}
 
 		edge = resp


### PR DESCRIPTION
Helps with logs a bit :) 