### PR TITLE
discovery+graph: various preparations for moving funding tx validation to the gossiper

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -2678,10 +2678,9 @@ func (d *AuthenticatedGossiper) handleChanAnnouncement(nMsg *networkMsg,
 
 			return anns, true
 
-		case graph.IsError(
-			err, graph.ErrNoFundingTransaction,
-			graph.ErrInvalidFundingOutput,
-		):
+		case errors.Is(err, graph.ErrNoFundingTransaction),
+			errors.Is(err, graph.ErrInvalidFundingOutput):
+
 			key := newRejectCacheKey(
 				scid.ToUint64(),
 				sourceToPub(nMsg.source),
@@ -2695,7 +2694,7 @@ func (d *AuthenticatedGossiper) handleChanAnnouncement(nMsg *networkMsg,
 				d.banman.incrementBanScore(nMsg.peer.PubKey())
 			}
 
-		case graph.IsError(err, graph.ErrChannelSpent):
+		case errors.Is(err, graph.ErrChannelSpent):
 			key := newRejectCacheKey(
 				scid.ToUint64(),
 				sourceToPub(nMsg.source),

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -243,8 +243,11 @@ The underlying functionality between those two options remain the same.
 * [Golang was updated to
   `v1.22.11`](https://github.com/lightningnetwork/lnd/pull/9462). 
 
-* Various refactors to simplify the 
-  `graph.Builder` [1](https://github.com/lightningnetwork/lnd/pull/9476).
+* Various refactors and preparations to simplify the 
+  `graph.Builder` and to move the funding tx validation to the gossiper.
+   [1](https://github.com/lightningnetwork/lnd/pull/9476)
+   [2](https://github.com/lightningnetwork/lnd/pull/9477)
+
 
 ## Breaking Changes
 ## Performance Improvements

--- a/graph/builder.go
+++ b/graph/builder.go
@@ -1314,8 +1314,7 @@ func (b *Builder) addEdge(edge *models.ChannelEdgeInfo,
 		default:
 		}
 
-		return NewErrf(ErrNoFundingTransaction, "unable to "+
-			"locate funding tx: %v", err)
+		return fmt.Errorf("%w: %w", ErrNoFundingTransaction, err)
 	}
 
 	// Recreate witness output to be sure that declared in channel edge
@@ -1348,8 +1347,7 @@ func (b *Builder) addEdge(edge *models.ChannelEdgeInfo,
 			return err
 		}
 
-		return NewErrf(ErrInvalidFundingOutput, "output failed "+
-			"validation: %w", err)
+		return fmt.Errorf("%w: %w", ErrInvalidFundingOutput, err)
 	}
 
 	// Now that we have the funding outpoint of the channel, ensure
@@ -1366,8 +1364,8 @@ func (b *Builder) addEdge(edge *models.ChannelEdgeInfo,
 			}
 		}
 
-		return NewErrf(ErrChannelSpent, "unable to fetch utxo for "+
-			"chan_id=%v, chan_point=%v: %v", edge.ChannelID,
+		return fmt.Errorf("%w: unable to fetch utxo for chan_id=%v, "+
+			"chan_point=%v: %w", ErrChannelSpent, scid.ToUint64(),
 			fundingPoint, err)
 	}
 

--- a/graph/builder_test.go
+++ b/graph/builder_test.go
@@ -1275,14 +1275,12 @@ func newChannelEdgeInfo(t *testing.T, ctx *testCtx, fundingHeight uint32,
 }
 
 func assertChanChainRejection(t *testing.T, ctx *testCtx,
-	edge *models.ChannelEdgeInfo, failCode ErrorCode) {
+	edge *models.ChannelEdgeInfo, expectedErr error) {
 
 	t.Helper()
 
 	err := ctx.builder.AddEdge(edge)
-	if !IsError(err, failCode) {
-		t.Fatalf("validation should have failed: %v", err)
-	}
+	require.ErrorIs(t, err, expectedErr)
 
 	// This channel should now be present in the zombie channel index.
 	_, _, _, isZombie, err := ctx.graph.HasChannelEdge(

--- a/graph/errors.go
+++ b/graph/errors.go
@@ -2,6 +2,25 @@ package graph
 
 import "github.com/go-errors/errors"
 
+var (
+	// ErrNoFundingTransaction is returned when we are unable to find the
+	// funding transaction described by the short channel ID on chain.
+	ErrNoFundingTransaction = errors.New(
+		"unable to find the funding transaction",
+	)
+
+	// ErrInvalidFundingOutput is returned if the channel funding output
+	// fails validation.
+	ErrInvalidFundingOutput = errors.New(
+		"channel funding output validation failed",
+	)
+
+	// ErrChannelSpent is returned when we go to validate a channel, but
+	// the purported funding output has actually already been spent on
+	// chain.
+	ErrChannelSpent = errors.New("channel output has been spent")
+)
+
 // ErrorCode is used to represent the various errors that can occur within this
 // package.
 type ErrorCode uint8
@@ -15,19 +34,6 @@ const (
 	// this update can't bring us something new, or because a node
 	// announcement was given for node not found in any channel.
 	ErrIgnored
-
-	// ErrChannelSpent is returned when we go to validate a channel, but
-	// the purported funding output has actually already been spent on
-	// chain.
-	ErrChannelSpent
-
-	// ErrNoFundingTransaction is returned when we are unable to find the
-	// funding transaction described by the short channel ID on chain.
-	ErrNoFundingTransaction
-
-	// ErrInvalidFundingOutput is returned if the channel funding output
-	// fails validation.
-	ErrInvalidFundingOutput
 )
 
 // Error is a structure that represent the error inside the graph package,

--- a/lnmock/chain.go
+++ b/lnmock/chain.go
@@ -74,6 +74,18 @@ func (m *MockChain) GetBlockHeader(hash *chainhash.Hash) (
 	return args.Get(0).(*wire.BlockHeader), args.Error(1)
 }
 
+func (m *MockChain) GetUtxo(op *wire.OutPoint, pkScript []byte,
+	heightHint uint32, cancel <-chan struct{}) (*wire.TxOut, error) {
+
+	args := m.Called(op, pkScript, heightHint, cancel)
+
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*wire.TxOut), args.Error(1)
+}
+
 func (m *MockChain) IsCurrent() bool {
 	args := m.Called()
 


### PR DESCRIPTION
Part of https://github.com/lightningnetwork/lnd/issues/9475

This PR does some refactoring along with test preparation:

1) First, in preparation for moving the funding tx validation code from the graph.Builder to the gossiper, we convert some of the `graph.ErrorCode`s to just normal error variables. We do this for any error that is constructed during tx validation. This will make the commit which moves the actual validation code easier to review since then these errors will just be moved as is to to the `discovery` package. 
2) The rest of the commits are just about preparing the discovery package tests to test funding transaction validation later on. We pretty much duplicate how blocks/utxos are mocked and added from the `graph/notifications_test.go` file. None of this code is used yet. 


https://github.com/lightningnetwork/lnd/pull/9478 is where we make use of the work done here. 