### PR TITLE
graph: extract cache from CRUD [6]

### DIFF
--- a/autopilot/prefattach_test.go
+++ b/autopilot/prefattach_test.go
@@ -49,6 +49,11 @@ func newDiskChanGraph(t *testing.T) (testGraph, error) {
 	graphDB, err := graphdb.NewChannelGraph(&graphdb.Config{KVDB: backend})
 	require.NoError(t, err)
 
+	require.NoError(t, graphDB.Start())
+	t.Cleanup(func() {
+		require.NoError(t, graphDB.Stop())
+	})
+
 	return &testDBGraph{
 		db: graphDB,
 		databaseChannelGraph: databaseChannelGraph{

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -268,6 +268,7 @@ The underlying functionality between those two options remain the same.
       - [3](https://github.com/lightningnetwork/lnd/pull/9550)
       - [4](https://github.com/lightningnetwork/lnd/pull/9551)
       - [5](https://github.com/lightningnetwork/lnd/pull/9552)
+      - [6](https://github.com/lightningnetwork/lnd/pull/9555)
 
 * [Golang was updated to
   `v1.22.11`](https://github.com/lightningnetwork/lnd/pull/9462). 

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -93,8 +93,6 @@ func NewChannelGraph(cfg *Config, options ...ChanGraphOption) (*ChannelGraph,
 	log.Debugf("Finished populating in-memory channel graph (took %v, %s)",
 		time.Since(startTime), graphCache.Stats())
 
-	store.setGraphCache(graphCache)
-
 	return &ChannelGraph{
 		KVStore:    store,
 		graphCache: graphCache,

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -4077,6 +4077,10 @@ func TestGraphLoading(t *testing.T) {
 
 	graph, err := NewChannelGraph(&Config{KVDB: backend})
 	require.NoError(t, err)
+	require.NoError(t, graph.Start())
+	t.Cleanup(func() {
+		require.NoError(t, graph.Stop())
+	})
 
 	// Populate the graph with test data.
 	const numNodes = 100
@@ -4087,6 +4091,10 @@ func TestGraphLoading(t *testing.T) {
 	// populated.
 	graphReloaded, err := NewChannelGraph(&Config{KVDB: backend})
 	require.NoError(t, err)
+	require.NoError(t, graphReloaded.Start())
+	t.Cleanup(func() {
+		require.NoError(t, graphReloaded.Stop())
+	})
 
 	// Assert that the cache content is identical.
 	require.Equal(

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -3994,7 +3994,6 @@ func TestGraphCacheForEachNodeChannel(t *testing.T) {
 	// Unset the channel graph cache to simulate the user running with the
 	// option turned off.
 	graph.graphCache = nil
-	graph.KVStore.graphCache = nil
 
 	node1, err := createTestVertex(graph.db)
 	require.Nil(t, err)

--- a/graph/db/kv_store.go
+++ b/graph/db/kv_store.go
@@ -184,13 +184,12 @@ const (
 type KVStore struct {
 	db kvdb.Backend
 
-	// cacheMu guards all caches (rejectCache, chanCache, graphCache). If
+	// cacheMu guards all caches (rejectCache and chanCache). If
 	// this mutex will be acquired at the same time as the DB mutex then
 	// the cacheMu MUST be acquired first to prevent deadlock.
 	cacheMu     sync.RWMutex
 	rejectCache *rejectCache
 	chanCache   *channelCache
-	graphCache  *GraphCache
 
 	chanScheduler batch.Scheduler
 	nodeScheduler batch.Scheduler
@@ -225,15 +224,6 @@ func NewKVStore(db kvdb.Backend, options ...KVStoreOptionModifier) (*KVStore,
 	)
 
 	return g, nil
-}
-
-// setGraphCache sets the KVStore's graphCache.
-//
-// NOTE: this is temporary and will only be called from the ChannelGraph's
-// constructor before the KVStore methods are available to be called. This will
-// be removed once the graph cache is fully owned by the ChannelGraph.
-func (c *KVStore) setGraphCache(cache *GraphCache) {
-	c.graphCache = cache
 }
 
 // channelMapKey is the key structure used for storing channel edge policies.

--- a/graph/db/kv_store.go
+++ b/graph/db/kv_store.go
@@ -26,6 +26,7 @@ import (
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -4722,10 +4723,12 @@ func MakeTestGraph(t testing.TB, modifiers ...KVStoreOptionModifier) (
 
 		return nil, err
 	}
+	require.NoError(t, graph.Start())
 
 	t.Cleanup(func() {
 		_ = backend.Close()
 		backendCleanup()
+		require.NoError(t, graph.Stop())
 	})
 
 	return graph, nil

--- a/graph/notifications_test.go
+++ b/graph/notifications_test.go
@@ -1100,6 +1100,10 @@ func makeTestGraph(t *testing.T, useCache bool) (*graphdb.ChannelGraph,
 	if err != nil {
 		return nil, nil, err
 	}
+	require.NoError(t, graph.Start())
+	t.Cleanup(func() {
+		require.NoError(t, graph.Stop())
+	})
 
 	return graph, backend, nil
 }

--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -619,6 +619,10 @@ func createTestPeer(t *testing.T) *peerTestCtx {
 		KVDB: graphBackend,
 	})
 	require.NoError(t, err)
+	require.NoError(t, dbAliceGraph.Start())
+	t.Cleanup(func() {
+		require.NoError(t, dbAliceGraph.Stop())
+	})
 
 	dbAliceChannel := channeldb.OpenForTesting(t, dbPath)
 

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -173,6 +173,10 @@ func makeTestGraph(t *testing.T, useCache bool) (*graphdb.ChannelGraph,
 	if err != nil {
 		return nil, nil, err
 	}
+	require.NoError(t, graph.Start())
+	t.Cleanup(func() {
+		require.NoError(t, graph.Stop())
+	})
 
 	return graph, backend, nil
 }

--- a/server.go
+++ b/server.go
@@ -2287,6 +2287,12 @@ func (s *server) Start() error {
 			return
 		}
 
+		cleanup = cleanup.add(s.graphDB.Stop)
+		if err := s.graphDB.Start(); err != nil {
+			startErr = err
+			return
+		}
+
 		cleanup = cleanup.add(s.graphBuilder.Stop)
 		if err := s.graphBuilder.Start(); err != nil {
 			startErr = err
@@ -2587,6 +2593,9 @@ func (s *server) Stop() error {
 		}
 		if err := s.graphBuilder.Stop(); err != nil {
 			srvrLog.Warnf("failed to stop graphBuilder %v", err)
+		}
+		if err := s.graphDB.Stop(); err != nil {
+			srvrLog.Warnf("failed to stop graphDB %v", err)
 		}
 		if err := s.chainArb.Stop(); err != nil {
 			srvrLog.Warnf("failed to stop chainArb: %v", err)


### PR DESCRIPTION
** Final PR in the cache-RIP series **

This builds towards [this](https://github.com/lightningnetwork/lnd/pull/9529) final result by building [this](https://github.com/lightningnetwork/lnd/pull/9544) side branch incrementally.

In this PR, the extraction of the `graphCache` from the CRUD layer (`KVStore`) into the `ChannelGraph` layer is completed. 
The opportunity is also taken to move the graphCache population logic out of the constructor of the ChannelGraph and into
a new `Start` method instead. 