### PR TITLE
contractcourt: fix rebase issue with removed variadic option

### DIFF
--- a/contractcourt/commit_sweep_resolver.go
+++ b/contractcourt/commit_sweep_resolver.go
@@ -413,17 +413,22 @@ func (c *commitSweepResolver) Launch() error {
 			&c.commitResolution.SelfOutPoint, witnessType,
 			&c.commitResolution.SelfOutputSignDesc,
 			c.broadcastHeight, c.commitResolution.MaturityDelay,
-			c.leaseExpiry,
+			c.leaseExpiry, input.WithResolutionBlob(
+				c.commitResolution.ResolutionBlob,
+			),
 		)
 	} else {
 		inp = input.NewCsvInput(
 			&c.commitResolution.SelfOutPoint, witnessType,
 			&c.commitResolution.SelfOutputSignDesc,
 			c.broadcastHeight, c.commitResolution.MaturityDelay,
+			input.WithResolutionBlob(
+				c.commitResolution.ResolutionBlob,
+			),
 		)
 	}
 
-	// TODO(roasbeef): instead of ading ctrl block to the sign desc, make
+	// TODO(roasbeef): instead of adding ctrl block to the sign desc, make
 	// new input type, have sweeper set it?
 
 	// Calculate the budget for the sweeping this input.

--- a/contractcourt/htlc_lease_resolver.go
+++ b/contractcourt/htlc_lease_resolver.go
@@ -58,10 +58,8 @@ func (h *htlcLeaseResolver) makeSweepInput(op *wire.OutPoint,
 
 	if h.hasCLTV() {
 		return input.NewCsvInputWithCltv(
-			op, cltvWtype, signDesc,
-			broadcastHeight, csvDelay,
-			h.leaseExpiry,
-			input.WithResolutionBlob(resBlob),
+			op, cltvWtype, signDesc, broadcastHeight, csvDelay,
+			h.leaseExpiry, input.WithResolutionBlob(resBlob),
 		)
 	}
 


### PR DESCRIPTION
The optional variadic functional parameters probably got lost during a rebase.

