### PR TITLE
scripts: use LND status to determine when a node is ready for RPC calls

### DIFF
--- a/scripts/bw-compatibility-test/network.sh
+++ b/scripts/bw-compatibility-test/network.sh
@@ -60,7 +60,7 @@ wait_for_node() {
 
   echo -n "⌛ Waiting for $node to start (timeout: ${TIMEOUT}s)"
 
-  while ! $node getinfo 2>/dev/null | grep -q identity_pubkey; do
+  while ! $node state 2>/dev/null | grep -q SERVER_ACTIVE; do
       echo -n "."
       sleep 0.5
 
@@ -96,9 +96,9 @@ do_for() {
 
 # setup_network sets up the basic A <> B <> C <> D network.
 function setup_network() {
-  wait_for_nodes alice bob charlie dave
-
   setup_bitcoin
+
+  wait_for_nodes alice bob charlie dave
 
   do_for fund_node alice bob charlie dave
   mine 6


### PR DESCRIPTION
## Context

The backwards compatibility test sometimes fails due to the `[lncli] rpc error: code = Unknown desc = server is still in the process of starting` error when we try to connect nodes right after checking if they have started. This is cause the `has started` check currently only checks if the GetInfo call is available - but it can be available before LND has actually fully started.  

## This PR:

use The `StateServer` (via `lncli status`) when waiting for a node to be ready as this is a more reliable/accurate signal that the node is ready for other RPC calls. 