### PR TITLE
aezeed : add error handling for unexpected plaintext size in decipherCiph…

### DIFF
--- a/aezeed/cipherseed.go
+++ b/aezeed/cipherseed.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/binary"
+	"fmt"
 	"hash/crc32"
 	"io"
 	"time"
@@ -534,6 +535,12 @@ func decipherCipherSeed(cipherSeedBytes [EncipheredCipherSeedSize]byte,
 	)
 	if !ok {
 		return plainSeed, salt, ErrInvalidPass
+	}
+	if len(plainSeedBytes) != DecipheredCipherSeedSize {
+		return plainSeed, salt,
+			fmt.Errorf("unexpected plaintext "+
+				"size: got %d, want %d", len(plainSeedBytes),
+				DecipheredCipherSeedSize)
 	}
 	copy(plainSeed[:], plainSeedBytes)
 


### PR DESCRIPTION
## Change Description

This pull request enhances the decipherCipherSeed function by adding an explicit check to verify that the decrypted plaintext size matches the expected DecipheredCipherSeedSize (19 bytes) before copying it into the plainSeed array. This change introduces an additional safety net, ensuring the code fails explicitly if the AEZ decryption yields an unexpected plaintext size. 

While the current AEZ implementation should always return the correct size when decryption succeeds, this validation improves robustness against potential library bugs or future changes. 
`The modification preserves the existing logic and adds minimal overhead.
`

## Proposed Changes:

Modify the decipherCipherSeed function in cipherseed.go to include a size check after decryption succeeds. If the size does not match, return a new error with a descriptive message.