### PR TITLE
sqldb+graph/db: fix UpsertNode query to account for nullable `last_update` field

### DIFF
--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -3361,18 +3361,7 @@ func TestAddChannelEdgeShellNodes(t *testing.T) {
 	require.ErrorIs(t, err, ErrEdgeAlreadyExist)
 
 	// Show that updating the shell node to a full node record works.
-	err = graph.AddLightningNode(node2)
-	_, ok := graph.V1Store.(*KVStore)
-	if ok {
-		require.NoError(t, err)
-	} else {
-		// Currently the SQL UpsertNode query prevents us from updating
-		// the node record if the current record's last_update field
-		// is null (which is the case for node2). This is a bug that
-		// will be fixed in the following commit.
-		require.ErrorContains(t, graph.AddLightningNode(node2),
-			"sql: no rows in result set")
-	}
+	require.NoError(t, graph.AddLightningNode(node2))
 }
 
 // TestNodePruningUpdateIndexDeletion tests that once a node has been removed

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -3359,6 +3359,20 @@ func TestAddChannelEdgeShellNodes(t *testing.T) {
 	// error.
 	err = graph.AddChannelEdge(&edgeInfo)
 	require.ErrorIs(t, err, ErrEdgeAlreadyExist)
+
+	// Show that updating the shell node to a full node record works.
+	err = graph.AddLightningNode(node2)
+	_, ok := graph.V1Store.(*KVStore)
+	if ok {
+		require.NoError(t, err)
+	} else {
+		// Currently the SQL UpsertNode query prevents us from updating
+		// the node record if the current record's last_update field
+		// is null (which is the case for node2). This is a bug that
+		// will be fixed in the following commit.
+		require.ErrorContains(t, graph.AddLightningNode(node2),
+			"sql: no rows in result set")
+	}
 }
 
 // TestNodePruningUpdateIndexDeletion tests that once a node has been removed

--- a/sqldb/sqlc/graph.sql.go
+++ b/sqldb/sqlc/graph.sql.go
@@ -542,7 +542,8 @@ ON CONFLICT (pub_key, version)
         last_update = EXCLUDED.last_update,
         color = EXCLUDED.color,
         signature = EXCLUDED.signature
-WHERE EXCLUDED.last_update > nodes.last_update
+WHERE nodes.last_update IS NULL
+    OR EXCLUDED.last_update > nodes.last_update
 RETURNING id
 `
 

--- a/sqldb/sqlc/queries/graph.sql
+++ b/sqldb/sqlc/queries/graph.sql
@@ -17,7 +17,8 @@ ON CONFLICT (pub_key, version)
         last_update = EXCLUDED.last_update,
         color = EXCLUDED.color,
         signature = EXCLUDED.signature
-WHERE EXCLUDED.last_update > nodes.last_update
+WHERE nodes.last_update IS NULL
+    OR EXCLUDED.last_update > nodes.last_update
 RETURNING id;
 
 -- name: GetNodeByPubKey :one


### PR DESCRIPTION
Fix the SQL implementation of `AddLightningNode` so that it's underlying `UpsertNode` query accounts
for the `last_update` field being null in the case of the initial node record being a shell node (a shell node
is one for which we only know the version and pubkey). 