### PR TITLE
multi: add support for simple payments related metrics

### DIFF
--- a/monitoring/metrics.go
+++ b/monitoring/metrics.go
@@ -1,0 +1,76 @@
+//go:build monitoring
+// +build monitoring
+
+package monitoring
+
+import (
+	"sync"
+
+	"github.com/lightningnetwork/lnd/lncfg"
+)
+
+// MetricGroupCreator is a factory function that initializes a metric group.
+type MetricGroupCreator func(cfg *lncfg.Prometheus) (MetricGroup, error)
+
+// Global registry for all metric groups.
+var (
+	// metricGroups is a global variable of all registered metrics
+	// protected by the mutex below. All new MetricGroups should add
+	// themselves to this map within the init() method of their file.
+	metricGroups = make(map[string]MetricGroupCreator)
+
+	// activeGroups is a global map of all active metric groups. This can
+	// be used by some of the "static' package level methods to look up the
+	// target metric group to export observations.
+	activeMetrics = make(map[string]MetricGroup)
+
+	metricsMtx sync.Mutex
+)
+
+// MetricGroup is the primary interface for metric groups.
+type MetricGroup interface {
+	// Name returns the name of the metric group.
+	Name() string
+
+	// RegisterMetrics registers all metrics within the group.
+	RegisterMetrics() error
+
+	// ShouldRegister indicates whether this groups metrics should actually
+	// be registered.
+	ShouldRegister(cfg *lncfg.Prometheus) bool
+}
+
+// RegisterMetricGroup adds a new metric group to the registry.
+func RegisterMetricGroup(name string, creator MetricGroupCreator) {
+	metricsMtx.Lock()
+	defer metricsMtx.Unlock()
+	metricGroups[name] = creator
+}
+
+// InitializeMetrics initializes and registers all active metric groups.
+func InitializeMetrics(cfg *lncfg.Prometheus) error {
+	metricsMtx.Lock()
+	defer metricsMtx.Unlock()
+
+	for name, creator := range metricGroups {
+		// We'll pass the configuration struct to permit conditional
+		// metric registration in the future.
+		group, err := creator(cfg)
+		if err != nil {
+			return err
+		}
+
+		// Check whether this metric group should be registered.
+		if !group.ShouldRegister(cfg) {
+			continue
+		}
+
+		if err := group.RegisterMetrics(); err != nil {
+			return err
+		}
+
+		activeMetrics[name] = group
+	}
+
+	return nil
+}

--- a/monitoring/monitoring_off.go
+++ b/monitoring/monitoring_off.go
@@ -23,3 +23,13 @@ func ExportPrometheusMetrics(_ *grpc.Server, _ lncfg.Prometheus) error {
 	return fmt.Errorf("lnd must be built with the monitoring tag to " +
 		"enable exporting Prometheus metrics")
 }
+
+// IncrementPaymentCount increments a counter tracking the number of payments
+// made by lnd when monitoring is enabled. This method no-ops as monitoring is
+// disabled.
+func IncrementPaymentCount() {}
+
+// IncrementHTLCAttemptCount increments a counter tracking the number of HTLC
+// attempts made by lnd when monitoring is enabled. This method no-ops as
+// monitoring is disabled.
+func IncrementHTLCAttemptCount() {}

--- a/monitoring/payments_metrics.go
+++ b/monitoring/payments_metrics.go
@@ -1,0 +1,79 @@
+//go:build monitoring
+// +build monitoring
+
+package monitoring
+
+import (
+	"github.com/lightningnetwork/lnd/lncfg"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const paymentsMetricGroupName string = "payments"
+
+// paymentMetrics tracks payment-related Prometheus metrics.
+type paymentMetrics struct {
+	totalPayments     prometheus.Counter
+	totalHTLCAttempts prometheus.Counter
+}
+
+// NewPaymentMetrics creates a new instance of payment metrics.
+func NewPaymentMetrics(cfg *lncfg.Prometheus) (MetricGroup, error) {
+	return &paymentMetrics{
+		totalPayments: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "lnd_total_payments",
+			Help: "Total number of payments initiated",
+		}),
+		totalHTLCAttempts: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "lnd_total_htlc_attempts",
+			Help: "Total number of HTLC attempts",
+		}),
+	}, nil
+}
+
+// Name returns the metric group name.
+func (p *paymentMetrics) Name() string {
+	return paymentsMetricGroupName
+}
+
+// RegisterMetrics registers payment-related Prometheus metrics.
+func (p *paymentMetrics) RegisterMetrics() error {
+	err := prometheus.Register(p.totalPayments)
+	if err != nil {
+		return err
+	}
+	return prometheus.Register(p.totalHTLCAttempts)
+}
+
+// ShouldRegister indicates whether the payments related metrics should be
+// registered with prometheus.
+func (p *paymentMetrics) ShouldRegister(cfg *lncfg.Prometheus) bool {
+	// TODO: Can condition this on application config.
+	return true
+}
+
+// IncrementPaymentCount increments the counter tracking the number of payments
+// made by lnd when monitoring is enabled and the metric is configured
+func IncrementPaymentCount() {
+	group, ok := activeMetrics[paymentsMetricGroupName].(*paymentMetrics)
+	if !ok {
+		return
+	}
+
+	group.totalPayments.Inc()
+}
+
+// IncrementHTLCAttemptCount increments the counter tracking the number of HTLC
+// attempts made by lnd when monitoring is enabled and the metric is configured.
+func IncrementHTLCAttemptCount() {
+	group, ok := activeMetrics[paymentsMetricGroupName].(*paymentMetrics)
+	if !ok {
+		return
+	}
+
+	group.totalHTLCAttempts.Inc()
+}
+
+// Register the payments metric group.
+func init() {
+	RegisterMetricGroup(paymentsMetricGroupName, NewPaymentMetrics)
+}

--- a/routing/control_tower.go
+++ b/routing/control_tower.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/monitoring"
 	"github.com/lightningnetwork/lnd/multimutex"
 	"github.com/lightningnetwork/lnd/queue"
 )
@@ -190,6 +191,9 @@ func (p *controlTower) InitPayment(paymentHash lntypes.Hash,
 	if err != nil {
 		return err
 	}
+
+	// Observe the creation of a new payment.
+	monitoring.IncrementPaymentCount()
 
 	// Take lock before querying the db to prevent missing or duplicating
 	// an update.

--- a/routing/payment_lifecycle.go
+++ b/routing/payment_lifecycle.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/monitoring"
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/routing/shards"
 	"github.com/lightningnetwork/lnd/tlv"
@@ -595,6 +596,9 @@ func (p *paymentLifecycle) registerAttempt(rt *route.Route,
 	err = p.router.cfg.Control.RegisterAttempt(
 		p.identifier, &attempt.HTLCAttemptInfo,
 	)
+
+	// Observe a new HTLC attempt for the payment.
+	monitoring.IncrementHTLCAttemptCount()
 
 	return attempt, err
 }


### PR DESCRIPTION
## Change Description
Add support for real time tracking of counters for payments and attempts. These can be used to compute and create visualizations for things like average payment throughput and average # of attempts per payment.

```
rate(lnd_total_payments[5m])
rate(lnd_total_htlc_attempts[30m]) / rate(lnd_total_payments[30m])
```

- The registration of the metrics is hidden behind the `monitoring` build tag as is the case for the existing gRPC related metrics.
- The structure was intended to allow reasonably easy extension if we want to allow application configuration to conditionally register some metrics but not others. You'd just need to add a flag similar to the existing `PerfHistograms` on the `lncfg.Prometheus` type and then conditionally indicate that the metric should not be registered via `ShouldRegister`. For now the payments related metrics are registered by default if the `monitoring` build tag is used.
- The counters are in-memory only so will reset to 0 after _**lnd**_ restart. Despite this, they are still useful for tracking the throughput and other statistics. As a result they will not show the total # of payments made during the lifetime of the lightning node.

### Questions
- I know that a lot of metric gathering has historically been off-loaded to _**lndmon**_. Is that a preferable pattern to continue here as well? I ask because incrementing counters in real-time is not possible via an external mechanism like _**lndmon**_ which must query _**lnd**_ for the information, likely via `ListPayments` RPC and will have to take care to count payments properly and not run into trouble if the paginated queries take longer than the scrape interval.

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
