### PR TITLE
scripts+GitHub: use bitcoind v29.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ defaults:
     shell: bash
 
 env:
-  BITCOIN_VERSION: "28"
+  BITCOIN_VERSION: "29"
   
   # TRANCHES defines the number of tranches used in the itests.
   TRANCHES: 16

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -330,6 +330,10 @@ The underlying functionality between those two options remain the same.
    [2](https://github.com/lightningnetwork/lnd/pull/9477)
    [3](https://github.com/lightningnetwork/lnd/pull/9478).
 
+* [CI has been updated to build against
+  `bitcoind 29.0`](https://github.com/lightningnetwork/lnd/pull/9628) to ensure
+  compatibility.
+
 ## Breaking Changes
 ## Performance Improvements
 


### PR DESCRIPTION
Make sure `lnd 0.19.0-beta` will be compatible with `bitcoind v29.0`.