### PR TITLE
Update wtclient.go

### DIFF
--- a/cmd/commands/wtclient.go
+++ b/cmd/commands/wtclient.go
@@ -376,15 +376,23 @@ func policy(ctx *cli.Context) error {
 }
 
 var sessionCommands = cli.Command{
-	Name: "session",
+	Name:  "session",
+	Usage: "Manage watchtower client sessions.",
+	Description: "This command allows users  " +
+		"to manage their watchtower client sessions," +
+		"specifically to terminate an active session",
 	Subcommands: []cli.Command{
 		terminateSessionCommand,
 	},
 }
 
 var terminateSessionCommand = cli.Command{
-	Name:      "terminate",
-	ArgsUsage: "id",
+	Name:  "terminate",
+	Usage: "Terminate an active watchtower session.",
+	Description: "This command ends a session using " +
+		"its unique session ID. It stops further backups " +
+		"but does not affect past backup data",
+	ArgsUsage: "session_id",
 	Action:    actionDecorator(terminateSession),
 }
 

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -270,6 +270,11 @@ The underlying functionality between those two options remain the same.
    [1](https://github.com/lightningnetwork/lnd/pull/9476)
    [2](https://github.com/lightningnetwork/lnd/pull/9477)
    [3](https://github.com/lightningnetwork/lnd/pull/9478).
+   
+* [Watchtower Client Commands](https://github.com/lightningnetwork/lnd/pull/9588): -  
+Added detailed descriptions for the session and terminate commands in lncli wtclient.
+The session command now explains its purpose and how it manages watchtower sessions.
+The terminate command provides clear guidance on terminating an active session by specifying its unique session ID.
 
 ## Breaking Changes
 ## Performance Improvements


### PR DESCRIPTION
wtclient: Add descriptions for session and terminate commands
Improved user guidance by adding detailed CLI help text for the session and terminate subcommands in the watchtower client (wtclient).

Fixed formatting issues flagged by the linter.

Fixes: #9583

Change Description
Adds helpful descriptions for lncli wtclient session and lncli wtclient terminate to make the CLI more user-friendly. No logic changes.

Steps to Test

1. lncli wtclient
Check that the session and terminate commands now have clear descriptions.

2. make lint


PR Checklist
 Passes all CI checks

 Follows code and doc style (80 char lines, proper formatting)

 Commits follow [ideal structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#ideal-git-commit-structure)

 Not a typo-only change

 No tests required (CLI help text only)

 No release notes change needed