### PR TITLE
Fix context management in channelLink to prevent goroutine leaks.

### DIFF
--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -413,6 +413,11 @@ type channelLink struct {
 	// allows contexts that either block or cancel on those depending on
 	// the use case.
 	cg *fn.ContextGuard
+
+	// cancel is the cancellation function for the context passed to
+	// htlcManager. It should be called when the link is stopped to clean up
+	// resources.
+	cancel context.CancelFunc
 }
 
 // hookMap is a data structure that is used to track the hooks that need to be
@@ -597,8 +602,13 @@ func (l *channelLink) Start() error {
 
 	l.updateFeeTimer = time.NewTimer(l.randomFeeUpdateTimeout())
 
+	// Create a background context that can be canceled when the link is
+	// stopped
+	ctx, cancel := context.WithCancel(context.Background())
+	l.cancel = cancel
+
 	l.cg.WgAdd(1)
-	go l.htlcManager(context.TODO())
+	go l.htlcManager(ctx)
 
 	return nil
 }
@@ -621,6 +631,11 @@ func (l *channelLink) Stop() {
 
 	if l.cfg.ChainEvents.Cancel != nil {
 		l.cfg.ChainEvents.Cancel()
+	}
+
+	// Cancel the context used by the htlcManager to clean up resources
+	if l.cancel != nil {
+		l.cancel()
 	}
 
 	// Ensure the channel for the timer is drained.


### PR DESCRIPTION
## Change Description
The channelLink.Start() method was using context.TODO() when starting the htlcManager goroutine, which turns out doesn't provide any cancellation mechanism. This can lead to goroutine leaks if the context is never canceled.

## Pull Request Checklist
### Testing
- [X] Your PR passes all CI checks.
- [] Tests covering the positive and negative (error paths) are included. ~ not needed for this PR/
- [] Bug fixes contain tests triggering the bug to prevent regressions. ~ not needed for this PR.

### Code Style and Documentation
- [X] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [X] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [X] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [X] Any new logging statements use an appropriate subsystem and logging level.
- [X] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [X] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
