### PR TITLE
tlv: catch unhandled type in SizeBigSize

### DIFF
--- a/tlv/record.go
+++ b/tlv/record.go
@@ -273,14 +273,14 @@ func SortRecords(records []Record) {
 //
 // NOTE: for uint32, we would only gain space reduction if the encoded value is
 // no greater than 65535, which requires at most 3 bytes to encode.
-func MakeBigSizeRecord(typ Type, val interface{}) Record {
+func MakeBigSizeRecord[T constraintUint32Or64](typ Type, val *T) Record {
 	var (
 		staticSize uint64
 		sizeFunc   SizeFunc
 		encoder    Encoder
 		decoder    Decoder
 	)
-	switch val.(type) {
+	switch any(val).(type) {
 	case *uint32:
 		sizeFunc = SizeBigSize(val)
 		encoder = EBigSize


### PR DESCRIPTION
Ensure that we do not silently return zero size if the type passed to SizeBigSize is not handled within the function.

This is an alternative to https://github.com/lightningnetwork/lnd/pull/9788 which opts for instead changing the function signature of SizeFunc so that we return explicit errors. This alternative allows us to fix this issue with a smaller impact zone. 

If this is merged, we can close https://github.com/lightningnetwork/lnd/pull/9788 and https://github.com/btcsuite/btcwallet/pull/1010 and then update https://github.com/lightningnetwork/lnd/pull/9789 to just point to this new `tlv` package version
