### PR TITLE
docs: add a new category of docs -> databases to explain sphinx replay

### DIFF
--- a/docs/databases/sphinxreplay.md
+++ b/docs/databases/sphinxreplay.md
@@ -1,0 +1,16 @@
+# Understanding Sphinx Replay Protection
+
+Sphinx is a protocol enabling anonymous and untraceable messaging in networks, commonly used in Lightning's onion routing. To prevent replay attacks, a Sphinx replay database stores message hashes along with metadata (e.g., timestamp, sender ID).
+
+## How It Works
+1. **Message Check**: When a message is received, its hash is compared against stored entries.
+2. **Replay Prevention**: If the message exists, it is discarded; otherwise, it is added to the database.
+3. **Network Integrity**: This ensures that previously sent messages cannot be resent maliciously.
+
+## Onion Routing in Lightning
+Sphinx follows source-based onion routing, where messages are encrypted in nested layers. Each node peels one layer, revealing only the next hop, ensuring sender anonymity and path secrecy.
+
+Lightning’s **Sphinx Mix Format** differs from Tor, offering enhanced security tailored to payments.
+
+For deeper insights, refer to [Chapter 10 of the Lightning Network Book](https://github.com/lnbook/lnbook/blob/develop/10_onion_routing.asciidoc).
+


### PR DESCRIPTION
## Change Description
The explaination of the `sphinxreplay.db` was earlier not provided so I created a new category of `docs` to provide documentation of databases. Fixes #6584 

## Steps to Test
Documentation Changes - can be seen directly

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
