### PR TITLE
itest: fix flake in `testAnchorThirdPartySpend`

### DIFF
--- a/itest/list_exclude_test.go
+++ b/itest/list_exclude_test.go
@@ -39,8 +39,8 @@ var excludedTestsWindows = []string{
 	"multihop-htlc aggregation simple taproot",
 	"multihop-htlc aggregation simple taproot zero conf",
 
-	"channel force closure anchor",
-	"channel force closure simple taproot",
+	"channel force close-anchor",
+	"channel force close-simple taproot",
 	"channel backup restore force close",
 	"wipe forwarding packages",
 

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -206,18 +206,6 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testChannelUnsettledBalance,
 	},
 	{
-		Name:     "channel force closure anchor",
-		TestFunc: testChannelForceClosureAnchor,
-	},
-	{
-		Name:     "channel force closure simple taproot",
-		TestFunc: testChannelForceClosureSimpleTaproot,
-	},
-	{
-		Name:     "failing channel",
-		TestFunc: testFailingChannel,
-	},
-	{
 		Name:     "chain kit",
 		TestFunc: testChainKit,
 	},
@@ -735,6 +723,9 @@ func init() {
 	)
 	allTestCases = appendPrefixed(
 		"send to route", allTestCases, sendToRouteTestCases,
+	)
+	allTestCases = appendPrefixed(
+		"channel force close", allTestCases, channelForceCloseTestCases,
 	)
 
 	// Prepare the test cases for windows to exclude some of the flaky

--- a/itest/lnd_channel_force_close_test.go
+++ b/itest/lnd_channel_force_close_test.go
@@ -18,6 +18,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var channelForceCloseTestCases = []*lntest.TestCase{
+	{
+		Name:     "anchor",
+		TestFunc: testChannelForceClosureAnchor,
+	},
+	{
+		Name:     "simple taproot",
+		TestFunc: testChannelForceClosureSimpleTaproot,
+	},
+	{
+		Name:     "wrong preimage",
+		TestFunc: testFailingChannel,
+	},
+}
+
 const pushAmt = btcutil.Amount(5e5)
 
 // testChannelForceClosureAnchor runs `runChannelForceClosureTest` with anchor

--- a/itest/lnd_onchain_test.go
+++ b/itest/lnd_onchain_test.go
@@ -564,7 +564,13 @@ func testAnchorThirdPartySpend(ht *lntest.HarnessTest) {
 	//
 	// TODO(yy): also check the restart behavior of Alice.
 	const anchorCsv = 16
-	ht.MineEmptyBlocks(anchorCsv - defaultCSV)
+	blocks := anchorCsv - defaultCSV
+
+	// Mine empty blocks and check Alice still has the two pending sweeps.
+	for i := 0; i < blocks; i++ {
+		ht.MineEmptyBlocks(1)
+		ht.AssertNumPendingSweeps(alice, 2)
+	}
 
 	// Now that the channel has been closed, and Alice has an unconfirmed
 	// transaction spending the output produced by her anchor sweep, we'll


### PR DESCRIPTION
Cherry-picked from the sweeper PR.

When mining lots of blocks in the itest, the subsystems can be out of
sync in terms of the best block height. We now assert the num of pending
sweeps on Alice's node to give her more time to sync the blocks,
essentially behaving like a `time.Sleep` as in reality, the blocks would
never be generated this fast.