### PR TITLE
htlcswitch+peer [2/2]: thread context through in preparation for passing to graph DB calls

### DIFF
--- a/discovery/bootstrapper.go
+++ b/discovery/bootstrapper.go
@@ -157,11 +157,9 @@ func NewGraphBootstrapper(cg autopilot.ChannelGraph) (NetworkPeerBootstrapper, e
 // many valid peer addresses to return.
 //
 // NOTE: Part of the NetworkPeerBootstrapper interface.
-func (c *ChannelGraphBootstrapper) SampleNodeAddrs(_ context.Context,
+func (c *ChannelGraphBootstrapper) SampleNodeAddrs(ctx context.Context,
 	numAddrs uint32,
 	ignore map[autopilot.NodeID]struct{}) ([]*lnwire.NetAddress, error) {
-
-	ctx := context.TODO()
 
 	// We'll merge the ignore map with our currently selected map in order
 	// to ensure we don't return any duplicate nodes.

--- a/htlcswitch/interceptable_switch.go
+++ b/htlcswitch/interceptable_switch.go
@@ -1,6 +1,7 @@
 package htlcswitch
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"sync"
@@ -748,6 +749,8 @@ func (f *interceptedForward) Fail(reason []byte) error {
 // FailWithCode notifies the intention to fail an existing hold forward with the
 // specified failure code.
 func (f *interceptedForward) FailWithCode(code lnwire.FailCode) error {
+	ctx := context.TODO()
+
 	shaOnionBlob := func() [32]byte {
 		return sha256.Sum256(f.htlc.OnionBlob[:])
 	}
@@ -779,7 +782,7 @@ func (f *interceptedForward) FailWithCode(code lnwire.FailCode) error {
 			// Fallback to the original, non-alias behavior.
 			var err error
 			update, err = f.htlcSwitch.cfg.FetchLastChannelUpdate(
-				f.packet.incomingChanID,
+				ctx, f.packet.incomingChanID,
 			)
 			if err != nil {
 				return err
@@ -790,7 +793,7 @@ func (f *interceptedForward) FailWithCode(code lnwire.FailCode) error {
 
 	case lnwire.CodeExpiryTooSoon:
 		update, err := f.htlcSwitch.cfg.FetchLastChannelUpdate(
-			f.packet.incomingChanID,
+			ctx, f.packet.incomingChanID,
 		)
 		if err != nil {
 			return err

--- a/htlcswitch/interceptable_switch.go
+++ b/htlcswitch/interceptable_switch.go
@@ -435,7 +435,7 @@ func (s *InterceptableSwitch) resolve(ctx context.Context,
 
 	case FwdActionResumeModified:
 		return intercepted.ResumeModified(
-			res.InAmountMsat, res.OutAmountMsat,
+			ctx, res.InAmountMsat, res.OutAmountMsat,
 			res.OutWireCustomRecords,
 		)
 
@@ -687,12 +687,10 @@ func (f *interceptedForward) Resume(ctx context.Context) error {
 // should be interpreted differently from the on-chain amount during further
 // validation. The presence of an output amount and/or custom records indicates
 // that those values should be modified on the outgoing HTLC.
-func (f *interceptedForward) ResumeModified(
+func (f *interceptedForward) ResumeModified(ctx context.Context,
 	inAmountMsat fn.Option[lnwire.MilliSatoshi],
 	outAmountMsat fn.Option[lnwire.MilliSatoshi],
 	outWireCustomRecords fn.Option[lnwire.CustomRecords]) error {
-
-	ctx := context.TODO()
 
 	// Convert the optional custom records to the correct type and validate
 	// them.

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -85,7 +85,7 @@ type dustHandler interface {
 type scidAliasHandler interface {
 	// attachFailAliasUpdate allows the link to properly fail incoming
 	// HTLCs on option_scid_alias channels.
-	attachFailAliasUpdate(failClosure func(
+	attachFailAliasUpdate(failClosure func(ctx context.Context,
 		sid lnwire.ShortChannelID,
 		incoming bool) *lnwire.ChannelUpdate1)
 

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -439,7 +439,7 @@ type InterceptedForward interface {
 
 	// ResumeModified notifies the intention to resume an existing hold
 	// forward with modified fields.
-	ResumeModified(inAmountMsat,
+	ResumeModified(ctx context.Context, inAmountMsat,
 		outAmountMsat fn.Option[lnwire.MilliSatoshi],
 		outWireCustomRecords fn.Option[lnwire.CustomRecords]) error
 

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -281,7 +281,8 @@ type ChannelLink interface {
 	// a LinkError with a valid protocol failure message should be returned
 	// in order to signal to the source of the HTLC, the policy consistency
 	// issue.
-	CheckHtlcForward(payHash [32]byte, incomingAmt lnwire.MilliSatoshi,
+	CheckHtlcForward(ctx context.Context, payHash [32]byte,
+		incomingAmt lnwire.MilliSatoshi,
 		amtToForward lnwire.MilliSatoshi, incomingTimeout,
 		outgoingTimeout uint32, inboundFee models.InboundFee,
 		heightNow uint32, scid lnwire.ShortChannelID,

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -452,7 +452,7 @@ type InterceptedForward interface {
 
 	// FailWithCode notifies the intention to fail an existing hold forward
 	// with the specified failure code.
-	FailWithCode(code lnwire.FailCode) error
+	FailWithCode(ctx context.Context, code lnwire.FailCode) error
 }
 
 // htlcNotifier is an interface which represents the input side of the

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -293,8 +293,8 @@ type ChannelLink interface {
 	// valid protocol failure message should be returned in order to signal
 	// the violation. This call is intended to be used for locally initiated
 	// payments for which there is no corresponding incoming htlc.
-	CheckHtlcTransit(payHash [32]byte, amt lnwire.MilliSatoshi,
-		timeout uint32, heightNow uint32,
+	CheckHtlcTransit(ctx context.Context, payHash [32]byte,
+		amt lnwire.MilliSatoshi, timeout uint32, heightNow uint32,
 		customRecords lnwire.CustomRecords) *LinkError
 
 	// Stats return the statistics of channel link. Number of updates,

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -435,7 +435,7 @@ type InterceptedForward interface {
 	// Resume notifies the intention to resume an existing hold forward. This
 	// basically means the caller wants to resume with the default behavior for
 	// this htlc which usually means forward it.
-	Resume() error
+	Resume(ctx context.Context) error
 
 	// ResumeModified notifies the intention to resume an existing hold
 	// forward with modified fields.

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -263,7 +263,7 @@ type ChannelLinkConfig struct {
 
 	// FailAliasUpdate is a function used to fail an HTLC for an
 	// option_scid_alias channel.
-	FailAliasUpdate func(sid lnwire.ShortChannelID,
+	FailAliasUpdate func(ctx context.Context, sid lnwire.ShortChannelID,
 		incoming bool) *lnwire.ChannelUpdate1
 
 	// GetAliases is used by the link and switch to fetch the set of
@@ -872,7 +872,7 @@ func (l *channelLink) createFailureWithUpdate(ctx context.Context,
 
 	// Try using the FailAliasUpdate function. If it returns nil, fallback
 	// to the non-alias behavior.
-	update := l.cfg.FailAliasUpdate(scid, incoming)
+	update := l.cfg.FailAliasUpdate(ctx, scid, incoming)
 	if update == nil {
 		// Fallback to the non-alias behavior.
 		var err error
@@ -3210,7 +3210,7 @@ func (l *channelLink) getAliases() []lnwire.ShortChannelID {
 // attachFailAliasUpdate sets the link's FailAliasUpdate function.
 //
 // Part of the scidAliasHandler interface.
-func (l *channelLink) attachFailAliasUpdate(closure func(
+func (l *channelLink) attachFailAliasUpdate(closure func(ctx context.Context,
 	sid lnwire.ShortChannelID, incoming bool) *lnwire.ChannelUpdate1) {
 
 	l.Lock()

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -3354,11 +3354,9 @@ func (l *channelLink) CheckHtlcForward(ctx context.Context, payHash [32]byte,
 // valid protocol failure message should be returned in order to signal
 // the violation. This call is intended to be used for locally initiated
 // payments for which there is no corresponding incoming htlc.
-func (l *channelLink) CheckHtlcTransit(payHash [32]byte,
+func (l *channelLink) CheckHtlcTransit(ctx context.Context, payHash [32]byte,
 	amt lnwire.MilliSatoshi, timeout uint32, heightNow uint32,
 	customRecords lnwire.CustomRecords) *LinkError {
-
-	ctx := context.TODO()
 
 	l.RLock()
 	policy := l.cfg.FwrdingPolicy

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -3260,13 +3260,11 @@ func (l *channelLink) UpdateForwardingPolicy(
 // issue.
 //
 // NOTE: Part of the ChannelLink interface.
-func (l *channelLink) CheckHtlcForward(payHash [32]byte, incomingHtlcAmt,
-	amtToForward lnwire.MilliSatoshi, incomingTimeout,
+func (l *channelLink) CheckHtlcForward(ctx context.Context, payHash [32]byte,
+	incomingHtlcAmt, amtToForward lnwire.MilliSatoshi, incomingTimeout,
 	outgoingTimeout uint32, inboundFee models.InboundFee,
 	heightNow uint32, originalScid lnwire.ShortChannelID,
 	customRecords lnwire.CustomRecords) *LinkError {
-
-	ctx := context.TODO()
 
 	l.RLock()
 	policy := l.cfg.FwrdingPolicy

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -537,6 +537,8 @@ func (l *channelLink) Start() error {
 		return err
 	}
 
+	ctx, _ := l.cg.Create(context.Background())
+
 	l.log.Info("starting")
 
 	// If the config supplied watchtower client, ensure the channel is
@@ -598,7 +600,7 @@ func (l *channelLink) Start() error {
 	l.updateFeeTimer = time.NewTimer(l.randomFeeUpdateTimeout())
 
 	l.cg.WgAdd(1)
-	go l.htlcManager(context.TODO())
+	go l.htlcManager(ctx)
 
 	return nil
 }

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -121,8 +121,8 @@ type ChannelLinkConfig struct {
 	// specified when we receive an incoming HTLC.  This will be used to
 	// provide payment senders our latest policy when sending encrypted
 	// error messages.
-	FetchLastChannelUpdate func(lnwire.ShortChannelID) (
-		*lnwire.ChannelUpdate1, error)
+	FetchLastChannelUpdate func(context.Context,
+		lnwire.ShortChannelID) (*lnwire.ChannelUpdate1, error)
 
 	// Peer is a lightning network node with which we have the channel link
 	// opened.
@@ -862,6 +862,8 @@ type failCb func(update *lnwire.ChannelUpdate1) lnwire.FailureMessage
 func (l *channelLink) createFailureWithUpdate(incoming bool,
 	outgoingScid lnwire.ShortChannelID, cb failCb) lnwire.FailureMessage {
 
+	ctx := context.TODO()
+
 	// Determine which SCID to use in case we need to use aliases in the
 	// ChannelUpdate.
 	scid := outgoingScid
@@ -875,7 +877,7 @@ func (l *channelLink) createFailureWithUpdate(incoming bool,
 	if update == nil {
 		// Fallback to the non-alias behavior.
 		var err error
-		update, err = l.cfg.FetchLastChannelUpdate(l.ShortChanID())
+		update, err = l.cfg.FetchLastChannelUpdate(ctx, l.ShortChanID())
 		if err != nil {
 			return &lnwire.FailTemporaryNodeFailure{}
 		}

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1695,7 +1695,7 @@ func (l *channelLink) handleDownstreamUpdateAdd(ctx context.Context,
 	// already sent Stfu, then we can't add new htlcs to the link and we
 	// need to bounce it.
 	if l.IsFlushing(Outgoing) || !l.quiescer.CanSendUpdates() {
-		l.mailBox.FailAdd(pkt)
+		l.mailBox.FailAdd(ctx, pkt)
 
 		return NewDetailedLinkError(
 			&lnwire.FailTemporaryChannelFailure{},
@@ -1718,7 +1718,7 @@ func (l *channelLink) handleDownstreamUpdateAdd(ctx context.Context,
 		l.log.Debugf("Unable to handle downstream HTLC - max fee " +
 			"exposure exceeded")
 
-		l.mailBox.FailAdd(pkt)
+		l.mailBox.FailAdd(ctx, pkt)
 
 		return NewDetailedLinkError(
 			lnwire.NewTemporaryChannelFailure(nil),
@@ -1752,7 +1752,7 @@ func (l *channelLink) handleDownstreamUpdateAdd(ctx context.Context,
 		// the switch, since the circuit was never fully opened,
 		// and the forwarding package shows it as
 		// unacknowledged.
-		l.mailBox.FailAdd(pkt)
+		l.mailBox.FailAdd(ctx, pkt)
 
 		return NewDetailedLinkError(
 			lnwire.NewTemporaryChannelFailure(nil),

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -6206,8 +6206,8 @@ func TestForwardingAsymmetricTimeLockPolicies(t *testing.T) {
 // TestCheckHtlcForward tests that a link is properly enforcing the HTLC
 // forwarding policy.
 func TestCheckHtlcForward(t *testing.T) {
-	fetchLastChannelUpdate := func(lnwire.ShortChannelID) (
-		*lnwire.ChannelUpdate1, error) {
+	fetchLastChannelUpdate := func(context.Context,
+		lnwire.ShortChannelID) (*lnwire.ChannelUpdate1, error) {
 
 		return &lnwire.ChannelUpdate1{}, nil
 	}

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1624,7 +1624,8 @@ func TestChannelLinkMultiHopUnknownPaymentHash(t *testing.T) {
 
 	// Send payment and expose err channel.
 	err = n.aliceServer.htlcSwitch.SendHTLC(
-		n.firstBobChannelLink.ShortChanID(), pid, htlc,
+		context.Background(), n.firstBobChannelLink.ShortChanID(), pid,
+		htlc,
 	)
 	require.NoError(t, err, "unable to get send payment")
 
@@ -4520,6 +4521,7 @@ func TestChannelLinkUpdateCommitFee(t *testing.T) {
 // failures, reducing ambiguity when a batch is only partially processed.
 func TestChannelLinkAcceptDuplicatePayment(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	// First, we'll create our traditional three hop network. We'll only be
 	// interacting with and asserting the state of two of the end points
@@ -4553,15 +4555,13 @@ func TestChannelLinkAcceptDuplicatePayment(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = n.carolServer.registry.AddInvoice(
-		context.Background(), *invoice, htlc.PaymentHash,
-	)
+	err = n.carolServer.registry.AddInvoice(ctx, *invoice, htlc.PaymentHash)
 	require.NoError(t, err, "unable to add invoice in carol registry")
 
 	// With the invoice now added to Carol's registry, we'll send the
 	// payment.
 	err = n.aliceServer.htlcSwitch.SendHTLC(
-		n.firstBobChannelLink.ShortChanID(), pid, htlc,
+		ctx, n.firstBobChannelLink.ShortChanID(), pid, htlc,
 	)
 	require.NoError(t, err, "unable to send payment to carol")
 
@@ -4573,7 +4573,7 @@ func TestChannelLinkAcceptDuplicatePayment(t *testing.T) {
 	// Now, if we attempt to send the payment *again* it should be rejected
 	// as it's a duplicate request.
 	err = n.aliceServer.htlcSwitch.SendHTLC(
-		n.firstBobChannelLink.ShortChanID(), pid, htlc,
+		ctx, n.firstBobChannelLink.ShortChanID(), pid, htlc,
 	)
 	if err != ErrDuplicateAdd {
 		t.Fatalf("ErrDuplicateAdd should have been "+

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -2200,7 +2200,9 @@ func newSingleLinkTestHarness(t *testing.T, chanAmt,
 	forwardPackets := func(linkQuit <-chan struct{}, _ bool,
 		packets ...*htlcPacket) error {
 
-		return aliceSwitch.ForwardPackets(linkQuit, packets...)
+		return aliceSwitch.ForwardPackets(
+			context.Background(), linkQuit, packets...,
+		)
 	}
 
 	// Instantiate with a long interval, so that we can precisely control
@@ -4882,7 +4884,9 @@ func (h *persistentLinkHarness) restartLink(
 	forwardPackets := func(linkQuit <-chan struct{}, _ bool,
 		packets ...*htlcPacket) error {
 
-		return h.hSwitch.ForwardPackets(linkQuit, packets...)
+		return h.hSwitch.ForwardPackets(
+			context.Background(), linkQuit, packets...,
+		)
 	}
 
 	// Instantiate with a long interval, so that we can precisely control
@@ -6212,7 +6216,7 @@ func TestCheckHtlcForward(t *testing.T) {
 		return &lnwire.ChannelUpdate1{}, nil
 	}
 
-	failAliasUpdate := func(sid lnwire.ShortChannelID,
+	failAliasUpdate := func(_ context.Context, sid lnwire.ShortChannelID,
 		incoming bool) *lnwire.ChannelUpdate1 {
 
 		return nil

--- a/htlcswitch/mailbox.go
+++ b/htlcswitch/mailbox.go
@@ -109,7 +109,7 @@ type mailBoxConfig struct {
 
 	// failMailboxUpdate is used to fail an expired HTLC and use the
 	// correct SCID if the underlying channel uses aliases.
-	failMailboxUpdate func(outScid,
+	failMailboxUpdate func(ctx context.Context, outScid,
 		mailboxScid lnwire.ShortChannelID) lnwire.FailureMessage
 }
 
@@ -707,7 +707,7 @@ func (m *memoryMailBox) FailAdd(pkt *htlcPacket) {
 	// peer if this is a forward, or report to the user if the failed
 	// payment was locally initiated.
 	failure := m.cfg.failMailboxUpdate(
-		pkt.originalOutgoingChanID, m.cfg.shortChanID,
+		ctx, pkt.originalOutgoingChanID, m.cfg.shortChanID,
 	)
 
 	// If the payment was locally initiated (which is indicated by a nil
@@ -821,7 +821,7 @@ type mailOrchConfig struct {
 
 	// failMailboxUpdate is used to fail an expired HTLC and use the
 	// correct SCID if the underlying channel uses aliases.
-	failMailboxUpdate func(outScid,
+	failMailboxUpdate func(ctx context.Context, outScid,
 		mailboxScid lnwire.ShortChannelID) lnwire.FailureMessage
 }
 

--- a/htlcswitch/mailbox_test.go
+++ b/htlcswitch/mailbox_test.go
@@ -207,7 +207,7 @@ func newMailboxContextWithClock(t *testing.T,
 		forwards: make(chan *htlcPacket, 1),
 	}
 
-	failMailboxUpdate := func(outScid,
+	failMailboxUpdate := func(_ context.Context, outScid,
 		mboxScid lnwire.ShortChannelID) lnwire.FailureMessage {
 
 		return &lnwire.FailTemporaryNodeFailure{}
@@ -233,7 +233,7 @@ func newMailboxContext(t *testing.T, startTime time.Time,
 		forwards: make(chan *htlcPacket, 1),
 	}
 
-	failMailboxUpdate := func(outScid,
+	failMailboxUpdate := func(_ context.Context, outScid,
 		mboxScid lnwire.ShortChannelID) lnwire.FailureMessage {
 
 		return &lnwire.FailTemporaryNodeFailure{}
@@ -698,7 +698,7 @@ func testMailBoxDust(t *testing.T, chantype channeldb.ChannelType) {
 func TestMailOrchestrator(t *testing.T) {
 	t.Parallel()
 
-	failMailboxUpdate := func(outScid,
+	failMailboxUpdate := func(_ context.Context, outScid,
 		mboxScid lnwire.ShortChannelID) lnwire.FailureMessage {
 
 		return &lnwire.FailTemporaryNodeFailure{}

--- a/htlcswitch/mailbox_test.go
+++ b/htlcswitch/mailbox_test.go
@@ -334,6 +334,8 @@ func (c *mailboxContext) checkFails(adds []*htlcPacket) {
 // TestMailBoxFailAdd asserts that FailAdd returns a response to the switch
 // under various interleavings with other operations on the mailbox.
 func TestMailBoxFailAdd(t *testing.T) {
+	t.Parallel()
+
 	var (
 		batchDelay       = time.Second
 		expiry           = time.Minute
@@ -346,7 +348,7 @@ func TestMailBoxFailAdd(t *testing.T) {
 
 	failAdds := func(adds []*htlcPacket) {
 		for _, add := range adds {
-			ctx.mailbox.FailAdd(add)
+			ctx.mailbox.FailAdd(context.Background(), add)
 		}
 	}
 

--- a/htlcswitch/mailbox_test.go
+++ b/htlcswitch/mailbox_test.go
@@ -1,6 +1,7 @@
 package htlcswitch
 
 import (
+	"context"
 	prand "math/rand"
 	"reflect"
 	"testing"
@@ -250,7 +251,7 @@ func newMailboxContext(t *testing.T, startTime time.Time,
 	return ctx
 }
 
-func (c *mailboxContext) forward(_ <-chan struct{},
+func (c *mailboxContext) forward(_ context.Context, _ <-chan struct{},
 	pkts ...*htlcPacket) error {
 
 	for _, pkt := range pkts {
@@ -706,7 +707,7 @@ func TestMailOrchestrator(t *testing.T) {
 	// First, we'll create a new instance of our orchestrator.
 	mo := newMailOrchestrator(&mailOrchConfig{
 		failMailboxUpdate: failMailboxUpdate,
-		forwardPackets: func(_ <-chan struct{},
+		forwardPackets: func(_ context.Context, _ <-chan struct{},
 			pkts ...*htlcPacket) error {
 
 			return nil

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -845,9 +845,10 @@ func (f *mockChannelLink) HandleChannelUpdate(lnwire.Message) {
 
 func (f *mockChannelLink) UpdateForwardingPolicy(_ models.ForwardingPolicy) {
 }
-func (f *mockChannelLink) CheckHtlcForward([32]byte, lnwire.MilliSatoshi,
-	lnwire.MilliSatoshi, uint32, uint32, models.InboundFee, uint32,
-	lnwire.ShortChannelID, lnwire.CustomRecords) *LinkError {
+func (f *mockChannelLink) CheckHtlcForward(context.Context, [32]byte,
+	lnwire.MilliSatoshi, lnwire.MilliSatoshi, uint32, uint32,
+	models.InboundFee, uint32, lnwire.ShortChannelID,
+	lnwire.CustomRecords) *LinkError {
 
 	return f.checkHtlcForwardResult
 }

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -736,7 +736,7 @@ type mockChannelLink struct {
 
 	checkHtlcForwardResult *LinkError
 
-	failAliasUpdate func(sid lnwire.ShortChannelID,
+	failAliasUpdate func(ctx context.Context, sid lnwire.ShortChannelID,
 		incoming bool) *lnwire.ChannelUpdate1
 
 	confirmedZC bool
@@ -871,7 +871,7 @@ func (f *mockChannelLink) AttachMailBox(mailBox MailBox) {
 	mailBox.SetDustClosure(f.getDustClosure())
 }
 
-func (f *mockChannelLink) attachFailAliasUpdate(closure func(
+func (f *mockChannelLink) attachFailAliasUpdate(closure func(_ context.Context,
 	sid lnwire.ShortChannelID, incoming bool) *lnwire.ChannelUpdate1) {
 
 	f.failAliasUpdate = closure

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -183,8 +183,9 @@ func initSwitchWithDB(startingHeight uint32, db *channeldb.DB) (*Switch, error) 
 		FwdingLog: &mockForwardingLog{
 			events: make(map[time.Time]channeldb.ForwardingEvent),
 		},
-		FetchLastChannelUpdate: func(scid lnwire.ShortChannelID) (
-			*lnwire.ChannelUpdate1, error) {
+		FetchLastChannelUpdate: func(_ context.Context,
+			scid lnwire.ShortChannelID) (*lnwire.ChannelUpdate1,
+			error) {
 
 			return &lnwire.ChannelUpdate1{
 				ShortChannelID: scid,

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -853,7 +853,7 @@ func (f *mockChannelLink) CheckHtlcForward(context.Context, [32]byte,
 	return f.checkHtlcForwardResult
 }
 
-func (f *mockChannelLink) CheckHtlcTransit(payHash [32]byte,
+func (f *mockChannelLink) CheckHtlcTransit(_ context.Context, payHash [32]byte,
 	amt lnwire.MilliSatoshi, timeout uint32,
 	heightNow uint32, _ lnwire.CustomRecords) *LinkError {
 

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -249,8 +249,9 @@ type Switch struct {
 	// This will be retrieved by the registered links atomically.
 	bestHeight uint32
 
-	wg   sync.WaitGroup
-	quit chan struct{}
+	wg     sync.WaitGroup
+	quit   chan struct{}
+	cancel fn.Option[context.CancelFunc]
 
 	// cfg is a copy of the configuration struct that the htlc switch
 	// service was initialized with.
@@ -676,10 +677,8 @@ func (s *Switch) IsForwardedHTLC(chanID lnwire.ShortChannelID,
 // given to forward them through the router. The sending link's quit channel is
 // used to prevent deadlocks when the switch stops a link in the midst of
 // forwarding.
-func (s *Switch) ForwardPackets(linkQuit <-chan struct{},
+func (s *Switch) ForwardPackets(ctx context.Context, linkQuit <-chan struct{},
 	packets ...*htlcPacket) error {
-
-	ctx := context.TODO()
 
 	var (
 		// fwdChan is a buffered channel used to receive err msgs from
@@ -793,7 +792,7 @@ func (s *Switch) ForwardPackets(linkQuit <-chan struct{},
 
 		// If the incoming channel is an option_scid_alias channel,
 		// then we'll need to replace the SCID in the ChannelUpdate.
-		update := s.failAliasUpdate(incomingID, true)
+		update := s.failAliasUpdate(ctx, incomingID, true)
 		if update == nil {
 			// Fallback to the original non-option behavior.
 			update, err := s.cfg.FetchLastChannelUpdate(
@@ -1759,6 +1758,9 @@ func (s *Switch) Start() error {
 		return errors.New("htlc switch already started")
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancel = fn.Some(cancel)
+
 	log.Infof("HTLC Switch starting")
 
 	blockEpochStream, err := s.cfg.Notifier.RegisterBlockEpochNtfn(nil)
@@ -1770,13 +1772,13 @@ func (s *Switch) Start() error {
 	s.wg.Add(1)
 	go s.htlcForwarder()
 
-	if err := s.reforwardResponses(); err != nil {
+	if err := s.reforwardResponses(ctx); err != nil {
 		s.Stop()
 		log.Errorf("unable to reforward responses: %v", err)
 		return err
 	}
 
-	if err := s.reforwardResolutions(); err != nil {
+	if err := s.reforwardResolutions(ctx); err != nil {
 		// We are already stopping so we can ignore the error.
 		_ = s.Stop()
 		log.Errorf("unable to reforward resolutions: %v", err)
@@ -1789,7 +1791,7 @@ func (s *Switch) Start() error {
 // reforwardResolutions fetches the set of resolution messages stored on-disk
 // and reforwards them if their circuits are still open. If the circuits have
 // been deleted, then we will delete the resolution message from the database.
-func (s *Switch) reforwardResolutions() error {
+func (s *Switch) reforwardResolutions(ctx context.Context) error {
 	// Fetch all stored resolution messages, deleting the ones that are
 	// resolved.
 	resMsgs, err := s.resMsgStore.fetchAllResolutionMsg()
@@ -1840,7 +1842,7 @@ func (s *Switch) reforwardResolutions() error {
 	// We'll now dispatch the set of resolution messages to the proper
 	// destination. An error is only encountered here if the switch is
 	// shutting down.
-	if err := s.ForwardPackets(nil, switchPackets...); err != nil {
+	if err := s.ForwardPackets(ctx, nil, switchPackets...); err != nil {
 		return err
 	}
 
@@ -1852,7 +1854,7 @@ func (s *Switch) reforwardResolutions() error {
 // used to resurrect the switch's mailboxes after a restart. This also runs for
 // waiting close channels since there may be settles or fails that need to be
 // reforwarded before they completely close.
-func (s *Switch) reforwardResponses() error {
+func (s *Switch) reforwardResponses(ctx context.Context) error {
 	openChannels, err := s.cfg.FetchAllChannels()
 	if err != nil {
 		return err
@@ -1885,7 +1887,7 @@ func (s *Switch) reforwardResponses() error {
 			return err
 		}
 
-		s.reforwardSettleFails(fwdPkgs)
+		s.reforwardSettleFails(ctx, fwdPkgs)
 	}
 
 	return nil
@@ -1918,7 +1920,9 @@ func (s *Switch) loadChannelFwdPkgs(source lnwire.ShortChannelID) ([]*channeldb.
 // outgoing link never comes back online.
 //
 // NOTE: This should mimic the behavior processRemoteSettleFails.
-func (s *Switch) reforwardSettleFails(fwdPkgs []*channeldb.FwdPkg) {
+func (s *Switch) reforwardSettleFails(ctx context.Context,
+	fwdPkgs []*channeldb.FwdPkg) {
+
 	for _, fwdPkg := range fwdPkgs {
 		switchPackets := make([]*htlcPacket, 0, len(fwdPkg.SettleFails))
 		for i, update := range fwdPkg.SettleFails {
@@ -1980,9 +1984,10 @@ func (s *Switch) reforwardSettleFails(fwdPkgs []*channeldb.FwdPkg) {
 		// Since this send isn't tied to a specific link, we pass a nil
 		// link quit channel, meaning the send will fail only if the
 		// switch receives a shutdown request.
-		if err := s.ForwardPackets(nil, switchPackets...); err != nil {
-			log.Errorf("Unhandled error while reforwarding packets "+
-				"settle/fail over htlcswitch: %v", err)
+		err := s.ForwardPackets(ctx, nil, switchPackets...)
+		if err != nil {
+			log.Errorf("Unhandled error while reforwarding "+
+				"packets settle/fail over htlcswitch: %v", err)
 		}
 	}
 }
@@ -1998,6 +2003,7 @@ func (s *Switch) Stop() error {
 	log.Info("HTLC Switch shutting down...")
 	defer log.Debug("HTLC Switch shutdown complete")
 
+	s.cancel.WhenSome(func(fn context.CancelFunc) { fn() })
 	close(s.quit)
 
 	s.wg.Wait()
@@ -2638,7 +2644,7 @@ func (s *Switch) failMailboxUpdate(outgoingScid,
 	// Try to use the failAliasUpdate function in case this is a channel
 	// that uses aliases. If it returns nil, we'll fallback to the original
 	// pre-alias behavior.
-	update := s.failAliasUpdate(outgoingScid, false)
+	update := s.failAliasUpdate(ctx, outgoingScid, false)
 	if update == nil {
 		// Execute the fallback behavior.
 		var err error
@@ -2656,10 +2662,8 @@ func (s *Switch) failMailboxUpdate(outgoingScid,
 // the associated channel is not one of these, this function will return nil
 // and the caller is expected to handle this properly. In this case, a return
 // to the original non-alias behavior is expected.
-func (s *Switch) failAliasUpdate(scid lnwire.ShortChannelID,
-	incoming bool) *lnwire.ChannelUpdate1 {
-
-	ctx := context.TODO()
+func (s *Switch) failAliasUpdate(ctx context.Context,
+	scid lnwire.ShortChannelID, incoming bool) *lnwire.ChannelUpdate1 {
 
 	// This function does not defer the unlocking because of the database
 	// lookups for ChannelUpdate.

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -546,10 +546,8 @@ func (s *Switch) CleanStore(keepPids map[uint64]struct{}) error {
 // package in order to send the htlc update. The attemptID used MUST be unique
 // for this HTLC, and MUST be used only once, otherwise the switch might reject
 // it.
-func (s *Switch) SendHTLC(firstHop lnwire.ShortChannelID, attemptID uint64,
-	htlc *lnwire.UpdateAddHTLC) error {
-
-	ctx := context.TODO()
+func (s *Switch) SendHTLC(ctx context.Context, firstHop lnwire.ShortChannelID,
+	attemptID uint64, htlc *lnwire.UpdateAddHTLC) error {
 
 	// Generate and send new update packet, if error will be received on
 	// this stage it means that packet haven't left boundaries of our

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -1119,13 +1119,15 @@ func (s *Switch) parseFailedPayment(deobfuscator ErrorDecrypter,
 // handlePacketForward is used in cases when we need forward the htlc update
 // from one channel link to another and be able to propagate the settle/fail
 // updates back. This behaviour is achieved by creation of payment circuits.
-func (s *Switch) handlePacketForward(packet *htlcPacket) error {
+func (s *Switch) handlePacketForward(ctx context.Context,
+	packet *htlcPacket) error {
+
 	switch htlc := packet.htlc.(type) {
 	// Channel link forwarded us a new htlc, therefore we initiate the
 	// payment circuit within our internal state so we can properly forward
 	// the ultimate settle message back latter.
 	case *lnwire.UpdateAddHTLC:
-		return s.handlePacketAdd(packet, htlc)
+		return s.handlePacketAdd(ctx, packet, htlc)
 
 	case *lnwire.UpdateFulfillHTLC:
 		return s.handlePacketSettle(packet)
@@ -1459,7 +1461,9 @@ func (s *Switch) CloseLink(ctx context.Context, chanPoint *wire.OutPoint,
 // total link capacity.
 //
 // NOTE: This MUST be run as a goroutine.
-func (s *Switch) htlcForwarder() {
+//
+//nolint:funlen
+func (s *Switch) htlcForwarder(ctx context.Context) {
 	defer s.wg.Done()
 
 	defer func() {
@@ -1619,7 +1623,7 @@ out:
 			// encounter is due to the circuit already being
 			// closed. This is fine, as processing this message is
 			// meant to be idempotent.
-			err = s.handlePacketForward(pkt)
+			err = s.handlePacketForward(ctx, pkt)
 			if err != nil {
 				log.Errorf("Unable to forward resolution msg: %v", err)
 			}
@@ -1628,7 +1632,7 @@ out:
 		// packet concretely, then either forward it along, or
 		// interpret a return packet to a locally initialized one.
 		case cmd := <-s.htlcPlex:
-			cmd.err <- s.handlePacketForward(cmd.pkt)
+			cmd.err <- s.handlePacketForward(ctx, cmd.pkt)
 
 		// When this time ticks, then it indicates that we should
 		// collect all the forwarding events since the last internal,
@@ -1770,7 +1774,7 @@ func (s *Switch) Start() error {
 	s.blockEpochStream = blockEpochStream
 
 	s.wg.Add(1)
-	go s.htlcForwarder()
+	go s.htlcForwarder(ctx)
 
 	if err := s.reforwardResponses(ctx); err != nil {
 		s.Stop()
@@ -2836,7 +2840,7 @@ func (s *Switch) AddAliasForLink(chanID lnwire.ChannelID,
 }
 
 // handlePacketAdd handles forwarding an Add packet.
-func (s *Switch) handlePacketAdd(packet *htlcPacket,
+func (s *Switch) handlePacketAdd(ctx context.Context, packet *htlcPacket,
 	htlc *lnwire.UpdateAddHTLC) error {
 
 	// Check if the node is set to reject all onward HTLCs and also make
@@ -2909,7 +2913,7 @@ func (s *Switch) handlePacketAdd(packet *htlcPacket,
 			// forwarding conditions of this target link.
 			currentHeight := atomic.LoadUint32(&s.bestHeight)
 			failure = link.CheckHtlcForward(
-				htlc.PaymentHash, packet.incomingAmount,
+				ctx, htlc.PaymentHash, packet.incomingAmount,
 				packet.amount, packet.incomingTimeout,
 				packet.outgoingTimeout, packet.inboundFee,
 				currentHeight, packet.originalOutgoingChanID,

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -2642,10 +2642,8 @@ func (s *Switch) dustExceedsFeeThreshold(link ChannelLink,
 // used in the onion. The mailboxScid is the SCID that the mailbox and link
 // use. The mailboxScid is only used in the non-alias case, so it is always
 // the confirmed SCID.
-func (s *Switch) failMailboxUpdate(outgoingScid,
+func (s *Switch) failMailboxUpdate(ctx context.Context, outgoingScid,
 	mailboxScid lnwire.ShortChannelID) lnwire.FailureMessage {
-
-	ctx := context.TODO()
 
 	// Try to use the failAliasUpdate function in case this is a channel
 	// that uses aliases. If it returns nil, we'll fallback to the original

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -134,6 +134,7 @@ func TestSwitchHasActiveLink(t *testing.T) {
 // over pending links.
 func TestSwitchSendPending(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	alicePeer, err := newMockServer(
 		t, "alice", testStartingHeight, nil, testDefaultDelta,
@@ -190,7 +191,7 @@ func TestSwitchSendPending(t *testing.T) {
 
 	// Send the ADD packet, this should not be forwarded out to the link
 	// since there are no eligible links.
-	if err = s.ForwardPackets(nil, packet); err != nil {
+	if err = s.ForwardPackets(ctx, nil, packet); err != nil {
 		t.Fatal(err)
 	}
 	select {
@@ -459,6 +460,8 @@ func testSwitchForwardMapping(t *testing.T, alicePrivate, aliceZeroConf,
 	useAlias, optionScid bool, aliceAlias, aliceReal lnwire.ShortChannelID,
 	expectErr bool) {
 
+	ctx := context.Background()
+
 	alicePeer, err := newMockServer(
 		t, "alice", testStartingHeight, nil, testDefaultDelta,
 	)
@@ -535,7 +538,7 @@ func testSwitchForwardMapping(t *testing.T, alicePrivate, aliceZeroConf,
 			Amount:      1,
 		},
 	}
-	err = s.ForwardPackets(nil, packet)
+	err = s.ForwardPackets(ctx, nil, packet)
 	require.NoError(t, err)
 
 	// If we expect a forwarding error, then assert that we receive one.
@@ -873,6 +876,7 @@ func TestSwitchUpdateScid(t *testing.T) {
 // requests.
 func TestSwitchForward(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	alicePeer, err := newMockServer(
 		t, "alice", testStartingHeight, nil, testDefaultDelta,
@@ -932,7 +936,7 @@ func TestSwitchForward(t *testing.T) {
 	}
 
 	// Handle the request and checks that bob channel link received it.
-	if err := s.ForwardPackets(nil, packet); err != nil {
+	if err := s.ForwardPackets(ctx, nil, packet); err != nil {
 		t.Fatal(err)
 	}
 
@@ -966,7 +970,7 @@ func TestSwitchForward(t *testing.T) {
 	}
 
 	// Handle the request and checks that payment circuit works properly.
-	if err := s.ForwardPackets(nil, packet); err != nil {
+	if err := s.ForwardPackets(ctx, nil, packet); err != nil {
 		t.Fatal(err)
 	}
 
@@ -986,6 +990,7 @@ func TestSwitchForward(t *testing.T) {
 
 func TestSwitchForwardFailAfterFullAdd(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	chanID1, chanID2, aliceChanID, bobChanID := genIDs()
 
@@ -1053,7 +1058,7 @@ func TestSwitchForwardFailAfterFullAdd(t *testing.T) {
 	}
 
 	// Handle the request and checks that bob channel link received it.
-	if err := s.ForwardPackets(nil, ogPacket); err != nil {
+	if err := s.ForwardPackets(ctx, nil, ogPacket); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1138,7 +1143,7 @@ func TestSwitchForwardFailAfterFullAdd(t *testing.T) {
 	}
 
 	// Send the fail packet from the remote peer through the switch.
-	if err := s2.ForwardPackets(nil, fail); err != nil {
+	if err := s2.ForwardPackets(ctx, nil, fail); err != nil {
 		t.Fatalf(err.Error())
 	}
 
@@ -1162,7 +1167,7 @@ func TestSwitchForwardFailAfterFullAdd(t *testing.T) {
 	}
 
 	// Send the fail packet from the remote peer through the switch.
-	if err := s.ForwardPackets(nil, fail); err != nil {
+	if err := s.ForwardPackets(ctx, nil, fail); err != nil {
 		t.Fatal(err)
 	}
 	select {
@@ -1174,6 +1179,7 @@ func TestSwitchForwardFailAfterFullAdd(t *testing.T) {
 
 func TestSwitchForwardSettleAfterFullAdd(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	chanID1, chanID2, aliceChanID, bobChanID := genIDs()
 
@@ -1239,7 +1245,7 @@ func TestSwitchForwardSettleAfterFullAdd(t *testing.T) {
 	}
 
 	// Handle the request and checks that bob channel link received it.
-	if err := s.ForwardPackets(nil, ogPacket); err != nil {
+	if err := s.ForwardPackets(ctx, nil, ogPacket); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1326,7 +1332,7 @@ func TestSwitchForwardSettleAfterFullAdd(t *testing.T) {
 	}
 
 	// Send the settle packet from the remote peer through the switch.
-	if err := s2.ForwardPackets(nil, settle); err != nil {
+	if err := s2.ForwardPackets(ctx, nil, settle); err != nil {
 		t.Fatalf(err.Error())
 	}
 
@@ -1351,7 +1357,7 @@ func TestSwitchForwardSettleAfterFullAdd(t *testing.T) {
 	}
 
 	// Send the settle packet again, which not arrive at destination.
-	if err := s2.ForwardPackets(nil, settle); err != nil {
+	if err := s2.ForwardPackets(ctx, nil, settle); err != nil {
 		t.Fatal(err)
 	}
 	select {
@@ -1363,6 +1369,7 @@ func TestSwitchForwardSettleAfterFullAdd(t *testing.T) {
 
 func TestSwitchForwardDropAfterFullAdd(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	chanID1, chanID2, aliceChanID, bobChanID := genIDs()
 
@@ -1428,7 +1435,7 @@ func TestSwitchForwardDropAfterFullAdd(t *testing.T) {
 	}
 
 	// Handle the request and checks that bob channel link received it.
-	if err := s.ForwardPackets(nil, ogPacket); err != nil {
+	if err := s.ForwardPackets(ctx, nil, ogPacket); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1498,7 +1505,7 @@ func TestSwitchForwardDropAfterFullAdd(t *testing.T) {
 
 	// Resend the failed htlc. The packet will be dropped silently since the
 	// switch will detect that it has been half added previously.
-	if err := s2.ForwardPackets(nil, ogPacket); err != nil {
+	if err := s2.ForwardPackets(ctx, nil, ogPacket); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1515,6 +1522,7 @@ func TestSwitchForwardDropAfterFullAdd(t *testing.T) {
 
 func TestSwitchForwardFailAfterHalfAdd(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	chanID1, chanID2, aliceChanID, bobChanID := genIDs()
 
@@ -1580,7 +1588,7 @@ func TestSwitchForwardFailAfterHalfAdd(t *testing.T) {
 	}
 
 	// Handle the request and checks that bob channel link received it.
-	if err := s.ForwardPackets(nil, ogPacket); err != nil {
+	if err := s.ForwardPackets(ctx, nil, ogPacket); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1645,7 +1653,7 @@ func TestSwitchForwardFailAfterHalfAdd(t *testing.T) {
 
 	// Resend the failed htlc, it should be returned to alice since the
 	// switch will detect that it has been half added previously.
-	err = s2.ForwardPackets(nil, ogPacket)
+	err = s2.ForwardPackets(ctx, nil, ogPacket)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1668,6 +1676,7 @@ func TestSwitchForwardFailAfterHalfAdd(t *testing.T) {
 // maintain the proper entries in the circuit map in the face of restarts.
 func TestSwitchForwardCircuitPersistence(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	chanID1, chanID2, aliceChanID, bobChanID := genIDs()
 
@@ -1733,7 +1742,7 @@ func TestSwitchForwardCircuitPersistence(t *testing.T) {
 	}
 
 	// Handle the request and checks that bob channel link received it.
-	if err := s.ForwardPackets(nil, ogPacket); err != nil {
+	if err := s.ForwardPackets(ctx, nil, ogPacket); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1820,7 +1829,7 @@ func TestSwitchForwardCircuitPersistence(t *testing.T) {
 	}
 
 	// Handle the request and checks that payment circuit works properly.
-	if err := s2.ForwardPackets(nil, ogPacket); err != nil {
+	if err := s2.ForwardPackets(ctx, nil, ogPacket); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1893,6 +1902,9 @@ type multiHopFwdTest struct {
 // through the same channel in the case where the switch is configured to allow
 // and disallow same channel circular forwards.
 func TestCircularForwards(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
 	chanID1, aliceChanID := genID()
 	preimage := [sha256.Size]byte{1}
 	hash := sha256.Sum256(preimage[:])
@@ -1968,9 +1980,9 @@ func TestCircularForwards(t *testing.T) {
 
 			// Attempt to forward the packet and check for the expected
 			// error.
-			if err = s.ForwardPackets(nil, packet); err != nil {
-				t.Fatal(err)
-			}
+			err = s.ForwardPackets(ctx, nil, packet)
+			require.NoError(t, err)
+
 			select {
 			case p := <-aliceChannelLink.packets:
 				if p.linkFailure != nil {
@@ -2198,6 +2210,7 @@ func testSkipIneligibleLinksMultiHopForward(t *testing.T,
 	testCase *multiHopFwdTest) {
 
 	t.Parallel()
+	ctx := context.Background()
 
 	var packet *htlcPacket
 
@@ -2266,7 +2279,7 @@ func testSkipIneligibleLinksMultiHopForward(t *testing.T,
 	}
 
 	// The request to forward should fail as
-	if err := s.ForwardPackets(nil, packet); err != nil {
+	if err := s.ForwardPackets(ctx, nil, packet); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2378,6 +2391,7 @@ func testSkipLinkLocalForward(t *testing.T, eligible bool,
 // circuits.
 func TestSwitchCancel(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	alicePeer, err := newMockServer(
 		t, "alice", testStartingHeight, nil, testDefaultDelta,
@@ -2429,7 +2443,7 @@ func TestSwitchCancel(t *testing.T) {
 	}
 
 	// Handle the request and checks that bob channel link received it.
-	if err := s.ForwardPackets(nil, request); err != nil {
+	if err := s.ForwardPackets(ctx, nil, request); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2461,7 +2475,7 @@ func TestSwitchCancel(t *testing.T) {
 	}
 
 	// Handle the request and checks that payment circuit works properly.
-	if err := s.ForwardPackets(nil, request); err != nil {
+	if err := s.ForwardPackets(ctx, nil, request); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2487,6 +2501,7 @@ func TestSwitchCancel(t *testing.T) {
 // payment hash.
 func TestSwitchAddSamePayment(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	chanID1, chanID2, aliceChanID, bobChanID := genIDs()
 
@@ -2538,7 +2553,7 @@ func TestSwitchAddSamePayment(t *testing.T) {
 	}
 
 	// Handle the request and checks that bob channel link received it.
-	if err := s.ForwardPackets(nil, request); err != nil {
+	if err := s.ForwardPackets(ctx, nil, request); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2568,7 +2583,7 @@ func TestSwitchAddSamePayment(t *testing.T) {
 	}
 
 	// Handle the request and checks that bob channel link received it.
-	if err := s.ForwardPackets(nil, request); err != nil {
+	if err := s.ForwardPackets(ctx, nil, request); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2597,7 +2612,7 @@ func TestSwitchAddSamePayment(t *testing.T) {
 	}
 
 	// Handle the request and checks that payment circuit works properly.
-	if err := s.ForwardPackets(nil, request); err != nil {
+	if err := s.ForwardPackets(ctx, nil, request); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2623,7 +2638,7 @@ func TestSwitchAddSamePayment(t *testing.T) {
 	}
 
 	// Handle the request and checks that payment circuit works properly.
-	if err := s.ForwardPackets(nil, request); err != nil {
+	if err := s.ForwardPackets(ctx, nil, request); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2646,6 +2661,7 @@ func TestSwitchAddSamePayment(t *testing.T) {
 // users when response is came back from channel link.
 func TestSwitchSendPayment(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	alicePeer, err := newMockServer(
 		t, "alice", testStartingHeight, nil, testDefaultDelta,
@@ -2759,7 +2775,7 @@ func TestSwitchSendPayment(t *testing.T) {
 		},
 	}
 
-	if err := s.ForwardPackets(nil, packet); err != nil {
+	if err := s.ForwardPackets(ctx, nil, packet); err != nil {
 		t.Fatalf("can't forward htlc packet: %v", err)
 	}
 
@@ -3163,6 +3179,7 @@ func TestSwitchGetAttemptResult(t *testing.T) {
 // if the failure cannot be decrypted.
 func TestInvalidFailure(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	alicePeer, err := newMockServer(
 		t, "alice", testStartingHeight, nil, testDefaultDelta,
@@ -3228,7 +3245,7 @@ func TestInvalidFailure(t *testing.T) {
 		},
 	}
 
-	if err := s.ForwardPackets(nil, packet); err != nil {
+	if err := s.ForwardPackets(ctx, nil, packet); err != nil {
 		t.Fatalf("can't forward htlc packet: %v", err)
 	}
 
@@ -4570,6 +4587,7 @@ func sendDustHtlcs(t *testing.T, n *threeHopNetwork, alice bool,
 // channel state, so this only tests the switch-mailbox interaction.
 func TestSwitchMailboxDust(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	alicePeer, err := newMockServer(
 		t, "alice", testStartingHeight, nil, testDefaultDelta,
@@ -4679,7 +4697,7 @@ func TestSwitchMailboxDust(t *testing.T) {
 		},
 	}
 
-	err = s.ForwardPackets(nil, packet)
+	err = s.ForwardPackets(ctx, nil, packet)
 	require.NoError(t, err)
 
 	// Bob should receive a failure from the switch.
@@ -4699,6 +4717,7 @@ func TestSwitchMailboxDust(t *testing.T) {
 // resolution messages.
 func TestSwitchResolution(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	alicePeer, err := newMockServer(
 		t, "alice", testStartingHeight, nil, testDefaultDelta,
@@ -4752,7 +4771,7 @@ func TestSwitchResolution(t *testing.T) {
 		},
 	}
 
-	err = s.ForwardPackets(nil, packet)
+	err = s.ForwardPackets(ctx, nil, packet)
 	require.NoError(t, err)
 
 	// Bob will receive the packet and open the circuit.
@@ -4875,6 +4894,7 @@ func TestSwitchForwardFailAlias(t *testing.T) {
 
 func testSwitchForwardFailAlias(t *testing.T, zeroConf bool) {
 	t.Parallel()
+	ctx := context.Background()
 
 	chanID1, chanID2, aliceChanID, bobChanID := genIDs()
 
@@ -4943,7 +4963,7 @@ func testSwitchForwardFailAlias(t *testing.T, zeroConf bool) {
 	}
 
 	// Forward the packet and check that Bob's channel link received it.
-	err = s.ForwardPackets(nil, ogPacket)
+	err = s.ForwardPackets(ctx, nil, ogPacket)
 	require.NoError(t, err)
 
 	// Assert that the circuits are in the expected state.
@@ -5001,7 +5021,7 @@ func testSwitchForwardFailAlias(t *testing.T, zeroConf bool) {
 
 	// Reforward the ogPacket and wait for Alice to receive a failure
 	// packet.
-	err = s2.ForwardPackets(nil, ogPacket)
+	err = s2.ForwardPackets(ctx, nil, ogPacket)
 	require.NoError(t, err)
 
 	select {
@@ -5087,6 +5107,7 @@ func TestSwitchAliasFailAdd(t *testing.T) {
 
 func testSwitchAliasFailAdd(t *testing.T, zeroConf, private, useAlias bool) {
 	t.Parallel()
+	ctx := context.Background()
 
 	chanID1, chanID2, aliceChanID, bobChanID := genIDs()
 
@@ -5177,7 +5198,7 @@ func testSwitchAliasFailAdd(t *testing.T, zeroConf, private, useAlias bool) {
 	ogPacket.outgoingChanID = outgoingChanID
 
 	// Forward the packet so Alice's mailbox fails it backwards.
-	err = s.ForwardPackets(nil, ogPacket)
+	err = s.ForwardPackets(ctx, nil, ogPacket)
 	require.NoError(t, err)
 
 	// Assert that the circuits are in the expected state.
@@ -5279,6 +5300,7 @@ func testSwitchHandlePacketForward(t *testing.T, zeroConf, private,
 	useAlias, optionFeature bool) {
 
 	t.Parallel()
+	ctx := context.Background()
 
 	// Create a link for Alice that we'll add to the switch.
 	harness, err :=
@@ -5383,7 +5405,7 @@ func testSwitchHandlePacketForward(t *testing.T, zeroConf, private,
 
 	// Forward the packet to Alice and she should fail it back with an
 	// AmountBelowMinimum FailureMessage.
-	err = s.ForwardPackets(nil, ogPacket)
+	err = s.ForwardPackets(ctx, nil, ogPacket)
 	require.NoError(t, err)
 
 	select {

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -5545,11 +5545,13 @@ func testSwitchAliasInterceptFail(t *testing.T, zeroConf bool) {
 	require.NoError(t, err)
 
 	inCircuit := forwardInterceptor.getIntercepted().IncomingCircuit
-	require.NoError(t, interceptSwitch.resolve(&FwdResolution{
-		Action:      FwdActionFail,
-		Key:         inCircuit,
-		FailureCode: lnwire.CodeTemporaryChannelFailure,
-	}))
+	require.NoError(t, interceptSwitch.resolve(
+		context.Background(), &FwdResolution{
+			Action:      FwdActionFail,
+			Key:         inCircuit,
+			FailureCode: lnwire.CodeTemporaryChannelFailure,
+		},
+	))
 
 	select {
 	case failPacket := <-aliceLink.packets:

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -3927,7 +3927,7 @@ func TestSwitchHoldForward(t *testing.T) {
 
 	// Simulate an error during the composition of the failure message.
 	currentCallback := c.s.cfg.FetchLastChannelUpdate
-	c.s.cfg.FetchLastChannelUpdate = func(
+	c.s.cfg.FetchLastChannelUpdate = func(context.Context,
 		lnwire.ShortChannelID) (*lnwire.ChannelUpdate1, error) {
 
 		return nil, errors.New("cannot fetch update")

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -794,7 +794,7 @@ func preparePayment(sendingPeer, receivingPeer lnpeer.Peer,
 	// Send payment and expose err channel.
 	return invoice, func() error {
 		err := sender.htlcSwitch.SendHTLC(
-			firstHop, pid, htlc,
+			context.Background(), firstHop, pid, htlc,
 		)
 		if err != nil {
 			return err
@@ -1362,7 +1362,9 @@ func (n *twoHopNetwork) makeHoldPayment(sendingPeer, receivingPeer lnpeer.Peer,
 	}
 
 	// Send payment and expose err channel.
-	err = sender.htlcSwitch.SendHTLC(firstHop, pid, htlc)
+	err = sender.htlcSwitch.SendHTLC(
+		context.Background(), firstHop, pid, htlc,
+	)
 	if err != nil {
 		paymentErr <- err
 		return paymentErr

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -1134,7 +1134,9 @@ func (h *hopNetwork) createChannelLink(server, peer *mockServer,
 	forwardPackets := func(linkQuit <-chan struct{}, _ bool,
 		packets ...*htlcPacket) error {
 
-		return server.htlcSwitch.ForwardPackets(linkQuit, packets...)
+		return server.htlcSwitch.ForwardPackets(
+			context.Background(), linkQuit, packets...,
+		)
 	}
 
 	//nolint:ll

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -95,8 +95,8 @@ func genIDs() (lnwire.ChannelID, lnwire.ChannelID, lnwire.ShortChannelID,
 
 // mockGetChanUpdateMessage helper function which returns topology update of
 // the channel
-func mockGetChanUpdateMessage(_ lnwire.ShortChannelID) (*lnwire.ChannelUpdate1,
-	error) {
+func mockGetChanUpdateMessage(_ context.Context,
+	_ lnwire.ShortChannelID) (*lnwire.ChannelUpdate1, error) {
 
 	return &lnwire.ChannelUpdate1{
 		Signature: wireSig,

--- a/intercepted_forward.go
+++ b/intercepted_forward.go
@@ -55,7 +55,8 @@ func (f *interceptedForward) Resume(_ context.Context) error {
 
 // ResumeModified notifies the intention to resume an existing hold forward with
 // a modified htlc.
-func (f *interceptedForward) ResumeModified(_, _ fn.Option[lnwire.MilliSatoshi],
+func (f *interceptedForward) ResumeModified(_ context.Context, _,
+	_ fn.Option[lnwire.MilliSatoshi],
 	_ fn.Option[lnwire.CustomRecords]) error {
 
 	return ErrCannotResume

--- a/intercepted_forward.go
+++ b/intercepted_forward.go
@@ -49,7 +49,7 @@ func (f *interceptedForward) Packet() htlcswitch.InterceptedPacket {
 // Resume notifies the intention to resume an existing hold forward. This
 // basically means the caller wants to resume with the default behavior for this
 // htlc which usually means forward it.
-func (f *interceptedForward) Resume() error {
+func (f *interceptedForward) Resume(_ context.Context) error {
 	return ErrCannotResume
 }
 

--- a/intercepted_forward.go
+++ b/intercepted_forward.go
@@ -1,6 +1,7 @@
 package lnd
 
 import (
+	"context"
 	"errors"
 
 	"github.com/lightningnetwork/lnd/fn/v2"
@@ -72,7 +73,9 @@ func (f *interceptedForward) Fail(_ []byte) error {
 
 // FailWithCode notifies the intention to fail an existing hold forward with the
 // specified failure code.
-func (f *interceptedForward) FailWithCode(_ lnwire.FailCode) error {
+func (f *interceptedForward) FailWithCode(_ context.Context,
+	_ lnwire.FailCode) error {
+
 	return ErrCannotFail
 }
 

--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -923,7 +923,7 @@ func (s *Server) SendToRouteV2(ctx context.Context,
 	// db.
 	if req.SkipTempErr {
 		attempt, err = s.cfg.Router.SendToRouteSkipTempErr(
-			hash, route, firstHopRecords,
+			ctx, hash, route, firstHopRecords,
 		)
 	} else {
 		attempt, err = s.cfg.Router.SendToRoute(

--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -927,7 +927,7 @@ func (s *Server) SendToRouteV2(ctx context.Context,
 		)
 	} else {
 		attempt, err = s.cfg.Router.SendToRoute(
-			hash, route, firstHopRecords,
+			ctx, hash, route, firstHopRecords,
 		)
 	}
 	if attempt != nil {

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -336,8 +336,8 @@ type Config struct {
 
 	// FetchLastChanUpdate fetches our latest channel update for a target
 	// channel.
-	FetchLastChanUpdate func(lnwire.ShortChannelID) (*lnwire.ChannelUpdate1,
-		error)
+	FetchLastChanUpdate func(context.Context,
+		lnwire.ShortChannelID) (*lnwire.ChannelUpdate1, error)
 
 	// FundingManager is an implementation of the funding.Controller interface.
 	FundingManager funding.Controller
@@ -1498,6 +1498,8 @@ func (p *Brontide) maybeSendChannelUpdates() {
 	maybeSendUpd := func(cid lnwire.ChannelID,
 		lnChan *lnwallet.LightningChannel) error {
 
+		ctx := context.TODO()
+
 		// Nil channels are pending, so we'll skip them.
 		if lnChan == nil {
 			return nil
@@ -1521,7 +1523,7 @@ func (p *Brontide) maybeSendChannelUpdates() {
 		// to fetch the update to send to the remote peer. If the
 		// channel is pending, and not a zero conf channel, we'll get
 		// an error here which we'll ignore.
-		chanUpd, err := p.cfg.FetchLastChanUpdate(scid)
+		chanUpd, err := p.cfg.FetchLastChanUpdate(ctx, scid)
 		if err != nil {
 			p.log.Debugf("Unable to fetch channel update for "+
 				"ChannelPoint(%v), scid=%v: %v",

--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -2,6 +2,7 @@ package peer
 
 import (
 	"bytes"
+	"context"
 	crand "crypto/rand"
 	"encoding/binary"
 	"io"
@@ -748,8 +749,9 @@ func createTestPeer(t *testing.T) *peerTestCtx {
 			return nil
 		},
 		PongBuf: make([]byte, lnwire.MaxPongBytes),
-		FetchLastChanUpdate: func(chanID lnwire.ShortChannelID,
-		) (*lnwire.ChannelUpdate1, error) {
+		FetchLastChanUpdate: func(_ context.Context,
+			_ lnwire.ShortChannelID) (*lnwire.ChannelUpdate1,
+			error) {
 
 			return &lnwire.ChannelUpdate1{}, nil
 		},

--- a/routing/mock_test.go
+++ b/routing/mock_test.go
@@ -1,6 +1,7 @@
 package routing
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -29,7 +30,7 @@ type mockPaymentAttemptDispatcherOld struct {
 
 var _ PaymentAttemptDispatcher = (*mockPaymentAttemptDispatcherOld)(nil)
 
-func (m *mockPaymentAttemptDispatcherOld) SendHTLC(
+func (m *mockPaymentAttemptDispatcherOld) SendHTLC(_ context.Context,
 	firstHop lnwire.ShortChannelID, pid uint64,
 	_ *lnwire.UpdateAddHTLC) error {
 
@@ -206,7 +207,7 @@ type mockPayerOld struct {
 
 var _ PaymentAttemptDispatcher = (*mockPayerOld)(nil)
 
-func (m *mockPayerOld) SendHTLC(_ lnwire.ShortChannelID,
+func (m *mockPayerOld) SendHTLC(_ context.Context, _ lnwire.ShortChannelID,
 	paymentID uint64,
 	_ *lnwire.UpdateAddHTLC) error {
 
@@ -592,7 +593,8 @@ type mockPaymentAttemptDispatcher struct {
 
 var _ PaymentAttemptDispatcher = (*mockPaymentAttemptDispatcher)(nil)
 
-func (m *mockPaymentAttemptDispatcher) SendHTLC(firstHop lnwire.ShortChannelID,
+func (m *mockPaymentAttemptDispatcher) SendHTLC(_ context.Context,
+	firstHop lnwire.ShortChannelID,
 	pid uint64, htlcAdd *lnwire.UpdateAddHTLC) error {
 
 	args := m.Called(firstHop, pid, htlcAdd)

--- a/routing/payment_lifecycle.go
+++ b/routing/payment_lifecycle.go
@@ -304,7 +304,7 @@ lifecycle:
 		}
 
 		// Once the attempt is created, send it to the htlcswitch.
-		result, err := p.sendAttempt(attempt)
+		result, err := p.sendAttempt(ctx, attempt)
 		if err != nil {
 			return exitWithErr(err)
 		}
@@ -649,7 +649,7 @@ func (p *paymentLifecycle) createNewPaymentAttempt(rt *route.Route,
 // sendAttempt attempts to send the current attempt to the switch to complete
 // the payment. If this attempt fails, then we'll continue on to the next
 // available route.
-func (p *paymentLifecycle) sendAttempt(
+func (p *paymentLifecycle) sendAttempt(ctx context.Context,
 	attempt *channeldb.HTLCAttempt) (*attemptResult, error) {
 
 	log.Debugf("Sending HTLC attempt(id=%v, total_amt=%v, first_hop_amt=%d"+
@@ -690,7 +690,9 @@ func (p *paymentLifecycle) sendAttempt(
 	// the Switch successfully has persisted the payment attempt,
 	// such that we can resume waiting for the result after a
 	// restart.
-	err = p.router.cfg.Payer.SendHTLC(firstHop, attempt.AttemptID, htlcAdd)
+	err = p.router.cfg.Payer.SendHTLC(
+		ctx, firstHop, attempt.AttemptID, htlcAdd,
+	)
 	if err != nil {
 		log.Errorf("Failed sending attempt %d for payment %v to "+
 			"switch: %v", attempt.AttemptID, p.identifier, err)

--- a/routing/router.go
+++ b/routing/router.go
@@ -108,7 +108,7 @@ type PaymentAttemptDispatcher interface {
 	// forward a fully encoded payment to the first hop in the route
 	// denoted by its public key. A non-nil error is to be returned if the
 	// payment was unsuccessful.
-	SendHTLC(firstHop lnwire.ShortChannelID,
+	SendHTLC(ctx context.Context, firstHop lnwire.ShortChannelID,
 		attemptID uint64,
 		htlcAdd *lnwire.UpdateAddHTLC) error
 
@@ -1024,7 +1024,9 @@ func (r *ChannelRouter) SendToRoute(htlcHash lntypes.Hash, rt *route.Route,
 	firstHopCustomRecords lnwire.CustomRecords) (*channeldb.HTLCAttempt,
 	error) {
 
-	return r.sendToRoute(htlcHash, rt, false, firstHopCustomRecords)
+	ctx := context.TODO()
+
+	return r.sendToRoute(ctx, htlcHash, rt, false, firstHopCustomRecords)
 }
 
 // SendToRouteSkipTempErr sends a payment using the provided route and fails
@@ -1034,7 +1036,9 @@ func (r *ChannelRouter) SendToRouteSkipTempErr(htlcHash lntypes.Hash,
 	firstHopCustomRecords lnwire.CustomRecords) (*channeldb.HTLCAttempt,
 	error) {
 
-	return r.sendToRoute(htlcHash, rt, true, firstHopCustomRecords)
+	ctx := context.TODO()
+
+	return r.sendToRoute(ctx, htlcHash, rt, true, firstHopCustomRecords)
 }
 
 // sendToRoute attempts to send a payment with the given hash through the
@@ -1043,8 +1047,8 @@ func (r *ChannelRouter) SendToRouteSkipTempErr(htlcHash lntypes.Hash,
 // information will contain the preimage. If an error occurs after the attempt
 // was initiated, both return values will be non-nil. If skipTempErr is true,
 // the payment won't be failed unless a terminal error has occurred.
-func (r *ChannelRouter) sendToRoute(htlcHash lntypes.Hash, rt *route.Route,
-	skipTempErr bool,
+func (r *ChannelRouter) sendToRoute(ctx context.Context, htlcHash lntypes.Hash,
+	rt *route.Route, skipTempErr bool,
 	firstHopCustomRecords lnwire.CustomRecords) (*channeldb.HTLCAttempt,
 	error) {
 
@@ -1166,7 +1170,7 @@ func (r *ChannelRouter) sendToRoute(htlcHash lntypes.Hash, rt *route.Route,
 	// the `err` returned here has already been processed by
 	// `handleSwitchErr`, which means if there's a terminal failure, the
 	// payment has been failed.
-	result, err := p.sendAttempt(attempt)
+	result, err := p.sendAttempt(ctx, attempt)
 	if err != nil {
 		return nil, err
 	}

--- a/routing/router.go
+++ b/routing/router.go
@@ -1020,11 +1020,10 @@ func (r *ChannelRouter) PreparePayment(payment *LightningPayment) (
 
 // SendToRoute sends a payment using the provided route and fails the payment
 // when an error is returned from the attempt.
-func (r *ChannelRouter) SendToRoute(htlcHash lntypes.Hash, rt *route.Route,
+func (r *ChannelRouter) SendToRoute(ctx context.Context, htlcHash lntypes.Hash,
+	rt *route.Route,
 	firstHopCustomRecords lnwire.CustomRecords) (*channeldb.HTLCAttempt,
 	error) {
-
-	ctx := context.TODO()
 
 	return r.sendToRoute(ctx, htlcHash, rt, false, firstHopCustomRecords)
 }

--- a/routing/router.go
+++ b/routing/router.go
@@ -1030,12 +1030,10 @@ func (r *ChannelRouter) SendToRoute(ctx context.Context, htlcHash lntypes.Hash,
 
 // SendToRouteSkipTempErr sends a payment using the provided route and fails
 // the payment ONLY when a terminal error is returned from the attempt.
-func (r *ChannelRouter) SendToRouteSkipTempErr(htlcHash lntypes.Hash,
-	rt *route.Route,
+func (r *ChannelRouter) SendToRouteSkipTempErr(ctx context.Context,
+	htlcHash lntypes.Hash, rt *route.Route,
 	firstHopCustomRecords lnwire.CustomRecords) (*channeldb.HTLCAttempt,
 	error) {
-
-	ctx := context.TODO()
 
 	return r.sendToRoute(ctx, htlcHash, rt, true, firstHopCustomRecords)
 }

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -2,6 +2,7 @@ package routing
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"image/color"
 	"math"
@@ -519,7 +520,9 @@ func TestChannelUpdateValidation(t *testing.T) {
 	// Send off the payment request to the router. The specified route
 	// should be attempted and the channel update should be received by
 	// graph and ignored because it is missing a valid signature.
-	_, err = ctx.router.SendToRoute(payment, rt, nil)
+	_, err = ctx.router.SendToRoute(
+		context.Background(), payment, rt, nil,
+	)
 	require.Error(t, err, "expected route to fail with channel update")
 
 	_, e1, e2, err = ctx.graph.FetchChannelEdgesByID(
@@ -539,7 +542,9 @@ func TestChannelUpdateValidation(t *testing.T) {
 	ctx.graphBuilder.setNextReject(false)
 
 	// Retry the payment using the same route as before.
-	_, err = ctx.router.SendToRoute(payment, rt, nil)
+	_, err = ctx.router.SendToRoute(
+		context.Background(), payment, rt, nil,
+	)
 	require.Error(t, err, "expected route to fail with channel update")
 
 	// This time a valid signature was supplied and the policy change should
@@ -1422,7 +1427,9 @@ func TestSendToRouteStructuredError(t *testing.T) {
 			// update should be received by router and ignored
 			// because it is missing a valid
 			// signature.
-			_, err = ctx.router.SendToRoute(payment, rt, nil)
+			_, err = ctx.router.SendToRoute(
+				context.Background(), payment, rt, nil,
+			)
 
 			fErr, ok := err.(*htlcswitch.ForwardingError)
 			require.True(
@@ -1501,7 +1508,7 @@ func TestSendToRouteMaxHops(t *testing.T) {
 	// Send off the payment request to the router. We expect an error back
 	// indicating that the route is too long.
 	var payHash lntypes.Hash
-	_, err = ctx.router.SendToRoute(payHash, rt, nil)
+	_, err = ctx.router.SendToRoute(context.Background(), payHash, rt, nil)
 	if err != route.ErrMaxRouteHopsExceeded {
 		t.Fatalf("expected ErrMaxRouteHopsExceeded, but got %v", err)
 	}
@@ -2524,7 +2531,9 @@ func TestSendToRouteTempFailure(t *testing.T) {
 	).Return(nil, nil)
 
 	// Expect a failed send to route.
-	attempt, err := router.SendToRoute(payHash, rt, nil)
+	attempt, err := router.SendToRoute(
+		context.Background(), payHash, rt, nil,
+	)
 	require.Equal(t, tempErr, err)
 	require.Equal(t, testAttempt, attempt)
 

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -2223,7 +2223,9 @@ func TestSendToRouteSkipTempErrSuccess(t *testing.T) {
 	).Return(nil)
 
 	// Expect a successful send to route.
-	attempt, err := router.SendToRouteSkipTempErr(payHash, rt, nil)
+	attempt, err := router.SendToRouteSkipTempErr(
+		context.Background(), payHash, rt, nil,
+	)
 	require.NoError(t, err)
 	require.Equal(t, testAttempt, attempt)
 
@@ -2278,7 +2280,9 @@ func TestSendToRouteSkipTempErrNonMPP(t *testing.T) {
 	}}
 
 	// Expect an error to be returned.
-	attempt, err := router.SendToRouteSkipTempErr(payHash, rt, nil)
+	attempt, err := router.SendToRouteSkipTempErr(
+		context.Background(), payHash, rt, nil,
+	)
 	require.ErrorIs(t, ErrSkipTempErr, err)
 	require.Nil(t, attempt)
 
@@ -2358,7 +2362,9 @@ func TestSendToRouteSkipTempErrTempFailure(t *testing.T) {
 	).Return(nil, nil)
 
 	// Expect a failed send to route.
-	attempt, err := router.SendToRouteSkipTempErr(payHash, rt, nil)
+	attempt, err := router.SendToRouteSkipTempErr(
+		context.Background(), payHash, rt, nil,
+	)
 	require.Equal(t, tempErr, err)
 	require.Equal(t, testAttempt, attempt)
 
@@ -2442,7 +2448,9 @@ func TestSendToRouteSkipTempErrPermanentFailure(t *testing.T) {
 	).Return(&failureReason, nil)
 
 	// Expect a failed send to route.
-	attempt, err := router.SendToRouteSkipTempErr(payHash, rt, nil)
+	attempt, err := router.SendToRouteSkipTempErr(
+		context.Background(), payHash, rt, nil,
+	)
 	require.Equal(t, permErr, err)
 	require.Equal(t, testAttempt, attempt)
 

--- a/server.go
+++ b/server.go
@@ -5227,11 +5227,13 @@ func (s *server) fetchNodeAdvertisedAddrs(pub *btcec.PublicKey) ([]net.Addr, err
 
 // fetchLastChanUpdate returns a function which is able to retrieve our latest
 // channel update for a target channel.
-func (s *server) fetchLastChanUpdate() func(lnwire.ShortChannelID) (
-	*lnwire.ChannelUpdate1, error) {
+func (s *server) fetchLastChanUpdate() func(context.Context,
+	lnwire.ShortChannelID) (*lnwire.ChannelUpdate1, error) {
 
 	ourPubKey := s.identityECDH.PubKey().SerializeCompressed()
-	return func(cid lnwire.ShortChannelID) (*lnwire.ChannelUpdate1, error) {
+	return func(_ context.Context, cid lnwire.ShortChannelID) (
+		*lnwire.ChannelUpdate1, error) {
+
 		info, edge1, edge2, err := s.graphBuilder.GetChannelByID(cid)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Depends on https://github.com/lightningnetwork/lnd/pull/9691.

### PR context

This is part of the last step required to complete https://github.com/lightningnetwork/lnd/issues/9494. We want all calls to the graph DB (and hence, ChannelGraph) to take a context since later, this context will be passed through to any remote graph RPC calls as well as any DB calls to a SQL graph backend. 

### This PR specifically: This is part 2 of a 2 part PR series that addresses the `htlcswitch`

In this PR, we tackle the `htlcswitch` & `peer` packages. This is split over 2 PRs since it is quite a lot. This PR is part 2. This package makes calls to the graph's `FetchLastChannelUpdate` call. So this PR is all aimed at threading contexts through to the call-sites of this call-back. It leaves 1 `context.TODO()` in the main LND `server` which will be addressed in a follow up.

### Branch strategy:

This series of PRs is basically a big code refactor. So once 19 is shipped, we can merge any work that has been merged into `elle-graph` and from then on we can just merge into master. 