### PR TITLE
feature: start to set the require bit for channel_type

### DIFF
--- a/feature/default_sets.go
+++ b/feature/default_sets.go
@@ -60,7 +60,7 @@ var defaultSetDesc = setDesc{
 	lnwire.AMPRequired: {
 		SetInvoiceAmp: {}, // 9A
 	},
-	lnwire.ExplicitChannelTypeOptional: {
+	lnwire.ExplicitChannelTypeRequired: {
 		SetInit:    {}, // I
 		SetNodeAnn: {}, // N
 	},


### PR DESCRIPTION
Related to this spec PR: https://github.com/lightning/bolts/pull/1232.

To start with, we'll start to set the required feature bit for the `channel_type` feature where applicable.
