### PR TITLE
 docs: fix description of protocol.rbf-coop-close default state in sample-lnd.conf

### DIFF
--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1419,7 +1419,7 @@
 ; Set to disable experimental endorsement signaling.
 ; protocol.no-experimental-endorsement=false
 
-; Set to disable support for RBF based coop close.
+; Set to enable support for RBF based coop close.
 ; protocol.rbf-coop-close=false
 
 ; Set to handle messages of a particular type that falls outside of the


### PR DESCRIPTION
## Change Description
Modified description regarding the real default value for the parameter `protocol.rbf-coop-close` to avoid confusion. Replaced: "disable" with "enable".

## Steps to Test
If not specified: `protocol.rbf-coop-close=true` on `lnd.conf`

After `lncli getinfo`, the following lines don't appear:

```
"161":  {
            "name":  "rbf-coop-close-x",
            "is_required":  false,
            "is_known":  true
```

## References
- PR with the sample-lnd.conf addition: https://github.com/lightningnetwork/lnd/pull/9610 line: https://github.com/lightningnetwork/lnd/pull/9610/files#diff-3a6efa92418cc425498701df4dbd84e1d143908b58b9872f566a952baa281200R1416
- Release note fragment where this default and correct state is mentioned: https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/release-notes-0.19.0.md?plain=1#L154