### PR TITLE
refactor: unify the error handling methods that are different from the project style & use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/amp/shard_tracker.go
+++ b/amp/shard_tracker.go
@@ -3,6 +3,7 @@ package amp
 import (
 	"crypto/rand"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -139,7 +140,7 @@ func (s *ShardTracker) CancelShard(pid uint64) error {
 
 	c, ok := s.shards[pid]
 	if !ok {
-		return fmt.Errorf("pid not found")
+		return errors.New("pid not found")
 	}
 	delete(s.shards, pid)
 

--- a/amp/sharer.go
+++ b/amp/sharer.go
@@ -2,7 +2,7 @@ package amp
 
 import (
 	"crypto/rand"
-	"fmt"
+	"errors"
 )
 
 // zeroShare is the all-zero 32-byte share.
@@ -97,7 +97,7 @@ func (s *SeedSharer) Root() Share {
 func (s *SeedSharer) Split() (Sharer, Sharer, error) {
 	// We cannot split the zero-Sharer.
 	if s.curr == zeroShare {
-		return nil, nil, fmt.Errorf("cannot split zero-Sharer")
+		return nil, nil, errors.New("cannot split zero-Sharer")
 	}
 
 	shareLeft, shareRight, err := split(&s.curr)

--- a/cmd/commands/chainrpc_active.go
+++ b/cmd/commands/chainrpc_active.go
@@ -5,7 +5,6 @@ package commands
 
 import (
 	"bytes"
-	"fmt"
 	"strconv"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -80,7 +79,7 @@ func getBlock(ctx *cli.Context) error {
 		blockHashString = args.First()
 
 	default:
-		return fmt.Errorf("hash argument missing")
+		return errors.New("hash argument missing")
 	}
 
 	blockHash, err := chainhash.NewHashFromStr(blockHashString)
@@ -233,7 +232,7 @@ func getBlockHash(ctx *cli.Context) error {
 		}
 
 	default:
-		return fmt.Errorf("block height argument missing")
+		return errors.New("block height argument missing")
 	}
 
 	client, cleanUp := getChainClient(ctx)

--- a/cmd/commands/commands.go
+++ b/cmd/commands/commands.go
@@ -267,7 +267,7 @@ func actionDecorator(f func(*cli.Context) error) func(*cli.Context) error {
 					c.Command.Name == "changepassword" ||
 					c.Command.Name == "createwatchonly") {
 
-				return fmt.Errorf("Wallet is already unlocked")
+				return errors.New("Wallet is already unlocked")
 			}
 
 			// lnd might be active, but not possible to contact
@@ -277,7 +277,7 @@ func actionDecorator(f func(*cli.Context) error) func(*cli.Context) error {
 			// WalletUnlocker server active) and most likely this
 			// is because of an encrypted wallet.
 			if ok && s.Code() == codes.Unimplemented {
-				return fmt.Errorf("Wallet is encrypted. " +
+				return errors.New("Wallet is encrypted. " +
 					"Please unlock using 'lncli unlock', " +
 					"or set password using 'lncli create'" +
 					" if this is the first time starting " +

--- a/cmd/commands/peersrpc_active.go
+++ b/cmd/commands/peersrpc_active.go
@@ -4,8 +4,6 @@
 package commands
 
 import (
-	"fmt"
-
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/peersrpc"
 	"github.com/urfave/cli"
@@ -147,7 +145,7 @@ func updateNodeAnnouncement(ctx *cli.Context) error {
 	}
 
 	if !change {
-		return fmt.Errorf("no changes for the node information " +
+		return errors.New("no changes for the node information " +
 			"detected")
 	}
 

--- a/cmd/commands/profile.go
+++ b/cmd/commands/profile.go
@@ -43,7 +43,7 @@ func (e *profileEntry) cert() (*x509.CertPool, error) {
 
 	cp := x509.NewCertPool()
 	if !cp.AppendCertsFromPEM([]byte(e.TLSCert)) {
-		return nil, fmt.Errorf("credentials: failed to append " +
+		return nil, errors.New("credentials: failed to append " +
 			"certificate")
 	}
 	return cp, nil
@@ -140,7 +140,7 @@ func profileFromContext(ctx *cli.Context, store, skipMacaroons bool) (
 	for _, m := range ctx.GlobalStringSlice("metadata") {
 		pair := strings.Split(m, ":")
 		if len(pair) != 2 {
-			return nil, fmt.Errorf("invalid format for metadata " +
+			return nil, errors.New("invalid format for metadata " +
 				"flag; expected \"key:value\"")
 		}
 

--- a/config.go
+++ b/config.go
@@ -1930,7 +1930,7 @@ func parseRPCParams(cConfig *lncfg.Chain, nodeConfig interface{},
 
 			splitCookie := strings.Split(string(cookie), ":")
 			if len(splitCookie) != 2 {
-				return fmt.Errorf("cookie file has a wrong " +
+				return errors.New("cookie file has a wrong " +
 					"format")
 			}
 			conf.RPCUser = splitCookie[0]
@@ -1968,7 +1968,7 @@ func parseRPCParams(cConfig *lncfg.Chain, nodeConfig interface{},
 	// the RPC credentials from the configuration. So if lnd wasn't
 	// specified the parameters, then we won't be able to start.
 	if cConfig.SimNet {
-		return fmt.Errorf("rpcuser and rpcpass must be set to your " +
+		return errors.New("rpcuser and rpcpass must be set to your " +
 			"btcd node's RPC parameters for simnet mode")
 	}
 
@@ -2097,7 +2097,7 @@ func extractBtcdRPCParams(btcdConfigPath string) (string, string, error) {
 	}
 	userSubmatches := rpcUserRegexp.FindSubmatch(configContents)
 	if userSubmatches == nil {
-		return "", "", fmt.Errorf("unable to find rpcuser in config")
+		return "", "", errors.New("unable to find rpcuser in config")
 	}
 
 	// Similarly, we'll use another regular expression to find the set

--- a/config_builder.go
+++ b/config_builder.go
@@ -272,7 +272,7 @@ func (d *DefaultWalletImpl) ValidateMacaroon(ctx context.Context,
 	// Because the default implementation does not return any permissions,
 	// we shouldn't be registered as an external validator at all and this
 	// should never be invoked.
-	return fmt.Errorf("default implementation does not support external " +
+	return errors.New("default implementation does not support external " +
 		"macaroon validation")
 }
 
@@ -376,7 +376,7 @@ func (d *DefaultWalletImpl) BuildWalletConfig(ctx context.Context,
 	if d.cfg.WalletUnlockPasswordFile != "" && !walletExists &&
 		!d.cfg.WalletUnlockAllowCreate {
 
-		return nil, nil, nil, fmt.Errorf("wallet unlock password file " +
+		return nil, nil, nil, errors.New("wallet unlock password file " +
 			"was specified but wallet does not exist; initialize " +
 			"the wallet before using auto unlocking")
 	}
@@ -1173,7 +1173,7 @@ func (d *DefaultDatabaseBuilder) BuildDatabase(
 			return nil, nil, err
 		}
 		if ripInvoices {
-			err = fmt.Errorf("invoices bucket tombstoned, please " +
+			err = errors.New("invoices bucket tombstoned, please " +
 				"switch back to native SQL")
 			d.logger.Error(err)
 

--- a/fn/recv.go
+++ b/fn/recv.go
@@ -1,7 +1,7 @@
 package fn
 
 import (
-	"fmt"
+	"errors"
 	"time"
 )
 
@@ -14,7 +14,7 @@ func RecvOrTimeout[T any](c <-chan T, timeout time.Duration) (T, error) {
 
 	case <-time.After(timeout):
 		var zero T
-		return zero, fmt.Errorf("timeout hit")
+		return zero, errors.New("timeout hit")
 	}
 }
 
@@ -33,6 +33,6 @@ func RecvResp[T any](r <-chan T, e <-chan error, q <-chan struct{}) (T, error) {
 		return noResp, err
 
 	case <-q:
-		return noResp, fmt.Errorf("quitting")
+		return noResp, errors.New("quitting")
 	}
 }

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -3,6 +3,7 @@ package funding
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -1112,7 +1113,7 @@ func (f *Manager) advanceFundingState(channel *channeldb.OpenChannel,
 		channelState, shortChanID, err := f.getChannelOpeningState(
 			&channel.FundingOutpoint,
 		)
-		if err == channeldb.ErrChannelNotFound {
+		if errors.Is(err, channeldb.ErrChannelNotFound) {
 			// Channel not in fundingManager's opening database,
 			// meaning it was successfully announced to the
 			// network.
@@ -1326,7 +1327,7 @@ func (f *Manager) advancePendingChannelState(channel *channeldb.OpenChannel,
 	}
 
 	confChannel, err := f.waitForFundingWithTimeout(channel)
-	if err == ErrConfirmationTimeout {
+	if errors.Is(err, ErrConfirmationTimeout) {
 		return f.fundingTimeout(channel, pendingChanID)
 	} else if err != nil {
 		return fmt.Errorf("error waiting for funding "+

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -1076,7 +1076,7 @@ func (c *ChannelGraph) AddChannelEdge(edge *models.ChannelEdgeInfo,
 
 			// Silence ErrEdgeAlreadyExist so that the batch can
 			// succeed, but propagate the error via local state.
-			if err == ErrEdgeAlreadyExist {
+			if errors.Is(err, ErrEdgeAlreadyExist) {
 				alreadyExists = true
 				return nil
 			}
@@ -3493,7 +3493,7 @@ func (c *ChannelGraph) FetchChannelEdgesByID(chanID uint64) (
 		policy1 = nil
 		policy2 = nil
 	})
-	if err == ErrZombieEdge {
+	if errors.Is(err, ErrZombieEdge) {
 		return edgeInfo, nil, nil, err
 	}
 	if err != nil {

--- a/lnrpc/websocket_proxy.go
+++ b/lnrpc/websocket_proxy.go
@@ -5,6 +5,7 @@ package lnrpc
 
 import (
 	"bufio"
+	"errors"
 	"io"
 	"net/http"
 	"net/textproto"
@@ -500,7 +501,7 @@ func IsClosedConnError(err error) bool {
 	if err == nil {
 		return false
 	}
-	if err == http.ErrServerClosed {
+	if errors.Is(err, http.ErrServerClosed) {
 		return true
 	}
 

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -4001,7 +4001,7 @@ func (p *Brontide) handleCloseMsg(msg *closeMsg) {
 	chanCloser, err := p.fetchActiveChanCloser(msg.cid)
 	if err != nil {
 		// If the channel is not known to us, we'll simply ignore this message.
-		if err == ErrChannelNotFound {
+		if errors.Is(err, ErrChannelNotFound) {
 			return
 		}
 

--- a/pilot.go
+++ b/pilot.go
@@ -66,7 +66,7 @@ func validateAtplCfg(cfg *lncfg.AutoPilot) ([]*autopilot.WeightedHeuristic,
 	}
 
 	if sum != 1.0 {
-		return nil, fmt.Errorf("heuristic weights must sum to 1.0")
+		return nil, errors.New("heuristic weights must sum to 1.0")
 	}
 	return heuristics, nil
 }

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1440,7 +1440,7 @@ func (r *rpcServer) SendCoins(ctx context.Context,
 		// If sending everything to this address would invalidate our
 		// reserved wallet balance, we create a new sweep tx, where
 		// we'll send the reserved value back to our wallet.
-		if err == lnwallet.ErrReservedValueInvalidated {
+		if errors.Is(err, lnwallet.ErrReservedValueInvalidated) {
 			sweepTxPkg.CancelSweepAttempt()
 
 			rpcsLog.Debugf("Reserved value %v not satisfied after "+
@@ -4348,7 +4348,7 @@ func (r *rpcServer) nurseryPopulateForceCloseResp(chanPoint *wire.OutPoint,
 	// didn't have any time-locked outputs, then the nursery may not know of
 	// the contract.
 	nurseryInfo, err := r.server.utxoNursery.NurseryReport(chanPoint)
-	if err == contractcourt.ErrContractNotFound {
+	if errors.Is(err, contractcourt.ErrContractNotFound) {
 		return nil
 	}
 	if err != nil {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -226,7 +226,7 @@ var (
 	// If the --no-macaroons flag is used to start lnd, the macaroon service
 	// is not initialized. errMacaroonDisabled is then returned when
 	// macaroon related services are used.
-	errMacaroonDisabled = fmt.Errorf("macaroon authentication disabled, " +
+	errMacaroonDisabled = errors.New("macaroon authentication disabled, " +
 		"remove --no-macaroons flag to enable")
 )
 
@@ -1355,7 +1355,7 @@ func (r *rpcServer) SendCoins(ctx context.Context,
 	decodedAddr, _ := hex.DecodeString(in.Addr)
 	_, err = btcec.ParsePubKey(decodedAddr)
 	if err == nil {
-		return nil, fmt.Errorf("cannot send coins to pubkeys")
+		return nil, errors.New("cannot send coins to pubkeys")
 	}
 
 	label, err := labels.ValidateAPI(in.Label)
@@ -1385,7 +1385,7 @@ func (r *rpcServer) SendCoins(ctx context.Context,
 		}
 
 		if fn.HasDuplicates(wireOutpoints) {
-			return nil, fmt.Errorf("selected outpoints contain " +
+			return nil, errors.New("selected outpoints contain " +
 				"duplicate values")
 		}
 
@@ -1400,7 +1400,7 @@ func (r *rpcServer) SendCoins(ctx context.Context,
 		// At this point, the amount shouldn't be set since we've been
 		// instructed to sweep all the coins from the wallet.
 		if in.Amount != 0 {
-			return nil, fmt.Errorf("amount set while SendAll is " +
+			return nil, errors.New("amount set while SendAll is " +
 				"active")
 		}
 

--- a/server.go
+++ b/server.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math/big"
 	prand "math/rand"
@@ -4906,7 +4907,7 @@ func (s *server) DisconnectPeer(pubKey *btcec.PublicKey) error {
 	// exit in an error as we can't disconnect from a peer that we're not
 	// currently connected to.
 	peer, err := s.findPeerByPubStr(pubStr)
-	if err == ErrPeerNotConnected {
+	if errors.Is(err, ErrPeerNotConnected) {
 		return fmt.Errorf("peer %x is not connected", pubBytes)
 	}
 

--- a/server.go
+++ b/server.go
@@ -572,7 +572,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 	if cfg.ProtocolOptions.TaprootOverlayChans &&
 		implCfg.AuxFundingController.IsNone() {
 
-		return nil, fmt.Errorf("taproot overlay flag set, but not " +
+		return nil, errors.New("taproot overlay flag set, but not " +
 			"aux controllers")
 	}
 
@@ -1428,7 +1428,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 
 		if ourPolicy == nil {
 			// Something is wrong, so return an error.
-			return nil, fmt.Errorf("we don't have an edge")
+			return nil, errors.New("we don't have an edge")
 		}
 
 		err = s.graphDB.DeleteChannelEdges(


### PR DESCRIPTION
Replaced fmt.Errorf with errors.New in cases where formatting is not required. This reduces unnecessary function calls, leading to slightly improved performance and cleaner code.