### PR TITLE
macaroons+kvdb: improve signal-to-noise ratio of `context.TODO`

### DIFF
--- a/kvdb/backend.go
+++ b/kvdb/backend.go
@@ -270,7 +270,7 @@ func GetTestBackend(path, name string) (Backend, func(), error) {
 			return nil, empty, err
 		}
 		backend, err := Open(
-			EtcdBackendName, context.TODO(), etcdConfig,
+			EtcdBackendName, context.Background(), etcdConfig,
 		)
 		return backend, cancel, err
 

--- a/kvdb/etcd/db_test.go
+++ b/kvdb/etcd/db_test.go
@@ -19,7 +19,7 @@ func TestDump(t *testing.T) {
 
 	f := NewEtcdTestFixture(t)
 
-	db, err := newEtcdBackend(context.TODO(), f.BackendConfig())
+	db, err := newEtcdBackend(context.Background(), f.BackendConfig())
 	require.NoError(t, err)
 
 	err = db.Update(func(tx walletdb.ReadWriteTx) error {

--- a/kvdb/etcd/fixture.go
+++ b/kvdb/etcd/fixture.go
@@ -76,7 +76,7 @@ func (f *EtcdTestFixture) NewBackend(singleWriter bool) walletdb.DB {
 		cfg.SingleWriter = true
 	}
 
-	db, err := newEtcdBackend(context.TODO(), cfg)
+	db, err := newEtcdBackend(context.Background(), cfg)
 	require.NoError(f.t, err)
 
 	return db
@@ -84,7 +84,9 @@ func (f *EtcdTestFixture) NewBackend(singleWriter bool) walletdb.DB {
 
 // Put puts a string key/value into the test etcd database.
 func (f *EtcdTestFixture) Put(key, value string) {
-	ctx, cancel := context.WithTimeout(context.TODO(), testEtcdTimeout)
+	ctx, cancel := context.WithTimeout(
+		context.Background(), testEtcdTimeout,
+	)
 	defer cancel()
 
 	_, err := f.cli.Put(ctx, key, value)
@@ -95,7 +97,9 @@ func (f *EtcdTestFixture) Put(key, value string) {
 
 // Get queries a key and returns the stored value from the test etcd database.
 func (f *EtcdTestFixture) Get(key string) string {
-	ctx, cancel := context.WithTimeout(context.TODO(), testEtcdTimeout)
+	ctx, cancel := context.WithTimeout(
+		context.Background(), testEtcdTimeout,
+	)
 	defer cancel()
 
 	resp, err := f.cli.Get(ctx, key)
@@ -112,7 +116,9 @@ func (f *EtcdTestFixture) Get(key string) string {
 
 // Dump scans and returns all key/values from the test etcd database.
 func (f *EtcdTestFixture) Dump() map[string]string {
-	ctx, cancel := context.WithTimeout(context.TODO(), testEtcdTimeout)
+	ctx, cancel := context.WithTimeout(
+		context.Background(), testEtcdTimeout,
+	)
 	defer cancel()
 
 	resp, err := f.cli.Get(ctx, "\x00", clientv3.WithFromKey())

--- a/kvdb/etcd/readwrite_tx_test.go
+++ b/kvdb/etcd/readwrite_tx_test.go
@@ -16,7 +16,7 @@ func TestChangeDuringManualTx(t *testing.T) {
 
 	f := NewEtcdTestFixture(t)
 
-	db, err := newEtcdBackend(context.TODO(), f.BackendConfig())
+	db, err := newEtcdBackend(context.Background(), f.BackendConfig())
 	require.NoError(t, err)
 
 	tx, err := db.BeginReadWriteTx()
@@ -44,7 +44,7 @@ func TestChangeDuringUpdate(t *testing.T) {
 
 	f := NewEtcdTestFixture(t)
 
-	db, err := newEtcdBackend(context.TODO(), f.BackendConfig())
+	db, err := newEtcdBackend(context.Background(), f.BackendConfig())
 	require.NoError(t, err)
 
 	count := 0

--- a/kvdb/etcd/walletdb_interface_test.go
+++ b/kvdb/etcd/walletdb_interface_test.go
@@ -15,5 +15,5 @@ import (
 func TestWalletDBInterface(t *testing.T) {
 	f := NewEtcdTestFixture(t)
 	cfg := f.BackendConfig()
-	walletdbtest.TestInterface(t, dbType, context.TODO(), &cfg)
+	walletdbtest.TestInterface(t, dbType, context.Background(), &cfg)
 }

--- a/macaroons/store_test.go
+++ b/macaroons/store_test.go
@@ -58,12 +58,15 @@ func openTestStore(t *testing.T, tempDir string) *macaroons.RootKeyStorage {
 // TestStore tests the normal use cases of the store like creating, unlocking,
 // reading keys and closing it.
 func TestStore(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
 	tempDir, store := newTestStore(t)
 
-	_, _, err := store.RootKey(context.TODO())
+	_, _, err := store.RootKey(ctx)
 	require.Equal(t, macaroons.ErrStoreLocked, err)
 
-	_, err = store.Get(context.TODO(), nil)
+	_, err = store.Get(ctx, nil)
 	require.Equal(t, macaroons.ErrStoreLocked, err)
 
 	pw := []byte("weks")
@@ -72,18 +75,18 @@ func TestStore(t *testing.T) {
 
 	// Check ErrContextRootKeyID is returned when no root key ID found in
 	// context.
-	_, _, err = store.RootKey(context.TODO())
+	_, _, err = store.RootKey(ctx)
 	require.Equal(t, macaroons.ErrContextRootKeyID, err)
 
 	// Check ErrMissingRootKeyID is returned when empty root key ID is used.
 	emptyKeyID := make([]byte, 0)
-	badCtx := macaroons.ContextWithRootKeyID(context.TODO(), emptyKeyID)
+	badCtx := macaroons.ContextWithRootKeyID(ctx, emptyKeyID)
 	_, _, err = store.RootKey(badCtx)
 	require.Equal(t, macaroons.ErrMissingRootKeyID, err)
 
 	// Create a context with illegal root key ID value.
 	encryptedKeyID := []byte("enckey")
-	badCtx = macaroons.ContextWithRootKeyID(context.TODO(), encryptedKeyID)
+	badCtx = macaroons.ContextWithRootKeyID(ctx, encryptedKeyID)
 	_, _, err = store.RootKey(badCtx)
 	require.Equal(t, macaroons.ErrKeyValueForbidden, err)
 


### PR DESCRIPTION
### PR context

This is part of the last step required to complete https://github.com/lightningnetwork/lnd/issues/9494. We want all calls to the graph DB (and hence, ChannelGraph) to take a context since later, this context will be passed through to any remote graph RPC calls as well as any DB calls to a SQL graph backend. 

### This PR specifically

All this PR does is remove any existing `context.TODO()` invocations that are made in test code. We do this to improve the signal-to-noise ratio of the `context.TODO` call which should signal that work needs to be done to thread contexts through accordingly in order to remove the call. 
With this PR, there is only one remaining call to `context.TODO()` in the code base. 
