### PR TITLE
rpcserver: warn if sendcoins default conf target is used

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1295,7 +1295,7 @@ func maybeUseDefaultConf(satPerByte int64, satPerVByte uint64,
 
 	// If the fee rate is not set, yet the conf target is zero, the default
 	// 6 will be returned.
-	rpcsLog.Errorf("Expected either 'sat_per_vbyte' or 'conf_target' to " +
+	rpcsLog.Warnf("Expected either 'sat_per_vbyte' or 'conf_target' to " +
 		"be set, using default conf of 6 instead")
 
 	return defaultNumBlocksEstimate


### PR DESCRIPTION
Instead of alerting an error, we degrade the log level to a warning if sendcoins is called without `sat_per_vbyte` and `conf_target`.