### PR TITLE
peer+lnd: add new CLI option to control if we D/C on slow pongs

### DIFF
--- a/config.go
+++ b/config.go
@@ -251,6 +251,11 @@ const (
 
 	defaultPrunedNodeMaxPeers = 4
 	defaultNeutrinoMaxPeers   = 8
+
+	// defaultNoDisconnectOnPongFailure is the default value for whether we
+	// should *not* disconnect from a peer if we don't receive a pong
+	// response in time after we send a ping.
+	defaultNoDisconnectOnPongFailure = false
 )
 
 var (
@@ -527,6 +532,10 @@ type Config struct {
 	// NumRestrictedSlots is the number of restricted slots we'll allocate
 	// in the server.
 	NumRestrictedSlots uint64 `long:"num-restricted-slots" description:"The number of restricted slots we'll allocate in the server."`
+
+	// NoDisconnectOnPongFailure controls if we'll disconnect if a peer
+	// doesn't respond to a pong in time.
+	NoDisconnectOnPongFailure bool `long:"no-disconnect-on-pong-failure" description:"If true, a peer will *not* be disconnected if a pong is not received in time or is mismatched. Defaults to false, meaning peers *will* be disconnected on pong failure."`
 }
 
 // GRPCConfig holds the configuration options for the gRPC server.
@@ -747,10 +756,11 @@ func DefaultConfig() Config {
 			ServerPingTimeout: defaultGrpcServerPingTimeout,
 			ClientPingMinWait: defaultGrpcClientPingMinWait,
 		},
-		LogConfig:          build.DefaultLogConfig(),
-		WtClient:           lncfg.DefaultWtClientCfg(),
-		HTTPHeaderTimeout:  DefaultHTTPHeaderTimeout,
-		NumRestrictedSlots: DefaultNumRestrictedSlots,
+		LogConfig:                 build.DefaultLogConfig(),
+		WtClient:                  lncfg.DefaultWtClientCfg(),
+		HTTPHeaderTimeout:         DefaultHTTPHeaderTimeout,
+		NumRestrictedSlots:        DefaultNumRestrictedSlots,
+		NoDisconnectOnPongFailure: defaultNoDisconnectOnPongFailure,
 	}
 }
 

--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -305,6 +305,10 @@ when running LND with an aux component injected (custom channels).
 
 * [remove x/exp/maps dependency](https://github.com/lightningnetwork/lnd/pull/9621)
 
+* [Add a new configuration option](https://github.com/lightningnetwork/lnd/pull/9801)
+  `--no-disconnect-on-pong-failure` (defaulting to false) to control whether a
+  peer is disconnected if a pong message is not received in time or is mismatched.
+
 ## RPC Updates
 
 * Some RPCs that previously just returned an empty response message now at least

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -569,6 +569,11 @@
 ; The number of restricted slots the server will allocate for peers.
 ; num-restricted-slots=30
 
+; If true, a peer will *not* be disconnected if a pong is not received in time
+; or is mismatched. Defaults to false, meaning peers *will* be disconnected on
+; pong failure.
+; no-disconnect-on-pong-failure=false
+
 [fee]
 
 ; Optional URL for external fee estimation. If no URL is specified, the method

--- a/server.go
+++ b/server.go
@@ -4493,6 +4493,7 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 				EndorsementExperimentEnd,
 			)
 		},
+		NoDisconnectOnPongFailure: s.cfg.NoDisconnectOnPongFailure,
 	}
 
 	copy(pCfg.PubKeyBytes[:], peerAddr.IdentityKey.SerializeCompressed())


### PR DESCRIPTION
In this commit, we add a new CLI option to control if we D/C on slow pongs or not. Due to the existence of head-of-the-line blocking at various levels of abstraction (app buffer, slow processing, TCP kernel buffers, etc), if there's a flurry of gossip messages (eg: 1K channel updates), then even with a reasonable processing latency, a peer may still not read our ping in time.

To combat this, we change the default behavior to just logging for slow pongs, and add a new CLI option to re-enable the old behavior.

Along the way, we also add some more enhanced logging, so we can tell when the last successful ping was, and also the deadline reached.

