### PR TITLE
Aux bandwidth manager: also pass HTLC blob to `ShouldHandleTraffic`

### DIFF
--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -509,7 +509,7 @@ type AuxTrafficShaper interface {
 	// identified by the provided channel ID may have external mechanisms
 	// that would allow it to carry out the payment.
 	ShouldHandleTraffic(cid lnwire.ShortChannelID,
-		fundingBlob fn.Option[tlv.Blob]) (bool, error)
+		fundingBlob, htlcBlob fn.Option[tlv.Blob]) (bool, error)
 
 	// PaymentBandwidth returns the available bandwidth for a custom channel
 	// decided by the given channel aux blob and HTLC blob. A return value

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -3484,7 +3484,7 @@ func (l *channelLink) AuxBandwidth(amount lnwire.MilliSatoshi,
 	ts AuxTrafficShaper) fn.Result[OptionalBandwidth] {
 
 	fundingBlob := l.FundingCustomBlob()
-	shouldHandle, err := ts.ShouldHandleTraffic(cid, fundingBlob)
+	shouldHandle, err := ts.ShouldHandleTraffic(cid, fundingBlob, htlcBlob)
 	if err != nil {
 		return fn.Err[OptionalBandwidth](fmt.Errorf("traffic shaper "+
 			"failed to decide whether to handle traffic: %w", err))

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -1149,6 +1149,9 @@ func (s *Switch) handlePacketForward(packet *htlcPacket) error {
 func (s *Switch) checkCircularForward(incoming, outgoing lnwire.ShortChannelID,
 	allowCircular bool, paymentHash lntypes.Hash) *LinkError {
 
+	log.Tracef("Checking for circular route: incoming=%v, outgoing=%v "+
+		"(payment hash: %x)", incoming, outgoing, paymentHash[:])
+
 	// If they are equal, we can skip the alias mapping checks.
 	if incoming == outgoing {
 		// The switch may be configured to allow circular routes, so
@@ -1189,6 +1192,10 @@ func (s *Switch) checkCircularForward(incoming, outgoing lnwire.ShortChannelID,
 
 	// Check base SCID equality.
 	if incomingBaseScid != outgoingBaseScid {
+		log.Tracef("Incoming base SCID %v does not match outgoing "+
+			"base SCID %v (payment hash: %x)", incomingBaseScid,
+			outgoingBaseScid, paymentHash[:])
+
 		// The base SCIDs are not equal so these are not the same
 		// channel.
 		return nil

--- a/routing/bandwidth_test.go
+++ b/routing/bandwidth_test.go
@@ -140,7 +140,7 @@ type mockTrafficShaper struct{}
 // by the provided channel ID may have external mechanisms that would
 // allow it to carry out the payment.
 func (*mockTrafficShaper) ShouldHandleTraffic(_ lnwire.ShortChannelID,
-	_ fn.Option[tlv.Blob]) (bool, error) {
+	_, _ fn.Option[tlv.Blob]) (bool, error) {
 
 	return true, nil
 }


### PR DESCRIPTION
Whether we should let the aux bandwidth manager decide what the
bandwidth of a channel is should also depend on whether the HTLC is a
custom HTLC, not just the channel.
