### PR TITLE
cmd: fix error parsed from status

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -229,6 +229,12 @@
 
 ## lncli Updates
 
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/9605) a case where
+  inaccurate error message is displayed. Previously, when the `lnd` is built
+  without with a given RPC service yet the `cli` does, running a command to
+  access the RPC server would give an error saying the wallet is encrypted. This
+  is now fixed to show specifically which RPC server is missing.
+
 ## Code Health
 
 * [Add retry logic](https://github.com/lightningnetwork/lnd/pull/8381) for


### PR DESCRIPTION
A user was having trouble debugging its node, which was running in an `lnd` without the `walletrpc` enabled. The user then tried to build the `lncli` with the RPC enabled, but the `lnd` node could not be built since it was running remotely. Then the command failed with the following weird msg,
```
./lncli wallet pendingsweeps
[lncli] Wallet is encrypted. Please unlock using 'lncli unlock', or set password using 'lncli create' if this is the first time starting lnd.
```

This message is confusing as it doesn't show the RPC isn't built. This is now changed to,
```
./lncli-debug wallet pendingsweeps
[lncli] rpc error: code = Unimplemented desc = unknown service walletrpc.WalletKit
```

In addition, this error msg is also fixed,
```
./lncli unlock       
Input wallet password: 
[lncli] rpc error: code = Unknown desc = wallet already unlocked, WalletUnlocker service is no longer available
```
is now changed to,
```
./lncli-debug unlock              
Input wallet password: 
[lncli] Wallet is already unlocked
```