### PR TITLE
GitHub+docs: no longer accept typo fixes to fight PR spam

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,8 +11,9 @@ Steps for reviewers to follow to test the change.
 - [ ] Bug fixes contain tests triggering the bug to prevent regressions.
 
 ### Code Style and Documentation
-- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
-- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
+- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
+- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
+- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#ideal-git-commit-structure).
 - [ ] Any new logging statements use an appropriate subsystem and logging level.
 - [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
 - [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

--- a/docs/code_contribution_guidelines.md
+++ b/docs/code_contribution_guidelines.md
@@ -98,6 +98,20 @@ Once the specification is finalized, it will be the most up-to-date
 comprehensive document explaining the Lightning Network. As a result, it will
 be recommended for newcomers to read first in order to get up to speed. 
 
+# Substantial contributions only
+
+Due to the prevalence of automated analysis and pull request authoring tools
+and online competitions that incentivize creating commits in popular
+repositories, the maintainers of this project are flooded with trivial pull
+requests that only change some typos or other insubstantial content (e.g. the
+year in the license file).
+If you are an honest user that wants to contribute to this project, please
+consider that every pull request takes precious time from the maintainers to
+review and consider the impact of changes. Time that could be spent writing
+features or fixing bugs.
+If you really want to contribute, consider reviewing and testing other users'
+pull requests instead. Or add value to the project by writing unit tests.
+
 # Development Practices
 
 Developers are expected to work in their own trees and submit pull requests when


### PR DESCRIPTION
We've seen an unnaturally high number of typo fixes coming in lately.
Not sure if a new "typo analyzing LLM" is at work or a new competition that pays people tokens for contributions to popular repositories.

But the amount of work required to deal with those PRs outweighs the benefit in the eyes of the maintainers.

Also, GitHub added a security feature that prevents first-time contributors from running the CI. Distinguishing between honest users that just want to contribute from automated bots that open hundreds of PRs to multiple repositories in a short amount of time to get around those security measures is a non-trivial task.

Some examples, all within the couple of days (some of them even trying to fix the same typos in exactly the same commit structure, further hinting at bots at work):
 - https://github.com/lightningnetwork/lnd/pull/9564
 - https://github.com/lightningnetwork/lnd/pull/9561
 - https://github.com/lightningnetwork/lnd/pull/9556
 - https://github.com/lightningnetwork/lnd/pull/9553
 - https://github.com/lightningnetwork/lnd/pull/9557
 - https://github.com/btcsuite/btcwallet/pull/982