### PR TITLE
batch: dont expose kvdb.RwTx in batch.SchedulerOptions

### DIFF
--- a/batch/scheduler.go
+++ b/batch/scheduler.go
@@ -43,6 +43,10 @@ func NewTimeScheduler(db kvdb.Backend, locker sync.Locker,
 //
 // NOTE: Part of the Scheduler interface.
 func (s *TimeScheduler) Execute(r *Request) error {
+	if r.Opts == nil {
+		r.Opts = NewDefaultSchedulerOpts()
+	}
+
 	req := request{
 		Request: r,
 		errChan: make(chan error, 1),
@@ -62,7 +66,7 @@ func (s *TimeScheduler) Execute(r *Request) error {
 	s.b.reqs = append(s.b.reqs, &req)
 
 	// If this is a non-lazy request, we'll execute the batch immediately.
-	if !r.lazy {
+	if !r.Opts.lazy {
 		go s.b.trigger()
 	}
 

--- a/graph/db/kv_store.go
+++ b/graph/db/kv_store.go
@@ -848,16 +848,13 @@ func (c *KVStore) SetSourceNode(node *models.LightningNode) error {
 //
 // TODO(roasbeef): also need sig of announcement.
 func (c *KVStore) AddLightningNode(node *models.LightningNode,
-	op ...batch.SchedulerOption) error {
+	opts ...batch.SchedulerOption) error {
 
 	r := &batch.Request{
+		Opts: batch.NewSchedulerOptions(opts...),
 		Update: func(tx kvdb.RwTx) error {
 			return addLightningNode(tx, node)
 		},
-	}
-
-	for _, f := range op {
-		f(r)
 	}
 
 	return c.nodeScheduler.Execute(r)
@@ -986,10 +983,11 @@ func (c *KVStore) deleteLightningNode(nodes kvdb.RwBucket,
 // supports. The chanPoint and chanID are used to uniquely identify the edge
 // globally within the database.
 func (c *KVStore) AddChannelEdge(edge *models.ChannelEdgeInfo,
-	op ...batch.SchedulerOption) error {
+	opts ...batch.SchedulerOption) error {
 
 	var alreadyExists bool
 	r := &batch.Request{
+		Opts: batch.NewSchedulerOptions(opts...),
 		Reset: func() {
 			alreadyExists = false
 		},
@@ -1017,14 +1015,6 @@ func (c *KVStore) AddChannelEdge(edge *models.ChannelEdgeInfo,
 				return nil
 			}
 		},
-	}
-
-	for _, f := range op {
-		if f == nil {
-			return fmt.Errorf("nil scheduler option was used")
-		}
-
-		f(r)
 	}
 
 	return c.chanScheduler.Execute(r)
@@ -2696,7 +2686,7 @@ func makeZombiePubkeys(info *models.ChannelEdgeInfo,
 // determined by the lexicographical ordering of the identity public keys of the
 // nodes on either side of the channel.
 func (c *KVStore) UpdateEdgePolicy(edge *models.ChannelEdgePolicy,
-	op ...batch.SchedulerOption) (route.Vertex, route.Vertex, error) {
+	opts ...batch.SchedulerOption) (route.Vertex, route.Vertex, error) {
 
 	var (
 		isUpdate1    bool
@@ -2705,6 +2695,7 @@ func (c *KVStore) UpdateEdgePolicy(edge *models.ChannelEdgePolicy,
 	)
 
 	r := &batch.Request{
+		Opts: batch.NewSchedulerOptions(opts...),
 		Reset: func() {
 			isUpdate1 = false
 			edgeNotFound = false
@@ -2736,10 +2727,6 @@ func (c *KVStore) UpdateEdgePolicy(edge *models.ChannelEdgePolicy,
 				return nil
 			}
 		},
-	}
-
-	for _, f := range op {
-		f(r)
 	}
 
 	err := c.chanScheduler.Execute(r)


### PR DESCRIPTION
Currently, a few of the graph KVStore methods take the `batch.SchedularOptions` param. This is only used to set the `LazyAdd` option. A `SchedularOption` is a functional option that takes a `batch.Request` which has bbolt-specific fields in it. This commit restructures things a bit such that the `batch.Request` type is no longer part of the `batch.SchedularOptions` - this will make it easier to implement the graph store with a different DB backend (since we can then introduce an interface to describe the graph Store that is db agnostic and doesnt have bbolt specific types). 


