### PR TITLE
Replace a flaky test with a benchmark

### DIFF
--- a/fn/slice_test.go
+++ b/fn/slice_test.go
@@ -300,48 +300,6 @@ func TestPropForEachConcMapIsomorphism(t *testing.T) {
 	}
 }
 
-// TestPropForEachConcOutperformsMapWhenExpensive ensures the property that
-// ForEachConc will beat Map in a race in circumstances where the computation in
-// the argument closure is expensive.
-func TestPropForEachConcOutperformsMapWhenExpensive(t *testing.T) {
-	f := func(incSize int, s []int) bool {
-		if len(s) < 2 {
-			// Intuitively we don't expect the extra overhead of
-			// ForEachConc to justify itself for list sizes of 1 or
-			// 0.
-			return true
-		}
-
-		inc := func(i int) int {
-			time.Sleep(time.Millisecond)
-			return i + incSize
-		}
-		c := make(chan bool, 1)
-
-		go func() {
-			Map(s, inc)
-			select {
-			case c <- false:
-			default:
-			}
-		}()
-
-		go func() {
-			ForEachConc(s, inc)
-			select {
-			case c <- true:
-			default:
-			}
-		}()
-
-		return <-c
-	}
-
-	if err := quick.Check(f, nil); err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestPropFindIdxFindIdentity(t *testing.T) {
 	f := func(div, mod uint8, s []uint8) bool {
 		if div == 0 || div == 1 {


### PR DESCRIPTION
Fixes #9578 

## Change Description
As mentioned in the [comment](https://github.com/lightningnetwork/lnd/issues/9578#issuecomment-2725505073):
> The test TestPropForEachConcOutperformsMapWhenExpensive compares the speed of Map and ForEachConc functions when executing an expensive operation on a slice. In this case, the expensive operation is time.Sleep(time.Millisecond).
Since the [Map](https://github.com/lightningnetwork/lnd/blob/master/fn/slice.go#L44) function operates sequentially, we expect [ForEachConc](https://github.com/lightningnetwork/lnd/blob/master/fn/slice.go#L262) to always complete first because it runs concurrently.
However ForEachConc has some overheads including creating and managing goroutines, semaphore acquisition & release, and waitgroup operations (which I think are non-deterministic).

The non-deterministic nature of `ForEachConc`, along with its overhead, can cause the `Map` function to sometimes finish executing before it, which results in CI failures. 

This PR replaces the [flaky test](https://github.com/lightningnetwork/lnd/issues/9578), comparing two functions, `Map` and `ForEachConc`, under expensive operations, with a benchmark.

## Steps to Test
```go
cd fn && go test -bench=BenchmarkMapVsForEachConc
```

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
