### PR TITLE
htlcswitch+peer [1/2]: thread context through in preparation for passing to graph DB calls

### DIFF
--- a/htlcswitch/interceptable_switch.go
+++ b/htlcswitch/interceptable_switch.go
@@ -1,6 +1,7 @@
 package htlcswitch
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"sync"
@@ -748,6 +749,8 @@ func (f *interceptedForward) Fail(reason []byte) error {
 // FailWithCode notifies the intention to fail an existing hold forward with the
 // specified failure code.
 func (f *interceptedForward) FailWithCode(code lnwire.FailCode) error {
+	ctx := context.TODO()
+
 	shaOnionBlob := func() [32]byte {
 		return sha256.Sum256(f.htlc.OnionBlob[:])
 	}
@@ -779,7 +782,7 @@ func (f *interceptedForward) FailWithCode(code lnwire.FailCode) error {
 			// Fallback to the original, non-alias behavior.
 			var err error
 			update, err = f.htlcSwitch.cfg.FetchLastChannelUpdate(
-				f.packet.incomingChanID,
+				ctx, f.packet.incomingChanID,
 			)
 			if err != nil {
 				return err
@@ -790,7 +793,7 @@ func (f *interceptedForward) FailWithCode(code lnwire.FailCode) error {
 
 	case lnwire.CodeExpiryTooSoon:
 		update, err := f.htlcSwitch.cfg.FetchLastChannelUpdate(
-			f.packet.incomingChanID,
+			ctx, f.packet.incomingChanID,
 		)
 		if err != nil {
 			return err

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -85,7 +85,7 @@ type dustHandler interface {
 type scidAliasHandler interface {
 	// attachFailAliasUpdate allows the link to properly fail incoming
 	// HTLCs on option_scid_alias channels.
-	attachFailAliasUpdate(failClosure func(
+	attachFailAliasUpdate(failClosure func(ctx context.Context,
 		sid lnwire.ShortChannelID,
 		incoming bool) *lnwire.ChannelUpdate1)
 

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -281,7 +281,8 @@ type ChannelLink interface {
 	// a LinkError with a valid protocol failure message should be returned
 	// in order to signal to the source of the HTLC, the policy consistency
 	// issue.
-	CheckHtlcForward(payHash [32]byte, incomingAmt lnwire.MilliSatoshi,
+	CheckHtlcForward(ctx context.Context, payHash [32]byte,
+		incomingAmt lnwire.MilliSatoshi,
 		amtToForward lnwire.MilliSatoshi, incomingTimeout,
 		outgoingTimeout uint32, inboundFee models.InboundFee,
 		heightNow uint32, scid lnwire.ShortChannelID,

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -452,7 +452,7 @@ type InterceptedForward interface {
 
 	// FailWithCode notifies the intention to fail an existing hold forward
 	// with the specified failure code.
-	FailWithCode(code lnwire.FailCode) error
+	FailWithCode(ctx context.Context, code lnwire.FailCode) error
 }
 
 // htlcNotifier is an interface which represents the input side of the

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -293,8 +293,8 @@ type ChannelLink interface {
 	// valid protocol failure message should be returned in order to signal
 	// the violation. This call is intended to be used for locally initiated
 	// payments for which there is no corresponding incoming htlc.
-	CheckHtlcTransit(payHash [32]byte, amt lnwire.MilliSatoshi,
-		timeout uint32, heightNow uint32,
+	CheckHtlcTransit(ctx context.Context, payHash [32]byte,
+		amt lnwire.MilliSatoshi, timeout uint32, heightNow uint32,
 		customRecords lnwire.CustomRecords) *LinkError
 
 	// Stats return the statistics of channel link. Number of updates,

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -263,7 +263,7 @@ type ChannelLinkConfig struct {
 
 	// FailAliasUpdate is a function used to fail an HTLC for an
 	// option_scid_alias channel.
-	FailAliasUpdate func(sid lnwire.ShortChannelID,
+	FailAliasUpdate func(ctx context.Context, sid lnwire.ShortChannelID,
 		incoming bool) *lnwire.ChannelUpdate1
 
 	// GetAliases is used by the link and switch to fetch the set of
@@ -872,7 +872,7 @@ func (l *channelLink) createFailureWithUpdate(ctx context.Context,
 
 	// Try using the FailAliasUpdate function. If it returns nil, fallback
 	// to the non-alias behavior.
-	update := l.cfg.FailAliasUpdate(scid, incoming)
+	update := l.cfg.FailAliasUpdate(ctx, scid, incoming)
 	if update == nil {
 		// Fallback to the non-alias behavior.
 		var err error
@@ -3210,7 +3210,7 @@ func (l *channelLink) getAliases() []lnwire.ShortChannelID {
 // attachFailAliasUpdate sets the link's FailAliasUpdate function.
 //
 // Part of the scidAliasHandler interface.
-func (l *channelLink) attachFailAliasUpdate(closure func(
+func (l *channelLink) attachFailAliasUpdate(closure func(ctx context.Context,
 	sid lnwire.ShortChannelID, incoming bool) *lnwire.ChannelUpdate1) {
 
 	l.Lock()

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -3354,11 +3354,9 @@ func (l *channelLink) CheckHtlcForward(ctx context.Context, payHash [32]byte,
 // valid protocol failure message should be returned in order to signal
 // the violation. This call is intended to be used for locally initiated
 // payments for which there is no corresponding incoming htlc.
-func (l *channelLink) CheckHtlcTransit(payHash [32]byte,
+func (l *channelLink) CheckHtlcTransit(ctx context.Context, payHash [32]byte,
 	amt lnwire.MilliSatoshi, timeout uint32, heightNow uint32,
 	customRecords lnwire.CustomRecords) *LinkError {
-
-	ctx := context.TODO()
 
 	l.RLock()
 	policy := l.cfg.FwrdingPolicy

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -3260,13 +3260,11 @@ func (l *channelLink) UpdateForwardingPolicy(
 // issue.
 //
 // NOTE: Part of the ChannelLink interface.
-func (l *channelLink) CheckHtlcForward(payHash [32]byte, incomingHtlcAmt,
-	amtToForward lnwire.MilliSatoshi, incomingTimeout,
+func (l *channelLink) CheckHtlcForward(ctx context.Context, payHash [32]byte,
+	incomingHtlcAmt, amtToForward lnwire.MilliSatoshi, incomingTimeout,
 	outgoingTimeout uint32, inboundFee models.InboundFee,
 	heightNow uint32, originalScid lnwire.ShortChannelID,
 	customRecords lnwire.CustomRecords) *LinkError {
-
-	ctx := context.TODO()
 
 	l.RLock()
 	policy := l.cfg.FwrdingPolicy

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -121,8 +121,8 @@ type ChannelLinkConfig struct {
 	// specified when we receive an incoming HTLC.  This will be used to
 	// provide payment senders our latest policy when sending encrypted
 	// error messages.
-	FetchLastChannelUpdate func(lnwire.ShortChannelID) (
-		*lnwire.ChannelUpdate1, error)
+	FetchLastChannelUpdate func(context.Context,
+		lnwire.ShortChannelID) (*lnwire.ChannelUpdate1, error)
 
 	// Peer is a lightning network node with which we have the channel link
 	// opened.
@@ -862,6 +862,8 @@ type failCb func(update *lnwire.ChannelUpdate1) lnwire.FailureMessage
 func (l *channelLink) createFailureWithUpdate(incoming bool,
 	outgoingScid lnwire.ShortChannelID, cb failCb) lnwire.FailureMessage {
 
+	ctx := context.TODO()
+
 	// Determine which SCID to use in case we need to use aliases in the
 	// ChannelUpdate.
 	scid := outgoingScid
@@ -875,7 +877,7 @@ func (l *channelLink) createFailureWithUpdate(incoming bool,
 	if update == nil {
 		// Fallback to the non-alias behavior.
 		var err error
-		update, err = l.cfg.FetchLastChannelUpdate(l.ShortChanID())
+		update, err = l.cfg.FetchLastChannelUpdate(ctx, l.ShortChanID())
 		if err != nil {
 			return &lnwire.FailTemporaryNodeFailure{}
 		}

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1695,7 +1695,7 @@ func (l *channelLink) handleDownstreamUpdateAdd(ctx context.Context,
 	// already sent Stfu, then we can't add new htlcs to the link and we
 	// need to bounce it.
 	if l.IsFlushing(Outgoing) || !l.quiescer.CanSendUpdates() {
-		l.mailBox.FailAdd(pkt)
+		l.mailBox.FailAdd(ctx, pkt)
 
 		return NewDetailedLinkError(
 			&lnwire.FailTemporaryChannelFailure{},
@@ -1718,7 +1718,7 @@ func (l *channelLink) handleDownstreamUpdateAdd(ctx context.Context,
 		l.log.Debugf("Unable to handle downstream HTLC - max fee " +
 			"exposure exceeded")
 
-		l.mailBox.FailAdd(pkt)
+		l.mailBox.FailAdd(ctx, pkt)
 
 		return NewDetailedLinkError(
 			lnwire.NewTemporaryChannelFailure(nil),
@@ -1752,7 +1752,7 @@ func (l *channelLink) handleDownstreamUpdateAdd(ctx context.Context,
 		// the switch, since the circuit was never fully opened,
 		// and the forwarding package shows it as
 		// unacknowledged.
-		l.mailBox.FailAdd(pkt)
+		l.mailBox.FailAdd(ctx, pkt)
 
 		return NewDetailedLinkError(
 			lnwire.NewTemporaryChannelFailure(nil),

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -6206,8 +6206,8 @@ func TestForwardingAsymmetricTimeLockPolicies(t *testing.T) {
 // TestCheckHtlcForward tests that a link is properly enforcing the HTLC
 // forwarding policy.
 func TestCheckHtlcForward(t *testing.T) {
-	fetchLastChannelUpdate := func(lnwire.ShortChannelID) (
-		*lnwire.ChannelUpdate1, error) {
+	fetchLastChannelUpdate := func(context.Context,
+		lnwire.ShortChannelID) (*lnwire.ChannelUpdate1, error) {
 
 		return &lnwire.ChannelUpdate1{}, nil
 	}

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -2200,7 +2200,9 @@ func newSingleLinkTestHarness(t *testing.T, chanAmt,
 	forwardPackets := func(linkQuit <-chan struct{}, _ bool,
 		packets ...*htlcPacket) error {
 
-		return aliceSwitch.ForwardPackets(linkQuit, packets...)
+		return aliceSwitch.ForwardPackets(
+			context.Background(), linkQuit, packets...,
+		)
 	}
 
 	// Instantiate with a long interval, so that we can precisely control
@@ -4882,7 +4884,9 @@ func (h *persistentLinkHarness) restartLink(
 	forwardPackets := func(linkQuit <-chan struct{}, _ bool,
 		packets ...*htlcPacket) error {
 
-		return h.hSwitch.ForwardPackets(linkQuit, packets...)
+		return h.hSwitch.ForwardPackets(
+			context.Background(), linkQuit, packets...,
+		)
 	}
 
 	// Instantiate with a long interval, so that we can precisely control
@@ -6212,7 +6216,7 @@ func TestCheckHtlcForward(t *testing.T) {
 		return &lnwire.ChannelUpdate1{}, nil
 	}
 
-	failAliasUpdate := func(sid lnwire.ShortChannelID,
+	failAliasUpdate := func(_ context.Context, sid lnwire.ShortChannelID,
 		incoming bool) *lnwire.ChannelUpdate1 {
 
 		return nil

--- a/htlcswitch/mailbox.go
+++ b/htlcswitch/mailbox.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/lightningnetwork/lnd/clock"
+	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -53,7 +54,7 @@ type MailBox interface {
 	// packet from being delivered after the link restarts if the switch has
 	// remained online. The generated LinkError will show an
 	// OutgoingFailureDownstreamHtlcAdd FailureDetail.
-	FailAdd(pkt *htlcPacket)
+	FailAdd(ctx context.Context, pkt *htlcPacket)
 
 	// MessageOutBox returns a channel that any new messages ready for
 	// delivery will be sent on.
@@ -149,6 +150,7 @@ type memoryMailBox struct {
 	wireShutdown chan struct{}
 	pktShutdown  chan struct{}
 	quit         chan struct{}
+	cancel       fn.Option[context.CancelFunc]
 
 	// feeRate is set when the link receives or sends out fee updates. It
 	// is refreshed when AttachMailBox is called in case a fee update did
@@ -207,8 +209,11 @@ const (
 // NOTE: This method is part of the MailBox interface.
 func (m *memoryMailBox) Start() {
 	m.started.Do(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		m.cancel = fn.Some(cancel)
+
 		go m.wireMailCourier()
-		go m.pktMailCourier()
+		go m.pktMailCourier(ctx)
 	})
 }
 
@@ -324,6 +329,7 @@ func (m *memoryMailBox) HasPacket(inKey CircuitKey) bool {
 // NOTE: This method is part of the MailBox interface.
 func (m *memoryMailBox) Stop() {
 	m.stopped.Do(func() {
+		m.cancel.WhenSome(func(fn context.CancelFunc) { fn() })
 		close(m.quit)
 
 		m.signalUntilShutdown(wireCourier)
@@ -424,7 +430,7 @@ func (m *memoryMailBox) wireMailCourier() {
 
 // pktMailCourier is a dedicated goroutine whose job is to reliably deliver
 // packet messages.
-func (m *memoryMailBox) pktMailCourier() {
+func (m *memoryMailBox) pktMailCourier(ctx context.Context) {
 	defer close(m.pktShutdown)
 
 	for {
@@ -445,6 +451,10 @@ func (m *memoryMailBox) pktMailCourier() {
 				close(pktDone)
 
 			case <-m.quit:
+				m.pktCond.L.Unlock()
+				return
+
+			case <-ctx.Done():
 				m.pktCond.L.Unlock()
 				return
 			default:
@@ -541,7 +551,7 @@ func (m *memoryMailBox) pktMailCourier() {
 		case <-deadline:
 			log.Debugf("Expiring add htlc with "+
 				"keystone=%v", add.keystone())
-			m.FailAdd(add)
+			m.FailAdd(ctx, add)
 
 		case pktDone := <-m.pktReset:
 			m.pktCond.L.Lock()
@@ -552,6 +562,9 @@ func (m *memoryMailBox) pktMailCourier() {
 			close(pktDone)
 
 		case <-m.quit:
+			return
+
+		case <-ctx.Done():
 			return
 		}
 	}
@@ -688,9 +701,7 @@ func (m *memoryMailBox) DustPackets() (lnwire.MilliSatoshi,
 // delivered after the link restarts if the switch has remained online. The
 // generated LinkError will show an OutgoingFailureDownstreamHtlcAdd
 // FailureDetail.
-func (m *memoryMailBox) FailAdd(pkt *htlcPacket) {
-	ctx := context.TODO()
-
+func (m *memoryMailBox) FailAdd(ctx context.Context, pkt *htlcPacket) {
 	// First, remove the packet from mailbox. If we didn't find the packet
 	// because it has already been acked, we'll exit early to avoid sending
 	// a duplicate fail message through the switch.

--- a/htlcswitch/mailbox.go
+++ b/htlcswitch/mailbox.go
@@ -109,7 +109,7 @@ type mailBoxConfig struct {
 
 	// failMailboxUpdate is used to fail an expired HTLC and use the
 	// correct SCID if the underlying channel uses aliases.
-	failMailboxUpdate func(outScid,
+	failMailboxUpdate func(ctx context.Context, outScid,
 		mailboxScid lnwire.ShortChannelID) lnwire.FailureMessage
 }
 
@@ -707,7 +707,7 @@ func (m *memoryMailBox) FailAdd(pkt *htlcPacket) {
 	// peer if this is a forward, or report to the user if the failed
 	// payment was locally initiated.
 	failure := m.cfg.failMailboxUpdate(
-		pkt.originalOutgoingChanID, m.cfg.shortChanID,
+		ctx, pkt.originalOutgoingChanID, m.cfg.shortChanID,
 	)
 
 	// If the payment was locally initiated (which is indicated by a nil
@@ -821,7 +821,7 @@ type mailOrchConfig struct {
 
 	// failMailboxUpdate is used to fail an expired HTLC and use the
 	// correct SCID if the underlying channel uses aliases.
-	failMailboxUpdate func(outScid,
+	failMailboxUpdate func(ctx context.Context, outScid,
 		mailboxScid lnwire.ShortChannelID) lnwire.FailureMessage
 }
 

--- a/htlcswitch/mailbox_test.go
+++ b/htlcswitch/mailbox_test.go
@@ -207,7 +207,7 @@ func newMailboxContextWithClock(t *testing.T,
 		forwards: make(chan *htlcPacket, 1),
 	}
 
-	failMailboxUpdate := func(outScid,
+	failMailboxUpdate := func(_ context.Context, outScid,
 		mboxScid lnwire.ShortChannelID) lnwire.FailureMessage {
 
 		return &lnwire.FailTemporaryNodeFailure{}
@@ -233,7 +233,7 @@ func newMailboxContext(t *testing.T, startTime time.Time,
 		forwards: make(chan *htlcPacket, 1),
 	}
 
-	failMailboxUpdate := func(outScid,
+	failMailboxUpdate := func(_ context.Context, outScid,
 		mboxScid lnwire.ShortChannelID) lnwire.FailureMessage {
 
 		return &lnwire.FailTemporaryNodeFailure{}
@@ -698,7 +698,7 @@ func testMailBoxDust(t *testing.T, chantype channeldb.ChannelType) {
 func TestMailOrchestrator(t *testing.T) {
 	t.Parallel()
 
-	failMailboxUpdate := func(outScid,
+	failMailboxUpdate := func(_ context.Context, outScid,
 		mboxScid lnwire.ShortChannelID) lnwire.FailureMessage {
 
 		return &lnwire.FailTemporaryNodeFailure{}

--- a/htlcswitch/mailbox_test.go
+++ b/htlcswitch/mailbox_test.go
@@ -334,6 +334,8 @@ func (c *mailboxContext) checkFails(adds []*htlcPacket) {
 // TestMailBoxFailAdd asserts that FailAdd returns a response to the switch
 // under various interleavings with other operations on the mailbox.
 func TestMailBoxFailAdd(t *testing.T) {
+	t.Parallel()
+
 	var (
 		batchDelay       = time.Second
 		expiry           = time.Minute
@@ -346,7 +348,7 @@ func TestMailBoxFailAdd(t *testing.T) {
 
 	failAdds := func(adds []*htlcPacket) {
 		for _, add := range adds {
-			ctx.mailbox.FailAdd(add)
+			ctx.mailbox.FailAdd(context.Background(), add)
 		}
 	}
 

--- a/htlcswitch/mailbox_test.go
+++ b/htlcswitch/mailbox_test.go
@@ -1,6 +1,7 @@
 package htlcswitch
 
 import (
+	"context"
 	prand "math/rand"
 	"reflect"
 	"testing"
@@ -250,7 +251,7 @@ func newMailboxContext(t *testing.T, startTime time.Time,
 	return ctx
 }
 
-func (c *mailboxContext) forward(_ <-chan struct{},
+func (c *mailboxContext) forward(_ context.Context, _ <-chan struct{},
 	pkts ...*htlcPacket) error {
 
 	for _, pkt := range pkts {
@@ -706,7 +707,7 @@ func TestMailOrchestrator(t *testing.T) {
 	// First, we'll create a new instance of our orchestrator.
 	mo := newMailOrchestrator(&mailOrchConfig{
 		failMailboxUpdate: failMailboxUpdate,
-		forwardPackets: func(_ <-chan struct{},
+		forwardPackets: func(_ context.Context, _ <-chan struct{},
 			pkts ...*htlcPacket) error {
 
 			return nil

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -845,9 +845,10 @@ func (f *mockChannelLink) HandleChannelUpdate(lnwire.Message) {
 
 func (f *mockChannelLink) UpdateForwardingPolicy(_ models.ForwardingPolicy) {
 }
-func (f *mockChannelLink) CheckHtlcForward([32]byte, lnwire.MilliSatoshi,
-	lnwire.MilliSatoshi, uint32, uint32, models.InboundFee, uint32,
-	lnwire.ShortChannelID, lnwire.CustomRecords) *LinkError {
+func (f *mockChannelLink) CheckHtlcForward(context.Context, [32]byte,
+	lnwire.MilliSatoshi, lnwire.MilliSatoshi, uint32, uint32,
+	models.InboundFee, uint32, lnwire.ShortChannelID,
+	lnwire.CustomRecords) *LinkError {
 
 	return f.checkHtlcForwardResult
 }

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -736,7 +736,7 @@ type mockChannelLink struct {
 
 	checkHtlcForwardResult *LinkError
 
-	failAliasUpdate func(sid lnwire.ShortChannelID,
+	failAliasUpdate func(ctx context.Context, sid lnwire.ShortChannelID,
 		incoming bool) *lnwire.ChannelUpdate1
 
 	confirmedZC bool
@@ -871,7 +871,7 @@ func (f *mockChannelLink) AttachMailBox(mailBox MailBox) {
 	mailBox.SetDustClosure(f.getDustClosure())
 }
 
-func (f *mockChannelLink) attachFailAliasUpdate(closure func(
+func (f *mockChannelLink) attachFailAliasUpdate(closure func(_ context.Context,
 	sid lnwire.ShortChannelID, incoming bool) *lnwire.ChannelUpdate1) {
 
 	f.failAliasUpdate = closure

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -183,8 +183,9 @@ func initSwitchWithDB(startingHeight uint32, db *channeldb.DB) (*Switch, error) 
 		FwdingLog: &mockForwardingLog{
 			events: make(map[time.Time]channeldb.ForwardingEvent),
 		},
-		FetchLastChannelUpdate: func(scid lnwire.ShortChannelID) (
-			*lnwire.ChannelUpdate1, error) {
+		FetchLastChannelUpdate: func(_ context.Context,
+			scid lnwire.ShortChannelID) (*lnwire.ChannelUpdate1,
+			error) {
 
 			return &lnwire.ChannelUpdate1{
 				ShortChannelID: scid,

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -853,7 +853,7 @@ func (f *mockChannelLink) CheckHtlcForward(context.Context, [32]byte,
 	return f.checkHtlcForwardResult
 }
 
-func (f *mockChannelLink) CheckHtlcTransit(payHash [32]byte,
+func (f *mockChannelLink) CheckHtlcTransit(_ context.Context, payHash [32]byte,
 	amt lnwire.MilliSatoshi, timeout uint32,
 	heightNow uint32, _ lnwire.CustomRecords) *LinkError {
 

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -2644,10 +2644,8 @@ func (s *Switch) dustExceedsFeeThreshold(link ChannelLink,
 // used in the onion. The mailboxScid is the SCID that the mailbox and link
 // use. The mailboxScid is only used in the non-alias case, so it is always
 // the confirmed SCID.
-func (s *Switch) failMailboxUpdate(outgoingScid,
+func (s *Switch) failMailboxUpdate(ctx context.Context, outgoingScid,
 	mailboxScid lnwire.ShortChannelID) lnwire.FailureMessage {
-
-	ctx := context.TODO()
 
 	// Try to use the failAliasUpdate function in case this is a channel
 	// that uses aliases. If it returns nil, we'll fallback to the original

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -549,6 +549,8 @@ func (s *Switch) CleanStore(keepPids map[uint64]struct{}) error {
 func (s *Switch) SendHTLC(firstHop lnwire.ShortChannelID, attemptID uint64,
 	htlc *lnwire.UpdateAddHTLC) error {
 
+	ctx := context.TODO()
+
 	// Generate and send new update packet, if error will be received on
 	// this stage it means that packet haven't left boundaries of our
 	// system and something wrong happened.
@@ -563,7 +565,7 @@ func (s *Switch) SendHTLC(firstHop lnwire.ShortChannelID, attemptID uint64,
 	// Attempt to fetch the target link before creating a circuit so that
 	// we don't leave dangling circuits. The getLocalLink method does not
 	// require the circuit variable to be set on the *htlcPacket.
-	link, linkErr := s.getLocalLink(packet, htlc)
+	link, linkErr := s.getLocalLink(ctx, packet, htlc)
 	if linkErr != nil {
 		// Notify the htlc notifier of a link failure on our outgoing
 		// link. Incoming timelock/amount values are not set because
@@ -877,8 +879,8 @@ func (s *Switch) routeAsync(packet *htlcPacket, errChan chan error,
 // getLocalLink handles the addition of a htlc for a send that originates from
 // our node. It returns the link that the htlc should be forwarded outwards on,
 // and a link error if the htlc cannot be forwarded.
-func (s *Switch) getLocalLink(pkt *htlcPacket, htlc *lnwire.UpdateAddHTLC) (
-	ChannelLink, *LinkError) {
+func (s *Switch) getLocalLink(ctx context.Context, pkt *htlcPacket,
+	htlc *lnwire.UpdateAddHTLC) (ChannelLink, *LinkError) {
 
 	// Try to find links by node destination.
 	s.indexMtx.RLock()
@@ -923,7 +925,7 @@ func (s *Switch) getLocalLink(pkt *htlcPacket, htlc *lnwire.UpdateAddHTLC) (
 	// Ensure that the htlc satisfies the outgoing channel policy.
 	currentHeight := atomic.LoadUint32(&s.bestHeight)
 	htlcErr := link.CheckHtlcTransit(
-		htlc.PaymentHash, htlc.Amount, htlc.Expiry, currentHeight,
+		ctx, htlc.PaymentHash, htlc.Amount, htlc.Expiry, currentHeight,
 		htlc.CustomRecords,
 	)
 	if htlcErr != nil {

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -134,6 +134,7 @@ func TestSwitchHasActiveLink(t *testing.T) {
 // over pending links.
 func TestSwitchSendPending(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	alicePeer, err := newMockServer(
 		t, "alice", testStartingHeight, nil, testDefaultDelta,
@@ -190,7 +191,7 @@ func TestSwitchSendPending(t *testing.T) {
 
 	// Send the ADD packet, this should not be forwarded out to the link
 	// since there are no eligible links.
-	if err = s.ForwardPackets(nil, packet); err != nil {
+	if err = s.ForwardPackets(ctx, nil, packet); err != nil {
 		t.Fatal(err)
 	}
 	select {
@@ -459,6 +460,8 @@ func testSwitchForwardMapping(t *testing.T, alicePrivate, aliceZeroConf,
 	useAlias, optionScid bool, aliceAlias, aliceReal lnwire.ShortChannelID,
 	expectErr bool) {
 
+	ctx := context.Background()
+
 	alicePeer, err := newMockServer(
 		t, "alice", testStartingHeight, nil, testDefaultDelta,
 	)
@@ -535,7 +538,7 @@ func testSwitchForwardMapping(t *testing.T, alicePrivate, aliceZeroConf,
 			Amount:      1,
 		},
 	}
-	err = s.ForwardPackets(nil, packet)
+	err = s.ForwardPackets(ctx, nil, packet)
 	require.NoError(t, err)
 
 	// If we expect a forwarding error, then assert that we receive one.
@@ -873,6 +876,7 @@ func TestSwitchUpdateScid(t *testing.T) {
 // requests.
 func TestSwitchForward(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	alicePeer, err := newMockServer(
 		t, "alice", testStartingHeight, nil, testDefaultDelta,
@@ -932,7 +936,7 @@ func TestSwitchForward(t *testing.T) {
 	}
 
 	// Handle the request and checks that bob channel link received it.
-	if err := s.ForwardPackets(nil, packet); err != nil {
+	if err := s.ForwardPackets(ctx, nil, packet); err != nil {
 		t.Fatal(err)
 	}
 
@@ -966,7 +970,7 @@ func TestSwitchForward(t *testing.T) {
 	}
 
 	// Handle the request and checks that payment circuit works properly.
-	if err := s.ForwardPackets(nil, packet); err != nil {
+	if err := s.ForwardPackets(ctx, nil, packet); err != nil {
 		t.Fatal(err)
 	}
 
@@ -986,6 +990,7 @@ func TestSwitchForward(t *testing.T) {
 
 func TestSwitchForwardFailAfterFullAdd(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	chanID1, chanID2, aliceChanID, bobChanID := genIDs()
 
@@ -1053,7 +1058,7 @@ func TestSwitchForwardFailAfterFullAdd(t *testing.T) {
 	}
 
 	// Handle the request and checks that bob channel link received it.
-	if err := s.ForwardPackets(nil, ogPacket); err != nil {
+	if err := s.ForwardPackets(ctx, nil, ogPacket); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1138,7 +1143,7 @@ func TestSwitchForwardFailAfterFullAdd(t *testing.T) {
 	}
 
 	// Send the fail packet from the remote peer through the switch.
-	if err := s2.ForwardPackets(nil, fail); err != nil {
+	if err := s2.ForwardPackets(ctx, nil, fail); err != nil {
 		t.Fatalf(err.Error())
 	}
 
@@ -1162,7 +1167,7 @@ func TestSwitchForwardFailAfterFullAdd(t *testing.T) {
 	}
 
 	// Send the fail packet from the remote peer through the switch.
-	if err := s.ForwardPackets(nil, fail); err != nil {
+	if err := s.ForwardPackets(ctx, nil, fail); err != nil {
 		t.Fatal(err)
 	}
 	select {
@@ -1174,6 +1179,7 @@ func TestSwitchForwardFailAfterFullAdd(t *testing.T) {
 
 func TestSwitchForwardSettleAfterFullAdd(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	chanID1, chanID2, aliceChanID, bobChanID := genIDs()
 
@@ -1239,7 +1245,7 @@ func TestSwitchForwardSettleAfterFullAdd(t *testing.T) {
 	}
 
 	// Handle the request and checks that bob channel link received it.
-	if err := s.ForwardPackets(nil, ogPacket); err != nil {
+	if err := s.ForwardPackets(ctx, nil, ogPacket); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1326,7 +1332,7 @@ func TestSwitchForwardSettleAfterFullAdd(t *testing.T) {
 	}
 
 	// Send the settle packet from the remote peer through the switch.
-	if err := s2.ForwardPackets(nil, settle); err != nil {
+	if err := s2.ForwardPackets(ctx, nil, settle); err != nil {
 		t.Fatalf(err.Error())
 	}
 
@@ -1351,7 +1357,7 @@ func TestSwitchForwardSettleAfterFullAdd(t *testing.T) {
 	}
 
 	// Send the settle packet again, which not arrive at destination.
-	if err := s2.ForwardPackets(nil, settle); err != nil {
+	if err := s2.ForwardPackets(ctx, nil, settle); err != nil {
 		t.Fatal(err)
 	}
 	select {
@@ -1363,6 +1369,7 @@ func TestSwitchForwardSettleAfterFullAdd(t *testing.T) {
 
 func TestSwitchForwardDropAfterFullAdd(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	chanID1, chanID2, aliceChanID, bobChanID := genIDs()
 
@@ -1428,7 +1435,7 @@ func TestSwitchForwardDropAfterFullAdd(t *testing.T) {
 	}
 
 	// Handle the request and checks that bob channel link received it.
-	if err := s.ForwardPackets(nil, ogPacket); err != nil {
+	if err := s.ForwardPackets(ctx, nil, ogPacket); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1498,7 +1505,7 @@ func TestSwitchForwardDropAfterFullAdd(t *testing.T) {
 
 	// Resend the failed htlc. The packet will be dropped silently since the
 	// switch will detect that it has been half added previously.
-	if err := s2.ForwardPackets(nil, ogPacket); err != nil {
+	if err := s2.ForwardPackets(ctx, nil, ogPacket); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1515,6 +1522,7 @@ func TestSwitchForwardDropAfterFullAdd(t *testing.T) {
 
 func TestSwitchForwardFailAfterHalfAdd(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	chanID1, chanID2, aliceChanID, bobChanID := genIDs()
 
@@ -1580,7 +1588,7 @@ func TestSwitchForwardFailAfterHalfAdd(t *testing.T) {
 	}
 
 	// Handle the request and checks that bob channel link received it.
-	if err := s.ForwardPackets(nil, ogPacket); err != nil {
+	if err := s.ForwardPackets(ctx, nil, ogPacket); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1645,7 +1653,7 @@ func TestSwitchForwardFailAfterHalfAdd(t *testing.T) {
 
 	// Resend the failed htlc, it should be returned to alice since the
 	// switch will detect that it has been half added previously.
-	err = s2.ForwardPackets(nil, ogPacket)
+	err = s2.ForwardPackets(ctx, nil, ogPacket)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1668,6 +1676,7 @@ func TestSwitchForwardFailAfterHalfAdd(t *testing.T) {
 // maintain the proper entries in the circuit map in the face of restarts.
 func TestSwitchForwardCircuitPersistence(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	chanID1, chanID2, aliceChanID, bobChanID := genIDs()
 
@@ -1733,7 +1742,7 @@ func TestSwitchForwardCircuitPersistence(t *testing.T) {
 	}
 
 	// Handle the request and checks that bob channel link received it.
-	if err := s.ForwardPackets(nil, ogPacket); err != nil {
+	if err := s.ForwardPackets(ctx, nil, ogPacket); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1820,7 +1829,7 @@ func TestSwitchForwardCircuitPersistence(t *testing.T) {
 	}
 
 	// Handle the request and checks that payment circuit works properly.
-	if err := s2.ForwardPackets(nil, ogPacket); err != nil {
+	if err := s2.ForwardPackets(ctx, nil, ogPacket); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1893,6 +1902,9 @@ type multiHopFwdTest struct {
 // through the same channel in the case where the switch is configured to allow
 // and disallow same channel circular forwards.
 func TestCircularForwards(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
 	chanID1, aliceChanID := genID()
 	preimage := [sha256.Size]byte{1}
 	hash := sha256.Sum256(preimage[:])
@@ -1968,9 +1980,9 @@ func TestCircularForwards(t *testing.T) {
 
 			// Attempt to forward the packet and check for the expected
 			// error.
-			if err = s.ForwardPackets(nil, packet); err != nil {
-				t.Fatal(err)
-			}
+			err = s.ForwardPackets(ctx, nil, packet)
+			require.NoError(t, err)
+
 			select {
 			case p := <-aliceChannelLink.packets:
 				if p.linkFailure != nil {
@@ -2198,6 +2210,7 @@ func testSkipIneligibleLinksMultiHopForward(t *testing.T,
 	testCase *multiHopFwdTest) {
 
 	t.Parallel()
+	ctx := context.Background()
 
 	var packet *htlcPacket
 
@@ -2266,7 +2279,7 @@ func testSkipIneligibleLinksMultiHopForward(t *testing.T,
 	}
 
 	// The request to forward should fail as
-	if err := s.ForwardPackets(nil, packet); err != nil {
+	if err := s.ForwardPackets(ctx, nil, packet); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2378,6 +2391,7 @@ func testSkipLinkLocalForward(t *testing.T, eligible bool,
 // circuits.
 func TestSwitchCancel(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	alicePeer, err := newMockServer(
 		t, "alice", testStartingHeight, nil, testDefaultDelta,
@@ -2429,7 +2443,7 @@ func TestSwitchCancel(t *testing.T) {
 	}
 
 	// Handle the request and checks that bob channel link received it.
-	if err := s.ForwardPackets(nil, request); err != nil {
+	if err := s.ForwardPackets(ctx, nil, request); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2461,7 +2475,7 @@ func TestSwitchCancel(t *testing.T) {
 	}
 
 	// Handle the request and checks that payment circuit works properly.
-	if err := s.ForwardPackets(nil, request); err != nil {
+	if err := s.ForwardPackets(ctx, nil, request); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2487,6 +2501,7 @@ func TestSwitchCancel(t *testing.T) {
 // payment hash.
 func TestSwitchAddSamePayment(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	chanID1, chanID2, aliceChanID, bobChanID := genIDs()
 
@@ -2538,7 +2553,7 @@ func TestSwitchAddSamePayment(t *testing.T) {
 	}
 
 	// Handle the request and checks that bob channel link received it.
-	if err := s.ForwardPackets(nil, request); err != nil {
+	if err := s.ForwardPackets(ctx, nil, request); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2568,7 +2583,7 @@ func TestSwitchAddSamePayment(t *testing.T) {
 	}
 
 	// Handle the request and checks that bob channel link received it.
-	if err := s.ForwardPackets(nil, request); err != nil {
+	if err := s.ForwardPackets(ctx, nil, request); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2597,7 +2612,7 @@ func TestSwitchAddSamePayment(t *testing.T) {
 	}
 
 	// Handle the request and checks that payment circuit works properly.
-	if err := s.ForwardPackets(nil, request); err != nil {
+	if err := s.ForwardPackets(ctx, nil, request); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2623,7 +2638,7 @@ func TestSwitchAddSamePayment(t *testing.T) {
 	}
 
 	// Handle the request and checks that payment circuit works properly.
-	if err := s.ForwardPackets(nil, request); err != nil {
+	if err := s.ForwardPackets(ctx, nil, request); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2646,6 +2661,7 @@ func TestSwitchAddSamePayment(t *testing.T) {
 // users when response is came back from channel link.
 func TestSwitchSendPayment(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	alicePeer, err := newMockServer(
 		t, "alice", testStartingHeight, nil, testDefaultDelta,
@@ -2759,7 +2775,7 @@ func TestSwitchSendPayment(t *testing.T) {
 		},
 	}
 
-	if err := s.ForwardPackets(nil, packet); err != nil {
+	if err := s.ForwardPackets(ctx, nil, packet); err != nil {
 		t.Fatalf("can't forward htlc packet: %v", err)
 	}
 
@@ -3163,6 +3179,7 @@ func TestSwitchGetAttemptResult(t *testing.T) {
 // if the failure cannot be decrypted.
 func TestInvalidFailure(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	alicePeer, err := newMockServer(
 		t, "alice", testStartingHeight, nil, testDefaultDelta,
@@ -3228,7 +3245,7 @@ func TestInvalidFailure(t *testing.T) {
 		},
 	}
 
-	if err := s.ForwardPackets(nil, packet); err != nil {
+	if err := s.ForwardPackets(ctx, nil, packet); err != nil {
 		t.Fatalf("can't forward htlc packet: %v", err)
 	}
 
@@ -4570,6 +4587,7 @@ func sendDustHtlcs(t *testing.T, n *threeHopNetwork, alice bool,
 // channel state, so this only tests the switch-mailbox interaction.
 func TestSwitchMailboxDust(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	alicePeer, err := newMockServer(
 		t, "alice", testStartingHeight, nil, testDefaultDelta,
@@ -4679,7 +4697,7 @@ func TestSwitchMailboxDust(t *testing.T) {
 		},
 	}
 
-	err = s.ForwardPackets(nil, packet)
+	err = s.ForwardPackets(ctx, nil, packet)
 	require.NoError(t, err)
 
 	// Bob should receive a failure from the switch.
@@ -4699,6 +4717,7 @@ func TestSwitchMailboxDust(t *testing.T) {
 // resolution messages.
 func TestSwitchResolution(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	alicePeer, err := newMockServer(
 		t, "alice", testStartingHeight, nil, testDefaultDelta,
@@ -4752,7 +4771,7 @@ func TestSwitchResolution(t *testing.T) {
 		},
 	}
 
-	err = s.ForwardPackets(nil, packet)
+	err = s.ForwardPackets(ctx, nil, packet)
 	require.NoError(t, err)
 
 	// Bob will receive the packet and open the circuit.
@@ -4875,6 +4894,7 @@ func TestSwitchForwardFailAlias(t *testing.T) {
 
 func testSwitchForwardFailAlias(t *testing.T, zeroConf bool) {
 	t.Parallel()
+	ctx := context.Background()
 
 	chanID1, chanID2, aliceChanID, bobChanID := genIDs()
 
@@ -4943,7 +4963,7 @@ func testSwitchForwardFailAlias(t *testing.T, zeroConf bool) {
 	}
 
 	// Forward the packet and check that Bob's channel link received it.
-	err = s.ForwardPackets(nil, ogPacket)
+	err = s.ForwardPackets(ctx, nil, ogPacket)
 	require.NoError(t, err)
 
 	// Assert that the circuits are in the expected state.
@@ -5001,7 +5021,7 @@ func testSwitchForwardFailAlias(t *testing.T, zeroConf bool) {
 
 	// Reforward the ogPacket and wait for Alice to receive a failure
 	// packet.
-	err = s2.ForwardPackets(nil, ogPacket)
+	err = s2.ForwardPackets(ctx, nil, ogPacket)
 	require.NoError(t, err)
 
 	select {
@@ -5087,6 +5107,7 @@ func TestSwitchAliasFailAdd(t *testing.T) {
 
 func testSwitchAliasFailAdd(t *testing.T, zeroConf, private, useAlias bool) {
 	t.Parallel()
+	ctx := context.Background()
 
 	chanID1, chanID2, aliceChanID, bobChanID := genIDs()
 
@@ -5177,7 +5198,7 @@ func testSwitchAliasFailAdd(t *testing.T, zeroConf, private, useAlias bool) {
 	ogPacket.outgoingChanID = outgoingChanID
 
 	// Forward the packet so Alice's mailbox fails it backwards.
-	err = s.ForwardPackets(nil, ogPacket)
+	err = s.ForwardPackets(ctx, nil, ogPacket)
 	require.NoError(t, err)
 
 	// Assert that the circuits are in the expected state.
@@ -5279,6 +5300,7 @@ func testSwitchHandlePacketForward(t *testing.T, zeroConf, private,
 	useAlias, optionFeature bool) {
 
 	t.Parallel()
+	ctx := context.Background()
 
 	// Create a link for Alice that we'll add to the switch.
 	harness, err :=
@@ -5383,7 +5405,7 @@ func testSwitchHandlePacketForward(t *testing.T, zeroConf, private,
 
 	// Forward the packet to Alice and she should fail it back with an
 	// AmountBelowMinimum FailureMessage.
-	err = s.ForwardPackets(nil, ogPacket)
+	err = s.ForwardPackets(ctx, nil, ogPacket)
 	require.NoError(t, err)
 
 	select {

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -5545,11 +5545,13 @@ func testSwitchAliasInterceptFail(t *testing.T, zeroConf bool) {
 	require.NoError(t, err)
 
 	inCircuit := forwardInterceptor.getIntercepted().IncomingCircuit
-	require.NoError(t, interceptSwitch.resolve(&FwdResolution{
-		Action:      FwdActionFail,
-		Key:         inCircuit,
-		FailureCode: lnwire.CodeTemporaryChannelFailure,
-	}))
+	require.NoError(t, interceptSwitch.resolve(
+		context.Background(), &FwdResolution{
+			Action:      FwdActionFail,
+			Key:         inCircuit,
+			FailureCode: lnwire.CodeTemporaryChannelFailure,
+		},
+	))
 
 	select {
 	case failPacket := <-aliceLink.packets:

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -3927,7 +3927,7 @@ func TestSwitchHoldForward(t *testing.T) {
 
 	// Simulate an error during the composition of the failure message.
 	currentCallback := c.s.cfg.FetchLastChannelUpdate
-	c.s.cfg.FetchLastChannelUpdate = func(
+	c.s.cfg.FetchLastChannelUpdate = func(context.Context,
 		lnwire.ShortChannelID) (*lnwire.ChannelUpdate1, error) {
 
 		return nil, errors.New("cannot fetch update")

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -1134,7 +1134,9 @@ func (h *hopNetwork) createChannelLink(server, peer *mockServer,
 	forwardPackets := func(linkQuit <-chan struct{}, _ bool,
 		packets ...*htlcPacket) error {
 
-		return server.htlcSwitch.ForwardPackets(linkQuit, packets...)
+		return server.htlcSwitch.ForwardPackets(
+			context.Background(), linkQuit, packets...,
+		)
 	}
 
 	//nolint:ll

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -95,8 +95,8 @@ func genIDs() (lnwire.ChannelID, lnwire.ChannelID, lnwire.ShortChannelID,
 
 // mockGetChanUpdateMessage helper function which returns topology update of
 // the channel
-func mockGetChanUpdateMessage(_ lnwire.ShortChannelID) (*lnwire.ChannelUpdate1,
-	error) {
+func mockGetChanUpdateMessage(_ context.Context,
+	_ lnwire.ShortChannelID) (*lnwire.ChannelUpdate1, error) {
 
 	return &lnwire.ChannelUpdate1{
 		Signature: wireSig,

--- a/intercepted_forward.go
+++ b/intercepted_forward.go
@@ -1,6 +1,7 @@
 package lnd
 
 import (
+	"context"
 	"errors"
 
 	"github.com/lightningnetwork/lnd/fn/v2"
@@ -72,7 +73,9 @@ func (f *interceptedForward) Fail(_ []byte) error {
 
 // FailWithCode notifies the intention to fail an existing hold forward with the
 // specified failure code.
-func (f *interceptedForward) FailWithCode(_ lnwire.FailCode) error {
+func (f *interceptedForward) FailWithCode(_ context.Context,
+	_ lnwire.FailCode) error {
+
 	return ErrCannotFail
 }
 

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -336,8 +336,8 @@ type Config struct {
 
 	// FetchLastChanUpdate fetches our latest channel update for a target
 	// channel.
-	FetchLastChanUpdate func(lnwire.ShortChannelID) (*lnwire.ChannelUpdate1,
-		error)
+	FetchLastChanUpdate func(context.Context,
+		lnwire.ShortChannelID) (*lnwire.ChannelUpdate1, error)
 
 	// FundingManager is an implementation of the funding.Controller interface.
 	FundingManager funding.Controller
@@ -1498,6 +1498,8 @@ func (p *Brontide) maybeSendChannelUpdates() {
 	maybeSendUpd := func(cid lnwire.ChannelID,
 		lnChan *lnwallet.LightningChannel) error {
 
+		ctx := context.TODO()
+
 		// Nil channels are pending, so we'll skip them.
 		if lnChan == nil {
 			return nil
@@ -1521,7 +1523,7 @@ func (p *Brontide) maybeSendChannelUpdates() {
 		// to fetch the update to send to the remote peer. If the
 		// channel is pending, and not a zero conf channel, we'll get
 		// an error here which we'll ignore.
-		chanUpd, err := p.cfg.FetchLastChanUpdate(scid)
+		chanUpd, err := p.cfg.FetchLastChanUpdate(ctx, scid)
 		if err != nil {
 			p.log.Debugf("Unable to fetch channel update for "+
 				"ChannelPoint(%v), scid=%v: %v",

--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -2,6 +2,7 @@ package peer
 
 import (
 	"bytes"
+	"context"
 	crand "crypto/rand"
 	"encoding/binary"
 	"io"
@@ -748,8 +749,9 @@ func createTestPeer(t *testing.T) *peerTestCtx {
 			return nil
 		},
 		PongBuf: make([]byte, lnwire.MaxPongBytes),
-		FetchLastChanUpdate: func(chanID lnwire.ShortChannelID,
-		) (*lnwire.ChannelUpdate1, error) {
+		FetchLastChanUpdate: func(_ context.Context,
+			_ lnwire.ShortChannelID) (*lnwire.ChannelUpdate1,
+			error) {
 
 			return &lnwire.ChannelUpdate1{}, nil
 		},

--- a/server.go
+++ b/server.go
@@ -5227,11 +5227,13 @@ func (s *server) fetchNodeAdvertisedAddrs(pub *btcec.PublicKey) ([]net.Addr, err
 
 // fetchLastChanUpdate returns a function which is able to retrieve our latest
 // channel update for a target channel.
-func (s *server) fetchLastChanUpdate() func(lnwire.ShortChannelID) (
-	*lnwire.ChannelUpdate1, error) {
+func (s *server) fetchLastChanUpdate() func(context.Context,
+	lnwire.ShortChannelID) (*lnwire.ChannelUpdate1, error) {
 
 	ourPubKey := s.identityECDH.PubKey().SerializeCompressed()
-	return func(cid lnwire.ShortChannelID) (*lnwire.ChannelUpdate1, error) {
+	return func(_ context.Context, cid lnwire.ShortChannelID) (
+		*lnwire.ChannelUpdate1, error) {
+
 		info, edge1, edge2, err := s.graphBuilder.GetChannelByID(cid)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
### PR context

This is part of the last step required to complete https://github.com/lightningnetwork/lnd/issues/9494. We want all calls to the graph DB (and hence, ChannelGraph) to take a context since later, this context will be passed through to any remote graph RPC calls as well as any DB calls to a SQL graph backend. 

### This PR specifically: This is part 1 of a 2 part PR series that addresses the `htlcswitch`

In this PR, we tackle the `htlcswitch` & `peer` packages. This is split over 2 PRs since it is quite a lot. This PR is part 1. See [part 2](https://github.com/lightningnetwork/lnd/pull/9699) for the full picture. This package makes calls to the graph's `FetchLastChannelUpdate` call. So this PR is all aimed at threading contexts through to the call-sites of this call-back. It leaves 1 `context.TODO()` in the main LND `server` which will be addressed in a follow up.

### Branch strategy:

This series of PRs is basically a big code refactor. So once 19 is shipped, we can merge any work that has been merged into `elle-graph` and from then on we can just merge into master. 