### PR TITLE
build: add yaml tags to some LogConfig fields

### DIFF
--- a/build/config.go
+++ b/build/config.go
@@ -57,7 +57,7 @@ func DefaultLogConfig() *LogConfig {
 			Compressor:     defaultLogCompressor,
 			MaxLogFiles:    DefaultMaxLogFiles,
 			MaxLogFileSize: DefaultMaxLogFileSize,
-			LoggerConfig: LoggerConfig{
+			LoggerConfig: &LoggerConfig{
 				CallSite: callSiteOff,
 			},
 		},
@@ -92,7 +92,7 @@ func (cfg *LoggerConfig) HandlerOptions() []btclog.HandlerOption {
 //
 //nolint:ll
 type FileLoggerConfig struct {
-	LoggerConfig
+	*LoggerConfig  `yaml:",inline"`
 	Compressor     string `long:"compressor" description:"Compression algorithm to use when rotating logs." choice:"gzip" choice:"zstd"`
 	MaxLogFiles    int    `long:"max-files" description:"Maximum logfiles to keep (0 for no rotation)"`
 	MaxLogFileSize int    `long:"max-file-size" description:"Maximum logfile size in MB"`

--- a/build/config_dev.go
+++ b/build/config_dev.go
@@ -24,15 +24,15 @@ const (
 //
 //nolint:ll
 type consoleLoggerCfg struct {
-	LoggerConfig
-	Style bool `long:"style" description:"If set, the output will be styled with color and fonts"`
+	*LoggerConfig `yaml:",inline"`
+	Style         bool `long:"style" description:"If set, the output will be styled with color and fonts"`
 }
 
 // defaultConsoleLoggerCfg returns the default consoleLoggerCfg for the dev
 // console logger.
 func defaultConsoleLoggerCfg() *consoleLoggerCfg {
 	return &consoleLoggerCfg{
-		LoggerConfig: LoggerConfig{
+		LoggerConfig: &LoggerConfig{
 			CallSite: callSiteShort,
 		},
 	}

--- a/build/config_prod.go
+++ b/build/config_prod.go
@@ -8,14 +8,14 @@ package build
 //
 //nolint:ll
 type consoleLoggerCfg struct {
-	LoggerConfig
+	*LoggerConfig `yaml:",inline"`
 }
 
 // defaultConsoleLoggerCfg returns the default consoleLoggerCfg for the prod
 // console logger.
 func defaultConsoleLoggerCfg() *consoleLoggerCfg {
 	return &consoleLoggerCfg{
-		LoggerConfig: LoggerConfig{
+		LoggerConfig: &LoggerConfig{
 			CallSite: callSiteOff,
 		},
 	}


### PR DESCRIPTION
For the `LogConfig` struct, add the `yaml:",inline"` tag to embedded structs.

This is needed for any project that uses the `LogConfig` struct to parse a `yaml` config file (like [aperture](https://github.com/lightninglabs/aperture/pull/148)).