### PR TITLE
rpcserver: remove duplicate info from `RoutingPolicy`

### DIFF
--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -94,6 +94,12 @@ circuit. The indices are only available for forwarding events saved after v0.20.
     * [11](https://github.com/lightningnetwork/lnd/pull/9972)
 
 ## RPC Updates
+* Previously the `RoutingPolicy` would return the inbound fee record in its
+  `CustomRecords` field, which is duplicated info as it's already presented in
+  fields `InboundFeeBaseMsat` and `InboundFeeRateMilliMsat`. This is now
+  [fixed](https://github.com/lightningnetwork/lnd/pull/9572), the affected RPCs
+  are `SubscribeChannelGraph`, `GetChanInfo`, `GetNodeInfo` and `DescribeGraph`.
+
 
 ## lncli Updates
 

--- a/lnrpc/devrpc/dev.swagger.json
+++ b/lnrpc/devrpc/dev.swagger.json
@@ -320,7 +320,7 @@
             "type": "string",
             "format": "byte"
           },
-          "description": "Custom channel update tlv records."
+          "description": "Custom channel update tlv records. These are customized fields that are\nnot defined by LND and cannot be extracted."
         },
         "inbound_fee_base_msat": {
           "type": "integer",

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -10993,7 +10993,8 @@ type RoutingPolicy struct {
 	Disabled         bool   `protobuf:"varint,5,opt,name=disabled,proto3" json:"disabled,omitempty"`
 	MaxHtlcMsat      uint64 `protobuf:"varint,6,opt,name=max_htlc_msat,json=maxHtlcMsat,proto3" json:"max_htlc_msat,omitempty"`
 	LastUpdate       uint32 `protobuf:"varint,7,opt,name=last_update,json=lastUpdate,proto3" json:"last_update,omitempty"`
-	// Custom channel update tlv records.
+	// Custom channel update tlv records. These are customized fields that are
+	// not defined by LND and cannot be extracted.
 	CustomRecords           map[uint64][]byte `protobuf:"bytes,8,rep,name=custom_records,json=customRecords,proto3" json:"custom_records,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	InboundFeeBaseMsat      int32             `protobuf:"varint,9,opt,name=inbound_fee_base_msat,json=inboundFeeBaseMsat,proto3" json:"inbound_fee_base_msat,omitempty"`
 	InboundFeeRateMilliMsat int32             `protobuf:"varint,10,opt,name=inbound_fee_rate_milli_msat,json=inboundFeeRateMilliMsat,proto3" json:"inbound_fee_rate_milli_msat,omitempty"`

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -3471,7 +3471,8 @@ message RoutingPolicy {
     uint64 max_htlc_msat = 6;
     uint32 last_update = 7;
 
-    // Custom channel update tlv records.
+    // Custom channel update tlv records. These are customized fields that are
+    // not defined by LND and cannot be extracted.
     map<uint64, bytes> custom_records = 8;
 
     int32 inbound_fee_base_msat = 9;

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -7350,7 +7350,7 @@
             "type": "string",
             "format": "byte"
           },
-          "description": "Custom channel update tlv records."
+          "description": "Custom channel update tlv records. These are customized fields that are\nnot defined by LND and cannot be extracted."
         },
         "inbound_fee_base_msat": {
           "type": "integer",

--- a/lntest/node/watcher.go
+++ b/lntest/node/watcher.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -723,6 +724,28 @@ func CheckChannelPolicy(policy, expectedPolicy *lnrpc.RoutingPolicy) error {
 	}
 	if policy.Disabled != expectedPolicy.Disabled {
 		return errors.New("edge should be disabled but isn't")
+	}
+
+	// We now validate custom records.
+	records := policy.CustomRecords
+
+	if len(records) != len(expectedPolicy.CustomRecords) {
+		return fmt.Errorf("expected %v CustomRecords, got %v, "+
+			"records: %v", len(expectedPolicy.CustomRecords),
+			len(records), records)
+	}
+
+	expectedRecords := expectedPolicy.CustomRecords
+	for k, record := range records {
+		expected, found := expectedRecords[k]
+		if !found {
+			return fmt.Errorf("CustomRecords %v not found", k)
+		}
+
+		if !bytes.Equal(record, expected) {
+			return fmt.Errorf("want CustomRecords(%v) %s, got %s",
+				k, expected, record)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Found from this [build](https://github.com/lightningnetwork/lnd/actions/runs/13583650550/job/37973971226), where the inbound fee info was set in the `custom_records` of a channel policy response,
```json
{
	"time_lock_delta": 22,
	"min_htlc": 1000,
	"fee_base_msat": 800,
	"fee_rate_milli_msat": 123000000,
	"max_htlc_msat": 1000000,
	"custom_records": {
		"55555": "///+cP///8Q="
	},
	"inbound_fee_base_msat": -400,
	"inbound_fee_rate_milli_msat": -60,
	"connecting_node": "021f81f97732d32fd0eb39cca08bb05d2377486d1bd5cbbdcad176915364c17e2a",
	"timestamp": "2025-02-28T08:10:22.626242157Z"
}
```
We remove the inbound fee record from `RoutingPolicy.CustomRecords` as we already have fields `InboundFeeBaseMsat` and `InboundFeeRateMilliMsat`.