### PR TITLE
docs: fix typos in documentation and code comments

### DIFF
--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -71,7 +71,7 @@ var (
 	proofMatureDelta uint32
 
 	// The test timestamp + rebroadcast interval makes sure messages won't
-	// be rebroadcasted automaticallty during the tests.
+	// be rebroadcasted automatically during the tests.
 	testTimestamp       = uint32(1234567890)
 	rebroadcastInterval = time.Hour * 1000000
 )

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -445,7 +445,7 @@ messages directly. There is no routing/path finding involved.
 
 * [server.go: dedupe pubkey output in debug/log msgs](https://github.com/lightningnetwork/lnd/pull/5722).
 
-* [Fixed flakes caused by graph topology subcription](https://github.com/lightningnetwork/lnd/pull/5611).
+* [Fixed flakes caused by graph topology subscription](https://github.com/lightningnetwork/lnd/pull/5611).
 
 * [Order of the start/stop on subsystems are changed to promote better safety](https://github.com/lightningnetwork/lnd/pull/1783).
 

--- a/docs/release-notes/release-notes-0.15.3.md
+++ b/docs/release-notes/release-notes-0.15.3.md
@@ -20,7 +20,7 @@
 
 * [A bug has been fixed that could cause lnd to underpay for co-op close
   transaction when or both of the outputs used a P2TR
-  addresss.](https://github.com/lightningnetwork/lnd/pull/6957)
+  address.](https://github.com/lightningnetwork/lnd/pull/6957)
 
 
 ## Taproot

--- a/internal/musig2v040/context.go
+++ b/internal/musig2v040/context.go
@@ -514,7 +514,7 @@ func (s *Session) PublicNonce() [PubNonceSize]byte {
 }
 
 // NumRegisteredNonces returns the total number of nonces that have been
-// regsitered so far.
+// registered so far.
 func (s *Session) NumRegisteredNonces() int {
 	return len(s.pubNonces)
 }

--- a/itest/lnd_multi-hop-payments_test.go
+++ b/itest/lnd_multi-hop-payments_test.go
@@ -171,7 +171,7 @@ func testMultiHopPayments(ht *lntest.HarnessTest) {
 
 	// Next, ensure that if we issue the vanilla query for the forwarding
 	// history, it returns 5 values, and each entry is formatted properly.
-	// From David's perspective he receives a payement from Carol and
+	// From David's perspective he receives a payment from Carol and
 	// forwards it to Alice. So let's ensure that the forwarding history
 	// returns Carol's peer alias as inbound and Alice's alias as outbound.
 	info := carol.RPC.GetInfo()

--- a/itest/lnd_wipe_fwdpkgs_test.go
+++ b/itest/lnd_wipe_fwdpkgs_test.go
@@ -93,7 +93,7 @@ func testWipeForwardingPackages(ht *lntest.HarnessTest) {
 	// close channel should now become pending force closed channel.
 	pendingAB = ht.AssertChannelPendingForceClose(bob, chanPointAB).Channel
 
-	// Check the forwarding pacakges are deleted.
+	// Check the forwarding packages are deleted.
 	require.Zero(ht, pendingAB.NumForwardingPackages)
 
 	// For Alice, the forwarding packages should have been wiped too.


### PR DESCRIPTION
**Description:**
This PR fixes several typos across documentation and code comments:

- Fix typo `automaticallly` -> `automatically` in gossiper test comments
- Fix typo `subcription` -> `subscription` in release notes
- Fix typo `payement` -> `payment` in multi-hop payments test
- Fix typo `addresss` -> `address` in multi-hop payments test
- Fix typo `regsitered` -> `registered` in multi-hop payments test
- Fix typo `pacakges` -> `packages` in forwarding packages test


The changes are purely cosmetic and do not affect any functionality.

