### PR TITLE
config: only create a sub-log manager if one doesnt already exist

### DIFF
--- a/config.go
+++ b/config.go
@@ -1416,9 +1416,15 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 		return nil, mkErr("error validating logging config: %w", err)
 	}
 
-	cfg.SubLogMgr = build.NewSubLoggerManager(build.NewDefaultLogHandlers(
-		cfg.LogConfig, cfg.LogRotator,
-	)...)
+	// If a sub-log manager was not already created, then we'll create one
+	// now using the default log handlers.
+	if cfg.SubLogMgr == nil {
+		cfg.SubLogMgr = build.NewSubLoggerManager(
+			build.NewDefaultLogHandlers(
+				cfg.LogConfig, cfg.LogRotator,
+			)...,
+		)
+	}
 
 	// Initialize logging at the default logging level.
 	SetupLoggers(cfg.SubLogMgr, interceptor)


### PR DESCRIPTION
The `ValidateConfig` method needs to account for the caller already having an initialised build.SubLoggerManager and then should not override it.

This lets any callers of `ValidateConfig` (such as LiT), to initialise the sub logger manager themselves.