### PR TITLE
graph/db: correctly handle de(ser)ialisation of `models.LightningNode` opaque addresses

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1982,21 +1982,7 @@ func (d *AuthenticatedGossiper) addNode(msg *lnwire.NodeAnnouncement,
 			err)
 	}
 
-	timestamp := time.Unix(int64(msg.Timestamp), 0)
-	features := lnwire.NewFeatureVector(msg.Features, lnwire.Features)
-	node := &models.LightningNode{
-		HaveNodeAnnouncement: true,
-		LastUpdate:           timestamp,
-		Addresses:            msg.Addresses,
-		PubKeyBytes:          msg.NodeID,
-		Alias:                msg.Alias.String(),
-		AuthSigBytes:         msg.Signature.ToSignatureBytes(),
-		Features:             features,
-		Color:                msg.RGBColor,
-		ExtraOpaqueData:      msg.ExtraOpaqueData,
-	}
-
-	return d.cfg.Graph.AddNode(node, op...)
+	return d.cfg.Graph.AddNode(models.NodeFromWireAnnouncement(msg), op...)
 }
 
 // isPremature decides whether a given network message has a block height+delta

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -64,6 +64,10 @@
 * [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/9322) that caused
     estimateroutefee to ignore the default payment timeout.
 
+* [Fix a bug](https://github.com/lightningnetwork/lnd/pull/9474) where LND would
+  fail to persist (and hence, propagate) node announcements containing address 
+  types (such as a DNS hostname) unknown to LND.
+
 # New Features
 
 * [Support](https://github.com/lightningnetwork/lnd/pull/8390) for 

--- a/graph/db/models/node.go
+++ b/graph/db/models/node.go
@@ -131,3 +131,22 @@ func (l *LightningNode) NodeAnnouncement(signed bool) (*lnwire.NodeAnnouncement,
 
 	return nodeAnn, nil
 }
+
+// NodeFromWireAnnouncement creates a LightningNode instance from an
+// lnwire.NodeAnnouncement message.
+func NodeFromWireAnnouncement(msg *lnwire.NodeAnnouncement) *LightningNode {
+	timestamp := time.Unix(int64(msg.Timestamp), 0)
+	features := lnwire.NewFeatureVector(msg.Features, lnwire.Features)
+
+	return &LightningNode{
+		HaveNodeAnnouncement: true,
+		LastUpdate:           timestamp,
+		Addresses:            msg.Addresses,
+		PubKeyBytes:          msg.NodeID,
+		Alias:                msg.Alias.String(),
+		AuthSigBytes:         msg.Signature.ToSignatureBytes(),
+		Features:             features,
+		Color:                msg.RGBColor,
+		ExtraOpaqueData:      msg.ExtraOpaqueData,
+	}
+}

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -356,8 +356,8 @@ func TestChanUpdateChanFlags(t *testing.T) {
 	}
 }
 
-// TestDecodeUnknownAddressType shows that an unknown address type is currently
-// incorrectly dealt with.
+// TestDecodeUnknownAddressType shows that an unknown address type is correctly
+// decoded and encoded.
 func TestDecodeUnknownAddressType(t *testing.T) {
 	// Add a normal, clearnet address.
 	tcpAddr := &net.TCPAddr{


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/9473

In https://github.com/lightningnetwork/lnd/pull/6435, we started to correctly handle the serialisation/deserialisation of unknown addresses in node announcement wire messages but we were still not persisting these node announcements correctly. 

In this PR, the bug is first demonstrated and then fixed by properly handing the `OpaqueAddrs` case when persisting the `models.LightningNode` type. 