### PR TITLE
discovery: make broadcast calls from gossiper to server async

### DIFF
--- a/discovery/sync_manager.go
+++ b/discovery/sync_manager.go
@@ -582,7 +582,7 @@ func (m *SyncManager) waitMsgDelay(ctx context.Context, peerPub [33]byte,
 	// to be sent.
 	delay := limitReservation.Delay()
 	if delay > 0 {
-		log.Infof("GossipSyncer(%x): rate limiting gossip replies, "+
+		log.Tracef("GossipSyncer(%x): rate limiting gossip replies, "+
 			"responding in %s", peerPub, delay)
 
 		select {

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -94,7 +94,7 @@ const (
 	torTimeoutMultiplier = 3
 
 	// msgStreamSize is the size of the message streams.
-	msgStreamSize = 5
+	msgStreamSize = 256
 )
 
 var (


### PR DESCRIPTION
In this commit, we make the broadcast calls from the gossiper to the server async. This ensures that the gossiper is always ready to process new incoming messages. Along the way, we demote the rate limiting logs due to bandwidth from `Infof` to `Tracef` to reduce log spam.

