### PR TITLE
lntest+itest: document and fix more flakes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/lightningnetwork/lnd/sqldb v1.0.7
 	github.com/lightningnetwork/lnd/ticker v1.1.1
 	github.com/lightningnetwork/lnd/tlv v1.3.0
-	github.com/lightningnetwork/lnd/tor v1.1.5
+	github.com/lightningnetwork/lnd/tor v1.1.6
 	github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796
 	github.com/miekg/dns v1.1.43
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -470,8 +470,8 @@ github.com/lightningnetwork/lnd/ticker v1.1.1 h1:J/b6N2hibFtC7JLV77ULQp++QLtCwT6
 github.com/lightningnetwork/lnd/ticker v1.1.1/go.mod h1:waPTRAAcwtu7Ji3+3k+u/xH5GHovTsCoSVpho0KDvdA=
 github.com/lightningnetwork/lnd/tlv v1.3.0 h1:exS/KCPEgpOgviIttfiXAPaUqw2rHQrnUOpP7HPBPiY=
 github.com/lightningnetwork/lnd/tlv v1.3.0/go.mod h1:pJuiBj1ecr1WWLOtcZ+2+hu9Ey25aJWFIsjmAoPPnmc=
-github.com/lightningnetwork/lnd/tor v1.1.5 h1:kZ1Ab4EcPFCny3a179rZGKeDUlgYilEcfKx3tD5+L+k=
-github.com/lightningnetwork/lnd/tor v1.1.5/go.mod h1:qSRB8llhAK+a6kaTPWOLLXSZc6Hg8ZC0mq1sUQ/8JfI=
+github.com/lightningnetwork/lnd/tor v1.1.6 h1:WHUumk7WgU6BUFsqHuqszI9P6nfhMeIG+rjJBlVE6OE=
+github.com/lightningnetwork/lnd/tor v1.1.6/go.mod h1:qSRB8llhAK+a6kaTPWOLLXSZc6Hg8ZC0mq1sUQ/8JfI=
 github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796 h1:sjOGyegMIhvgfq5oaue6Td+hxZuf3tDC8lAPrFldqFw=
 github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796/go.mod h1:3p7ZTf9V1sNPI5H8P3NkTFF4LuwMdPl2DodF60qAKqY=
 github.com/ltcsuite/ltcutil v0.0.0-20181217130922-17f3b04680b6/go.mod h1:8Vg/LTOO0KYa/vlHWJ6XZAevPQThGH5sufO0Hrou/lA=

--- a/itest/flakes.go
+++ b/itest/flakes.go
@@ -142,3 +142,22 @@ func flakeInconsistentHTLCView() {
 	// the ListChannels.
 	time.Sleep(2 * time.Second)
 }
+
+// flakePaymentStreamReturnEarly documents a flake found in the test which
+// relies on a given payment to be settled before testing other state changes.
+// The issue comes from the payment stream created from the RPC `SendPaymentV2`
+// gives premature settled event for a given payment, which is found in,
+//   - if we force close the channel immediately, we may get an error because
+//     the commitment dance is not finished.
+//   - if we subscribe HTLC events immediately, we may get extra events, which
+//     is also related to the above unfinished commitment dance.
+//
+// TODO(yy): Make sure we only mark the payment being settled once the
+// commitment dance is finished. In addition, we should also fix the exit hop
+// logic in the invoice settlement flow to make sure the invoice is only marked
+// as settled after the commitment dance is finished.
+func flakePaymentStreamReturnEarly() {
+	// Sleep 2 seconds so the pending HTLCs will be removed from the
+	// commitment.
+	time.Sleep(2 * time.Second)
+}

--- a/itest/lnd_channel_backup_test.go
+++ b/itest/lnd_channel_backup_test.go
@@ -1224,13 +1224,7 @@ func testDataLossProtection(ht *lntest.HarnessTest) {
 		// payment hashes.
 		ht.CompletePaymentRequests(carol, payReqs[numInvoices/2:])
 
-		// TODO(yy): remove the sleep once the following bug is fixed.
-		//
-		// While the payment is reported as settled, the commitment
-		// dance may not be finished, which leaves several HTLCs in the
-		// commitment. Later on, when Carol force closes this channel,
-		// she would have HTLCs there and the test won't pass.
-		time.Sleep(2 * time.Second)
+		flakePaymentStreamReturnEarly()
 
 		// Now we shutdown Dave, copying over the its temporary
 		// database state which has the *prior* channel state over his

--- a/itest/lnd_coop_close_with_htlcs_test.go
+++ b/itest/lnd_coop_close_with_htlcs_test.go
@@ -196,11 +196,14 @@ func coopCloseWithHTLCsWithRestart(ht *lntest.HarnessTest) {
 	ht.AssertChannelInactive(bob, chanPoint)
 	ht.AssertChannelInactive(alice, chanPoint)
 
-	// Now restart Alice and Bob.
-	ht.RestartNode(alice)
-	ht.RestartNode(bob)
+	// Shutdown both Alice and Bob.
+	restartAlice := ht.SuspendNode(alice)
+	restartBob := ht.SuspendNode(bob)
 
-	ht.AssertConnected(alice, bob)
+	// Once shutdown, restart and connect them.
+	require.NoError(ht, restartAlice())
+	require.NoError(ht, restartBob())
+	ht.EnsureConnected(alice, bob)
 
 	// Show that both nodes still see the channel as waiting for close after
 	// the restart.

--- a/itest/lnd_route_blinding_test.go
+++ b/itest/lnd_route_blinding_test.go
@@ -667,6 +667,10 @@ func testRelayingBlindedError(ht *lntest.HarnessTest) {
 	// so that she can't forward the payment to Dave.
 	testCase.drainCarolLiquidity(false)
 
+	// NOTE: The above draining requires Carol to send a payment, which may
+	// create extra events, causing the `AssertHtlcEvents` to fail below.
+	flakePaymentStreamReturnEarly()
+
 	// Subscribe to Carol's HTLC events so that we can observe the payment
 	// coming in.
 	carolEvents := testCase.carol.RPC.SubscribeHtlcEvents()

--- a/itest/lnd_route_blinding_test.go
+++ b/itest/lnd_route_blinding_test.go
@@ -815,6 +815,7 @@ func testErrorHandlingOnChainFailure(ht *lntest.HarnessTest) {
 	ht.MineBlocksAndAssertNumTxes(1, 1)
 
 	// Assert that the HTLC has cleared.
+	flakeInconsistentHTLCView()
 	ht.AssertHTLCNotActive(bob, testCase.channels[0], hash[:])
 	ht.AssertHTLCNotActive(alice, testCase.channels[0], hash[:])
 

--- a/itest/lnd_sweep_test.go
+++ b/itest/lnd_sweep_test.go
@@ -499,6 +499,7 @@ func testSweepCPFPAnchorIncomingTimeout(ht *lntest.HarnessTest) {
 	carol.RPC.SettleInvoice(preimage[:])
 
 	// Bob should have settled his outgoing HTLC with Carol.
+	flakeInconsistentHTLCView()
 	ht.AssertHTLCNotActive(bob, bcChanPoint, payHash[:])
 
 	// We'll now mine enough blocks to trigger Bob to force close channel
@@ -850,6 +851,7 @@ func testSweepHTLCs(ht *lntest.HarnessTest) {
 	carol.RPC.SettleInvoice(preimageSettled[:])
 
 	// Bob should have settled his outgoing HTLC with Carol.
+	flakeInconsistentHTLCView()
 	ht.AssertHTLCNotActive(bob, bcChanPoint, payHashSettled[:])
 
 	// Let Carol go offline so we can focus on testing Bob's sweeping

--- a/itest/lnd_wipe_fwdpkgs_test.go
+++ b/itest/lnd_wipe_fwdpkgs_test.go
@@ -1,8 +1,6 @@
 package itest
 
 import (
-	"time"
-
 	"github.com/lightningnetwork/lnd/chainreg"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lntest"
@@ -49,13 +47,7 @@ func testWipeForwardingPackages(ht *lntest.HarnessTest) {
 		ht.CompletePaymentRequests(alice, []string{resp.PaymentRequest})
 	}
 
-	// TODO(yy): remove the sleep once the following bug is fixed.
-	// When the invoice is reported settled, the commitment dance is not
-	// yet finished, which can cause an error when closing the channel,
-	// saying there's active HTLCs. We need to investigate this issue and
-	// reverse the order to, first finish the commitment dance, then report
-	// the invoice as settled.
-	time.Sleep(2 * time.Second)
+	flakePaymentStreamReturnEarly()
 
 	// Firstly, Bob force closes the channel.
 	ht.CloseChannelAssertPending(bob, chanPointAB, true)

--- a/lntest/harness_assertion.go
+++ b/lntest/harness_assertion.go
@@ -401,7 +401,7 @@ func (h *HarnessTest) assertChannelStatus(hn *node.HarnessNode,
 	}, DefaultTimeout)
 
 	require.NoErrorf(h, err, "%s: timeout checking for channel point: %v",
-		hn.Name(), cp)
+		hn.Name(), h.OutPointFromChannelPoint(cp))
 
 	return channel
 }

--- a/lntest/harness_assertion.go
+++ b/lntest/harness_assertion.go
@@ -2329,7 +2329,8 @@ func (h *HarnessTest) AssertHtlcEvents(client rpc.HtlcEventsClient,
 		event := h.ReceiveHtlcEvent(client)
 
 		require.Containsf(h, eventTypes, event.EventType,
-			"wrong event type, got %v", userType, event.EventType)
+			"wrong event type, want %v, got %v", userType,
+			event.EventType)
 
 		events = append(events, event)
 


### PR DESCRIPTION
Depends on #9595, only the last four commits are new.

From this [build](https://github.com/yyforyongyu/lnd/actions/runs/13746923229/job/38442991178)
```
--- FAIL: TestLightningNetworkDaemon/tranche06/206-of-272/bitcoind/coop_close_with_htlcs (176.61s)
        --- FAIL: TestLightningNetworkDaemon/tranche06/206-of-272/bitcoind/coop_close_with_htlcs/with_restart (137.87s)
            harness_node.go:403: Starting node (name=Alice) with PID=5843
            harness_node.go:403: Starting node (name=bob) with PID=6028
            harness_node.go:403: Starting node (name=Alice) with PID=6450
            harness_node.go:403: Starting node (name=bob) with PID=6563
            harness_assertion.go:403: 
                	Error Trace:	/home/runner/work/lnd/lnd/lntest/harness_assertion.go:403
                	            				/home/runner/work/lnd/lnd/lntest/harness_assertion.go:374
                	            				/home/runner/work/lnd/lnd/itest/lnd_coop_close_with_htlcs_test.go:207
                	            				/home/runner/work/lnd/lnd/itest/lnd_coop_close_with_htlcs_test.go:33
                	Error:      	Received unexpected error:
                	            	bob: channel not found using 92cf35783e64f5129efc2ba99ae62a5893740bc08530a4d395e264b560ec855a:0
                	Test:       	TestLightningNetworkDaemon/tranche06/206-of-272/bitcoind/coop_close_with_htlcs/with_restart
                	Messages:   	bob: timeout checking for channel point: funding_txid_bytes:"Z\x85\xec`\xb5d\xe2\x95Ӥ0\x85\xc0\x0bt\x93X*暩+\xfc\x9e\x12\xf5d>x5ϒ"
            harness.go:382: finished test: coop_close_with_htlcs, start height=473, end height=481, mined blocks=8
            harness.go:341: test failed, skipped cleanup
        harness.go:382: finished test: coop_close_with_htlcs, start height=464, end height=481, mined blocks=17
        harness.go:341: test failed, skipped cleanup
```

From this [build](https://github.com/yyforyongyu/lnd/actions/runs/13749556985/job/38448769961),
```
--- FAIL: TestLightningNetworkDaemon/tranche07/243-of-272/bitcoind/relayer_blinded_error (79.30s)
        harness_node.go:403: Starting node (name=Alice) with PID=13146
        harness_node.go:403: Starting node (name=Bob) with PID=13440
        harness_node.go:403: Starting node (name=Carol) with PID=13651
        harness_node.go:403: Starting node (name=Dave) with PID=13801
        harness_assertion.go:2348: 
            	Error Trace:	/home/runner/work/lnd/lnd/lntest/harness_assertion.go:2348
            	            				/home/runner/work/lnd/lnd/itest/lnd_route_blinding_test.go:682
            	            				/home/runner/work/lnd/lnd/lntest/harness.go:304
            	            				/home/runner/work/lnd/lnd/itest/lnd_test.go:130
            	Error:      	[]routerrpc.HtlcEvent_EventType{3, 0} does not contain 1
            	Test:       	TestLightningNetworkDaemon/tranche07/243-of-272/bitcoind/relayer_blinded_error
            	Messages:   	wrong event type, got FORWARD%!(EXTRA routerrpc.HtlcEvent_EventType=SEND)
        harness.go:382: finished test: relayer_blinded_error, start height=512, end height=519, mined blocks=7
        harness.go:341: test failed, skipped cleanup
    lnd_test.go:138: Failure time: 2025-03-09 14:52:54.007
```


From this [build](https://github.com/yyforyongyu/lnd/actions/runs/13758399019/job/38469491561)
```
--- FAIL: TestLightningNetworkDaemon/tranche00/05-of-228/btcd/funding_expiry_blocks_on_pending (23.93s)
        harness_node.go:403: Starting node (name=Alice) with PID=1220
        harness_node.go:403: Starting node (name=Bob) with PID=5956
        lnd_open_channel_test.go:850: 
            	Error Trace:	D:/a/lnd/lnd/itest/lnd_open_channel_test.go:850
            	            				D:/a/lnd/lnd/lntest/harness.go:304
            	            				D:/a/lnd/lnd/itest/lnd_test.go:130
            	Error:      	Not equal: 
            	            	expected: 2015
            	            	actual  : 2016
            	Test:       	TestLightningNetworkDaemon/tranche00/05-of-228/btcd/funding_expiry_blocks_on_pending
        harness.go:382: finished test: funding_expiry_blocks_on_pending, start height=500, end height=502, mined blocks=2
        harness.go:341: test failed, skipped cleanup
```