### PR TITLE
graph: Restrict interface to update channel proof instead of entire channel

### DIFF
--- a/graph/builder.go
+++ b/graph/builder.go
@@ -1441,14 +1441,7 @@ func (b *Builder) ForAllOutgoingChannels(cb func(*models.ChannelEdgeInfo,
 func (b *Builder) AddProof(chanID lnwire.ShortChannelID,
 	proof *models.ChannelAuthProof) error {
 
-	info, _, _, err := b.cfg.Graph.FetchChannelEdgesByID(chanID.ToUint64())
-	if err != nil {
-		return err
-	}
-
-	info.AuthProof = proof
-
-	return b.cfg.Graph.UpdateChannelEdge(info)
+	return b.cfg.Graph.AddEdgeProof(chanID, proof)
 }
 
 // IsStaleNode returns true if the graph source has a node announcement for the

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -1309,7 +1309,7 @@ func (c *ChannelGraph) UpdateChannelEdge(edge *models.ChannelEdgeInfo) error {
 
 	return kvdb.Update(c.db, func(tx kvdb.RwTx) error {
 		edges := tx.ReadWriteBucket(edgeBucket)
-		if edge == nil {
+		if edges == nil {
 			return ErrEdgeNotFound
 		}
 

--- a/graph/interfaces.go
+++ b/graph/interfaces.go
@@ -259,12 +259,10 @@ type DB interface {
 		*models.ChannelEdgePolicy,
 		*models.ChannelEdgePolicy) error) error
 
-	// UpdateChannelEdge retrieves and update edge of the graph database.
-	// Method only reserved for updating an edge info after its already been
-	// created. In order to maintain this constraints, we return an error in
-	// the scenario that an edge info hasn't yet been created yet, but
-	// someone attempts to update it.
-	UpdateChannelEdge(edge *models.ChannelEdgeInfo) error
+	// AddEdgeProof sets the proof of an existing edge in the graph
+	// database.
+	AddEdgeProof(chanID lnwire.ShortChannelID,
+		proof *models.ChannelAuthProof) error
 
 	// IsPublicNode is a helper method that determines whether the node with
 	// the given public key is seen as a public node in the graph from the


### PR DESCRIPTION
This commit restricts the graph CRUD interface such that one can only add a proof to a channel announcement and not update any other fields. This pattern is better suited for SQL land too.

This also fixes a bug where we were not doing a nil check on the `edges` bucket but instead on passed `edge` object. 

