### PR TITLE
graph/db: clean up test code in preparation for DB abtraction

### DIFF
--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -1103,13 +1103,11 @@ func TestGraphTraversalCacheable(t *testing.T) {
 	// Create a map of all nodes with the iteration we know works (because
 	// it is tested in another test).
 	nodeMap := make(map[route.Vertex]struct{})
-	err = graph.forEachNode(
-		func(tx kvdb.RTx, n *models.LightningNode) error {
-			nodeMap[n.PubKeyBytes] = struct{}{}
+	err = graph.ForEachNode(func(tx NodeRTx) error {
+		nodeMap[tx.Node().PubKeyBytes] = struct{}{}
 
-			return nil
-		},
-	)
+		return nil
+	})
 	require.NoError(t, err)
 	require.Len(t, nodeMap, numNodes)
 
@@ -1225,12 +1223,10 @@ func fillTestGraph(t testing.TB, graph *ChannelGraph, numNodes,
 
 	// Iterate over each node as returned by the graph, if all nodes are
 	// reached, then the map created above should be empty.
-	err := graph.forEachNode(
-		func(_ kvdb.RTx, node *models.LightningNode) error {
-			delete(nodeIndex, node.Alias)
-			return nil
-		},
-	)
+	err := graph.ForEachNode(func(tx NodeRTx) error {
+		delete(nodeIndex, tx.Node().Alias)
+		return nil
+	})
 	require.NoError(t, err)
 	require.Len(t, nodeIndex, 0)
 
@@ -1337,12 +1333,11 @@ func assertNumChans(t *testing.T, graph *ChannelGraph, n int) {
 
 func assertNumNodes(t *testing.T, graph *ChannelGraph, n int) {
 	numNodes := 0
-	err := graph.forEachNode(
-		func(_ kvdb.RTx, _ *models.LightningNode) error {
-			numNodes++
-			return nil
-		},
-	)
+	err := graph.ForEachNode(func(tx NodeRTx) error {
+		numNodes++
+
+		return nil
+	})
 	if err != nil {
 		_, _, line, _ := runtime.Caller(1)
 		t.Fatalf("line %v: unable to scan nodes: %v", line, err)

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -597,7 +597,7 @@ func assertEdgeInfoEqual(t *testing.T, e1 *models.ChannelEdgeInfo,
 	}
 }
 
-func createChannelEdge(db kvdb.Backend, node1, node2 *models.LightningNode) (
+func createChannelEdge(node1, node2 *models.LightningNode) (
 	*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
 	*models.ChannelEdgePolicy) {
 
@@ -693,7 +693,7 @@ func TestEdgeInfoUpdates(t *testing.T) {
 	assertNodeInCache(t, graph, node2, testFeatures)
 
 	// Create an edge and add it to the db.
-	edgeInfo, edge1, edge2 := createChannelEdge(graph.db, node1, node2)
+	edgeInfo, edge1, edge2 := createChannelEdge(node1, node2)
 
 	// Make sure inserting the policy at this point, before the edge info
 	// is added, will fail.
@@ -3337,7 +3337,7 @@ func TestDisabledChannelIDs(t *testing.T) {
 	}
 
 	// Adding a new channel edge to the graph.
-	edgeInfo, edge1, edge2 := createChannelEdge(graph.db, node1, node2)
+	edgeInfo, edge1, edge2 := createChannelEdge(node1, node2)
 	if err := graph.AddLightningNode(node2); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
@@ -3416,7 +3416,7 @@ func TestEdgePolicyMissingMaxHtcl(t *testing.T) {
 	}
 	node2 := createTestVertex(t)
 
-	edgeInfo, edge1, edge2 := createChannelEdge(graph.db, node1, node2)
+	edgeInfo, edge1, edge2 := createChannelEdge(node1, node2)
 	if err := graph.AddLightningNode(node2); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
@@ -3580,7 +3580,7 @@ func TestGraphZombieIndex(t *testing.T) {
 		node1, node2 = node2, node1
 	}
 
-	edge, _, _ := createChannelEdge(graph.db, node1, node2)
+	edge, _, _ := createChannelEdge(node1, node2)
 	require.NoError(t, graph.AddChannelEdge(edge))
 
 	// Since the edge is known the graph and it isn't a zombie, IsZombieEdge
@@ -3868,7 +3868,7 @@ func TestBatchedUpdateEdgePolicy(t *testing.T) {
 	require.Nil(t, err)
 
 	// Create an edge and add it to the db.
-	edgeInfo, edge1, edge2 := createChannelEdge(graph.db, node1, node2)
+	edgeInfo, edge1, edge2 := createChannelEdge(node1, node2)
 
 	// Make sure inserting the policy at this point, before the edge info
 	// is added, will fail.
@@ -3979,7 +3979,7 @@ func TestGraphCacheForEachNodeChannel(t *testing.T) {
 	require.Nil(t, err)
 
 	// Create an edge and add it to the db.
-	edgeInfo, e1, e2 := createChannelEdge(graph.db, node1, node2)
+	edgeInfo, e1, e2 := createChannelEdge(node1, node2)
 
 	// Because of lexigraphical sorting and the usage of random node keys in
 	// this test, we need to determine which edge belongs to node 1 at


### PR DESCRIPTION
This PR does some clean up in the `graph/db` test code to start preparing the tests to be ready to run against an abstract DB (either kvdb or sql schema). 