### PR TITLE
routerrpc: reject payment to invoice that don't have payment secret or blinded paths

### DIFF
--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -114,6 +114,9 @@ circuit. The indices are only available for forwarding events saved after v0.20.
   `channel_update` message and handle it explicitly throughout the code base 
   instead of extracting it from the TLV stream at various call-sites.
 
+* [Require invoices to include a payment address or blinded paths](https://github.com/lightningnetwork/lnd/pull/9752) 
+  to comply with updated BOLT 11 specifications before sending payments.
+
 ## Testing
 
 ## Database
@@ -126,6 +129,7 @@ circuit. The indices are only available for forwarding events saved after v0.20.
 
 * Abdulkbk
 * Elle Mouton
+* Erick Cestari
 * Funyug
 * Mohamed Awnallah
 * Pins

--- a/lnrpc/routerrpc/router_backend.go
+++ b/lnrpc/routerrpc/router_backend.go
@@ -990,6 +990,15 @@ func (r *RouterBackend) extractIntentFromSendRequest(
 			return nil, err
 		}
 
+		// An invoice must include either a payment address or
+		// blinded paths.
+		if payReq.PaymentAddr.IsNone() &&
+			len(payReq.BlindedPaymentPaths) == 0 {
+
+			return nil, errors.New("payment request must contain " +
+				"either a payment address or blinded paths")
+		}
+
 		// If the amount was not included in the invoice, then we let
 		// the payer specify the amount of satoshis they wish to send.
 		// We override the amount to pay with the amount provided from
@@ -1006,7 +1015,7 @@ func (r *RouterBackend) extractIntentFromSendRequest(
 			if reqAmt != 0 {
 				return nil, errors.New("amount must not be " +
 					"specified when paying a non-zero " +
-					" amount invoice")
+					"amount invoice")
 			}
 
 			payIntent.Amount = *payReq.MilliSat

--- a/lnrpc/routerrpc/router_backend_test.go
+++ b/lnrpc/routerrpc/router_backend_test.go
@@ -505,6 +505,13 @@ func TestExtractIntentFromSendRequest(t *testing.T) {
 		"g6aykds4ydvf2x9lpngqcfux3hv8qlraan9v3s9296r5w5eh959yzadgh5ck" +
 		"gjydgyfxdpumxtuk3p3caugmlqpz5necs"
 
+	const paymentReqMissingAddr = "lnbcrt100p1p70xwfzpp5qqqsyqcyq5rqwzqfq" +
+		"qqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kge" +
+		"tjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaqnp4q0n326hr8v9zprg8" +
+		"gsvezcch06gfaqqhde2aj730yg0durunfhv669qypqqqz3uu8wnr7883qzxr" +
+		"566nuhled49fx6e6q0jn06w6gpgyznwzxwf8xdmye87kpx0y8lqtcgwywsau" +
+		"0jkm66evelkw7cggwlegp4anv3cq62wusm"
+
 	destNodeBytes, err := hex.DecodeString(destKey)
 	require.NoError(t, err)
 
@@ -719,6 +726,23 @@ func TestExtractIntentFromSendRequest(t *testing.T) {
 			},
 			valid:            false,
 			expectedErrorMsg: "invoice expired.",
+		},
+		{
+			name: "Invoice missing payment address",
+			backend: &RouterBackend{
+				ShouldSetExpEndorsement: func() bool {
+					return false
+				},
+				ActiveNetParams:  &chaincfg.RegressionNetParams,
+				MaxTotalTimelock: 1000,
+				Clock:            mockClock,
+			},
+			sendReq: &SendPaymentRequest{
+				PaymentRequest: paymentReqMissingAddr,
+			},
+			valid: false,
+			expectedErrorMsg: "payment request must contain " +
+				"either a payment address or blinded paths",
 		},
 		{
 			name: "Invalid dest vertex length",

--- a/lnrpc/routerrpc/router_backend_test.go
+++ b/lnrpc/routerrpc/router_backend_test.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"encoding/hex"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/lightningnetwork/lnd/lnmock"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
@@ -509,6 +511,9 @@ func TestExtractIntentFromSendRequest(t *testing.T) {
 	target, err := route.NewVertexFromBytes(destNodeBytes)
 	require.NoError(t, err)
 
+	mockClock := &lnmock.MockClock{}
+	mockClock.On("Now").Return(time.Date(2025, 3, 1, 13, 0, 0, 0, time.UTC))
+
 	testCases := []extractIntentTestCase{
 		{
 			name:    "Time preference out of range",
@@ -706,6 +711,7 @@ func TestExtractIntentFromSendRequest(t *testing.T) {
 					return false
 				},
 				ActiveNetParams: &chaincfg.RegressionNetParams,
+				Clock:           mockClock,
 			},
 			sendReq: &SendPaymentRequest{
 				Amt:            int64(paymentAmount),

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -696,6 +696,7 @@ func (r *rpcServer) addDeps(s *server, macService *macaroons.Service,
 
 	routerBackend := &routerrpc.RouterBackend{
 		SelfNode: selfNode.PubKeyBytes,
+		Clock:    clock.NewDefaultClock(),
 		FetchChannelCapacity: func(chanID uint64) (btcutil.Amount,
 			error) {
 
@@ -5609,7 +5610,9 @@ func (r *rpcServer) extractPaymentIntent(rpcPayReq *rpcPaymentRequest) (rpcPayme
 		}
 
 		// Next, we'll ensure that this payreq hasn't already expired.
-		err = routerrpc.ValidatePayReqExpiry(payReq)
+		err = routerrpc.ValidatePayReqExpiry(
+			r.routerBackend.Clock, payReq,
+		)
 		if err != nil {
 			return payIntent, err
 		}


### PR DESCRIPTION
This PR introduces the initial phase of enforcing payment secret validation for invoices, as described in issue [#9718](https://github.com/lightningnetwork/lnd/issues/9718).

> Reject a payment to invoice that don't have a payment secret.

## Change Description
Adds validation to `extractIntentFromSendRequest` to ensure that an invoice includes either a payment address (payment secret) or at least one blinded path when parsing the SendRequest details.

Related to: #9700, #9718