### PR TITLE
`AuxTrafficShaper.PaymentBandwidth` uses HTLC view

### DIFF
--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lightningnetwork/lnd/graph/db/models"
 	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
@@ -516,8 +517,8 @@ type AuxTrafficShaper interface {
 	// is a custom channel that should be handled by the traffic shaper, the
 	// ShouldHandleTraffic method should be called first.
 	PaymentBandwidth(htlcBlob, commitmentBlob fn.Option[tlv.Blob],
-		linkBandwidth,
-		htlcAmt lnwire.MilliSatoshi) (lnwire.MilliSatoshi, error)
+		linkBandwidth, htlcAmt lnwire.MilliSatoshi,
+		htlcView lnwallet.AuxHtlcView) (lnwire.MilliSatoshi, error)
 
 	// IsCustomHTLC returns true if the HTLC carries the set of relevant
 	// custom records to put it under the purview of the traffic shaper,

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -3505,6 +3505,7 @@ func (l *channelLink) AuxBandwidth(amount lnwire.MilliSatoshi,
 	commitmentBlob := l.CommitmentCustomBlob()
 	auxBandwidth, err := ts.PaymentBandwidth(
 		htlcBlob, commitmentBlob, l.Bandwidth(), amount,
+		l.channel.FetchLatestAuxHTLCView(),
 	)
 	if err != nil {
 		return fn.Err[OptionalBandwidth](fmt.Errorf("failed to get "+

--- a/routing/bandwidth_test.go
+++ b/routing/bandwidth_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/htlcswitch"
+	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/stretchr/testify/require"
@@ -150,7 +151,8 @@ func (*mockTrafficShaper) ShouldHandleTraffic(_ lnwire.ShortChannelID,
 // is a custom channel that should be handled by the traffic shaper, the
 // HandleTraffic method should be called first.
 func (*mockTrafficShaper) PaymentBandwidth(_, _ fn.Option[tlv.Blob],
-	linkBandwidth, _ lnwire.MilliSatoshi) (lnwire.MilliSatoshi, error) {
+	linkBandwidth, _ lnwire.MilliSatoshi,
+	_ lnwallet.AuxHtlcView) (lnwire.MilliSatoshi, error) {
 
 	return linkBandwidth, nil
 }


### PR DESCRIPTION
## Description

This PR adds an extra argument to the `PaymentBandwidth` hook, which helps with computing a more precise aux htlc view, ultimately leading to more precise bandwidth results.

We expose the HtlcView from the lighting channel for the link to use when checking whether an HTLC can be added to the channel.