### PR TITLE
protofsm: add option to allow conf resp to return full block

### DIFF
--- a/protofsm/daemon_events.go
+++ b/protofsm/daemon_events.go
@@ -116,6 +116,11 @@ type RegisterConf[Event any] struct {
 	// transaction needs to dispatch an event.
 	NumConfs fn.Option[uint32]
 
+	// FullBlock is a boolean that indicates whether we want the full block
+	// in the returned response. This is useful if callers want to create an
+	// SPV proof for the transaction post conf.
+	FullBlock bool
+
 	// PostConfMapper is a special conf mapper, that if present, will be
 	// used to map the protofsm confirmation event to a custom event.
 	PostConfMapper fn.Option[ConfMapper[Event]]

--- a/protofsm/state_machine.go
+++ b/protofsm/state_machine.go
@@ -510,10 +510,15 @@ func (s *StateMachine[Event, Env]) executeDaemonEvent(ctx context.Context,
 		s.log.DebugS(ctx, "Registering conf",
 			"txid", daemonEvent.Txid)
 
+		var opts []chainntnfs.NotifierOption
+		if daemonEvent.FullBlock {
+			opts = append(opts, chainntnfs.WithIncludeBlock())
+		}
+
 		numConfs := daemonEvent.NumConfs.UnwrapOr(1)
 		confEvent, err := s.cfg.Daemon.RegisterConfirmationsNtfn(
 			&daemonEvent.Txid, daemonEvent.PkScript,
-			numConfs, daemonEvent.HeightHint,
+			numConfs, daemonEvent.HeightHint, opts...,
 		)
 		if err != nil {
 			return fmt.Errorf("unable to register conf: %w", err)


### PR DESCRIPTION
In this PR, we add an option to allow a conf req caller to receive
the full block. This is useful if the caller wants to be able to create
an SPV proof.