### PR TITLE
sweep: start tracking input spending status in the fee bumper

### DIFF
--- a/chainntnfs/mempool.go
+++ b/chainntnfs/mempool.go
@@ -211,7 +211,7 @@ func (m *MempoolNotifier) findRelevantInputs(tx *btcutil.Tx) (inputsWithTx,
 
 		// If found, save it to watchedInputs to notify the
 		// subscriber later.
-		Log.Infof("Found input %s, spent in %s", op, txid)
+		Log.Debugf("Found input %s, spent in %s", op, txid)
 
 		// Construct the spend details.
 		details := &SpendDetail{

--- a/contractcourt/anchor_resolver.go
+++ b/contractcourt/anchor_resolver.go
@@ -108,7 +108,7 @@ func (c *anchorResolver) Resolve() (ContractResolver, error) {
 
 		// Anchor was swept by someone else. This is possible after the
 		// 16 block csv lock.
-		case sweep.ErrRemoteSpend:
+		case sweep.ErrRemoteSpend, sweep.ErrInputMissing:
 			c.log.Warnf("our anchor spent by someone else")
 			outcome = channeldb.ResolverOutcomeUnclaimed
 

--- a/contractcourt/anchor_resolver.go
+++ b/contractcourt/anchor_resolver.go
@@ -98,9 +98,11 @@ func (c *anchorResolver) Resolve() (ContractResolver, error) {
 
 	select {
 	case sweepRes := <-c.sweepResultChan:
-		switch sweepRes.Err {
+		err := sweepRes.Err
+
+		switch {
 		// Anchor was swept successfully.
-		case nil:
+		case err == nil:
 			sweepTxID := sweepRes.Tx.TxHash()
 
 			spendTx = &sweepTxID
@@ -108,7 +110,9 @@ func (c *anchorResolver) Resolve() (ContractResolver, error) {
 
 		// Anchor was swept by someone else. This is possible after the
 		// 16 block csv lock.
-		case sweep.ErrRemoteSpend, sweep.ErrInputMissing:
+		case errors.Is(err, sweep.ErrRemoteSpend),
+			errors.Is(err, sweep.ErrInputMissing):
+
 			c.log.Warnf("our anchor spent by someone else")
 			outcome = channeldb.ResolverOutcomeUnclaimed
 

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -344,6 +344,11 @@ The underlying functionality between those two options remain the same.
 * A code refactor that [replaces min/max helpers with built-in min/max
   functions](https://github.com/lightningnetwork/lnd/pull/9451).
 
+* [Unified](https://github.com/lightningnetwork/lnd/pull/9447) the monitoring
+  inputs spending logic in the sweeper so it can properly handle missing inputs
+  and recover from restart.
+
+
 ## Tooling and Documentation
 
 * [Improved `lncli create` command help text](https://github.com/lightningnetwork/lnd/pull/9077)

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -662,6 +662,10 @@ var allTestCases = []*lntest.TestCase{
 		Name:     "invoice migration",
 		TestFunc: testInvoiceMigration,
 	},
+	{
+		Name:     "fee replacement",
+		TestFunc: testFeeReplacement,
+	},
 }
 
 // appendPrefixed is used to add a prefix to each test name in the subtests

--- a/itest/lnd_channel_force_close_test.go
+++ b/itest/lnd_channel_force_close_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd"
 	"github.com/lightningnetwork/lnd/lnrpc"
@@ -27,6 +26,15 @@ var channelForceCloseTestCases = []*lntest.TestCase{
 		Name:     "simple taproot",
 		TestFunc: testChannelForceClosureSimpleTaproot,
 	},
+	{
+		Name:     "anchor restart",
+		TestFunc: testChannelForceClosureAnchorRestart,
+	},
+	{
+		Name:     "simple taproot restart",
+		TestFunc: testChannelForceClosureSimpleTaprootRestart,
+	},
+
 	{
 		Name:     "wrong preimage",
 		TestFunc: testFailingChannel,
@@ -87,11 +95,600 @@ func testChannelForceClosureSimpleTaproot(ht *lntest.HarnessTest) {
 // commitment transaction, a transaction sweeping the local CSV delayed output,
 // a transaction sweeping the CSV delayed 2nd-layer htlcs outputs, and n htlc
 // timeout transactions, where n is the number of payments Alice attempted
-// to send to Carol.  This test includes several restarts to ensure that the
-// transaction output states are persisted throughout the forced closure
-// process.
+// to send to Carol.
 func runChannelForceClosureTest(ht *lntest.HarnessTest,
 	cfgs [][]string, params lntest.OpenChannelParams) {
+
+	const (
+		numInvoices   = 6
+		commitFeeRate = 20000
+	)
+
+	ht.SetFeeEstimate(commitFeeRate)
+
+	// Create a three hop network: Alice -> Carol.
+	chanPoints, nodes := ht.CreateSimpleNetwork(cfgs, params)
+	alice, carol := nodes[0], nodes[1]
+	chanPoint := chanPoints[0]
+
+	// We need one additional UTXO for sweeping the remote anchor.
+	if ht.IsNeutrinoBackend() {
+		ht.FundCoins(btcutil.SatoshiPerBitcoin, alice)
+	}
+
+	// Before we start, obtain Carol's current wallet balance, we'll check
+	// to ensure that at the end of the force closure by Alice, Carol
+	// recognizes his new on-chain output.
+	carolBalResp := carol.RPC.WalletBalance()
+	carolStartingBalance := carolBalResp.ConfirmedBalance
+
+	// Send payments from Alice to Carol, since Carol is htlchodl mode, the
+	// htlc outputs should be left unsettled, and should be swept by the
+	// utxo nursery.
+	carolPubKey := carol.PubKey[:]
+	for i := 0; i < numInvoices; i++ {
+		req := &routerrpc.SendPaymentRequest{
+			Dest:           carolPubKey,
+			Amt:            int64(paymentAmt),
+			PaymentHash:    ht.Random32Bytes(),
+			FinalCltvDelta: finalCltvDelta,
+			FeeLimitMsat:   noFeeLimitMsat,
+		}
+		ht.SendPaymentAssertInflight(alice, req)
+	}
+
+	// Once the HTLC has cleared, all the nodes in our mini network should
+	// show that the HTLC has been locked in.
+	ht.AssertNumActiveHtlcs(alice, numInvoices)
+	ht.AssertNumActiveHtlcs(carol, numInvoices)
+
+	// Fetch starting height of this test so we can compute the block
+	// heights we expect certain events to take place.
+	curHeight := int32(ht.CurrentHeight())
+
+	// Using the current height of the chain, derive the relevant heights
+	// for sweeping two-stage htlcs.
+	var (
+		startHeight           = uint32(curHeight)
+		commCsvMaturityHeight = startHeight + 1 + defaultCSV
+		htlcExpiryHeight      = padCLTV(startHeight + finalCltvDelta)
+		htlcCsvMaturityHeight = padCLTV(
+			startHeight + finalCltvDelta + 1 + defaultCSV,
+		)
+	)
+
+	aliceChan := ht.QueryChannelByChanPoint(alice, chanPoint)
+	require.NotZero(ht, aliceChan.NumUpdates,
+		"alice should see at least one update to her channel")
+
+	// Now that the channel is open and we have unsettled htlcs,
+	// immediately execute a force closure of the channel. This will also
+	// assert that the commitment transaction was immediately broadcast in
+	// order to fulfill the force closure request.
+	ht.CloseChannelAssertPending(alice, chanPoint, true)
+
+	// Now that the channel has been force closed, it should show up in the
+	// PendingChannels RPC under the waiting close section.
+	waitingClose := ht.AssertChannelWaitingClose(alice, chanPoint)
+
+	// Immediately after force closing, all of the funds should be in
+	// limbo.
+	require.NotZero(ht, waitingClose.LimboBalance,
+		"all funds should still be in limbo")
+
+	// Create a map of outpoints to expected resolutions for alice and
+	// carol which we will add reports to as we sweep outputs.
+	var (
+		aliceReports = make(map[string]*lnrpc.Resolution)
+		carolReports = make(map[string]*lnrpc.Resolution)
+	)
+
+	// We expect to see Alice's force close tx in the mempool.
+	ht.AssertNumTxsInMempool(1)
+
+	// Mine a block which should confirm the commitment transaction
+	// broadcast as a result of the force closure. Once mined, we also
+	// expect Alice's anchor sweeping tx being published.
+	ht.MineBlocksAndAssertNumTxes(1, 1)
+
+	// Assert Alice's has one pending anchor output - because she doesn't
+	// have incoming HTLCs, her outgoing HTLC won't have a deadline, thus
+	// she won't use the anchor to perform CPFP.
+	aliceAnchor := ht.AssertNumPendingSweeps(alice, 1)[0]
+	require.Equal(ht, aliceAnchor.Outpoint.TxidStr,
+		waitingClose.Commitments.LocalTxid)
+
+	// Now that the commitment has been confirmed, the channel should be
+	// marked as force closed.
+	forceClose := ht.AssertChannelPendingForceClose(alice, chanPoint)
+
+	// Now that the channel has been force closed, it should now
+	// have the height and number of blocks to confirm populated.
+	err := checkCommitmentMaturity(
+		forceClose, commCsvMaturityHeight, int32(defaultCSV),
+	)
+	require.NoError(ht, err)
+
+	// None of our outputs have been swept, so they should all be in limbo.
+	require.NotZero(ht, forceClose.LimboBalance)
+	require.Zero(ht, forceClose.RecoveredBalance)
+
+	// Carol should offer her commit and anchor outputs to the sweeper.
+	sweepTxns := ht.AssertNumPendingSweeps(carol, 2)
+
+	// Identify Carol's pending sweeps.
+	var carolAnchor, carolCommit = sweepTxns[0], sweepTxns[1]
+	if carolAnchor.AmountSat != uint32(anchorSize) {
+		carolCommit = carolAnchor
+	}
+
+	// Carol's sweep tx should be in the mempool already, as her output is
+	// not timelocked. This sweep tx should spend her to_local output as
+	// the anchor output is not economical to spend.
+	carolTx := ht.GetNumTxsFromMempool(1)[0]
+
+	// Carol's sweeping tx should have 1-input-1-output shape.
+	require.Len(ht, carolTx.TxIn, 1)
+	require.Len(ht, carolTx.TxOut, 1)
+
+	// Calculate the total fee Carol paid.
+	totalFeeCarol := ht.CalculateTxFee(carolTx)
+
+	// Carol's anchor report won't be created since it's uneconomical to
+	// sweep. So we expect to see only the commit sweep report.
+	op := fmt.Sprintf("%v:%v", carolCommit.Outpoint.TxidStr,
+		carolCommit.Outpoint.OutputIndex)
+	carolReports[op] = &lnrpc.Resolution{
+		ResolutionType: lnrpc.ResolutionType_COMMIT,
+		Outcome:        lnrpc.ResolutionOutcome_CLAIMED,
+		Outpoint:       carolCommit.Outpoint,
+		AmountSat:      uint64(pushAmt),
+		SweepTxid:      carolTx.TxHash().String(),
+	}
+
+	// We also expect Carol to broadcast her sweeping tx which spends her
+	// commit and anchor outputs.
+	ht.MineBlocksAndAssertNumTxes(1, 1)
+
+	// Alice should still have the anchor sweeping request.
+	ht.AssertNumPendingSweeps(alice, 1)
+
+	// Alice should see the channel in her set of pending force closed
+	// channels with her funds still in limbo.
+	forceClose = ht.AssertChannelPendingForceClose(alice, chanPoint)
+
+	// Make a record of the balances we expect for alice and carol.
+	aliceBalance := forceClose.Channel.LocalBalance
+
+	// Get the closing txid.
+	txid, err := chainhash.NewHashFromStr(forceClose.ClosingTxid)
+	require.NoError(ht, err)
+	closingTxID := txid
+
+	// At this point, the nursery should show that the commitment output has
+	// 3 block left before its CSV delay expires. In total, we have mined
+	// exactly defaultCSV blocks, so the htlc outputs should also reflect
+	// that this many blocks have passed.
+	err = checkCommitmentMaturity(forceClose, commCsvMaturityHeight, 3)
+	require.NoError(ht, err)
+
+	// All funds should still be shown in limbo.
+	require.NotZero(ht, forceClose.LimboBalance)
+	require.Zero(ht, forceClose.RecoveredBalance)
+
+	// Generate two blocks, which should cause the CSV delayed output from
+	// the commitment txn to expire.
+	ht.MineEmptyBlocks(2)
+
+	// At this point, the CSV will expire in the next block, meaning that
+	// the output should be offered to the sweeper.
+	sweeps := ht.AssertNumPendingSweeps(alice, 2)
+	commitSweep, anchorSweep := sweeps[0], sweeps[1]
+	if commitSweep.AmountSat < anchorSweep.AmountSat {
+		commitSweep = anchorSweep
+	}
+
+	// Alice's sweeping transaction should now be broadcast. So we fetch the
+	// node's mempool to ensure it has been properly broadcast.
+	sweepTx := ht.GetNumTxsFromMempool(1)[0]
+	sweepTxid := sweepTx.TxHash()
+
+	// The sweep transaction's inputs spending should be from the commitment
+	// transaction.
+	for _, txIn := range sweepTx.TxIn {
+		require.Equal(ht, &txIn.PreviousOutPoint.Hash, closingTxID,
+			"sweep transaction not spending from commit")
+	}
+
+	// Alice's anchor report won't be created since it's uneconomical to
+	// sweep. We expect a resolution which spends our commit output.
+	op = fmt.Sprintf("%v:%v", commitSweep.Outpoint.TxidStr,
+		commitSweep.Outpoint.OutputIndex)
+	aliceReports[op] = &lnrpc.Resolution{
+		ResolutionType: lnrpc.ResolutionType_COMMIT,
+		Outcome:        lnrpc.ResolutionOutcome_CLAIMED,
+		SweepTxid:      sweepTxid.String(),
+		Outpoint:       commitSweep.Outpoint,
+		AmountSat:      uint64(aliceBalance),
+	}
+
+	// Check that we can find the commitment sweep in our set of known
+	// sweeps, using the simple transaction id ListSweeps output.
+	ht.AssertSweepFound(alice, sweepTxid.String(), false, 0)
+
+	// Next, we mine an additional block which should include the sweep
+	// transaction as the input scripts and the sequence locks on the
+	// inputs should be properly met.
+	ht.MineBlocksAndAssertNumTxes(1, 1)
+
+	// Update current height
+	curHeight = int32(ht.CurrentHeight())
+
+	// checkForceClosedChannelNumHtlcs verifies that a force closed channel
+	// has the proper number of htlcs.
+	checkPendingChannelNumHtlcs := func(
+		forceClose lntest.PendingForceClose) error {
+
+		if len(forceClose.PendingHtlcs) != numInvoices {
+			return fmt.Errorf("expected force closed channel to "+
+				"have %d pending htlcs, found %d instead",
+				numInvoices, len(forceClose.PendingHtlcs))
+		}
+
+		return nil
+	}
+
+	err = wait.NoError(func() error {
+		// Now that the commit output has been fully swept, check to
+		// see that the channel remains open for the pending htlc
+		// outputs.
+		forceClose := ht.AssertChannelPendingForceClose(
+			alice, chanPoint,
+		)
+
+		// The commitment funds will have been recovered after the
+		// commit txn was included in the last block. The htlc funds
+		// will be shown in limbo.
+		err := checkPendingChannelNumHtlcs(forceClose)
+		if err != nil {
+			return err
+		}
+
+		err = checkPendingHtlcStageAndMaturity(
+			forceClose, 1, htlcExpiryHeight,
+			int32(htlcExpiryHeight)-curHeight,
+		)
+		if err != nil {
+			return err
+		}
+
+		if forceClose.LimboBalance == 0 {
+			return fmt.Errorf("expected funds in limbo, found 0")
+		}
+
+		return nil
+	}, defaultTimeout)
+	require.NoError(ht, err, "timeout checking pending force close channel")
+
+	// Compute the height preceding that which will cause the htlc CLTV
+	// timeouts will expire. The outputs entered at the same height as the
+	// output spending from the commitment txn, so we must deduct the
+	// number of blocks we have generated since adding it to the nursery,
+	// and take an additional block off so that we end up one block shy of
+	// the expiry height, and add the block padding.
+	cltvHeightDelta := int(htlcExpiryHeight - uint32(curHeight) - 1)
+
+	// Advance the blockchain until just before the CLTV expires, nothing
+	// exciting should have happened during this time.
+	ht.MineEmptyBlocks(cltvHeightDelta)
+
+	// Alice should now see the channel in her set of pending force closed
+	// channels with one pending HTLC.
+	err = wait.NoError(func() error {
+		forceClose := ht.AssertChannelPendingForceClose(
+			alice, chanPoint,
+		)
+
+		// We should now be at the block just before the utxo nursery
+		// will attempt to broadcast the htlc timeout transactions.
+		err = checkPendingChannelNumHtlcs(forceClose)
+		if err != nil {
+			return err
+		}
+		err = checkPendingHtlcStageAndMaturity(
+			forceClose, 1, htlcExpiryHeight, 1,
+		)
+		if err != nil {
+			return err
+		}
+
+		// Now that our commitment confirmation depth has been
+		// surpassed, we should now see a non-zero recovered balance.
+		// All htlc outputs are still left in limbo, so it should be
+		// non-zero as well.
+		if forceClose.LimboBalance == 0 {
+			return errors.New("htlc funds should still be in limbo")
+		}
+
+		return nil
+	}, defaultTimeout)
+	require.NoError(ht, err, "timeout while checking force closed channel")
+
+	// Now, generate the block which will cause Alice to offer the presigned
+	// htlc timeout txns to the sweeper.
+	ht.MineEmptyBlocks(1)
+
+	// Since Alice had numInvoices (6) htlcs extended to Carol before force
+	// closing, we expect Alice to broadcast an htlc timeout txn for each
+	// one. We also expect Alice to still have her anchor since it's not
+	// swept.
+	ht.AssertNumPendingSweeps(alice, numInvoices+1)
+
+	// Wait for them all to show up in the mempool
+	htlcTx := ht.GetNumTxsFromMempool(1)[0]
+	htlcTxid := htlcTx.TxHash()
+
+	// Retrieve each htlc timeout txn from the mempool, and ensure it is
+	// well-formed. The sweeping tx should spend all the htlc outputs.
+	//
+	// NOTE: We also add 1 output as the outgoing HTLC needs a wallet utxo
+	// to pay for its fee.
+	numInputs := 6 + 1
+
+	var htlcLessFees uint64
+
+	// Ensure the htlc transaction has the expected number of inputs.
+	require.Len(ht, htlcTx.TxIn, numInputs, "num inputs mismatch")
+
+	// The number of outputs should be the same.
+	require.Len(ht, htlcTx.TxOut, numInputs, "num outputs mismatch")
+
+	// Ensure all the htlc transaction inputs are spending from the
+	// commitment transaction, except if this is an extra input added to pay
+	// for fees for anchor channels.
+	for _, txIn := range htlcTx.TxIn {
+		if !closingTxID.IsEqual(&txIn.PreviousOutPoint.Hash) {
+			// This was an extra input added to pay fees,
+			// continue to the next one.
+			continue
+		}
+
+		// For each htlc timeout transaction, we expect a resolver
+		// report recording this on chain resolution for both alice and
+		// carol.
+		outpoint := txIn.PreviousOutPoint
+		resolutionOutpoint := &lnrpc.OutPoint{
+			TxidBytes:   outpoint.Hash[:],
+			TxidStr:     outpoint.Hash.String(),
+			OutputIndex: outpoint.Index,
+		}
+
+		// We expect alice to have a timeout tx resolution with an
+		// amount equal to the payment amount.
+		aliceReports[outpoint.String()] = &lnrpc.Resolution{
+			ResolutionType: lnrpc.ResolutionType_OUTGOING_HTLC,
+			Outcome:        lnrpc.ResolutionOutcome_FIRST_STAGE,
+			SweepTxid:      htlcTxid.String(),
+			Outpoint:       resolutionOutpoint,
+			AmountSat:      uint64(paymentAmt),
+		}
+
+		// We expect carol to have a resolution with an incoming htlc
+		// timeout which reflects the full amount of the htlc. It has no
+		// spend tx, because carol stops monitoring the htlc once it has
+		// timed out.
+		carolReports[outpoint.String()] = &lnrpc.Resolution{
+			ResolutionType: lnrpc.ResolutionType_INCOMING_HTLC,
+			Outcome:        lnrpc.ResolutionOutcome_TIMEOUT,
+			SweepTxid:      "",
+			Outpoint:       resolutionOutpoint,
+			AmountSat:      uint64(paymentAmt),
+		}
+	}
+
+	// We record the htlc amount less fees here, so that we know what value
+	// to expect for the second stage of our htlc resolution.
+	htlcLessFees = uint64(htlcTx.TxOut[0].Value)
+
+	// Generate a block that mines the htlc timeout txns. Doing so now
+	// activates the 2nd-stage CSV delayed outputs.
+	ht.MineBlocksAndAssertNumTxes(1, 1)
+
+	// Advance the chain until just before the 2nd-layer CSV delays expire.
+	// For anchor channels this is one block earlier.
+	curHeight = int32(ht.CurrentHeight())
+	ht.Logf("current height: %v, htlcCsvMaturityHeight=%v", curHeight,
+		htlcCsvMaturityHeight)
+	numBlocks := int(htlcCsvMaturityHeight - uint32(curHeight) - 1)
+	ht.MineEmptyBlocks(numBlocks)
+
+	ht.AssertNumPendingSweeps(alice, numInvoices+1)
+
+	// Now that the channel has been fully swept, it should no longer show
+	// incubated, check to see that Alice's node still reports the channel
+	// as pending force closed.
+	err = wait.NoError(func() error {
+		forceClose := ht.AssertChannelPendingForceClose(
+			alice, chanPoint,
+		)
+
+		if forceClose.LimboBalance == 0 {
+			return fmt.Errorf("htlc funds should still be in limbo")
+		}
+
+		return checkPendingChannelNumHtlcs(forceClose)
+	}, defaultTimeout)
+	require.NoError(ht, err, "timeout while checking force closed channel")
+
+	ht.AssertNumPendingSweeps(alice, numInvoices+1)
+
+	// Wait for the single sweep txn to appear in the mempool.
+	htlcSweepTx := ht.GetNumTxsFromMempool(1)[0]
+	htlcSweepTxid := htlcSweepTx.TxHash()
+
+	// Ensure the htlc sweep transaction only has one input for each htlc
+	// Alice extended before force closing.
+	require.Len(ht, htlcSweepTx.TxIn, numInvoices,
+		"htlc transaction has wrong num of inputs")
+	require.Len(ht, htlcSweepTx.TxOut, 1,
+		"htlc sweep transaction should have one output")
+
+	// Ensure that each output spends from exactly one htlc timeout output.
+	for _, txIn := range htlcSweepTx.TxIn {
+		op := txIn.PreviousOutPoint
+
+		// Since we have now swept our htlc timeout tx, we expect to
+		// have timeout resolutions for each of our htlcs.
+		aliceReports[op.String()] = &lnrpc.Resolution{
+			ResolutionType: lnrpc.ResolutionType_OUTGOING_HTLC,
+			Outcome:        lnrpc.ResolutionOutcome_TIMEOUT,
+			SweepTxid:      htlcSweepTxid.String(),
+			Outpoint: &lnrpc.OutPoint{
+				TxidBytes:   op.Hash[:],
+				TxidStr:     op.Hash.String(),
+				OutputIndex: op.Index,
+			},
+			AmountSat: htlcLessFees,
+		}
+	}
+
+	// Check that we can find the htlc sweep in our set of sweeps using
+	// the verbose output of the listsweeps output.
+	ht.AssertSweepFound(alice, htlcSweepTxid.String(), true, 0)
+
+	// Now that the channel has been fully swept, it should no longer show
+	// incubated, check to see that Alice's node still reports the channel
+	// as pending force closed.
+	err = wait.NoError(func() error {
+		forceClose := ht.AssertChannelPendingForceClose(
+			alice, chanPoint,
+		)
+		err := checkPendingChannelNumHtlcs(forceClose)
+		if err != nil {
+			return err
+		}
+
+		err = checkPendingHtlcStageAndMaturity(
+			forceClose, 2, htlcCsvMaturityHeight-1, 0,
+		)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}, defaultTimeout)
+	require.NoError(ht, err, "timeout while checking force closed channel")
+
+	// Generate the final block that sweeps all htlc funds into the user's
+	// wallet, and make sure the sweep is in this block.
+	block := ht.MineBlocksAndAssertNumTxes(1, 1)[0]
+	ht.AssertTxInBlock(block, htlcSweepTxid)
+
+	// Now that the channel has been fully swept, it should no longer show
+	// up within the pending channels RPC.
+	err = wait.NoError(func() error {
+		ht.AssertNumPendingForceClose(alice, 0)
+
+		// In addition to there being no pending channels, we verify
+		// that pending channels does not report any money still in
+		// limbo.
+		pendingChanResp := alice.RPC.PendingChannels()
+		if pendingChanResp.TotalLimboBalance != 0 {
+			return errors.New("no user funds should be left " +
+				"in limbo after incubation")
+		}
+
+		return nil
+	}, defaultTimeout)
+	require.NoError(ht, err, "timeout checking limbo balance")
+
+	// At this point, Carol should now be aware of her new immediately
+	// spendable on-chain balance, as it was Alice who broadcast the
+	// commitment transaction.
+	carolBalResp = carol.RPC.WalletBalance()
+
+	// Carol's expected balance should be its starting balance plus the
+	// push amount sent by Alice and minus the miner fee paid.
+	carolExpectedBalance := btcutil.Amount(carolStartingBalance) +
+		pushAmt - totalFeeCarol
+
+	require.Equal(ht, carolExpectedBalance,
+		btcutil.Amount(carolBalResp.ConfirmedBalance),
+		"carol's balance is incorrect")
+
+	// Finally, we check that alice and carol have the set of resolutions
+	// we expect.
+	assertReports(ht, alice, chanPoint, aliceReports)
+	assertReports(ht, carol, chanPoint, carolReports)
+}
+
+// testChannelForceClosureAnchor runs `runChannelForceClosureTestRestart` with
+// anchor channels.
+func testChannelForceClosureAnchorRestart(ht *lntest.HarnessTest) {
+	// Create a simple network: Alice -> Carol, using anchor channels.
+	//
+	// Prepare params.
+	openChannelParams := lntest.OpenChannelParams{
+		Amt:            chanAmt,
+		PushAmt:        pushAmt,
+		CommitmentType: lnrpc.CommitmentType_ANCHORS,
+	}
+
+	cfg := node.CfgAnchor
+	cfgCarol := append([]string{"--hodl.exit-settle"}, cfg...)
+	cfgs := [][]string{cfg, cfgCarol}
+
+	runChannelForceClosureTestRestart(ht, cfgs, openChannelParams)
+}
+
+// testChannelForceClosureSimpleTaprootRestart runs
+// `runChannelForceClosureTestRestart` with simple taproot channels.
+func testChannelForceClosureSimpleTaprootRestart(ht *lntest.HarnessTest) {
+	// Create a simple network: Alice -> Carol, using simple taproot
+	// channels.
+	//
+	// Prepare params.
+	openChannelParams := lntest.OpenChannelParams{
+		Amt:     chanAmt,
+		PushAmt: pushAmt,
+		// If the channel is a taproot channel, then we'll need to
+		// create a private channel.
+		//
+		// TODO(roasbeef): lift after G175
+		CommitmentType: lnrpc.CommitmentType_SIMPLE_TAPROOT,
+		Private:        true,
+	}
+
+	cfg := node.CfgSimpleTaproot
+	cfgCarol := append([]string{"--hodl.exit-settle"}, cfg...)
+	cfgs := [][]string{cfg, cfgCarol}
+
+	runChannelForceClosureTestRestart(ht, cfgs, openChannelParams)
+}
+
+// runChannelForceClosureTestRestart performs a test to exercise the behavior of
+// "force" closing a channel or unilaterally broadcasting the latest local
+// commitment state on-chain. The test creates a new channel between Alice and
+// Carol, then force closes the channel after some cursory assertions. Within
+// the test, a total of 3 + n transactions will be broadcast, representing the
+// commitment transaction, a transaction sweeping the local CSV delayed output,
+// a transaction sweeping the CSV delayed 2nd-layer htlcs outputs, and n htlc
+// timeout transactions, where n is the number of payments Alice attempted
+// to send to Carol. This test includes several restarts to ensure that the
+// transaction output states are persisted throughout the forced closure
+// process.
+func runChannelForceClosureTestRestart(ht *lntest.HarnessTest,
+	cfgs [][]string, params lntest.OpenChannelParams) {
+
+	// Skip this test for neutrino, as it cannot create RBF-compliant
+	// sweeping txns due to no access to `testmempoolaccept`. For neutrino
+	// nodes connected to a btcd node, they can rely on a reject msg being
+	// sent back to decide how do perform the fee replacement.
+	//
+	// TODO(yy): refactor `createRBFCompliantTx` to also work for neutrino.
+	if ht.IsNeutrinoBackend() {
+		ht.Skipf("skipping persistence test for neutrino backend")
+	}
 
 	const (
 		numInvoices   = 6
@@ -202,32 +799,18 @@ func runChannelForceClosureTest(ht *lntest.HarnessTest,
 
 	// Now that the commitment has been confirmed, the channel should be
 	// marked as force closed.
-	err := wait.NoError(func() error {
-		forceClose := ht.AssertChannelPendingForceClose(
-			alice, chanPoint,
-		)
+	forceClose := ht.AssertChannelPendingForceClose(alice, chanPoint)
 
-		// Now that the channel has been force closed, it should now
-		// have the height and number of blocks to confirm populated.
-		err := checkCommitmentMaturity(
-			forceClose, commCsvMaturityHeight, int32(defaultCSV),
-		)
-		if err != nil {
-			return err
-		}
+	// Now that the channel has been force closed, it should now
+	// have the height and number of blocks to confirm populated.
+	err := checkCommitmentMaturity(
+		forceClose, commCsvMaturityHeight, int32(defaultCSV),
+	)
+	require.NoError(ht, err)
 
-		// None of our outputs have been swept, so they should all be
-		// in limbo.
-		if forceClose.LimboBalance == 0 {
-			return errors.New("all funds should still be in limbo")
-		}
-		if forceClose.RecoveredBalance != 0 {
-			return errors.New("no funds should be recovered")
-		}
-
-		return nil
-	}, defaultTimeout)
-	require.NoError(ht, err, "timeout while checking force closed channel")
+	// None of our outputs have been swept, so they should all be in limbo.
+	require.NotZero(ht, forceClose.LimboBalance)
+	require.Zero(ht, forceClose.RecoveredBalance)
 
 	// The following restart is intended to ensure that outputs from the
 	// force close commitment transaction have been persisted once the
@@ -241,7 +824,7 @@ func runChannelForceClosureTest(ht *lntest.HarnessTest,
 	// Identify Carol's pending sweeps.
 	var carolAnchor, carolCommit = sweepTxns[0], sweepTxns[1]
 	if carolAnchor.AmountSat != uint32(anchorSize) {
-		carolAnchor, carolCommit = carolCommit, carolAnchor
+		carolCommit = carolAnchor
 	}
 
 	// Carol's sweep tx should be in the mempool already, as her output is
@@ -331,7 +914,7 @@ func runChannelForceClosureTest(ht *lntest.HarnessTest,
 
 	// Generate two blocks, which should cause the CSV delayed output from
 	// the commitment txn to expire.
-	ht.MineBlocks(2)
+	ht.MineEmptyBlocks(2)
 
 	// At this point, the CSV will expire in the next block, meaning that
 	// the output should be offered to the sweeper.
@@ -341,54 +924,55 @@ func runChannelForceClosureTest(ht *lntest.HarnessTest,
 		commitSweep, anchorSweep = anchorSweep, commitSweep
 	}
 
-	// Mine one block and the sweeping transaction should now be broadcast.
-	// So we fetch the node's mempool to ensure it has been properly
-	// broadcast.
-	sweepingTXID := ht.AssertNumTxsInMempool(1)[0]
+	// Alice's sweeping transaction should now be broadcast. So we fetch the
+	// node's mempool to ensure it has been properly broadcast.
+	sweepTx := ht.GetNumTxsFromMempool(1)[0]
+	sweepTxid := sweepTx.TxHash()
 
 	// Fetch the sweep transaction, all input it's spending should be from
 	// the commitment transaction which was broadcast on-chain.
-	sweepTx := ht.GetRawTransaction(sweepingTXID)
-	for _, txIn := range sweepTx.MsgTx().TxIn {
+	for _, txIn := range sweepTx.TxIn {
 		require.Equal(ht, &txIn.PreviousOutPoint.Hash, closingTxID,
 			"sweep transaction not spending from commit")
-	}
-
-	// For neutrino backend, due to it has no mempool, we need to check the
-	// sweep tx has already been saved to db before restarting. This is due
-	// to the possible race,
-	// - the fee bumper returns a TxPublished event, which is received by
-	//   the sweeper and the sweep tx is saved to db.
-	// - the sweeper receives a shutdown signal before it receives the
-	//   above event.
-	//
-	// TODO(yy): fix the above race.
-	if ht.IsNeutrinoBackend() {
-		// Check that we can find the commitment sweep in our set of
-		// known sweeps, using the simple transaction id ListSweeps
-		// output.
-		ht.AssertSweepFound(alice, sweepingTXID.String(), false, 0)
 	}
 
 	// Restart Alice to ensure that she resumes watching the finalized
 	// commitment sweep txid.
 	ht.RestartNode(alice)
 
-	// Alice's anchor report won't be created since it's uneconomical to
-	// sweep. We expect a resolution which spends our commit output.
+	// Once restarted, Alice will offer her anchor and to_local outputs to
+	// the sweeper again. This time the two inputs will be swept using the
+	// same tx as they both have None deadline height, the sweeper will
+	// group these two inputs together.
+	//
+	// The new sweeping tx will replace the old one. We check it by
+	// asserting the old one no longer exists in the mempool.
+	ht.AssertTxNotInMempool(sweepTxid)
+	sweepTxid = ht.AssertNumTxsInMempool(1)[0]
+
+	// We expect two resolutions - anchor and commit outputs.
 	op = fmt.Sprintf("%v:%v", commitSweep.Outpoint.TxidStr,
 		commitSweep.Outpoint.OutputIndex)
 	aliceReports[op] = &lnrpc.Resolution{
 		ResolutionType: lnrpc.ResolutionType_COMMIT,
 		Outcome:        lnrpc.ResolutionOutcome_CLAIMED,
-		SweepTxid:      sweepingTXID.String(),
+		SweepTxid:      sweepTxid.String(),
 		Outpoint:       commitSweep.Outpoint,
 		AmountSat:      uint64(aliceBalance),
+	}
+	op = fmt.Sprintf("%v:%v", anchorSweep.Outpoint.TxidStr,
+		anchorSweep.Outpoint.OutputIndex)
+	aliceReports[op] = &lnrpc.Resolution{
+		ResolutionType: lnrpc.ResolutionType_ANCHOR,
+		Outcome:        lnrpc.ResolutionOutcome_CLAIMED,
+		SweepTxid:      sweepTxid.String(),
+		Outpoint:       anchorSweep.Outpoint,
+		AmountSat:      uint64(anchorSweep.AmountSat),
 	}
 
 	// Check that we can find the commitment sweep in our set of known
 	// sweeps, using the simple transaction id ListSweeps output.
-	ht.AssertSweepFound(alice, sweepingTXID.String(), false, 0)
+	ht.AssertSweepFound(alice, sweepTxid.String(), false, 0)
 
 	// Next, we mine an additional block which should include the sweep
 	// transaction as the input scripts and the sequence locks on the
@@ -450,12 +1034,11 @@ func runChannelForceClosureTest(ht *lntest.HarnessTest,
 	// number of blocks we have generated since adding it to the nursery,
 	// and take an additional block off so that we end up one block shy of
 	// the expiry height, and add the block padding.
-	currentHeight := int32(ht.CurrentHeight())
-	cltvHeightDelta := int(htlcExpiryHeight - uint32(currentHeight) - 1)
+	cltvHeightDelta := int(htlcExpiryHeight - uint32(curHeight) - 1)
 
 	// Advance the blockchain until just before the CLTV expires, nothing
 	// exciting should have happened during this time.
-	ht.MineBlocks(cltvHeightDelta)
+	ht.MineEmptyBlocks(cltvHeightDelta)
 
 	// We now restart Alice, to ensure that she will broadcast the
 	// presigned htlc timeout txns after the delay expires after
@@ -496,126 +1079,93 @@ func runChannelForceClosureTest(ht *lntest.HarnessTest,
 
 	// Now, generate the block which will cause Alice to offer the
 	// presigned htlc timeout txns to the sweeper.
-	ht.MineBlocks(1)
+	ht.MineEmptyBlocks(1)
 
 	// Since Alice had numInvoices (6) htlcs extended to Carol before force
 	// closing, we expect Alice to broadcast an htlc timeout txn for each
-	// one. We also expect Alice to still have her anchor since it's not
-	// swept.
-	ht.AssertNumPendingSweeps(alice, numInvoices+1)
+	// one.
+	ht.AssertNumPendingSweeps(alice, numInvoices)
 
 	// Wait for them all to show up in the mempool
-	htlcTxIDs := ht.AssertNumTxsInMempool(1)
-
-	// Retrieve each htlc timeout txn from the mempool, and ensure it is
-	// well-formed. The sweeping tx should spend all the htlc outputs.
-	//
-	// NOTE: We also add 1 output as the outgoing HTLC is swept using twice
-	// its value as its budget, so a wallet utxo is used.
-	numInputs := 6 + 1
-
-	// Construct a map of the already confirmed htlc timeout outpoints,
-	// that will count the number of times each is spent by the sweep txn.
-	// We prepopulate it in this way so that we can later detect if we are
-	// spending from an output that was not a confirmed htlc timeout txn.
-	var htlcTxOutpointSet = make(map[wire.OutPoint]int)
-
-	var htlcLessFees uint64
-
-	//nolint:ll
-	for _, htlcTxID := range htlcTxIDs {
-		// Fetch the sweep transaction, all input it's spending should
-		// be from the commitment transaction which was broadcast
-		// on-chain. In case of an anchor type channel, we expect one
-		// extra input that is not spending from the commitment, that
-		// is added for fees.
-		htlcTx := ht.GetRawTransaction(htlcTxID)
-
-		// Ensure the htlc transaction has the expected number of
-		// inputs.
-		inputs := htlcTx.MsgTx().TxIn
-		require.Len(ht, inputs, numInputs, "num inputs mismatch")
-
-		// The number of outputs should be the same.
-		outputs := htlcTx.MsgTx().TxOut
-		require.Len(ht, outputs, numInputs, "num outputs mismatch")
-
-		// Ensure all the htlc transaction inputs are spending from the
-		// commitment transaction, except if this is an extra input
-		// added to pay for fees for anchor channels.
-		nonCommitmentInputs := 0
-		for i, txIn := range inputs {
-			if !closingTxID.IsEqual(&txIn.PreviousOutPoint.Hash) {
-				nonCommitmentInputs++
-
-				require.Lessf(ht, nonCommitmentInputs, 2,
-					"htlc transaction not "+
-						"spending from commit "+
-						"tx %v, instead spending %v",
-					closingTxID, txIn.PreviousOutPoint)
-
-				// This was an extra input added to pay fees,
-				// continue to the next one.
-				continue
-			}
-
-			// For each htlc timeout transaction, we expect a
-			// resolver report recording this on chain resolution
-			// for both alice and carol.
-			outpoint := txIn.PreviousOutPoint
-			resolutionOutpoint := &lnrpc.OutPoint{
-				TxidBytes:   outpoint.Hash[:],
-				TxidStr:     outpoint.Hash.String(),
-				OutputIndex: outpoint.Index,
-			}
-
-			// We expect alice to have a timeout tx resolution with
-			// an amount equal to the payment amount.
-			//nolint:ll
-			aliceReports[outpoint.String()] = &lnrpc.Resolution{
-				ResolutionType: lnrpc.ResolutionType_OUTGOING_HTLC,
-				Outcome:        lnrpc.ResolutionOutcome_FIRST_STAGE,
-				SweepTxid:      htlcTx.Hash().String(),
-				Outpoint:       resolutionOutpoint,
-				AmountSat:      uint64(paymentAmt),
-			}
-
-			// We expect carol to have a resolution with an
-			// incoming htlc timeout which reflects the full amount
-			// of the htlc. It has no spend tx, because carol stops
-			// monitoring the htlc once it has timed out.
-			//nolint:ll
-			carolReports[outpoint.String()] = &lnrpc.Resolution{
-				ResolutionType: lnrpc.ResolutionType_INCOMING_HTLC,
-				Outcome:        lnrpc.ResolutionOutcome_TIMEOUT,
-				SweepTxid:      "",
-				Outpoint:       resolutionOutpoint,
-				AmountSat:      uint64(paymentAmt),
-			}
-
-			// Recorf the HTLC outpoint, such that we can later
-			// check whether it gets swept
-			op := wire.OutPoint{
-				Hash:  htlcTxID,
-				Index: uint32(i),
-			}
-			htlcTxOutpointSet[op] = 0
-		}
-
-		// We record the htlc amount less fees here, so that we know
-		// what value to expect for the second stage of our htlc
-		// resolution.
-		htlcLessFees = uint64(outputs[0].Value)
-	}
+	htlcTxid := ht.AssertNumTxsInMempool(1)[0]
 
 	// With the htlc timeout txns still in the mempool, we restart Alice to
 	// verify that she can resume watching the htlc txns she broadcasted
 	// before crashing.
 	ht.RestartNode(alice)
 
+	// Once restarted, Alice will offer her HTLC outputs to the sweeper
+	// again. The new sweeping tx will replace the old one. We check it by
+	// asserting the old one no longer exists in the mempool.
+	ht.AssertTxNotInMempool(htlcTxid)
+	htlcTx := ht.GetNumTxsFromMempool(1)[0]
+	htlcTxid = htlcTx.TxHash()
+
 	// Generate a block that mines the htlc timeout txns. Doing so now
 	// activates the 2nd-stage CSV delayed outputs.
 	ht.MineBlocksAndAssertNumTxes(1, 1)
+
+	// Retrieve each htlc timeout txn from the mempool, and ensure it is
+	// well-formed. The sweeping tx should spend all the htlc outputs.
+	//
+	// NOTE: We also add 1 output as the outgoing HTLC needs a wallet utxo
+	// to pay for its fee.
+	numInputs := 6 + 1
+
+	var htlcLessFees uint64
+
+	// Ensure the htlc transaction has the expected number of inputs.
+	require.Len(ht, htlcTx.TxIn, numInputs, "num inputs mismatch")
+
+	// The number of outputs should be the same.
+	require.Len(ht, htlcTx.TxOut, numInputs, "num outputs mismatch")
+
+	// Ensure all the htlc transaction inputs are spending from the
+	// commitment transaction, except if this is an extra input added to pay
+	// for fees for anchor channels.
+	for _, txIn := range htlcTx.TxIn {
+		if !closingTxID.IsEqual(&txIn.PreviousOutPoint.Hash) {
+			// This was an extra input added to pay fees,
+			// continue to the next one.
+			continue
+		}
+
+		// For each htlc timeout transaction, we expect a resolver
+		// report recording this on chain resolution for both alice and
+		// carol.
+		outpoint := txIn.PreviousOutPoint
+		resolutionOutpoint := &lnrpc.OutPoint{
+			TxidBytes:   outpoint.Hash[:],
+			TxidStr:     outpoint.Hash.String(),
+			OutputIndex: outpoint.Index,
+		}
+
+		// We expect alice to have a timeout tx resolution with an
+		// amount equal to the payment amount.
+		aliceReports[outpoint.String()] = &lnrpc.Resolution{
+			ResolutionType: lnrpc.ResolutionType_OUTGOING_HTLC,
+			Outcome:        lnrpc.ResolutionOutcome_FIRST_STAGE,
+			SweepTxid:      htlcTxid.String(),
+			Outpoint:       resolutionOutpoint,
+			AmountSat:      uint64(paymentAmt),
+		}
+
+		// We expect carol to have a resolution with an incoming htlc
+		// timeout which reflects the full amount of the htlc. It has no
+		// spend tx, because carol stops monitoring the htlc once it has
+		// timed out.
+		carolReports[outpoint.String()] = &lnrpc.Resolution{
+			ResolutionType: lnrpc.ResolutionType_INCOMING_HTLC,
+			Outcome:        lnrpc.ResolutionOutcome_TIMEOUT,
+			SweepTxid:      "",
+			Outpoint:       resolutionOutpoint,
+			AmountSat:      uint64(paymentAmt),
+		}
+	}
+
+	// We record the htlc amount less fees here, so that we know what value
+	// to expect for the second stage of our htlc resolution.
+	htlcLessFees = uint64(htlcTx.TxOut[0].Value)
 
 	// Alice is restarted here to ensure that her contract court properly
 	// handles the 2nd-stage sweeps after the htlc timeout txns were
@@ -624,22 +1174,17 @@ func runChannelForceClosureTest(ht *lntest.HarnessTest,
 
 	// Advance the chain until just before the 2nd-layer CSV delays expire.
 	// For anchor channels this is one block earlier.
-	currentHeight = int32(ht.CurrentHeight())
-	ht.Logf("current height: %v, htlcCsvMaturityHeight=%v", currentHeight,
+	curHeight = int32(ht.CurrentHeight())
+	ht.Logf("current height: %v, htlcCsvMaturityHeight=%v", curHeight,
 		htlcCsvMaturityHeight)
-	numBlocks := int(htlcCsvMaturityHeight - uint32(currentHeight) - 1)
-	ht.MineBlocks(numBlocks)
+	numBlocks := int(htlcCsvMaturityHeight - uint32(curHeight) - 1)
+	ht.MineEmptyBlocks(numBlocks)
 
-	ht.AssertNumPendingSweeps(alice, numInvoices+1)
+	ht.AssertNumPendingSweeps(alice, numInvoices)
 
-	// Restart Alice to ensure that she can recover from a failure.
-	//
-	// TODO(yy): Skip this step for neutrino as it cannot recover the
-	// sweeping txns from the mempool. We need to also store the txns in
-	// the sweeper store to make it work for the neutrino case.
-	if !ht.IsNeutrinoBackend() {
-		ht.RestartNode(alice)
-	}
+	// Fetch the htlc sweep transaction from the mempool.
+	htlcSweepTx := ht.GetNumTxsFromMempool(1)[0]
+	htlcSweepTxid := htlcSweepTx.TxHash()
 
 	// Now that the channel has been fully swept, it should no longer show
 	// incubated, check to see that Alice's node still reports the channel
@@ -657,59 +1202,14 @@ func runChannelForceClosureTest(ht *lntest.HarnessTest,
 	}, defaultTimeout)
 	require.NoError(ht, err, "timeout while checking force closed channel")
 
-	ht.AssertNumPendingSweeps(alice, numInvoices+1)
-
-	// Wait for the single sweep txn to appear in the mempool.
-	htlcSweepTxid := ht.AssertNumTxsInMempool(1)[0]
-
-	// Fetch the htlc sweep transaction from the mempool.
-	htlcSweepTx := ht.GetRawTransaction(htlcSweepTxid)
+	ht.AssertNumPendingSweeps(alice, numInvoices)
 
 	// Ensure the htlc sweep transaction only has one input for each htlc
 	// Alice extended before force closing.
-	require.Len(ht, htlcSweepTx.MsgTx().TxIn, numInvoices,
+	require.Len(ht, htlcSweepTx.TxIn, numInvoices,
 		"htlc transaction has wrong num of inputs")
-	require.Len(ht, htlcSweepTx.MsgTx().TxOut, 1,
+	require.Len(ht, htlcSweepTx.TxOut, 1,
 		"htlc sweep transaction should have one output")
-
-	// Ensure that each output spends from exactly one htlc timeout output.
-	for _, txIn := range htlcSweepTx.MsgTx().TxIn {
-		outpoint := txIn.PreviousOutPoint
-
-		// Check that the input is a confirmed htlc timeout txn.
-		_, ok := htlcTxOutpointSet[outpoint]
-		require.Truef(ht, ok, "htlc sweep output not spending from "+
-			"htlc tx, instead spending output %v", outpoint)
-
-		// Increment our count for how many times this output was spent.
-		htlcTxOutpointSet[outpoint]++
-
-		// Check that each is only spent once.
-		require.Lessf(ht, htlcTxOutpointSet[outpoint], 2,
-			"htlc sweep tx has multiple spends from "+
-				"outpoint %v", outpoint)
-
-		// Since we have now swept our htlc timeout tx, we expect to
-		// have timeout resolutions for each of our htlcs.
-		output := txIn.PreviousOutPoint
-		aliceReports[output.String()] = &lnrpc.Resolution{
-			ResolutionType: lnrpc.ResolutionType_OUTGOING_HTLC,
-			Outcome:        lnrpc.ResolutionOutcome_TIMEOUT,
-			SweepTxid:      htlcSweepTx.Hash().String(),
-			Outpoint: &lnrpc.OutPoint{
-				TxidBytes:   output.Hash[:],
-				TxidStr:     output.Hash.String(),
-				OutputIndex: output.Index,
-			},
-			AmountSat: htlcLessFees,
-		}
-	}
-
-	// Check that each HTLC output was spent exactly once.
-	for op, num := range htlcTxOutpointSet {
-		require.Equalf(ht, 1, num,
-			"HTLC outpoint:%s was spent times", op)
-	}
 
 	// Check that we can find the htlc sweep in our set of sweeps using
 	// the verbose output of the listsweeps output.
@@ -719,6 +1219,31 @@ func runChannelForceClosureTest(ht *lntest.HarnessTest,
 	// the txid of the previously broadcast htlc sweep txn, and that it
 	// begins watching that txid after restarting.
 	ht.RestartNode(alice)
+
+	// Once restarted, Alice will offer her HTLC outputs to the sweeper
+	// again. The new sweeping tx will replace the old one. We check it by
+	// asserting the old one no longer exists in the mempool.
+	ht.AssertTxNotInMempool(htlcSweepTxid)
+	htlcSweepTxid = ht.AssertNumTxsInMempool(1)[0]
+
+	// Ensure that each output spends from exactly one htlc timeout output.
+	for _, txIn := range htlcSweepTx.TxIn {
+		op := txIn.PreviousOutPoint
+
+		// Since we have now swept our htlc timeout tx, we expect to
+		// have timeout resolutions for each of our htlcs.
+		aliceReports[op.String()] = &lnrpc.Resolution{
+			ResolutionType: lnrpc.ResolutionType_OUTGOING_HTLC,
+			Outcome:        lnrpc.ResolutionOutcome_TIMEOUT,
+			SweepTxid:      htlcSweepTxid.String(),
+			Outpoint: &lnrpc.OutPoint{
+				TxidBytes:   op.Hash[:],
+				TxidStr:     op.Hash.String(),
+				OutputIndex: op.Index,
+			},
+			AmountSat: htlcLessFees,
+		}
+	}
 
 	// Now that the channel has been fully swept, it should no longer show
 	// incubated, check to see that Alice's node still reports the channel
@@ -752,6 +1277,7 @@ func runChannelForceClosureTest(ht *lntest.HarnessTest,
 	// up within the pending channels RPC.
 	err = wait.NoError(func() error {
 		ht.AssertNumPendingForceClose(alice, 0)
+
 		// In addition to there being no pending channels, we verify
 		// that pending channels does not report any money still in
 		// limbo.

--- a/itest/lnd_sweep_test.go
+++ b/itest/lnd_sweep_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
 	"github.com/lightningnetwork/lnd/lntest"
 	"github.com/lightningnetwork/lnd/lntest/node"
+	"github.com/lightningnetwork/lnd/lntest/rpc"
 	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
@@ -2080,4 +2081,256 @@ func testBumpForceCloseFee(ht *lntest.HarnessTest) {
 	// Mine both transactions, the closing tx and the anchor cpfp tx.
 	// This is needed to clean up the mempool.
 	ht.MineBlocksAndAssertNumTxes(1, 2)
+}
+
+// testFeeReplacement tests that when a sweeping txns aggregates multiple
+// outgoing HTLCs, and one of the outgoing HTLCs has been spent via the direct
+// preimage path by the remote peer, the remaining HTLCs will be grouped again
+// and swept immediately.
+//
+// Setup:
+//  1. Fund Alice with 1 UTXOs - she only needs one for the funding process,
+//  2. Fund Bob with 3 UTXOs - he needs one for the funding process, one for
+//     his CPFP anchor sweeping, and one for sweeping his outgoing HTLCs.
+//  3. Create a linear network from Alice -> Bob -> Carol.
+//  4. Alice pays two invoices to Carol, with Carol holding the settlement.
+//  5. Bob goes offline.
+//  6. Carol settles one of the invoices, so she can later spend Bob's outgoing
+//     HTLC via the direct preimage path.
+//  7. Carol goes offline and Bob comes online.
+//  8. Mine enough blocks so Bob will force close Bob=>Carol to claim his
+//     outgoing HTLCs.
+//  9. Carol comes online, sweeps one of Bob's outgoing HTLCs and it confirms.
+//  10. Bob creates a new sweeping tx to sweep his remaining HTLC with a
+//     previous fee rate.
+//
+// Test:
+//  1. Bob will immediately sweeps his remaining outgoing HTLC given that the
+//     other one has been spent by Carol.
+//  2. Bob's new sweeping tx will use the previous fee rate instead of
+//     initializing a new starting fee rate.
+func testFeeReplacement(ht *lntest.HarnessTest) {
+	// Set the min relay feerate to be 10 sat/vbyte so the non-CPFP anchor
+	// is never swept.
+	//
+	// TODO(yy): delete this line once the normal anchor sweeping is
+	// removed.
+	ht.SetMinRelayFeerate(10_000)
+
+	// Setup testing params.
+	//
+	// Invoice is 100k sats.
+	invoiceAmt := btcutil.Amount(100_000)
+
+	// Alice will send two payments.
+	numPayments := 2
+
+	// Use the smallest CLTV so we can mine fewer blocks.
+	cltvDelta := routing.MinCLTVDelta
+
+	// Prepare params.
+	cfg := []string{
+		"--protocol.anchors",
+		// Use a small CLTV to mine less blocks.
+		fmt.Sprintf("--bitcoin.timelockdelta=%d", cltvDelta),
+		// Use a very large CSV, this way to_local outputs are never
+		// swept so we can focus on testing HTLCs.
+		fmt.Sprintf("--bitcoin.defaultremotedelay=%v", cltvDelta*10),
+	}
+	cfgs := [][]string{cfg, cfg, cfg}
+
+	openChannelParams := lntest.OpenChannelParams{
+		Amt: invoiceAmt * 100,
+	}
+
+	// Create a three hop network: Alice -> Bob -> Carol.
+	_, nodes := ht.CreateSimpleNetwork(cfgs, openChannelParams)
+
+	// Unwrap the results.
+	alice, bob, carol := nodes[0], nodes[1], nodes[2]
+
+	// Bob needs two more wallet utxos:
+	// - when sweeping anchors, he needs one utxo for each sweep.
+	// - when sweeping HTLCs, he needs one utxo for each sweep.
+	numUTXOs := 2
+
+	// Bob should have enough wallet UTXOs here to sweep the HTLC in the
+	// end of this test. However, due to a known issue, Bob's wallet may
+	// report there's no UTXO available. For details,
+	// - https://github.com/lightningnetwork/lnd/issues/8786
+	//
+	// TODO(yy): remove this extra UTXO once the issue is resolved.
+	numUTXOs++
+
+	// For neutrino backend, we need two more UTXOs for Bob to create his
+	// sweeping txns.
+	if ht.IsNeutrinoBackend() {
+		numUTXOs += 2
+	}
+
+	ht.FundNumCoins(bob, numUTXOs)
+
+	// We also give Carol 2 coins to create her sweeping txns.
+	ht.FundNumCoins(carol, 2)
+
+	// Create numPayments HTLCs on Bob's incoming and outgoing channels.
+	preimages := make([][]byte, 0, numPayments)
+	streams := make([]rpc.SingleInvoiceClient, 0, numPayments)
+	for i := 0; i < numPayments; i++ {
+		// Create the preimage.
+		var preimage lntypes.Preimage
+		copy(preimage[:], ht.Random32Bytes())
+		payHashHold := preimage.Hash()
+		preimages = append(preimages, preimage[:])
+
+		// Subscribe the invoices.
+		stream := carol.RPC.SubscribeSingleInvoice(payHashHold[:])
+		streams = append(streams, stream)
+
+		// Carol create the hold invoice.
+		invoiceReqHold := &invoicesrpc.AddHoldInvoiceRequest{
+			Value:      int64(invoiceAmt),
+			CltvExpiry: finalCltvDelta,
+			Hash:       payHashHold[:],
+		}
+		invoiceHold := carol.RPC.AddHoldInvoice(invoiceReqHold)
+
+		// Let Alice pay the invoices.
+		req := &routerrpc.SendPaymentRequest{
+			PaymentRequest: invoiceHold.PaymentRequest,
+			TimeoutSeconds: 60,
+			FeeLimitMsat:   noFeeLimitMsat,
+		}
+
+		// Assert the payments are inflight.
+		ht.SendPaymentAndAssertStatus(
+			alice, req, lnrpc.Payment_IN_FLIGHT,
+		)
+
+		// Wait for Carol to mark invoice as accepted. There is a small
+		// gap to bridge between adding the htlc to the channel and
+		// executing the exit hop logic.
+		ht.AssertInvoiceState(stream, lnrpc.Invoice_ACCEPTED)
+	}
+
+	// At this point, all 3 nodes should now have an active channel with
+	// the created HTLCs pending on all of them.
+	//
+	// Alice should have numPayments outgoing HTLCs on channel Alice -> Bob.
+	ht.AssertNumActiveHtlcs(alice, numPayments)
+
+	// Bob should have 2 * numPayments HTLCs,
+	// - numPayments incoming HTLCs on channel Alice -> Bob.
+	// - numPayments outgoing HTLCs on channel Bob -> Carol.
+	ht.AssertNumActiveHtlcs(bob, numPayments*2)
+
+	// Carol should have numPayments incoming HTLCs on channel Bob -> Carol.
+	ht.AssertNumActiveHtlcs(carol, numPayments)
+
+	// Suspend Bob so he won't get the preimage from Carol.
+	restartBob := ht.SuspendNode(bob)
+
+	// Carol settles the first invoice.
+	carol.RPC.SettleInvoice(preimages[0])
+	ht.AssertInvoiceState(streams[0], lnrpc.Invoice_SETTLED)
+
+	// Carol goes offline so the preimage won't be sent to Bob.
+	restartCarol := ht.SuspendNode(carol)
+
+	// Bob comes online.
+	require.NoError(ht, restartBob())
+
+	// We'll now mine enough blocks to trigger Bob to force close channel
+	// Bob->Carol due to his outgoing HTLC is about to timeout. With the
+	// default outgoing broadcast delta of zero, this will be the same
+	// height as the outgoing htlc's expiry height.
+	numBlocks := padCLTV(uint32(
+		finalCltvDelta - lncfg.DefaultOutgoingBroadcastDelta,
+	))
+	ht.MineEmptyBlocks(int(numBlocks))
+
+	// Assert Bob's force closing tx has been broadcast. We should see two
+	// txns in the mempool:
+	// 1. Bob's force closing tx.
+	// 2. Bob's anchor sweeping tx CPFPing the force close tx.
+	ht.AssertForceCloseAndAnchorTxnsInMempool()
+
+	// Mine a block to confirm Bob's force close tx and anchor sweeping tx
+	// so we can focus on testing his outgoing HTLCs.
+	ht.MineBlocksAndAssertNumTxes(1, 2)
+
+	// Bob should have numPayments pending sweep for the outgoing HTLCs.
+	ht.AssertNumPendingSweeps(bob, numPayments)
+
+	// Bob should have one sweeping tx in the mempool, which sweeps all his
+	// outgoing HTLCs.
+	outgoingSweep0 := ht.GetNumTxsFromMempool(1)[0]
+
+	// We now mine one empty block so Bob will perform one fee bump, after
+	// which his sweeping tx should be updated with a new fee rate. We do
+	// this so we can test later when Bob sweeps his remaining HTLC, the new
+	// sweeping tx will start with the current fee rate.
+	//
+	// Calculate Bob's initial sweeping fee rate.
+	initialFeeRate := ht.CalculateTxFeeRate(outgoingSweep0)
+
+	// Mine one block to trigger Bob's RBF.
+	ht.MineEmptyBlocks(1)
+
+	// Make sure Bob's old sweeping tx has been removed from the mempool.
+	ht.AssertTxNotInMempool(outgoingSweep0.TxHash())
+
+	// Get the feerate of Bob's current sweeping tx.
+	outgoingSweep1 := ht.GetNumTxsFromMempool(1)[0]
+	currentFeeRate := ht.CalculateTxFeeRate(outgoingSweep1)
+
+	// Assert the Bob has updated the fee rate.
+	require.Greater(ht, currentFeeRate, initialFeeRate)
+
+	delta := currentFeeRate - initialFeeRate
+
+	// Check the shape of the sweeping tx - we expect it to be
+	// 3-input-3-output as a wallet utxo is used and a required output is
+	// made.
+	require.Len(ht, outgoingSweep1.TxIn, numPayments+1)
+	require.Len(ht, outgoingSweep1.TxOut, numPayments+1)
+
+	// Restart Carol, once she is online, she will try to settle the HTLCs
+	// via the direct preimage spend.
+	require.NoError(ht, restartCarol())
+
+	// Carol should have 1 incoming HTLC and 1 anchor output to sweep.
+	ht.AssertNumPendingSweeps(carol, 2)
+
+	// Assert Bob's sweeping tx has been replaced by Carol's.
+	ht.AssertTxNotInMempool(outgoingSweep1.TxHash())
+	carolSweepTx := ht.GetNumTxsFromMempool(1)[0]
+
+	// Assume the miner is now happy with Carol's fee, and it gets included
+	// in the next block.
+	ht.MineBlockWithTx(carolSweepTx)
+
+	// Upon receiving the above block, Bob should immediately create a
+	// sweeping tx and broadcast it using the remaining outgoing HTLC.
+	//
+	// Bob should have numPayments-1 pending sweep for the outgoing HTLCs.
+	ht.AssertNumPendingSweeps(bob, numPayments-1)
+
+	// Assert Bob immediately sweeps his remaining HTLC with the previous
+	// fee rate.
+	outgoingSweep2 := ht.GetNumTxsFromMempool(1)[0]
+
+	// Calculate the fee rate.
+	feeRate := ht.CalculateTxFeeRate(outgoingSweep2)
+
+	// We expect the current fee rate to be equal to the last fee rate he
+	// used plus the delta, as we expect the fee rate to stay on the initial
+	// line given by his fee function.
+	expectedFeeRate := currentFeeRate + delta
+	require.InEpsilonf(ht, uint64(expectedFeeRate),
+		uint64(feeRate), 0.02, "want %d, got %d in tx=%v",
+		currentFeeRate, feeRate, outgoingSweep2.TxHash())
+
+	// Finally, clean the mempol.
+	ht.MineBlocksAndAssertNumTxes(1, 1)
 }

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -1172,6 +1172,19 @@ func (t *TxPublisher) handleUnknownSpent(r *monitorRecord) {
 
 	// Create a result that will be sent to the resultChan which is listened
 	// by the caller.
+	result := t.createUnknownSpentBumpResult(r)
+
+	// Notify the sweeper about this result in the end.
+	t.handleResult(result)
+}
+
+// createUnknownSpentBumpResult creates and returns a BumpResult given the
+// monitored record has unknown spends.
+func (t *TxPublisher) createUnknownSpentBumpResult(
+	r *monitorRecord) *BumpResult {
+
+	// Create a result that will be sent to the resultChan which is listened
+	// by the caller.
 	result := &BumpResult{
 		Event:       TxUnknownSpend,
 		Tx:          r.tx,
@@ -1208,10 +1221,7 @@ func (t *TxPublisher) handleUnknownSpent(r *monitorRecord) {
 			result.Event = TxFatal
 			result.Err = err
 
-			// Notify the sweeper about this result in the end.
-			t.handleResult(result)
-
-			return
+			return result
 		}
 
 		feeFunc = f
@@ -1234,8 +1244,7 @@ func (t *TxPublisher) handleUnknownSpent(r *monitorRecord) {
 	// Attach the new fee rate to be used for the next sweeping attempt.
 	result.FeeRate = feeFunc.FeeRate()
 
-	// Notify the sweeper about this result in the end.
-	t.handleResult(result)
+	return result
 }
 
 // createAndPublishTx creates a new tx with a higher fee rate and publishes it

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -40,9 +40,9 @@ var (
 	// preparation, usually due to the output being dust.
 	ErrTxNoOutput = errors.New("tx has no output")
 
-	// ErrThirdPartySpent is returned when a third party has spent the
-	// input in the sweeping tx.
-	ErrThirdPartySpent = errors.New("third party spent the output")
+	// ErrUnknownSpent is returned when an unknown tx has spent an input in
+	// the sweeping tx.
+	ErrUnknownSpent = errors.New("unknown spend of input")
 )
 
 var (
@@ -80,10 +80,6 @@ const (
 	// during its creation or broadcast, or an internal error from the fee
 	// bumper. In either case the inputs in this tx should be retried with
 	// either a different grouping strategy or an increased budget.
-	//
-	// NOTE: We also send this event when there's a third party spend
-	// event, and the sweeper will handle cleaning this up once it's
-	// confirmed.
 	//
 	// TODO(yy): Remove the above usage once we remove sweeping non-CPFP
 	// anchors.
@@ -929,7 +925,7 @@ func (t *TxPublisher) processRecords() {
 
 			// Check whether the inputs has been spent by a unknown
 			// tx.
-			if t.isThirdPartySpent(r, spends) {
+			if t.isUnknownSpent(r, spends) {
 				failedRecords[requestID] = r
 
 				// Move to the next record.
@@ -989,7 +985,7 @@ func (t *TxPublisher) processRecords() {
 	// result.
 	for _, r := range failedRecords {
 		t.wg.Add(1)
-		go t.handleThirdPartySpent(r)
+		go t.handleUnknownSpent(r)
 	}
 }
 
@@ -1151,12 +1147,12 @@ func (t *TxPublisher) handleFeeBumpTx(r *monitorRecord, currentHeight int32) {
 	})
 }
 
-// handleThirdPartySpent is called when the inputs in an unconfirmed tx is
-// spent. It will notify the subscriber then remove the record from the maps
-// and send a TxFailed event to the subscriber.
+// handleUnknownSpent is called when the inputs are spent by a unknown tx. It
+// will notify the subscriber then remove the record from the maps and send a
+// TxUnknownSpend event to the subscriber.
 //
 // NOTE: Must be run as a goroutine to avoid blocking on sending the result.
-func (t *TxPublisher) handleThirdPartySpent(r *monitorRecord) {
+func (t *TxPublisher) handleUnknownSpent(r *monitorRecord) {
 	defer t.wg.Done()
 
 	log.Debugf("Record %v has inputs spent by a tx unknown to the fee "+
@@ -1169,7 +1165,7 @@ func (t *TxPublisher) handleThirdPartySpent(r *monitorRecord) {
 		Event:     TxUnknownSpend,
 		Tx:        r.tx,
 		requestID: r.requestID,
-		Err:       ErrThirdPartySpent,
+		Err:       ErrUnknownSpent,
 	}
 
 	// Notify that this tx is confirmed and remove the record from the map.
@@ -1277,10 +1273,11 @@ func (t *TxPublisher) createAndPublishTx(
 	return fn.Some(*result)
 }
 
-// isThirdPartySpent checks whether the inputs of the tx has already been spent
-// by a third party. When a tx is not confirmed, yet its inputs has been spent,
-// then it must be spent by a different tx other than the sweeping tx here.
-func (t *TxPublisher) isThirdPartySpent(r *monitorRecord,
+// isUnknownSpent checks whether the inputs of the tx has already been spent by
+// a tx not known to us. When a tx is not confirmed, yet its inputs has been
+// spent, then it must be spent by a different tx other than the sweeping tx
+// here.
+func (t *TxPublisher) isUnknownSpent(r *monitorRecord,
 	spends map[wire.OutPoint]*wire.MsgTx) bool {
 
 	txid := r.tx.TxHash()
@@ -1290,14 +1287,14 @@ func (t *TxPublisher) isThirdPartySpent(r *monitorRecord,
 	for op, spendingTx := range spends {
 		spendingTxID := spendingTx.TxHash()
 
-		// If the spending tx is the same as the sweeping tx
-		// then we are good.
+		// If the spending tx is the same as the sweeping tx then we are
+		// good.
 		if spendingTxID == txid {
 			continue
 		}
 
-		log.Warnf("Detected third party spent of output=%v "+
-			"in tx=%v", op, spendingTx.TxHash())
+		log.Warnf("Detected unknown spend of input=%v in tx=%v", op,
+			spendingTx.TxHash())
 
 		return true
 	}

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -1356,7 +1356,9 @@ func (t *TxPublisher) createAndPublishTx(
 	if errors.Is(result.Err, chain.ErrInsufficientFee) ||
 		errors.Is(result.Err, lnwallet.ErrMempoolFee) {
 
-		log.Debugf("Failed to bump tx %v: %v", oldTx.TxHash(), err)
+		log.Debugf("Failed to bump tx %v: %v", oldTx.TxHash(),
+			result.Err)
+
 		return fn.None[BumpResult]()
 	}
 

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -95,6 +95,17 @@ const (
 	// TxConfirmed is sent when the tx is confirmed.
 	TxConfirmed
 
+	// TxUnknownSpend is sent when at least one of the inputs is spent but
+	// not by the current sweeping tx, this can happen when,
+	// - a remote party has replaced our sweeping tx by spending the
+	//   input(s), e.g., via the direct preimage spend on our outgoing HTLC.
+	// - a third party has replaced our sweeping tx, e.g., the anchor output
+	//   after 16 blocks.
+	// - A previous sweeping tx has confirmed but the fee bumper is not
+	//   aware of it, e.g., a restart happens right after the sweeping tx is
+	//   broadcast and confirmed.
+	TxUnknownSpend
+
 	// TxFatal is sent when the inputs in this tx cannot be retried. Txns
 	// will end up in this state if they have encountered a non-fee related
 	// error, which means they cannot be retried with increased budget.
@@ -115,6 +126,8 @@ func (e BumpEvent) String() string {
 		return "Replaced"
 	case TxConfirmed:
 		return "Confirmed"
+	case TxUnknownSpend:
+		return "UnknownSpend"
 	case TxFatal:
 		return "Fatal"
 	default:
@@ -280,7 +293,8 @@ func (b *BumpResult) String() string {
 
 // Validate validates the BumpResult so it's safe to use.
 func (b *BumpResult) Validate() error {
-	isFailureEvent := b.Event == TxFailed || b.Event == TxFatal
+	isFailureEvent := b.Event == TxFailed || b.Event == TxFatal ||
+		b.Event == TxUnknownSpend
 
 	// Every result must have a tx except the fatal or failed case.
 	if b.Tx == nil && !isFailureEvent {
@@ -754,6 +768,11 @@ func (t *TxPublisher) removeResult(result *BumpResult) {
 		log.Debugf("Removing monitor record=%v due to fatal err: %v",
 			id, result.Err)
 
+	case TxUnknownSpend:
+		// Remove the record if there's an unknown spend.
+		log.Debugf("Removing monitor record=%v due unknown spent: "+
+			"%v", id, result.Err)
+
 	// Do nothing if it's neither failed or confirmed.
 	default:
 		log.Tracef("Skipping record removal for id=%v, event=%v", id,
@@ -1120,12 +1139,8 @@ func (t *TxPublisher) handleThirdPartySpent(r *monitorRecord) {
 
 	// Create a result that will be sent to the resultChan which is
 	// listened by the caller.
-	//
-	// TODO(yy): create a new state `TxThirdPartySpent` to notify the
-	// sweeper to remove the input, hence moving the monitoring of inputs
-	// spent inside the fee bumper.
 	result := &BumpResult{
-		Event:     TxFailed,
+		Event:     TxUnknownSpend,
 		Tx:        r.tx,
 		requestID: r.requestID,
 		Err:       ErrThirdPartySpent,

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -897,8 +897,6 @@ func (t *TxPublisher) processRecords() {
 
 	// failedRecords stores a map of records which has inputs being spent
 	// by a third party.
-	//
-	// NOTE: this is only used for neutrino backend.
 	failedRecords := make(map[uint64]*monitorRecord)
 
 	// initialRecords stores a map of records which are being created and
@@ -908,32 +906,55 @@ func (t *TxPublisher) processRecords() {
 	// visitor is a helper closure that visits each record and divides them
 	// into two groups.
 	visitor := func(requestID uint64, r *monitorRecord) error {
-		if r.tx == nil {
-			initialRecords[requestID] = r
-			return nil
-		}
+		log.Tracef("Checking monitor recordID=%v", requestID)
 
-		log.Tracef("Checking monitor recordID=%v for tx=%v", requestID,
-			r.tx.TxHash())
+		// Check whether the inputs have already been spent.
+		spends := t.getSpentInputs(r)
 
-		// If the tx is already confirmed, we can stop monitoring it.
-		if t.isConfirmed(r.tx.TxHash()) {
+		// If the any of the inputs has been spent, the record will be
+		// marked as failed or confirmed.
+		if len(spends) != 0 {
+			// When tx is nil, it means we haven't tried the initial
+			// broadcast yet the input is already spent. This could
+			// happen when the node shuts down, a previous sweeping
+			// tx confirmed, then the node comes back online and
+			// reoffers the inputs. Another case is the remote node
+			// spends the input quickly before we even attempt the
+			// sweep. In either case we will fail the record and let
+			// the sweeper handles it.
+			if r.tx == nil {
+				failedRecords[requestID] = r
+				return nil
+			}
+
+			// Check whether the inputs has been spent by a unknown
+			// tx.
+			if t.isThirdPartySpent(r, spends) {
+				failedRecords[requestID] = r
+
+				// Move to the next record.
+				return nil
+			}
+
+			// The tx is ours, we can move it to the confirmed queue
+			// and stop monitoring it.
 			confirmedRecords[requestID] = r
 
 			// Move to the next record.
 			return nil
 		}
 
-		// Check whether the inputs has been spent by a third party.
-		//
-		// NOTE: this check is only done for neutrino backend.
-		if t.isThirdPartySpent(r) {
-			failedRecords[requestID] = r
+		// This is the first time we see this record, so we put it in
+		// the initial queue.
+		if r.tx == nil {
+			initialRecords[requestID] = r
 
-			// Move to the next record.
 			return nil
 		}
 
+		// We can only get here when the inputs are not spent and a
+		// previous sweeping tx has been attempted. In this case we will
+		// perform an RBF on it in the current block.
 		feeBumpRecords[requestID] = r
 
 		// Return nil to move to the next record.
@@ -1265,17 +1286,10 @@ func (t *TxPublisher) isConfirmed(txid chainhash.Hash) bool {
 // isThirdPartySpent checks whether the inputs of the tx has already been spent
 // by a third party. When a tx is not confirmed, yet its inputs has been spent,
 // then it must be spent by a different tx other than the sweeping tx here.
-//
-// NOTE: this check is only performed for neutrino backend as it has no
-// reliable way to tell a tx has been replaced.
-func (t *TxPublisher) isThirdPartySpent(r *monitorRecord) bool {
-	// Skip this check for if this is not neutrino backend.
-	if !t.isNeutrinoBackend() {
-		return false
-	}
+func (t *TxPublisher) isThirdPartySpent(r *monitorRecord,
+	spends map[wire.OutPoint]*wire.MsgTx) bool {
 
 	txid := r.tx.TxHash()
-	spends := t.getSpentInputs(r)
 
 	// Iterate all the spending txns and check if they match the sweeping
 	// tx.

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -908,7 +908,7 @@ func (t *TxPublisher) processRecords() {
 		// Check whether the inputs has been spent by a third party.
 		//
 		// NOTE: this check is only done for neutrino backend.
-		if t.isThirdPartySpent(r.tx.TxHash(), r.req.Inputs) {
+		if t.isThirdPartySpent(r) {
 			failedRecords[requestID] = r
 
 			// Move to the next record.
@@ -1253,26 +1253,59 @@ func (t *TxPublisher) isConfirmed(txid chainhash.Hash) bool {
 //
 // NOTE: this check is only performed for neutrino backend as it has no
 // reliable way to tell a tx has been replaced.
-func (t *TxPublisher) isThirdPartySpent(txid chainhash.Hash,
-	inputs []input.Input) bool {
-
+func (t *TxPublisher) isThirdPartySpent(r *monitorRecord) bool {
 	// Skip this check for if this is not neutrino backend.
 	if !t.isNeutrinoBackend() {
 		return false
 	}
 
+	txid := r.tx.TxHash()
+	spends := t.getSpentInputs(r)
+
+	// Iterate all the spending txns and check if they match the sweeping
+	// tx.
+	for op, spendingTx := range spends {
+		spendingTxID := spendingTx.TxHash()
+
+		// If the spending tx is the same as the sweeping tx
+		// then we are good.
+		if spendingTxID == txid {
+			continue
+		}
+
+		log.Warnf("Detected third party spent of output=%v "+
+			"in tx=%v", op, spendingTx.TxHash())
+
+		return true
+	}
+
+	return false
+}
+
+// getSpentInputs performs a non-blocking read on the spending subscriptions to
+// see whether any of the monitored inputs has been spent. A map of inputs with
+// their spending txns are returned if found.
+func (t *TxPublisher) getSpentInputs(
+	r *monitorRecord) map[wire.OutPoint]*wire.MsgTx {
+
+	// Create a slice to record the inputs spent.
+	spentInputs := make(map[wire.OutPoint]*wire.MsgTx, len(r.req.Inputs))
+
 	// Iterate all the inputs and check if they have been spent already.
-	for _, inp := range inputs {
+	for _, inp := range r.req.Inputs {
 		op := inp.OutPoint()
 
 		// For wallet utxos, the height hint is not set - we don't need
 		// to monitor them for third party spend.
+		//
+		// TODO(yy): We need to properly lock wallet utxos before
+		// skipping this check as the same wallet utxo can be used by
+		// different sweeping txns.
 		heightHint := inp.HeightHint()
 		if heightHint == 0 {
-			log.Debugf("Skipped third party check for wallet "+
-				"input %v", op)
-
-			continue
+			heightHint = uint32(t.currentHeight.Load())
+			log.Debugf("Checking wallet input %v using heightHint "+
+				"%v", op, heightHint)
 		}
 
 		// If the input has already been spent after the height hint, a
@@ -1283,7 +1316,8 @@ func (t *TxPublisher) isThirdPartySpent(txid chainhash.Hash,
 		if err != nil {
 			log.Criticalf("Failed to register spend ntfn for "+
 				"input=%v: %v", op, err)
-			return false
+
+			return nil
 		}
 
 		// Remove the subscription when exit.
@@ -1294,28 +1328,24 @@ func (t *TxPublisher) isThirdPartySpent(txid chainhash.Hash,
 		case spend, ok := <-spendEvent.Spend:
 			if !ok {
 				log.Debugf("Spend ntfn for %v canceled", op)
-				return false
-			}
 
-			spendingTxID := spend.SpendingTx.TxHash()
-
-			// If the spending tx is the same as the sweeping tx
-			// then we are good.
-			if spendingTxID == txid {
 				continue
 			}
 
-			log.Warnf("Detected third party spent of output=%v "+
-				"in tx=%v", op, spend.SpendingTx.TxHash())
+			spendingTx := spend.SpendingTx
 
-			return true
+			log.Debugf("Detected spent of input=%v in tx=%v", op,
+				spendingTx.TxHash())
+
+			spentInputs[op] = spendingTx
 
 		// Move to the next input.
 		default:
+			log.Tracef("Input %v not spent yet", op)
 		}
 	}
 
-	return false
+	return spentInputs
 }
 
 // calcCurrentConfTarget calculates the current confirmation target based on

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -504,9 +504,14 @@ func TestCreateAndCheckTx(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 
+		r := &monitorRecord{
+			req:         tc.req,
+			feeFunction: m.feeFunc,
+		}
+
 		t.Run(tc.name, func(t *testing.T) {
 			// Call the method under test.
-			_, err := tp.createAndCheckTx(tc.req, m.feeFunc)
+			_, err := tp.createAndCheckTx(r)
 
 			// Check the result is as expected.
 			require.ErrorIs(t, err, tc.expectedErr)

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -1597,7 +1597,7 @@ func TestProcessRecordsInitialSpent(t *testing.T) {
 		require.Nil(t, result.ReplacedTx)
 
 		// The error should be set.
-		require.ErrorIs(t, result.Err, ErrThirdPartySpent)
+		require.ErrorIs(t, result.Err, ErrUnknownSpent)
 		require.Equal(t, requestID, result.requestID)
 	}
 }
@@ -1786,7 +1786,7 @@ func TestProcessRecordsSpent(t *testing.T) {
 		require.Equal(t, tx, result.Tx)
 
 		// No error should be set.
-		require.ErrorIs(t, result.Err, ErrThirdPartySpent)
+		require.ErrorIs(t, result.Err, ErrUnknownSpent)
 		require.Equal(t, requestID, result.requestID)
 	}
 }

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -55,7 +55,7 @@ func createTestInput(value int64,
 				PubKey: testPubKey,
 			},
 		},
-		0,
+		1,
 		nil,
 	)
 
@@ -1775,4 +1775,127 @@ func TestHandleInitialBroadcastFail(t *testing.T) {
 	// Validate the record was removed.
 	require.Equal(t, 0, tp.records.Len())
 	require.Equal(t, 0, tp.subscriberChans.Len())
+}
+
+// TestHasInputsSpent checks the expected outpoint:tx map is returned.
+func TestHasInputsSpent(t *testing.T) {
+	t.Parallel()
+
+	// Create a publisher using the mocks.
+	tp, m := createTestPublisher(t)
+
+	// Create mock inputs.
+	op1 := wire.OutPoint{
+		Hash:  chainhash.Hash{1},
+		Index: 1,
+	}
+	inp1 := &input.MockInput{}
+	heightHint1 := uint32(1)
+	defer inp1.AssertExpectations(t)
+
+	op2 := wire.OutPoint{
+		Hash:  chainhash.Hash{1},
+		Index: 2,
+	}
+	inp2 := &input.MockInput{}
+	heightHint2 := uint32(2)
+	defer inp2.AssertExpectations(t)
+
+	op3 := wire.OutPoint{
+		Hash:  chainhash.Hash{1},
+		Index: 3,
+	}
+	walletInp := &input.MockInput{}
+	heightHint3 := uint32(0)
+	defer walletInp.AssertExpectations(t)
+
+	// We expect all the inputs to call OutPoint and HeightHint.
+	inp1.On("OutPoint").Return(op1).Once()
+	inp2.On("OutPoint").Return(op2).Once()
+	walletInp.On("OutPoint").Return(op3).Once()
+	inp1.On("HeightHint").Return(heightHint1).Once()
+	inp2.On("HeightHint").Return(heightHint2).Once()
+	walletInp.On("HeightHint").Return(heightHint3).Once()
+
+	// We expect the normal inputs to call SignDesc.
+	pkScript1 := []byte{1}
+	sd1 := &input.SignDescriptor{
+		Output: &wire.TxOut{
+			PkScript: pkScript1,
+		},
+	}
+	inp1.On("SignDesc").Return(sd1).Once()
+
+	pkScript2 := []byte{1}
+	sd2 := &input.SignDescriptor{
+		Output: &wire.TxOut{
+			PkScript: pkScript2,
+		},
+	}
+	inp2.On("SignDesc").Return(sd2).Once()
+
+	pkScript3 := []byte{3}
+	sd3 := &input.SignDescriptor{
+		Output: &wire.TxOut{
+			PkScript: pkScript3,
+		},
+	}
+	walletInp.On("SignDesc").Return(sd3).Once()
+
+	// Mock RegisterSpendNtfn.
+	//
+	// spendingTx1 is the tx spending op1.
+	spendingTx1 := &wire.MsgTx{}
+	se1 := createTestSpendEvent(spendingTx1)
+	m.notifier.On("RegisterSpendNtfn",
+		&op1, pkScript1, heightHint1).Return(se1, nil).Once()
+
+	// Create the spending event that doesn't send an event.
+	se2 := &chainntnfs.SpendEvent{
+		Cancel: func() {},
+	}
+	m.notifier.On("RegisterSpendNtfn",
+		&op2, pkScript2, heightHint2).Return(se2, nil).Once()
+
+	se3 := &chainntnfs.SpendEvent{
+		Cancel: func() {},
+	}
+	m.notifier.On("RegisterSpendNtfn",
+		&op3, pkScript3, heightHint3).Return(se3, nil).Once()
+
+	// Prepare the test inputs.
+	inputs := []input.Input{inp1, inp2, walletInp}
+
+	// Prepare the test record.
+	record := &monitorRecord{
+		req: &BumpRequest{
+			Inputs: inputs,
+		},
+	}
+
+	// Call the method under test.
+	result := tp.getSpentInputs(record)
+
+	// Assert the expected map is created.
+	expected := map[wire.OutPoint]*wire.MsgTx{
+		op1: spendingTx1,
+	}
+	require.Equal(t, expected, result)
+}
+
+// createTestSpendEvent creates a SpendEvent which places the specified tx in
+// the channel, which can be read by a spending subscriber.
+func createTestSpendEvent(tx *wire.MsgTx) *chainntnfs.SpendEvent {
+	// Create a monitor record that's confirmed.
+	spendDetails := chainntnfs.SpendDetail{
+		SpendingTx: tx,
+	}
+	spendChan1 := make(chan *chainntnfs.SpendDetail, 1)
+	spendChan1 <- &spendDetails
+
+	// Create the spend events.
+	return &chainntnfs.SpendEvent{
+		Spend:  spendChan1,
+		Cancel: func() {},
+	}
 }

--- a/sweep/mock_test.go
+++ b/sweep/mock_test.go
@@ -24,10 +24,10 @@ func NewMockSweeperStore() *MockSweeperStore {
 }
 
 // IsOurTx determines whether a tx is published by us, based on its hash.
-func (s *MockSweeperStore) IsOurTx(hash chainhash.Hash) (bool, error) {
+func (s *MockSweeperStore) IsOurTx(hash chainhash.Hash) bool {
 	args := s.Called(hash)
 
-	return args.Bool(0), args.Error(1)
+	return args.Bool(0)
 }
 
 // StoreTx stores a tx we are about to publish.

--- a/sweep/store_test.go
+++ b/sweep/store_test.go
@@ -57,18 +57,15 @@ func TestStore(t *testing.T) {
 	require.NoError(t, err)
 
 	// Assert that both txes are recognized as our own.
-	ours, err := store.IsOurTx(tx1.TxHash())
-	require.NoError(t, err)
+	ours := store.IsOurTx(tx1.TxHash())
 	require.True(t, ours, "expected tx to be ours")
 
-	ours, err = store.IsOurTx(tx2.TxHash())
-	require.NoError(t, err)
+	ours = store.IsOurTx(tx2.TxHash())
 	require.True(t, ours, "expected tx to be ours")
 
 	// An different hash should be reported as not being ours.
 	var unknownHash chainhash.Hash
-	ours, err = store.IsOurTx(unknownHash)
-	require.NoError(t, err)
+	ours = store.IsOurTx(unknownHash)
 	require.False(t, ours, "expected tx to not be ours")
 
 	txns, err := store.ListSweeps()

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1847,6 +1847,12 @@ func (s *UtxoSweeper) handleBumpEvent(r *bumpResp) error {
 	case TxReplaced:
 		return s.handleBumpEventTxReplaced(r)
 
+	// There are inputs being spent in a tx which the fee bumper doesn't
+	// understand. We will remove the tx from the sweeper db and mark the
+	// inputs as swept.
+	case TxUnknownSpend:
+		s.handleBumpEventTxUnknownSpend(r)
+
 	// There's a fatal error in creating the tx, we will remove the tx from
 	// the sweeper db and mark the inputs as failed.
 	case TxFatal:
@@ -1877,4 +1883,142 @@ func (s *UtxoSweeper) IsSweeperOutpoint(op wire.OutPoint) bool {
 	}
 
 	return found
+}
+
+// markInputSwept marks the given input as swept by the tx. It will also notify
+// all the subscribers of this input.
+func (s *UtxoSweeper) markInputSwept(inp *SweeperInput, tx *wire.MsgTx) {
+	log.Debugf("Marking input as swept: %v from state=%v", inp.OutPoint(),
+		inp.state)
+
+	inp.state = Swept
+
+	// Signal result channels.
+	s.signalResult(inp, Result{
+		Tx: tx,
+	})
+
+	// Remove all other inputs in this exclusive group.
+	if inp.params.ExclusiveGroup != nil {
+		s.removeExclusiveGroup(*inp.params.ExclusiveGroup)
+	}
+}
+
+// handleUnknownSpendTx takes an input and its spending tx. If the spending tx
+// cannot be found in the sweeper store, the input will be marked as fatal,
+// otherwise it will be marked as swept.
+func (s *UtxoSweeper) handleUnknownSpendTx(inp *SweeperInput, tx *wire.MsgTx) {
+	op := inp.OutPoint()
+	txid := tx.TxHash()
+
+	isOurTx, err := s.cfg.Store.IsOurTx(txid)
+	if err != nil {
+		log.Errorf("Cannot determine if tx %v is ours: %v", txid, err)
+		return
+	}
+
+	// If this is our tx, it means it's a previous sweeping tx that got
+	// confirmed, which could happen when a restart happens during the
+	// sweeping process.
+	if isOurTx {
+		log.Debugf("Found our sweeping tx %v, marking input %v as "+
+			"swept", txid, op)
+
+		// We now use the spending tx to update the state of the inputs.
+		s.markInputSwept(inp, tx)
+
+		return
+	}
+
+	// Since the input is spent by others, we now mark it as fatal and won't
+	// be retried.
+	s.markInputFatal(inp, ErrRemoteSpend)
+
+	log.Debugf("Removing descendant txns invalidated by (txid=%v): %v",
+		txid, lnutils.SpewLogClosure(tx))
+
+	// Construct a map of the inputs this transaction spends.
+	spentInputs := make(map[wire.OutPoint]struct{}, len(tx.TxIn))
+	for _, txIn := range tx.TxIn {
+		spentInputs[txIn.PreviousOutPoint] = struct{}{}
+	}
+
+	err = s.removeConflictSweepDescendants(spentInputs)
+	if err != nil {
+		log.Warnf("unable to remove descendant transactions "+
+			"due to tx %v: ", txid)
+	}
+}
+
+// handleBumpEventTxUnknownSpend handles the case where the confirmed tx is
+// unknown to the fee bumper. In the case when the sweeping tx has been replaced
+// by another party with their tx being confirmed. It will retry sweeping the
+// "good" inputs once the "bad" ones are kicked out.
+func (s *UtxoSweeper) handleBumpEventTxUnknownSpend(r *bumpResp) {
+	// Mark the inputs as publish failed, which means they will be retried
+	// later.
+	s.markInputsPublishFailed(r.set)
+
+	// Get all the inputs that are not spent in the current sweeping tx.
+	spentInputs := r.result.SpentInputs
+
+	// Create a slice to track inputs to be retried.
+	inputsToRetry := make([]input.Input, 0, len(r.set.Inputs()))
+
+	// Iterate all the inputs found in this bump and mark the ones spent by
+	// the third party as failed. The rest of inputs will then be updated
+	// with a new fee rate and be retried immediately.
+	for _, inp := range r.set.Inputs() {
+		op := inp.OutPoint()
+		input, ok := s.inputs[op]
+
+		// Wallet inputs are not tracked so we will not find them from
+		// the inputs map.
+		if !ok {
+			log.Debugf("Skipped marking input: %v not found in "+
+				"pending inputs", op)
+
+			continue
+		}
+
+		// Check whether this input has been spent, if so we mark it as
+		// fatal or swept based on whether this is one of our previous
+		// sweeping txns, then move to the next.
+		tx, spent := spentInputs[op]
+		if spent {
+			s.handleUnknownSpendTx(input, tx)
+
+			continue
+		}
+
+		log.Debugf("Input(%v): updating params: starting fee rate "+
+			"[%v -> %v], immediate [%v -> true]", op,
+			input.params.StartingFeeRate, r.result.FeeRate,
+			input.params.Immediate)
+
+		// Update the input using the fee rate specified from the
+		// BumpResult, which should be the starting fee rate to use for
+		// the next sweeping attempt.
+		input.params.StartingFeeRate = fn.Some(r.result.FeeRate)
+		input.params.Immediate = true
+		inputsToRetry = append(inputsToRetry, input)
+	}
+
+	// Exit early if there are no inputs to be retried.
+	if len(inputsToRetry) == 0 {
+		return
+	}
+
+	log.Debugf("Retry sweeping inputs with updated params: %v",
+		inputTypeSummary(inputsToRetry))
+
+	// Get the latest inputs, which should put the PublishFailed inputs back
+	// to the sweeping queue.
+	inputs := s.updateSweeperInputs()
+
+	// Immediately sweep the remaining inputs - the previous inputs should
+	// now be swept with the updated StartingFeeRate immediately. We may
+	// also include more inputs in the new sweeping tx if new ones with the
+	// same deadline are offered.
+	s.sweepPendingInputs(inputs)
 }

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1230,20 +1230,25 @@ func (s *UtxoSweeper) handleNewInput(input *sweepInputMessage) error {
 	}
 
 	// This is a new input, and we want to query the mempool to see if this
-	// input has already been spent. If so, we'll start the input with
-	// state Published and attach the RBFInfo.
-	state, rbfInfo := s.decideStateAndRBFInfo(input.input.OutPoint())
+	// input has already been spent. If so, we'll start the input with the
+	// RBFInfo.
+	rbfInfo := s.decideRBFInfo(input.input.OutPoint())
 
 	// Create a new pendingInput and initialize the listeners slice with
 	// the passed in result channel. If this input is offered for sweep
 	// again, the result channel will be appended to this slice.
 	pi = &SweeperInput{
-		state:     state,
+		state:     Init,
 		listeners: []chan Result{input.resultChan},
 		Input:     input.input,
 		params:    input.params,
 		rbf:       rbfInfo,
 	}
+
+	// Set the starting fee rate if a previous sweeping tx is found.
+	rbfInfo.WhenSome(func(info RBFInfo) {
+		pi.params.StartingFeeRate = fn.Some(info.FeeRate)
+	})
 
 	// Set the acutal deadline height.
 	pi.DeadlineHeight = input.params.DeadlineHeight.UnwrapOr(
@@ -1277,13 +1282,12 @@ func (s *UtxoSweeper) handleNewInput(input *sweepInputMessage) error {
 	return nil
 }
 
-// decideStateAndRBFInfo queries the mempool to see whether the given input has
-// already been spent. If so, the state Published will be returned, otherwise
-// state Init. When spent, it will query the sweeper store to fetch the fee
-// info of the spending transction, and construct an RBFInfo based on it.
-// Suppose an error occurs, fn.None is returned.
-func (s *UtxoSweeper) decideStateAndRBFInfo(op wire.OutPoint) (
-	SweepState, fn.Option[RBFInfo]) {
+// decideRBFInfo queries the mempool to see whether the given input has already
+// been spent. When spent, it will query the sweeper store to fetch the fee info
+// of the spending transction, and construct an RBFInfo based on it. Suppose an
+// error occurs, fn.None is returned.
+func (s *UtxoSweeper) decideRBFInfo(
+	op wire.OutPoint) fn.Option[RBFInfo] {
 
 	// Check if we can find the spending tx of this input in mempool.
 	txOption := s.mempoolLookup(op)
@@ -1301,7 +1305,7 @@ func (s *UtxoSweeper) decideStateAndRBFInfo(op wire.OutPoint) (
 	// - for neutrino we don't have a mempool.
 	// - for btcd below v0.24.1 we don't have `gettxspendingprevout`.
 	if tx == nil {
-		return Init, fn.None[RBFInfo]()
+		return fn.None[RBFInfo]()
 	}
 
 	// Otherwise the input is already spent in the mempool, so eventually
@@ -1313,12 +1317,15 @@ func (s *UtxoSweeper) decideStateAndRBFInfo(op wire.OutPoint) (
 	txid := tx.TxHash()
 	tr, err := s.cfg.Store.GetTx(txid)
 
+	log.Debugf("Found spending tx %v in mempool for input %v", tx.TxHash(),
+		op)
+
 	// If the tx is not found in the store, it means it's not broadcast by
 	// us, hence we can't find the fee info. This is fine as, later on when
 	// this tx is confirmed, we will remove the input from our inputs.
 	if errors.Is(err, ErrTxNotFound) {
 		log.Warnf("Spending tx %v not found in sweeper store", txid)
-		return Published, fn.None[RBFInfo]()
+		return fn.None[RBFInfo]()
 	}
 
 	// Exit if we get an db error.
@@ -1326,7 +1333,7 @@ func (s *UtxoSweeper) decideStateAndRBFInfo(op wire.OutPoint) (
 		log.Errorf("Unable to get tx %v from sweeper store: %v",
 			txid, err)
 
-		return Published, fn.None[RBFInfo]()
+		return fn.None[RBFInfo]()
 	}
 
 	// Prepare the fee info and return it.
@@ -1336,7 +1343,7 @@ func (s *UtxoSweeper) decideStateAndRBFInfo(op wire.OutPoint) (
 		FeeRate: chainfee.SatPerKWeight(tr.FeeRate),
 	})
 
-	return Published, rbf
+	return rbf
 }
 
 // handleExistingInput processes an input that is already known to the sweeper.

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -497,10 +497,9 @@ func TestUpdateSweeperInputs(t *testing.T) {
 	require.Equal(expectedInputs, s.inputs)
 }
 
-// TestDecideStateAndRBFInfo checks that the expected state and RBFInfo are
-// returned based on whether this input can be found both in mempool and the
-// sweeper store.
-func TestDecideStateAndRBFInfo(t *testing.T) {
+// TestDecideRBFInfo checks that the expected RBFInfo is returned based on
+// whether this input can be found both in mempool and the sweeper store.
+func TestDecideRBFInfo(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
@@ -524,11 +523,9 @@ func TestDecideStateAndRBFInfo(t *testing.T) {
 	mockMempool.On("LookupInputMempoolSpend", op).Return(
 		fn.None[wire.MsgTx]()).Once()
 
-	// Since the mempool lookup failed, we exepect state Init and no
-	// RBFInfo.
-	state, rbf := s.decideStateAndRBFInfo(op)
+	// Since the mempool lookup failed, we expect no RBFInfo.
+	rbf := s.decideRBFInfo(op)
 	require.True(rbf.IsNone())
-	require.Equal(Init, state)
 
 	// Mock the mempool lookup to return a tx three times as we are calling
 	// attachAvailableRBFInfo three times.
@@ -539,19 +536,17 @@ func TestDecideStateAndRBFInfo(t *testing.T) {
 	// Mock the store to return an error saying the tx cannot be found.
 	mockStore.On("GetTx", tx.TxHash()).Return(nil, ErrTxNotFound).Once()
 
-	// Although the db lookup failed, we expect the state to be Published.
-	state, rbf = s.decideStateAndRBFInfo(op)
+	// The db lookup failed, we expect no RBFInfo.
+	rbf = s.decideRBFInfo(op)
 	require.True(rbf.IsNone())
-	require.Equal(Published, state)
 
 	// Mock the store to return a db error.
 	dummyErr := errors.New("dummy error")
 	mockStore.On("GetTx", tx.TxHash()).Return(nil, dummyErr).Once()
 
-	// Although the db lookup failed, we expect the state to be Published.
-	state, rbf = s.decideStateAndRBFInfo(op)
+	// The db lookup failed, we expect no RBFInfo.
+	rbf = s.decideRBFInfo(op)
 	require.True(rbf.IsNone())
-	require.Equal(Published, state)
 
 	// Mock the store to return a record.
 	tr := &TxRecord{
@@ -561,7 +556,7 @@ func TestDecideStateAndRBFInfo(t *testing.T) {
 	mockStore.On("GetTx", tx.TxHash()).Return(tr, nil).Once()
 
 	// Call the method again.
-	state, rbf = s.decideStateAndRBFInfo(op)
+	rbf = s.decideRBFInfo(op)
 
 	// Assert that the RBF info is returned.
 	rbfInfo := fn.Some(RBFInfo{
@@ -570,9 +565,6 @@ func TestDecideStateAndRBFInfo(t *testing.T) {
 		FeeRate: chainfee.SatPerKWeight(tr.FeeRate),
 	})
 	require.Equal(rbfInfo, rbf)
-
-	// Assert the state is updated.
-	require.Equal(Published, state)
 }
 
 // TestMarkInputFatal checks that the input is marked as expected.

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -1227,7 +1227,7 @@ func TestHandleUnknownSpendTxOurs(t *testing.T) {
 	txid := tx.TxHash()
 
 	// Mock the store to return true when calling IsOurTx.
-	store.On("IsOurTx", txid).Return(true, nil).Once()
+	store.On("IsOurTx", txid).Return(true).Once()
 
 	// Call the method under test.
 	s.handleUnknownSpendTx(si, tx)
@@ -1271,7 +1271,7 @@ func TestHandleInputSpendTxThirdParty(t *testing.T) {
 	txid := tx.TxHash()
 
 	// Mock the store to return false when calling IsOurTx.
-	store.On("IsOurTx", txid).Return(false, nil).Once()
+	store.On("IsOurTx", txid).Return(false).Once()
 
 	// Mock `ListSweeps` to return an empty slice as we are testing the
 	// workflow here, not the method `removeConflictSweepDescendants`.
@@ -1333,7 +1333,7 @@ func TestHandleBumpEventTxUnknownSpendNoRetry(t *testing.T) {
 	}
 
 	// Mock the store to return true when calling IsOurTx.
-	store.On("IsOurTx", txid).Return(true, nil).Once()
+	store.On("IsOurTx", txid).Return(true).Once()
 
 	// Call the method under test.
 	s.handleBumpEventTxUnknownSpend(resp)
@@ -1419,7 +1419,7 @@ func TestHandleBumpEventTxUnknownSpendWithRetry(t *testing.T) {
 	}
 
 	// Mock the store to return true when calling IsOurTx.
-	store.On("IsOurTx", txid).Return(true, nil).Once()
+	store.On("IsOurTx", txid).Return(true).Once()
 
 	// Mock the aggregator to return an empty slice as we are not testing
 	// the actual sweeping behavior.

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -1199,3 +1199,246 @@ func TestHandleBumpEventTxFatal(t *testing.T) {
 	err = s.handleBumpEventTxFatal(resp)
 	rt.NoError(err)
 }
+
+// TestHandleUnknownSpendTxOurs checks that `handleUnknownSpendTx` correctly
+// marks an input as swept given the tx is ours.
+func TestHandleUnknownSpendTxOurs(t *testing.T) {
+	t.Parallel()
+
+	// Create a mock store.
+	store := &MockSweeperStore{}
+	defer store.AssertExpectations(t)
+
+	// Create a mock input set.
+	set := &MockInputSet{}
+	defer set.AssertExpectations(t)
+
+	// Create a test sweeper.
+	s := New(&UtxoSweeperConfig{
+		Store: store,
+	})
+
+	// Create a mock input.
+	inp := createMockInput(t, s, PublishFailed)
+	op := inp.OutPoint()
+
+	si, ok := s.inputs[op]
+	require.True(t, ok)
+
+	// Create a testing tx that spends the input.
+	tx := &wire.MsgTx{
+		LockTime: 1,
+		TxIn: []*wire.TxIn{
+			{PreviousOutPoint: op},
+		},
+	}
+	txid := tx.TxHash()
+
+	// Mock the store to return true when calling IsOurTx.
+	store.On("IsOurTx", txid).Return(true, nil).Once()
+
+	// Call the method under test.
+	s.handleUnknownSpendTx(si, tx)
+
+	// Assert the state of the input is updated.
+	require.Equal(t, Swept, s.inputs[op].state)
+}
+
+// TestHandleUnknownSpendTxThirdParty checks that `handleUnknownSpendTx`
+// correctly marks an input as fatal given the tx is not ours.
+func TestHandleInputSpendTxThirdParty(t *testing.T) {
+	t.Parallel()
+
+	// Create a mock store.
+	store := &MockSweeperStore{}
+	defer store.AssertExpectations(t)
+
+	// Create a mock input set.
+	set := &MockInputSet{}
+	defer set.AssertExpectations(t)
+
+	// Create a test sweeper.
+	s := New(&UtxoSweeperConfig{
+		Store: store,
+	})
+
+	// Create a mock input.
+	inp := createMockInput(t, s, PublishFailed)
+	op := inp.OutPoint()
+
+	si, ok := s.inputs[op]
+	require.True(t, ok)
+
+	// Create a testing tx that spends the input.
+	tx := &wire.MsgTx{
+		LockTime: 1,
+		TxIn: []*wire.TxIn{
+			{PreviousOutPoint: op},
+		},
+	}
+	txid := tx.TxHash()
+
+	// Mock the store to return false when calling IsOurTx.
+	store.On("IsOurTx", txid).Return(false, nil).Once()
+
+	// Mock `ListSweeps` to return an empty slice as we are testing the
+	// workflow here, not the method `removeConflictSweepDescendants`.
+	store.On("ListSweeps").Return([]chainhash.Hash{}, nil).Once()
+
+	// Call the method under test.
+	s.handleUnknownSpendTx(si, tx)
+
+	// Assert the state of the input is updated.
+	require.Equal(t, Fatal, s.inputs[op].state)
+}
+
+// TestHandleBumpEventTxUnknownSpendNoRetry checks the case when all the inputs
+// are failed due to them being spent by another party.
+func TestHandleBumpEventTxUnknownSpendNoRetry(t *testing.T) {
+	t.Parallel()
+
+	// Create a mock store.
+	store := &MockSweeperStore{}
+	defer store.AssertExpectations(t)
+
+	// Create a mock input set.
+	set := &MockInputSet{}
+	defer set.AssertExpectations(t)
+
+	// Create a test sweeper.
+	s := New(&UtxoSweeperConfig{
+		Store: store,
+	})
+
+	// Create a mock input.
+	inp := createMockInput(t, s, PendingPublish)
+	set.On("Inputs").Return([]input.Input{inp})
+
+	op := inp.OutPoint()
+
+	// Create a testing tx that spends the input.
+	tx := &wire.MsgTx{
+		LockTime: 1,
+		TxIn: []*wire.TxIn{
+			{PreviousOutPoint: op},
+		},
+	}
+	txid := tx.TxHash()
+
+	// Create a testing bump result.
+	br := &BumpResult{
+		Tx:    tx,
+		Event: TxUnknownSpend,
+		SpentInputs: map[wire.OutPoint]*wire.MsgTx{
+			op: tx,
+		},
+	}
+
+	// Create a testing bump response.
+	resp := &bumpResp{
+		result: br,
+		set:    set,
+	}
+
+	// Mock the store to return true when calling IsOurTx.
+	store.On("IsOurTx", txid).Return(true, nil).Once()
+
+	// Call the method under test.
+	s.handleBumpEventTxUnknownSpend(resp)
+
+	// Assert the state of the input is updated.
+	require.Equal(t, Swept, s.inputs[op].state)
+}
+
+// TestHandleBumpEventTxUnknownSpendWithRetry checks the case when some the
+// inputs are retried after the bad inputs are filtered out.
+func TestHandleBumpEventTxUnknownSpendWithRetry(t *testing.T) {
+	t.Parallel()
+
+	// Create a mock store.
+	store := &MockSweeperStore{}
+	defer store.AssertExpectations(t)
+
+	// Create a mock wallet and aggregator.
+	wallet := &MockWallet{}
+	defer wallet.AssertExpectations(t)
+
+	aggregator := &mockUtxoAggregator{}
+	defer aggregator.AssertExpectations(t)
+
+	publisher := &MockBumper{}
+	defer publisher.AssertExpectations(t)
+
+	// Create a test sweeper.
+	s := New(&UtxoSweeperConfig{
+		Wallet:     wallet,
+		Aggregator: aggregator,
+		Publisher:  publisher,
+		GenSweepScript: func() fn.Result[lnwallet.AddrWithKey] {
+			//nolint:ll
+			return fn.Ok(lnwallet.AddrWithKey{
+				DeliveryAddress: testPubKey.SerializeCompressed(),
+			})
+		},
+		NoDeadlineConfTarget: uint32(DefaultDeadlineDelta),
+		Store:                store,
+	})
+
+	// Create a mock input set.
+	set := &MockInputSet{}
+	defer set.AssertExpectations(t)
+
+	// Create mock inputs - inp1 will be the bad input, and inp2 will be
+	// retried.
+	inp1 := createMockInput(t, s, PendingPublish)
+	inp2 := createMockInput(t, s, PendingPublish)
+	set.On("Inputs").Return([]input.Input{inp1, inp2})
+
+	op1 := inp1.OutPoint()
+	op2 := inp2.OutPoint()
+
+	inp2.On("RequiredLockTime").Return(
+		uint32(s.currentHeight), false).Once()
+	inp2.On("BlocksToMaturity").Return(uint32(0)).Once()
+	inp2.On("HeightHint").Return(uint32(s.currentHeight)).Once()
+
+	// Create a testing tx that spends inp1.
+	tx := &wire.MsgTx{
+		LockTime: 1,
+		TxIn: []*wire.TxIn{
+			{PreviousOutPoint: op1},
+		},
+	}
+	txid := tx.TxHash()
+
+	// Create a testing bump result.
+	br := &BumpResult{
+		Tx:    tx,
+		Event: TxUnknownSpend,
+		SpentInputs: map[wire.OutPoint]*wire.MsgTx{
+			op1: tx,
+		},
+	}
+
+	// Create a testing bump response.
+	resp := &bumpResp{
+		result: br,
+		set:    set,
+	}
+
+	// Mock the store to return true when calling IsOurTx.
+	store.On("IsOurTx", txid).Return(true, nil).Once()
+
+	// Mock the aggregator to return an empty slice as we are not testing
+	// the actual sweeping behavior.
+	aggregator.On("ClusterInputs", mock.Anything).Return([]InputSet{})
+
+	// Call the method under test.
+	s.handleBumpEventTxUnknownSpend(resp)
+
+	// Assert the first input is removed.
+	require.NotContains(t, s.inputs, op1)
+
+	// Assert the state of the input is updated.
+	require.Equal(t, PublishFailed, s.inputs[op2].state)
+}

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -596,7 +596,7 @@ func TestMarkInputFailed(t *testing.T) {
 	}
 
 	// Call the method under test.
-	s.markInputFatal(pi, errors.New("dummy error"))
+	s.markInputFatal(pi, nil, errors.New("dummy error"))
 
 	// Assert the state is updated.
 	require.Equal(t, Fatal, pi.state)


### PR DESCRIPTION
There are two places tracking the spending status of a given input - one in the sweeper, the other in the fee bumper. We now move the tracking to be handled in the fee bumper so we always have a single source of truth. By the end of this fix, we should see that,
- the fee func will be kept on the original line when retrying sweeps.
- both the sweeper and the fee bumper can recover their state from a restart.
- for the neutrino backend, the initial sweeping tx is now always RBF-compliant.

The fix is made of two PRs to keep the size small - the first PR will enable tracking the spending status of inputs in the fee bumper, and the second will fix the rest.

Depends on,
- #9446

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lightningnetwork/lnd/9447)
<!-- Reviewable:end -->
