### PR TITLE
routerrpc: add nil check for MilliSat

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -68,6 +68,10 @@
   `estimateroutefee` to assume probing an LSP when given an invoice with a route 
   hint containing a public channel to the destination.
 
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/9634) that caused
+  lnd to crash due to a nil pointer dereference when `estimateroutefee` is
+  called for a payment request that contains a zero amount.
+
 * [Fix a bug](https://github.com/lightningnetwork/lnd/pull/9474) where LND would
   fail to persist (and hence, propagate) node announcements containing address 
   types (such as a DNS hostname) unknown to LND.

--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -519,7 +519,7 @@ func (s *Server) probePaymentRequest(ctx context.Context, paymentRequest string,
 		return nil, err
 	}
 
-	if *payReq.MilliSat <= 0 {
+	if payReq.MilliSat == nil || *payReq.MilliSat <= 0 {
 		return nil, errors.New("payment request amount must be " +
 			"greater than 0")
 	}


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/9633

Routing fee estimation via `lncli estimateroutefee --pay_req ...` for an invoice with zero amount crashes lnd.

