### PR TITLE
itest: make sure to not hit the natural ChannelUpdate rate limit

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -330,6 +330,11 @@ The underlying functionality between those two options remain the same.
 * Add a new CI-step to do some basic [backwards compatibility 
   testing](https://github.com/lightningnetwork/lnd/pull/9540) for each PR. 
 
+* [Fix](https://github.com/lightningnetwork/lnd/pull/9567) an itest flake where 
+  if a channel update is sent too quickly after the previous one, then it would 
+  be ignored due to the timestamp of the second update not being after the 
+  previous one. 
+
 ## Database
 
 * [Migrate the mission control 

--- a/itest/lnd_channel_policy_test.go
+++ b/itest/lnd_channel_policy_test.go
@@ -341,10 +341,10 @@ func testUpdateChannelPolicy(ht *lntest.HarnessTest) {
 	// but not the second, as she only allows two updates per day and a day
 	// has yet to elapse from the previous update.
 
-	// assertAliceAndBob is a helper closure which updates Alice's policy
-	// and asserts that both Alice and Bob have heard and updated the
+	// updateAndAssertAliceAndBob is a helper closure which updates Alice's
+	// policy and asserts that both Alice and Bob have heard and updated the
 	// policy in their graph.
-	assertAliceAndBob := func(req *lnrpc.PolicyUpdateRequest,
+	updateAndAssertAliceAndBob := func(req *lnrpc.PolicyUpdateRequest,
 		expectedPolicy *lnrpc.RoutingPolicy) {
 
 		alice.RPC.UpdateChannelPolicy(req)
@@ -390,7 +390,7 @@ func testUpdateChannelPolicy(ht *lntest.HarnessTest) {
 	expectedPolicy.FeeBaseMsat = baseFee1
 	req.BaseFeeMsat = baseFee1
 	req.InboundFee = nil
-	assertAliceAndBob(req, expectedPolicy)
+	updateAndAssertAliceAndBob(req, expectedPolicy)
 
 	// Check that Carol has both heard the policy and updated it in her
 	// graph.
@@ -419,7 +419,7 @@ func testUpdateChannelPolicy(ht *lntest.HarnessTest) {
 	baseFee2 := baseFee1 * 2
 	expectedPolicy.FeeBaseMsat = baseFee2
 	req.BaseFeeMsat = baseFee2
-	assertAliceAndBob(req, expectedPolicy)
+	updateAndAssertAliceAndBob(req, expectedPolicy)
 
 	// Since Carol didn't receive the last update, she still has Alice's
 	// old policy. We validate this by checking the base fee is the older

--- a/itest/lnd_channel_policy_test.go
+++ b/itest/lnd_channel_policy_test.go
@@ -377,6 +377,12 @@ func testUpdateChannelPolicy(ht *lntest.HarnessTest) {
 		)
 	}
 
+	// Channel Updates actually also have a natural rate limit of 1 update
+	// per second due to the fact that the timestamp carried in the update
+	// is only accurate to the second. So we need to ensure that the next
+	// update we send in the burst is at least 1 second after the last one.
+	time.Sleep(time.Second)
+
 	// Double the base fee and attach to the policy. Moreover, we set the
 	// inbound fee to nil and test that it does not change the propagated
 	// inbound fee.
@@ -402,6 +408,12 @@ func testUpdateChannelPolicy(ht *lntest.HarnessTest) {
 	ht.AssertChannelPolicy(
 		carol, alice.PubKeyStr, expectedPolicy, chanPoint3,
 	)
+
+	// Similarly to above, we again wait for the natural rate limit of the
+	// ChannelUpdate to pass so that we are really testing that Carol is
+	// _not_ getting this next update due to her rate limiting settings and
+	// not due to the natural rate limit being met.
+	time.Sleep(time.Second)
 
 	// Double the base fee and attach to the policy.
 	baseFee2 := baseFee1 * 2


### PR DESCRIPTION
Channel Updates have a natural rate limit of 1 update per second due to the fact that the timestamp carried in the update is only accurate to the second. So we need to ensure that the next update we send in the burst is at least 1 second after the last one.

This flake was appearing in the `update channel policy` itest in the part of the tests where we are testing
the burst rate limit logic of Carol. It's flaky at the moment though due to Carol sometimes rejecting a channel update
due to the natural 1-update-per-second rate limit. So we need to ensure that Alice waits at least a second between
sending updates for this logic to be tested properly. The log line that appears after the channel updates are sent too quickly after each there ie:
`builder.go:1331: process network updates got: Ignoring outdated update (flags=00000001|00000000) for known chan_id=8015439768453121`

As to why this is flake is appearing more often now, I think it may be due to [this PR](https://github.com/lightningnetwork/lnd/pull/9534) which removes the logic that would pass channel updates through the same channel before handling them in a goroutine - All that did was make it less likely for the flake to occur though cause it added a small artificial delay between the updates. 