### PR TITLE
chainreg: send dummy epoch in `no_chain_backend`

### DIFF
--- a/chainreg/no_chain_backend.go
+++ b/chainreg/no_chain_backend.go
@@ -73,7 +73,18 @@ func (n *NoChainBackend) RegisterSpendNtfn(*wire.OutPoint, []byte,
 func (n *NoChainBackend) RegisterBlockEpochNtfn(
 	*chainntnfs.BlockEpoch) (*chainntnfs.BlockEpochEvent, error) {
 
-	epochChan := make(chan *chainntnfs.BlockEpoch)
+	epochChan := make(chan *chainntnfs.BlockEpoch, 1)
+
+	blockHeader := &wire.BlockHeader{
+		Nonce: 1,
+	}
+	block := &chainntnfs.BlockEpoch{
+		BlockHeader: blockHeader,
+		Hash:   noChainBackendBestHash,
+		Height: noChainBackendBestHeight,
+	}
+	epochChan <- block
+
 	return &chainntnfs.BlockEpochEvent{
 		Epochs: epochChan,
 		Cancel: func() {


### PR DESCRIPTION
## Change Description
Currently, `getStartingBeat()` does not work properly when the chain backend is `nochainbackend`.

This is because if the function never receives a `bestBlock` from `blockEpochs.Epochs`, the code drops into the case `<-s.quit:` branch (or simply times out), doesn’t set beat.

`server.Start()` sees no error from `getStartingBeat()`, so it calls `s.txPublisher.Start(beat)` with a `nil` `beat`.

Inside `TxPublisher.Start()`, we call `t.currentHeight.Store(beat.Height())` which tries to do `beat.Height()`.

Since `beat` is `nil`, we throw a panic: `panic: runtime error: invalid memory address or nil pointer dereference.`

That is in turn because the `RegisterBlockEpochNtfn()` method returns a channel that’s never written to.

This PR introduces a dummy payload to send back to unblock startup and avoid these nil pointer dereferences.

## Steps to Test
Steps for reviewers to follow to test the change.

1. Deploy LND 0.19.0-rc1 in remote signing mode.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
