### PR TITLE
GitHub: remove duplicate caching

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -22,6 +22,7 @@ runs:
       uses: actions/setup-go@v5
       with:
         go-version: '${{ inputs.go-version }}'
+        cache: 'false'
 
     - name: go cache
       if: ${{ inputs.use-build-cache == 'yes' }}
@@ -44,7 +45,7 @@ runs:
 
     - name: go module cache
       if: ${{ inputs.use-build-cache == 'no' }}
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         # Just the module download cache.
         path: |


### PR DESCRIPTION
Turns out that actions/setup-go starting with @v4 also adds caching. With that, our cache size on disk has almost doubled, leading to the GitHub runner running out of space in certain situation. We fix that by disabling the automated caching since we already have our own, custom-tailored version.
