### PR TITLE
lntest: wait for ChanUpdate req to be fully processed before sending another

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -323,6 +323,9 @@ The underlying functionality between those two options remain the same.
 * Add a new CI-step to do some basic [backwards compatibility 
   testing](https://github.com/lightningnetwork/lnd/pull/9540) for each PR. 
 
+* [Fix](https://github.com/lightningnetwork/lnd/pull/9574) an integration test 
+  flake that could lead to a "close of a closed channel" panic.
+
 ## Database
 
 * [Migrate the mission control 


### PR DESCRIPTION
Before this commit, it was possible for a request to be sent on the `chanWatchRequests` channel in `WaitForChannelPolicyUpdate` and then for the `ticker.C` case to select _before_ the `eventChan` select gets triggered when the `topologyWatcher` closes the `eventChan` in its call to `handlePolicyUpdateWatchRequest`. This could lead to a "close of a closed channel" panic.

To fix this, this commit ensures that we only move on to the next iteration of the select statement in `WaitForChannelPolicyUpdate` once the request sent on `chanWatchRequests` has been fully handled.

See [this build](https://github.com/lightningnetwork/lnd/actions/runs/13630660920/job/38097538076?pr=9544) for an instance of where this panic was triggered. 
