### PR TITLE
lnwallet/chancloser: fix flake in TestRbfCloseClosingNegotiationLocal

### DIFF
--- a/lnwallet/chancloser/rbf_coop_test.go
+++ b/lnwallet/chancloser/rbf_coop_test.go
@@ -508,7 +508,7 @@ func (d dustExpectation) String() string {
 // message to the remote party, and all the other intermediate steps.
 func (r *rbfCloserTestHarness) expectHalfSignerIteration(
 	initEvent ProtocolEvent, balanceAfterClose, absoluteFee btcutil.Amount,
-	dustExpect dustExpectation) {
+	dustExpect dustExpectation, iteration bool) {
 
 	ctx := context.Background()
 	numFeeCalls := 2
@@ -569,8 +569,14 @@ func (r *rbfCloserTestHarness) expectHalfSignerIteration(
 		}
 
 	case *SendOfferEvent:
-
 		expectedStates = []RbfState{&ClosingNegotiation{}}
+
+		// If we're in the middle of an iteration, then we expect a transition
+		// from ClosePending -> LocalCloseStart.
+		if iteration {
+			expectedStates = append(expectedStates, &ClosingNegotiation{})
+		}
+
 	case *ChannelFlushed:
 		// If we're sending a flush event here, then this means that we
 		// also have enough balance to cover the fee so we'll have
@@ -585,10 +591,6 @@ func (r *rbfCloserTestHarness) expectHalfSignerIteration(
 
 	// We should transition from the negotiation state back to
 	// itself.
-	//
-	// TODO(roasbeef): take in expected set of transitions!!!
-	//  * or base off of event, if shutdown recv'd know we're doing a full
-	//  loop
 	r.assertStateTransitions(expectedStates...)
 
 	// If we examine the final resting state, we should see that
@@ -610,7 +612,7 @@ func (r *rbfCloserTestHarness) expectHalfSignerIteration(
 
 func (r *rbfCloserTestHarness) assertSingleRbfIteration(
 	initEvent ProtocolEvent, balanceAfterClose, absoluteFee btcutil.Amount,
-	dustExpect dustExpectation) {
+	dustExpect dustExpectation, iteration bool) {
 
 	ctx := context.Background()
 
@@ -618,6 +620,7 @@ func (r *rbfCloserTestHarness) assertSingleRbfIteration(
 	// the RBF loop, ending us in the LocalOfferSent state.
 	r.expectHalfSignerIteration(
 		initEvent, balanceAfterClose, absoluteFee, noDustExpect,
+		iteration,
 	)
 
 	// Now that we're in the local offer sent state, we'll send the
@@ -1299,7 +1302,7 @@ func TestRbfChannelFlushingTransitions(t *testing.T) {
 			// flow.
 			closeHarness.expectHalfSignerIteration(
 				&flushEvent, balanceAfterClose, absoluteFee,
-				noDustExpect,
+				noDustExpect, false,
 			)
 		})
 	}
@@ -1418,7 +1421,7 @@ func TestRbfCloseClosingNegotiationLocal(t *testing.T) {
 		// pending state.
 		closeHarness.assertSingleRbfIteration(
 			sendOfferEvent, balanceAfterClose, absoluteFee,
-			noDustExpect,
+			noDustExpect, false,
 		)
 	})
 
@@ -1434,7 +1437,7 @@ func TestRbfCloseClosingNegotiationLocal(t *testing.T) {
 		// event to advance the state machine.
 		closeHarness.expectHalfSignerIteration(
 			sendOfferEvent, balanceAfterClose, absoluteFee,
-			noDustExpect,
+			noDustExpect, false,
 		)
 
 		// We'll now craft the local sig received event, but this time
@@ -1489,7 +1492,7 @@ func TestRbfCloseClosingNegotiationLocal(t *testing.T) {
 		// proper field is set.
 		closeHarness.expectHalfSignerIteration(
 			sendOfferEvent, balanceAfterClose, absoluteFee,
-			remoteDustExpect,
+			remoteDustExpect, false,
 		)
 	})
 
@@ -1516,7 +1519,7 @@ func TestRbfCloseClosingNegotiationLocal(t *testing.T) {
 		dustBalance := btcutil.Amount(100)
 		closeHarness.expectHalfSignerIteration(
 			sendOfferEvent, dustBalance, absoluteFee,
-			localDustExpect,
+			localDustExpect, false,
 		)
 	})
 
@@ -1581,7 +1584,7 @@ func TestRbfCloseClosingNegotiationLocal(t *testing.T) {
 		// assuming we start in this negotiation state.
 		closeHarness.assertSingleRbfIteration(
 			sendOfferEvent, balanceAfterClose, absoluteFee,
-			noDustExpect,
+			noDustExpect, false,
 		)
 
 		// Next, we'll send in a new SendOfferEvent event which
@@ -1596,12 +1599,7 @@ func TestRbfCloseClosingNegotiationLocal(t *testing.T) {
 		// initiate a new local sig).
 		closeHarness.assertSingleRbfIteration(
 			localOffer, balanceAfterClose, absoluteFee,
-			noDustExpect,
-		)
-
-		// We should terminate in the negotiation state.
-		closeHarness.assertStateTransitions(
-			&ClosingNegotiation{},
+			noDustExpect, true,
 		)
 	})
 
@@ -2004,7 +2002,7 @@ func TestRbfCloseErr(t *testing.T) {
 		// initiate a new local sig).
 		closeHarness.assertSingleRbfIteration(
 			localOffer, balanceAfterClose, absoluteFee,
-			noDustExpect,
+			noDustExpect, false,
 		)
 
 		// We should terminate in the negotiation state.


### PR DESCRIPTION
In this commit, we fix a flake in the rbf loop sub-test for the TestRbfCloseClosingNegotiationLocal test case.

The fix here is that when we go from ClosePending for an RBF iteration loop, we first transition to LocalCloseStart. However we only do this extra transition if we're doing an iteration (starting from ClosePending).

To fix this, we add a new bool that tracks if this is an iteration or not. We can then also eliminate the extra assertion at the end, as we'll terminate in `ClosePending` which is checked by
`assertLocalClosePending()` in `assertSingleRbfIteration`.

Fixes https://github.com/lightningnetwork/lnd/issues/9526.

