### PR TITLE
.github: ignore Send coverage errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -262,6 +262,7 @@ jobs:
       - name: Send coverage
         uses: ziggie1984/actions-goveralls@c440f43938a4032b627d2b03d61d4ae1a2ba2b5c
         if: matrix.unit_type == 'btcd unit-cover'
+        continue-on-error: true
         with:
           path-to-profile: coverage.txt
           flag-name: 'unit'
@@ -315,6 +316,7 @@ jobs:
 
       - name: Send coverage
         if: ${{ contains(matrix.args, 'cover=1') }}
+        continue-on-error: true
         uses: ziggie1984/actions-goveralls@c440f43938a4032b627d2b03d61d4ae1a2ba2b5c
         with:
           path-to-profile: coverage.txt
@@ -382,6 +384,7 @@ jobs:
 
       - name: Send coverage
         if: ${{ contains(matrix.args, 'cover=1') }}
+        continue-on-error: true
         uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: coverage.txt


### PR DESCRIPTION
Sometimes only the "Send coverage" step of a CI job will fail. This commit turns this step into a "best effort" step instead so that it does not block a CI job from passing.

It can, for example, often happen that a single job is re-run from the GH UI, it then passes but the "Send coverage" step fails due to the "Can't add a job to a build that is already closed." error meaning that the only way to get the CI step to pass is to re-push and retrigger a full CI run. (example: https://github.com/lightningnetwork/lnd/actions/runs/13257033750/job/37078871135?pr=9496)