### PR TITLE
Make MaxWaitNumBlocksFundingConf Configurable for itest

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -110,6 +110,11 @@
 * [Add ability](https://github.com/lightningnetwork/lnd/pull/8998) to paginate 
  wallet transactions.
 
+* [Make](https://github.com/lightningnetwork/lnd/pull/9562)
+  `MaxWaitNumBlocksFundingConf` configurable, allowing integration/development
+  tests to set a lower value for faster funding confirmation timeout while
+  keeping the default of 2016 blocks for production stability.
+
 ## RPC Additions
 
 * [Add a new rpc endpoint](https://github.com/lightningnetwork/lnd/pull/8843)

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -2334,14 +2334,15 @@ func TestFundingManagerFundingTimeout(t *testing.T) {
 	// mine 2016-1, and check that it is still pending.
 	bob.mockNotifier.epochChan <- &chainntnfs.BlockEpoch{
 		Height: fundingBroadcastHeight +
-			MaxWaitNumBlocksFundingConf - 1,
+			lncfg.DefaultMaxWaitNumBlocksFundingConf - 1,
 	}
 
 	// Bob should still be waiting for the channel to open.
 	assertNumPendingChannelsRemains(t, bob, 1)
 
 	bob.mockNotifier.epochChan <- &chainntnfs.BlockEpoch{
-		Height: fundingBroadcastHeight + MaxWaitNumBlocksFundingConf,
+		Height: fundingBroadcastHeight +
+			lncfg.DefaultMaxWaitNumBlocksFundingConf,
 	}
 
 	// Bob should have sent an Error message to Alice.
@@ -2387,16 +2388,16 @@ func TestFundingManagerFundingNotTimeoutInitiator(t *testing.T) {
 		t.Fatalf("alice did not publish funding tx")
 	}
 
-	// Increase the height to 1 minus the MaxWaitNumBlocksFundingConf
+	// Increase the height to 1 minus the DefaultMaxWaitNumBlocksFundingConf
 	// height.
 	alice.mockNotifier.epochChan <- &chainntnfs.BlockEpoch{
 		Height: fundingBroadcastHeight +
-			MaxWaitNumBlocksFundingConf - 1,
+			lncfg.DefaultMaxWaitNumBlocksFundingConf - 1,
 	}
 
 	bob.mockNotifier.epochChan <- &chainntnfs.BlockEpoch{
 		Height: fundingBroadcastHeight +
-			MaxWaitNumBlocksFundingConf - 1,
+			lncfg.DefaultMaxWaitNumBlocksFundingConf - 1,
 	}
 
 	// Assert both and Alice and Bob still have 1 pending channels.
@@ -2404,13 +2405,16 @@ func TestFundingManagerFundingNotTimeoutInitiator(t *testing.T) {
 
 	assertNumPendingChannelsRemains(t, bob, 1)
 
-	// Increase both Alice and Bob to MaxWaitNumBlocksFundingConf height.
+	// Increase both Alice and Bob to DefaultMaxWaitNumBlocksFundingConf
+	// height.
 	alice.mockNotifier.epochChan <- &chainntnfs.BlockEpoch{
-		Height: fundingBroadcastHeight + MaxWaitNumBlocksFundingConf,
+		Height: fundingBroadcastHeight +
+			lncfg.DefaultMaxWaitNumBlocksFundingConf,
 	}
 
 	bob.mockNotifier.epochChan <- &chainntnfs.BlockEpoch{
-		Height: fundingBroadcastHeight + MaxWaitNumBlocksFundingConf,
+		Height: fundingBroadcastHeight +
+			lncfg.DefaultMaxWaitNumBlocksFundingConf,
 	}
 
 	// Since Alice was the initiator, the channel should not have timed out.

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -670,6 +670,10 @@ var allTestCases = []*lntest.TestCase{
 		Name:     "fee replacement",
 		TestFunc: testFeeReplacement,
 	},
+	{
+		Name:     "funding manager funding timeout",
+		TestFunc: testFundingManagerFundingTimeout,
+	},
 }
 
 // appendPrefixed is used to add a prefix to each test name in the subtests

--- a/lncfg/config.go
+++ b/lncfg/config.go
@@ -72,6 +72,11 @@ const (
 	// DefaultZombieSweeperInterval is the default time interval at which
 	// unfinished (zombiestate) open channel flows are purged from memory.
 	DefaultZombieSweeperInterval = 1 * time.Minute
+
+	// DefaultMaxWaitNumBlocksFundingConf is the maximum number of blocks to
+	// wait for the funding transaction to confirm before forgetting
+	// channels that aren't initiated by us. 2016 blocks is ~2 weeks.
+	DefaultMaxWaitNumBlocksFundingConf = 2016
 )
 
 // CleanAndExpandPath expands environment variables and leading ~ in the

--- a/lncfg/dev.go
+++ b/lncfg/dev.go
@@ -46,3 +46,9 @@ func (d *DevConfig) GetReservationTimeout() time.Duration {
 func (d *DevConfig) GetZombieSweeperInterval() time.Duration {
 	return DefaultZombieSweeperInterval
 }
+
+// GetMaxWaitNumBlocksFundingConf returns the config value for
+// `MaxWaitNumBlocksFundingConf`.
+func (d *DevConfig) GetMaxWaitNumBlocksFundingConf() uint32 {
+	return DefaultMaxWaitNumBlocksFundingConf
+}

--- a/lncfg/dev_integration.go
+++ b/lncfg/dev_integration.go
@@ -21,10 +21,11 @@ func IsDevBuild() bool {
 //
 //nolint:ll
 type DevConfig struct {
-	ProcessChannelReadyWait time.Duration `long:"processchannelreadywait" description:"Time to sleep before processing remote node's channel_ready message."`
-	ReservationTimeout      time.Duration `long:"reservationtimeout" description:"The maximum time we keep a pending channel open flow in memory."`
-	ZombieSweeperInterval   time.Duration `long:"zombiesweeperinterval" description:"The time interval at which channel opening flows are evaluated for zombie status."`
-	UnsafeDisconnect        bool          `long:"unsafedisconnect" description:"Allows the rpcserver to intentionally disconnect from peers with open channels."`
+	ProcessChannelReadyWait     time.Duration `long:"processchannelreadywait" description:"Time to sleep before processing remote node's channel_ready message."`
+	ReservationTimeout          time.Duration `long:"reservationtimeout" description:"The maximum time we keep a pending channel open flow in memory."`
+	ZombieSweeperInterval       time.Duration `long:"zombiesweeperinterval" description:"The time interval at which channel opening flows are evaluated for zombie status."`
+	UnsafeDisconnect            bool          `long:"unsafedisconnect" description:"Allows the rpcserver to intentionally disconnect from peers with open channels."`
+	MaxWaitNumBlocksFundingConf uint32        `long:"maxwaitnumblocksfundingconf" description:"Maximum blocks to wait for funding confirmation before discarding non-initiated channels."`
 }
 
 // ChannelReadyWait returns the config value `ProcessChannelReadyWait`.
@@ -53,4 +54,14 @@ func (d *DevConfig) GetZombieSweeperInterval() time.Duration {
 // ChannelReadyWait returns the config value `UnsafeDisconnect`.
 func (d *DevConfig) GetUnsafeDisconnect() bool {
 	return d.UnsafeDisconnect
+}
+
+// GetMaxWaitNumBlocksFundingConf returns the config value for
+// `MaxWaitNumBlocksFundingConf`.
+func (d *DevConfig) GetMaxWaitNumBlocksFundingConf() uint32 {
+	if d.MaxWaitNumBlocksFundingConf == 0 {
+		return DefaultMaxWaitNumBlocksFundingConf
+	}
+
+	return d.MaxWaitNumBlocksFundingConf
 }

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3850,9 +3850,21 @@ func (r *rpcServer) fetchPendingOpenChannels() (pendingOpenChannels, error) {
 		commitBaseWeight := blockchain.GetTransactionWeight(utx)
 		commitWeight := commitBaseWeight + witnessWeight
 
+		// The value of waitBlocksForFundingConf is adjusted in a
+		// development environment to enhance test capabilities.
+		// Otherwise, it is set to DefaultMaxWaitNumBlocksFundingConf.
+		waitBlocksForFundingConf := uint32(
+			lncfg.DefaultMaxWaitNumBlocksFundingConf,
+		)
+
+		if lncfg.IsDevBuild() {
+			waitBlocksForFundingConf =
+				r.cfg.Dev.GetMaxWaitNumBlocksFundingConf()
+		}
+
 		// FundingExpiryBlocks is the distance from the current block
-		// height to the broadcast height + MaxWaitNumBlocksFundingConf.
-		maxFundingHeight := funding.MaxWaitNumBlocksFundingConf +
+		// height to the broadcast height + waitBlocksForFundingConf.
+		maxFundingHeight := waitBlocksForFundingConf +
 			pendingChan.BroadcastHeight()
 		fundingExpiryBlocks := int32(maxFundingHeight) - currentHeight
 

--- a/server.go
+++ b/server.go
@@ -1449,6 +1449,8 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 	if lncfg.IsDevBuild() {
 		devCfg = &funding.DevConfig{
 			ProcessChannelReadyWait: cfg.Dev.ChannelReadyWait(),
+			MaxWaitNumBlocksFundingConf: cfg.Dev.
+				GetMaxWaitNumBlocksFundingConf(),
 		}
 
 		reservationTimeout = cfg.Dev.GetReservationTimeout()


### PR DESCRIPTION
## Change Description
Fixes: #9511 
This PR introduces a configurable parameter for the constant `MaxWaitNumBlocksFundingConf` used in funding manager. The change allows developers and integration environments to override the default value (2016 blocks) via a build tag, enabling the mining of fewer blocks to trigger timeout scenarios during testing. In production builds, the default value remains unchanged to ensure stability.

### Key Changes:

- **Configurable Timeout Constant:**
  - Added MaxWaitNumBlocksFundingConf to DevConfig so that its value can be modified.
- **Production Safety:**
  - Retains the default value of 2016 blocks for production, ensuring no impact on production behavior.
- **Improved Testing Flexibility:**
  - Allows tests to simulate timeout conditions more efficiently by reducing the number of blocks that need to be mined during integration testing.

## Steps to Test
- Added itest to confirm that timeout conditions are triggered as expected with the modified constant.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
