### PR TITLE
Move neutrino db also to postgres when using postgres as a backend

### DIFF
--- a/config_builder.go
+++ b/config_builder.go
@@ -1430,6 +1430,74 @@ func importWatchOnlyAccounts(wallet *wallet.Wallet,
 	return nil
 }
 
+// handleNeutrinoPostgresDBMigration handles the migration of the neutrino db
+// to postgres. Initially we kept the neutrino db in the bolt db when running
+// with kvdb postgres backend. Now now move it to postgres as well. However we
+// need to make a distinction whether the user migrated the neutrino db to
+// postgres via lndinit or not. Currently if the db is not migrated we start
+// with a fresh db in postgres.
+//
+// TODO(ziggie): Also migrate the db to postgres in case it is still not
+// migrated ?
+func handleNeutrinoPostgresDBMigration(dbName, dbPath string,
+	cfg *Config) error {
+
+	if !lnrpc.FileExists(dbName) {
+		return nil
+	}
+
+	// Open bolt db to check if it is tombstoned. If it is we assume that
+	// the neutrino db was successfully migrated to postgres. We open it
+	// in read-only mode to avoid long db open times.
+	boltDB, err := kvdb.Open(
+		kvdb.BoltBackendName, dbName, true,
+		cfg.DB.Bolt.DBTimeout, true,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to open bolt db: %w", err)
+	}
+	defer boltDB.Close()
+
+	isTombstoned := false
+	err = boltDB.View(func(tx kvdb.RTx) error {
+		_, err = channeldb.CheckMarkerPresent(
+			tx, channeldb.TombstoneKey,
+		)
+
+		return err
+	}, func() {})
+	if err == nil {
+		isTombstoned = true
+	}
+
+	if isTombstoned {
+		ltndLog.Infof("Neutrino Bolt DB is tombstoned, assuming " +
+			"database was successfully migrated to postgres")
+
+		return nil
+	}
+
+	// If the db is not tombstoned, we remove the files and start fresh with
+	// postgres. This is the case when a user was running lnd with the
+	// postgres backend from the beginning without migrating from bolt.
+	ltndLog.Infof("Neutrino Bolt DB found but NOT tombstoned, removing " +
+		"it and starting fresh with postgres")
+
+	filesToRemove := []string{
+		filepath.Join(dbPath, "block_headers.bin"),
+		filepath.Join(dbPath, "reg_filter_headers.bin"),
+		dbName,
+	}
+
+	for _, file := range filesToRemove {
+		if err := os.Remove(file); err != nil {
+			ltndLog.Warnf("Could not remove %s: %v", file, err)
+		}
+	}
+
+	return nil
+}
+
 // initNeutrinoBackend inits a new instance of the neutrino light client
 // backend given a target chain directory to store the chain state.
 func initNeutrinoBackend(ctx context.Context, cfg *Config, chainDir string,
@@ -1471,8 +1539,26 @@ func initNeutrinoBackend(ctx context.Context, cfg *Config, chainDir string,
 			lncfg.SqliteNeutrinoDBName, lncfg.NSNeutrinoDB,
 		)
 
+	case cfg.DB.Backend == kvdb.PostgresBackendName:
+		dbName := filepath.Join(dbPath, lncfg.NeutrinoDBName)
+
+		// This code needs to be in place because we did not start
+		// the postgres backend for neutrino at the beginning. Now we
+		// are also moving it into the postgres backend so we can phase
+		// out the bolt backend.
+		err = handleNeutrinoPostgresDBMigration(dbName, dbPath, cfg)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		postgresConfig := lncfg.GetPostgresConfigKVDB(cfg.DB.Postgres)
+		db, err = kvdb.Open(
+			kvdb.PostgresBackendName, ctx, postgresConfig,
+			lncfg.NSNeutrinoDB,
+		)
+
 	default:
-		dbName := filepath.Join(dbPath, "neutrino.db")
+		dbName := filepath.Join(dbPath, lncfg.NeutrinoDBName)
 		db, err = walletdb.Create(
 			kvdb.BoltBackendName, dbName, !cfg.SyncFreelist,
 			cfg.DB.Bolt.DBTimeout, false,

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -150,8 +150,6 @@ close transaction.
   initial historical sync may be blocked due to a race condition in handling the
   syncer's internal state.
 
-
-
 * [The max fee rate](https://github.com/lightningnetwork/lnd/pull/9491) is now
   respected when a coop close is initiated. Before the max fee rate would only
   be effective for the remote party in the negotiation.
@@ -465,6 +463,9 @@ the on going rate we'll permit.
 
 * [Establish a base DB version even if it is not yet
   tracked](https://github.com/lightningnetwork/lnd/pull/9647).
+
+* [When running with neutrino as a backend with the kv-db backend `postgres`
+selected use postgres for the neutrino.db store](https://github.com/lightningnetwork/lnd/pull/9674).
 
 ## Code Health
 

--- a/lncfg/db.go
+++ b/lncfg/db.go
@@ -25,6 +25,7 @@ const (
 	TowerClientDBName = "wtclient.db"
 	TowerServerDBName = "watchtower.db"
 	WalletDBName      = "wallet.db"
+	NeutrinoDBName    = "neutrino.db"
 
 	SqliteChannelDBName  = "channel.sqlite"
 	SqliteChainDBName    = "chain.sqlite"


### PR DESCRIPTION
We now also move the neutrino data storage to postgres when we run the backend in postgres mode. This is still not natvie sql for neutrino but it moves everything in one place so we do not have the scattered db across multiple backends.

The migration tool will migrate the `neutrino.db` to the new sql-db schema. However if you were running postgres and neutrino initially this change will just start the `neutrino.db` from a fresh state because there is no critical data to preserve and it would just overcomplicate things to move the migration code from `lndinit` to this place.

Maybe the neutrino.db can be migrated as soon as we have the migration code in LND ?