### PR TITLE
htlcswitch+routing: add funding blob to PaymentBandwidth

### DIFF
--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -512,11 +512,13 @@ type AuxTrafficShaper interface {
 		fundingBlob, htlcBlob fn.Option[tlv.Blob]) (bool, error)
 
 	// PaymentBandwidth returns the available bandwidth for a custom channel
-	// decided by the given channel aux blob and HTLC blob. A return value
-	// of 0 means there is no bandwidth available. To find out if a channel
-	// is a custom channel that should be handled by the traffic shaper, the
-	// ShouldHandleTraffic method should be called first.
-	PaymentBandwidth(htlcBlob, commitmentBlob fn.Option[tlv.Blob],
+	// decided by the given channel funding/commitment aux blob and HTLC
+	// blob. A return value of 0 means there is no bandwidth available. To
+	// find out if a channel is a custom channel that should be handled by
+	// the traffic shaper, the ShouldHandleTraffic method should be called
+	// first.
+	PaymentBandwidth(fundingBlob, htlcBlob,
+		commitmentBlob fn.Option[tlv.Blob],
 		linkBandwidth, htlcAmt lnwire.MilliSatoshi,
 		htlcView lnwallet.AuxHtlcView) (lnwire.MilliSatoshi, error)
 

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -3504,7 +3504,7 @@ func (l *channelLink) AuxBandwidth(amount lnwire.MilliSatoshi,
 	// Ask for a specific bandwidth to be used for the channel.
 	commitmentBlob := l.CommitmentCustomBlob()
 	auxBandwidth, err := ts.PaymentBandwidth(
-		htlcBlob, commitmentBlob, l.Bandwidth(), amount,
+		fundingBlob, htlcBlob, commitmentBlob, l.Bandwidth(), amount,
 		l.channel.FetchLatestAuxHTLCView(),
 	)
 	if err != nil {

--- a/routing/bandwidth_test.go
+++ b/routing/bandwidth_test.go
@@ -145,12 +145,12 @@ func (*mockTrafficShaper) ShouldHandleTraffic(_ lnwire.ShortChannelID,
 	return true, nil
 }
 
-// PaymentBandwidth returns the available bandwidth for a custom channel
-// decided by the given channel aux blob and HTLC blob. A return value
-// of 0 means there is no bandwidth available. To find out if a channel
-// is a custom channel that should be handled by the traffic shaper, the
-// HandleTraffic method should be called first.
-func (*mockTrafficShaper) PaymentBandwidth(_, _ fn.Option[tlv.Blob],
+// PaymentBandwidth returns the available bandwidth for a custom channel decided
+// by the given channel funding/commitment aux blob and HTLC blob. A return
+// value of 0 means there is no bandwidth available. To find out if a channel is
+// a custom channel that should be handled by the traffic shaper, the
+// ShouldHandleTraffic method should be called first.
+func (*mockTrafficShaper) PaymentBandwidth(_, _, _ fn.Option[tlv.Blob],
 	linkBandwidth, _ lnwire.MilliSatoshi,
 	_ lnwallet.AuxHtlcView) (lnwire.MilliSatoshi, error) {
 


### PR DESCRIPTION
For certain auxiliary bandwidth checks we need to know the funding blob that was present when the channel was created.

