### PR TITLE
lntest+itest: change the method signature of `AssertPaymentStatus`

### DIFF
--- a/itest/lnd_experimental_endorsement.go
+++ b/itest/lnd_experimental_endorsement.go
@@ -76,7 +76,7 @@ func testEndorsement(ht *lntest.HarnessTest, aliceEndorse bool) {
 
 	var preimage lntypes.Preimage
 	copy(preimage[:], invoice.RPreimage)
-	ht.AssertPaymentStatus(alice, preimage, lnrpc.Payment_SUCCEEDED)
+	ht.AssertPaymentStatus(alice, preimage.Hash(), lnrpc.Payment_SUCCEEDED)
 }
 
 func validateEndorsedAndResume(ht *lntest.HarnessTest,

--- a/itest/lnd_forward_interceptor_test.go
+++ b/itest/lnd_forward_interceptor_test.go
@@ -122,7 +122,7 @@ func testForwardInterceptorDedupHtlc(ht *lntest.HarnessTest) {
 	// We expect one in flight payment since we held the htlcs.
 	var preimage lntypes.Preimage
 	copy(preimage[:], invoice.RPreimage)
-	ht.AssertPaymentStatus(alice, preimage, lnrpc.Payment_IN_FLIGHT)
+	ht.AssertPaymentStatus(alice, preimage.Hash(), lnrpc.Payment_IN_FLIGHT)
 
 	// At this point if we have more than one held htlcs then we should
 	// fail. This means we hold the same htlc twice which is a risk we want
@@ -275,7 +275,7 @@ func testForwardInterceptorBasic(ht *lntest.HarnessTest) {
 		copy(preimage[:], testCase.invoice.RPreimage)
 
 		payment := ht.AssertPaymentStatus(
-			alice, preimage, lnrpc.Payment_IN_FLIGHT,
+			alice, preimage.Hash(), lnrpc.Payment_IN_FLIGHT,
 		)
 		expectedAmt := testCase.invoice.ValueMsat
 		require.Equal(ht, expectedAmt, payment.ValueMsat,
@@ -408,7 +408,7 @@ func testForwardInterceptorRestart(ht *lntest.HarnessTest) {
 	// The payment should now be in flight.
 	var preimage lntypes.Preimage
 	copy(preimage[:], invoice.RPreimage)
-	ht.AssertPaymentStatus(alice, preimage, lnrpc.Payment_IN_FLIGHT)
+	ht.AssertPaymentStatus(alice, preimage.Hash(), lnrpc.Payment_IN_FLIGHT)
 
 	// We don't resume the payment on Carol, so it should be held there.
 	// We now restart first Bob, then Alice, so we can make sure we've
@@ -456,7 +456,7 @@ func testForwardInterceptorRestart(ht *lntest.HarnessTest) {
 
 	// Assert that the payment was successful.
 	ht.AssertPaymentStatus(
-		alice, preimage, lnrpc.Payment_SUCCEEDED,
+		alice, preimage.Hash(), lnrpc.Payment_SUCCEEDED,
 		func(p *lnrpc.Payment) error {
 			recordsEqual := reflect.DeepEqual(
 				lntest.CustomRecordsWithUnendorsed(

--- a/itest/lnd_hold_persistence_test.go
+++ b/itest/lnd_hold_persistence_test.go
@@ -185,9 +185,7 @@ func testHoldInvoicePersistence(ht *lntest.HarnessTest) {
 		payStream := alice.RPC.TrackPaymentV2(hash[:])
 		ht.ReceiveTrackPayment(payStream)
 
-		ht.AssertPaymentStatus(
-			alice, preimg, lnrpc.Payment_IN_FLIGHT,
-		)
+		ht.AssertPaymentStatus(alice, hash, lnrpc.Payment_IN_FLIGHT)
 	}
 
 	// Settle invoices half the invoices, cancel the rest.
@@ -211,11 +209,11 @@ func testHoldInvoicePersistence(ht *lntest.HarnessTest) {
 	for i, preimg := range preimages {
 		if i%2 == 0 {
 			ht.AssertPaymentStatus(
-				alice, preimg, lnrpc.Payment_SUCCEEDED,
+				alice, preimg.Hash(), lnrpc.Payment_SUCCEEDED,
 			)
 		} else {
 			payment := ht.AssertPaymentStatus(
-				alice, preimg, lnrpc.Payment_FAILED,
+				alice, preimg.Hash(), lnrpc.Payment_FAILED,
 			)
 			require.Equal(ht, reason, payment.FailureReason,
 				"wrong failure reason")

--- a/itest/lnd_htlc_timeout_resolver_test.go
+++ b/itest/lnd_htlc_timeout_resolver_test.go
@@ -197,7 +197,7 @@ func testHtlcTimeoutResolverExtractPreimageRemote(ht *lntest.HarnessTest) {
 	// Finally, check that the Alice's payment is marked as succeeded as
 	// Bob has settled the htlc using the preimage extracted from Carol's
 	// 2nd level success tx.
-	ht.AssertPaymentStatus(alice, preimage, lnrpc.Payment_SUCCEEDED)
+	ht.AssertPaymentStatus(alice, preimage.Hash(), lnrpc.Payment_SUCCEEDED)
 
 	// Mine a block to clean the mempool.
 	ht.MineBlocksAndAssertNumTxes(1, 2)
@@ -371,7 +371,7 @@ func testHtlcTimeoutResolverExtractPreimageLocal(ht *lntest.HarnessTest) {
 	// Finally, check that the Alice's payment is marked as succeeded as
 	// Bob has settled the htlc using the preimage extracted from Carol's
 	// direct spend tx.
-	ht.AssertPaymentStatus(alice, preimage, lnrpc.Payment_SUCCEEDED)
+	ht.AssertPaymentStatus(alice, preimage.Hash(), lnrpc.Payment_SUCCEEDED)
 
 	// NOTE: for non-standby nodes there's no need to clean up the force
 	// close as long as the mempool is cleaned.

--- a/itest/lnd_mpp_test.go
+++ b/itest/lnd_mpp_test.go
@@ -200,7 +200,7 @@ func testSendToRouteMultiPath(ht *lntest.HarnessTest) {
 		copy(preimage[:], invoices[0].RPreimage)
 
 		payment := ht.AssertPaymentStatus(
-			hn, preimage, lnrpc.Payment_SUCCEEDED,
+			hn, preimage.Hash(), lnrpc.Payment_SUCCEEDED,
 		)
 
 		htlcs := payment.Htlcs

--- a/itest/lnd_multi-hop_force_close_test.go
+++ b/itest/lnd_multi-hop_force_close_test.go
@@ -894,7 +894,7 @@ func runMultiHopReceiverPreimageClaim(ht *lntest.HarnessTest,
 	ht.AssertNumActiveHtlcs(alice, 0)
 
 	// Check that the Alice's payment is correctly marked succeeded.
-	ht.AssertPaymentStatus(alice, preimage, lnrpc.Payment_SUCCEEDED)
+	ht.AssertPaymentStatus(alice, preimage.Hash(), lnrpc.Payment_SUCCEEDED)
 
 	// Carol's pending channel report should now show two outputs under
 	// limbo: her commitment output, as well as the second-layer claim
@@ -1918,7 +1918,7 @@ func runLocalClaimIncomingHTLC(ht *lntest.HarnessTest,
 
 	// Finally, check that the Alice's payment is correctly marked
 	// succeeded.
-	ht.AssertPaymentStatus(alice, preimage, lnrpc.Payment_SUCCEEDED)
+	ht.AssertPaymentStatus(alice, preimage.Hash(), lnrpc.Payment_SUCCEEDED)
 }
 
 // testLocalClaimIncomingHTLCLeasedZeroConf tests
@@ -2221,7 +2221,7 @@ func runLocalClaimIncomingHTLCLeased(ht *lntest.HarnessTest,
 
 	// Finally, check that the Alice's payment is correctly marked
 	// succeeded.
-	ht.AssertPaymentStatus(alice, preimage, lnrpc.Payment_SUCCEEDED)
+	ht.AssertPaymentStatus(alice, preimage.Hash(), lnrpc.Payment_SUCCEEDED)
 }
 
 // testLocalPreimageClaimAnchorZeroConf tests `runLocalPreimageClaim` with
@@ -2575,7 +2575,7 @@ func runLocalPreimageClaim(ht *lntest.HarnessTest,
 
 	// Finally, check that the Alice's payment is correctly marked
 	// succeeded.
-	ht.AssertPaymentStatus(alice, preimage, lnrpc.Payment_SUCCEEDED)
+	ht.AssertPaymentStatus(alice, preimage.Hash(), lnrpc.Payment_SUCCEEDED)
 }
 
 // testLocalPreimageClaimLeasedZeroConf tests `runLocalPreimageClaim` with
@@ -2839,7 +2839,7 @@ func runLocalPreimageClaimLeased(ht *lntest.HarnessTest,
 	ht.AssertInvoiceState(stream, lnrpc.Invoice_SETTLED)
 
 	// Check that the Alice's payment is correctly marked succeeded.
-	ht.AssertPaymentStatus(alice, preimage, lnrpc.Payment_SUCCEEDED)
+	ht.AssertPaymentStatus(alice, preimage.Hash(), lnrpc.Payment_SUCCEEDED)
 
 	// With the script-enforced lease commitment type, Alice and Bob still
 	// haven't been able to sweep their respective commit outputs due to

--- a/itest/lnd_route_blinding_test.go
+++ b/itest/lnd_route_blinding_test.go
@@ -509,7 +509,7 @@ func (b *blindedForwardTest) sendToRoute(route *lnrpc.Route,
 	require.NoError(b.ht, err)
 
 	pmt := b.ht.AssertPaymentStatus(
-		b.alice, preimage, lnrpc.Payment_FAILED,
+		b.alice, preimage.Hash(), lnrpc.Payment_FAILED,
 	)
 	require.Len(b.ht, pmt.Htlcs, 1)
 


### PR DESCRIPTION
So this can be used in other tests when we only care about the payment hash.