### PR TITLE
graph+lnwire: start validating that extra lnwire msg bytes are valid TLV

### DIFF
--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -34,7 +34,8 @@
 * Graph Store SQL implementation and migration project:
   * Introduce an [abstract graph 
     store](https://github.com/lightningnetwork/lnd/pull/9791) interface. 
- 
+  * Start [validating](https://github.com/lightningnetwork/lnd/pull/9787) that 
+    byte blobs at the end of gossip messages are valid TLV streams.
 
 ## RPC Updates
 

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -110,7 +110,7 @@ func TestNodeInsertionAndDeletion(t *testing.T) {
 		Alias:                "kek",
 		Features:             testFeatures,
 		Addresses:            testAddrs,
-		ExtraOpaqueData:      []byte("extra new data"),
+		ExtraOpaqueData:      []byte{1, 1, 1, 2, 2, 2, 2},
 		PubKeyBytes:          testPub,
 	}
 
@@ -631,9 +631,13 @@ func createChannelEdge(node1, node2 *models.LightningNode) (
 			BitcoinSig1Bytes: testSig.Serialize(),
 			BitcoinSig2Bytes: testSig.Serialize(),
 		},
-		ChannelPoint:    outpoint,
-		Capacity:        1000,
-		ExtraOpaqueData: []byte("new unknown feature"),
+		ChannelPoint: outpoint,
+		Capacity:     1000,
+		ExtraOpaqueData: []byte{
+			1, 1, 1,
+			2, 2, 2, 2,
+			3, 3, 3, 3, 3,
+		},
 	}
 	copy(edgeInfo.NodeKey1Bytes[:], firstNode[:])
 	copy(edgeInfo.NodeKey2Bytes[:], secondNode[:])

--- a/lnwire/channel_announcement.go
+++ b/lnwire/channel_announcement.go
@@ -70,8 +70,8 @@ var _ SizeableMessage = (*ChannelAnnouncement1)(nil)
 // io.Reader observing the specified protocol version.
 //
 // This is part of the lnwire.Message interface.
-func (a *ChannelAnnouncement1) Decode(r io.Reader, pver uint32) error {
-	return ReadElements(r,
+func (a *ChannelAnnouncement1) Decode(r io.Reader, _ uint32) error {
+	err := ReadElements(r,
 		&a.NodeSig1,
 		&a.NodeSig2,
 		&a.BitcoinSig1,
@@ -85,6 +85,11 @@ func (a *ChannelAnnouncement1) Decode(r io.Reader, pver uint32) error {
 		&a.BitcoinKey2,
 		&a.ExtraOpaqueData,
 	)
+	if err != nil {
+		return err
+	}
+
+	return a.ExtraOpaqueData.ValidateTLV()
 }
 
 // Encode serializes the target ChannelAnnouncement into the passed io.Writer

--- a/lnwire/channel_announcement_2.go
+++ b/lnwire/channel_announcement_2.go
@@ -126,7 +126,7 @@ func (c *ChannelAnnouncement2) DecodeTLVRecords(r io.Reader) error {
 		c.ExtraOpaqueData = tlvRecords
 	}
 
-	return nil
+	return c.ExtraOpaqueData.ValidateTLV()
 }
 
 // Encode serializes the target AnnounceSignatures1 into the passed io.Writer

--- a/lnwire/channel_update.go
+++ b/lnwire/channel_update.go
@@ -132,7 +132,7 @@ var _ SizeableMessage = (*ChannelUpdate1)(nil)
 // io.Reader observing the specified protocol version.
 //
 // This is part of the lnwire.Message interface.
-func (a *ChannelUpdate1) Decode(r io.Reader, pver uint32) error {
+func (a *ChannelUpdate1) Decode(r io.Reader, _ uint32) error {
 	err := ReadElements(r,
 		&a.Signature,
 		a.ChainHash[:],
@@ -156,7 +156,12 @@ func (a *ChannelUpdate1) Decode(r io.Reader, pver uint32) error {
 		}
 	}
 
-	return a.ExtraOpaqueData.Decode(r)
+	err = a.ExtraOpaqueData.Decode(r)
+	if err != nil {
+		return err
+	}
+
+	return a.ExtraOpaqueData.ValidateTLV()
 }
 
 // Encode serializes the target ChannelUpdate into the passed io.Writer

--- a/lnwire/channel_update_2.go
+++ b/lnwire/channel_update_2.go
@@ -154,7 +154,7 @@ func (c *ChannelUpdate2) DecodeTLVRecords(r io.Reader) error {
 		c.ExtraOpaqueData = tlvRecords
 	}
 
-	return nil
+	return c.ExtraOpaqueData.ValidateTLV()
 }
 
 // Encode serializes the target ChannelUpdate2 into the passed io.Writer

--- a/lnwire/extra_bytes.go
+++ b/lnwire/extra_bytes.go
@@ -63,6 +63,28 @@ func (e *ExtraOpaqueData) Decode(r io.Reader) error {
 	return nil
 }
 
+// ValidateTLV checks that the raw bytes that make up the ExtraOpaqueData
+// instance are a valid TLV stream.
+func (e *ExtraOpaqueData) ValidateTLV() error {
+	// There is nothing to validate if the ExtraOpaqueData is nil or empty.
+	if e == nil || len(*e) == 0 {
+		return nil
+	}
+
+	tlvStream, err := tlv.NewStream()
+	if err != nil {
+		return err
+	}
+
+	// Ensure that the TLV stream is valid by attempting to decode it.
+	_, err = tlvStream.DecodeWithParsedTypesP2P(bytes.NewReader(*e))
+	if err != nil {
+		return fmt.Errorf("invalid TLV stream: %w: %v", err, *e)
+	}
+
+	return nil
+}
+
 // PackRecords attempts to encode the set of tlv records into the target
 // ExtraOpaqueData instance. The records will be encoded as a raw TLV stream
 // and stored within the backing slice pointer.

--- a/lnwire/node_announcement.go
+++ b/lnwire/node_announcement.go
@@ -112,8 +112,8 @@ var _ SizeableMessage = (*NodeAnnouncement)(nil)
 // io.Reader observing the specified protocol version.
 //
 // This is part of the lnwire.Message interface.
-func (a *NodeAnnouncement) Decode(r io.Reader, pver uint32) error {
-	return ReadElements(r,
+func (a *NodeAnnouncement) Decode(r io.Reader, _ uint32) error {
+	err := ReadElements(r,
 		&a.Signature,
 		&a.Features,
 		&a.Timestamp,
@@ -123,6 +123,11 @@ func (a *NodeAnnouncement) Decode(r io.Reader, pver uint32) error {
 		&a.Addresses,
 		&a.ExtraOpaqueData,
 	)
+	if err != nil {
+		return err
+	}
+
+	return a.ExtraOpaqueData.ValidateTLV()
 }
 
 // Encode serializes the target NodeAnnouncement into the passed io.Writer


### PR DESCRIPTION
In this PR, we start validating that any gossip message we decode has a valid TLV stream. 
This is in preparation for creating a SQL version of the graph store in which we will store the TLV
records in a normalised fashion instead of in a flat structure as is done today. 

part of https://github.com/lightningnetwork/lnd/issues/9795
