### PR TITLE
lnwallet+protofsm: fix logging

### DIFF
--- a/lnwallet/chancloser/rbf_coop_transitions.go
+++ b/lnwallet/chancloser/rbf_coop_transitions.go
@@ -193,7 +193,8 @@ func (c *ChannelActive) ProcessEvent(event ProtocolEvent, env *Environment,
 	// also emit similar events like the above to send out shutdown, and
 	// also disable the channel.
 	case *ShutdownReceived:
-		chancloserLog.Infof("ChannelPoint(%v): received shutdown msg")
+		chancloserLog.Infof("ChannelPoint(%v): received shutdown msg",
+			env.ChanPoint)
 
 		// Validate that they can send the message now, and also that
 		// they haven't violated their commitment to a prior upfront
@@ -204,7 +205,7 @@ func (c *ChannelActive) ProcessEvent(event ProtocolEvent, env *Environment,
 		)
 		if err != nil {
 			chancloserLog.Errorf("ChannelPoint(%v): rejecting "+
-				"shutdown attempt: %v", err)
+				"shutdown attempt: %v", env.ChanPoint, err)
 
 			return nil, err
 		}
@@ -302,7 +303,7 @@ func (s *ShutdownPending) ProcessEvent(event ProtocolEvent, env *Environment,
 		)
 		if err != nil {
 			chancloserLog.Errorf("ChannelPoint(%v): rejecting "+
-				"shutdown attempt: %v", err)
+				"shutdown attempt: %v", env.ChanPoint, err)
 
 			return nil, err
 		}

--- a/protofsm/state_machine.go
+++ b/protofsm/state_machine.go
@@ -345,7 +345,7 @@ func (s *StateMachine[Event, Env]) executeDaemonEvent(ctx context.Context,
 	// any preconditions as well as post-send events.
 	case *SendMsgEvent[Event]:
 		sendAndCleanUp := func() error {
-			s.log.DebugS(ctx, "Sending message to target",
+			s.log.DebugS(ctx, "Sending message:",
 				btclog.Hex6("target", daemonEvent.TargetPeer.SerializeCompressed()),
 				"messages", lnutils.SpewLogClosure(daemonEvent.Msgs))
 


### PR DESCRIPTION
Fix the missing `ChannelPoint` and redundant string `target` in the logging.