### PR TITLE
kvdb/sqlite: enable incremental auto_vacuum on DB creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -210,6 +210,10 @@ replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 // allows us to specify that as an option.
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display
 
+replace github.com/lightningnetwork/lnd/sqldb => ./sqldb
+
+replace github.com/lightningnetwork/lnd/kvdb => ./kvdb
+
 // If you change this please also update docs/INSTALL.md and GO_VERSION in
 // Makefile (then run `make lint` to see where else it needs to be updated as
 // well).

--- a/go.sum
+++ b/go.sum
@@ -371,12 +371,8 @@ github.com/lightningnetwork/lnd/fn/v2 v2.0.8 h1:r2SLz7gZYQPVc3IZhU82M66guz3Zk2oY
 github.com/lightningnetwork/lnd/fn/v2 v2.0.8/go.mod h1:TOzwrhjB/Azw1V7aa8t21ufcQmdsQOQMDtxVOQWNl8s=
 github.com/lightningnetwork/lnd/healthcheck v1.2.6 h1:1sWhqr93GdkWy4+6U7JxBfcyZIE78MhIHTJZfPx7qqI=
 github.com/lightningnetwork/lnd/healthcheck v1.2.6/go.mod h1:Mu02um4CWY/zdTOvFje7WJgJcHyX2zq/FG3MhOAiGaQ=
-github.com/lightningnetwork/lnd/kvdb v1.4.13 h1:fe3sFBxsgcXl16G1zj6O/wZf0hbBHOxFe8pCgmnHZxM=
-github.com/lightningnetwork/lnd/kvdb v1.4.13/go.mod h1:1y0Z81CGQu4SMpcnAie/oK4tzgEqFQqFdj6k3fz2s8s=
 github.com/lightningnetwork/lnd/queue v1.1.1 h1:99ovBlpM9B0FRCGYJo6RSFDlt8/vOkQQZznVb18iNMI=
 github.com/lightningnetwork/lnd/queue v1.1.1/go.mod h1:7A6nC1Qrm32FHuhx/mi1cieAiBZo5O6l8IBIoQxvkz4=
-github.com/lightningnetwork/lnd/sqldb v1.0.8 h1:bTrMwEVDTthkfea+ShdzfK0XkKQz3VNN9dbE+B+gvEk=
-github.com/lightningnetwork/lnd/sqldb v1.0.8/go.mod h1:OG09zL/PHPaBJefp4HsPz2YLUJ+zIQHbpgCtLnOx8I4=
 github.com/lightningnetwork/lnd/ticker v1.1.1 h1:J/b6N2hibFtC7JLV77ULQp++QLtCwT6ijJlbdiZFbSM=
 github.com/lightningnetwork/lnd/ticker v1.1.1/go.mod h1:waPTRAAcwtu7Ji3+3k+u/xH5GHovTsCoSVpho0KDvdA=
 github.com/lightningnetwork/lnd/tlv v1.3.0 h1:exS/KCPEgpOgviIttfiXAPaUqw2rHQrnUOpP7HPBPiY=

--- a/kvdb/sqlite/db.go
+++ b/kvdb/sqlite/db.go
@@ -24,6 +24,12 @@ const (
 	sqliteTxLockImmediate = "_txlock=immediate"
 )
 
+// pragmaOption holds a key-value pair for a SQLite pragma setting.
+type pragmaOption struct {
+	name  string
+	value string
+}
+
 // NewSqliteBackend returns a db object initialized with the passed backend
 // config. If a sqlite connection cannot be established, then an error is
 // returned.
@@ -31,10 +37,7 @@ func NewSqliteBackend(ctx context.Context, cfg *Config, dbPath, fileName,
 	prefix string) (walletdb.DB, error) {
 
 	// First, we add a set of mandatory pragma options to the query.
-	pragmaOptions := []struct {
-		name  string
-		value string
-	}{
+	pragmaOptions := []pragmaOption{
 		{
 			name: "busy_timeout",
 			value: fmt.Sprintf(
@@ -49,7 +52,12 @@ func NewSqliteBackend(ctx context.Context, cfg *Config, dbPath, fileName,
 			name:  "journal_mode",
 			value: "WAL",
 		},
+		{
+			name:  "auto_vacuum",
+			value: "incremental",
+		},
 	}
+
 	sqliteOptions := make(url.Values)
 	for _, option := range pragmaOptions {
 		sqliteOptions.Add(

--- a/sqldb/sqlite.go
+++ b/sqldb/sqlite.go
@@ -40,6 +40,12 @@ var (
 	_ DB = (*SqliteStore)(nil)
 )
 
+// pragmaOption holds a key-value pair for a SQLite pragma setting.
+type pragmaOption struct {
+	name  string
+	value string
+}
+
 // SqliteStore is a database store implementation that uses a sqlite backend.
 type SqliteStore struct {
 	cfg *SqliteConfig
@@ -53,10 +59,7 @@ func NewSqliteStore(cfg *SqliteConfig, dbPath string) (*SqliteStore, error) {
 	// The set of pragma options are accepted using query options. For now
 	// we only want to ensure that foreign key constraints are properly
 	// enforced.
-	pragmaOptions := []struct {
-		name  string
-		value string
-	}{
+	pragmaOptions := []pragmaOption{
 		{
 			name:  "foreign_keys",
 			value: "on",
@@ -83,6 +86,10 @@ func NewSqliteStore(cfg *SqliteConfig, dbPath string) (*SqliteStore, error) {
 			// call to ensure items are fully flushed to disk.
 			name:  "fullfsync",
 			value: "true",
+		},
+		{
+			name:  "auto_vacuum",
+			value: "incremental",
 		},
 	}
 	sqliteOptions := make(url.Values)


### PR DESCRIPTION
In this commit, we make a change that enables the `auto_vacuum = incremental` pragma for SQLite databases, but only when the database file is first created. Incremental auto-vacuum allows SQLite to reclaim unused space within the database file over time, preventing indefinite growth.

According to the SQLite documentation, the `auto_vacuum` mode must be set *before* any tables are created in the database. To achieve this, a new boolean parameter `isCreate` has been added to the `NewSqliteBackend` function.

The `createDBDriver` now passes `true` for this parameter, ensuring the pragma is set during initial database setup. Conversely, `openDBDriver` passes `false` when opening an existing database, leaving the existing vacuum mode untouched.

We also change, the internal representation of pragma options was refactored to use a named struct `pragmaOption` for improved clarity.