### PR TITLE
multi: remove x/exp/maps dependency

### DIFF
--- a/aliasmgr/aliasmgr.go
+++ b/aliasmgr/aliasmgr.go
@@ -3,13 +3,14 @@ package aliasmgr
 import (
 	"encoding/binary"
 	"fmt"
+	"maps"
+	"slices"
 	"sync"
 
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"golang.org/x/exp/maps"
 )
 
 // UpdateLinkAliases is a function type for a function that locates the active
@@ -515,7 +516,7 @@ func (m *Manager) RequestAlias() (lnwire.ShortChannelID, error) {
 	// channel in the baseToSet map.
 	haveAlias := func(maybeNextAlias lnwire.ShortChannelID) bool {
 		return fn.Any(
-			maps.Values(m.baseToSet),
+			slices.Collect(maps.Values(m.baseToSet)),
 			func(aliasList []lnwire.ShortChannelID) bool {
 				return fn.Any(
 					aliasList,

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -237,6 +237,8 @@ close transaction.
 * [The bitcoin `testnet4` test network is now also
   supported](https://github.com/lightningnetwork/lnd/pull/9620).
 
+* [remove x/exp/maps dependency](https://github.com/lightningnetwork/lnd/pull/9621)
+
 ## RPC Updates
 
 * Some RPCs that previously just returned an empty response message now at least

--- a/fn/map.go
+++ b/fn/map.go
@@ -2,13 +2,13 @@ package fn
 
 import (
 	"fmt"
-
-	"golang.org/x/exp/maps"
+	"maps"
+	"slices"
 )
 
 // KeySet converts a map into a Set containing the keys of the map.
 func KeySet[K comparable, V any](m map[K]V) Set[K] {
-	return NewSet(maps.Keys(m)...)
+	return NewSet(slices.Collect(maps.Keys(m))...)
 }
 
 // NewSubMapIntersect returns a sub-map of `m` containing only the keys found in

--- a/fn/set.go
+++ b/fn/set.go
@@ -1,6 +1,9 @@
 package fn
 
-import "golang.org/x/exp/maps"
+import (
+	"maps"
+	"slices"
+)
 
 // Set is a generic set using type params that supports the following
 // operations: diff, union, intersection, and subset.
@@ -92,7 +95,7 @@ func (s Set[T]) Equal(other Set[T]) bool {
 
 // ToSlice returns the set as a slice.
 func (s Set[T]) ToSlice() []T {
-	return maps.Keys(s)
+	return slices.Collect(maps.Keys(s))
 }
 
 // Copy copies s and returns the result.

--- a/lnrpc/marshall_utils.go
+++ b/lnrpc/marshall_utils.go
@@ -4,6 +4,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -14,7 +16,6 @@ import (
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"golang.org/x/exp/maps"
 )
 
 var (
@@ -222,7 +223,7 @@ func UnmarshallCoinSelectionStrategy(strategy CoinSelectionStrategy,
 // used in various RPCs that handle scid alias mappings.
 func MarshalAliasMap(scidMap aliasmgr.ScidAliasMap) []*AliasMap {
 	return fn.Map(
-		maps.Keys(scidMap),
+		slices.Collect(maps.Keys(scidMap)),
 		func(base lnwire.ShortChannelID) *AliasMap {
 			return &AliasMap{
 				BaseScid: base.ToUint64(),

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -10,9 +10,11 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"time"
 
@@ -43,7 +45,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet/chanfunding"
 	"github.com/lightningnetwork/lnd/macaroons"
 	"github.com/lightningnetwork/lnd/sweep"
-	"golang.org/x/exp/maps"
 	"google.golang.org/grpc"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 )
@@ -1269,7 +1270,7 @@ func (w *WalletKit) BumpForceCloseFee(_ context.Context,
 			err)
 	}
 
-	pendingSweeps := maps.Values(inputsMap)
+	pendingSweeps := slices.Collect(maps.Values(inputsMap))
 
 	// Discard everything except for the anchor sweeps.
 	anchors := fn.Filter(

--- a/sweep/walletsweep.go
+++ b/sweep/walletsweep.go
@@ -3,7 +3,9 @@ package sweep
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"math"
+	"slices"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -15,7 +17,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwallet/chanfunding"
-	"golang.org/x/exp/maps"
 )
 
 var (
@@ -425,7 +426,7 @@ func fetchUtxosFromOutpoints(utxos []*lnwallet.Utxo,
 		return nil, fmt.Errorf("%w: %v", ErrUnknownUTXO, err.Error())
 	}
 
-	fetchedUtxos := maps.Values(subMap)
+	fetchedUtxos := slices.Collect(maps.Values(subMap))
 
 	return fetchedUtxos, nil
 }


### PR DESCRIPTION
## Change Description
Description of change / link to associated issue.
follow up:https://github.com/lightningnetwork/lnd/pull/9604

The original returned the keys in a slice, but when it became 'native' the signature changed to return an iterator, so the new idiom is slices.Collect(maps.Keys(theMap)), unless of course the raw iterator can be used instead.

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
