### PR TITLE
graph/db: synchronous topology client subscriptions/cancellations

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -128,6 +128,9 @@ when running LND with an aux component injected (custom channels).
   such that the probability is evaluated quicker and to be more accurate in
   outdated scenarios.
 
+* [Fix a bug](https://github.com/lightningnetwork/lnd/pull/9798) that could
+  result in a new topology client missing a channel-close notifications. 
+
 # New Features
 
 * Add support for [archiving channel backup](https://github.com/lightningnetwork/lnd/pull/9232)

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -492,9 +492,12 @@ func (c *ChannelGraph) PruneGraph(spentOutputs []*wire.OutPoint,
 		closeSummaries := createCloseSummaries(
 			blockHeight, edges...,
 		)
-		c.notifyTopologyChange(&TopologyChange{
-			ClosedChannels: closeSummaries,
-		})
+
+		select {
+		case c.topologyUpdate <- closeSummaries:
+		case <-c.quit:
+			return nil, ErrChanGraphShuttingDown
+		}
 	}
 
 	return edges, nil


### PR DESCRIPTION
In this commit, a race is fixed that could result in notifications being missed by a topology client if the notifications are sent too soon after the SubscribeTopology call is made due to the fact that the topology client is stored asynchronously at the moment in
`handleTopologySubscriptions`. This means that the client may only be stored _after_ `SubscribeTopology` has exited _and_ new notifications have already been sent. NOTE: this is only the case for notifications originating from `PruneGraph` as those are not currently forced to go via the `topologyUpdates` channel. This commit fixes that. 

See [this build](https://github.com/lightningnetwork/lnd/actions/runs/14904423814/job/41863427226?pr=9692) for an example of this race condition being triggered. 

To see the race in action: add a `time.Sleep()` on `master` between the read from the `ntfnClientUpdate` channel and the call to `topologyClients.Store` and then run: `make unit pkg=graph case=TestChannelCloseNotification`

```
diff --git a/graph/db/graph.go b/graph/db/graph.go
index 9e35e58dd..22de239ed 100644
--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -165,6 +165,8 @@ func (c *ChannelGraph) handleTopologySubscriptions() {
                                continue
                        }
 
+                       time.Sleep(time.Second * 2)
+
                        c.topologyClients.Store(clientID, &topologyClient{
                                ntfnChan: ntfnUpdate.ntfnChan,
                                exit:     make(chan struct{}),
~
~
```