### PR TITLE
discovery+graph:  move funding tx validation to the gossiper

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -364,6 +364,11 @@ type Config struct {
 	// updates for a channel and returns true if the channel should be
 	// considered a zombie based on these timestamps.
 	IsStillZombieChannel func(time.Time, time.Time) bool
+
+	// AssumeChannelValid toggles whether the gossiper will check for
+	// spent-ness of channel outpoints. For neutrino, this saves long
+	// rescans from blocking initial usage of the daemon.
+	AssumeChannelValid bool
 }
 
 // processedNetworkMsg is a wrapper around networkMsg and a boolean. It is

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -27,15 +27,18 @@ import (
 	"github.com/lightningnetwork/lnd/graph"
 	graphdb "github.com/lightningnetwork/lnd/graph/db"
 	"github.com/lightningnetwork/lnd/graph/db/models"
+	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnmock"
 	"github.com/lightningnetwork/lnd/lnpeer"
 	"github.com/lightningnetwork/lnd/lntest/mock"
 	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/lightningnetwork/lnd/lnwallet/btcwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/netann"
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/ticker"
+	tmock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -82,7 +85,6 @@ type mockGraphSource struct {
 	edges         map[uint64][]models.ChannelEdgePolicy
 	zombies       map[uint64][][33]byte
 	chansToReject map[uint64]struct{}
-	addEdgeErr    error
 }
 
 func newMockRouter(height uint32) *mockGraphSource {
@@ -130,10 +132,6 @@ func (r *mockGraphSource) AddEdge(info *models.ChannelEdgeInfo,
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if r.addEdgeErr != nil {
-		return r.addEdgeErr
-	}
-
 	if _, ok := r.infos[info.ChannelID]; ok {
 		return errors.New("info already exist")
 	}
@@ -144,14 +142,6 @@ func (r *mockGraphSource) AddEdge(info *models.ChannelEdgeInfo,
 
 	r.infos[info.ChannelID] = *info
 	return nil
-}
-
-func (r *mockGraphSource) resetAddEdgeErr() {
-	r.addEdgeErr = nil
-}
-
-func (r *mockGraphSource) setAddEdgeErr(err error) {
-	r.addEdgeErr = err
 }
 
 func (r *mockGraphSource) queueValidationFail(chanID uint64) {
@@ -600,7 +590,7 @@ func createUpdateAnnouncement(blockHeight uint32,
 
 	var err error
 
-	htlcMinMsat := lnwire.MilliSatoshi(prand.Int63())
+	htlcMinMsat := lnwire.MilliSatoshi(100)
 	a := &lnwire.ChannelUpdate1{
 		ShortChannelID: lnwire.ShortChannelID{
 			BlockHeight: blockHeight,
@@ -700,15 +690,55 @@ func (ctx *testCtx) createAnnouncementWithoutProof(blockHeight uint32,
 		opt(&opts)
 	}
 
-	// TODO(elle): prepare the mock chain calls accordingly.
 	switch opts.fundingTxPrep {
 	case fundingTxPrepTypeGood:
+		info := makeFundingTxInBlock(ctx.t)
+
+		ctx.chain.On("GetBlockHash", int64(blockHeight)).
+			Return(&chainhash.Hash{}, nil).Once()
+
+		ctx.chain.On("GetBlock", tmock.Anything).
+			Return(info.fundingBlock, nil).Once()
+
+		ctx.chain.On(
+			"GetUtxo", tmock.Anything, tmock.Anything,
+			tmock.Anything, tmock.Anything,
+		).Return(info.fundingTx, nil).Once()
 
 	case fundingTxPrepTypeInvalidOutput:
+		ctx.chain.On(
+			"GetBlockHash", int64(blockHeight),
+		).Return(&chainhash.Hash{}, nil).Once()
+
+		ctx.chain.On(
+			"GetBlock", tmock.Anything,
+		).Return(
+			&wire.MsgBlock{Transactions: []*wire.MsgTx{{}}}, nil,
+		).Once()
 
 	case fundingTxPrepTypeSpent:
+		info := makeFundingTxInBlock(ctx.t)
+
+		ctx.chain.On(
+			"GetBlockHash", int64(blockHeight),
+		).Return(&chainhash.Hash{}, nil).Once()
+
+		ctx.chain.On(
+			"GetBlock", tmock.Anything,
+		).Return(info.fundingBlock, nil).Once()
+
+		ctx.chain.On(
+			"GetUtxo", tmock.Anything, tmock.Anything,
+			tmock.Anything, tmock.Anything,
+		).Return(nil, btcwallet.ErrOutputSpent).Once()
 
 	case fundingTxPrepTypeNoTx:
+		ctx.chain.On("GetBlockHash", int64(blockHeight)).Return(
+			&chainhash.Hash{}, nil,
+		).Once()
+		ctx.chain.On("GetBlock", tmock.Anything).Return(
+			nil, fmt.Errorf("block not found"),
+		).Once()
 
 	case fundingTxPrepTypeNone:
 	}
@@ -728,6 +758,38 @@ func (ctx *testCtx) createAnnouncementWithoutProof(blockHeight uint32,
 	a.ExtraOpaqueData = opts.extraBytes
 
 	return a
+}
+
+type fundingTxInfo struct {
+	chanUtxo     *wire.OutPoint
+	fundingBlock *wire.MsgBlock
+	fundingTx    *wire.TxOut
+}
+
+func makeFundingTxInBlock(t *testing.T) *fundingTxInfo {
+	fundingTx := wire.NewMsgTx(2)
+	_, tx, err := input.GenFundingPkScript(
+		bitcoinKeyPub1.SerializeCompressed(),
+		bitcoinKeyPub2.SerializeCompressed(),
+		int64(1000),
+	)
+	require.NoError(t, err)
+
+	fundingTx.TxOut = append(fundingTx.TxOut, tx)
+	chanUtxo := &wire.OutPoint{
+		Hash:  fundingTx.TxHash(),
+		Index: 0,
+	}
+
+	block := &wire.MsgBlock{
+		Transactions: []*wire.MsgTx{fundingTx},
+	}
+
+	return &fundingTxInfo{
+		chanUtxo:     chanUtxo,
+		fundingBlock: block,
+		fundingTx:    tx,
+	}
 }
 
 func (ctx *testCtx) createRemoteChannelAnnouncement(blockHeight uint32,
@@ -4306,8 +4368,6 @@ func TestChanAnnBanningNonChanPeer(t *testing.T) {
 		remoteKeyPriv2.PubKey(), nil, nil, atomic.Bool{},
 	}
 
-	ctx.router.setAddEdgeErr(graph.ErrInvalidFundingOutput)
-
 	// Loop 100 times to get nodePeer banned.
 	for i := 0; i < 100; i++ {
 		// Craft a valid channel announcement for a channel we don't
@@ -4323,7 +4383,7 @@ func TestChanAnnBanningNonChanPeer(t *testing.T) {
 		case err = <-ctx.gossiper.ProcessRemoteAnnouncement(
 			ca, nodePeer1,
 		):
-			require.ErrorIs(t, err, graph.ErrInvalidFundingOutput)
+			require.ErrorIs(t, err, ErrInvalidFundingOutput)
 
 		case <-time.After(2 * time.Second):
 			t.Fatalf("remote announcement not processed")
@@ -4343,13 +4403,9 @@ func TestChanAnnBanningNonChanPeer(t *testing.T) {
 	)
 	require.NoError(t, err, "can't create channel announcement")
 
-	// Set the error to ErrChannelSpent so that we can test that the
-	// gossiper ignores closed channels.
-	ctx.router.setAddEdgeErr(graph.ErrChannelSpent)
-
 	select {
 	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(ca, nodePeer2):
-		require.ErrorIs(t, err, graph.ErrChannelSpent)
+		require.ErrorIs(t, err, ErrChannelSpent)
 
 	case <-time.After(2 * time.Second):
 		t.Fatalf("remote announcement not processed")
@@ -4370,13 +4426,15 @@ func TestChanAnnBanningNonChanPeer(t *testing.T) {
 
 	ctx.gossiper.recentRejects.Delete(key)
 
-	// Reset the AddEdge error and pass the same announcement again. An
-	// error should be returned even though AddEdge won't fail.
-	ctx.router.resetAddEdgeErr()
+	// The validateFundingTransaction method will mark this channel
+	// as a zombie if any error occurs in the chanvalidate.Validate call.
+	// For the sake of the rest of the test, however, we mark it as live
+	// here.
+	_ = ctx.router.MarkEdgeLive(ca.ShortChannelID)
 
 	select {
 	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(ca, nodePeer2):
-		require.NotNil(t, err)
+		require.ErrorContains(t, err, "ignoring closed channel")
 
 	case <-time.After(2 * time.Second):
 		t.Fatalf("remote announcement not processed")
@@ -4393,8 +4451,6 @@ func TestChanAnnBanningChanPeer(t *testing.T) {
 
 	nodePeer := &mockPeer{remoteKeyPriv1.PubKey(), nil, nil, atomic.Bool{}}
 
-	ctx.router.setAddEdgeErr(graph.ErrInvalidFundingOutput)
-
 	// Loop 100 times to get nodePeer banned.
 	for i := 0; i < 100; i++ {
 		// Craft a valid channel announcement for a channel we don't
@@ -4410,7 +4466,7 @@ func TestChanAnnBanningChanPeer(t *testing.T) {
 		case err = <-ctx.gossiper.ProcessRemoteAnnouncement(
 			ca, nodePeer,
 		):
-			require.ErrorIs(t, err, graph.ErrInvalidFundingOutput)
+			require.ErrorIs(t, err, ErrInvalidFundingOutput)
 
 		case <-time.After(2 * time.Second):
 			t.Fatalf("remote announcement not processed")
@@ -4422,4 +4478,76 @@ func TestChanAnnBanningChanPeer(t *testing.T) {
 
 	// Assert that the peer wasn't disconnected.
 	require.False(t, nodePeer.disconnected.Load())
+}
+
+// TestChannelOnChainRejectionZombie tests that if we fail validating a channel
+// due to some sort of on-chain rejection (no funding transaction, or invalid
+// UTXO), then we'll mark the channel as a zombie.
+func TestChannelOnChainRejectionZombie(t *testing.T) {
+	t.Parallel()
+
+	ctx, err := createTestCtx(t, 1000, true)
+	require.NoError(t, err)
+
+	// To start,  we'll make an edge for the channel, but we won't add the
+	// funding transaction to the mock blockchain, which should cause the
+	// validation to fail below.
+	chanAnn, err := ctx.createRemoteChannelAnnouncement(
+		1, withFundingTxPrep(fundingTxPrepTypeNoTx),
+	)
+	require.NoError(t, err)
+
+	// We expect this to fail as the transaction isn't present in the
+	// chain (nor the block).
+	assertChanChainRejection(t, ctx, chanAnn, ErrNoFundingTransaction)
+
+	// Next, we'll make another channel edge, but actually add it to the
+	// graph this time.
+	chanAnn, err = ctx.createRemoteChannelAnnouncement(
+		2, withFundingTxPrep(fundingTxPrepTypeSpent),
+	)
+	require.NoError(t, err)
+
+	// Instead now, we'll remove it from the set of UTXOs which should
+	// cause the spentness validation to fail.
+	assertChanChainRejection(t, ctx, chanAnn, ErrChannelSpent)
+
+	// If we cause the funding transaction the chain to fail validation, we
+	// should see similar behavior.
+	chanAnn, err = ctx.createRemoteChannelAnnouncement(
+		3, withFundingTxPrep(fundingTxPrepTypeInvalidOutput),
+	)
+	require.NoError(t, err)
+	assertChanChainRejection(t, ctx, chanAnn, ErrInvalidFundingOutput)
+}
+
+func assertChanChainRejection(t *testing.T, ctx *testCtx,
+	edge *lnwire.ChannelAnnouncement1, expectedErr error) {
+
+	t.Helper()
+
+	nodePeer := &mockPeer{bitcoinKeyPub2, nil, nil, atomic.Bool{}}
+	errChan := make(chan error, 1)
+	nMsg := &networkMsg{
+		msg:      edge,
+		isRemote: true,
+		peer:     nodePeer,
+		source:   nodePeer.IdentityKey(),
+		err:      errChan,
+	}
+
+	_, added := ctx.gossiper.handleChanAnnouncement(nMsg, edge)
+	require.False(t, added)
+
+	select {
+	case err := <-errChan:
+		require.ErrorIs(t, err, expectedErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("channel announcement not processed")
+	}
+
+	// This channel should now be present in the zombie channel index.
+	isZombie, err := ctx.router.IsZombieEdge(edge.ShortChannelID)
+	require.NoError(t, err)
+	require.True(t, isZombie, "edge should be marked as zombie")
 }

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -113,6 +113,17 @@ func (r *mockGraphSource) MarkZombieEdge(scid uint64) error {
 	)
 }
 
+func (r *mockGraphSource) IsZombieEdge(chanID lnwire.ShortChannelID) (bool,
+	error) {
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	_, ok := r.zombies[chanID.ToUint64()]
+
+	return ok, nil
+}
+
 func (r *mockGraphSource) AddEdge(info *models.ChannelEdgeInfo,
 	_ ...batch.SchedulerOption) error {
 

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -107,6 +107,12 @@ func (r *mockGraphSource) AddNode(node *models.LightningNode,
 	return nil
 }
 
+func (r *mockGraphSource) MarkZombieEdge(scid uint64) error {
+	return r.MarkEdgeZombie(
+		lnwire.NewShortChanIDFromInt(scid), [33]byte{}, [33]byte{},
+	)
+}
+
 func (r *mockGraphSource) AddEdge(info *models.ChannelEdgeInfo,
 	_ ...batch.SchedulerOption) error {
 

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -251,10 +251,10 @@ The underlying functionality between those two options remain the same.
 * [Golang was updated to
   `v1.22.11`](https://github.com/lightningnetwork/lnd/pull/9462). 
 
-* Various refactors and preparations to simplify the 
-  `graph.Builder` and to move the funding tx validation to the gossiper.
+* Move funding transaction validation to the gossiper
    [1](https://github.com/lightningnetwork/lnd/pull/9476)
    [2](https://github.com/lightningnetwork/lnd/pull/9477)
+   [3](https://github.com/lightningnetwork/lnd/pull/9478).
 
 
 ## Breaking Changes

--- a/graph/builder.go
+++ b/graph/builder.go
@@ -1630,6 +1630,16 @@ func (b *Builder) IsKnownEdge(chanID lnwire.ShortChannelID) bool {
 	return exists || isZombie
 }
 
+// IsZombieEdge returns true if the graph source has marked the given channel ID
+// as a zombie edge.
+//
+// NOTE: This method is part of the ChannelGraphSource interface.
+func (b *Builder) IsZombieEdge(chanID lnwire.ShortChannelID) (bool, error) {
+	_, _, _, isZombie, err := b.cfg.Graph.HasChannelEdge(chanID.ToUint64())
+
+	return isZombie, err
+}
+
 // IsStaleEdgePolicy returns true if the graph source has a channel edge for
 // the passed channel ID (and flags) that have a more recent timestamp.
 //

--- a/graph/builder.go
+++ b/graph/builder.go
@@ -1008,9 +1008,9 @@ func (b *Builder) assertNodeAnnFreshness(node route.Vertex,
 	return nil
 }
 
-// addZombieEdge adds a channel that failed complete validation into the zombie
+// MarkZombieEdge adds a channel that failed complete validation into the zombie
 // index so we can avoid having to re-validate it in the future.
-func (b *Builder) addZombieEdge(chanID uint64) error {
+func (b *Builder) MarkZombieEdge(chanID uint64) error {
 	// If the edge fails validation we'll mark the edge itself as a zombie
 	// so we don't continue to request it. We use the "zero key" for both
 	// node pubkeys so this edge can't be resurrected.
@@ -1306,7 +1306,7 @@ func (b *Builder) addEdge(edge *models.ChannelEdgeInfo,
 			// we'll mark the edge itself as a zombie so we don't
 			// continue to request it. We use the "zero key" for
 			// both node pubkeys so this edge can't be resurrected.
-			zErr := b.addZombieEdge(edge.ChannelID)
+			zErr := b.MarkZombieEdge(edge.ChannelID)
 			if zErr != nil {
 				return zErr
 			}
@@ -1343,7 +1343,7 @@ func (b *Builder) addEdge(edge *models.ChannelEdgeInfo,
 	if err != nil {
 		// Mark the edge as a zombie so we won't try to re-validate it
 		// on start up.
-		if err := b.addZombieEdge(edge.ChannelID); err != nil {
+		if err := b.MarkZombieEdge(edge.ChannelID); err != nil {
 			return err
 		}
 
@@ -1358,7 +1358,7 @@ func (b *Builder) addEdge(edge *models.ChannelEdgeInfo,
 	)
 	if err != nil {
 		if errors.Is(err, btcwallet.ErrOutputSpent) {
-			zErr := b.addZombieEdge(edge.ChannelID)
+			zErr := b.MarkZombieEdge(edge.ChannelID)
 			if zErr != nil {
 				return zErr
 			}

--- a/graph/builder.go
+++ b/graph/builder.go
@@ -2,13 +2,11 @@ package graph
 
 import (
 	"fmt"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/batch"
@@ -18,8 +16,6 @@ import (
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnutils"
 	"github.com/lightningnetwork/lnd/lnwallet"
-	"github.com/lightningnetwork/lnd/lnwallet/btcwallet"
-	"github.com/lightningnetwork/lnd/lnwallet/chanvalidate"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/multimutex"
 	"github.com/lightningnetwork/lnd/netann"
@@ -91,9 +87,9 @@ type Config struct {
 	// blocked by this job.
 	FirstTimePruneDelay time.Duration
 
-	// AssumeChannelValid toggles whether the router will check for
-	// spentness of channel outpoints. For neutrino, this saves long rescans
-	// from blocking initial usage of the daemon.
+	// AssumeChannelValid toggles whether the builder will prune channels
+	// based on their spentness vs using the fact that they are considered
+	// zombies.
 	AssumeChannelValid bool
 
 	// StrictZombiePruning determines if we attempt to prune zombie
@@ -1188,29 +1184,33 @@ func (b *Builder) addEdge(edge *models.ChannelEdgeInfo,
 			edge.ChannelID)
 	}
 
-	// If AssumeChannelValid is present, then we are unable to perform any
-	// of the expensive checks below, so we'll short-circuit our path
-	// straight to adding the edge to our graph. If the passed
-	// ShortChannelID is an alias, then we'll skip validation as it will
-	// not map to a legitimate tx. This is not a DoS vector as only we can
-	// add an alias ChannelAnnouncement from the gossiper.
+	if err := b.cfg.Graph.AddChannelEdge(edge, op...); err != nil {
+		return fmt.Errorf("unable to add edge: %w", err)
+	}
+
+	b.stats.incNumEdgesDiscovered()
+
+	// If AssumeChannelValid is present, of if the SCID is an alias, then
+	// the gossiper would not have done the expensive work of fetching
+	// a funding transaction and validating it. So we won't have the channel
+	// capacity nor the funding script. So we just log and return here.
 	scid := lnwire.NewShortChanIDFromInt(edge.ChannelID)
 	if b.cfg.AssumeChannelValid || b.cfg.IsAlias(scid) {
-		err := b.cfg.Graph.AddChannelEdge(edge, op...)
-		if err != nil {
-			return fmt.Errorf("unable to add edge: %w", err)
-		}
 		log.Tracef("New channel discovered! Link connects %x and %x "+
 			"with ChannelID(%v)", edge.NodeKey1Bytes,
 			edge.NodeKey2Bytes, edge.ChannelID)
-		b.stats.incNumEdgesDiscovered()
 
 		return nil
 	}
 
-	// If AssumeChannelValid is false, then we expect the funding script to
-	// be present on the edge since it would have been fetched when the
-	// gossiper validated the announcement.
+	log.Debugf("New channel discovered! Link connects %x and %x with "+
+		"ChannelPoint(%v): chan_id=%v, capacity=%v", edge.NodeKey1Bytes,
+		edge.NodeKey2Bytes, edge.ChannelPoint, edge.ChannelID,
+		edge.Capacity)
+
+	// Otherwise, then we expect the funding script to be present on the
+	// edge since it would have been fetched when the gossiper validated the
+	// announcement.
 	fundingPkScript, err := edge.FundingScript.UnwrapOrErr(fmt.Errorf(
 		"expected the funding transaction script to be set",
 	))
@@ -1218,107 +1218,13 @@ func (b *Builder) addEdge(edge *models.ChannelEdgeInfo,
 		return err
 	}
 
-	// Before we can add the channel to the channel graph, we need to obtain
-	// the full funding outpoint that's encoded within the channel ID.
-	channelID := lnwire.NewShortChanIDFromInt(edge.ChannelID)
-	fundingTx, err := lnwallet.FetchFundingTxWrapper(
-		b.cfg.Chain, &channelID, b.quit,
-	)
-	if err != nil {
-		//nolint:ll
-		//
-		// In order to ensure we don't erroneously mark a channel as a
-		// zombie due to an RPC failure, we'll attempt to string match
-		// for the relevant errors.
-		//
-		// * btcd:
-		//    * https://github.com/btcsuite/btcd/blob/master/rpcserver.go#L1316
-		//    * https://github.com/btcsuite/btcd/blob/master/rpcserver.go#L1086
-		// * bitcoind:
-		//    * https://github.com/bitcoin/bitcoin/blob/7fcf53f7b4524572d1d0c9a5fdc388e87eb02416/src/rpc/blockchain.cpp#L770
-		//     * https://github.com/bitcoin/bitcoin/blob/7fcf53f7b4524572d1d0c9a5fdc388e87eb02416/src/rpc/blockchain.cpp#L954
-		switch {
-		case strings.Contains(err.Error(), "not found"):
-			fallthrough
-
-		case strings.Contains(err.Error(), "out of range"):
-			// If the funding transaction isn't found at all, then
-			// we'll mark the edge itself as a zombie so we don't
-			// continue to request it. We use the "zero key" for
-			// both node pubkeys so this edge can't be resurrected.
-			zErr := b.MarkZombieEdge(edge.ChannelID)
-			if zErr != nil {
-				return zErr
-			}
-
-		default:
-		}
-
-		return fmt.Errorf("%w: %w", ErrNoFundingTransaction, err)
-	}
-
-	// Next we'll validate that this channel is actually well formed. If
-	// this check fails, then this channel either doesn't exist, or isn't
-	// the one that was meant to be created according to the passed channel
-	// proofs.
-	fundingPoint, err := chanvalidate.Validate(
-		&chanvalidate.Context{
-			Locator: &chanvalidate.ShortChanIDChanLocator{
-				ID: channelID,
-			},
-			MultiSigPkScript: fundingPkScript,
-			FundingTx:        fundingTx,
-		},
-	)
-	if err != nil {
-		// Mark the edge as a zombie so we won't try to re-validate it
-		// on start up.
-		if err := b.MarkZombieEdge(edge.ChannelID); err != nil {
-			return err
-		}
-
-		return fmt.Errorf("%w: %w", ErrInvalidFundingOutput, err)
-	}
-
-	// Now that we have the funding outpoint of the channel, ensure
-	// that it hasn't yet been spent. If so, then this channel has
-	// been closed so we'll ignore it.
-	chanUtxo, err := b.cfg.Chain.GetUtxo(
-		fundingPoint, fundingPkScript, channelID.BlockHeight, b.quit,
-	)
-	if err != nil {
-		if errors.Is(err, btcwallet.ErrOutputSpent) {
-			zErr := b.MarkZombieEdge(edge.ChannelID)
-			if zErr != nil {
-				return zErr
-			}
-		}
-
-		return fmt.Errorf("%w: unable to fetch utxo for chan_id=%v, "+
-			"chan_point=%v: %w", ErrChannelSpent, scid.ToUint64(),
-			fundingPoint, err)
-	}
-
-	// TODO(roasbeef): this is a hack, needs to be removed after commitment
-	// fees are dynamic.
-	edge.Capacity = btcutil.Amount(chanUtxo.Value)
-	edge.ChannelPoint = *fundingPoint
-	if err := b.cfg.Graph.AddChannelEdge(edge, op...); err != nil {
-		return errors.Errorf("unable to add edge: %v", err)
-	}
-
-	log.Debugf("New channel discovered! Link connects %x and %x with "+
-		"ChannelPoint(%v): chan_id=%v, capacity=%v", edge.NodeKey1Bytes,
-		edge.NodeKey2Bytes, fundingPoint, edge.ChannelID, edge.Capacity)
-	b.stats.incNumEdgesDiscovered()
-
 	// As a new edge has been added to the channel graph, we'll update the
 	// current UTXO filter within our active FilteredChainView so we are
 	// notified if/when this channel is closed.
 	filterUpdate := []graphdb.EdgePoint{
 		{
 			FundingPkScript: fundingPkScript,
-			OutPoint:        *fundingPoint,
+			OutPoint:        edge.ChannelPoint,
 		},
 	}
 

--- a/graph/db/models/channel_edge_info.go
+++ b/graph/db/models/channel_edge_info.go
@@ -63,10 +63,11 @@ type ChannelEdgeInfo struct {
 	// the value output in the outpoint that created this channel.
 	Capacity btcutil.Amount
 
-	// TapscriptRoot is the optional Merkle root of the tapscript tree if
-	// this channel is a taproot channel that also commits to a tapscript
-	// tree (custom channel).
-	TapscriptRoot fn.Option[chainhash.Hash]
+	// FundingScript holds the script of the channel's funding transaction.
+	//
+	// NOTE: this is not currently persisted and so will not be present if
+	// the edge object is loaded from the database.
+	FundingScript fn.Option[[]byte]
 
 	// ExtraOpaqueData is the set of data that was appended to this
 	// message, some of which we may not actually know how to iterate or

--- a/graph/errors.go
+++ b/graph/errors.go
@@ -2,25 +2,6 @@ package graph
 
 import "github.com/go-errors/errors"
 
-var (
-	// ErrNoFundingTransaction is returned when we are unable to find the
-	// funding transaction described by the short channel ID on chain.
-	ErrNoFundingTransaction = errors.New(
-		"unable to find the funding transaction",
-	)
-
-	// ErrInvalidFundingOutput is returned if the channel funding output
-	// fails validation.
-	ErrInvalidFundingOutput = errors.New(
-		"channel funding output validation failed",
-	)
-
-	// ErrChannelSpent is returned when we go to validate a channel, but
-	// the purported funding output has actually already been spent on
-	// chain.
-	ErrChannelSpent = errors.New("channel output has been spent")
-)
-
 // ErrorCode is used to represent the various errors that can occur within this
 // package.
 type ErrorCode uint8

--- a/graph/interfaces.go
+++ b/graph/interfaces.go
@@ -85,6 +85,9 @@ type ChannelGraphSource interface {
 	// public key. channeldb.ErrGraphNodeNotFound is returned if the node
 	// doesn't exist within the graph.
 	FetchLightningNode(route.Vertex) (*models.LightningNode, error)
+
+	// MarkZombieEdge marks the channel with the given ID as a zombie edge.
+	MarkZombieEdge(chanID uint64) error
 }
 
 // DB is an interface describing a persisted Lightning Network graph.

--- a/graph/interfaces.go
+++ b/graph/interfaces.go
@@ -88,6 +88,10 @@ type ChannelGraphSource interface {
 
 	// MarkZombieEdge marks the channel with the given ID as a zombie edge.
 	MarkZombieEdge(chanID uint64) error
+
+	// IsZombieEdge returns true if the edge with the given channel ID is
+	// currently marked as a zombie edge.
+	IsZombieEdge(chanID lnwire.ShortChannelID) (bool, error)
 }
 
 // DB is an interface describing a persisted Lightning Network graph.

--- a/server.go
+++ b/server.go
@@ -1142,6 +1142,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		FindChannel:             s.findChannel,
 		IsStillZombieChannel:    s.graphBuilder.IsZombieChannel,
 		ScidCloser:              scidCloserMan,
+		AssumeChannelValid:      cfg.Routing.AssumeChannelValid,
 	}, nodeKeyDesc)
 
 	selfVertex := route.Vertex(nodeKeyDesc.PubKey.SerializeCompressed())


### PR DESCRIPTION
Depends on: 
- https://github.com/lightningnetwork/lnd/pull/9476
- https://github.com/lightningnetwork/lnd/pull/9477

Fixes https://github.com/lightningnetwork/lnd/issues/9475

```
This commit is a pure refactor. We move the transaction validation
(existence, spentness, correctness) from the `graph.Builder` to the
gossiper since this is where all protocol level checks should happen.
All tests involved are also updated/moved.
```