### PR TITLE
accessman: add logging to new sub-system

### DIFF
--- a/lnutils/log.go
+++ b/lnutils/log.go
@@ -1,8 +1,11 @@
 package lnutils
 
 import (
+	"log/slog"
 	"strings"
 
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/davecgh/go-spew/spew"
 )
 
@@ -35,4 +38,15 @@ func NewSeparatorClosure() LogClosure {
 	return func() string {
 		return strings.Repeat("=", 80)
 	}
+}
+
+// LogPubKey returns a slog attribute for logging a public key in hex format.
+func LogPubKey(key string, pubKey *btcec.PublicKey) slog.Attr {
+	// Handle nil pubkey gracefully, although callers should ideally prevent
+	// this.
+	if pubKey == nil {
+		return btclog.Fmt(key, "<nil>")
+	}
+
+	return btclog.Hex6(key, pubKey.SerializeCompressed())
 }

--- a/log.go
+++ b/log.go
@@ -99,6 +99,7 @@ var (
 	rpcsLog = addLndPkgLogger("RPCS")
 	srvrLog = addLndPkgLogger("SRVR")
 	atplLog = addLndPkgLogger("ATPL")
+	acsmLog = addLndPkgLogger("ACSM")
 )
 
 // genSubLogger creates a logger for a subsystem. We provide an instance of


### PR DESCRIPTION
In this PR, we add logging to the new Access Manager. It was committed without any logs at all, which otherwise would've made it hard to monitor and debug the new sub-system. 