### PR TITLE
GitHub: fix order of operations for release build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,14 +24,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: cleanup space
+        run: rm -rf /opt/hostedtoolcache && mkdir -p /opt/hostedtoolcache/go
+
       - name: setup go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v5
         with:
           go-version: '${{ env.GO_VERSION }}'
           cache: 'false'
-
-      - name: cleanup space
-        run: rm -rf /opt/hostedtoolcache
 
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV


### PR DESCRIPTION
Fixes the release build. Turns out the Golang installation is now also stored under the `/opt/hostedtoolcache` folder. So if we delete that _after_ installing Go, then things don't work as expected.

Successful run can be seen here: https://github.com/guggero/lnd/actions/runs/14635083197/job/41064400208