### PR TITLE
channeldb: perform init of top level buckets first

### DIFF
--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -479,17 +479,17 @@ func initChannelDB(db kvdb.Backend) error {
 			return err
 		}
 
+		for _, tlb := range dbTopLevelBuckets {
+			if _, err := tx.CreateTopLevelBucket(tlb); err != nil {
+				return err
+			}
+		}
+
 		meta := &Meta{}
 		// Check if DB is already initialized.
 		err := FetchMeta(meta, tx)
 		if err == nil {
 			return nil
-		}
-
-		for _, tlb := range dbTopLevelBuckets {
-			if _, err := tx.CreateTopLevelBucket(tlb); err != nil {
-				return err
-			}
 		}
 
 		meta.DbVersionNumber = getLatestDBVersion(dbVersions)


### PR DESCRIPTION
## Change Description
Resolves https://github.com/lightningnetwork/lnd/issues/6155 by creating the top level buckets before the potential early return for metadata check.

## Steps to Test
1. Deploy lnd in remote-signer on an older version of LND.
2. Upgrade to 0.19.0-rc1.

The signer LND node should fail to start due to an error:
```
2025-03-26 14:33:08.912 [INF] CRTR: Loaded 0 mission control entries
2025-03-26 14:33:08.913 [ERR] LTND: Shutting down due to error in main method rev=0053fd err="historical channel bucket has not yet been created"
2025-03-26 14:33:08.914 [INF] LTND: Stopping pprof server... rev=0053fd
```

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
