### PR TITLE
autopilot: thread contexts through in preparation for GraphSource methods taking a context

### DIFF
--- a/autopilot/agent.go
+++ b/autopilot/agent.go
@@ -2,6 +2,7 @@ package autopilot
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math/rand"
 	"net"
@@ -11,6 +12,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
 
@@ -166,8 +168,9 @@ type Agent struct {
 	pendingOpens map[NodeID]LocalChannel
 	pendingMtx   sync.Mutex
 
-	quit chan struct{}
-	wg   sync.WaitGroup
+	quit   chan struct{}
+	wg     sync.WaitGroup
+	cancel fn.Option[context.CancelFunc]
 }
 
 // New creates a new instance of the Agent instantiated using the passed
@@ -199,20 +202,23 @@ func New(cfg Config, initialState []LocalChannel) (*Agent, error) {
 
 // Start starts the agent along with any goroutines it needs to perform its
 // normal duties.
-func (a *Agent) Start() error {
+func (a *Agent) Start(ctx context.Context) error {
 	var err error
 	a.started.Do(func() {
-		err = a.start()
+		ctx, cancel := context.WithCancel(ctx)
+		a.cancel = fn.Some(cancel)
+
+		err = a.start(ctx)
 	})
 	return err
 }
 
-func (a *Agent) start() error {
+func (a *Agent) start(ctx context.Context) error {
 	rand.Seed(time.Now().Unix())
 	log.Infof("Autopilot Agent starting")
 
 	a.wg.Add(1)
-	go a.controller()
+	go a.controller(ctx)
 
 	return nil
 }
@@ -230,6 +236,7 @@ func (a *Agent) Stop() error {
 func (a *Agent) stop() error {
 	log.Infof("Autopilot Agent stopping")
 
+	a.cancel.WhenSome(func(fn context.CancelFunc) { fn() })
 	close(a.quit)
 	a.wg.Wait()
 
@@ -401,7 +408,7 @@ func mergeChanState(pendingChans map[NodeID]LocalChannel,
 // and external state changes as a result of decisions it makes w.r.t channel
 // allocation, or attributes affecting its control loop being updated by the
 // backing Lightning Node.
-func (a *Agent) controller() {
+func (a *Agent) controller(ctx context.Context) {
 	defer a.wg.Done()
 
 	// We'll start off by assigning our starting balance, and injecting
@@ -502,6 +509,9 @@ func (a *Agent) controller() {
 		// immediately.
 		case <-a.quit:
 			return
+
+		case <-ctx.Done():
+			return
 		}
 
 		a.pendingMtx.Lock()
@@ -539,7 +549,7 @@ func (a *Agent) controller() {
 		log.Infof("Triggering attachment directive dispatch, "+
 			"total_funds=%v", a.totalBalance)
 
-		err := a.openChans(availableFunds, numChans, totalChans)
+		err := a.openChans(ctx, availableFunds, numChans, totalChans)
 		if err != nil {
 			log.Errorf("Unable to open channels: %v", err)
 		}
@@ -548,8 +558,8 @@ func (a *Agent) controller() {
 
 // openChans queries the agent's heuristic for a set of channel candidates, and
 // attempts to open channels to them.
-func (a *Agent) openChans(availableFunds btcutil.Amount, numChans uint32,
-	totalChans []LocalChannel) error {
+func (a *Agent) openChans(ctx context.Context, availableFunds btcutil.Amount,
+	numChans uint32, totalChans []LocalChannel) error {
 
 	// As channel size we'll use the maximum channel size available.
 	chanSize := a.cfg.Constraints.MaxChanSize()
@@ -598,7 +608,9 @@ func (a *Agent) openChans(availableFunds btcutil.Amount, numChans uint32,
 	selfPubBytes := a.cfg.Self.SerializeCompressed()
 	nodes := make(map[NodeID]struct{})
 	addresses := make(map[NodeID][]net.Addr)
-	if err := a.cfg.Graph.ForEachNode(func(node Node) error {
+	if err := a.cfg.Graph.ForEachNode(ctx, func(_ context.Context,
+		node Node) error {
+
 		nID := NodeID(node.PubKey())
 
 		// If we come across ourselves, them we'll continue in

--- a/autopilot/agent.go
+++ b/autopilot/agent.go
@@ -648,7 +648,7 @@ func (a *Agent) openChans(ctx context.Context, availableFunds btcutil.Amount,
 	// graph.
 	log.Debugf("Scoring %d nodes for chan_size=%v", len(nodes), chanSize)
 	scores, err := a.cfg.Heuristic.NodeScores(
-		a.cfg.Graph, totalChans, chanSize, nodes,
+		ctx, a.cfg.Graph, totalChans, chanSize, nodes,
 	)
 	if err != nil {
 		return fmt.Errorf("unable to calculate node scores : %w", err)

--- a/autopilot/agent_test.go
+++ b/autopilot/agent_test.go
@@ -86,9 +86,9 @@ func (m *mockHeuristic) Name() string {
 	return "mock"
 }
 
-func (m *mockHeuristic) NodeScores(g ChannelGraph, chans []LocalChannel,
-	chanSize btcutil.Amount, nodes map[NodeID]struct{}) (
-	map[NodeID]*NodeScore, error) {
+func (m *mockHeuristic) NodeScores(_ context.Context, g ChannelGraph,
+	chans []LocalChannel, chanSize btcutil.Amount,
+	nodes map[NodeID]struct{}) (map[NodeID]*NodeScore, error) {
 
 	if m.nodeScoresArgs != nil {
 		directive := directiveArg{

--- a/autopilot/agent_test.go
+++ b/autopilot/agent_test.go
@@ -1,6 +1,7 @@
 package autopilot
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -220,7 +221,7 @@ func setup(t *testing.T, initialChans []LocalChannel) *testContext {
 
 	// With the autopilot agent and all its dependencies we'll start the
 	// primary controller goroutine.
-	if err := agent.Start(); err != nil {
+	if err := agent.Start(context.Background()); err != nil {
 		t.Fatalf("unable to start agent: %v", err)
 	}
 

--- a/autopilot/betweenness_centrality.go
+++ b/autopilot/betweenness_centrality.go
@@ -169,8 +169,8 @@ func betweennessCentrality(g *SimpleGraph, s int, centrality []float64) {
 }
 
 // Refresh recalculates and stores centrality values.
-func (bc *BetweennessCentrality) Refresh(graph ChannelGraph) error {
-	ctx := context.TODO()
+func (bc *BetweennessCentrality) Refresh(ctx context.Context,
+	graph ChannelGraph) error {
 
 	cache, err := NewSimpleGraph(ctx, graph)
 	if err != nil {

--- a/autopilot/betweenness_centrality.go
+++ b/autopilot/betweenness_centrality.go
@@ -1,6 +1,7 @@
 package autopilot
 
 import (
+	"context"
 	"fmt"
 	"sync"
 )
@@ -169,7 +170,9 @@ func betweennessCentrality(g *SimpleGraph, s int, centrality []float64) {
 
 // Refresh recalculates and stores centrality values.
 func (bc *BetweennessCentrality) Refresh(graph ChannelGraph) error {
-	cache, err := NewSimpleGraph(graph)
+	ctx := context.TODO()
+
+	cache, err := NewSimpleGraph(ctx, graph)
 	if err != nil {
 		return err
 	}

--- a/autopilot/betweenness_centrality_test.go
+++ b/autopilot/betweenness_centrality_test.go
@@ -1,6 +1,7 @@
 package autopilot
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -30,6 +31,9 @@ func TestBetweennessCentralityMetricConstruction(t *testing.T) {
 
 // Tests that empty graph results in empty centrality result.
 func TestBetweennessCentralityEmptyGraph(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
 	centralityMetric, err := NewBetweennessCentralityMetric(1)
 	require.NoError(
 		t, err,
@@ -42,7 +46,7 @@ func TestBetweennessCentralityEmptyGraph(t *testing.T) {
 		require.NoError(t, err, "unable to create graph")
 
 		success := t.Run(chanGraph.name, func(t1 *testing.T) {
-			err = centralityMetric.Refresh(graph)
+			err = centralityMetric.Refresh(ctx, graph)
 			require.NoError(t1, err)
 
 			centrality := centralityMetric.GetMetric(false)
@@ -59,6 +63,9 @@ func TestBetweennessCentralityEmptyGraph(t *testing.T) {
 
 // Test betweenness centrality calculating using an example graph.
 func TestBetweennessCentralityWithNonEmptyGraph(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
 	workers := []int{1, 3, 9, 100}
 
 	tests := []struct {
@@ -100,7 +107,7 @@ func TestBetweennessCentralityWithNonEmptyGraph(t *testing.T) {
 					t1, graph, centralityTestGraph,
 				)
 
-				err = metric.Refresh(graph)
+				err = metric.Refresh(ctx, graph)
 				require.NoError(t1, err)
 
 				for _, expected := range tests {

--- a/autopilot/combinedattach.go
+++ b/autopilot/combinedattach.go
@@ -1,6 +1,7 @@
 package autopilot
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -70,9 +71,9 @@ func (c *WeightedCombAttachment) Name() string {
 // is the maximum possible improvement in connectivity.
 //
 // NOTE: This is a part of the AttachmentHeuristic interface.
-func (c *WeightedCombAttachment) NodeScores(g ChannelGraph, chans []LocalChannel,
-	chanSize btcutil.Amount, nodes map[NodeID]struct{}) (
-	map[NodeID]*NodeScore, error) {
+func (c *WeightedCombAttachment) NodeScores(ctx context.Context, g ChannelGraph,
+	chans []LocalChannel, chanSize btcutil.Amount,
+	nodes map[NodeID]struct{}) (map[NodeID]*NodeScore, error) {
 
 	// We now query each heuristic to determine the score they give to the
 	// nodes for the given channel size.
@@ -81,7 +82,7 @@ func (c *WeightedCombAttachment) NodeScores(g ChannelGraph, chans []LocalChannel
 		log.Tracef("Getting scores from sub heuristic %v", h.Name())
 
 		s, err := h.NodeScores(
-			g, chans, chanSize, nodes,
+			ctx, g, chans, chanSize, nodes,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get sub score: %w",

--- a/autopilot/externalscoreattach.go
+++ b/autopilot/externalscoreattach.go
@@ -1,6 +1,7 @@
 package autopilot
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -80,9 +81,9 @@ func (s *ExternalScoreAttachment) SetNodeScores(targetHeuristic string,
 // not known will get a score of 0.
 //
 // NOTE: This is a part of the AttachmentHeuristic interface.
-func (s *ExternalScoreAttachment) NodeScores(g ChannelGraph, chans []LocalChannel,
-	chanSize btcutil.Amount, nodes map[NodeID]struct{}) (
-	map[NodeID]*NodeScore, error) {
+func (s *ExternalScoreAttachment) NodeScores(_ context.Context, g ChannelGraph,
+	chans []LocalChannel, chanSize btcutil.Amount,
+	nodes map[NodeID]struct{}) (map[NodeID]*NodeScore, error) {
 
 	existingPeers := make(map[NodeID]struct{})
 	for _, c := range chans {

--- a/autopilot/externalscoreattach_test.go
+++ b/autopilot/externalscoreattach_test.go
@@ -1,6 +1,7 @@
 package autopilot_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -22,6 +23,7 @@ func randKey() (*btcec.PublicKey, error) {
 // ExternalScoreAttachment correctly reflects the scores we set last.
 func TestSetNodeScores(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	const name = "externalscore"
 
@@ -62,7 +64,7 @@ func TestSetNodeScores(t *testing.T) {
 		q[nID] = struct{}{}
 	}
 	resp, err := h.NodeScores(
-		nil, nil, btcutil.Amount(btcutil.SatoshiPerBitcoin), q,
+		ctx, nil, nil, btcutil.Amount(btcutil.SatoshiPerBitcoin), q,
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/autopilot/interface.go
+++ b/autopilot/interface.go
@@ -1,6 +1,7 @@
 package autopilot
 
 import (
+	"context"
 	"net"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -35,7 +36,8 @@ type Node interface {
 	// iterate through all edges emanating from/to the target node. For
 	// each active channel, this function should be called with the
 	// populated ChannelEdge that describes the active channel.
-	ForEachChannel(func(ChannelEdge) error) error
+	ForEachChannel(context.Context, func(context.Context,
+		ChannelEdge) error) error
 }
 
 // LocalChannel is a simple struct which contains relevant details of a
@@ -83,7 +85,7 @@ type ChannelGraph interface {
 	// ForEachNode is a higher-order function that should be called once
 	// for each connected node within the channel graph. If the passed
 	// callback returns an error, then execution should be terminated.
-	ForEachNode(func(Node) error) error
+	ForEachNode(context.Context, func(context.Context, Node) error) error
 }
 
 // NodeScore is a tuple mapping a NodeID to a score indicating the preference

--- a/autopilot/interface.go
+++ b/autopilot/interface.go
@@ -157,7 +157,7 @@ type NodeMetric interface {
 	Name() string
 
 	// Refresh refreshes the metric values based on the current graph.
-	Refresh(graph ChannelGraph) error
+	Refresh(ctx context.Context, graph ChannelGraph) error
 
 	// GetMetric returns the latest value of this metric. Values in the
 	// map are per node and can be in arbitrary domain. If normalize is

--- a/autopilot/interface.go
+++ b/autopilot/interface.go
@@ -144,7 +144,7 @@ type AttachmentHeuristic interface {
 	//
 	// NOTE: A NodeID not found in the returned map is implicitly given a
 	// score of 0.
-	NodeScores(g ChannelGraph, chans []LocalChannel,
+	NodeScores(ctx context.Context, g ChannelGraph, chans []LocalChannel,
 		chanSize btcutil.Amount, nodes map[NodeID]struct{}) (
 		map[NodeID]*NodeScore, error)
 }

--- a/autopilot/manager.go
+++ b/autopilot/manager.go
@@ -276,8 +276,8 @@ func (m *Manager) StopAgent() error {
 }
 
 // QueryHeuristics queries the available autopilot heuristics for node scores.
-func (m *Manager) QueryHeuristics(nodes []NodeID, localState bool) (
-	HeuristicScores, error) {
+func (m *Manager) QueryHeuristics(ctx context.Context, nodes []NodeID,
+	localState bool) (HeuristicScores, error) {
 
 	m.Lock()
 	defer m.Unlock()
@@ -288,7 +288,8 @@ func (m *Manager) QueryHeuristics(nodes []NodeID, localState bool) (
 	}
 
 	log.Debugf("Querying heuristics for %d nodes", len(n))
-	return m.queryHeuristics(n, localState)
+
+	return m.queryHeuristics(ctx, n, localState)
 }
 
 // HeuristicScores is an alias for a map that maps heuristic names to a map of
@@ -299,8 +300,8 @@ type HeuristicScores map[string]map[NodeID]float64
 // the agent's current active heuristic.
 //
 // NOTE: Must be called with the manager's lock.
-func (m *Manager) queryHeuristics(nodes map[NodeID]struct{}, localState bool) (
-	HeuristicScores, error) {
+func (m *Manager) queryHeuristics(ctx context.Context,
+	nodes map[NodeID]struct{}, localState bool) (HeuristicScores, error) {
 
 	// If we want to take the local state into action when querying the
 	// heuristics, we fetch it. If not we'll just pass an empty slice to
@@ -348,7 +349,7 @@ func (m *Manager) queryHeuristics(nodes map[NodeID]struct{}, localState bool) (
 		}
 
 		s, err := h.NodeScores(
-			m.cfg.PilotCfg.Graph, totalChans, chanSize, nodes,
+			ctx, m.cfg.PilotCfg.Graph, totalChans, chanSize, nodes,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get sub score: %w",

--- a/autopilot/prefattach.go
+++ b/autopilot/prefattach.go
@@ -79,11 +79,9 @@ func (p *PrefAttachment) Name() string {
 // given to nodes already having high connectivity in the graph.
 //
 // NOTE: This is a part of the AttachmentHeuristic interface.
-func (p *PrefAttachment) NodeScores(g ChannelGraph, chans []LocalChannel,
-	chanSize btcutil.Amount, nodes map[NodeID]struct{}) (
-	map[NodeID]*NodeScore, error) {
-
-	ctx := context.TODO()
+func (p *PrefAttachment) NodeScores(ctx context.Context, g ChannelGraph,
+	chans []LocalChannel, chanSize btcutil.Amount,
+	nodes map[NodeID]struct{}) (map[NodeID]*NodeScore, error) {
 
 	// We first run though the graph once in order to find the median
 	// channel size.

--- a/autopilot/prefattach_test.go
+++ b/autopilot/prefattach_test.go
@@ -88,6 +88,8 @@ var chanGraphs = []struct {
 // TestPrefAttachmentSelectEmptyGraph ensures that when passed an
 // empty graph, the NodeSores function always returns a score of 0.
 func TestPrefAttachmentSelectEmptyGraph(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
 	prefAttach := NewPrefAttachment()
 
 	// Create a random public key, which we will query to get a score for.
@@ -108,7 +110,7 @@ func TestPrefAttachmentSelectEmptyGraph(t *testing.T) {
 			// attempt to get the score for this one node.
 			const walletFunds = btcutil.SatoshiPerBitcoin
 			scores, err := prefAttach.NodeScores(
-				graph, nil, walletFunds, nodes,
+				ctx, graph, nil, walletFunds, nodes,
 			)
 			require.NoError(t1, err)
 
@@ -172,7 +174,7 @@ func TestPrefAttachmentSelectTwoVertexes(t *testing.T) {
 			// attempt to get our candidates channel score given
 			// the current state of the graph.
 			candidates, err := prefAttach.NodeScores(
-				graph, nil, maxChanSize, nodes,
+				ctx, graph, nil, maxChanSize, nodes,
 			)
 			require.NoError(t1, err)
 
@@ -280,7 +282,7 @@ func TestPrefAttachmentSelectGreedyAllocation(t *testing.T) {
 			// result, the heuristic should try to greedily
 			// allocate funds to channels.
 			scores, err := prefAttach.NodeScores(
-				graph, nil, maxChanSize, nodes,
+				ctx, graph, nil, maxChanSize, nodes,
 			)
 			require.NoError(t1, err)
 
@@ -298,7 +300,7 @@ func TestPrefAttachmentSelectGreedyAllocation(t *testing.T) {
 			// candidates of that size.
 			const remBalance = btcutil.SatoshiPerBitcoin * 0.5
 			scores, err = prefAttach.NodeScores(
-				graph, nil, remBalance, nodes,
+				ctx, graph, nil, remBalance, nodes,
 			)
 			require.NoError(t1, err)
 
@@ -358,7 +360,7 @@ func TestPrefAttachmentSelectSkipNodes(t *testing.T) {
 			// With our graph created, we'll now get the scores for
 			// all nodes in the graph.
 			scores, err := prefAttach.NodeScores(
-				graph, nil, maxChanSize, nodes,
+				ctx, graph, nil, maxChanSize, nodes,
 			)
 			require.NoError(t1, err)
 
@@ -386,7 +388,7 @@ func TestPrefAttachmentSelectSkipNodes(t *testing.T) {
 			// then all nodes should have a score of zero, since we
 			// already got channels to them.
 			scores, err = prefAttach.NodeScores(
-				graph, chans, maxChanSize, nodes,
+				ctx, graph, chans, maxChanSize, nodes,
 			)
 			require.NoError(t1, err)
 

--- a/autopilot/simple_graph.go
+++ b/autopilot/simple_graph.go
@@ -1,5 +1,7 @@
 package autopilot
 
+import "context"
+
 // diameterCutoff is used to discard nodes in the diameter calculation.
 // It is the multiplier for the eccentricity of the highest-degree node,
 // serving as a cutoff to discard all nodes with a smaller hop distance. This
@@ -20,7 +22,7 @@ type SimpleGraph struct {
 // NewSimpleGraph creates a simplified graph from the current channel graph.
 // Returns an error if the channel graph iteration fails due to underlying
 // failure.
-func NewSimpleGraph(g ChannelGraph) (*SimpleGraph, error) {
+func NewSimpleGraph(ctx context.Context, g ChannelGraph) (*SimpleGraph, error) {
 	nodes := make(map[NodeID]int)
 	adj := make(map[int][]int)
 	nextIndex := 0
@@ -42,17 +44,22 @@ func NewSimpleGraph(g ChannelGraph) (*SimpleGraph, error) {
 		return nodeIndex
 	}
 
-	// Iterate over each node and each channel and update the adj and the node
-	// index.
-	err := g.ForEachNode(func(node Node) error {
+	// Iterate over each node and each channel and update the adj and the
+	// node index.
+	err := g.ForEachNode(ctx, func(ctx context.Context, node Node) error {
 		u := getNodeIndex(node)
 
-		return node.ForEachChannel(func(edge ChannelEdge) error {
-			v := getNodeIndex(edge.Peer)
+		return node.ForEachChannel(
+			ctx, func(_ context.Context,
+				edge ChannelEdge) error {
 
-			adj[u] = append(adj[u], v)
-			return nil
-		})
+				v := getNodeIndex(edge.Peer)
+
+				adj[u] = append(adj[u], v)
+
+				return nil
+			},
+		)
 	})
 	if err != nil {
 		return nil, err

--- a/autopilot/top_centrality.go
+++ b/autopilot/top_centrality.go
@@ -51,11 +51,9 @@ func (g *TopCentrality) Name() string {
 // As our current implementation of betweenness centrality is non-incremental,
 // NodeScores will recalculate the centrality values on every call, which is
 // slow for large graphs.
-func (g *TopCentrality) NodeScores(graph ChannelGraph, chans []LocalChannel,
-	chanSize btcutil.Amount, nodes map[NodeID]struct{}) (
-	map[NodeID]*NodeScore, error) {
-
-	ctx := context.TODO()
+func (g *TopCentrality) NodeScores(ctx context.Context, graph ChannelGraph,
+	chans []LocalChannel, chanSize btcutil.Amount,
+	nodes map[NodeID]struct{}) (map[NodeID]*NodeScore, error) {
 
 	// Calculate betweenness centrality for the whole graph.
 	if err := g.centralityMetric.Refresh(ctx, graph); err != nil {

--- a/autopilot/top_centrality.go
+++ b/autopilot/top_centrality.go
@@ -1,6 +1,7 @@
 package autopilot
 
 import (
+	"context"
 	"runtime"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -54,8 +55,10 @@ func (g *TopCentrality) NodeScores(graph ChannelGraph, chans []LocalChannel,
 	chanSize btcutil.Amount, nodes map[NodeID]struct{}) (
 	map[NodeID]*NodeScore, error) {
 
+	ctx := context.TODO()
+
 	// Calculate betweenness centrality for the whole graph.
-	if err := g.centralityMetric.Refresh(graph); err != nil {
+	if err := g.centralityMetric.Refresh(ctx, graph); err != nil {
 		return nil, err
 	}
 

--- a/autopilot/top_centrality_test.go
+++ b/autopilot/top_centrality_test.go
@@ -1,6 +1,7 @@
 package autopilot
 
 import (
+	"context"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -58,7 +59,7 @@ func testTopCentrality(t *testing.T, graph testGraph,
 		// Attempt to get centrality scores and expect
 		// that the result equals with the expected set.
 		scores, err := topCentrality.NodeScores(
-			graph, channels, chanSize, nodes,
+			context.Background(), graph, channels, chanSize, nodes,
 		)
 
 		require.NoError(t, err)

--- a/discovery/bootstrapper.go
+++ b/discovery/bootstrapper.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"errors"
@@ -155,6 +156,8 @@ func NewGraphBootstrapper(cg autopilot.ChannelGraph) (NetworkPeerBootstrapper, e
 func (c *ChannelGraphBootstrapper) SampleNodeAddrs(numAddrs uint32,
 	ignore map[autopilot.NodeID]struct{}) ([]*lnwire.NetAddress, error) {
 
+	ctx := context.TODO()
+
 	// We'll merge the ignore map with our currently selected map in order
 	// to ensure we don't return any duplicate nodes.
 	for n := range ignore {
@@ -177,7 +180,9 @@ func (c *ChannelGraphBootstrapper) SampleNodeAddrs(numAddrs uint32,
 			errFound = fmt.Errorf("found node")
 		)
 
-		err := c.chanGraph.ForEachNode(func(node autopilot.Node) error {
+		err := c.chanGraph.ForEachNode(ctx, func(_ context.Context,
+			node autopilot.Node) error {
+
 			nID := autopilot.NodeID(node.PubKey())
 			if _, ok := c.tried[nID]; ok {
 				return nil

--- a/lnd.go
+++ b/lnd.go
@@ -788,7 +788,7 @@ func Main(cfg *Config, lisCfg ListenerCfg, implCfg *ImplementationCfg,
 	// active, then we'll start the autopilot agent immediately. It will be
 	// stopped together with the autopilot service.
 	if cfg.Autopilot.Active {
-		if err := atplManager.StartAgent(); err != nil {
+		if err := atplManager.StartAgent(ctx); err != nil {
 			return mkErr("unable to start autopilot agent", err)
 		}
 	}

--- a/lnrpc/autopilotrpc/autopilot_server.go
+++ b/lnrpc/autopilotrpc/autopilot_server.go
@@ -205,7 +205,7 @@ func (s *Server) ModifyStatus(ctx context.Context,
 
 	var err error
 	if in.Enable {
-		err = s.manager.StartAgent()
+		err = s.manager.StartAgent(ctx)
 	} else {
 		err = s.manager.StopAgent()
 	}

--- a/lnrpc/autopilotrpc/autopilot_server.go
+++ b/lnrpc/autopilotrpc/autopilot_server.go
@@ -236,7 +236,7 @@ func (s *Server) QueryScores(ctx context.Context, in *QueryScoresRequest) (
 
 	// Query the heuristics.
 	heuristicScores, err := s.manager.QueryHeuristics(
-		nodes, !in.IgnoreLocalState,
+		ctx, nodes, !in.IgnoreLocalState,
 	)
 	if err != nil {
 		return nil, err

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -6857,7 +6857,7 @@ func (r *rpcServer) GetNodeMetrics(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	if err := centralityMetric.Refresh(channelGraph); err != nil {
+	if err := centralityMetric.Refresh(ctx, channelGraph); err != nil {
 		return nil, err
 	}
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -7140,7 +7140,7 @@ func (r *rpcServer) GetNetworkInfo(ctx context.Context,
 
 	// Graph diameter.
 	channelGraph := autopilot.ChannelGraphFromCachedDatabase(graph)
-	simpleGraph, err := autopilot.NewSimpleGraph(channelGraph)
+	simpleGraph, err := autopilot.NewSimpleGraph(ctx, channelGraph)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### PR context

This is part of the last step required to complete https://github.com/lightningnetwork/lnd/issues/9494. We want all calls to the graph DB (and hence, ChannelGraph) to take a context since later, this context will be passed through to any remote graph RPC calls as well as any DB calls to a SQL graph backend. 

### This PR specifically:

In this PR, we tackle the `autopilot` package. This package has a `GraphSource` interface which redirects to the graph DB. So later on, all methods in this interface will take a context. In preparation for this, we update the autopilot server to thread contexts through accordingly. 

### Branch strategy:

This series of PRs is basically a big code refactor. So once 19 is shipped, we can merge any work that has been merged into `elle-graph` and from then on we can just merge into master. 