### PR TITLE
discovery: unify rate.Limiter across all gossip peers

### DIFF
--- a/config.go
+++ b/config.go
@@ -707,6 +707,8 @@ func DefaultConfig() Config {
 			ChannelUpdateInterval: discovery.DefaultChannelUpdateInterval,
 			SubBatchDelay:         discovery.DefaultSubBatchDelay,
 			AnnouncementConf:      discovery.DefaultProofMatureDelta,
+			MsgRateBytes:          discovery.DefaultMsgBytesPerSecond,
+			MsgBurstBytes:         discovery.DefaultMsgBytesBurst,
 		},
 		Invoices: &lncfg.Invoices{
 			HoldExpiryDelta: lncfg.DefaultHoldInvoiceExpiryDelta,

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -390,6 +390,14 @@ type Config struct {
 	// spent-ness of channel outpoints. For neutrino, this saves long
 	// rescans from blocking initial usage of the daemon.
 	AssumeChannelValid bool
+
+	// MsgRateBytes is the rate limit for the number of bytes per second
+	// that we'll allocate to outbound gossip messages.
+	MsgRateBytes uint64
+
+	// MsgBurstBytes is the allotted burst amount in bytes. This is the
+	// number of starting tokens in our token bucket algorithm.
+	MsgBurstBytes uint64
 }
 
 // processedNetworkMsg is a wrapper around networkMsg and a boolean. It is
@@ -574,16 +582,18 @@ func New(cfg Config, selfKeyDesc *keychain.KeyDescriptor) *AuthenticatedGossiper
 	gossiper.vb = NewValidationBarrier(1000, gossiper.quit)
 
 	gossiper.syncMgr = newSyncManager(&SyncManagerCfg{
-		ChainHash:               cfg.ChainHash,
-		ChanSeries:              cfg.ChanSeries,
-		RotateTicker:            cfg.RotateTicker,
-		HistoricalSyncTicker:    cfg.HistoricalSyncTicker,
-		NumActiveSyncers:        cfg.NumActiveSyncers,
-		NoTimestampQueries:      cfg.NoTimestampQueries,
-		IgnoreHistoricalFilters: cfg.IgnoreHistoricalFilters,
-		BestHeight:              gossiper.latestHeight,
-		PinnedSyncers:           cfg.PinnedSyncers,
-		IsStillZombieChannel:    cfg.IsStillZombieChannel,
+		ChainHash:                cfg.ChainHash,
+		ChanSeries:               cfg.ChanSeries,
+		RotateTicker:             cfg.RotateTicker,
+		HistoricalSyncTicker:     cfg.HistoricalSyncTicker,
+		NumActiveSyncers:         cfg.NumActiveSyncers,
+		NoTimestampQueries:       cfg.NoTimestampQueries,
+		IgnoreHistoricalFilters:  cfg.IgnoreHistoricalFilters,
+		BestHeight:               gossiper.latestHeight,
+		PinnedSyncers:            cfg.PinnedSyncers,
+		IsStillZombieChannel:     cfg.IsStillZombieChannel,
+		AllotedMsgBytesPerSecond: cfg.MsgRateBytes,
+		AllotedMsgBytesBurst:     cfg.MsgBurstBytes,
 	})
 
 	gossiper.reliableSender = newReliableSender(&reliableSenderCfg{

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -344,6 +344,13 @@ The underlying functionality between those two options remain the same.
 ## Breaking Changes
 ## Performance Improvements
 
+* Users can now [limit the total amount of
+bandwidth](https://github.com/lightningnetwork/lnd/pull/9607) that will be allocated to
+outbound gossip traffic via two new args: `--gossip.msg-rate-bytes` and
+`--gossip.msg-rate-burst`. The burst value should be set to the largest amount
+of bytes that can be transmitted in a go without rate limiting, and the rate to
+the on going rate we'll permit.
+
 * Log rotation can now use ZSTD
 
 * [Remove redundant 

--- a/lncfg/gossip.go
+++ b/lncfg/gossip.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/lightningnetwork/lnd/discovery"
+	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
 )
 
@@ -32,6 +33,10 @@ type Gossip struct {
 	SubBatchDelay time.Duration `long:"sub-batch-delay" description:"The duration to wait before sending the next announcement batch if there are multiple. Use a small value if there are a lot announcements and they need to be broadcast quickly."`
 
 	AnnouncementConf uint32 `long:"announcement-conf" description:"The number of confirmations required before processing channel announcements."`
+
+	MsgRateBytes uint64 `long:"msg-rate-bytes" description:"The maximum number of bytes of gossip messages that will be sent per second. This is a global limit that applies to all peers."`
+
+	MsgBurstBytes uint64 `long:"msg-burst-bytes" description:"The maximum number of bytes of gossip messages that will be sent in a burst. This is a global limit that applies to all peers. This value should be set to something greater than 130 KB"`
 }
 
 // Parse the pubkeys for the pinned syncers.
@@ -56,6 +61,11 @@ func (g *Gossip) Validate() error {
 	if g.AnnouncementConf < minAnnouncementConf {
 		return fmt.Errorf("announcement-conf=%v must be no less than "+
 			"%v", g.AnnouncementConf, minAnnouncementConf)
+	}
+
+	if g.MsgBurstBytes < lnwire.MaxSliceLength {
+		return fmt.Errorf("msg-burst-bytes=%v must be at least %v",
+			g.MsgBurstBytes, lnwire.MaxSliceLength)
 	}
 
 	return nil

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1746,6 +1746,17 @@
 ; The number of confirmations required before processing channel announcements.
 ; gossip.announcement-conf=6
 
+; The allotted bandwidth rate expressed in bytes/second that will be allocated
+; towards outbound gossip messages. Realized rates above this value will be 
+; throttled. This value is shared across all peers.
+; gossip.msg-rate-bytes=102400
+
+; The amount of bytes of gossip messages that can be sent at a given time. This
+; is used as the amount of tokens in the token bucket algorithm. This value
+; MUST be set to something about 65 KB, otherwise a single max sized message
+; can never be sent.
+; gossip.msg-burst-bytes=204800
+
 [invoices]
 
 ; If a hold invoice has accepted htlcs that reach their expiry height and are

--- a/server.go
+++ b/server.go
@@ -1188,6 +1188,8 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		IsStillZombieChannel:    s.graphBuilder.IsZombieChannel,
 		ScidCloser:              scidCloserMan,
 		AssumeChannelValid:      cfg.Routing.AssumeChannelValid,
+		MsgRateBytes:            cfg.Gossip.MsgRateBytes,
+		MsgBurstBytes:           cfg.Gossip.MsgBurstBytes,
 	}, nodeKeyDesc)
 
 	accessCfg := &accessManConfig{


### PR DESCRIPTION
In this commit, we revamp the old message based rate limiting. First, we
move to meter by bytes/s instead of messages/s. The old logic had an
error in that it limited groups of message replies, instead of each
message. With this new approach, we'll use the newly added
SerializedSize method to implement fine grained bandwidth metering.

We need to pick two values, the burst rate, and the msg bytes rate. The
burst rate is the max amt that can be sent in a given period of time. We
need to set this above 65 KB, or the max msg limit, otherwise no
messages can be sent. The bucket starts with this many tokens (bytes).
As those are depleted, the amount of tokens is refilled at the msg
bytes rate.

As conservative values, we've chosen 200 KB as the burst rate, and 100
KB/s as the limit.

Depends on https://github.com/lightningnetwork/lnd/pull/9623