### PR TITLE
accessman: remove restrictions on protected/temporary peers

### DIFF
--- a/config.go
+++ b/config.go
@@ -240,7 +240,7 @@ const (
 
 	// DefaultNumRestrictedSlots is the default number of restricted slots
 	// we'll allocate in the server.
-	DefaultNumRestrictedSlots = 30
+	DefaultNumRestrictedSlots = 100
 
 	// BitcoinChainName is a string that represents the Bitcoin blockchain.
 	BitcoinChainName = "bitcoin"

--- a/docs/release-notes/release-notes-0.19.1.md
+++ b/docs/release-notes/release-notes-0.19.1.md
@@ -34,6 +34,10 @@
 - Fixed [a case](https://github.com/lightningnetwork/lnd/pull/9890) where LND
   would crash because of misaligned of a data struct on 32 bit systems.
 
+- Fixed [a case](https://github.com/lightningnetwork/lnd/pull/9876) where a peer
+  may be treated as restricted peer although it used to have a channel with the
+  node.
+
 # New Features
 
 ## Functional Enhancements

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -567,7 +567,7 @@
 ; http-header-timeout=5s
 
 ; The number of restricted slots the server will allocate for peers.
-; num-restricted-slots=30
+; num-restricted-slots=100
 
 ; If true, a peer will *not* be disconnected if a pong is not received in time
 ; or is mismatched. Defaults to false, meaning peers *will* be disconnected on


### PR DESCRIPTION
If a peer has, or used to have a channel with us there's no need to check for the ban score.