### PR TITLE
multi: downgrade to legacy coop close for taproot channels

### DIFF
--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -611,6 +611,10 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testCoopCloseWithHtlcs,
 	},
 	{
+		Name:     "coop close with htlcs restart",
+		TestFunc: testCoopCloseWithHtlcsWithRestart,
+	},
+	{
 		Name:     "coop close exceeds max fee",
 		TestFunc: testCoopCloseExceedsMaxFee,
 	},

--- a/lncfg/protocol.go
+++ b/lncfg/protocol.go
@@ -37,7 +37,7 @@ type ProtocolOptions struct {
 
 	// RbfCoopClose should be set if we want to signal that we support for
 	// the new experimental RBF coop close feature.
-	RbfCoopClose bool `long:"rbf-coop-close" description:"if set, then lnd will signal that it supports the new RBF based coop close protocol"`
+	RbfCoopClose bool `long:"rbf-coop-close" description:"if set, then lnd will signal that it supports the new RBF based coop close protocol, taproot channels are not supported"`
 
 	// NoAnchors should be set if we don't want to support opening or accepting
 	// channels having the anchor commitment type.

--- a/lntest/node/config.go
+++ b/lntest/node/config.go
@@ -68,6 +68,12 @@ var (
 		"--protocol.simple-taproot-chans",
 	}
 
+	// CfgRbfCoopClose specifies the config used to create a node that
+	// supports the new RBF close protocol.
+	CfgRbfClose = []string{
+		"--protocol.rbf-coop-close",
+	}
+
 	// CfgZeroConf specifies the config used to create a node that uses the
 	// zero-conf channel feature.
 	CfgZeroConf = []string{

--- a/server.go
+++ b/server.go
@@ -612,17 +612,6 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 			"aux controllers")
 	}
 
-	// For now, the RBF coop close flag and the taproot channel type cannot
-	// be used together.
-	//
-	// TODO(roasbeef): fix
-	if cfg.ProtocolOptions.RbfCoopClose &&
-		cfg.ProtocolOptions.TaprootChans {
-
-		return nil, fmt.Errorf("RBF coop close and taproot " +
-			"channels cannot be used together")
-	}
-
 	//nolint:ll
 	featureMgr, err := feature.NewManager(feature.Config{
 		NoTLVOnion:                cfg.ProtocolOptions.LegacyOnion(),


### PR DESCRIPTION
In this commit, we implement logic to downgrade to the legacy coop close
for taproot channels. Before this commit, we wouldn't allow nodes to
start up with both the taproot flag and the rbf flag activated.

In the future, once we implement the spec updates, we'll add support for
this combo, and can revert parts of this commit.

We then test all the combinations of rbf close and taproot
chans. This ensures that the downgrade logic works properly.

Along the way we refactor the tests slightly, and also split them up, as
running all the combos back to back mines more than 50 blocks in a test,
which triggers an error in the itest sanity checks.
