### PR TITLE
[FIX] Minor format & grammatical fixes on release notes 0.19.0

### DIFF
--- a/docs/release-notes/release-notes-0.19.0.md
+++ b/docs/release-notes/release-notes-0.19.0.md
@@ -271,8 +271,8 @@ when running LND with an aux component injected (custom channels).
   logs during rotation with ZSTD via the `logging.file.compressor` startup 
   argument.
 
-* The SCB file now [contains more data][https://github.com/lightningnetwork/lnd/pull/8183]
-  that enable a last resort rescue for certain cases where the peer is no longer
+* The SCB file now [contains more data](https://github.com/lightningnetwork/lnd/pull/8183)
+  that enables a last resort rescue for certain cases where the peer is no longer
   around.
 
 * LND updates channel.backup file at shutdown time.


### PR DESCRIPTION
Minor format & grammatical fixes on release notes 0.19.0:

### What's changed
- [] to ()
- "enable" to "enables"