### PR TITLE
graph: extract cache from CRUD [2] 

### DIFF
--- a/autopilot/prefattach_test.go
+++ b/autopilot/prefattach_test.go
@@ -46,7 +46,7 @@ func newDiskChanGraph(t *testing.T) (testGraph, error) {
 	})
 	require.NoError(t, err)
 
-	graphDB, err := graphdb.NewChannelGraph(backend)
+	graphDB, err := graphdb.NewChannelGraph(&graphdb.Config{KVDB: backend})
 	require.NoError(t, err)
 
 	return &testDBGraph{

--- a/config_builder.go
+++ b/config_builder.go
@@ -1030,14 +1030,17 @@ func (d *DefaultDatabaseBuilder) BuildDatabase(
 		graphdb.WithRejectCacheSize(cfg.Caches.RejectCacheSize),
 		graphdb.WithChannelCacheSize(cfg.Caches.ChannelCacheSize),
 		graphdb.WithBatchCommitInterval(cfg.DB.BatchCommitInterval),
+	}
+
+	chanGraphOpts := []graphdb.ChanGraphOption{
 		graphdb.WithUseGraphCache(!cfg.DB.NoGraphCache),
 	}
 
 	// We want to pre-allocate the channel graph cache according to what we
 	// expect for mainnet to speed up memory allocation.
 	if cfg.ActiveNetParams.Name == chaincfg.MainNetParams.Name {
-		graphDBOptions = append(
-			graphDBOptions, graphdb.WithPreAllocCacheNumNodes(
+		chanGraphOpts = append(
+			chanGraphOpts, graphdb.WithPreAllocCacheNumNodes(
 				graphdb.DefaultPreAllocCacheNumNodes,
 			),
 		)
@@ -1046,7 +1049,7 @@ func (d *DefaultDatabaseBuilder) BuildDatabase(
 	dbs.GraphDB, err = graphdb.NewChannelGraph(&graphdb.Config{
 		KVDB:        databaseBackends.GraphDB,
 		KVStoreOpts: graphDBOptions,
-	})
+	}, chanGraphOpts...)
 	if err != nil {
 		cleanUp()
 

--- a/config_builder.go
+++ b/config_builder.go
@@ -1026,7 +1026,7 @@ func (d *DefaultDatabaseBuilder) BuildDatabase(
 			"instances")
 	}
 
-	graphDBOptions := []graphdb.OptionModifier{
+	graphDBOptions := []graphdb.KVStoreOptionModifier{
 		graphdb.WithRejectCacheSize(cfg.Caches.RejectCacheSize),
 		graphdb.WithChannelCacheSize(cfg.Caches.ChannelCacheSize),
 		graphdb.WithBatchCommitInterval(cfg.DB.BatchCommitInterval),

--- a/config_builder.go
+++ b/config_builder.go
@@ -1043,9 +1043,10 @@ func (d *DefaultDatabaseBuilder) BuildDatabase(
 		)
 	}
 
-	dbs.GraphDB, err = graphdb.NewChannelGraph(
-		databaseBackends.GraphDB, graphDBOptions...,
-	)
+	dbs.GraphDB, err = graphdb.NewChannelGraph(&graphdb.Config{
+		KVDB:        databaseBackends.GraphDB,
+		KVStoreOpts: graphDBOptions,
+	})
 	if err != nil {
 		cleanUp()
 

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -260,6 +260,7 @@ The underlying functionality between those two options remain the same.
     - [Refactor to hide DB transactions](https://github.com/lightningnetwork/lnd/pull/9513)
     - Move the graph cache out of the graph CRUD layer:
       - [1](https://github.com/lightningnetwork/lnd/pull/9533)
+      - [2](https://github.com/lightningnetwork/lnd/pull/9545)
 
 * [Golang was updated to
   `v1.22.11`](https://github.com/lightningnetwork/lnd/pull/9462). 

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -12,8 +12,8 @@ type ChannelGraph struct {
 }
 
 // NewChannelGraph creates a new ChannelGraph instance with the given backend.
-func NewChannelGraph(db kvdb.Backend, options ...OptionModifier) (*ChannelGraph,
-	error) {
+func NewChannelGraph(db kvdb.Backend, options ...KVStoreOptionModifier) (
+	*ChannelGraph, error) {
 
 	store, err := NewKVStore(db, options...)
 	if err != nil {

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -2,6 +2,18 @@ package graphdb
 
 import "github.com/lightningnetwork/lnd/kvdb"
 
+// Config is a struct that holds all the necessary dependencies for a
+// ChannelGraph.
+type Config struct {
+	// KVDB is the kvdb.Backend that will be used for initializing the
+	// KVStore CRUD layer.
+	KVDB kvdb.Backend
+
+	// KVStoreOpts is a list of functional options that will be used when
+	// initializing the KVStore.
+	KVStoreOpts []KVStoreOptionModifier
+}
+
 // ChannelGraph is a layer above the graph's CRUD layer.
 //
 // NOTE: currently, this is purely a pass-through layer directly to the backing
@@ -12,10 +24,8 @@ type ChannelGraph struct {
 }
 
 // NewChannelGraph creates a new ChannelGraph instance with the given backend.
-func NewChannelGraph(db kvdb.Backend, options ...KVStoreOptionModifier) (
-	*ChannelGraph, error) {
-
-	store, err := NewKVStore(db, options...)
+func NewChannelGraph(cfg *Config) (*ChannelGraph, error) {
+	store, err := NewKVStore(cfg.KVDB, cfg.KVStoreOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -1,6 +1,13 @@
 package graphdb
 
-import "github.com/lightningnetwork/lnd/kvdb"
+import (
+	"time"
+
+	"github.com/lightningnetwork/lnd/graph/db/models"
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/route"
+)
 
 // Config is a struct that holds all the necessary dependencies for a
 // ChannelGraph.
@@ -20,17 +27,67 @@ type Config struct {
 // KVStore. Upcoming commits will move the graph cache out of the KVStore and
 // into this layer so that the KVStore is only responsible for CRUD operations.
 type ChannelGraph struct {
+	graphCache *GraphCache
+
 	*KVStore
 }
 
 // NewChannelGraph creates a new ChannelGraph instance with the given backend.
-func NewChannelGraph(cfg *Config) (*ChannelGraph, error) {
+func NewChannelGraph(cfg *Config, options ...ChanGraphOption) (*ChannelGraph,
+	error) {
+
+	opts := defaultChanGraphOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
 	store, err := NewKVStore(cfg.KVDB, cfg.KVStoreOpts...)
 	if err != nil {
 		return nil, err
 	}
 
+	if !opts.useGraphCache {
+		return &ChannelGraph{
+			KVStore: store,
+		}, nil
+	}
+
+	// The graph cache can be turned off (e.g. for mobile users) for a
+	// speed/memory usage tradeoff.
+	graphCache := NewGraphCache(opts.preAllocCacheNumNodes)
+	startTime := time.Now()
+	log.Debugf("Populating in-memory channel graph, this might take a " +
+		"while...")
+
+	err = store.ForEachNodeCacheable(func(node route.Vertex,
+		features *lnwire.FeatureVector) error {
+
+		graphCache.AddNodeFeatures(node, features)
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	err = store.ForEachChannel(func(info *models.ChannelEdgeInfo,
+		policy1, policy2 *models.ChannelEdgePolicy) error {
+
+		graphCache.AddChannel(info, policy1, policy2)
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debugf("Finished populating in-memory channel graph (took %v, %s)",
+		time.Since(startTime), graphCache.Stats())
+
+	store.setGraphCache(graphCache)
+
 	return &ChannelGraph{
-		KVStore: store,
+		KVStore:    store,
+		graphCache: graphCache,
 	}, nil
 }

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -4005,7 +4005,7 @@ func TestGraphLoading(t *testing.T) {
 	defer backend.Close()
 	defer backendCleanup()
 
-	graph, err := NewChannelGraph(backend)
+	graph, err := NewChannelGraph(&Config{KVDB: backend})
 	require.NoError(t, err)
 
 	// Populate the graph with test data.
@@ -4015,7 +4015,7 @@ func TestGraphLoading(t *testing.T) {
 
 	// Recreate the graph. This should cause the graph cache to be
 	// populated.
-	graphReloaded, err := NewChannelGraph(backend)
+	graphReloaded, err := NewChannelGraph(&Config{KVDB: backend})
 	require.NoError(t, err)
 
 	// Assert that the cache content is identical.

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -3924,6 +3924,7 @@ func TestGraphCacheForEachNodeChannel(t *testing.T) {
 	// Unset the channel graph cache to simulate the user running with the
 	// option turned off.
 	graph.graphCache = nil
+	graph.KVStore.graphCache = nil
 
 	node1, err := createTestVertex(graph.db)
 	require.Nil(t, err)

--- a/graph/db/kv_store.go
+++ b/graph/db/kv_store.go
@@ -198,7 +198,7 @@ type KVStore struct {
 
 // NewKVStore allocates a new KVStore backed by a DB instance. The
 // returned instance has its own unique reject cache and channel cache.
-func NewKVStore(db kvdb.Backend, options ...OptionModifier) (*KVStore,
+func NewKVStore(db kvdb.Backend, options ...KVStoreOptionModifier) (*KVStore,
 	error) {
 
 	opts := DefaultOptions()
@@ -4827,8 +4827,8 @@ func (c *chanGraphNodeTx) ForEachChannel(f func(*models.ChannelEdgeInfo,
 
 // MakeTestGraph creates a new instance of the KVStore for testing
 // purposes.
-func MakeTestGraph(t testing.TB, modifiers ...OptionModifier) (*ChannelGraph,
-	error) {
+func MakeTestGraph(t testing.TB, modifiers ...KVStoreOptionModifier) (
+	*ChannelGraph, error) {
 
 	opts := DefaultOptions()
 	for _, modifier := range modifiers {

--- a/graph/db/kv_store.go
+++ b/graph/db/kv_store.go
@@ -4843,7 +4843,10 @@ func MakeTestGraph(t testing.TB, modifiers ...KVStoreOptionModifier) (
 		return nil, err
 	}
 
-	graph, err := NewChannelGraph(backend)
+	graph, err := NewChannelGraph(&Config{
+		KVDB:        backend,
+		KVStoreOpts: modifiers,
+	})
 	if err != nil {
 		backendCleanup()
 

--- a/graph/db/options.go
+++ b/graph/db/options.go
@@ -20,6 +20,47 @@ const (
 	DefaultPreAllocCacheNumNodes = 15000
 )
 
+// chanGraphOptions holds parameters for tuning and customizing the
+// ChannelGraph.
+type chanGraphOptions struct {
+	// useGraphCache denotes whether the in-memory graph cache should be
+	// used or a fallback version that uses the underlying database for
+	// path finding.
+	useGraphCache bool
+
+	// preAllocCacheNumNodes is the number of nodes we expect to be in the
+	// graph cache, so we can pre-allocate the map accordingly.
+	preAllocCacheNumNodes int
+}
+
+// defaultChanGraphOptions returns a new chanGraphOptions instance populated
+// with default values.
+func defaultChanGraphOptions() *chanGraphOptions {
+	return &chanGraphOptions{
+		useGraphCache:         true,
+		preAllocCacheNumNodes: DefaultPreAllocCacheNumNodes,
+	}
+}
+
+// ChanGraphOption describes the signature of a functional option that can be
+// used to customize a ChannelGraph instance.
+type ChanGraphOption func(*chanGraphOptions)
+
+// WithUseGraphCache sets whether the in-memory graph cache should be used.
+func WithUseGraphCache(use bool) ChanGraphOption {
+	return func(o *chanGraphOptions) {
+		o.useGraphCache = use
+	}
+}
+
+// WithPreAllocCacheNumNodes sets the number of nodes we expect to be in the
+// graph cache, so we can pre-allocate the map accordingly.
+func WithPreAllocCacheNumNodes(n int) ChanGraphOption {
+	return func(o *chanGraphOptions) {
+		o.preAllocCacheNumNodes = n
+	}
+}
+
 // KVStoreOptions holds parameters for tuning and customizing a graph.DB.
 type KVStoreOptions struct {
 	// RejectCacheSize is the maximum number of rejectCacheEntries to hold
@@ -34,15 +75,6 @@ type KVStoreOptions struct {
 	// wait before attempting to commit a pending set of updates.
 	BatchCommitInterval time.Duration
 
-	// PreAllocCacheNumNodes is the number of nodes we expect to be in the
-	// graph cache, so we can pre-allocate the map accordingly.
-	PreAllocCacheNumNodes int
-
-	// UseGraphCache denotes whether the in-memory graph cache should be
-	// used or a fallback version that uses the underlying database for
-	// path finding.
-	UseGraphCache bool
-
 	// NoMigration specifies that underlying backend was opened in read-only
 	// mode and migrations shouldn't be performed. This can be useful for
 	// applications that use the channeldb package as a library.
@@ -52,11 +84,9 @@ type KVStoreOptions struct {
 // DefaultOptions returns a KVStoreOptions populated with default values.
 func DefaultOptions() *KVStoreOptions {
 	return &KVStoreOptions{
-		RejectCacheSize:       DefaultRejectCacheSize,
-		ChannelCacheSize:      DefaultChannelCacheSize,
-		PreAllocCacheNumNodes: DefaultPreAllocCacheNumNodes,
-		UseGraphCache:         true,
-		NoMigration:           false,
+		RejectCacheSize:  DefaultRejectCacheSize,
+		ChannelCacheSize: DefaultChannelCacheSize,
+		NoMigration:      false,
 	}
 }
 
@@ -78,24 +108,10 @@ func WithChannelCacheSize(n int) KVStoreOptionModifier {
 	}
 }
 
-// WithPreAllocCacheNumNodes sets the PreAllocCacheNumNodes to n.
-func WithPreAllocCacheNumNodes(n int) KVStoreOptionModifier {
-	return func(o *KVStoreOptions) {
-		o.PreAllocCacheNumNodes = n
-	}
-}
-
 // WithBatchCommitInterval sets the batch commit interval for the interval batch
 // schedulers.
 func WithBatchCommitInterval(interval time.Duration) KVStoreOptionModifier {
 	return func(o *KVStoreOptions) {
 		o.BatchCommitInterval = interval
-	}
-}
-
-// WithUseGraphCache sets the UseGraphCache option to the given value.
-func WithUseGraphCache(use bool) KVStoreOptionModifier {
-	return func(o *KVStoreOptions) {
-		o.UseGraphCache = use
 	}
 }

--- a/graph/db/options.go
+++ b/graph/db/options.go
@@ -20,8 +20,8 @@ const (
 	DefaultPreAllocCacheNumNodes = 15000
 )
 
-// Options holds parameters for tuning and customizing a graph.DB.
-type Options struct {
+// KVStoreOptions holds parameters for tuning and customizing a graph.DB.
+type KVStoreOptions struct {
 	// RejectCacheSize is the maximum number of rejectCacheEntries to hold
 	// in the rejection cache.
 	RejectCacheSize int
@@ -49,9 +49,9 @@ type Options struct {
 	NoMigration bool
 }
 
-// DefaultOptions returns an Options populated with default values.
-func DefaultOptions() *Options {
-	return &Options{
+// DefaultOptions returns a KVStoreOptions populated with default values.
+func DefaultOptions() *KVStoreOptions {
+	return &KVStoreOptions{
 		RejectCacheSize:       DefaultRejectCacheSize,
 		ChannelCacheSize:      DefaultChannelCacheSize,
 		PreAllocCacheNumNodes: DefaultPreAllocCacheNumNodes,
@@ -60,41 +60,42 @@ func DefaultOptions() *Options {
 	}
 }
 
-// OptionModifier is a function signature for modifying the default Options.
-type OptionModifier func(*Options)
+// KVStoreOptionModifier is a function signature for modifying the default
+// KVStoreOptions.
+type KVStoreOptionModifier func(*KVStoreOptions)
 
 // WithRejectCacheSize sets the RejectCacheSize to n.
-func WithRejectCacheSize(n int) OptionModifier {
-	return func(o *Options) {
+func WithRejectCacheSize(n int) KVStoreOptionModifier {
+	return func(o *KVStoreOptions) {
 		o.RejectCacheSize = n
 	}
 }
 
 // WithChannelCacheSize sets the ChannelCacheSize to n.
-func WithChannelCacheSize(n int) OptionModifier {
-	return func(o *Options) {
+func WithChannelCacheSize(n int) KVStoreOptionModifier {
+	return func(o *KVStoreOptions) {
 		o.ChannelCacheSize = n
 	}
 }
 
 // WithPreAllocCacheNumNodes sets the PreAllocCacheNumNodes to n.
-func WithPreAllocCacheNumNodes(n int) OptionModifier {
-	return func(o *Options) {
+func WithPreAllocCacheNumNodes(n int) KVStoreOptionModifier {
+	return func(o *KVStoreOptions) {
 		o.PreAllocCacheNumNodes = n
 	}
 }
 
 // WithBatchCommitInterval sets the batch commit interval for the interval batch
 // schedulers.
-func WithBatchCommitInterval(interval time.Duration) OptionModifier {
-	return func(o *Options) {
+func WithBatchCommitInterval(interval time.Duration) KVStoreOptionModifier {
+	return func(o *KVStoreOptions) {
 		o.BatchCommitInterval = interval
 	}
 }
 
 // WithUseGraphCache sets the UseGraphCache option to the given value.
-func WithUseGraphCache(use bool) OptionModifier {
-	return func(o *Options) {
+func WithUseGraphCache(use bool) KVStoreOptionModifier {
+	return func(o *KVStoreOptions) {
 		o.UseGraphCache = use
 	}
 }

--- a/graph/notifications_test.go
+++ b/graph/notifications_test.go
@@ -1093,9 +1093,12 @@ func makeTestGraph(t *testing.T, useCache bool) (*graphdb.ChannelGraph,
 
 	t.Cleanup(backendCleanup)
 
-	graph, err := graphdb.NewChannelGraph(
-		backend, graphdb.WithUseGraphCache(useCache),
-	)
+	graph, err := graphdb.NewChannelGraph(&graphdb.Config{
+		KVDB: backend,
+		KVStoreOpts: []graphdb.KVStoreOptionModifier{
+			graphdb.WithUseGraphCache(useCache),
+		},
+	})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/graph/notifications_test.go
+++ b/graph/notifications_test.go
@@ -1093,12 +1093,10 @@ func makeTestGraph(t *testing.T, useCache bool) (*graphdb.ChannelGraph,
 
 	t.Cleanup(backendCleanup)
 
-	graph, err := graphdb.NewChannelGraph(&graphdb.Config{
-		KVDB: backend,
-		KVStoreOpts: []graphdb.KVStoreOptionModifier{
-			graphdb.WithUseGraphCache(useCache),
-		},
-	})
+	graph, err := graphdb.NewChannelGraph(
+		&graphdb.Config{KVDB: backend},
+		graphdb.WithUseGraphCache(useCache),
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -615,7 +615,9 @@ func createTestPeer(t *testing.T) *peerTestCtx {
 	})
 	require.NoError(t, err)
 
-	dbAliceGraph, err := graphdb.NewChannelGraph(graphBackend)
+	dbAliceGraph, err := graphdb.NewChannelGraph(&graphdb.Config{
+		KVDB: graphBackend,
+	})
 	require.NoError(t, err)
 
 	dbAliceChannel := channeldb.OpenForTesting(t, dbPath)

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -166,12 +166,10 @@ func makeTestGraph(t *testing.T, useCache bool) (*graphdb.ChannelGraph,
 
 	t.Cleanup(backendCleanup)
 
-	graph, err := graphdb.NewChannelGraph(&graphdb.Config{
-		KVDB: backend,
-		KVStoreOpts: []graphdb.KVStoreOptionModifier{
-			graphdb.WithUseGraphCache(useCache),
-		},
-	})
+	graph, err := graphdb.NewChannelGraph(
+		&graphdb.Config{KVDB: backend},
+		graphdb.WithUseGraphCache(useCache),
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -166,9 +166,12 @@ func makeTestGraph(t *testing.T, useCache bool) (*graphdb.ChannelGraph,
 
 	t.Cleanup(backendCleanup)
 
-	graph, err := graphdb.NewChannelGraph(
-		backend, graphdb.WithUseGraphCache(useCache),
-	)
+	graph, err := graphdb.NewChannelGraph(&graphdb.Config{
+		KVDB: backend,
+		KVStoreOpts: []graphdb.KVStoreOptionModifier{
+			graphdb.WithUseGraphCache(useCache),
+		},
+	})
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
** Part 2 **

This builds towards [this](https://github.com/lightningnetwork/lnd/pull/9529) final result by building [this](https://github.com/lightningnetwork/lnd/pull/9544) side branch incrementally.

In this PR, we first rename the existing KV store functional option type to be more context specific so that we 
free up the more general `Options` name for the new `ChannelGraph`. 

Then, we let the ChannelGraph init the KVStore using its config options. 

Finally, we let the ChannelGraph be responsible for the init of the graphCache. For now, both structs hold a pointer to the
graphCache. But the end of the series, the KVStore will no longer have a pointer to the graphCache