### PR TITLE
Fix unit test flake `TestHistoricalConfDetailsTxIndex`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,18 +276,18 @@ unit-bench: $(BTCD_BIN)
 # FLAKE HUNTING
 # =============
 
-#? flakehunter: Run the integration tests continuously until one fails
-flakehunter: build-itest
+#? flakehunter-itest: Run the integration tests continuously until one fails
+flakehunter-itest: build-itest
 	@$(call print, "Flake hunting ${backend} integration tests.")
 	while [ $$? -eq 0 ]; do make itest-only icase='${icase}' backend='${backend}'; done
 
-#? flake-unit: Run the unit tests continuously until one fails
-flake-unit:
-	@$(call print, "Flake hunting unit tests.")
-	while [ $$? -eq 0 ]; do GOTRACEBACK=all $(UNIT) -count=1; done
+#? flakehunter-unit: Run the unit tests continuously until one fails
+flakehunter-unit:
+	@$(call print, "Flake hunting unit test.")
+	scripts/unit-test-flake-hunter.sh ${pkg} ${case}
 
-#? flakehunter-parallel: Run the integration tests continuously until one fails, running up to ITEST_PARALLELISM test tranches in parallel (default 4)
-flakehunter-parallel:
+#? flakehunter-itest-parallel: Run the integration tests continuously until one fails, running up to ITEST_PARALLELISM test tranches in parallel (default 4)
+flakehunter-itest-parallel:
 	@$(call print, "Flake hunting ${backend} integration tests in parallel.")
 	while [ $$? -eq 0 ]; do make itest-parallel tranches=1 parallel=${ITEST_PARALLELISM} icase='${icase}' backend='${backend}'; done
 

--- a/chainntnfs/bitcoindnotify/bitcoind_test.go
+++ b/chainntnfs/bitcoindnotify/bitcoind_test.go
@@ -189,8 +189,6 @@ func testHistoricalConfDetailsTxIndex(t *testing.T, rpcPolling bool) {
 		t, bitcoindConn, hintCache, hintCache, blockCache,
 	)
 
-	syncNotifierWithMiner(t, notifier, miner)
-
 	// A transaction unknown to the node should not be found within the
 	// txindex even if it is enabled, so we should not proceed with any
 	// fallback methods.
@@ -296,7 +294,11 @@ func testHistoricalConfDetailsNoTxIndex(t *testing.T, rpcpolling bool) {
 	copy(unknownHash[:], bytes.Repeat([]byte{0x10}, 32))
 	unknownConfReq, err := chainntnfs.NewConfRequest(&unknownHash, testScript)
 	require.NoError(t, err, "unable to create conf request")
-	broadcastHeight := syncNotifierWithMiner(t, notifier, miner)
+
+	// Get the current best height.
+	_, broadcastHeight, err := miner.Client.GetBestBlock()
+	require.NoError(t, err, "unable to retrieve miner's current height")
+
 	_, txStatus, err := notifier.historicalConfDetails(
 		unknownConfReq, uint32(broadcastHeight), uint32(broadcastHeight),
 	)

--- a/chainntnfs/bitcoindnotify/bitcoind_test.go
+++ b/chainntnfs/bitcoindnotify/bitcoind_test.go
@@ -179,7 +179,7 @@ func testHistoricalConfDetailsTxIndex(t *testing.T, rpcPolling bool) {
 	)
 
 	bitcoindConn := unittest.NewBitcoindBackend(
-		t, unittest.NetParams, miner.P2PAddress(), true, rpcPolling,
+		t, unittest.NetParams, miner, true, rpcPolling,
 	)
 
 	hintCache := initHintCache(t)
@@ -279,7 +279,7 @@ func testHistoricalConfDetailsNoTxIndex(t *testing.T, rpcpolling bool) {
 	miner := unittest.NewMiner(t, unittest.NetParams, nil, true, 25)
 
 	bitcoindConn := unittest.NewBitcoindBackend(
-		t, unittest.NetParams, miner.P2PAddress(), false, rpcpolling,
+		t, unittest.NetParams, miner, false, rpcpolling,
 	)
 
 	hintCache := initHintCache(t)

--- a/chainntnfs/test/test_interface.go
+++ b/chainntnfs/test/test_interface.go
@@ -1932,7 +1932,7 @@ func TestInterfaces(t *testing.T, targetBackEnd string) {
 		case "bitcoind":
 			var bitcoindConn *chain.BitcoindConn
 			bitcoindConn = unittest.NewBitcoindBackend(
-				t, unittest.NetParams, p2pAddr, true, false,
+				t, unittest.NetParams, miner, true, false,
 			)
 			newNotifier = func() (chainntnfs.TestChainNotifier, error) {
 				return bitcoindnotify.New(
@@ -1944,7 +1944,7 @@ func TestInterfaces(t *testing.T, targetBackEnd string) {
 		case "bitcoind-rpc-polling":
 			var bitcoindConn *chain.BitcoindConn
 			bitcoindConn = unittest.NewBitcoindBackend(
-				t, unittest.NetParams, p2pAddr, true, true,
+				t, unittest.NetParams, miner, true, true,
 			)
 			newNotifier = func() (chainntnfs.TestChainNotifier, error) {
 				return bitcoindnotify.New(

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -317,6 +317,9 @@ The underlying functionality between those two options remain the same.
   now documented and
   [fixed](https://github.com/lightningnetwork/lnd/pull/9368).
 
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/9549) a long standing
+  unit test flake found in the `chainntnfs/bitcoindnotify` package.
+
 ## Database
 
 * [Migrate the mission control 

--- a/lntest/unittest/backend.go
+++ b/lntest/unittest/backend.go
@@ -112,6 +112,15 @@ func NewBitcoindBackend(t *testing.T, netParams *chaincfg.Params,
 		"-disablewallet",
 		"-zmqpubrawblock=" + zmqBlockHost,
 		"-zmqpubrawtx=" + zmqTxHost,
+
+		// whitelist localhost to speed up relay.
+		"-whitelist=127.0.0.1",
+
+		// Disable v2 transport as btcd doesn't support it yet.
+		//
+		// TODO(yy): Remove this line once v2 conn is supported in
+		// `btcd`.
+		"-v2transport=0",
 	}
 	if txindex {
 		args = append(args, "-txindex")

--- a/lntest/unittest/backend.go
+++ b/lntest/unittest/backend.go
@@ -83,7 +83,7 @@ func NewMiner(t *testing.T, netParams *chaincfg.Params, extraArgs []string,
 // used for block and tx notifications or if its ZMQ interface should be used.
 // A connection to the newly spawned bitcoind node is returned.
 func NewBitcoindBackend(t *testing.T, netParams *chaincfg.Params,
-	minerAddr string, txindex, rpcpolling bool) *chain.BitcoindConn {
+	miner *rpctest.Harness, txindex, rpcpolling bool) *chain.BitcoindConn {
 
 	t.Helper()
 
@@ -204,7 +204,7 @@ func NewBitcoindBackend(t *testing.T, netParams *chaincfg.Params,
 	require.NoError(t, err, "failed to create RPC client")
 
 	// Connect to the miner node.
-	err = rpcClient.AddNode(minerAddr, rpcclient.ANAdd)
+	err = rpcClient.AddNode(miner.P2PAddress(), rpcclient.ANAdd)
 	require.NoError(t, err, "failed to connect to miner")
 
 	// Get the network info and assert the num of outbound connections is 1.

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -3352,8 +3352,7 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 		case "bitcoind":
 			// Start a bitcoind instance.
 			chainConn := unittest.NewBitcoindBackend(
-				t, unittest.NetParams, miningNode.P2PAddress(),
-				true, false,
+				t, unittest.NetParams, miningNode, true, false,
 			)
 
 			// Create a btcwallet bitcoind client for both Alice and
@@ -3364,8 +3363,7 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 		case "bitcoind-rpc-polling":
 			// Start a bitcoind instance.
 			chainConn := unittest.NewBitcoindBackend(
-				t, unittest.NetParams, miningNode.P2PAddress(),
-				true, true,
+				t, unittest.NetParams, miningNode, true, true,
 			)
 
 			// Create a btcwallet bitcoind client for both Alice and

--- a/routing/chainview/interface_test.go
+++ b/routing/chainview/interface_test.go
@@ -730,6 +730,20 @@ var interfaceImpls = []struct {
 				chainConn, blockCache,
 			)
 
+			// When running in rpc polling mode, the `reorg` method
+			// in `BitcoindClient`'s `ntfnHandler` may be invoked to
+			// handle the last block received from the miner during
+			// bitcoind's startup. This behavior will cause a block
+			// disconnected and a block connected notifications to
+			// be sent to the channels.
+			//
+			// TODO(yy): unify the chain backend logic and put
+			// everything in `btcwallet/chain` instead. The only
+			// place we use this chain view is in `graph/builder`,
+			// in which we subscribe to `FilteredBlocks` and
+			// `DisconnectedBlocks`.
+			time.Sleep(1 * time.Second)
+
 			return chainView, nil
 		},
 	},

--- a/scripts/unit-test-flake-hunter.sh
+++ b/scripts/unit-test-flake-hunter.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Check if pkg and case variables are provided.
+if [ $# -lt 2 ] || [ $# -gt 3 ]; then
+	echo "Usage: $0 <pkg> <case> [timeout]"
+	exit 1
+fi
+
+pkg=$1
+case=$2
+timeout=${3:-30s} # Default to 30s if not provided.
+
+counter=0
+
+# Run the command in a loop until it fails.
+while output=$(go clean -testcache && make unit-debug log="stdlog trace" pkg=$pkg case=$case timeout=$timeout 2>&1); do
+	((counter++))
+	echo "Test $case passed, count: $counter"
+done
+
+# Only log the output when it fails.
+echo "Test $case failed. Output:"
+echo "$output"


### PR DESCRIPTION
Fix a long standing flake found in our unit test,
```
--- FAIL: TestHistoricalConfDetailsTxIndex (0.00s)
    --- FAIL: TestHistoricalConfDetailsTxIndex/rpc_polling_disabled (11.66s)
        bitcoind_test.go:143: miner height=430, bitcoind height=0
        ...
        bitcoind_test.go:143: miner height=430, bitcoind height=0
        bitcoind_test.go:143: timed out in syncNotifierWithMiner, got err=<nil>, minerHeight=430, bitcoindHeight=0
FAIL
FAIL	github.com/lightningnetwork/lnd/chainntnfs/bitcoindnotify	13.353s
FAIL
```

It turns out the peer connection between the `bitcoind` node and the `btcd` node (miner) is broken, causing the chain backend to never be synced. This unexpected behavior only happens when the test runs multiple times (ranging from 50-ish to 200-ish). To reproduce, remove the second-to-last commit and run,
```sh
pkg=chainntnfs/bitcoindnotify
case=TestHistoricalConfDetailsNoTxIndex/rpc_polling_enabled
make flakehunter-unit pkg=$pkg case=$case
```