### PR TITLE
multi: fix flakes and gossip syncer

### DIFF
--- a/discovery/syncer_test.go
+++ b/discovery/syncer_test.go
@@ -1478,10 +1478,7 @@ func TestGossipSyncerSynchronizeChanIDs(t *testing.T) {
 
 	for i := 0; i < chunkSize*2; i += 2 {
 		// With our set up complete, we'll request a sync of chan ID's.
-		done, err := syncer.synchronizeChanIDs()
-		if err != nil {
-			t.Fatalf("unable to sync chan IDs: %v", err)
-		}
+		done := syncer.synchronizeChanIDs()
 
 		// At this point, we shouldn't yet be done as only 2 items
 		// should have been queried for.
@@ -1528,8 +1525,7 @@ func TestGossipSyncerSynchronizeChanIDs(t *testing.T) {
 	}
 
 	// If we issue another query, the syncer should tell us that it's done.
-	done, err := syncer.synchronizeChanIDs()
-	require.NoError(t, err, "unable to sync chan IDs")
+	done := syncer.synchronizeChanIDs()
 	if done {
 		t.Fatalf("syncer should be finished!")
 	}

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -82,6 +82,9 @@
   could lead to our ChannelUpdate rate limiting logic being prematurely 
   triggered.
 
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/9595) where the
+  initial graph sync query may be failed due to inconsistent state.
+
 # New Features
 
 * [Support](https://github.com/lightningnetwork/lnd/pull/8390) for 

--- a/itest/lnd_forward_interceptor_test.go
+++ b/itest/lnd_forward_interceptor_test.go
@@ -438,12 +438,6 @@ func testForwardInterceptorRestart(ht *lntest.HarnessTest) {
 	require.Equal(ht, lntest.CustomRecordsWithUnendorsed(customRecords),
 		packet.InWireCustomRecords)
 
-	err = carolInterceptor.Send(&routerrpc.ForwardHtlcInterceptResponse{
-		IncomingCircuitKey: packet.IncomingCircuitKey,
-		Action:             actionResume,
-	})
-	require.NoError(ht, err, "failed to send request")
-
 	// And now we forward the payment at Carol, expecting only an
 	// endorsement signal in our incoming custom records.
 	packet = ht.ReceiveHtlcInterceptor(carolInterceptor)

--- a/lnrpc/routerrpc/forward_interceptor.go
+++ b/lnrpc/routerrpc/forward_interceptor.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnutils"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -60,6 +61,9 @@ func (r *forwardInterceptor) run() error {
 			return err
 		}
 
+		log.Tracef("Received packet from stream: %v",
+			lnutils.SpewLogClosure(resp))
+
 		if err := r.resolveFromClient(resp); err != nil {
 			return err
 		}
@@ -73,7 +77,8 @@ func (r *forwardInterceptor) run() error {
 func (r *forwardInterceptor) onIntercept(
 	htlc htlcswitch.InterceptedPacket) error {
 
-	log.Tracef("Sending intercepted packet to client %v", htlc)
+	log.Tracef("Sending intercepted packet to client %v",
+		lnutils.SpewLogClosure(htlc))
 
 	inKey := htlc.IncomingCircuit
 


### PR DESCRIPTION
Fix the following three flakes,

`TestReconnectSucceed` still fails, from this [build](https://github.com/yyforyongyu/lnd/actions/runs/13733368349/job/38414019489),
```
panic: Log in goroutine after TestReconnectSucceed has completed: 
                Error Trace:    /home/runner/go/pkg/mod/github.com/lightningnetwork/lnd/tor@v1.1.5/controller_test.go:357
                                                        /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/asm_amd64.s:1700
                Error:          Received unexpected error:
                                EOF
                Test:           TestReconnectSucceed
```


`forward_interceptor_restart` from this [build](https://github.com/yyforyongyu/lnd/actions/runs/13754484996/job/38459750034)
```
 --- FAIL: TestLightningNetworkDaemon/tranche09/165-of-272/bitcoind/forward_interceptor_restart (30.28s)
        harness_node.go:403: Starting node (name=Alice) with PID=10529
        harness_node.go:403: Starting node (name=Bob) with PID=10559
        harness_node.go:403: Starting node (name=Carol) with PID=10569
        harness_node.go:403: Starting node (name=Dave) with PID=10588
        harness_node.go:403: Starting node (name=Bob) with PID=10946
        harness_node.go:403: Starting node (name=Alice) with PID=10981
        lnd_forward_interceptor_test.go:455: 
            	Error Trace:	/home/runner/work/lnd/lnd/itest/lnd_forward_interceptor_test.go:455
            	            				/home/runner/work/lnd/lnd/lntest/harness.go:304
            	            				/home/runner/work/lnd/lnd/itest/lnd_test.go:130
            	Error:      	Received unexpected error:
            	            	EOF
            	Test:       	TestLightningNetworkDaemon/tranche09/165-of-272/bitcoind/forward_interceptor_restart
            	Messages:   	failed to send request
        harness.go:382: finished test: forward_interceptor_restart, start height=603, end height=610, mined blocks=7
        harness.go:341: test failed, skipped cleanup
```

`update_channel_status`, which has been seen in multiple builds already,
```
--- FAIL: TestLightningNetworkDaemon/tranche00/32-of-272/bitcoind/update_channel_status (109.15s)
        harness_node.go:403: Starting node (name=Alice) with PID=15096
        harness_node.go:403: Starting node (name=Bob) with PID=15120
        harness_node.go:403: Starting node (name=Carol) with PID=15200
        harness_assertion.go:745: 
            	Error Trace:	/home/runner/work/lnd/lnd/lntest/harness_assertion.go:745
            	            				/home/runner/work/lnd/lnd/itest/lnd_channel_graph_test.go:127
            	            				/home/runner/work/lnd/lnd/lntest/harness.go:304
            	            				/home/runner/work/lnd/lnd/itest/lnd_test.go:130
            	Error:      	Received unexpected error:
            	            	node not synced to graph
            	Test:       	TestLightningNetworkDaemon/tranche00/32-of-272/bitcoind/update_channel_status
            	Messages:   	Carol: timeout while sync to graph
        harness.go:382: finished test: update_channel_status, start height=916, end height=923, mined blocks=7
        harness.go:341: test failed, skipped cleanup
    lnd_test.go:138: Failure time: 2025-03-10 04:23:03.095
```

