### PR TITLE
batch: generic scheduler + benchmark tests

### DIFF
--- a/batch/batch.go
+++ b/batch/batch.go
@@ -1,10 +1,10 @@
 package batch
 
 import (
+	"context"
 	"errors"
 	"sync"
 
-	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/sqldb"
 )
 
@@ -14,28 +14,30 @@ var errSolo = errors.New(
 	"batch function returned an error and should be re-run solo",
 )
 
-type request struct {
-	*Request
+type request[Q any] struct {
+	*Request[Q]
 	errChan chan error
 }
 
-type batch struct {
-	db     kvdb.Backend
+type batch[Q any] struct {
+	db     sqldb.BatchedTx[Q]
 	start  sync.Once
-	reqs   []*request
-	clear  func(b *batch)
+	reqs   []*request[Q]
+	clear  func(b *batch[Q])
 	locker sync.Locker
 }
 
 // trigger is the entry point for the batch and ensures that run is started at
 // most once.
-func (b *batch) trigger() {
-	b.start.Do(b.run)
+func (b *batch[Q]) trigger(ctx context.Context) {
+	b.start.Do(func() {
+		b.run(ctx)
+	})
 }
 
 // run executes the current batch of requests. If any individual requests fail
 // alongside others they will be retried by the caller.
-func (b *batch) run() {
+func (b *batch[Q]) run(ctx context.Context) {
 	// Clear the batch from its scheduler, ensuring that no new requests are
 	// added to this batch.
 	b.clear(b)
@@ -50,9 +52,10 @@ func (b *batch) run() {
 
 	// Apply the batch until a subset succeeds or all of them fail. Requests
 	// that fail will be retried individually.
+	var writeTx writeOpts
 	for len(b.reqs) > 0 {
 		var failIdx = -1
-		err := kvdb.Update(b.db, func(tx kvdb.RwTx) error {
+		err := b.db.ExecTx(ctx, &writeTx, func(tx Q) error {
 			for i, req := range b.reqs {
 				err := req.Update(tx)
 				if err != nil {

--- a/batch/batch_test.go
+++ b/batch/batch_test.go
@@ -2,7 +2,9 @@ package batch
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -78,4 +80,166 @@ func TestRetry(t *testing.T) {
 	mu.Unlock()
 
 	require.ErrorContains(t, err, "could not serialize access")
+}
+
+// BenchmarkBoltBatching benchmarks the performance of the batch scheduler
+// against the bolt backend.
+func BenchmarkBoltBatching(b *testing.B) {
+	setUpDB := func(b *testing.B) kvdb.Backend {
+		// Create a new database backend for the test.
+		backend, backendCleanup, err := kvdb.GetTestBackend(
+			b.TempDir(), "db",
+		)
+		require.NoError(b, err)
+		b.Cleanup(func() { backendCleanup() })
+
+		return backend
+	}
+
+	// writeRecord is a helper that writes a simple record to the
+	// database. It creates a top-level bucket and a sub-bucket, then
+	// writes a record with a sequence number as the key.
+	writeRecord := func(b *testing.B, tx kvdb.RwTx) {
+		bucket, err := tx.CreateTopLevelBucket([]byte("top-level"))
+		require.NoError(b, err)
+
+		subBucket, err := bucket.CreateBucketIfNotExists(
+			[]byte("sub-bucket"),
+		)
+		require.NoError(b, err)
+
+		seq, err := subBucket.NextSequence()
+		require.NoError(b, err)
+
+		var key [8]byte
+		binary.BigEndian.PutUint64(key[:], seq)
+
+		err = subBucket.Put(key[:], []byte("value"))
+		require.NoError(b, err)
+	}
+
+	// verifyRecordsWritten is a helper that verifies that the writeRecord
+	// helper was called the expected number of times.
+	verifyRecordsWritten := func(b *testing.B, db kvdb.Backend, N int) {
+		err := db.View(func(tx kvdb.RTx) error {
+			bucket := tx.ReadBucket([]byte("top-level"))
+			require.NotNil(b, bucket)
+
+			subBucket := bucket.NestedReadBucket(
+				[]byte("sub-bucket"),
+			)
+			require.NotNil(b, subBucket)
+			require.EqualValues(b, subBucket.Sequence(), N)
+
+			return nil
+		}, func() {})
+		require.NoError(b, err)
+	}
+
+	// This test benchmarks the performance when using N new transactions
+	// for N write queries. This does not use the scheduler.
+	b.Run("N txs for N write queries", func(b *testing.B) {
+		db := setUpDB(b)
+		b.ResetTimer()
+
+		var wg sync.WaitGroup
+		for i := 0; i < b.N; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				err := db.Update(func(tx kvdb.RwTx) error {
+					writeRecord(b, tx)
+					return nil
+				}, func() {})
+				require.NoError(b, err)
+			}()
+		}
+		wg.Wait()
+
+		b.StopTimer()
+		verifyRecordsWritten(b, db, b.N)
+	})
+
+	// This test benchmarks the performance when using a single transaction
+	// for N write queries. This does not use the scheduler.
+	b.Run("1 txs for N write queries", func(b *testing.B) {
+		db := setUpDB(b)
+		b.ResetTimer()
+
+		err := db.Update(func(tx kvdb.RwTx) error {
+			for i := 0; i < b.N; i++ {
+				writeRecord(b, tx)
+			}
+
+			return nil
+		}, func() {})
+		require.NoError(b, err)
+
+		b.StopTimer()
+		verifyRecordsWritten(b, db, b.N)
+	})
+
+	// batchTest benches the performance of the batch scheduler configured
+	// with/without the LazyAdd option and with the given commit interval.
+	batchTest := func(b *testing.B, lazy bool, interval time.Duration) {
+		ctx := context.Background()
+
+		db := setUpDB(b)
+
+		scheduler := NewTimeScheduler(
+			NewBoltBackend[kvdb.RwTx](db), nil, interval,
+		)
+
+		var opts []SchedulerOption
+		if lazy {
+			opts = append(opts, LazyAdd())
+		}
+
+		b.ResetTimer()
+
+		var wg sync.WaitGroup
+		for i := 0; i < b.N; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				r := &Request[kvdb.RwTx]{
+					Opts: NewSchedulerOptions(
+						opts...,
+					),
+					Update: func(tx kvdb.RwTx) error {
+						writeRecord(b, tx)
+						return nil
+					},
+				}
+
+				err := scheduler.Execute(ctx, r)
+				require.NoError(b, err)
+			}()
+		}
+		wg.Wait()
+
+		b.StopTimer()
+		verifyRecordsWritten(b, db, b.N)
+	}
+
+	batchTestIntervals := []time.Duration{
+		time.Millisecond * 100,
+		time.Millisecond * 200,
+		time.Millisecond * 500,
+		time.Millisecond * 700,
+	}
+
+	for _, lazy := range []bool{true, false} {
+		for _, interval := range batchTestIntervals {
+			name := fmt.Sprintf(
+				"batched queries %s lazy: %v", interval, lazy,
+			)
+
+			b.Run(name, func(b *testing.B) {
+				batchTest(b, lazy, interval)
+			})
+		}
+	}
 }

--- a/batch/kvdb.go
+++ b/batch/kvdb.go
@@ -1,0 +1,41 @@
+package batch
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/sqldb"
+)
+
+// BoltBatcher is a bbolt implementation of the sqldb.BatchedTx interface.
+type BoltBatcher[Q any] struct {
+	db kvdb.Backend
+}
+
+// NewBoltBackend creates a new BoltBackend instance.
+func NewBoltBackend[Q any](db kvdb.Backend) *BoltBatcher[Q] {
+	return &BoltBatcher[Q]{db: db}
+}
+
+// ExecTx will execute the passed txBody, operating upon generic
+// parameter Q (usually a storage interface) in a single transaction.
+//
+// NOTE: This is part of the sqldb.BatchedTx interface.
+func (t *BoltBatcher[Q]) ExecTx(_ context.Context, opts sqldb.TxOptions,
+	txBody func(Q) error, reset func()) error {
+
+	if opts.ReadOnly() {
+		return fmt.Errorf("read-only transactions not supported")
+	}
+
+	return kvdb.Update(t.db, func(tx kvdb.RwTx) error {
+		q, ok := any(tx).(Q)
+		if !ok {
+			return fmt.Errorf("unable to cast tx(%T) into the "+
+				"type expected by the BoltBatcher(%T)", tx, t)
+		}
+
+		return txBody(q)
+	}, reset)
+}

--- a/batch/scheduler.go
+++ b/batch/scheduler.go
@@ -1,10 +1,11 @@
 package batch
 
 import (
+	"context"
 	"sync"
 	"time"
 
-	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/sqldb"
 )
 
 // TimeScheduler is a batching engine that executes requests within a fixed
@@ -12,13 +13,13 @@ import (
 // configurable duration for other concurrent requests to join the batch. Once
 // this time has elapsed, the batch is closed and executed. Subsequent requests
 // are then added to a new batch which undergoes the same process.
-type TimeScheduler struct {
-	db       kvdb.Backend
+type TimeScheduler[Q any] struct {
+	db       sqldb.BatchedTx[Q]
 	locker   sync.Locker
 	duration time.Duration
 
 	mu sync.Mutex
-	b  *batch
+	b  *batch[Q]
 }
 
 // NewTimeScheduler initializes a new TimeScheduler with a fixed duration at
@@ -26,14 +27,20 @@ type TimeScheduler struct {
 // cache, the cache's lock should be provided to so that external consistency
 // can be maintained, as successful db operations will cause a request's
 // OnCommit method to be executed while holding this lock.
-func NewTimeScheduler(db kvdb.Backend, locker sync.Locker,
-	duration time.Duration) *TimeScheduler {
+func NewTimeScheduler[Q any](db sqldb.BatchedTx[Q], locker sync.Locker,
+	duration time.Duration) *TimeScheduler[Q] {
 
-	return &TimeScheduler{
+	return &TimeScheduler[Q]{
 		db:       db,
 		locker:   locker,
 		duration: duration,
 	}
+}
+
+type writeOpts struct{}
+
+func (*writeOpts) ReadOnly() bool {
+	return false
 }
 
 // Execute schedules the provided request for batch execution along with other
@@ -42,12 +49,12 @@ func NewTimeScheduler(db kvdb.Backend, locker sync.Locker,
 // underlying operation is returned to the caller.
 //
 // NOTE: Part of the Scheduler interface.
-func (s *TimeScheduler) Execute(r *Request) error {
+func (s *TimeScheduler[Q]) Execute(ctx context.Context, r *Request[Q]) error {
 	if r.Opts == nil {
 		r.Opts = NewDefaultSchedulerOpts()
 	}
 
-	req := request{
+	req := request[Q]{
 		Request: r,
 		errChan: make(chan error, 1),
 	}
@@ -56,18 +63,21 @@ func (s *TimeScheduler) Execute(r *Request) error {
 	// or no batch exists, create a new one.
 	s.mu.Lock()
 	if s.b == nil {
-		s.b = &batch{
+		s.b = &batch[Q]{
 			db:     s.db,
 			clear:  s.clear,
 			locker: s.locker,
 		}
-		time.AfterFunc(s.duration, s.b.trigger)
+		trigger := s.b.trigger
+		time.AfterFunc(s.duration, func() {
+			trigger(ctx)
+		})
 	}
 	s.b.reqs = append(s.b.reqs, &req)
 
 	// If this is a non-lazy request, we'll execute the batch immediately.
-	if !r.Opts.lazy {
-		go s.b.trigger()
+	if !r.Opts.Lazy {
+		go s.b.trigger(ctx)
 	}
 
 	s.mu.Unlock()
@@ -87,7 +97,10 @@ func (s *TimeScheduler) Execute(r *Request) error {
 	}
 
 	// Otherwise, run the request on its own.
-	commitErr := kvdb.Update(s.db, req.Update, func() {
+	var writeTx writeOpts
+	commitErr := s.db.ExecTx(ctx, &writeTx, func(tx Q) error {
+		return req.Update(tx)
+	}, func() {
 		if req.Reset != nil {
 			req.Reset()
 		}
@@ -104,7 +117,7 @@ func (s *TimeScheduler) Execute(r *Request) error {
 
 // clear resets the scheduler's batch to nil so that no more requests can be
 // added.
-func (s *TimeScheduler) clear(b *batch) {
+func (s *TimeScheduler[Q]) clear(b *batch[Q]) {
 	s.mu.Lock()
 	if s.b == b {
 		s.b = nil

--- a/graph/db/kv_store.go
+++ b/graph/db/kv_store.go
@@ -861,7 +861,7 @@ func (c *KVStore) AddLightningNode(node *models.LightningNode,
 
 	r := &batch.Request[kvdb.RwTx]{
 		Opts: batch.NewSchedulerOptions(opts...),
-		Update: func(tx kvdb.RwTx) error {
+		Do: func(tx kvdb.RwTx) error {
 			return addLightningNode(tx, node)
 		},
 	}
@@ -1002,7 +1002,7 @@ func (c *KVStore) AddChannelEdge(edge *models.ChannelEdgeInfo,
 		Reset: func() {
 			alreadyExists = false
 		},
-		Update: func(tx kvdb.RwTx) error {
+		Do: func(tx kvdb.RwTx) error {
 			err := c.addChannelEdge(tx, edge)
 
 			// Silence ErrEdgeAlreadyExist so that the batch can
@@ -2712,7 +2712,7 @@ func (c *KVStore) UpdateEdgePolicy(edge *models.ChannelEdgePolicy,
 			isUpdate1 = false
 			edgeNotFound = false
 		},
-		Update: func(tx kvdb.RwTx) error {
+		Do: func(tx kvdb.RwTx) error {
 			var err error
 			from, to, isUpdate1, err = updateEdgePolicy(tx, edge)
 			if err != nil {


### PR DESCRIPTION
In preparation for using the same logic for non-bbolt backends, we adapt
the batch.Schedular to be more generic.

We also add a new BenchmarkBoltBatching test that helps us benchmark the
performance when writing to a bbolt backend using various different
configurations. We test using N txs for N writes, 1 tx for N writes and
then various configurations when using the TimeScheduler.

## Benchmark observations

### SQLite
Notice here the huge difference between N-for-N and 1-for-N. This shows us that batching in SQLite is preferable. So now we take a look at the batcher results and we can see that this confirms that batching is more efficient since when `lazy=true` the scheduler will batch more and this is more efficient. The sweet spot in terms of batch interval seems to be around 50ms. 
```
BenchmarkSQLBatching/sqlite/N_txs_for_N_write_queries-10                    1000           7015294 ns/op
BenchmarkSQLBatching/sqlite/1_txs_for_N_write_queries-10                    1000             71616 ns/op

BenchmarkSQLBatching/sqlite/batched_queries_0s_lazy:_true-10                1000           2983386 ns/op
BenchmarkSQLBatching/sqlite/batched_queries_50ms_lazy:_true-10              1000            130158 ns/op
BenchmarkSQLBatching/sqlite/batched_queries_100ms_lazy:_true-10             1000            236835 ns/op
BenchmarkSQLBatching/sqlite/batched_queries_200ms_lazy:_true-10             1000            291619 ns/op
BenchmarkSQLBatching/sqlite/batched_queries_500ms_lazy:_true-10             1000            580967 ns/op

BenchmarkSQLBatching/sqlite/batched_queries_0s_lazy:_false-10               1000           3584394 ns/op
BenchmarkSQLBatching/sqlite/batched_queries_50ms_lazy:_false-10             1000           2502846 ns/op
BenchmarkSQLBatching/sqlite/batched_queries_100ms_lazy:_false-10            1000           2390232 ns/op
BenchmarkSQLBatching/sqlite/batched_queries_200ms_lazy:_false-10            1000            812097 ns/op
BenchmarkSQLBatching/sqlite/batched_queries_500ms_lazy:_false-10            1000           2499183 ns/op
```

### Postgres
Notice that unlike SQLite, here the N-for-N is slightly more efficient than the 1-for-N
```
BenchmarkSQLBatching/postgres/N_txs_for_N_write_queries-10                  1000            572456 ns/op
BenchmarkSQLBatching/postgres/1_txs_for_N_write_queries-10                  1000            861949 ns/op

BenchmarkSQLBatching/postgres/batched_queries_0s_lazy:_true-10              1000            472168 ns/op
BenchmarkSQLBatching/postgres/batched_queries_50ms_lazy:_true-10            1000            881217 ns/op
BenchmarkSQLBatching/postgres/batched_queries_100ms_lazy:_true-10           1000            968508 ns/op
BenchmarkSQLBatching/postgres/batched_queries_200ms_lazy:_true-10           1000           1024036 ns/op
BenchmarkSQLBatching/postgres/batched_queries_500ms_lazy:_true-10           1000           1420014 ns/op

BenchmarkSQLBatching/postgres/batched_queries_0s_lazy:_false-10             1000            644807 ns/op
BenchmarkSQLBatching/postgres/batched_queries_50ms_lazy:_false-10           1000            729565 ns/op
BenchmarkSQLBatching/postgres/batched_queries_100ms_lazy:_false-10          1000            429378 ns/op
BenchmarkSQLBatching/postgres/batched_queries_200ms_lazy:_false-10          1000            718476 ns/op
BenchmarkSQLBatching/postgres/batched_queries_500ms_lazy:_false-10          1000           3526558 ns/op
```

### Bbolt

Like SQLite - 1-for-N is much more efficient than N-for-N. The Batched-lazy results compared to the Batched-non-lazy results confirm this. 
```
BenchmarkBoltBatching/N_txs_for_N_write_queries-10                  1000           9921091 ns/op
BenchmarkBoltBatching/1_txs_for_N_write_queries-10                  1000             15447 ns/op

BenchmarkBoltBatching/batched_queries_0s_lazy:_true-10              1000            640275 ns/op
BenchmarkBoltBatching/batched_queries_50ms_lazy:_true-10            1000             73317 ns/op
BenchmarkBoltBatching/batched_queries_100ms_lazy:_true-10           1000            124303 ns/op
BenchmarkBoltBatching/batched_queries_200ms_lazy:_true-10           1000            223366 ns/op
BenchmarkBoltBatching/batched_queries_500ms_lazy:_true-10           1000            520498 ns/op

BenchmarkBoltBatching/batched_queries_0s_lazy:_false-10             1000           2145651 ns/op
BenchmarkBoltBatching/batched_queries_50ms_lazy:_false-10           1000            188663 ns/op
BenchmarkBoltBatching/batched_queries_100ms_lazy:_false-10          1000            250087 ns/op
BenchmarkBoltBatching/batched_queries_200ms_lazy:_false-10          1000            235794 ns/op
BenchmarkBoltBatching/batched_queries_500ms_lazy:_false-10          1000            287778 ns/op
```

## Take away

If we want to use the TimeScheduler for all our backends, the happy middle ground seems to be: use the batcher, lazy=true with a commit interval of around 50ms (today we use 500ms fwiw). 