### PR TITLE
lntest: assert shutdown via logs only if log file handle is present

### DIFF
--- a/lntest/node/harness_node.go
+++ b/lntest/node/harness_node.go
@@ -671,14 +671,18 @@ func (hn *HarnessNode) WaitForProcessExit() error {
 		hn.printErrf("timeout waiting for process to exit")
 	}
 
-	// Make sure log file is closed and renamed if necessary.
-	filename := finalizeLogfile(hn)
+	// If the node has an open log file handle, inspect the log file
+	// to verify that the node shut down correctly.
+	if hn.logFile != nil {
+		// Make sure log file is closed and renamed if necessary.
+		filename := finalizeLogfile(hn)
 
-	// Assert the node has shut down from the log file.
-	err1 := assertNodeShutdown(filename)
-	if err1 != nil {
-		return fmt.Errorf("[%s]: assert shutdown failed in log[%s]: %w",
-			hn.Name(), filename, err1)
+		// Assert the node has shut down from the log file.
+		err1 := assertNodeShutdown(filename)
+		if err1 != nil {
+			return fmt.Errorf("[%s]: assert shutdown failed in "+
+				"log[%s]: %w", hn.Name(), filename, err1)
+		}
 	}
 
 	// Rename the etcd.log file if the node was running on embedded etcd.


### PR DESCRIPTION
## Change Description
Ensure shutdown assertions through log inspection are only performed when the harness node has an active log file handle. This avoids errors during shutdown when log file output is disabled.

## Steps to Test
Disable log file output via CLI flag, ensure harness nodes shutdown without error.