### PR TITLE
peer+feature: start to signal the prod rbf coop close bit

### DIFF
--- a/feature/default_sets.go
+++ b/feature/default_sets.go
@@ -107,4 +107,8 @@ var defaultSetDesc = setDesc{
 		SetInit:    {}, // I
 		SetNodeAnn: {}, // N
 	},
+	lnwire.RbfCoopCloseOptional: {
+		SetInit:    {}, // I
+		SetNodeAnn: {}, // N
+	},
 }

--- a/feature/manager.go
+++ b/feature/manager.go
@@ -219,6 +219,7 @@ func newManager(cfg Config, desc setDesc) (*Manager, error) {
 		}
 		if cfg.NoRbfCoopClose {
 			raw.Unset(lnwire.RbfCoopCloseOptionalStaging)
+			raw.Unset(lnwire.RbfCoopCloseOptional)
 		}
 
 		for _, custom := range cfg.CustomFeatures[set] {

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -975,11 +975,13 @@ func (p *Brontide) taprootShutdownAllowed() bool {
 // rbfCoopCloseAllowed returns true if both parties have negotiated the new RBF
 // coop close feature.
 func (p *Brontide) rbfCoopCloseAllowed() bool {
-	return p.RemoteFeatures().HasFeature(
-		lnwire.RbfCoopCloseOptionalStaging,
-	) && p.LocalFeatures().HasFeature(
-		lnwire.RbfCoopCloseOptionalStaging,
-	)
+	bothHaveBit := func(bit lnwire.FeatureBit) bool {
+		return p.RemoteFeatures().HasFeature(bit) &&
+			p.LocalFeatures().HasFeature(bit)
+	}
+
+	return bothHaveBit(lnwire.RbfCoopCloseOptional) ||
+		bothHaveBit(lnwire.RbfCoopCloseOptionalStaging)
 }
 
 // QuitSignal is a method that should return a channel which will be sent upon


### PR DESCRIPTION
In this commit, we start to signal the prod bit for the rbf coop close feature. We keep our signaling of the staging bit in place to ensure the protocol continues to work between those nodes in the wild that are still signaling the bit.

Fixes https://github.com/lightningnetwork/lnd/issues/9852

