### PR TITLE
fix graphbuilder flake

### DIFF
--- a/graph/builder_test.go
+++ b/graph/builder_test.go
@@ -582,7 +582,7 @@ func TestDisconnectedBlocks(t *testing.T) {
 // TestChansClosedOfflinePruneGraph tests that if channels we know of are
 // closed while we're offline, then once we resume operation of the
 // ChannelRouter, then the channels are properly pruned.
-func TestRouterChansClosedOfflinePruneGraph(t *testing.T) {
+func TestChansClosedOfflinePruneGraph(t *testing.T) {
 	t.Parallel()
 
 	const startingBlockHeight = 101


### PR DESCRIPTION
Observed in: https://github.com/lightningnetwork/lnd/actions/runs/13236175981/job/36941432766?pr=9491

We mock the ChainView with a buffered channel of 10 so there is the chance that no block is arrived and then we start our bestheight from the starting height, so we need to make sure the starting height is initialized.
