### PR TITLE
graph: remove redundant iteration through a node's persisted channels

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -257,6 +257,11 @@ The underlying functionality between those two options remain the same.
 
 * Log rotation can now use ZSTD
 
+* [Remove redundant 
+  iteration](https://github.com/lightningnetwork/lnd/pull/9496) over a node's 
+  persisted channels when updating the graph cache with a new node or node 
+  update.
+
 ## Deprecations
 
 ### ⚠️ **Warning:** The following RPCs will be removed in release version **0.21**:

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -904,10 +904,7 @@ func (c *ChannelGraph) AddLightningNode(node *models.LightningNode,
 				cNode := newGraphCacheNode(
 					node.PubKeyBytes, node.Features,
 				)
-				err := c.graphCache.AddNode(tx, cNode)
-				if err != nil {
-					return err
-				}
+				c.graphCache.AddNodeFeatures(cNode)
 			}
 
 			return addLightningNode(tx, node)

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -231,13 +231,13 @@ func NewChannelGraph(db kvdb.Backend, options ...OptionModifier) (*ChannelGraph,
 		log.Debugf("Populating in-memory channel graph, this might " +
 			"take a while...")
 
-		err := g.ForEachNodeCacheable(
-			func(tx kvdb.RTx, node GraphCacheNode) error {
-				g.graphCache.AddNodeFeatures(node)
+		err := g.ForEachNodeCacheable(func(node route.Vertex,
+			features *lnwire.FeatureVector) error {
 
-				return nil
-			},
-		)
+			g.graphCache.AddNodeFeatures(node, features)
+
+			return nil
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -772,8 +772,8 @@ func (c *ChannelGraph) forEachNode(
 // graph, executing the passed callback with each node encountered. If the
 // callback returns an error, then the transaction is aborted and the iteration
 // stops early.
-func (c *ChannelGraph) ForEachNodeCacheable(cb func(kvdb.RTx,
-	GraphCacheNode) error) error {
+func (c *ChannelGraph) ForEachNodeCacheable(cb func(route.Vertex,
+	*lnwire.FeatureVector) error) error {
 
 	traversal := func(tx kvdb.RTx) error {
 		// First grab the nodes bucket which stores the mapping from
@@ -792,7 +792,7 @@ func (c *ChannelGraph) ForEachNodeCacheable(cb func(kvdb.RTx,
 			}
 
 			nodeReader := bytes.NewReader(nodeBytes)
-			cacheableNode, err := deserializeLightningNodeCacheable(
+			node, features, err := deserializeLightningNodeCacheable( //nolint:ll
 				nodeReader,
 			)
 			if err != nil {
@@ -801,7 +801,7 @@ func (c *ChannelGraph) ForEachNodeCacheable(cb func(kvdb.RTx,
 
 			// Execute the callback, the transaction will abort if
 			// this returns an error.
-			return cb(tx, cacheableNode)
+			return cb(node, features)
 		})
 	}
 
@@ -901,10 +901,9 @@ func (c *ChannelGraph) AddLightningNode(node *models.LightningNode,
 	r := &batch.Request{
 		Update: func(tx kvdb.RwTx) error {
 			if c.graphCache != nil {
-				cNode := newGraphCacheNode(
+				c.graphCache.AddNodeFeatures(
 					node.PubKeyBytes, node.Features,
 				)
-				c.graphCache.AddNodeFeatures(cNode)
 			}
 
 			return addLightningNode(tx, node)
@@ -3056,50 +3055,6 @@ func (c *ChannelGraph) fetchLightningNode(tx kvdb.RTx,
 	return node, nil
 }
 
-// graphCacheNode is a struct that wraps a LightningNode in a way that it can be
-// cached in the graph cache.
-type graphCacheNode struct {
-	pubKeyBytes route.Vertex
-	features    *lnwire.FeatureVector
-}
-
-// newGraphCacheNode returns a new cache optimized node.
-func newGraphCacheNode(pubKey route.Vertex,
-	features *lnwire.FeatureVector) *graphCacheNode {
-
-	return &graphCacheNode{
-		pubKeyBytes: pubKey,
-		features:    features,
-	}
-}
-
-// PubKey returns the node's public identity key.
-func (n *graphCacheNode) PubKey() route.Vertex {
-	return n.pubKeyBytes
-}
-
-// Features returns the node's features.
-func (n *graphCacheNode) Features() *lnwire.FeatureVector {
-	return n.features
-}
-
-// ForEachChannel iterates through all channels of this node, executing the
-// passed callback with an edge info structure and the policies of each end
-// of the channel. The first edge policy is the outgoing edge *to* the
-// connecting node, while the second is the incoming edge *from* the
-// connecting node. If the callback returns an error, then the iteration is
-// halted with the error propagated back up to the caller.
-//
-// Unknown policies are passed into the callback as nil values.
-func (n *graphCacheNode) ForEachChannel(tx kvdb.RTx,
-	cb func(kvdb.RTx, *models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
-		*models.ChannelEdgePolicy) error) error {
-
-	return nodeTraversal(tx, n.pubKeyBytes[:], nil, cb)
-}
-
-var _ GraphCacheNode = (*graphCacheNode)(nil)
-
 // HasLightningNode determines if the graph has a vertex identified by the
 // target node identity public key. If the node exists in the database, a
 // timestamp of when the data for the node was lasted updated is returned along
@@ -4059,60 +4014,59 @@ func fetchLightningNode(nodeBucket kvdb.RBucket,
 	return deserializeLightningNode(nodeReader)
 }
 
-func deserializeLightningNodeCacheable(r io.Reader) (*graphCacheNode, error) {
-	// Always populate a feature vector, even if we don't have a node
-	// announcement and short circuit below.
-	node := newGraphCacheNode(
-		route.Vertex{},
-		lnwire.EmptyFeatureVector(),
-	)
+func deserializeLightningNodeCacheable(r io.Reader) (route.Vertex,
+	*lnwire.FeatureVector, error) {
 
-	var nodeScratch [8]byte
+	var (
+		pubKey      route.Vertex
+		features    = lnwire.EmptyFeatureVector()
+		nodeScratch [8]byte
+	)
 
 	// Skip ahead:
 	// - LastUpdate (8 bytes)
 	if _, err := r.Read(nodeScratch[:]); err != nil {
-		return nil, err
+		return pubKey, nil, err
 	}
 
-	if _, err := io.ReadFull(r, node.pubKeyBytes[:]); err != nil {
-		return nil, err
+	if _, err := io.ReadFull(r, pubKey[:]); err != nil {
+		return pubKey, nil, err
 	}
 
 	// Read the node announcement flag.
 	if _, err := r.Read(nodeScratch[:2]); err != nil {
-		return nil, err
+		return pubKey, nil, err
 	}
 	hasNodeAnn := byteOrder.Uint16(nodeScratch[:2])
 
 	// The rest of the data is optional, and will only be there if we got a
 	// node announcement for this node.
 	if hasNodeAnn == 0 {
-		return node, nil
+		return pubKey, features, nil
 	}
 
 	// We did get a node announcement for this node, so we'll have the rest
 	// of the data available.
 	var rgb uint8
 	if err := binary.Read(r, byteOrder, &rgb); err != nil {
-		return nil, err
+		return pubKey, nil, err
 	}
 	if err := binary.Read(r, byteOrder, &rgb); err != nil {
-		return nil, err
+		return pubKey, nil, err
 	}
 	if err := binary.Read(r, byteOrder, &rgb); err != nil {
-		return nil, err
+		return pubKey, nil, err
 	}
 
 	if _, err := wire.ReadVarString(r, 0); err != nil {
-		return nil, err
+		return pubKey, nil, err
 	}
 
-	if err := node.features.Decode(r); err != nil {
-		return nil, err
+	if err := features.Decode(r); err != nil {
+		return pubKey, nil, err
 	}
 
-	return node, nil
+	return pubKey, features, nil
 }
 
 func deserializeLightningNode(r io.Reader) (models.LightningNode, error) {

--- a/graph/db/graph_cache.go
+++ b/graph/db/graph_cache.go
@@ -136,23 +136,6 @@ func (c *GraphCache) AddNodeFeatures(node GraphCacheNode) {
 	c.mtx.Unlock()
 }
 
-// AddNode adds a graph node, including all the (directed) channels of that
-// node.
-func (c *GraphCache) AddNode(tx kvdb.RTx, node GraphCacheNode) error {
-	c.AddNodeFeatures(node)
-
-	return node.ForEachChannel(
-		tx, func(tx kvdb.RTx, info *models.ChannelEdgeInfo,
-			outPolicy *models.ChannelEdgePolicy,
-			inPolicy *models.ChannelEdgePolicy) error {
-
-			c.AddChannel(info, outPolicy, inPolicy)
-
-			return nil
-		},
-	)
-}
-
 // AddChannel adds a non-directed channel, meaning that the order of policy 1
 // and policy 2 does not matter, the directionality is extracted from the info
 // and policy flags automatically. The policy will be set as the outgoing policy

--- a/graph/db/graph_cache_test.go
+++ b/graph/db/graph_cache_test.go
@@ -88,18 +88,16 @@ func TestGraphCacheAddNode(t *testing.T) {
 		node := &node{
 			pubKey:   nodeA,
 			features: lnwire.EmptyFeatureVector(),
-			edgeInfos: []*models.ChannelEdgeInfo{{
-				ChannelID: 1000,
-				// Those are direction independent!
-				NodeKey1Bytes: pubKey1,
-				NodeKey2Bytes: pubKey2,
-				Capacity:      500,
-			}},
-			outPolicies: []*models.ChannelEdgePolicy{outPolicy1},
-			inPolicies:  []*models.ChannelEdgePolicy{inPolicy1},
 		}
 		cache := NewGraphCache(10)
-		require.NoError(t, cache.AddNode(nil, node))
+		cache.AddNodeFeatures(node)
+		cache.AddChannel(&models.ChannelEdgeInfo{
+			ChannelID: 1000,
+			// Those are direction independent!
+			NodeKey1Bytes: pubKey1,
+			NodeKey2Bytes: pubKey2,
+			Capacity:      500,
+		}, outPolicy1, inPolicy1)
 
 		var fromChannels, toChannels []*DirectedChannel
 		_ = cache.ForEachChannel(nodeA, func(c *DirectedChannel) error {


### PR DESCRIPTION
Today, each time the `GraphCache`s `AddNode` method is called, the DB is consulted and the node's 
known channels are iterated over and re-added to the cache. While this design made sense at the time
that the cache was added, it no longer is required with the updates to the architecture that have taken
place since. 

This change is part of https://github.com/lightningnetwork/lnd/issues/9494 as this removal of `AddNode` 
means that we no longer need to pass a `kvdb.RTx` to the `graphCache` methods and so it will be
easier to move the cache out of the CRUD layer in an upcoming PR. 

### More context:

The AddNode method on the GraphCache calls `AddNodeFeatures` underneath
and then iterates through all the node's persisted channels and adds
them to the cache too via `AddChannel`.

This is, however, not required since at the time the cache is populated
in `NewChannelGraph`, the cache is populated will all persisted nodes
and all persisted channels. Then, once any new channels come in, via
`AddChannelEdge`, they are added to the cache via AddChannel. If any new
nodes come in via `AddLightningNode`, then currently the cache's AddNode
method is called which the both adds the node and again iterates through
all persisted channels and re-adds them to the cache. This is definitely
redundent since the initial cache population and updates via
AddChannelEdge should keep the cache fresh in terms of channels.

So we remove this for 2 reasons: 1) to remove the redundent DB calls and
2) this requires a kvdb.RTx to be passed in to the GraphCache calls
   which will make it hard to extract the cache out of the CRUD layer
and be used more generally.

The AddNode method made sense when the cache was first added in the
code-base [here](https://github.com/lightningnetwork/lnd/commit/369c09be6152b76a24915050a8a5fe6bccf2b8f0#diff-ae36bdb6670644d20c4e43f3a0ed47f71886c2bcdf3cc2937de24315da5dc072R213) since then during graph cache population, nodes and channels 
would be added to the cache in a single DB transaction. This was, however,
changed [later on](https://github.com/lightningnetwork/lnd/commit/352008a0c22ffd9e97b9481ffa44dbc50fca2ddc) to be done in 2 separate DB calls for efficiency reasons.