### PR TITLE
routing: don't set custom amount if manager isn't handling

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -85,6 +85,9 @@
 * [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/9595) where the
   initial graph sync query may be failed due to inconsistent state.
 
+* [The aux bandwidth calculation was fixed for non-asset
+  channels](https://github.com/lightningnetwork/lnd/pull/9502).
+
 # New Features
 
 * [Support](https://github.com/lightningnetwork/lnd/pull/8390) for 

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -208,8 +208,18 @@ const (
 
 // OptionalBandwidth is a type alias for the result of a bandwidth query that
 // may return a bandwidth value or fn.None if the bandwidth is not available or
-// not applicable.
-type OptionalBandwidth = fn.Option[lnwire.MilliSatoshi]
+// not applicable. IsHandled is set to false if the external traffic shaper does
+// not handle the channel in question.
+type OptionalBandwidth struct {
+	// IsHandled is true if the external traffic shaper handles the channel.
+	// If this is false, then the bandwidth value is not applicable.
+	IsHandled bool
+
+	// Bandwidth is the available bandwidth for the channel, as determined
+	// by the external traffic shaper. If the external traffic shaper is not
+	// handling the channel, this value will be fn.None.
+	Bandwidth fn.Option[lnwire.MilliSatoshi]
+}
 
 // ChannelLink is an interface which represents the subsystem for managing the
 // incoming htlc requests, applying the changes to the channel, and also

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -976,7 +976,7 @@ func (f *mockChannelLink) AuxBandwidth(lnwire.MilliSatoshi,
 	lnwire.ShortChannelID,
 	fn.Option[tlv.Blob], AuxTrafficShaper) fn.Result[OptionalBandwidth] {
 
-	return fn.Ok(fn.None[lnwire.MilliSatoshi]())
+	return fn.Ok(OptionalBandwidth{})
 }
 
 var _ ChannelLink = (*mockChannelLink)(nil)

--- a/routing/bandwidth.go
+++ b/routing/bandwidth.go
@@ -143,6 +143,13 @@ func (b *bandwidthManager) getBandwidth(cid lnwire.ShortChannelID,
 					"auxiliary bandwidth: %w", err))
 			}
 
+			// If the external traffic shaper is not handling the
+			// channel, we'll just return the original bandwidth and
+			// no custom amount.
+			if !auxBandwidth.IsHandled {
+				return fn.Ok(bandwidthResult{})
+			}
+
 			// We don't know the actual HTLC amount that will be
 			// sent using the custom channel. But we'll still want
 			// to make sure we can add another HTLC, using the
@@ -152,7 +159,7 @@ func (b *bandwidthManager) getBandwidth(cid lnwire.ShortChannelID,
 			// the max number of HTLCs on the channel. A proper
 			// balance check is done elsewhere.
 			return fn.Ok(bandwidthResult{
-				bandwidth:  auxBandwidth,
+				bandwidth:  auxBandwidth.Bandwidth,
 				htlcAmount: fn.Some[lnwire.MilliSatoshi](0),
 			})
 		},

--- a/routing/mock_test.go
+++ b/routing/mock_test.go
@@ -904,9 +904,7 @@ func (m *mockLink) AuxBandwidth(lnwire.MilliSatoshi, lnwire.ShortChannelID,
 	fn.Option[tlv.Blob],
 	htlcswitch.AuxTrafficShaper) fn.Result[htlcswitch.OptionalBandwidth] {
 
-	return fn.Ok[htlcswitch.OptionalBandwidth](
-		fn.None[lnwire.MilliSatoshi](),
-	)
+	return fn.Ok(htlcswitch.OptionalBandwidth{})
 }
 
 // EligibleToForward returns the mock's configured eligibility.


### PR DESCRIPTION
Avoids overwriting the HTLC amount if the aux bandwidth manager isn't handling the channel.