### PR TITLE
server.go: prevent partial mutation of `currentNodeAnn` in `server.genNodeAnnouncement` on `netann.SignNodeAnnouncement` failures

### DIFF
--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -20,6 +20,12 @@
 
 # Bug Fixes
 
+- Fixed potential update inconsistencies in node announcements [by creating
+  a shallow copy before modifications](
+  https://github.com/lightningnetwork/lnd/pull/9815). This ensures the original
+  announcement remains unchanged until the new one is fully signed and
+  validated.
+
 # New Features
 
 ## Functional Enhancements
@@ -119,4 +125,5 @@ circuit. The indices are only available for forwarding events saved after v0.20.
 * Abdulkbk
 * Elle Mouton
 * Funyug
+* Mohamed Awnallah
 * Pins


### PR DESCRIPTION
## **Change Description**

In this commit, we prevent partial mutation of the current node announcement during announcement signing. Previously, if node announcement signing failed, the current node announcement could become inconsistent.

## **Motivation and Context**

This issue was discovered while working on issue #9455. Specifically, it was observed that:

- The enforcement of a single DNS hostname address related to Bolt 07 occurs in `WriteNetAddrs`.
- If there’s is an error, the error is correctly propagated from `netann.SignNodeAnnouncement`.
- However, part of the current node announcement (e.g., `Addresses []net.Addr` or CLI field `uris` from `getinfo`) was still being updated, leading to inconsistencies when inspecting with the command:

  ```bash
  lncli --network=regtest getinfo | jq '.uris'
  ```


## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
