### PR TITLE
lnd: pass through neutrino MaxPeers config

### DIFF
--- a/config.go
+++ b/config.go
@@ -248,6 +248,9 @@ const (
 	bitcoindBackendName = "bitcoind"
 	btcdBackendName     = "btcd"
 	neutrinoBackendName = "neutrino"
+
+	defaultPrunedNodeMaxPeers = 4
+	defaultNeutrinoMaxPeers   = 8
 )
 
 var (
@@ -285,8 +288,6 @@ var (
 	// estimatesmartfee RPC call.
 	defaultBitcoindEstimateMode = "CONSERVATIVE"
 	bitcoindEstimateModes       = [2]string{"ECONOMICAL", defaultBitcoindEstimateMode}
-
-	defaultPrunedNodeMaxPeers = 4
 )
 
 // Config defines the configuration options for lnd.
@@ -599,6 +600,7 @@ func DefaultConfig() Config {
 		NeutrinoMode: &lncfg.Neutrino{
 			UserAgentName:    neutrino.UserAgentName,
 			UserAgentVersion: neutrino.UserAgentVersion,
+			MaxPeers:         defaultNeutrinoMaxPeers,
 		},
 		BlockCacheSize:     defaultBlockCacheSize,
 		MaxPendingChannels: lncfg.DefaultMaxPendingChannels,

--- a/config_builder.go
+++ b/config_builder.go
@@ -1528,7 +1528,11 @@ func initNeutrinoBackend(ctx context.Context, cfg *Config, chainDir string,
 		PersistToDisk:      cfg.NeutrinoMode.PersistFilters,
 	}
 
-	neutrino.MaxPeers = 8
+	if cfg.NeutrinoMode.MaxPeers <= 0 {
+		return nil, nil, fmt.Errorf("a non-zero number must be set " +
+			"for neutrino max peers")
+	}
+	neutrino.MaxPeers = cfg.NeutrinoMode.MaxPeers
 	neutrino.BanDuration = time.Hour * 48
 	neutrino.UserAgentName = cfg.NeutrinoMode.UserAgentName
 	neutrino.UserAgentVersion = cfg.NeutrinoMode.UserAgentVersion

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -88,6 +88,9 @@
 * [The aux bandwidth calculation was fixed for non-asset
   channels](https://github.com/lightningnetwork/lnd/pull/9502).
 
+* [Pass through](https://github.com/lightningnetwork/lnd/pull/9601) the unused
+  `MaxPeers` configuration variable for neutrino mode.
+
 # New Features
 
 * [Support](https://github.com/lightningnetwork/lnd/pull/8390) for 
@@ -419,6 +422,7 @@ The underlying functionality between those two options remain the same.
 * Abdullahi Yunus
 * Andras Banki-Horvath
 * Animesh Bilthare
+* bitromortac
 * Boris Nagaev
 * Carla Kirk-Cohen
 * CharlieZKSmith

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -840,9 +840,7 @@
 ; neutrino.connect=
 
 ; Max number of inbound and outbound peers.
-;
-; NOTE: This value is currently unused.
-; neutrino.maxpeers=
+; neutrino.maxpeers=8
 
 ; Add a peer to connect with at startup.
 ; neutrino.addpeer=


### PR DESCRIPTION
This enables users to set the config. We check that the currently set value of `MaxPeers` isn't below the previous default to protect users from misconfiguration. Seen in https://github.com/lightningnetwork/lnd/discussions/9599.
