### PR TITLE
walletrpc: fix description of bumpfee.immediate

### DIFF
--- a/lnrpc/walletrpc/walletkit.pb.go
+++ b/lnrpc/walletrpc/walletkit.pb.go
@@ -3116,7 +3116,7 @@ type BumpFeeRequest struct {
 	// the estimated fee rate using the `target_conf` as the starting fee rate.
 	SatPerVbyte uint64 `protobuf:"varint,5,opt,name=sat_per_vbyte,json=satPerVbyte,proto3" json:"sat_per_vbyte,omitempty"`
 	// Optional. Whether this input will be swept immediately. When set to true,
-	// the sweeper will sweep this input without waiting for the next batch.
+	// the sweeper will sweep this input without waiting for the next block.
 	Immediate bool `protobuf:"varint,6,opt,name=immediate,proto3" json:"immediate,omitempty"`
 	// Optional. The max amount in sats that can be used as the fees. Setting this
 	// value greater than the input's value may result in CPFP - one or more wallet

--- a/lnrpc/walletrpc/walletkit.proto
+++ b/lnrpc/walletrpc/walletkit.proto
@@ -1216,7 +1216,7 @@ message BumpFeeRequest {
 
     /*
     Optional. Whether this input will be swept immediately. When set to true,
-    the sweeper will sweep this input without waiting for the next batch.
+    the sweeper will sweep this input without waiting for the next block.
     */
     bool immediate = 6;
 

--- a/lnrpc/walletrpc/walletkit.swagger.json
+++ b/lnrpc/walletrpc/walletkit.swagger.json
@@ -1440,7 +1440,7 @@
         },
         "immediate": {
           "type": "boolean",
-          "description": "Optional. Whether this input will be swept immediately. When set to true,\nthe sweeper will sweep this input without waiting for the next batch."
+          "description": "Optional. Whether this input will be swept immediately. When set to true,\nthe sweeper will sweep this input without waiting for the next block."
         },
         "budget": {
           "type": "string",


### PR DESCRIPTION
## Change Description

Changed description of option Immediate of https://pkg.go.dev/github.com/lightningnetwork/lnd@v0.18.5-beta/lnrpc/walletrpc#BumpFeeRequest

It waits for the next block and sends CPFP even if there are no other inputs to form a batch.


### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
