### PR TITLE
lnd: remove unnecessary debug log to avoid misunderstanding

### DIFF
--- a/config_builder.go
+++ b/config_builder.go
@@ -1166,9 +1166,6 @@ func (d *DefaultDatabaseBuilder) BuildDatabase(
 		// need to return and ask the user switch back to using the
 		// native SQL store.
 		ripInvoices, err := dbs.ChanStateDB.GetInvoiceBucketTombstone()
-		d.logger.Debugf("Invoice bucket tombstone set to: %v",
-			ripInvoices)
-
 		if err != nil {
 			err = fmt.Errorf("unable to check invoice bucket "+
 				"tombstone: %w", err)


### PR DESCRIPTION
This commit removes a log line that could be misunderstood in the context of bolt KV to SQL migration.
Fixes:  https://github.com/lightningnetwork/lnd/issues/9660