### PR TITLE
peer: make ping manager send sync

### DIFF
--- a/peer/ping_manager.go
+++ b/peer/ping_manager.go
@@ -141,14 +141,14 @@ func (m *PingManager) pingHandler() {
 				PaddingBytes: m.cfg.NewPingPayload(),
 			}
 
-			// Set up our bookkeeping for the new Ping.
+			m.cfg.SendPing(ping)
+
+			// Set up our bookkeeping as we've sent the ping.
 			if err := m.setPingState(pongSize); err != nil {
 				m.cfg.OnPongFailure(err)
 
 				return
 			}
-
-			m.cfg.SendPing(ping)
 
 		case <-m.pingTimeout.C:
 			m.resetPingState()


### PR DESCRIPTION
In this commit, we make the ping manager sync blocking. This ensures that we don't start the ping timer until after we've actually sent out the ping on the wire. Otherwise, it's possible that if processing the normal outgoing queue is very delayed, that we expire the ping timer before we even send anything out to the remote peer.

