### PR TITLE
discovery+autopilot: revert passing contexts to `Start` methods

### DIFF
--- a/autopilot/agent.go
+++ b/autopilot/agent.go
@@ -202,10 +202,10 @@ func New(cfg Config, initialState []LocalChannel) (*Agent, error) {
 
 // Start starts the agent along with any goroutines it needs to perform its
 // normal duties.
-func (a *Agent) Start(ctx context.Context) error {
+func (a *Agent) Start() error {
 	var err error
 	a.started.Do(func() {
-		ctx, cancel := context.WithCancel(ctx)
+		ctx, cancel := context.WithCancel(context.Background())
 		a.cancel = fn.Some(cancel)
 
 		err = a.start(ctx)

--- a/autopilot/agent_test.go
+++ b/autopilot/agent_test.go
@@ -221,7 +221,7 @@ func setup(t *testing.T, initialChans []LocalChannel) *testContext {
 
 	// With the autopilot agent and all its dependencies we'll start the
 	// primary controller goroutine.
-	if err := agent.Start(context.Background()); err != nil {
+	if err := agent.Start(); err != nil {
 		t.Fatalf("unable to start agent: %v", err)
 	}
 

--- a/autopilot/manager.go
+++ b/autopilot/manager.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/lightningnetwork/lnd/fn/v2"
 	graphdb "github.com/lightningnetwork/lnd/graph/db"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -55,9 +54,8 @@ type Manager struct {
 	// disabled.
 	pilot *Agent
 
-	quit   chan struct{}
-	wg     sync.WaitGroup
-	cancel fn.Option[context.CancelFunc]
+	quit chan struct{}
+	wg   sync.WaitGroup
 	sync.Mutex
 }
 
@@ -83,7 +81,6 @@ func (m *Manager) Stop() error {
 			log.Errorf("Unable to stop pilot: %v", err)
 		}
 
-		m.cancel.WhenSome(func(fn context.CancelFunc) { fn() })
 		close(m.quit)
 		m.wg.Wait()
 	})
@@ -100,7 +97,7 @@ func (m *Manager) IsActive() bool {
 
 // StartAgent creates and starts an autopilot agent from the Manager's
 // config.
-func (m *Manager) StartAgent(ctx context.Context) error {
+func (m *Manager) StartAgent() error {
 	m.Lock()
 	defer m.Unlock()
 
@@ -108,8 +105,6 @@ func (m *Manager) StartAgent(ctx context.Context) error {
 	if m.pilot != nil {
 		return nil
 	}
-	ctx, cancel := context.WithCancel(ctx)
-	m.cancel = fn.Some(cancel)
 
 	// Next, we'll fetch the current state of open channels from the
 	// database to use as initial state for the auto-pilot agent.
@@ -125,7 +120,7 @@ func (m *Manager) StartAgent(ctx context.Context) error {
 		return err
 	}
 
-	if err := pilot.Start(ctx); err != nil {
+	if err := pilot.Start(); err != nil {
 		return err
 	}
 
@@ -168,8 +163,6 @@ func (m *Manager) StartAgent(ctx context.Context) error {
 			case <-pilot.quit:
 				return
 			case <-m.quit:
-				return
-			case <-ctx.Done():
 				return
 			}
 		}
@@ -240,8 +233,6 @@ func (m *Manager) StartAgent(ctx context.Context) error {
 			case <-pilot.quit:
 				return
 			case <-m.quit:
-				return
-			case <-ctx.Done():
 				return
 			}
 		}

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -643,10 +643,10 @@ func (d *AuthenticatedGossiper) PropagateChanPolicyUpdate(
 
 // Start spawns network messages handler goroutine and registers on new block
 // notifications in order to properly handle the premature announcements.
-func (d *AuthenticatedGossiper) Start(ctx context.Context) error {
+func (d *AuthenticatedGossiper) Start() error {
 	var err error
 	d.started.Do(func() {
-		ctx, cancel := context.WithCancel(ctx)
+		ctx, cancel := context.WithCancel(context.Background())
 		d.cancel = fn.Some(cancel)
 
 		log.Info("Authenticated Gossiper starting")
@@ -674,11 +674,11 @@ func (d *AuthenticatedGossiper) start(ctx context.Context) error {
 	// Start the reliable sender. In case we had any pending messages ready
 	// to be sent when the gossiper was last shut down, we must continue on
 	// our quest to deliver them to their respective peers.
-	if err := d.reliableSender.Start(ctx); err != nil {
+	if err := d.reliableSender.Start(); err != nil {
 		return err
 	}
 
-	d.syncMgr.Start(ctx)
+	d.syncMgr.Start()
 
 	d.banman.start()
 

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -994,7 +994,7 @@ func createTestCtx(t *testing.T, startHeight uint32, isChanPeer bool) (
 		ScidCloser:            newMockScidCloser(isChanPeer),
 	}, selfKeyDesc)
 
-	if err := gossiper.Start(context.Background()); err != nil {
+	if err := gossiper.Start(); err != nil {
 		return nil, fmt.Errorf("unable to start router: %w", err)
 	}
 
@@ -1692,7 +1692,7 @@ func TestSignatureAnnouncementRetryAtStartup(t *testing.T) {
 		KeyLocator: tCtx.gossiper.selfKeyLoc,
 	})
 	require.NoError(t, err, "unable to recreate gossiper")
-	if err := gossiper.Start(context.Background()); err != nil {
+	if err := gossiper.Start(); err != nil {
 		t.Fatalf("unable to start recreated gossiper: %v", err)
 	}
 	defer gossiper.Stop()

--- a/discovery/reliable_sender.go
+++ b/discovery/reliable_sender.go
@@ -76,10 +76,10 @@ func newReliableSender(cfg *reliableSenderCfg) *reliableSender {
 }
 
 // Start spawns message handlers for any peers with pending messages.
-func (s *reliableSender) Start(ctx context.Context) error {
+func (s *reliableSender) Start() error {
 	var err error
 	s.start.Do(func() {
-		ctx, cancel := context.WithCancel(ctx)
+		ctx, cancel := context.WithCancel(context.Background())
 		s.cancel = fn.Some(cancel)
 
 		err = s.resendPendingMsgs(ctx)

--- a/discovery/sync_manager_test.go
+++ b/discovery/sync_manager_test.go
@@ -2,7 +2,6 @@ package discovery
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"reflect"
@@ -83,7 +82,7 @@ func TestSyncManagerNumActiveSyncers(t *testing.T) {
 	}
 
 	syncMgr := newPinnedTestSyncManager(numActiveSyncers, pinnedSyncers)
-	syncMgr.Start(context.Background())
+	syncMgr.Start()
 	defer syncMgr.Stop()
 
 	// First we'll start by adding the pinned syncers. These should
@@ -135,7 +134,7 @@ func TestSyncManagerNewActiveSyncerAfterDisconnect(t *testing.T) {
 
 	// We'll create our test sync manager to have two active syncers.
 	syncMgr := newTestSyncManager(2)
-	syncMgr.Start(context.Background())
+	syncMgr.Start()
 	defer syncMgr.Stop()
 
 	// The first will be an active syncer that performs a historical sync
@@ -188,7 +187,7 @@ func TestSyncManagerRotateActiveSyncerCandidate(t *testing.T) {
 
 	// We'll create our sync manager with three active syncers.
 	syncMgr := newTestSyncManager(1)
-	syncMgr.Start(context.Background())
+	syncMgr.Start()
 	defer syncMgr.Stop()
 
 	// The first syncer registered always performs a historical sync.
@@ -236,7 +235,7 @@ func TestSyncManagerNoInitialHistoricalSync(t *testing.T) {
 	t.Parallel()
 
 	syncMgr := newTestSyncManager(0)
-	syncMgr.Start(context.Background())
+	syncMgr.Start()
 	defer syncMgr.Stop()
 
 	// We should not expect any messages from the peer.
@@ -270,7 +269,7 @@ func TestSyncManagerInitialHistoricalSync(t *testing.T) {
 		t.Fatal("expected graph to not be considered as synced")
 	}
 
-	syncMgr.Start(context.Background())
+	syncMgr.Start()
 	defer syncMgr.Stop()
 
 	// We should expect to see a QueryChannelRange message with a
@@ -339,7 +338,7 @@ func TestSyncManagerHistoricalSyncOnReconnect(t *testing.T) {
 	t.Parallel()
 
 	syncMgr := newTestSyncManager(2)
-	syncMgr.Start(context.Background())
+	syncMgr.Start()
 	defer syncMgr.Stop()
 
 	// We should expect to see a QueryChannelRange message with a
@@ -373,7 +372,7 @@ func TestSyncManagerForceHistoricalSync(t *testing.T) {
 	t.Parallel()
 
 	syncMgr := newTestSyncManager(1)
-	syncMgr.Start(context.Background())
+	syncMgr.Start()
 	defer syncMgr.Stop()
 
 	// We should expect to see a QueryChannelRange message with a
@@ -411,7 +410,7 @@ func TestSyncManagerGraphSyncedAfterHistoricalSyncReplacement(t *testing.T) {
 	t.Parallel()
 
 	syncMgr := newTestSyncManager(1)
-	syncMgr.Start(context.Background())
+	syncMgr.Start()
 	defer syncMgr.Stop()
 
 	// We should expect to see a QueryChannelRange message with a
@@ -469,7 +468,7 @@ func TestSyncManagerWaitUntilInitialHistoricalSync(t *testing.T) {
 	// We'll start by creating our test sync manager which will hold up to
 	// 2 active syncers.
 	syncMgr := newTestSyncManager(numActiveSyncers)
-	syncMgr.Start(context.Background())
+	syncMgr.Start()
 	defer syncMgr.Stop()
 
 	// We'll go ahead and create our syncers.

--- a/discovery/syncer.go
+++ b/discovery/syncer.go
@@ -405,11 +405,11 @@ func newGossipSyncer(cfg gossipSyncerCfg, sema chan struct{}) *GossipSyncer {
 
 // Start starts the GossipSyncer and any goroutines that it needs to carry out
 // its duties.
-func (g *GossipSyncer) Start(ctx context.Context) {
+func (g *GossipSyncer) Start() {
 	g.started.Do(func() {
 		log.Debugf("Starting GossipSyncer(%x)", g.cfg.peerPub[:])
 
-		ctx, _ := g.cg.Create(ctx)
+		ctx, _ := g.cg.Create(context.Background())
 
 		// TODO(conner): only spawn channelGraphSyncer if remote
 		// supports gossip queries, and only spawn replyHandler if we

--- a/discovery/syncer_test.go
+++ b/discovery/syncer_test.go
@@ -1703,7 +1703,6 @@ func queryBatch(t *testing.T,
 // them.
 func TestGossipSyncerRoutineSync(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	// We'll modify the chunk size to be a smaller value, so we can ensure
 	// our chunk parsing works properly. With this value we should get 3
@@ -1718,13 +1717,13 @@ func TestGossipSyncerRoutineSync(t *testing.T) {
 	msgChan1, syncer1, chanSeries1 := newTestSyncer(
 		highestID, defaultEncoding, chunkSize, true, false,
 	)
-	syncer1.Start(ctx)
+	syncer1.Start()
 	defer syncer1.Stop()
 
 	msgChan2, syncer2, chanSeries2 := newTestSyncer(
 		highestID, defaultEncoding, chunkSize, false, true,
 	)
-	syncer2.Start(ctx)
+	syncer2.Start()
 	defer syncer2.Stop()
 
 	// Although both nodes are at the same height, syncer will have 3 chan
@@ -1851,7 +1850,6 @@ func TestGossipSyncerRoutineSync(t *testing.T) {
 // final state and not perform any channel queries.
 func TestGossipSyncerAlreadySynced(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	// We'll modify the chunk size to be a smaller value, so we can ensure
 	// our chunk parsing works properly. With this value we should get 3
@@ -1867,13 +1865,13 @@ func TestGossipSyncerAlreadySynced(t *testing.T) {
 	msgChan1, syncer1, chanSeries1 := newTestSyncer(
 		highestID, defaultEncoding, chunkSize,
 	)
-	syncer1.Start(ctx)
+	syncer1.Start()
 	defer syncer1.Stop()
 
 	msgChan2, syncer2, chanSeries2 := newTestSyncer(
 		highestID, defaultEncoding, chunkSize,
 	)
-	syncer2.Start(ctx)
+	syncer2.Start()
 	defer syncer2.Stop()
 
 	// The channel state of both syncers will be identical. They should
@@ -2073,7 +2071,6 @@ func TestGossipSyncerAlreadySynced(t *testing.T) {
 // carries out its duties when accepting a new sync transition request.
 func TestGossipSyncerSyncTransitions(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	assertMsgSent := func(t *testing.T, msgChan chan []lnwire.Message,
 		msg lnwire.Message) {
@@ -2194,7 +2191,7 @@ func TestGossipSyncerSyncTransitions(t *testing.T) {
 
 			// We'll then start the syncer in order to process the
 			// request.
-			syncer.Start(ctx)
+			syncer.Start()
 			defer syncer.Stop()
 
 			syncer.ProcessSyncTransition(test.finalSyncType)
@@ -2219,7 +2216,6 @@ func TestGossipSyncerSyncTransitions(t *testing.T) {
 // historical sync with the remote peer.
 func TestGossipSyncerHistoricalSync(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	// We'll create a new gossip syncer and manually override its state to
 	// chansSynced. This is necessary as the syncer can only process
@@ -2231,7 +2227,7 @@ func TestGossipSyncerHistoricalSync(t *testing.T) {
 	syncer.setSyncType(PassiveSync)
 	syncer.setSyncState(chansSynced)
 
-	syncer.Start(ctx)
+	syncer.Start()
 	defer syncer.Stop()
 
 	syncer.historicalSync()
@@ -2264,7 +2260,6 @@ func TestGossipSyncerHistoricalSync(t *testing.T) {
 // syncer reaches its terminal chansSynced state.
 func TestGossipSyncerSyncedSignal(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	// We'll create a new gossip syncer and manually override its state to
 	// chansSynced.
@@ -2279,7 +2274,7 @@ func TestGossipSyncerSyncedSignal(t *testing.T) {
 	signalChan := syncer.ResetSyncedSignal()
 
 	// Starting the gossip syncer should cause the signal to be delivered.
-	syncer.Start(ctx)
+	syncer.Start()
 
 	select {
 	case <-signalChan:
@@ -2298,7 +2293,7 @@ func TestGossipSyncerSyncedSignal(t *testing.T) {
 
 	syncer.setSyncState(chansSynced)
 
-	syncer.Start(ctx)
+	syncer.Start()
 	defer syncer.Stop()
 
 	signalChan = syncer.ResetSyncedSignal()
@@ -2317,7 +2312,6 @@ func TestGossipSyncerSyncedSignal(t *testing.T) {
 // said limit are not processed.
 func TestGossipSyncerMaxChannelRangeReplies(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	msgChan, syncer, chanSeries := newTestSyncer(
 		lnwire.ShortChannelID{BlockHeight: latestKnownHeight},
@@ -2328,7 +2322,7 @@ func TestGossipSyncerMaxChannelRangeReplies(t *testing.T) {
 	// the sake of testing.
 	syncer.cfg.maxQueryChanRangeReplies = 100
 
-	syncer.Start(ctx)
+	syncer.Start()
 	defer syncer.Stop()
 
 	// Upon initialization, the syncer should submit a QueryChannelRange

--- a/lnd.go
+++ b/lnd.go
@@ -788,7 +788,7 @@ func Main(cfg *Config, lisCfg ListenerCfg, implCfg *ImplementationCfg,
 	// active, then we'll start the autopilot agent immediately. It will be
 	// stopped together with the autopilot service.
 	if cfg.Autopilot.Active {
-		if err := atplManager.StartAgent(ctx); err != nil {
+		if err := atplManager.StartAgent(); err != nil {
 			return mkErr("unable to start autopilot agent", err)
 		}
 	}

--- a/lnrpc/autopilotrpc/autopilot_server.go
+++ b/lnrpc/autopilotrpc/autopilot_server.go
@@ -198,14 +198,14 @@ func (s *Server) Status(ctx context.Context,
 // ModifyStatus activates the current autopilot agent, if active.
 //
 // NOTE: Part of the AutopilotServer interface.
-func (s *Server) ModifyStatus(ctx context.Context,
+func (s *Server) ModifyStatus(_ context.Context,
 	in *ModifyStatusRequest) (*ModifyStatusResponse, error) {
 
 	log.Debugf("Setting agent enabled=%v", in.Enable)
 
 	var err error
 	if in.Enable {
-		err = s.manager.StartAgent(ctx)
+		err = s.manager.StartAgent()
 	} else {
 		err = s.manager.StopAgent()
 	}

--- a/server.go
+++ b/server.go
@@ -2390,7 +2390,7 @@ func (s *server) Start(ctx context.Context) error {
 		// The authGossiper depends on the chanRouter and therefore
 		// should be started after it.
 		cleanup = cleanup.add(s.authGossiper.Stop)
-		if err := s.authGossiper.Start(ctx); err != nil {
+		if err := s.authGossiper.Start(); err != nil {
 			startErr = err
 			return
 		}


### PR DESCRIPTION
Our pattern of having `Start/Stop` for each subsystem very much depends on `Stop` being responsible for proper clean-up of the subsystem - if we pass in a parent context to `Start` and it gets cancelled - `Stop` might not get to properly clean itself up. 

`ctx` threading is about making synchronous calls "stoppable". So it should only be passed to a `Start` method if `Start` itself is making synchronous calls before returning. If `Start` spins off asynchronous goroutines, those should be separate from the context & `Stop` should be responsible for cleaning those up. 

So im reverting two small changes from previous PR here. Luckily, if we follow the above approach, the scope for the remainder of the "context" thread PRs gets reduced significantly . 

