### PR TITLE
build: bump version to v0.19.0-beta.rc5

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -47,11 +47,11 @@ const (
 	AppMinor uint = 19
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 00
+	AppPatch uint = 0
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.
-	AppPreRelease = "beta.rc4"
+	AppPreRelease = "beta.rc5"
 )
 
 func init() {


### PR DESCRIPTION
Bumps the version to `v0.19.0-beta.rc5`.

Will be merged after https://github.com/lightningnetwork/lnd/pull/9801 has landed.