### PR TITLE
fix listchannels rpc call race condition

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -5007,7 +5007,7 @@ func createRPCOpenChannel(r *rpcServer, dbChannel *channeldb.OpenChannel,
 	info, err := r.server.chanEventStore.GetChanInfo(outpoint, peer)
 	switch err {
 	// If the store does not know about the channel, we just log it.
-	case chanfitness.ErrChannelNotFound:
+	case chanfitness.ErrChannelNotFound, chanfitness.ErrPeerNotFound:
 		rpcsLog.Infof("channel: %v not found by channel event store",
 			outpoint)
 

--- a/server.go
+++ b/server.go
@@ -4306,7 +4306,8 @@ func (s *server) notifyOpenChannelPeerEvent(op wire.OutPoint,
 	remotePub *btcec.PublicKey) error {
 
 	// Call newOpenChan to update the access manager's maps for this peer.
-	if err := s.peerAccessMan.newOpenChan(remotePub); err != nil {
+	err := s.peerAccessMan.newOpenChan(remotePub)
+	if err != nil && !errors.Is(err, ErrNoPeerScore) {
 		return err
 	}
 
@@ -4323,7 +4324,8 @@ func (s *server) notifyPendingOpenChannelPeerEvent(op wire.OutPoint,
 
 	// Call newPendingOpenChan to update the access manager's maps for this
 	// peer.
-	if err := s.peerAccessMan.newPendingOpenChan(remotePub); err != nil {
+	err := s.peerAccessMan.newPendingOpenChan(remotePub)
+	if err != nil && !errors.Is(err, ErrNoPeerScore) {
 		return err
 	}
 


### PR DESCRIPTION
In case the pending channel would confirm while we already
restarted and the peer remained offline there was a race
condition where we would not register the peer properly with the
event store.
