### PR TITLE
brontide: fix peer disconnection issue

### DIFF
--- a/docs/release-notes/release-notes-0.19.1.md
+++ b/docs/release-notes/release-notes-0.19.1.md
@@ -27,6 +27,10 @@
 - Fixed [a case](https://github.com/lightningnetwork/lnd/pull/9854) where the
   `BumpFee` doesn't give an error response.
 
+- Fixed [a case](https://github.com/lightningnetwork/lnd/pull/9872) where a
+  peer would not disconnect properly when both peers supported the new
+  "rbf-coop-close" feature leaving the peer connection in a borked state.
+
 # New Features
 
 ## Functional Enhancements
@@ -83,3 +87,4 @@
 
 * Elle Mouton
 * Yong Yu
+* Ziggie

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -700,6 +700,10 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testCoopCloseRbf,
 	},
 	{
+		Name:     "rbf coop close disconnect",
+		TestFunc: testRBFCoopCloseDisconnect,
+	},
+	{
 		Name:     "bump fee low budget",
 		TestFunc: testBumpFeeLowBudget,
 	},

--- a/itest/lnd_coop_close_rbf_test.go
+++ b/itest/lnd_coop_close_rbf_test.go
@@ -131,3 +131,25 @@ func testCoopCloseRbf(ht *lntest.HarnessTest) {
 	aliceClosingTxid := ht.WaitForChannelCloseEvent(aliceCloseStream)
 	ht.AssertTxInBlock(block, aliceClosingTxid)
 }
+
+// testRBFCoopCloseDisconnect tests that when a node disconnects that the node
+// is properly disconnected.
+func testRBFCoopCloseDisconnect(ht *lntest.HarnessTest) {
+	rbfCoopFlags := []string{"--protocol.rbf-coop-close"}
+
+	// To kick things off, we'll create two new nodes, then fund them with
+	// enough coins to make a 50/50 channel.
+	cfgs := [][]string{rbfCoopFlags, rbfCoopFlags}
+	params := lntest.OpenChannelParams{
+		Amt:     btcutil.Amount(1000000),
+		PushAmt: btcutil.Amount(1000000 / 2),
+	}
+	_, nodes := ht.CreateSimpleNetwork(cfgs, params)
+	alice, bob := nodes[0], nodes[1]
+
+	// Make sure the nodes are connected.
+	ht.AssertConnected(alice, bob)
+
+	// Disconnect Bob from Alice.
+	ht.DisconnectNodes(alice, bob)
+}


### PR DESCRIPTION
In case when the rbf coop close feature was active we would not
properly disconnect the peer.
