### PR TITLE
graph: extract cache from CRUD [5] 

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -263,6 +263,7 @@ The underlying functionality between those two options remain the same.
       - [2](https://github.com/lightningnetwork/lnd/pull/9545)
       - [3](https://github.com/lightningnetwork/lnd/pull/9550)
       - [4](https://github.com/lightningnetwork/lnd/pull/9551)
+      - [5](https://github.com/lightningnetwork/lnd/pull/9552)
 
 * [Golang was updated to
   `v1.22.11`](https://github.com/lightningnetwork/lnd/pull/9462). 

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -439,3 +439,24 @@ func (c *ChannelGraph) FilterKnownChanIDs(chansInfo []ChannelUpdateInfo,
 
 	return unknown, nil
 }
+
+// MarkEdgeZombie attempts to mark a channel identified by its channel ID as a
+// zombie. This method is used on an ad-hoc basis, when channels need to be
+// marked as zombies outside the normal pruning cycle.
+func (c *ChannelGraph) MarkEdgeZombie(chanID uint64,
+	pubKey1, pubKey2 [33]byte) error {
+
+	c.cacheMu.Lock()
+	defer c.cacheMu.Unlock()
+
+	err := c.KVStore.MarkEdgeZombie(chanID, pubKey1, pubKey2)
+	if err != nil {
+		return err
+	}
+
+	if c.graphCache != nil {
+		c.graphCache.RemoveChannel(pubKey1, pubKey2, chanID)
+	}
+
+	return nil
+}

--- a/graph/db/kv_store.go
+++ b/graph/db/kv_store.go
@@ -3588,10 +3588,6 @@ func (c *KVStore) MarkEdgeZombie(chanID uint64,
 				"bucket: %w", err)
 		}
 
-		if c.graphCache != nil {
-			c.graphCache.RemoveChannel(pubKey1, pubKey2, chanID)
-		}
-
 		return markEdgeZombie(zombieIndex, chanID, pubKey1, pubKey2)
 	})
 	if err != nil {

--- a/graph/db/kv_store.go
+++ b/graph/db/kv_store.go
@@ -2155,16 +2155,20 @@ func (c *KVStore) NodeUpdatesInHorizon(startTime,
 // ID's that we don't know and are not known zombies of the passed set. In other
 // words, we perform a set difference of our set of chan ID's and the ones
 // passed in. This method can be used by callers to determine the set of
-// channels another peer knows of that we don't.
-func (c *KVStore) FilterKnownChanIDs(chansInfo []ChannelUpdateInfo,
-	isZombieChan func(time.Time, time.Time) bool) ([]uint64, error) {
+// channels another peer knows of that we don't. The ChannelUpdateInfos for the
+// known zombies is also returned.
+func (c *KVStore) FilterKnownChanIDs(chansInfo []ChannelUpdateInfo) ([]uint64,
+	[]ChannelUpdateInfo, error) {
 
-	var newChanIDs []uint64
+	var (
+		newChanIDs   []uint64
+		knownZombies []ChannelUpdateInfo
+	)
 
 	c.cacheMu.Lock()
 	defer c.cacheMu.Unlock()
 
-	err := kvdb.Update(c.db, func(tx kvdb.RwTx) error {
+	err := kvdb.View(c.db, func(tx kvdb.RTx) error {
 		edges := tx.ReadBucket(edgeBucket)
 		if edges == nil {
 			return ErrGraphNoEdgesFound
@@ -2197,44 +2201,12 @@ func (c *KVStore) FilterKnownChanIDs(chansInfo []ChannelUpdateInfo,
 					zombieIndex, scid,
 				)
 
-				// TODO(ziggie): Make sure that for the strict
-				// pruning case we compare the pubkeys and
-				// whether the right timestamp is not older than
-				// the `ChannelPruneExpiry`.
-				//
-				// NOTE: The timestamp data has no verification
-				// attached to it in the `ReplyChannelRange` msg
-				// so we are trusting this data at this point.
-				// However it is not critical because we are
-				// just removing the channel from the db when
-				// the timestamps are more recent. During the
-				// querying of the gossip msg verification
-				// happens as usual.
-				// However we should start punishing peers when
-				// they don't provide us honest data ?
-				isStillZombie := isZombieChan(
-					info.Node1UpdateTimestamp,
-					info.Node2UpdateTimestamp,
-				)
+				if isZombie {
+					knownZombies = append(
+						knownZombies, info,
+					)
 
-				switch {
-				// If the edge is a known zombie and if we
-				// would still consider it a zombie given the
-				// latest update timestamps, then we skip this
-				// channel.
-				case isZombie && isStillZombie:
 					continue
-
-				// Otherwise, if we have marked it as a zombie
-				// but the latest update timestamps could bring
-				// it back from the dead, then we mark it alive,
-				// and we let it be added to the set of IDs to
-				// query our peer for.
-				case isZombie && !isStillZombie:
-					err := c.markEdgeLiveUnsafe(tx, scid)
-					if err != nil {
-						return err
-					}
 				}
 			}
 
@@ -2244,6 +2216,7 @@ func (c *KVStore) FilterKnownChanIDs(chansInfo []ChannelUpdateInfo,
 		return nil
 	}, func() {
 		newChanIDs = nil
+		knownZombies = nil
 	})
 	switch {
 	// If we don't know of any edges yet, then we'll return the entire set
@@ -2254,13 +2227,13 @@ func (c *KVStore) FilterKnownChanIDs(chansInfo []ChannelUpdateInfo,
 			ogChanIDs[i] = info.ShortChannelID.ToUint64()
 		}
 
-		return ogChanIDs, nil
+		return ogChanIDs, nil, nil
 
 	case err != nil:
-		return nil, err
+		return nil, nil, err
 	}
 
-	return newChanIDs, nil
+	return newChanIDs, knownZombies, nil
 }
 
 // ChannelUpdateInfo couples the SCID of a channel with the timestamps of the


### PR DESCRIPTION
** PR 5 ** (note: not dependent on PR 3 or 4)

This builds towards [this](https://github.com/lightningnetwork/lnd/pull/9529) final result by building [this](https://github.com/lightningnetwork/lnd/pull/9544) side branch incrementally.

In this PR, we move the cache writes for `MarkEdgeZombie` and `UpdateEdgePolicy`  from the KVStore to the ChannelGraph. For the MarkEdgeZombie change, we first need to adjust `FilterKnownChanIDs` so that its zombie related business logic is moved out of the CRUD code and into the ChannelGraph layer - so this is done as a first commit here. Note that this part replaces [this](https://github.com/lightningnetwork/lnd/pull/9522) PR which made this move to the ChanSeries layer - but it makes more sense to keep this out of that layer. 