### PR TITLE
multi: various test preparations for different graph store impl

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -222,6 +222,8 @@ jobs:
           - unit tags="kvdb_etcd"
           - unit tags="kvdb_postgres"
           - unit tags="kvdb_sqlite"
+          - unit tags="test_db_sqlite"
+          - unit tags="test_db_postgres"
           - unit-race
           - unit-module
 

--- a/autopilot/prefattach_test.go
+++ b/autopilot/prefattach_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	graphdb "github.com/lightningnetwork/lnd/graph/db"
 	"github.com/lightningnetwork/lnd/graph/db/models"
-	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/stretchr/testify/require"
@@ -37,22 +36,7 @@ type testDBGraph struct {
 }
 
 func newDiskChanGraph(t *testing.T) (testGraph, error) {
-	backend, err := kvdb.GetBoltBackend(&kvdb.BoltBackendConfig{
-		DBPath:            t.TempDir(),
-		DBFileName:        "graph.db",
-		NoFreelistSync:    true,
-		AutoCompact:       false,
-		AutoCompactMinAge: kvdb.DefaultBoltAutoCompactMinAge,
-		DBTimeout:         kvdb.DefaultDBTimeout,
-	})
-	require.NoError(t, err)
-
-	graphStore, err := graphdb.NewKVStore(backend)
-	require.NoError(t, err)
-
-	graphDB, err := graphdb.NewChannelGraph(graphStore)
-	require.NoError(t, err)
-
+	graphDB := graphdb.MakeTestGraph(t)
 	require.NoError(t, graphDB.Start())
 	t.Cleanup(func() {
 		require.NoError(t, graphDB.Stop())

--- a/go.mod
+++ b/go.mod
@@ -199,6 +199,10 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
+// TODO(elle): remove once all the schemas and queries for the graph
+// store have been included in a tagged sqldb version.
+replace github.com/lightningnetwork/lnd/sqldb => ./sqldb
+
 // This replace is for https://github.com/advisories/GHSA-25xm-hr59-7c27
 replace github.com/ulikunitz/xz => github.com/ulikunitz/xz v0.5.11
 

--- a/go.sum
+++ b/go.sum
@@ -375,8 +375,6 @@ github.com/lightningnetwork/lnd/kvdb v1.4.16 h1:9BZgWdDfjmHRHLS97cz39bVuBAqMc4/p
 github.com/lightningnetwork/lnd/kvdb v1.4.16/go.mod h1:HW+bvwkxNaopkz3oIgBV6NEnV4jCEZCACFUcNg4xSjM=
 github.com/lightningnetwork/lnd/queue v1.1.1 h1:99ovBlpM9B0FRCGYJo6RSFDlt8/vOkQQZznVb18iNMI=
 github.com/lightningnetwork/lnd/queue v1.1.1/go.mod h1:7A6nC1Qrm32FHuhx/mi1cieAiBZo5O6l8IBIoQxvkz4=
-github.com/lightningnetwork/lnd/sqldb v1.0.9 h1:7OHi+Hui823mB/U9NzCdlZTAGSVdDCbjp33+6d/Q+G0=
-github.com/lightningnetwork/lnd/sqldb v1.0.9/go.mod h1:OG09zL/PHPaBJefp4HsPz2YLUJ+zIQHbpgCtLnOx8I4=
 github.com/lightningnetwork/lnd/ticker v1.1.1 h1:J/b6N2hibFtC7JLV77ULQp++QLtCwT6ijJlbdiZFbSM=
 github.com/lightningnetwork/lnd/ticker v1.1.1/go.mod h1:waPTRAAcwtu7Ji3+3k+u/xH5GHovTsCoSVpho0KDvdA=
 github.com/lightningnetwork/lnd/tlv v1.3.1 h1:o7CZg06y+rJZfUMAo0WzBLr0pgBWCzrt0f9gpujYUzk=

--- a/graph/builder_test.go
+++ b/graph/builder_test.go
@@ -1352,7 +1352,7 @@ func parseTestGraph(t *testing.T, useCache bool, path string) (
 	testAddrs = append(testAddrs, testAddr)
 
 	// Next, create a temporary graph database for usage within the test.
-	graph := makeTestGraph(t, useCache)
+	graph := graphdb.MakeTestGraph(t, graphdb.WithUseGraphCache(useCache))
 
 	aliasMap := make(map[string]route.Vertex)
 	privKeyMap := make(map[string]*btcec.PrivateKey)
@@ -1726,7 +1726,7 @@ func createTestGraphFromChannels(t *testing.T, useCache bool,
 	testAddrs = append(testAddrs, testAddr)
 
 	// Next, create a temporary graph database for usage within the test.
-	graph := makeTestGraph(t, useCache)
+	graph := graphdb.MakeTestGraph(t, graphdb.WithUseGraphCache(useCache))
 
 	aliasMap := make(map[string]route.Vertex)
 	privKeyMap := make(map[string]*btcec.PrivateKey)

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -13,6 +14,7 @@ import (
 	"github.com/lightningnetwork/lnd/graph/db/models"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
+	"github.com/stretchr/testify/require"
 )
 
 // ErrChanGraphShuttingDown indicates that the ChannelGraph has shutdown or is
@@ -611,4 +613,31 @@ func (c *ChannelGraph) UpdateEdgePolicy(edge *models.ChannelEdgePolicy,
 	}
 
 	return nil
+}
+
+// MakeTestGraphNew creates a new instance of the ChannelGraph for testing
+// purposes. The backing V1Store implementation depends on the version of
+// NewTestDB included in the current build.
+//
+// NOTE: this is currently unused, but is left here for future use to show how
+// NewTestDB can be used. As the SQL implementation of the V1Store is
+// implemented, unit tests will be switched to use this function instead of
+// the existing MakeTestGraph helper. Once only this function is used, the
+// existing MakeTestGraph function will be removed and this one will be renamed.
+func MakeTestGraphNew(t testing.TB,
+	opts ...ChanGraphOption) *ChannelGraph { //nolint:unused
+
+	t.Helper()
+
+	store := NewTestDB(t)
+
+	graph, err := NewChannelGraph(store, opts...)
+	require.NoError(t, err)
+	require.NoError(t, graph.Start())
+
+	t.Cleanup(func() {
+		require.NoError(t, graph.Stop())
+	})
+
+	return graph
 }

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -4128,18 +4128,10 @@ func TestGraphCacheForEachNodeChannel(t *testing.T) {
 // TestGraphLoading asserts that the cache is properly reconstructed after a
 // restart.
 func TestGraphLoading(t *testing.T) {
-	// First, create a temporary directory to be used for the duration of
-	// this test.
-	tempDirName := t.TempDir()
+	t.Parallel()
 
 	// Next, create the graph for the first time.
-	backend, backendCleanup, err := kvdb.GetTestBackend(tempDirName, "cgr")
-	require.NoError(t, err)
-	defer backend.Close()
-	defer backendCleanup()
-
-	graphStore, err := NewKVStore(backend)
-	require.NoError(t, err)
+	graphStore := NewTestDB(t)
 
 	graph, err := NewChannelGraph(graphStore)
 	require.NoError(t, err)

--- a/graph/db/kv_store.go
+++ b/graph/db/kv_store.go
@@ -4707,16 +4707,9 @@ func (c *chanGraphNodeTx) ForEachChannel(f func(*models.ChannelEdgeInfo,
 	)
 }
 
-// MakeTestGraph creates a new instance of the KVStore for testing
+// MakeTestGraph creates a new instance of the ChannelGraph for testing
 // purposes.
-func MakeTestGraph(t testing.TB,
-	modifiers ...KVStoreOptionModifier) *ChannelGraph {
-
-	opts := DefaultOptions()
-	for _, modifier := range modifiers {
-		modifier(opts)
-	}
-
+func MakeTestGraph(t testing.TB, opts ...ChanGraphOption) *ChannelGraph {
 	// Next, create KVStore for the first time.
 	backend, backendCleanup, err := kvdb.GetTestBackend(t.TempDir(), "cgr")
 	t.Cleanup(backendCleanup)
@@ -4725,10 +4718,10 @@ func MakeTestGraph(t testing.TB,
 		require.NoError(t, backend.Close())
 	})
 
-	graphStore, err := NewKVStore(backend, modifiers...)
+	graphStore, err := NewKVStore(backend)
 	require.NoError(t, err)
 
-	graph, err := NewChannelGraph(graphStore)
+	graph, err := NewChannelGraph(graphStore, opts...)
 	require.NoError(t, err)
 	require.NoError(t, graph.Start())
 	t.Cleanup(func() {

--- a/graph/db/kv_store.go
+++ b/graph/db/kv_store.go
@@ -4710,6 +4710,8 @@ func (c *chanGraphNodeTx) ForEachChannel(f func(*models.ChannelEdgeInfo,
 // MakeTestGraph creates a new instance of the ChannelGraph for testing
 // purposes.
 func MakeTestGraph(t testing.TB, opts ...ChanGraphOption) *ChannelGraph {
+	t.Helper()
+
 	// Next, create KVStore for the first time.
 	backend, backendCleanup, err := kvdb.GetTestBackend(t.TempDir(), "cgr")
 	t.Cleanup(backendCleanup)

--- a/graph/db/kv_store.go
+++ b/graph/db/kv_store.go
@@ -4709,6 +4709,9 @@ func (c *chanGraphNodeTx) ForEachChannel(f func(*models.ChannelEdgeInfo,
 
 // MakeTestGraph creates a new instance of the ChannelGraph for testing
 // purposes.
+//
+// NOTE: this helper currently creates a ChannelGraph that is only ever backed
+// by the `KVStore` of the `V1Store` interface.
 func MakeTestGraph(t testing.TB, opts ...ChanGraphOption) *ChannelGraph {
 	t.Helper()
 

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -1,0 +1,45 @@
+package graphdb
+
+import (
+	"github.com/lightningnetwork/lnd/sqldb"
+)
+
+// SQLQueries is a subset of the sqlc.Querier interface that can be used to
+// execute queries against the SQL graph tables.
+type SQLQueries interface {
+}
+
+// BatchedSQLQueries is a version of SQLQueries that's capable of batched
+// database operations.
+type BatchedSQLQueries interface {
+	SQLQueries
+	sqldb.BatchedTx[SQLQueries]
+}
+
+// SQLStore is an implementation of the V1Store interface that uses a SQL
+// database as the backend.
+//
+// NOTE: currently, this temporarily embeds the KVStore struct so that we can
+// implement the V1Store interface incrementally. For any method not
+// implemented,  things will fall back to the KVStore. This is ONLY the case
+// for the time being while this struct is purely used in unit tests only.
+type SQLStore struct {
+	db BatchedSQLQueries
+
+	// Temporary fall-back to the KVStore so that we can implement the
+	// interface incrementally.
+	*KVStore
+}
+
+// A compile-time assertion to ensure that SQLStore implements the V1Store
+// interface.
+var _ V1Store = (*SQLStore)(nil)
+
+// NewSQLStore creates a new SQLStore instance given an open BatchedSQLQueries
+// storage backend.
+func NewSQLStore(db BatchedSQLQueries, kvStore *KVStore) *SQLStore {
+	return &SQLStore{
+		db:      db,
+		KVStore: kvStore,
+	}
+}

--- a/graph/db/test_kvdb.go
+++ b/graph/db/test_kvdb.go
@@ -1,0 +1,21 @@
+package graphdb
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/stretchr/testify/require"
+)
+
+// NewTestDB is a helper function that creates an BBolt database for testing.
+func NewTestDB(t testing.TB) *KVStore {
+	backend, backendCleanup, err := kvdb.GetTestBackend(t.TempDir(), "cgr")
+	require.NoError(t, err)
+
+	t.Cleanup(backendCleanup)
+
+	graphStore, err := NewKVStore(backend)
+	require.NoError(t, err)
+
+	return graphStore
+}

--- a/graph/db/test_postgres.go
+++ b/graph/db/test_postgres.go
@@ -1,0 +1,40 @@
+//go:build test_db_postgres && !test_db_sqlite
+
+package graphdb
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/sqldb"
+	"github.com/stretchr/testify/require"
+)
+
+// NewTestDB is a helper function that creates an BBolt database for testing.
+func NewTestDB(t testing.TB) *SQLStore {
+	backend, backendCleanup, err := kvdb.GetTestBackend(t.TempDir(), "cgr")
+	require.NoError(t, err)
+
+	t.Cleanup(backendCleanup)
+
+	graphStore, err := NewKVStore(backend)
+	require.NoError(t, err)
+
+	pgFixture := sqldb.NewTestPgFixture(
+		t, sqldb.DefaultPostgresFixtureLifetime,
+	)
+	t.Cleanup(func() {
+		pgFixture.TearDown(t)
+	})
+
+	db := sqldb.NewTestPostgresDB(t, pgFixture).BaseDB
+
+	executor := sqldb.NewTransactionExecutor(
+		db, func(tx *sql.Tx) SQLQueries {
+			return db.WithTx(tx)
+		},
+	)
+
+	return NewSQLStore(executor, graphStore)
+}

--- a/graph/db/test_sqlite.go
+++ b/graph/db/test_sqlite.go
@@ -1,16 +1,18 @@
-//go:build !test_db_sqlite && !test_db_postgres
+//go:build !test_db_posgres && test_db_sqlite
 
 package graphdb
 
 import (
+	"database/sql"
 	"testing"
 
 	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/sqldb"
 	"github.com/stretchr/testify/require"
 )
 
 // NewTestDB is a helper function that creates an BBolt database for testing.
-func NewTestDB(t testing.TB) *KVStore {
+func NewTestDB(t testing.TB) *SQLStore {
 	backend, backendCleanup, err := kvdb.GetTestBackend(t.TempDir(), "cgr")
 	require.NoError(t, err)
 
@@ -19,5 +21,13 @@ func NewTestDB(t testing.TB) *KVStore {
 	graphStore, err := NewKVStore(backend)
 	require.NoError(t, err)
 
-	return graphStore
+	db := sqldb.NewTestSqliteDB(t).BaseDB
+
+	executor := sqldb.NewTransactionExecutor(
+		db, func(tx *sql.Tx) SQLQueries {
+			return db.WithTx(tx)
+		},
+	)
+
+	return NewSQLStore(executor, graphStore)
 }

--- a/graph/notifications_test.go
+++ b/graph/notifications_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/lightningnetwork/lnd/graph/db/models"
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/input"
-	"github.com/lightningnetwork/lnd/kvdb"
 	lnmock "github.com/lightningnetwork/lnd/lntest/mock"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -1034,8 +1033,7 @@ type testCtx struct {
 func createTestCtxSingleNode(t *testing.T,
 	startingHeight uint32) *testCtx {
 
-	graph := makeTestGraph(t, true)
-
+	graph := graphdb.MakeTestGraph(t)
 	sourceNode := createTestNode(t)
 
 	require.NoError(t,
@@ -1080,32 +1078,6 @@ func (c *testCtx) RestartBuilder(t *testing.T) {
 	// Finally, we'll swap out the pointer in the testCtx with this fresh
 	// instance of the router.
 	c.builder = builder
-}
-
-// makeTestGraph creates a new instance of a channeldb.ChannelGraph for testing
-// purposes.
-func makeTestGraph(t *testing.T, useCache bool) *graphdb.ChannelGraph {
-	t.Helper()
-
-	// Create channelgraph for the first time.
-	backend, backendCleanup, err := kvdb.GetTestBackend(t.TempDir(), "cgr")
-	require.NoError(t, err)
-
-	t.Cleanup(backendCleanup)
-
-	graphStore, err := graphdb.NewKVStore(backend)
-	require.NoError(t, err)
-
-	graph, err := graphdb.NewChannelGraph(
-		graphStore, graphdb.WithUseGraphCache(useCache),
-	)
-	require.NoError(t, err)
-	require.NoError(t, graph.Start())
-	t.Cleanup(func() {
-		require.NoError(t, graph.Stop())
-	})
-
-	return graph
 }
 
 type testGraphInstance struct {

--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -23,7 +23,6 @@ import (
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
-	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lntest/channels"
 	"github.com/lightningnetwork/lnd/lntest/mock"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -603,29 +602,13 @@ func createTestPeer(t *testing.T) *peerTestCtx {
 
 	const chanActiveTimeout = time.Minute
 
-	dbPath := t.TempDir()
-
-	graphBackend, err := kvdb.GetBoltBackend(&kvdb.BoltBackendConfig{
-		DBPath:            dbPath,
-		DBFileName:        "graph.db",
-		NoFreelistSync:    true,
-		AutoCompact:       false,
-		AutoCompactMinAge: kvdb.DefaultBoltAutoCompactMinAge,
-		DBTimeout:         kvdb.DefaultDBTimeout,
-	})
-	require.NoError(t, err)
-
-	graphStore, err := graphdb.NewKVStore(graphBackend)
-	require.NoError(t, err)
-
-	dbAliceGraph, err := graphdb.NewChannelGraph(graphStore)
-	require.NoError(t, err)
+	dbAliceGraph := graphdb.MakeTestGraph(t)
 	require.NoError(t, dbAliceGraph.Start())
 	t.Cleanup(func() {
 		require.NoError(t, dbAliceGraph.Stop())
 	})
 
-	dbAliceChannel := channeldb.OpenForTesting(t, dbPath)
+	dbAliceChannel := channeldb.OpenForTesting(t, t.TempDir())
 
 	nodeSignerAlice := netann.NewNodeSigner(aliceKeySigner)
 

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -212,7 +212,7 @@ func parseTestGraph(t *testing.T, useCache bool, path string) (
 	testAddrs = append(testAddrs, testAddr)
 
 	// Next, create a temporary graph database for usage within the test.
-	graph, graphBackend, err := makeTestGraph(t, useCache)
+	graph, mcBackend, err := makeTestGraph(t, useCache)
 	if err != nil {
 		return nil, err
 	}
@@ -412,12 +412,12 @@ func parseTestGraph(t *testing.T, useCache bool, path string) (
 	}
 
 	return &testGraphInstance{
-		graph:        graph,
-		graphBackend: graphBackend,
-		aliasMap:     aliasMap,
-		privKeyMap:   privKeyMap,
-		channelIDs:   channelIDs,
-		links:        links,
+		graph:      graph,
+		mcBackend:  mcBackend,
+		aliasMap:   aliasMap,
+		privKeyMap: privKeyMap,
+		channelIDs: channelIDs,
+		links:      links,
 	}, nil
 }
 
@@ -481,8 +481,8 @@ type testChannel struct {
 }
 
 type testGraphInstance struct {
-	graph        *graphdb.ChannelGraph
-	graphBackend kvdb.Backend
+	graph     *graphdb.ChannelGraph
+	mcBackend kvdb.Backend
 
 	// aliasMap is a map from a node's alias to its public key. This type is
 	// provided in order to allow easily look up from the human memorable alias
@@ -749,11 +749,11 @@ func createTestGraphFromChannels(t *testing.T, useCache bool,
 	}
 
 	return &testGraphInstance{
-		graph:        graph,
-		graphBackend: graphBackend,
-		aliasMap:     aliasMap,
-		privKeyMap:   privKeyMap,
-		links:        links,
+		graph:      graph,
+		mcBackend:  graphBackend,
+		aliasMap:   aliasMap,
+		privKeyMap: privKeyMap,
+		links:      links,
 	}, nil
 }
 

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -159,28 +159,21 @@ func makeTestGraph(t *testing.T, useCache bool) (*graphdb.ChannelGraph,
 	kvdb.Backend, error) {
 
 	// Create channelgraph for the first time.
-	backend, backendCleanup, err := kvdb.GetTestBackend(t.TempDir(), "cgr")
-	if err != nil {
-		return nil, nil, err
-	}
-
-	t.Cleanup(backendCleanup)
-
-	graphStore, err := graphdb.NewKVStore(backend)
-	require.NoError(t, err)
-
-	graph, err := graphdb.NewChannelGraph(
-		graphStore, graphdb.WithUseGraphCache(useCache),
-	)
-	if err != nil {
-		return nil, nil, err
-	}
+	graph := graphdb.MakeTestGraph(t, graphdb.WithUseGraphCache(useCache))
 	require.NoError(t, graph.Start())
 	t.Cleanup(func() {
 		require.NoError(t, graph.Stop())
 	})
 
-	return graph, backend, nil
+	mcBackend, backendCleanup, err := kvdb.GetTestBackend(
+		t.TempDir(), "mission_control",
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	t.Cleanup(backendCleanup)
+
+	return graph, mcBackend, nil
 }
 
 // parseTestGraph returns a fully populated ChannelGraph given a path to a JSON

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -123,7 +123,7 @@ func createTestCtxFromGraphInstanceAssumeValid(t *testing.T,
 	mcConfig := &MissionControlConfig{Estimator: estimator}
 
 	mcController, err := NewMissionController(
-		graphInstance.graphBackend, route.Vertex{}, mcConfig,
+		graphInstance.mcBackend, route.Vertex{}, mcConfig,
 	)
 	require.NoError(t, err, "failed to create missioncontrol")
 

--- a/sqldb/postgres_fixture.go
+++ b/sqldb/postgres_fixture.go
@@ -39,7 +39,7 @@ type TestPgFixture struct {
 // NewTestPgFixture constructs a new TestPgFixture starting up a docker
 // container running Postgres 11. The started container will expire in after
 // the passed duration.
-func NewTestPgFixture(t *testing.T, expiry time.Duration) *TestPgFixture {
+func NewTestPgFixture(t testing.TB, expiry time.Duration) *TestPgFixture {
 	// Use a sensible default on Windows (tcp/http) and linux/osx (socket)
 	// by specifying an empty endpoint.
 	pool, err := dockertest.NewPool("")
@@ -119,13 +119,13 @@ func (f *TestPgFixture) GetConfig(dbName string) *PostgresConfig {
 }
 
 // TearDown stops the underlying docker container.
-func (f *TestPgFixture) TearDown(t *testing.T) {
+func (f *TestPgFixture) TearDown(t testing.TB) {
 	err := f.pool.Purge(f.resource)
 	require.NoError(t, err, "Could not purge resource")
 }
 
 // randomDBName generates a random database name.
-func randomDBName(t *testing.T) string {
+func randomDBName(t testing.TB) string {
 	randBytes := make([]byte, 8)
 	_, err := rand.Read(randBytes)
 	require.NoError(t, err)
@@ -135,7 +135,7 @@ func randomDBName(t *testing.T) string {
 
 // NewTestPostgresDB is a helper function that creates a Postgres database for
 // testing using the given fixture.
-func NewTestPostgresDB(t *testing.T, fixture *TestPgFixture) *PostgresStore {
+func NewTestPostgresDB(t testing.TB, fixture *TestPgFixture) *PostgresStore {
 	t.Helper()
 
 	dbName := randomDBName(t)

--- a/sqldb/sqlite.go
+++ b/sqldb/sqlite.go
@@ -220,7 +220,7 @@ func (s *SqliteStore) SetSchemaVersion(version int, dirty bool) error {
 
 // NewTestSqliteDB is a helper function that creates an SQLite database for
 // testing.
-func NewTestSqliteDB(t *testing.T) *SqliteStore {
+func NewTestSqliteDB(t testing.TB) *SqliteStore {
 	t.Helper()
 
 	t.Logf("Creating new SQLite DB for testing")


### PR DESCRIPTION
In this PR we start prepping various unit tests so that we can easily plug in a different `V1Store` implementation
simply by later adding new test build flags that will result in different versions of `NewTestDB` being compiled. 

We prepare for this here by ensuring that all test `ChannelGraph`s are created via a single `MakeTestGraph` helper
which uses this new `NewTestDB` helper. 

We also add the skeleton for the new `SQLStore` which we will step by step use to implement the sql version 
of the `V1Store` - only the framework is added in this PR. Reviewers can take a look at [this PoC](https://github.com/ellemouton/lnd/pull/197/commits) which shows how this framework will be used to implement the
SQLStore in a piece-meal manner. 

Part of #9795 