### PR TITLE
routing+migration: fix mission control migration with nil failure msg

### DIFF
--- a/channeldb/migration32/migration_test.go
+++ b/channeldb/migration32/migration_test.go
@@ -118,6 +118,32 @@ var (
 		},
 	}
 
+	resultOld3 = paymentResultOld{
+		id:               3,
+		timeFwd:          time.Unix(0, 4),
+		timeReply:        time.Unix(0, 7),
+		success:          false,
+		failure:          nil,
+		failureSourceIdx: &failureIndex,
+		route: &Route{
+			TotalTimeLock: 101,
+			TotalAmount:   401,
+			SourcePubKey:  testPub2,
+			Hops: []*Hop{
+				{
+					PubKeyBytes:      testPub,
+					ChannelID:        800,
+					OutgoingTimeLock: 4,
+					AmtToForward:     4,
+					BlindingPoint:    pubkey,
+					EncryptedData:    []byte{1, 2, 3},
+					CustomRecords:    customRecord,
+					TotalAmtMsat:     600,
+				},
+			},
+		},
+	}
+
 	//nolint:ll
 	resultNew1Hop1 = &mcHop{
 		channelID:   tlv.NewPrimitiveRecord[tlv.TlvType0, uint64](100),
@@ -182,7 +208,7 @@ var (
 		),
 		failure: tlv.SomeRecordT(
 			tlv.NewRecordT[tlv.TlvType3](
-				*newPaymentFailure(
+				newPaymentFailure(
 					&failureIndex,
 					&lnwire.FailFeeInsufficient{},
 				),
@@ -217,6 +243,31 @@ var (
 			}),
 		}),
 	}
+
+	//nolint:ll
+	resultNew3 = paymentResultNew{
+		id: 3,
+		timeFwd: tlv.NewPrimitiveRecord[tlv.TlvType0, uint64](
+			uint64(time.Unix(0, 4).UnixNano()),
+		),
+		timeReply: tlv.NewPrimitiveRecord[tlv.TlvType1, uint64](
+			uint64(time.Unix(0, 7).UnixNano()),
+		),
+		failure: tlv.SomeRecordT(
+			tlv.NewRecordT[tlv.TlvType3](
+				newPaymentFailure(
+					&failureIndex, nil,
+				),
+			),
+		),
+		route: tlv.NewRecordT[tlv.TlvType2](mcRoute{
+			sourcePubKey: tlv.NewRecordT[tlv.TlvType0](testPub2),
+			totalAmount:  tlv.NewRecordT[tlv.TlvType1, lnwire.MilliSatoshi](401),
+			hops: tlv.NewRecordT[tlv.TlvType2](mcHops{
+				resultNew2Hop1,
+			}),
+		}),
+	}
 )
 
 // TestMigrateMCRouteSerialisation tests that the MigrateMCRouteSerialisation
@@ -225,10 +276,10 @@ var (
 func TestMigrateMCRouteSerialisation(t *testing.T) {
 	var (
 		resultsOld = []*paymentResultOld{
-			&resultOld1, &resultOld2,
+			&resultOld1, &resultOld2, &resultOld3,
 		}
 		expectedResultsNew = []*paymentResultNew{
-			&resultNew1, &resultNew2,
+			&resultNew1, &resultNew2, &resultNew3,
 		}
 	)
 

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -459,10 +459,12 @@ the on going rate we'll permit.
 
 ## Database
 
-* [Migrate the mission control 
-  store](https://github.com/lightningnetwork/lnd/pull/8911) to use a more 
-  minimal encoding for payment attempt routes as well as use [pure TLV 
-  encoding](https://github.com/lightningnetwork/lnd/pull/9167).
+* [Migrate the mission control
+  store](https://github.com/lightningnetwork/lnd/pull/8911) to use a more
+  minimal encoding for payment attempt routes as well as use [pure TLV
+  encoding](https://github.com/lightningnetwork/lnd/pull/9167). [A
+  fix](https://github.com/lightningnetwork/lnd/pull/9770) was added to handle
+  nil routing failure messages and the serialization was optimized.
 
 * [Migrate the mission control 
   store](https://github.com/lightningnetwork/lnd/pull/9001) so that results are 

--- a/routing/missioncontrol.go
+++ b/routing/missioncontrol.go
@@ -837,21 +837,29 @@ func (n *namespacedDB) purge() error {
 func newPaymentFailure(sourceIdx *int,
 	failureMsg lnwire.FailureMessage) paymentFailure {
 
+	// If we can't identify a failure source, we also won't have a decrypted
+	// failure message. In this case we return an empty payment failure.
 	if sourceIdx == nil {
 		return paymentFailure{}
 	}
 
-	return paymentFailure{
+	info := paymentFailure{
 		sourceIdx: tlv.SomeRecordT(
 			tlv.NewPrimitiveRecord[tlv.TlvType0](
 				uint8(*sourceIdx),
-			)),
-		msg: tlv.SomeRecordT(
-			tlv.NewRecordT[tlv.TlvType1](
-				failureMessage{failureMsg},
 			),
 		),
 	}
+
+	if failureMsg != nil {
+		info.msg = tlv.SomeRecordT(
+			tlv.NewRecordT[tlv.TlvType1](
+				failureMessage{failureMsg},
+			),
+		)
+	}
+
+	return info
 }
 
 // paymentFailure holds additional information about a payment failure.

--- a/routing/result_interpretation.go
+++ b/routing/result_interpretation.go
@@ -126,7 +126,9 @@ func (i *interpretedResult) processSuccess(route *mcRoute) {
 
 // processFail processes a failed payment attempt.
 func (i *interpretedResult) processFail(rt *mcRoute, failure paymentFailure) {
-	if failure.info.IsNone() {
+	// Not having a source index means that we were unable to decrypt the
+	// error message.
+	if failure.sourceIdx.IsNone() {
 		i.processPaymentOutcomeUnknown(rt)
 		return
 	}
@@ -136,16 +138,14 @@ func (i *interpretedResult) processFail(rt *mcRoute, failure paymentFailure) {
 		failMsg lnwire.FailureMessage
 	)
 
-	failure.info.WhenSome(
-		func(r tlv.RecordT[tlv.TlvType0, paymentFailureInfo]) {
-			r.Val.sourceIdx.WhenSome(
-				func(r tlv.RecordT[tlv.TlvType0, uint8]) {
-					idx = int(r.Val)
-				},
-			)
+	failure.sourceIdx.WhenSome(
+		func(r tlv.RecordT[tlv.TlvType0, uint8]) {
+			idx = int(r.Val)
 
-			r.Val.msg.WhenSome(
-				func(r tlv.RecordT[tlv.TlvType1, failureMessage]) {
+			failure.msg.WhenSome(
+				func(r tlv.RecordT[tlv.TlvType1,
+					failureMessage]) {
+
 					failMsg = r.Val.FailureMessage
 				},
 			)

--- a/routing/result_interpretation.go
+++ b/routing/result_interpretation.go
@@ -138,8 +138,17 @@ func (i *interpretedResult) processFail(rt *mcRoute, failure paymentFailure) {
 
 	failure.info.WhenSome(
 		func(r tlv.RecordT[tlv.TlvType0, paymentFailureInfo]) {
-			idx = int(r.Val.sourceIdx.Val)
-			failMsg = r.Val.msg.Val.FailureMessage
+			r.Val.sourceIdx.WhenSome(
+				func(r tlv.RecordT[tlv.TlvType0, uint8]) {
+					idx = int(r.Val)
+				},
+			)
+
+			r.Val.msg.WhenSome(
+				func(r tlv.RecordT[tlv.TlvType1, failureMessage]) {
+					failMsg = r.Val.FailureMessage
+				},
+			)
 		},
 	)
 

--- a/routing/result_interpretation_test.go
+++ b/routing/result_interpretation_test.go
@@ -732,7 +732,7 @@ func TestResultInterpretation(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			var failure fn.Option[paymentFailure]
 			if !testCase.success {
-				failure = fn.Some(*newPaymentFailure(
+				failure = fn.Some(newPaymentFailure(
 					&testCase.failureSrcIdx,
 					testCase.failure,
 				))


### PR DESCRIPTION
Tries to fix https://github.com/lightningnetwork/lnd/issues/9769.

Demonstrates the migration error and attempts a fix by making the failure message an optional tlv record. I'm not sure if we want to do this because it's strange that the failure message is nil in the first place. Perhaps we want to instead migrate nil failure messages to `CodeNone` instead or drop these entries.