### PR TITLE
itest: fix flake in `testForwardInterceptorRestart`

### DIFF
--- a/itest/lnd_forward_interceptor_test.go
+++ b/itest/lnd_forward_interceptor_test.go
@@ -357,7 +357,7 @@ func testForwardInterceptorRestart(ht *lntest.HarnessTest) {
 	cfgs := [][]string{nil, nil, nil, nil}
 
 	// Open and wait for channels.
-	_, nodes := ht.CreateSimpleNetwork(cfgs, p)
+	chanPoints, nodes := ht.CreateSimpleNetwork(cfgs, p)
 	alice, bob, carol, dave := nodes[0], nodes[1], nodes[2], nodes[3]
 
 	// Connect an interceptor to Bob's node.
@@ -423,6 +423,13 @@ func testForwardInterceptorRestart(ht *lntest.HarnessTest) {
 	defer cancelBobInterceptor()
 
 	require.NoError(ht, restartAlice(), "failed to restart alice")
+
+	// Once restarted, we will wait until the reestabilishment of the links,
+	// Alice=>Bob and Bob=>Carol, finish before calling the interceptors. We
+	// check this by asserting that Carol is now aware of the two channels
+	// being active again.
+	ht.AssertChannelInGraph(carol, chanPoints[0])
+	ht.AssertChannelInGraph(carol, chanPoints[1])
 
 	// We should get another notification about the held HTLC.
 	packet = ht.ReceiveHtlcInterceptor(bobInterceptor)


### PR DESCRIPTION
Fix the flake found in this [build](https://github.com/lightningnetwork/lnd/actions/runs/13201855874/job/36855929097?pr=9477), and many other builds,
```
--- FAIL: TestLightningNetworkDaemon (115.68s)
    harness_setup.go:25: Setting up HarnessTest...
    harness_setup.go:38: Prepare the miner and mine blocks to activate segwit...
    harness_setup.go:46: Connecting the miner at 127.0.0.1:10045 with the chain backend...
    --- FAIL: TestLightningNetworkDaemon/tranche06/110-of-267/btcd/forward_interceptor_restart (29.50s)
        harness_node.go:403: Starting node (name=Alice) with PID=5473
        harness_node.go:403: Starting node (name=Bob) with PID=5507
        harness_node.go:403: Starting node (name=Carol) with PID=5537
        harness_node.go:403: Starting node (name=Dave) with PID=5570
        harness_node.go:403: Starting node (name=Bob) with PID=6063
        harness_node.go:403: Starting node (name=Alice) with PID=6093
        lnd_forward_interceptor_test.go:448: 
            	Error Trace:	/home/runner/work/lnd/lnd/itest/lnd_forward_interceptor_test.go:448
            	            				/home/runner/work/lnd/lnd/lntest/harness.go:297
            	            				/home/runner/work/lnd/lnd/itest/lnd_test.go:130
            	Error:      	Received unexpected error:
            	            	EOF
            	Test:       	TestLightningNetworkDaemon/tranche06/110-of-267/btcd/forward_interceptor_restart
            	Messages:   	failed to send request
        harness.go:375: finished test: forward_interceptor_restart, start height=485, end height=492, mined blocks=7
        harness.go:334: test failed, skipped cleanup
    lnd_test.go:138: Failure time: 2025-02-07 15:01:40.114
FAIL
```