### PR TITLE
lnwallet: no need to consult the aux unit for legacy channels

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -115,6 +115,9 @@ keysend payment validation is stricter.
 * [Fixed](https://github.com/lightningnetwork/lnd/pull/9703) a possible panic
   when reloading legacy inflight payments which don't have the MPP feature.
 
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/9746) a possible panic
+when running LND with an aux component injected (custom channels).
+
 # New Features
 
 * Add support for [archiving channel backup](https://github.com/lightningnetwork/lnd/pull/9232)

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -7351,6 +7351,23 @@ func newOutgoingHtlcResolution(signer input.Signer,
 		ControlBlock: ctrlBlock,
 	}
 
+	// In case it is a legacy channel we return early as no aux resolution
+	// is neeeded.
+	if txSignDetails == nil {
+		return &OutgoingHtlcResolution{
+			Expiry:          htlc.RefundTimeout,
+			SignedTimeoutTx: timeoutTx,
+			SignDetails:     txSignDetails,
+			CsvDelay:        csvDelay,
+			ResolutionBlob:  fn.None[tlv.Blob](),
+			ClaimOutpoint: wire.OutPoint{
+				Hash:  timeoutTx.TxHash(),
+				Index: 0,
+			},
+			SweepSignDesc: sweepSignDesc,
+		}, nil
+	}
+
 	// This might be an aux channel, so we'll go ahead and attempt to
 	// generate the resolution blob for the channel so we can pass along to
 	// the sweeping sub-system.
@@ -7692,6 +7709,20 @@ func newIncomingHtlcResolution(signer input.Signer,
 		),
 		SignMethod:   signMethod,
 		ControlBlock: ctrlBlock,
+	}
+
+	if txSignDetails == nil {
+		return &IncomingHtlcResolution{
+			SignedSuccessTx: successTx,
+			SignDetails:     txSignDetails,
+			CsvDelay:        csvDelay,
+			ResolutionBlob:  fn.None[tlv.Blob](),
+			ClaimOutpoint: wire.OutPoint{
+				Hash:  successTx.TxHash(),
+				Index: 0,
+			},
+			SweepSignDesc: sweepSignDesc,
+		}, nil
 	}
 
 	resolveRes := fn.MapOptionZ(


### PR DESCRIPTION
When running LND with an aux component injected we do not need to consult the aux component for non-anchor channels.

Probably we could add an itest or something on the LITD side.