### PR TITLE
Sweep inputs even the budget cannot be covered

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -158,6 +158,12 @@ close transaction.
   tests to set a lower value for faster funding confirmation timeout while
   keeping the default of 2016 blocks for production stability.
 
+* Previously when sweeping inputs, the sweeper will wait until the specified
+  budget can be covered by the inputs, which could cause the sweep to be
+  delayed, and the sweeping tx ends up using large fees. This is now
+  [changed](https://github.com/lightningnetwork/lnd/pull/9627) so the sweeper
+  will always attempt the sweep as long as the budget can be partially covered.
+
 ## RPC Additions
 
 * [Add a new rpc endpoint](https://github.com/lightningnetwork/lnd/pull/8843)

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -690,6 +690,10 @@ var allTestCases = []*lntest.TestCase{
 		Name:     "rbf coop close",
 		TestFunc: testCoopCloseRbf,
 	},
+	{
+		Name:     "bump fee low budget",
+		TestFunc: testBumpFeeLowBudget,
+	},
 }
 
 // appendPrefixed is used to add a prefix to each test name in the subtests

--- a/itest/lnd_funding_test.go
+++ b/itest/lnd_funding_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/chainreg"
 	"github.com/lightningnetwork/lnd/funding"
 	"github.com/lightningnetwork/lnd/labels"
@@ -466,20 +467,29 @@ func runChannelFundingInputTypes(ht *lntest.HarnessTest, alice,
 		burnAddr = "bcrt1qxsnqpdc842lu8c0xlllgvejt6rhy49u6fmpgyz"
 	)
 
-	fundMixed := func(amt btcutil.Amount, target *node.HarnessNode) {
+	fundMixed := func(amt btcutil.Amount,
+		target *node.HarnessNode) *wire.MsgTx {
+
 		ht.FundCoins(amt/5, target)
 		ht.FundCoins(amt/5, target)
 		ht.FundCoinsP2TR(amt/5, target)
 		ht.FundCoinsP2TR(amt/5, target)
 		ht.FundCoinsP2TR(amt/5, target)
+
+		return nil
 	}
-	fundMultipleP2TR := func(amt btcutil.Amount, target *node.HarnessNode) {
+	fundMultipleP2TR := func(amt btcutil.Amount,
+		target *node.HarnessNode) *wire.MsgTx {
+
 		ht.FundCoinsP2TR(amt/4, target)
 		ht.FundCoinsP2TR(amt/4, target)
 		ht.FundCoinsP2TR(amt/4, target)
 		ht.FundCoinsP2TR(amt/4, target)
+
+		return nil
 	}
-	fundWithTypes := []func(amt btcutil.Amount, target *node.HarnessNode){
+	fundWithTypes := []func(amt btcutil.Amount,
+		target *node.HarnessNode) *wire.MsgTx{
 		ht.FundCoins, ht.FundCoinsNP2WKH, ht.FundCoinsP2TR, fundMixed,
 		fundMultipleP2TR,
 	}

--- a/itest/lnd_multi-hop_force_close_test.go
+++ b/itest/lnd_multi-hop_force_close_test.go
@@ -2570,7 +2570,7 @@ func runLocalPreimageClaimLeased(ht *lntest.HarnessTest,
 	// We'll now mine enough blocks so Carol decides that she needs to go
 	// on-chain to claim the HTLC as Bob has been inactive.
 	numBlocks := padCLTV(
-		invoiceExpiry - ht.CurrentHeight() - incomingBroadcastDelta - 1,
+		invoiceExpiry - ht.CurrentHeight() - incomingBroadcastDelta,
 	)
 	ht.MineBlocks(int(numBlocks))
 

--- a/itest/lnd_sweep_test.go
+++ b/itest/lnd_sweep_test.go
@@ -1957,7 +1957,7 @@ func runBumpFee(ht *lntest.HarnessTest, alice *node.HarnessNode) {
 	// initial broadcast always succeeds.
 	assertFeeRateGreater(testFeeRate)
 
-	// Clean up the mempol.
+	// Clean up the mempool.
 	ht.MineBlocksAndAssertNumTxes(1, 2)
 }
 
@@ -2373,6 +2373,6 @@ func testFeeReplacement(ht *lntest.HarnessTest) {
 		uint64(feeRate), 0.02, "want %d, got %d in tx=%v",
 		currentFeeRate, feeRate, outgoingSweep2.TxHash())
 
-	// Finally, clean the mempol.
+	// Finally, clean the mempool.
 	ht.MineBlocksAndAssertNumTxes(1, 1)
 }

--- a/lntest/harness_miner.go
+++ b/lntest/harness_miner.go
@@ -247,7 +247,15 @@ func (h *HarnessTest) GetBestBlock() (*chainhash.Hash, int32) {
 
 // MineBlockWithTx mines a single block to include the specifies tx only.
 func (h *HarnessTest) MineBlockWithTx(tx *wire.MsgTx) *wire.MsgBlock {
-	return h.miner.MineBlockWithTx(tx)
+	// Update the harness's current height.
+	defer h.updateCurrentHeight()
+
+	block := h.miner.MineBlockWithTx(tx)
+
+	// Finally, make sure all the active nodes are synced.
+	h.AssertActiveNodesSyncedTo(block.BlockHash())
+
+	return block
 }
 
 // ConnectToMiner connects the miner to a temp miner.

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4841,12 +4841,17 @@ func createRPCOpenChannel(r *rpcServer, dbChannel *channeldb.OpenChannel,
 		)
 	}
 
-	// Create a set of the HTLCs found in the remote commitment, which is
+	// Create two sets of the HTLCs found in the remote commitment, which is
 	// used to decide whether the HTLCs from the local commitment has been
 	// locked in or not.
-	remoteHTLCs := fn.NewSet[[32]byte]()
+	remoteIncomingHTLCs := fn.NewSet[uint64]()
+	remoteOutgoingHTLCs := fn.NewSet[uint64]()
 	for _, htlc := range dbChannel.RemoteCommitment.Htlcs {
-		remoteHTLCs.Add(htlc.RHash)
+		if htlc.Incoming {
+			remoteIncomingHTLCs.Add(htlc.HtlcIndex)
+		} else {
+			remoteOutgoingHTLCs.Add(htlc.HtlcIndex)
+		}
 	}
 
 	for i, htlc := range localCommit.Htlcs {
@@ -4855,7 +4860,10 @@ func createRPCOpenChannel(r *rpcServer, dbChannel *channeldb.OpenChannel,
 
 		circuitMap := r.server.htlcSwitch.CircuitLookup()
 
-		var forwardingChannel, forwardingHtlcIndex uint64
+		var (
+			forwardingChannel, forwardingHtlcIndex uint64
+			lockedIn                               bool
+		)
 		switch {
 		case htlc.Incoming:
 			circuit := circuitMap.LookupCircuit(
@@ -4870,6 +4878,8 @@ func createRPCOpenChannel(r *rpcServer, dbChannel *channeldb.OpenChannel,
 
 				forwardingHtlcIndex = circuit.Outgoing.HtlcID
 			}
+
+			lockedIn = remoteIncomingHTLCs.Contains(htlc.HtlcIndex)
 
 		case !htlc.Incoming:
 			circuit := circuitMap.LookupOpenCircuit(
@@ -4890,6 +4900,8 @@ func createRPCOpenChannel(r *rpcServer, dbChannel *channeldb.OpenChannel,
 
 				forwardingHtlcIndex = circuit.Incoming.HtlcID
 			}
+
+			lockedIn = remoteOutgoingHTLCs.Contains(htlc.HtlcIndex)
 		}
 
 		channel.PendingHtlcs[i] = &lnrpc.HTLC{
@@ -4900,7 +4912,7 @@ func createRPCOpenChannel(r *rpcServer, dbChannel *channeldb.OpenChannel,
 			HtlcIndex:           htlc.HtlcIndex,
 			ForwardingChannel:   forwardingChannel,
 			ForwardingHtlcIndex: forwardingHtlcIndex,
-			LockedIn:            remoteHTLCs.Contains(rHash),
+			LockedIn:            lockedIn,
 		}
 
 		// Add the Pending Htlc Amount to UnsettledBalance field.

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -9056,6 +9056,9 @@ func (r *rpcServer) getChainSyncInfo() (*chainSyncInfo, error) {
 
 	// Exit early if the wallet is not synced.
 	if !isSynced {
+		rpcsLog.Debugf("Wallet is not synced to height %v yet",
+			bestHeight)
+
 		return info, nil
 	}
 
@@ -9074,6 +9077,9 @@ func (r *rpcServer) getChainSyncInfo() (*chainSyncInfo, error) {
 
 	// Exit early if the channel graph is not synced.
 	if !isSynced {
+		rpcsLog.Debugf("Graph is not synced to height %v yet",
+			bestHeight)
+
 		return info, nil
 	}
 
@@ -9083,6 +9089,11 @@ func (r *rpcServer) getChainSyncInfo() (*chainSyncInfo, error) {
 
 	// Overwrite isSynced and return.
 	info.isSynced = height == bestHeight
+
+	if !info.isSynced {
+		rpcsLog.Debugf("Blockbeat is not synced to height %v yet",
+			bestHeight)
+	}
 
 	return info, nil
 }

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -1267,56 +1267,17 @@ func (t *TxPublisher) createUnknownSpentBumpResult(
 		SpentInputs: r.spentInputs,
 	}
 
-	// Get the fee function, which will be used to decided the next fee rate
-	// to use if the sweeper decides to retry sweeping this input.
-	feeFunc := r.feeFunction
-
-	// When the record is failed before the initial broadcast is attempted,
-	// it will have a nil fee func. In this case, we'll create the fee func
-	// here.
-	//
-	// NOTE: Since the current record is failed and will be deleted, we
-	// don't need to update the record on this fee function. We only need
-	// the fee rate data so the sweeper can pick up where we left off.
-	if feeFunc == nil {
-		f, err := t.initializeFeeFunction(r.req)
-		// TODO(yy): The only error we would receive here is when the
-		// pkScript is not recognized by the weightEstimator. What we
-		// should do instead is to check the pkScript immediately after
-		// receiving a sweep request so we don't need to check it again,
-		// which will also save us from error checking from several
-		// callsites.
-		if err != nil {
-			log.Errorf("Failed to create fee func for record %v: "+
-				"%v", r.requestID, err)
-
-			// Overwrite the event and error so the sweeper will
-			// remove this input.
-			result.Event = TxFatal
-			result.Err = err
-
-			return result
-		}
-
-		feeFunc = f
-	}
-
-	// Since the sweeping tx has been replaced by another party's tx, we
-	// missed this block window to increase its fee rate. To make sure the
-	// fee rate stays in the initial line, we now ask the fee function to
-	// give us the next fee rate as if the sweeping tx were RBFed. This new
-	// fee rate will be used as the starting fee rate if the upper system
-	// decides to continue sweeping the rest of the inputs.
-	_, err := feeFunc.Increment()
+	// Calculate the next fee rate for the retry.
+	feeRate, err := t.calculateRetryFeeRate(r)
 	if err != nil {
-		// The fee function has reached its max position - nothing we
-		// can do here other than letting the user increase the budget.
-		log.Errorf("Failed to calculate the next fee rate for "+
-			"Record(%v): %v", r.requestID, err)
+		// Overwrite the event and error so the sweeper will
+		// remove this input.
+		result.Event = TxFatal
+		result.Err = err
 	}
 
 	// Attach the new fee rate to be used for the next sweeping attempt.
-	result.FeeRate = feeFunc.FeeRate()
+	result.FeeRate = feeRate
 
 	return result
 }
@@ -1892,4 +1853,60 @@ func (t *TxPublisher) handleReplacementTxError(r *monitorRecord,
 	log.Errorf("Failed to bump tx %v: %v", oldTx.TxHash(), err)
 
 	return result
+}
+
+// calculateRetryFeeRate calculates a new fee rate to be used as the starting
+// fee rate for the next sweep attempt if the inputs are to be retried. When the
+// fee function is nil it will be created here, and an error is returned if the
+// fee func cannot be initialized.
+func (t *TxPublisher) calculateRetryFeeRate(
+	r *monitorRecord) (chainfee.SatPerKWeight, error) {
+
+	// Get the fee function, which will be used to decided the next fee rate
+	// to use if the sweeper decides to retry sweeping this input.
+	feeFunc := r.feeFunction
+
+	// When the record is failed before the initial broadcast is attempted,
+	// it will have a nil fee func. In this case, we'll create the fee func
+	// here.
+	//
+	// NOTE: Since the current record is failed and will be deleted, we
+	// don't need to update the record on this fee function. We only need
+	// the fee rate data so the sweeper can pick up where we left off.
+	if feeFunc == nil {
+		f, err := t.initializeFeeFunction(r.req)
+
+		// TODO(yy): The only error we would receive here is when the
+		// pkScript is not recognized by the weightEstimator. What we
+		// should do instead is to check the pkScript immediately after
+		// receiving a sweep request so we don't need to check it again,
+		// which will also save us from error checking from several
+		// callsites.
+		if err != nil {
+			log.Errorf("Failed to create fee func for record %v: "+
+				"%v", r.requestID, err)
+
+			return 0, err
+		}
+
+		feeFunc = f
+	}
+
+	// Since we failed to sweep the inputs, either the sweeping tx has been
+	// replaced by another party's tx, or the current output values cannot
+	// cover the budget, we missed this block window to increase its fee
+	// rate. To make sure the fee rate stays in the initial line, we now ask
+	// the fee function to give us the next fee rate as if the sweeping tx
+	// were RBFed. This new fee rate will be used as the starting fee rate
+	// if the upper system decides to continue sweeping the rest of the
+	// inputs.
+	_, err := feeFunc.Increment()
+	if err != nil {
+		// The fee function has reached its max position - nothing we
+		// can do here other than letting the user increase the budget.
+		log.Errorf("Failed to calculate the next fee rate for "+
+			"Record(%v): %v", r.requestID, err)
+	}
+
+	return feeFunc.FeeRate(), nil
 }

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -1134,6 +1134,7 @@ func TestCreateAnPublishFail(t *testing.T) {
 	// Create a test feerate and return it from the mock fee function.
 	feerate := chainfee.SatPerKWeight(1000)
 	m.feeFunc.On("FeeRate").Return(feerate)
+	m.feeFunc.On("Increment").Return(true, nil).Once()
 
 	// Create a testing monitor record.
 	req := createTestBumpRequest()

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -232,39 +232,51 @@ func TestMarkInputsPublishFailed(t *testing.T) {
 		inputPublishFailed, inputSwept, inputExcluded, inputFatal,
 	})
 
+	feeRate := chainfee.SatPerKWeight(1000)
+
 	// Mark the test inputs. We expect the non-exist input and the
 	// inputInit to be skipped, and the final input to be marked as
 	// published.
-	s.markInputsPublishFailed(set)
+	s.markInputsPublishFailed(set, feeRate)
 
 	// We expect unchanged number of pending inputs.
 	require.Len(s.inputs, 7)
 
 	// We expect the init input's state to stay unchanged.
-	require.Equal(Init,
-		s.inputs[inputInit.OutPoint()].state)
+	pi := s.inputs[inputInit.OutPoint()]
+	require.Equal(Init, pi.state)
+	require.True(pi.params.StartingFeeRate.IsNone())
 
 	// We expect the pending-publish input's is now marked as publish
 	// failed.
-	require.Equal(PublishFailed,
-		s.inputs[inputPendingPublish.OutPoint()].state)
+	pi = s.inputs[inputPendingPublish.OutPoint()]
+	require.Equal(PublishFailed, pi.state)
+	require.Equal(feeRate, pi.params.StartingFeeRate.UnsafeFromSome())
 
 	// We expect the published input's is now marked as publish failed.
-	require.Equal(PublishFailed,
-		s.inputs[inputPublished.OutPoint()].state)
+	pi = s.inputs[inputPublished.OutPoint()]
+	require.Equal(PublishFailed, pi.state)
+	require.Equal(feeRate, pi.params.StartingFeeRate.UnsafeFromSome())
 
 	// We expect the publish failed input to stay unchanged.
-	require.Equal(PublishFailed,
-		s.inputs[inputPublishFailed.OutPoint()].state)
+	pi = s.inputs[inputPublishFailed.OutPoint()]
+	require.Equal(PublishFailed, pi.state)
+	require.True(pi.params.StartingFeeRate.IsNone())
 
 	// We expect the swept input to stay unchanged.
-	require.Equal(Swept, s.inputs[inputSwept.OutPoint()].state)
+	pi = s.inputs[inputSwept.OutPoint()]
+	require.Equal(Swept, pi.state)
+	require.True(pi.params.StartingFeeRate.IsNone())
 
 	// We expect the excluded input to stay unchanged.
-	require.Equal(Excluded, s.inputs[inputExcluded.OutPoint()].state)
+	pi = s.inputs[inputExcluded.OutPoint()]
+	require.Equal(Excluded, pi.state)
+	require.True(pi.params.StartingFeeRate.IsNone())
 
-	// We expect the failed input to stay unchanged.
-	require.Equal(Fatal, s.inputs[inputFatal.OutPoint()].state)
+	// We expect the fatal input to stay unchanged.
+	pi = s.inputs[inputFatal.OutPoint()]
+	require.Equal(Fatal, pi.state)
+	require.True(pi.params.StartingFeeRate.IsNone())
 
 	// Assert mocked statements are executed as expected.
 	mockStore.AssertExpectations(t)

--- a/sweep/tx_input_set.go
+++ b/sweep/tx_input_set.go
@@ -320,13 +320,6 @@ func (b *BudgetInputSet) NeedWalletInput() bool {
 	return budgetBorrowable < budgetNeeded
 }
 
-// copyInputs returns a copy of the slice of the inputs in the set.
-func (b *BudgetInputSet) copyInputs() []*SweeperInput {
-	inputs := make([]*SweeperInput, len(b.inputs))
-	copy(inputs, b.inputs)
-	return inputs
-}
-
 // hasNormalInput return a bool to indicate whether there exists an input that
 // doesn't require a TxOut. When an input has no required outputs, it's either a
 // wallet input, or an input we want to sweep.

--- a/sweep/tx_input_set_test.go
+++ b/sweep/tx_input_set_test.go
@@ -386,12 +386,12 @@ func TestNeedWalletInput(t *testing.T) {
 	}
 }
 
-// TestAddWalletInputReturnErr tests the three possible errors returned from
+// TestAddWalletInputsReturnErr tests the three possible errors returned from
 // AddWalletInputs:
 // - error from ListUnspentWitnessFromDefaultAccount.
 // - error from createWalletTxInput.
 // - error when wallet doesn't have utxos.
-func TestAddWalletInputReturnErr(t *testing.T) {
+func TestAddWalletInputsReturnErr(t *testing.T) {
 	t.Parallel()
 
 	wallet := &MockWallet{}
@@ -436,10 +436,9 @@ func TestAddWalletInputReturnErr(t *testing.T) {
 	require.ErrorIs(t, err, ErrNotEnoughInputs)
 }
 
-// TestAddWalletInputNotEnoughInputs checks that when there are not enough
-// wallet utxos, an error is returned and the budget set is reset to its
-// initial state.
-func TestAddWalletInputNotEnoughInputs(t *testing.T) {
+// TestAddWalletInputsNotEnoughInputs checks that when there are not enough
+// wallet utxos, no error is returned as long as the wallet is not empty.
+func TestAddWalletInputsNotEnoughInputs(t *testing.T) {
 	t.Parallel()
 
 	wallet := &MockWallet{}
@@ -476,19 +475,18 @@ func TestAddWalletInputNotEnoughInputs(t *testing.T) {
 	// Initialize an input set with the pending input.
 	set := BudgetInputSet{inputs: []*SweeperInput{pi}}
 
-	// Add wallet inputs to the input set, which should give us an error as
-	// the wallet cannot cover the budget.
+	// Add wallet inputs to the input set, which should return no error
+	// although the wallet cannot cover the budget.
 	err := set.AddWalletInputs(wallet)
-	require.ErrorIs(t, err, ErrNotEnoughInputs)
+	require.NoError(t, err)
 
-	// Check that the budget set is reverted to its initial state.
-	require.Len(t, set.inputs, 1)
-	require.Equal(t, pi, set.inputs[0])
+	// Check that the budget set is updated.
+	require.Len(t, set.inputs, 2)
 }
 
-// TestAddWalletInputSuccess checks that when there are enough wallet utxos,
+// TestAddWalletInputsSuccess checks that when there are enough wallet utxos,
 // they are added to the input set.
-func TestAddWalletInputSuccess(t *testing.T) {
+func TestAddWalletInputsSuccess(t *testing.T) {
 	t.Parallel()
 
 	wallet := &MockWallet{}


### PR DESCRIPTION
This PR fixes the issue of the sweep being delayed due to the current wallet UTXOs not being able to cover the full budget. An example case is this [sweeping tx](https://mempool.space/tx/df6e296f245de37eb097a2f16eeb97fd7fa82dc8ed291efe87bb81e502be4e95), in which an HTLC output was swept with overshooting fees. This happened because the sweeper requires the budget to be fully covered before attempting the sweep, otherwise the sweeper will wait until more wallet UTXOs are available - by that time, the deadline may already be very close, or even passed, causing the full budget to be used up at once.

This PR changes the *all or nothing* behavior by starting the sweeping process asap if the budget can be covered partially. Later on, when there are more wallet UTXOs, the sweeper will add them to make up the rest of the budget.