### PR TITLE
peer: only send pings if the connection is idle for one minute

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -207,6 +207,9 @@ when running LND with an aux component injected (custom channels).
   the payment. This prevents payments from entering a path finding loop that
   would eventually timeout.
 
+* [Only send a `Ping`](https://github.com/lightningnetwork/lnd/pull/9805) if we
+  haven't received any messages from the peer for one minute.
+
 ## RPC Additions
 
 * [Add a new rpc endpoint](https://github.com/lightningnetwork/lnd/pull/8843)

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -2061,6 +2061,12 @@ out:
 			}
 		}
 
+		// Reset the ticker to delay sending the Ping. As long as we are
+		// receiving a message here, we know for sure the connection is
+		// alive, thus we can delay firing pings to check for the
+		// liveness.
+		p.pingManager.ResetPingTicker()
+
 		// If a message router is active, then we'll try to have it
 		// handle this message. If it can, then we're able to skip the
 		// rest of the message handling logic.

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -2681,6 +2681,18 @@ out:
 			}
 			idleTimer.Reset(idleTimeout)
 
+			// Reset the ticker to delay sending the Ping. Since
+			// we've successfully wriiten a msg to the connection,
+			// we know for sure the connection is alive, thus we can
+			// delay firing pings to check for the liveness.
+			//
+			// NOTE: This means if the connection is idle, the
+			// interval of pings is not strictly one minute as we
+			// will reset it here after a successful write. This
+			// offset should be negligible if the connection is
+			// healthy.
+			p.pingManager.ResetPingTicker()
+
 			// If the peer requested a synchronous write, respond
 			// with the error.
 			if outMsg.errChan != nil {

--- a/peer/ping_manager.go
+++ b/peer/ping_manager.go
@@ -108,6 +108,11 @@ func (m *PingManager) Start() error {
 	return err
 }
 
+// ResetPingTicker resets the internal `pingTicker`.
+func (m *PingManager) ResetPingTicker() {
+	m.pingTicker.Reset(m.cfg.IntervalDuration)
+}
+
 // pingHandler is the main goroutine responsible for enforcing the ping/pong
 // protocol.
 func (m *PingManager) pingHandler() {


### PR DESCRIPTION
Based on the [specs](https://github.com/lightning/bolts/blob/master/01-messaging.md#the-ping-and-pong-messages), the `ping` is used for keeping the liveness of the connection. We perform this check every minute, regardless of whether the connection is live or not.

This PR now changes the behavior such that we only perform this check when the connection is idle - if we are busy receiving gossip messages over the wire, we know for sure the connection is alive and can delay sending the pings.