### PR TITLE
scripts+bw-compatibility-test: update Dave and make it use sqlite

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,6 +1,6 @@
 # If you change this please also update GO_VERSION in Makefile (then run
 # `make lint` to see where else it needs to be updated as well).
-FROM golang:1.23.6-alpine as builder
+FROM golang:1.23.6-alpine AS builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 
@@ -19,11 +19,11 @@ COPY . /go/src/github.com/lightningnetwork/lnd
 
 #  Install/build lnd.
 RUN cd /go/src/github.com/lightningnetwork/lnd \
-&&  make \
-&&  make install-all tags="signrpc walletrpc chainrpc invoicesrpc peersrpc"
+    &&  make \
+    &&  make install-all tags="signrpc walletrpc chainrpc invoicesrpc peersrpc kvdb_sqlite"
 
 # Start a new, final image to reduce size.
-FROM alpine as final
+FROM alpine AS final
 
 # Expose lnd ports (server, rpc).
 EXPOSE 9735 10009

--- a/scripts/bw-compatibility-test/docker-compose.override.yaml
+++ b/scripts/bw-compatibility-test/docker-compose.override.yaml
@@ -3,6 +3,7 @@ services:
     build:
       context: ../../
       dockerfile: dev.Dockerfile
+    image: lnd-dev:backward-compat-test-build
     container_name: bob-pr
     restart: unless-stopped
     ports:
@@ -41,3 +42,46 @@ services:
       --protocol.zero-conf
       --protocol.simple-taproot-chans
       --trickledelay=50
+
+  dave-pr:
+    image: lnd-dev:backward-compat-test-build
+    container_name: dave-pr
+    restart: unless-stopped
+    ports:
+      - 10014:10009
+      - 9744:9735
+      - 8094:8080
+    networks:
+      regtest:
+        aliases:
+          - dave
+    volumes:
+      - "dave:/root/.lnd"
+    depends_on:
+      - bitcoind
+    command: >
+      lnd
+      --logdir=/root/.lnd
+      --alias=dave
+      --rpclisten=0.0.0.0:10009
+      --restlisten=0.0.0.0:8080
+      --color=#cccccc
+      --noseedbackup
+      --bitcoin.active
+      --bitcoin.regtest
+      --bitcoin.node=bitcoind
+      --bitcoind.rpchost=bitcoind
+      --bitcoind.rpcuser=lightning
+      --bitcoind.rpcpass=lightning
+      --bitcoind.zmqpubrawblock=tcp://bitcoind:28332
+      --bitcoind.zmqpubrawtx=tcp://bitcoind:28333
+      --debuglevel=debug
+      --externalip=dave
+      --tlsextradomain=dave
+      --accept-keysend
+      --protocol.option-scid-alias
+      --protocol.zero-conf
+      --protocol.simple-taproot-chans
+      --trickledelay=50
+      --db.backend=sqlite
+      --db.use-native-sql

--- a/scripts/bw-compatibility-test/docker-compose.yaml
+++ b/scripts/bw-compatibility-test/docker-compose.yaml
@@ -185,6 +185,8 @@ services:
       - "--tlsextradomain=dave"
       - "--accept-keysend"
       - "--trickledelay=50"
+      - "--db.backend=sqlite"
+      - "--db.use-native-sql"
 
 networks:
   regtest:

--- a/scripts/bw-compatibility-test/test.sh
+++ b/scripts/bw-compatibility-test/test.sh
@@ -36,7 +36,7 @@ send_payment alice dave
 
 # Upgrade the compose variables so that the Bob configuration
 # is swapped out for the PR version.
-upgrade_bob
+upgrade_node bob
 
 # Wait for Bob to start.
 wait_for_node bob
@@ -46,6 +46,21 @@ wait_for_active_chans bob 2
 do_for print_version bob
 
 # Repeat the basic tests.
+send_payment bob dave
+send_payment dave bob
+send_payment alice dave
+
+# Upgrade the compose variables so that the Dave configuration
+# is swapped out for the PR version.
+upgrade_node dave
+
+wait_for_node dave
+wait_for_active_chans dave 1
+
+# Show that Dave is now running the current branch.
+do_for print_version dave
+
+# Repeat the basic tests (after potential migraton).
 send_payment bob dave
 send_payment dave bob
 send_payment alice dave


### PR DESCRIPTION
With this change, we'll test that a node with SQLite backend (using mixed KV and native schema) remains backward compatible.

It helps prevent incompatibility issues caused by SQL schema changes or invalid migrations, like the one fixed in: https://github.com/lightningnetwork/lnd/pull/9647.