### PR TITLE
graph+channeldb: test clean-up in preparation for different graph DB backend

### DIFF
--- a/channeldb/meta_test.go
+++ b/channeldb/meta_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/go-errors/errors"
-	graphdb "github.com/lightningnetwork/lnd/graph/db"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/stretchr/testify/require"
 )
@@ -21,13 +20,6 @@ func applyMigration(t *testing.T, beforeMigration, afterMigration func(d *DB),
 		t.Fatal(err)
 	}
 	cdb.dryRun = dryRun
-
-	// Create a test node that will be our source node.
-	testNode := createTestVertex(t)
-
-	graph, err := graphdb.MakeTestGraph(t)
-	require.NoError(t, err)
-	require.NoError(t, graph.SetSourceNode(testNode))
 
 	// beforeMigration usually used for populating the database
 	// with test data.

--- a/graph/builder_test.go
+++ b/graph/builder_test.go
@@ -1352,10 +1352,7 @@ func parseTestGraph(t *testing.T, useCache bool, path string) (
 	testAddrs = append(testAddrs, testAddr)
 
 	// Next, create a temporary graph database for usage within the test.
-	graph, graphBackend, err := makeTestGraph(t, useCache)
-	if err != nil {
-		return nil, err
-	}
+	graph := makeTestGraph(t, useCache)
 
 	aliasMap := make(map[string]route.Vertex)
 	privKeyMap := make(map[string]*btcec.PrivateKey)
@@ -1562,12 +1559,11 @@ func parseTestGraph(t *testing.T, useCache bool, path string) (
 	}
 
 	return &testGraphInstance{
-		graph:        graph,
-		graphBackend: graphBackend,
-		aliasMap:     aliasMap,
-		privKeyMap:   privKeyMap,
-		channelIDs:   channelIDs,
-		links:        links,
+		graph:      graph,
+		aliasMap:   aliasMap,
+		privKeyMap: privKeyMap,
+		channelIDs: channelIDs,
+		links:      links,
 	}, nil
 }
 
@@ -1730,10 +1726,7 @@ func createTestGraphFromChannels(t *testing.T, useCache bool,
 	testAddrs = append(testAddrs, testAddr)
 
 	// Next, create a temporary graph database for usage within the test.
-	graph, graphBackend, err := makeTestGraph(t, useCache)
-	if err != nil {
-		return nil, err
-	}
+	graph := makeTestGraph(t, useCache)
 
 	aliasMap := make(map[string]route.Vertex)
 	privKeyMap := make(map[string]*btcec.PrivateKey)
@@ -1947,11 +1940,10 @@ func createTestGraphFromChannels(t *testing.T, useCache bool,
 	}
 
 	return &testGraphInstance{
-		graph:        graph,
-		graphBackend: graphBackend,
-		aliasMap:     aliasMap,
-		privKeyMap:   privKeyMap,
-		links:        links,
+		graph:      graph,
+		aliasMap:   aliasMap,
+		privKeyMap: privKeyMap,
+		links:      links,
 	}, nil
 }
 

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -75,7 +75,7 @@ func createLightningNode(priv *btcec.PrivateKey) *models.LightningNode {
 		AuthSigBytes:         testSig.Serialize(),
 		LastUpdate:           time.Unix(updateTime, 0),
 		Color:                color.RGBA{1, 2, 3, 0},
-		Alias:                "kek" + string(pub[:]),
+		Alias:                "kek" + hex.EncodeToString(pub),
 		Features:             testFeatures,
 		Addresses:            testAddrs,
 	}

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -78,6 +78,7 @@ func createLightningNode(priv *btcec.PrivateKey) *models.LightningNode {
 		Alias:                "kek" + hex.EncodeToString(pub),
 		Features:             testFeatures,
 		Addresses:            testAddrs,
+		ExtraOpaqueData:      make([]byte, 0),
 	}
 	copy(n.PubKeyBytes[:], priv.PubKey().SerializeCompressed())
 
@@ -133,9 +134,7 @@ func TestNodeInsertionAndDeletion(t *testing.T) {
 	}
 
 	// The two nodes should match exactly!
-	if err := compareNodes(node, dbNode); err != nil {
-		t.Fatalf("nodes don't match: %v", err)
-	}
+	compareNodes(t, node, dbNode)
 
 	// Next, delete the node from the graph, this should purge all data
 	// related to the node.
@@ -192,8 +191,9 @@ func TestPartialNode(t *testing.T) {
 		HaveNodeAnnouncement: false,
 		LastUpdate:           time.Unix(0, 0),
 		PubKeyBytes:          pubKey1,
+		Features:             lnwire.EmptyFeatureVector(),
 	}
-	require.NoError(t, compareNodes(dbNode1, expectedNode1))
+	compareNodes(t, expectedNode1, dbNode1)
 
 	_, exists, err = graph.HasLightningNode(dbNode2.PubKeyBytes)
 	require.NoError(t, err)
@@ -205,8 +205,9 @@ func TestPartialNode(t *testing.T) {
 		HaveNodeAnnouncement: false,
 		LastUpdate:           time.Unix(0, 0),
 		PubKeyBytes:          pubKey2,
+		Features:             lnwire.EmptyFeatureVector(),
 	}
-	require.NoError(t, compareNodes(dbNode2, expectedNode2))
+	compareNodes(t, expectedNode2, dbNode2)
 
 	// Next, delete the node from the graph, this should purge all data
 	// related to the node.
@@ -282,9 +283,7 @@ func TestSourceNode(t *testing.T) {
 	// the one we set above.
 	sourceNode, err := graph.SourceNode()
 	require.NoError(t, err, "unable to fetch source node")
-	if err := compareNodes(testNode, sourceNode); err != nil {
-		t.Fatalf("nodes don't match: %v", err)
-	}
+	compareNodes(t, testNode, sourceNode)
 }
 
 func TestEdgeInsertionDeletion(t *testing.T) {
@@ -1985,10 +1984,7 @@ func TestNodeUpdatesInHorizon(t *testing.T) {
 		}
 
 		for i := 0; i < len(resp); i++ {
-			err := compareNodes(&queryCase.resp[i], &resp[i])
-			if err != nil {
-				t.Fatal(err)
-			}
+			compareNodes(t, &queryCase.resp[i], &resp[i])
 		}
 	}
 }
@@ -3222,9 +3218,7 @@ func TestNodePruningUpdateIndexDeletion(t *testing.T) {
 		t.Fatalf("should have 1 nodes instead have: %v",
 			len(nodesInHorizon))
 	}
-	if err := compareNodes(node1, &nodesInHorizon[0]); err != nil {
-		t.Fatalf("nodes don't match: %v", err)
-	}
+	compareNodes(t, node1, &nodesInHorizon[0])
 
 	// We'll now delete the node from the graph, this should result in it
 	// being removed from the update index as well.
@@ -3691,41 +3685,19 @@ func TestGraphZombieIndex(t *testing.T) {
 	assertNumZombies(t, graph, 1)
 }
 
-// compareNodes is used to compare two LightningNodes while excluding the
-// Features struct, which cannot be compared as the semantics for reserializing
-// the featuresMap have not been defined.
-func compareNodes(a, b *models.LightningNode) error {
-	if a.LastUpdate != b.LastUpdate {
-		return fmt.Errorf("node LastUpdate doesn't match: expected "+
-			"%v, got %v", a.LastUpdate, b.LastUpdate)
-	}
-	if !reflect.DeepEqual(a.Addresses, b.Addresses) {
-		return fmt.Errorf("Addresses doesn't match: expected %#v, \n "+
-			"got %#v", a.Addresses, b.Addresses)
-	}
-	if !reflect.DeepEqual(a.PubKeyBytes, b.PubKeyBytes) {
-		return fmt.Errorf("PubKey doesn't match: expected %#v, \n "+
-			"got %#v", a.PubKeyBytes, b.PubKeyBytes)
-	}
-	if !reflect.DeepEqual(a.Color, b.Color) {
-		return fmt.Errorf("Color doesn't match: expected %#v, \n "+
-			"got %#v", a.Color, b.Color)
-	}
-	if !reflect.DeepEqual(a.Alias, b.Alias) {
-		return fmt.Errorf("Alias doesn't match: expected %#v, \n "+
-			"got %#v", a.Alias, b.Alias)
-	}
-	if !reflect.DeepEqual(a.HaveNodeAnnouncement, b.HaveNodeAnnouncement) {
-		return fmt.Errorf("HaveNodeAnnouncement doesn't match: "+
-			"expected %#v, got %#v", a.HaveNodeAnnouncement,
-			b.HaveNodeAnnouncement)
-	}
-	if !bytes.Equal(a.ExtraOpaqueData, b.ExtraOpaqueData) {
-		return fmt.Errorf("extra data doesn't match: %v vs %v",
-			a.ExtraOpaqueData, b.ExtraOpaqueData)
-	}
+// compareNodes is used to compare two LightningNodes.
+func compareNodes(t *testing.T, a, b *models.LightningNode) {
+	t.Helper()
 
-	return nil
+	// Call the PubKey method for each node to ensure that the internal
+	// `pubKey` field is set for both objects and so require.Equals can
+	// then be used to compare the structs.
+	_, err := a.PubKey()
+	require.NoError(t, err)
+	_, err = b.PubKey()
+	require.NoError(t, err)
+
+	require.Equal(t, a, b)
 }
 
 // compareEdgePolicies is used to compare two ChannelEdgePolices using

--- a/graph/notifications_test.go
+++ b/graph/notifications_test.go
@@ -1034,8 +1034,7 @@ type testCtx struct {
 func createTestCtxSingleNode(t *testing.T,
 	startingHeight uint32) *testCtx {
 
-	graph, graphBackend, err := makeTestGraph(t, true)
-	require.NoError(t, err, "failed to make test graph")
+	graph := makeTestGraph(t, true)
 
 	sourceNode := createTestNode(t)
 
@@ -1044,8 +1043,7 @@ func createTestCtxSingleNode(t *testing.T,
 	)
 
 	graphInstance := &testGraphInstance{
-		graph:        graph,
-		graphBackend: graphBackend,
+		graph: graph,
 	}
 
 	return createTestCtxFromGraphInstance(
@@ -1086,14 +1084,12 @@ func (c *testCtx) RestartBuilder(t *testing.T) {
 
 // makeTestGraph creates a new instance of a channeldb.ChannelGraph for testing
 // purposes.
-func makeTestGraph(t *testing.T, useCache bool) (*graphdb.ChannelGraph,
-	kvdb.Backend, error) {
+func makeTestGraph(t *testing.T, useCache bool) *graphdb.ChannelGraph {
+	t.Helper()
 
 	// Create channelgraph for the first time.
 	backend, backendCleanup, err := kvdb.GetTestBackend(t.TempDir(), "cgr")
-	if err != nil {
-		return nil, nil, err
-	}
+	require.NoError(t, err)
 
 	t.Cleanup(backendCleanup)
 
@@ -1101,20 +1097,17 @@ func makeTestGraph(t *testing.T, useCache bool) (*graphdb.ChannelGraph,
 		&graphdb.Config{KVDB: backend},
 		graphdb.WithUseGraphCache(useCache),
 	)
-	if err != nil {
-		return nil, nil, err
-	}
+	require.NoError(t, err)
 	require.NoError(t, graph.Start())
 	t.Cleanup(func() {
 		require.NoError(t, graph.Stop())
 	})
 
-	return graph, backend, nil
+	return graph
 }
 
 type testGraphInstance struct {
-	graph        *graphdb.ChannelGraph
-	graphBackend kvdb.Backend
+	graph *graphdb.ChannelGraph
 
 	// aliasMap is a map from a node's alias to its public key. This type is
 	// provided in order to allow easily look up from the human memorable

--- a/graph/notifications_test.go
+++ b/graph/notifications_test.go
@@ -89,7 +89,7 @@ func createTestNode(t *testing.T) *models.LightningNode {
 		LastUpdate:           time.Unix(updateTime, 0),
 		Addresses:            testAddrs,
 		Color:                color.RGBA{1, 2, 3, 0},
-		Alias:                "kek" + string(pub[:]),
+		Alias:                "kek" + hex.EncodeToString(pub),
 		AuthSigBytes:         testSig.Serialize(),
 		Features:             testFeatures,
 	}


### PR DESCRIPTION
In this PR, we continue with some basic clean-up of the `graph/db`, `graph` and `channeldb` test code in preparation for plugging in a new graph backend DB type. See commit messages for more details. 

The goal is to get the unit tests in such a state so that in the PR that adds the new DB implementation, the unit tests dont need to change at all. 