### PR TITLE
Fix inaccurate `listunspent` result

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -91,6 +91,9 @@
 * [Pass through](https://github.com/lightningnetwork/lnd/pull/9601) the unused
   `MaxPeers` configuration variable for neutrino mode.
 
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/9609) a bug that may
+  cause `listunspent` to give inaccurate wallet UTXOs.
+
 # New Features
 
 * Add support for [archiving channel backup](https://github.com/lightningnetwork/lnd/pull/9232)

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/btcsuite/btclog v0.0.0-20241003133417-09c4e92e319c
 	github.com/btcsuite/btclog/v2 v2.0.1-0.20250110154127-3ae4bf1cb318
-	github.com/btcsuite/btcwallet v0.16.10
+	github.com/btcsuite/btcwallet v0.16.11
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.3.5
 	github.com/btcsuite/btcwallet/wallet/txrules v1.2.2
 	github.com/btcsuite/btcwallet/walletdb v1.4.4

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/btcsuite/btclog v0.0.0-20241003133417-09c4e92e319c/go.mod h1:w7xnGOhw
 github.com/btcsuite/btclog/v2 v2.0.1-0.20250110154127-3ae4bf1cb318 h1:oCjIcinPt7XQ644MP/22JcjYEC84qRc3bRBH0d7Hhd4=
 github.com/btcsuite/btclog/v2 v2.0.1-0.20250110154127-3ae4bf1cb318/go.mod h1:XItGUfVOxotJL8kkuk2Hj3EVow5KCugXl3wWfQ6K0AE=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
-github.com/btcsuite/btcwallet v0.16.10 h1:SDMS0Gp7oEJVvyZNQ6gDYkpkvp/cSMRcAAy3fvO3vTk=
-github.com/btcsuite/btcwallet v0.16.10/go.mod h1:1HJXYbjJzgumlnxOC2+ViR1U+gnHWoOn7WeK5OfY1eU=
+github.com/btcsuite/btcwallet v0.16.11 h1:c8RgW/HO79if8P+KFQLQE00ITmFnLPKAzIy9FwxE37A=
+github.com/btcsuite/btcwallet v0.16.11/go.mod h1:1HJXYbjJzgumlnxOC2+ViR1U+gnHWoOn7WeK5OfY1eU=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.5 h1:Rr0njWI3r341nhSPesKQ2JF+ugDSzdPoeckS75SeDZk=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.5/go.mod h1:+tXJ3Ym0nlQc/iHSwW1qzjmPs3ev+UVWMbGgfV1OZqU=
 github.com/btcsuite/btcwallet/wallet/txrules v1.2.2 h1:YEO+Lx1ZJJAtdRrjuhXjWrYsmAk26wLTlNzxt2q0lhk=

--- a/itest/flakes.go
+++ b/itest/flakes.go
@@ -3,9 +3,7 @@ package itest
 import (
 	"time"
 
-	"github.com/btcsuite/btcd/btcutil"
 	"github.com/lightningnetwork/lnd/lntest"
-	"github.com/lightningnetwork/lnd/lntest/node"
 )
 
 // flakePreimageSettlement documents a flake found when testing the preimage
@@ -32,19 +30,6 @@ func flakePreimageSettlement(ht *lntest.HarnessTest) {
 	// means Bob would have created the sweeping tx - mining another block
 	// would cause the sweeper to RBF it.
 	time.Sleep(2 * time.Second)
-}
-
-// flakeFundExtraUTXO documents a flake found when testing the sweeping behavior
-// of the given node, which would fail due to no wallet UTXO available, while
-// there should be enough.
-//
-// TODO(yy): remove it once the issue is resolved.
-func flakeFundExtraUTXO(ht *lntest.HarnessTest, node *node.HarnessNode) {
-	// The node should have enough wallet UTXOs here to sweep the HTLC in
-	// the end of this test. However, due to a known issue, the node's
-	// wallet may report there's no UTXO available. For details,
-	// - https://github.com/lightningnetwork/lnd/issues/8786
-	ht.FundCoins(btcutil.SatoshiPerBitcoin, node)
 }
 
 // flakeTxNotifierNeutrino documents a flake found when running force close

--- a/itest/flakes.go
+++ b/itest/flakes.go
@@ -112,3 +112,28 @@ func flakePaymentStreamReturnEarly() {
 	// commitment.
 	time.Sleep(2 * time.Second)
 }
+
+// flakeRaceInBitcoinClientNotifications documents a bug found that the
+// `ListUnspent` gives inaccurate results. In specific,
+//   - an output is confirmed in block X, which is under the process of being
+//     credited to our wallet.
+//   - `ListUnspent` is called between the above process, returning an
+//     inaccurate result, causing the sweeper to think there's no wallet utxo.
+//   - the sweeping will fail at block X due to not enough inputs.
+//
+// Under the hood, the RPC client created for handling wallet txns and handling
+// block notifications are independent. For the block notification, which is
+// registered via `RegisterBlockEpochNtfn`, is managed by the `chainntnfs`,
+// which is hooked to a bitcoind client created at startup. For the wallet, it
+// uses another bitcoind client to receive online events. Although they share
+// the same bitcoind RPC conn, these two clients are acting independently.
+// With this setup, it means there's no coordination between the two system -
+// `lnwallet` and `chainntnfs` can disagree on the latest onchain state for a
+// short period, causing an inconsistent state which leads to the failed
+// sweeping attempt.
+//
+// TODO(yy): We need to adhere to the SSOT principle, and make the effort to
+// ensure the whole system only uses one bitcoind client.
+func flakeRaceInBitcoinClientNotifications(ht *lntest.HarnessTest) {
+	ht.MineEmptyBlocks(1)
+}

--- a/itest/list_exclude_test.go
+++ b/itest/list_exclude_test.go
@@ -69,6 +69,13 @@ var excludedTestsWindows = []string{
 	"query blinded route",
 
 	"data loss protection",
+
+	// The following restart cases will fail in windows due to aggregation
+	// can sometimes miss grouping one or two inputs in the same sweeping
+	// tx, which is likely caused by how the blocks are notified in windows,
+	// more investigation is needed.
+	"channel force close-anchor restart",
+	"channel force close-simple taproot restart",
 }
 
 // filterWindowsFlakyTests filters out the flaky tests that are excluded from

--- a/itest/lnd_multi-hop_force_close_test.go
+++ b/itest/lnd_multi-hop_force_close_test.go
@@ -341,8 +341,6 @@ func runLocalClaimOutgoingHTLC(ht *lntest.HarnessTest,
 		ht.FundCoins(btcutil.SatoshiPerBitcoin, bob)
 	}
 
-	flakeFundExtraUTXO(ht, bob)
-
 	// Now that our channels are set up, we'll send two HTLC's from Alice
 	// to Carol. The first HTLC will be universally considered "dust",
 	// while the second will be a proper fully valued HTLC.
@@ -685,7 +683,6 @@ func runMultiHopReceiverPreimageClaim(ht *lntest.HarnessTest,
 
 	// Fund Carol one UTXO so she can sweep outputs.
 	ht.FundCoins(btcutil.SatoshiPerBitcoin, carol)
-	flakeFundExtraUTXO(ht, carol)
 
 	// If this is a taproot channel, then we'll need to make some manual
 	// route hints so Alice can actually find a route.
@@ -1601,8 +1598,6 @@ func runLocalClaimIncomingHTLC(ht *lntest.HarnessTest,
 
 	// Fund Carol one UTXO so she can sweep outputs.
 	ht.FundCoins(btcutil.SatoshiPerBitcoin, carol)
-	flakeFundExtraUTXO(ht, carol)
-	flakeFundExtraUTXO(ht, bob)
 
 	// If this is a taproot channel, then we'll need to make some manual
 	// route hints so Alice can actually find a route.
@@ -1897,7 +1892,6 @@ func runLocalClaimIncomingHTLCLeased(ht *lntest.HarnessTest,
 
 	// Fund Carol one UTXO so she can sweep outputs.
 	ht.FundCoins(btcutil.SatoshiPerBitcoin, carol)
-	flakeFundExtraUTXO(ht, carol)
 
 	// With the network active, we'll now add a new hodl invoice at Carol's
 	// end. Make sure the cltv expiry delta is large enough, otherwise Bob
@@ -2230,7 +2224,6 @@ func runLocalPreimageClaim(ht *lntest.HarnessTest,
 
 	// Fund Carol one UTXO so she can sweep outputs.
 	ht.FundCoins(btcutil.SatoshiPerBitcoin, carol)
-	flakeFundExtraUTXO(ht, carol)
 
 	// If this is a taproot channel, then we'll need to make some manual
 	// route hints so Alice can actually find a route.
@@ -2490,7 +2483,6 @@ func runLocalPreimageClaimLeased(ht *lntest.HarnessTest,
 
 	// Fund Carol one UTXO so she can sweep outputs.
 	ht.FundCoins(btcutil.SatoshiPerBitcoin, carol)
-	flakeFundExtraUTXO(ht, carol)
 
 	// With the network active, we'll now add a new hodl invoice at Carol's
 	// end. Make sure the cltv expiry delta is large enough, otherwise Bob
@@ -2842,7 +2834,6 @@ func runHtlcAggregation(ht *lntest.HarnessTest,
 	// We need one additional UTXO to create the sweeping tx for the
 	// second-level success txes.
 	ht.FundCoins(btcutil.SatoshiPerBitcoin, bob)
-	flakeFundExtraUTXO(ht, bob)
 
 	// If this is a taproot channel, then we'll need to make some manual
 	// route hints so Alice+Carol can actually find a route.

--- a/itest/lnd_sweep_test.go
+++ b/itest/lnd_sweep_test.go
@@ -340,6 +340,8 @@ func testSweepCPFPAnchorOutgoingTimeout(ht *lntest.HarnessTest) {
 	// needed to clean up the mempool.
 	ht.MineBlocksAndAssertNumTxes(1, 2)
 
+	flakeRaceInBitcoinClientNotifications(ht)
+
 	// The above mined block should confirm Bob's force close tx, and his
 	// contractcourt will offer the HTLC to his sweeper. We are not testing
 	// the HTLC sweeping behaviors so we just perform a simple check and

--- a/itest/lnd_sweep_test.go
+++ b/itest/lnd_sweep_test.go
@@ -115,8 +115,6 @@ func testSweepCPFPAnchorOutgoingTimeout(ht *lntest.HarnessTest) {
 		ht.FundCoins(btcutil.SatoshiPerBitcoin, bob)
 	}
 
-	flakeFundExtraUTXO(ht, bob)
-
 	// Subscribe the invoice.
 	streamCarol := carol.RPC.SubscribeSingleInvoice(payHash[:])
 
@@ -434,8 +432,6 @@ func testSweepCPFPAnchorIncomingTimeout(ht *lntest.HarnessTest) {
 	if ht.IsNeutrinoBackend() {
 		ht.FundCoins(btcutil.SatoshiPerBitcoin, bob)
 	}
-
-	flakeFundExtraUTXO(ht, bob)
 
 	// Subscribe the invoice.
 	streamCarol := carol.RPC.SubscribeSingleInvoice(payHash[:])

--- a/lnwallet/btcwallet/log.go
+++ b/lnwallet/btcwallet/log.go
@@ -2,6 +2,9 @@ package btcwallet
 
 import (
 	"github.com/btcsuite/btclog/v2"
+	"github.com/btcsuite/btcwallet/chain"
+	btcwallet "github.com/btcsuite/btcwallet/wallet"
+	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/lightningnetwork/lnd/build"
 )
 
@@ -29,4 +32,8 @@ func DisableLog() {
 // btclog.
 func UseLogger(logger btclog.Logger) {
 	log = logger
+
+	btcwallet.UseLogger(logger)
+	wtxmgr.UseLogger(logger)
+	chain.UseLogger(logger)
 }

--- a/lnwallet/log.go
+++ b/lnwallet/log.go
@@ -2,9 +2,6 @@ package lnwallet
 
 import (
 	"github.com/btcsuite/btclog/v2"
-	"github.com/btcsuite/btcwallet/chain"
-	btcwallet "github.com/btcsuite/btcwallet/wallet"
-	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 )
@@ -31,8 +28,5 @@ func DisableLog() {
 func UseLogger(logger btclog.Logger) {
 	walletLog = logger
 
-	btcwallet.UseLogger(logger)
-	wtxmgr.UseLogger(logger)
-	chain.UseLogger(logger)
 	chainfee.UseLogger(logger)
 }

--- a/log.go
+++ b/log.go
@@ -54,6 +54,7 @@ import (
 	"github.com/lightningnetwork/lnd/routing/localchans"
 	"github.com/lightningnetwork/lnd/rpcperms"
 	"github.com/lightningnetwork/lnd/signal"
+	"github.com/lightningnetwork/lnd/sqldb"
 	"github.com/lightningnetwork/lnd/sweep"
 	"github.com/lightningnetwork/lnd/tor"
 	"github.com/lightningnetwork/lnd/watchtower"
@@ -204,6 +205,7 @@ func SetupLoggers(root *build.SubLoggerManager, interceptor signal.Interceptor) 
 	AddV1SubLogger(root, graphdb.Subsystem, interceptor, graphdb.UseLogger)
 	AddSubLogger(root, chainio.Subsystem, interceptor, chainio.UseLogger)
 	AddSubLogger(root, msgmux.Subsystem, interceptor, msgmux.UseLogger)
+	AddSubLogger(root, sqldb.Subsystem, interceptor, sqldb.UseLogger)
 }
 
 // AddSubLogger is a helper method to conveniently create and register the

--- a/sqldb/interfaces.go
+++ b/sqldb/interfaces.go
@@ -247,6 +247,9 @@ func ExecuteSQLTransactionWithRetry(ctx context.Context, makeTx MakeTx,
 		tx, err := makeTx()
 		if err != nil {
 			dbErr := MapSQLError(err)
+			log.Tracef("Failed to makeTx: err=%v, dbErr=%v", err,
+				dbErr)
+
 			if IsSerializationError(dbErr) {
 				// Nothing to roll back here, since we haven't
 				// even get a transaction yet. We'll just wait
@@ -266,6 +269,8 @@ func ExecuteSQLTransactionWithRetry(ctx context.Context, makeTx MakeTx,
 		}()
 
 		if bodyErr := txBody(tx); bodyErr != nil {
+			log.Tracef("Error in txBody: %v", bodyErr)
+
 			// Roll back the transaction, then attempt a random
 			// backoff and try again if the error was a
 			// serialization error.
@@ -285,6 +290,8 @@ func ExecuteSQLTransactionWithRetry(ctx context.Context, makeTx MakeTx,
 
 		// Commit transaction.
 		if commitErr := tx.Commit(); commitErr != nil {
+			log.Tracef("Failed to commit tx: %v", commitErr)
+
 			// Roll back the transaction, then attempt a random
 			// backoff and try again if the error was a
 			// serialization error.

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -1371,7 +1371,7 @@ func (t *TxPublisher) createAndPublishTx(
 		return fn.Some(*result)
 	}
 
-	log.Infof("Replaced tx=%v with new tx=%v", oldTx.TxHash(),
+	log.Debugf("Replaced tx=%v with new tx=%v", oldTx.TxHash(),
 		sweepCtx.tx.TxHash())
 
 	// Otherwise, it's a successful RBF, set the event and return.

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -824,6 +824,9 @@ func (s *UtxoSweeper) sweep(set InputSet) error {
 			return fmt.Errorf("gen sweep script: %w", err)
 		}
 		s.currentOutputScript = fn.Some(addr)
+
+		log.Debugf("Created sweep DeliveryAddress %x",
+			addr.DeliveryAddress)
 	}
 
 	sweepAddr, err := s.currentOutputScript.UnwrapOrErr(
@@ -1725,8 +1728,8 @@ func (s *UtxoSweeper) handleBumpEventTxReplaced(resp *bumpResp) error {
 	s.cfg.Wallet.CancelRebroadcast(oldTxid)
 
 	log.Infof("RBFed tx=%v(fee=%v sats, feerate=%v sats/kw) with new "+
-		"tx=%v(fee=%v, "+"feerate=%v)", record.Txid, record.Fee,
-		record.FeeRate, tr.Txid, tr.Fee, tr.FeeRate)
+		"tx=%v(fee=%v sats, feerate=%v sats/kw)", record.Txid,
+		record.Fee, record.FeeRate, tr.Txid, tr.Fee, tr.FeeRate)
 
 	// The old sweeping tx has been replaced by a new one, we will update
 	// the tx record in the sweeper db.


### PR DESCRIPTION
This PR fixes the issue which `listunspent` gives inaccurate wallet balance. In addition, it moves the `walletdb` code back to `btcwallet`, to make sure we only have a single place managing it.

By fixing the bug, the itest flake `flakeFundExtraUTXO` is also now fixed.

Depends on,
- #9602 
- https://github.com/btcsuite/btcwallet/pull/995

### The issue

Down to the rabbit hole, there are multiple layers contributed to this bug.

**Watched filters are registered asynchronously**

The fix is at `btcwallet` side. When deciding to watch for an address, the registration was done in a goroutine, which could cause a relevant tx to be missed due to the watched address was not registered yet.

**Databse tx is too large**

It's common that we have a read and write tx as the following,
- `ListUnspentWitness`, which invokes a walletdb read tx that calls `ListUnspent`.
- when a spending tx confirms, in the `btcwallet`'s chain notification, a write tx is invoked to call `addRelevantTx`.

Here's the bug,
- `addRelevantTx` is writing the data, which has a confirmed output that can be used for sweeping. It also reads the buckets and attempts to send notification in a db tx.
- `ListUnspentWitness` is called in the sweeper, but it reads the old data from the bucket `wtxmgrNamespaceKey`, which the `addRelevantTx` is still writing.
- `ListUnspentWitness` cannot find the confirmed input, causing the sweep to fail due to no wallet inputs.

The fix is to remove the unnecessary reads and notifications in `addRelevantTx`, such that the write tx can be finished quickly.

**Race notification in bitcoind clients**

We have a single bitcoind conn, but three bitcoind clients, each independently handling the notifications such as block connected or tx filtered. If system A gets a block notification from one client, and expects a confirmed output from `ListUnspent`, yet it's system B's bitcoind client handling the watched filters and writing to the walletdb, we would have inconsistent result.

There's no simple fix as we need to refactor the system to use a single bitcoind client, sticking to SSOT. The plan is to improve this area in the upcoming walletdb sqlization series.


Fixes:
- #9481
- #5244
- #5959
- #6487
- #7104 
- #7181
- #8001
- #8812
- #8786