### PR TITLE
lnwallet/chancloser: fix flake in TestRbfChannelFlushingTransitions/early_offer

### DIFF
--- a/lnwallet/chancloser/rbf_coop_test.go
+++ b/lnwallet/chancloser/rbf_coop_test.go
@@ -1353,8 +1353,8 @@ func TestRbfChannelFlushingTransitions(t *testing.T) {
 		// offer and send our sig).
 		closeHarness.chanCloser.SendEvent(ctx, &flushEvent)
 		closeHarness.assertSingleRemoteRbfIteration(
-			remoteOffer, absoluteFee, absoluteFee, sequence, false,
-			true,
+			remoteOffer, absoluteFee, absoluteFee, sequence, true,
+			false,
 		)
 	})
 

--- a/protofsm/state_machine.go
+++ b/protofsm/state_machine.go
@@ -237,8 +237,7 @@ func (s *StateMachine[Event, Env]) Stop() {
 //
 // TODO(roasbeef): bool if processed?
 func (s *StateMachine[Event, Env]) SendEvent(ctx context.Context, event Event) {
-	s.log.DebugS(ctx, "Sending event",
-		"event", lnutils.SpewLogClosure(event))
+	s.log.Debugf("Sending event %T", event)
 
 	select {
 	case s.events <- event:
@@ -543,9 +542,6 @@ func (s *StateMachine[Event, Env]) executeDaemonEvent(ctx context.Context,
 func (s *StateMachine[Event, Env]) applyEvents(ctx context.Context,
 	currentState State[Event, Env], newEvent Event) (State[Event, Env],
 	error) {
-
-	s.log.DebugS(ctx, "Applying new event",
-		"event", lnutils.SpewLogClosure(newEvent))
 
 	eventQueue := fn.NewQueue(newEvent)
 


### PR DESCRIPTION
In this commit, we fix a flake in the
`TestRbfChannelFlushingTransitions/early_offer` test. The fix is simple:
this is actually an "iteration", as we have a self transition to the
ChannelNegotiation state first. We also don't need to send the
remoteOffer, so we set `sendInit` to false. The offer still needs to be
passed in to ensure that the assertions work however.