### PR TITLE
lntest: log timestamp when printing errors

### DIFF
--- a/lntest/node/harness_node.go
+++ b/lntest/node/harness_node.go
@@ -823,8 +823,8 @@ func (hn *HarnessNode) KillAndWait() error {
 
 // printErrf prints an error to the console.
 func (hn *HarnessNode) printErrf(format string, a ...interface{}) {
-	fmt.Printf("itest error from [%s:%s]: %s\n", //nolint:forbidigo
-		hn.Cfg.LogFilenamePrefix, hn.Cfg.Name,
+	fmt.Printf("%v: itest error from [%s:%s]: %s\n", //nolint:forbidigo
+		time.Now().UTC(), hn.Cfg.LogFilenamePrefix, hn.Cfg.Name,
 		fmt.Sprintf(format, a...))
 }
 


### PR DESCRIPTION
Found a flake from this [build](https://github.com/lightningnetwork/lnd/actions/runs/13156723364/job/36715442041?pr=9446), the root cause is unknown, and we now add a timestamp to the console logs so it's easier to debug next time.

```
--- FAIL: TestLightningNetworkDaemon (631.00s)
    harness_setup.go:25: Setting up HarnessTest...
    harness_setup.go:38: Prepare the miner and mine blocks to activate segwit...
    harness_setup.go:46: Connecting the miner at 127.0.0.1:10014 with the chain backend...
    --- FAIL: TestLightningNetworkDaemon/tranche04/152-of-267/bitcoind/send_to_route_error_propagation (133.32s)
        harness_node.go:403: Starting node (name=Alice) with PID=16073
        harness_node.go:403: Starting node (name=Bob) with PID=16172
        harness_node.go:403: Starting node (name=Carol) with PID=16257
        harness_node.go:403: Starting node (name=Charlie) with PID=16322
        harness.go:375: finished test: send_to_route_error_propagation, start height=626, end height=641, mined blocks=15
        harness.go:426: unable to shutdown Carol, got err: [Carol]: assert shutdown failed in log[.logs-tranche4/41-send_to_route_error_propagation-Carol-02ac8500.log]: node did not shut down properly: found log lines: C Sub-RPC Server
            2025-02-05 12:09:40.204 [INF] RPCS rpcserver.go:1009: Stopping PeersRPC Sub-RPC Server
            2025-02-05 12:09:40.204 [INF] RPCS rpcserver.go:1009: Stopping AutopilotRPC Sub-RPC Server
            2025-02-05 12:09:40.204 [INF] RPCS rpcserver.go:1009: Stopping ChainRPC Sub-RPC Server
            2025-02-05 12:09:40.204 [INF] RPCS rpcserver.go:1009: Stopping NeutrinoKitRPC Sub-RPC Server
            2025-02-05 12:09:40.204 [INF] RPCS rpcserver.go:1009: Stopping RouterRPC Sub-RPC Server
            2025-02-05 12:09:40.205 [INF] RPCS rpcserver.go:1009: Stopping DevRPC Sub-RPC Server
            2025-02-05 12:09:40.205 [INF] RPCS rpcserver.go:1009: Stopping WatchtowerClientRPC Sub-RPC Server
            2025-02-05 12:09:40.205 [INF] RPCS rpcserver.go:1009: Stopping VersionRPC Sub-RPC Server
            2025-02-05 12:09:40.205 [INF] RPCS rpcserver.go:1009: Stopping WalletKitRPC Sub-RPC Server
            2025-02-05 12:09:40.205 [INF] RPCS rpcserver.go:1009: Stopping InvoicesRPC Sub-RPC Server
            2025-02-05 12:09:40.205 [INF] LNWL estimator.go:877: Stopping web API fee estimator
        harness.go:429: 
            	Error Trace:	/home/runner/work/lnd/lnd/lntest/harness.go:429
            	            				/home/runner/work/lnd/lnd/lntest/harness.go:348
            	            				/opt/hostedtoolcache/go/1.22.11/x64/src/testing/testing.go:1175
            	            				/opt/hostedtoolcache/go/1.22.11/x64/src/testing/testing.go:1353
            	            				/opt/hostedtoolcache/go/1.22.11/x64/src/testing/testing.go:1683
            	Error:      	Received unexpected error:
            	            	[Carol]: assert shutdown failed in log[.logs-tranche4/41-send_to_route_error_propagation-Carol-02ac8500.log]: node did not shut down properly: found log lines: C Sub-RPC Server
            	            	2025-02-05 12:09:40.204 [INF] RPCS rpcserver.go:1009: Stopping PeersRPC Sub-RPC Server
            	            	2025-02-05 12:09:40.204 [INF] RPCS rpcserver.go:1009: Stopping AutopilotRPC Sub-RPC Server
            	            	2025-02-05 12:09:40.204 [INF] RPCS rpcserver.go:1009: Stopping ChainRPC Sub-RPC Server
            	            	2025-02-05 12:09:40.204 [INF] RPCS rpcserver.go:1009: Stopping NeutrinoKitRPC Sub-RPC Server
            	            	2025-02-05 12:09:40.204 [INF] RPCS rpcserver.go:1009: Stopping RouterRPC Sub-RPC Server
            	            	2025-02-05 12:09:40.205 [INF] RPCS rpcserver.go:1009: Stopping DevRPC Sub-RPC Server
            	            	2025-02-05 12:09:40.205 [INF] RPCS rpcserver.go:1009: Stopping WatchtowerClientRPC Sub-RPC Server
            	            	2025-02-05 12:09:40.205 [INF] RPCS rpcserver.go:1009: Stopping VersionRPC Sub-RPC Server
            	            	2025-02-05 12:09:40.205 [INF] RPCS rpcserver.go:1009: Stopping WalletKitRPC Sub-RPC Server
            	            	2025-02-05 12:09:40.205 [INF] RPCS rpcserver.go:1009: Stopping InvoicesRPC Sub-RPC Server
            	            	2025-02-05 12:09:40.205 [INF] LNWL estimator.go:877: Stopping web API fee estimator
            	Test:       	TestLightningNetworkDaemon/tranche04/152-of-267/bitcoind/send_to_route_error_propagation
            	Messages:   	failed to shutdown all nodes
    lnd_test.go:138: Failure time: 2025-02-05 12:11:10.180
FAIL
itest error from [leader_health_check:Carol-2]: found nil RPC clients
```