### PR TITLE
multi: fix debug log

### DIFF
--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -3450,7 +3450,7 @@ func (l *channelLink) canSendHtlc(policy models.ForwardingPolicy,
 	// Check to see if there is enough balance in this channel.
 	if amt > availableBandwidth {
 		l.log.Warnf("insufficient bandwidth to route htlc: %v is "+
-			"larger than %v", amt, l.Bandwidth())
+			"larger than %v", amt, availableBandwidth)
 		cb := func(upd *lnwire.ChannelUpdate1) lnwire.FailureMessage {
 			return lnwire.NewTemporaryChannelFailure(upd)
 		}

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -8871,13 +8871,16 @@ func (lc *LightningChannel) availableCommitmentBalance(view *HtlcView,
 			ourBalance, futureCommitWeight, feePerKw, buffer,
 		)
 		if err != nil {
-			lc.log.Warnf("Set available amount to 0 because we "+
-				"could not pay for the CommitmentFee of the "+
-				"new ChannelState: ourBalance is negative "+
-				"after applying the fee: ourBalance=%v, "+
+			lc.log.Debugf("No available local balance after "+
+				"applying the CommitmentFee of the new "+
+				"CommitmentState(%v): ourBalance would drop "+
+				"below the reserve: "+
+				"ourBalance(w/o reserve)=%v, reserve=%v, "+
 				"current commitFee(w/o additional htlc)=%v, "+
-				"feeBuffer=%v (type=%v) local_chan_initiator",
-				ourBalance, commitFee, bufferAmt, buffer)
+				"feeBuffer=%v (type=%v) "+
+				"local_chan_initiator=%v", whoseCommitChain,
+				ourBalance, ourReserve, commitFee, bufferAmt,
+				buffer, lc.channelState.IsInitiator)
 
 			return 0, commitWeight
 		}


### PR DESCRIPTION
Based on a user report that a debug output was printed several times because we were calling `l.Bandwidth` more than necessary.