### PR TITLE
docs: correct sample-lnd.conf link in MAKEFILE.md

### DIFF
--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -162,7 +162,7 @@ Compiles the `lnrpc` proto files.
 
 `sample-conf-check`
 -------------------
-Checks whether all required options of `lnd --help` are included in [sample-lnd.conf](github.com/lightningnetwork/lnd/blob/master/sample-lnd.conf) and that the default values of `lnd --help` are also mentioned correctly.
+Checks whether all required options of `lnd --help` are included in [sample-lnd.conf](https://github.com/lightningnetwork/lnd/blob/master/sample-lnd.conf) and that the default values of `lnd --help` are also mentioned correctly.
 
 `scratch`
 ---------


### PR DESCRIPTION
## Change Description
The link for [sample-lnd.conf](https://github.com/lightningnetwork/lnd/blob/master/docs/MAKEFILE.md#sample-conf-check) opens inside the repo, to fix this I simply added the prefix `https://`.

## Steps to Test
Visit [docs/MAKEFILE.md](https://github.com/lightningnetwork/lnd/blob/master/docs/MAKEFILE.md)  and press on the hyperlink [sample-lnd.conf](https://github.com/lightningnetwork/lnd/blob/master/docs/MAKEFILE.md#sample-conf-check).