### PR TITLE
GitHub: disable cache, remove hosted tools cache

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '${{ env.GO_VERSION }}'
+          cache: 'false'
+
+      - name: cleanup space
+        run: rm -rf /opt/hostedtoolcache
 
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV


### PR DESCRIPTION
In an attempt to fix the "out of disk space" build error during release builds, we first disable using Golang caches (which can be quite large) and then remove a bunch of pre-installed tools and their caches to provide some additional disk storage.

Attempts to fix this: https://github.com/lightningnetwork/lnd/actions/runs/14304105009/job/40084022789
