### PR TITLE
config: rename skip-sql-invoice-migration to skip-native-sql-migration

### DIFF
--- a/config_builder.go
+++ b/config_builder.go
@@ -1099,7 +1099,7 @@ func (d *DefaultDatabaseBuilder) BuildDatabase(
 		// run. If the database version is already above this custom
 		// migration's version (7), it will be skipped permanently,
 		// regardless of the flag.
-		if !d.cfg.DB.SkipSQLInvoiceMigration {
+		if !d.cfg.DB.SkipNativeSQLMigration {
 			migrationFn := func(tx *sqlc.Queries) error {
 				err := invoices.MigrateInvoicesToSQL(
 					ctx, dbs.ChanStateDB.Backend,

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -368,6 +368,10 @@ The underlying functionality between those two options remain the same.
   ](https://github.com/lightningnetwork/lnd/pull/9438) tombstone after native 
   SQL migration.
 
+* [Rename of skip migration
+  flag](https://github.com/lightningnetwork/lnd/pull/9606/) for future
+  compatibility.
+
 ## Code Health
 
 * A code refactor that [moves all the graph related DB code out of the 

--- a/lncfg/db.go
+++ b/lncfg/db.go
@@ -87,7 +87,7 @@ type DB struct {
 
 	UseNativeSQL bool `long:"use-native-sql" description:"Use native SQL for tables that already support it."`
 
-	SkipSQLInvoiceMigration bool `long:"skip-sql-invoice-migration" description:"Do not migrate invoices stored in our key-value database to native SQL."`
+	SkipNativeSQLMigration bool `long:"skip-native-sql-migration" description:"Do not run the KV to native SQL migration. It should only be used if errors are encountered normally."`
 
 	NoGraphCache bool `long:"no-graph-cache" description:"Don't use the in-memory graph cache for path finding. Much slower but uses less RAM. Can only be used with a bolt database backend."`
 
@@ -117,8 +117,8 @@ func DefaultDB() *DB {
 			MaxConnections: defaultSqliteMaxConnections,
 			BusyTimeout:    defaultSqliteBusyTimeout,
 		},
-		UseNativeSQL:            false,
-		SkipSQLInvoiceMigration: false,
+		UseNativeSQL:           false,
+		SkipNativeSQLMigration: false,
 	}
 }
 

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1478,9 +1478,10 @@
 ; own risk.
 ; db.use-native-sql=false
 
-; If set to true, native SQL invoice migration will be skipped. Note that this
-; option is intended for users who experience non-resolvable migration errors.
-; db.skip-sql-invoice-migration=false
+; If set to true, the KV to native SQL migration will be skipped. Note that
+; this option is intended for users who experience non-resolvable migration
+; errors.
+; db.skip-native-sql-migration=false
 
 [etcd]
 


### PR DESCRIPTION
In future releases we will use this flag to make potentially failing kv to native SQL migrations optional. For this reason it is better to rename it to avoid confusion.
