### PR TITLE
payment lifecycle small fix

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -94,6 +94,10 @@
 * [Fixed](https://github.com/lightningnetwork/lnd/pull/9609) a bug that may
   cause `listunspent` to give inaccurate wallet UTXOs.
 
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/9626) a bug where a
+keysend payment would not fail properly and only resolve after restart. Now
+keysend payment validation is stricter.
+
 # New Features
 
 * Add support for [archiving channel backup](https://github.com/lightningnetwork/lnd/pull/9232)

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -399,6 +399,10 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testSendToRouteAMP,
 	},
 	{
+		Name:     "send payment keysend mpp fail",
+		TestFunc: testSendPaymentKeysendMPPFail,
+	},
+	{
 		Name:     "forward interceptor dedup htlcs",
 		TestFunc: testForwardInterceptorDedupHtlc,
 	},

--- a/lnrpc/routerrpc/router_backend.go
+++ b/lnrpc/routerrpc/router_backend.go
@@ -884,6 +884,18 @@ func (r *RouterBackend) extractIntentFromSendRequest(
 	}
 	payIntent.DestCustomRecords = customRecords
 
+	// Keysend payments do not support MPP payments.
+	//
+	// NOTE: There is no need to validate the `MaxParts` value here because
+	// it is set to 1 somewhere else in case it's a keysend payment.
+	if customRecords.IsKeysend() {
+		if payIntent.MaxShardAmt != nil {
+			return nil, errors.New("keysend payments cannot " +
+				"specify a max shard amount - MPP not " +
+				"supported with keysend payments")
+		}
+	}
+
 	firstHopRecords := lnwire.CustomRecords(rpcPayReq.FirstHopCustomRecords)
 	if err := firstHopRecords.Validate(); err != nil {
 		return nil, err

--- a/record/custom_records.go
+++ b/record/custom_records.go
@@ -1,6 +1,8 @@
 package record
 
-import "fmt"
+import (
+	"fmt"
+)
 
 const (
 	// CustomTypeStart is the start of the custom tlv type range as defined
@@ -21,4 +23,9 @@ func (c CustomSet) Validate() error {
 	}
 
 	return nil
+}
+
+// IsKeysend checks if the custom records contain the key send type.
+func (c CustomSet) IsKeysend() bool {
+	return c[KeySendType] != nil
 }

--- a/routing/router.go
+++ b/routing/router.go
@@ -1247,6 +1247,8 @@ func (r *ChannelRouter) sendPayment(ctx context.Context,
 	}
 
 	// Validate the custom records before we attempt to send the payment.
+	// TODO(ziggie): Move this check before registering the payment in the
+	// db (InitPayment).
 	if err := firstHopCustomRecords.Validate(); err != nil {
 		return [32]byte{}, nil, err
 	}


### PR DESCRIPTION
While working on the payment lifecycle I came across this case. When trying to send a keysend with a max shard restriction we would not fail the payment properly and it would hang indefinitely being marked as `INFLIGHT` in the db although no payment was attempted.

Just try sending a payment via this cmd:

`lncli sendpayment --dest XXX  --amt 100 --keysend --max_shard_size_sat 10`

The payment lifecycle will fail here because keysend payments are not MPP payments but we try to shard them:

https://github.com/lightningnetwork/lnd/blob/5d921723b1929c08c7397bbbef52b8639a55ac21/channeldb/payment_control.go#L419-L422




