### PR TITLE
docs/release-notes: fix indentation in RBF close section

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -132,18 +132,18 @@ when running LND with an aux component injected (custom channels).
 ## Protocol Updates
 
 * `lnd` now [supports the new RBF cooperative close
-flow](https://github.com/lightningnetwork/lnd/pull/9610). Unlike the old flow,
-this version now uses RBF to enable either side to increase their fee rate using
-their _own_ channel funds. This removes the old "negotiation" logic that could
-fail, with a version where either side can increase the fee on their coop close
-transaction using their channel balance. 
+  flow](https://github.com/lightningnetwork/lnd/pull/9610). Unlike the old
+  flow, this version now uses RBF to enable either side to increase their fee
+  rate using their _own_ channel funds. This removes the old "negotiation"
+  logic that could fail, with a version where either side can increase the fee
+  on their coop close transaction using their channel balance. 
 
-This new feature can be activated with a new config flag:
-`--protocol.rbf-coop-close`.
+  This new feature can be activated with a new config flag:
+  `--protocol.rbf-coop-close`.
 
-With this new co-op close type, users can issue multiple `lncli closechannnel`
-commands with increasing fee rates to use RBF to bump an existing signed co-op
-close transaction.
+  With this new co-op close type, users can issue multiple `lncli closechannnel`
+  commands with increasing fee rates to use RBF to bump an existing signed co-op
+  close transaction.
 
 * [Support](https://github.com/lightningnetwork/lnd/pull/8390) for 
   [experimental endorsement](https://github.com/lightning/blips/pull/27) 


### PR DESCRIPTION
Indentations were messed up on the text for the RBF coop close section and were being rendered weird in markdown. It was hard to tell what text was actually part of RBF and what was related to other features discussed below it. This small change makes it much easier to read the rendered markdown.
