### PR TITLE
graph/db+sqldb: channel policy SQL schemas, queries and upsert CRUD

### DIFF
--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -58,6 +58,8 @@ circuit. The indices are only available for forwarding events saved after v0.20.
     cache population. 
   * Add graph schemas, queries and CRUD:
     * [1](https://github.com/lightningnetwork/lnd/pull/9866)
+    * [2](https://github.com/lightningnetwork/lnd/pull/9869)
+    * [3](https://github.com/lightningnetwork/lnd/pull/9887)
 
 ## RPC Updates
 

--- a/go.mod
+++ b/go.mod
@@ -199,6 +199,10 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
+// TODO(elle): remove once all the schemas and queries for the graph
+// store have been included in a tagged sqldb version.
+replace github.com/lightningnetwork/lnd/sqldb => ./sqldb
+
 // This replace is for https://github.com/advisories/GHSA-25xm-hr59-7c27
 replace github.com/ulikunitz/xz => github.com/ulikunitz/xz v0.5.11
 

--- a/go.sum
+++ b/go.sum
@@ -375,8 +375,6 @@ github.com/lightningnetwork/lnd/kvdb v1.4.16 h1:9BZgWdDfjmHRHLS97cz39bVuBAqMc4/p
 github.com/lightningnetwork/lnd/kvdb v1.4.16/go.mod h1:HW+bvwkxNaopkz3oIgBV6NEnV4jCEZCACFUcNg4xSjM=
 github.com/lightningnetwork/lnd/queue v1.1.1 h1:99ovBlpM9B0FRCGYJo6RSFDlt8/vOkQQZznVb18iNMI=
 github.com/lightningnetwork/lnd/queue v1.1.1/go.mod h1:7A6nC1Qrm32FHuhx/mi1cieAiBZo5O6l8IBIoQxvkz4=
-github.com/lightningnetwork/lnd/sqldb v1.0.10 h1:ZLV7TGwjnKupVfCd+DJ43MAc9BKVSFCnvhpSPGKdN3M=
-github.com/lightningnetwork/lnd/sqldb v1.0.10/go.mod h1:c/vWoQfcxu6FAfHzGajkIQi7CEIeIZFhhH4DYh1BJpc=
 github.com/lightningnetwork/lnd/ticker v1.1.1 h1:J/b6N2hibFtC7JLV77ULQp++QLtCwT6ijJlbdiZFbSM=
 github.com/lightningnetwork/lnd/ticker v1.1.1/go.mod h1:waPTRAAcwtu7Ji3+3k+u/xH5GHovTsCoSVpho0KDvdA=
 github.com/lightningnetwork/lnd/tlv v1.3.2 h1:MO4FCk7F4k5xPMqVZF6Nb/kOpxlwPrUQpYjmyKny5s0=

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -4038,7 +4038,7 @@ func TestBatchedAddChannelEdge(t *testing.T) {
 func TestBatchedUpdateEdgePolicy(t *testing.T) {
 	t.Parallel()
 
-	graph := MakeTestGraph(t)
+	graph := MakeTestGraphNew(t)
 
 	// We'd like to test the update of edges inserted into the database, so
 	// we create two vertexes to connect.

--- a/graph/db/test_postgres.go
+++ b/graph/db/test_postgres.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"testing"
 
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/sqldb"
 	"github.com/stretchr/testify/require"
@@ -38,7 +39,11 @@ func NewTestDB(t testing.TB) V1Store {
 		},
 	)
 
-	store, err := NewSQLStore(executor, graphStore)
+	store, err := NewSQLStore(
+		&SQLStoreConfig{
+			ChainHash: *chaincfg.MainNetParams.GenesisHash,
+		}, executor, graphStore,
+	)
 	require.NoError(t, err)
 
 	return store

--- a/graph/db/test_sqlite.go
+++ b/graph/db/test_sqlite.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"testing"
 
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/sqldb"
 	"github.com/stretchr/testify/require"
@@ -31,7 +32,11 @@ func NewTestDB(t testing.TB) V1Store {
 		},
 	)
 
-	store, err := NewSQLStore(executor, graphStore)
+	store, err := NewSQLStore(
+		&SQLStoreConfig{
+			ChainHash: *chaincfg.MainNetParams.GenesisHash,
+		}, executor, graphStore,
+	)
 	require.NoError(t, err)
 
 	return store

--- a/sqldb/sqlc/migrations/000007_graph.down.sql
+++ b/sqldb/sqlc/migrations/000007_graph.down.sql
@@ -12,11 +12,11 @@ DROP INDEX IF EXISTS channel_features_unique;
 DROP INDEX IF EXISTS channel_extra_types_unique;
 
 -- Drop tables in order of reverse dependencies.
+DROP TABLE IF EXISTS channel_features;
+DROP TABLE IF EXISTS channel_extra_types;
+DROP TABLE IF EXISTS channels;
 DROP TABLE IF EXISTS source_nodes;
 DROP TABLE IF EXISTS node_addresses;
 DROP TABLE IF EXISTS node_features;
 DROP TABLE IF EXISTS node_extra_types;
 DROP TABLE IF EXISTS nodes;
-DROP TABLE IF EXISTS channels;
-DROP TABLE IF EXISTS channel_features;
-DROP TABLE IF EXISTS channel_extra_types;

--- a/sqldb/sqlc/migrations/000007_graph.down.sql
+++ b/sqldb/sqlc/migrations/000007_graph.down.sql
@@ -10,8 +10,12 @@ DROP INDEX IF EXISTS channels_unique;
 DROP INDEX IF EXISTS channels_version_outpoint_idx;
 DROP INDEX IF EXISTS channel_features_unique;
 DROP INDEX IF EXISTS channel_extra_types_unique;
+DROP INDEX IF EXISTS channel_policies_unique;
+DROP INDEX IF EXISTS channel_policy_extra_types_unique;
 
 -- Drop tables in order of reverse dependencies.
+DROP TABLE IF EXISTS channel_policy_extra_types;
+DROP TABLE IF EXISTS channel_policies;
 DROP TABLE IF EXISTS channel_features;
 DROP TABLE IF EXISTS channel_extra_types;
 DROP TABLE IF EXISTS channels;

--- a/sqldb/sqlc/models.go
+++ b/sqldb/sqlc/models.go
@@ -55,6 +55,29 @@ type ChannelFeature struct {
 	FeatureBit int32
 }
 
+type ChannelPolicy struct {
+	ID                      int64
+	Version                 int16
+	ChannelID               int64
+	NodeID                  int64
+	Timelock                int32
+	FeePpm                  int64
+	BaseFeeMsat             int64
+	MinHtlcMsat             int64
+	MaxHtlcMsat             sql.NullInt64
+	LastUpdate              sql.NullInt64
+	Disabled                sql.NullBool
+	InboundBaseFeeMsat      sql.NullInt64
+	InboundFeeRateMilliMsat sql.NullInt64
+	Signature               []byte
+}
+
+type ChannelPolicyExtraType struct {
+	ChannelPolicyID int64
+	Type            int64
+	Value           []byte
+}
+
 type Invoice struct {
 	ID                 int64
 	Hash               []byte

--- a/sqldb/sqlc/querier.go
+++ b/sqldb/sqlc/querier.go
@@ -16,6 +16,7 @@ type Querier interface {
 	CreateChannel(ctx context.Context, arg CreateChannelParams) (int64, error)
 	CreateChannelExtraType(ctx context.Context, arg CreateChannelExtraTypeParams) error
 	DeleteCanceledInvoices(ctx context.Context) (sql.Result, error)
+	DeleteChannelPolicyExtraTypes(ctx context.Context, channelPolicyID int64) error
 	DeleteExtraNodeType(ctx context.Context, arg DeleteExtraNodeTypeParams) error
 	DeleteInvoice(ctx context.Context, arg DeleteInvoiceParams) (sql.Result, error)
 	DeleteNodeAddresses(ctx context.Context, nodeID int64) error
@@ -26,6 +27,7 @@ type Querier interface {
 	FetchSettledAMPSubInvoices(ctx context.Context, arg FetchSettledAMPSubInvoicesParams) ([]FetchSettledAMPSubInvoicesRow, error)
 	FilterInvoices(ctx context.Context, arg FilterInvoicesParams) ([]Invoice, error)
 	GetAMPInvoiceID(ctx context.Context, setID []byte) (int64, error)
+	GetChannelAndNodesBySCID(ctx context.Context, arg GetChannelAndNodesBySCIDParams) (GetChannelAndNodesBySCIDRow, error)
 	GetChannelBySCID(ctx context.Context, arg GetChannelBySCIDParams) (Channel, error)
 	GetDatabaseVersion(ctx context.Context) (int32, error)
 	GetExtraNodeTypes(ctx context.Context, nodeID int64) ([]NodeExtraType, error)
@@ -49,6 +51,7 @@ type Querier interface {
 	HighestSCID(ctx context.Context, version int16) ([]byte, error)
 	InsertAMPSubInvoice(ctx context.Context, arg InsertAMPSubInvoiceParams) error
 	InsertAMPSubInvoiceHTLC(ctx context.Context, arg InsertAMPSubInvoiceHTLCParams) error
+	InsertChanPolicyExtraType(ctx context.Context, arg InsertChanPolicyExtraTypeParams) error
 	InsertChannelFeature(ctx context.Context, arg InsertChannelFeatureParams) error
 	InsertInvoice(ctx context.Context, arg InsertInvoiceParams) (int64, error)
 	InsertInvoiceFeature(ctx context.Context, arg InsertInvoiceFeatureParams) error
@@ -74,6 +77,7 @@ type Querier interface {
 	UpdateInvoiceHTLCs(ctx context.Context, arg UpdateInvoiceHTLCsParams) error
 	UpdateInvoiceState(ctx context.Context, arg UpdateInvoiceStateParams) (sql.Result, error)
 	UpsertAMPSubInvoice(ctx context.Context, arg UpsertAMPSubInvoiceParams) (sql.Result, error)
+	UpsertEdgePolicy(ctx context.Context, arg UpsertEdgePolicyParams) (int64, error)
 	UpsertNode(ctx context.Context, arg UpsertNodeParams) (int64, error)
 	UpsertNodeExtraType(ctx context.Context, arg UpsertNodeExtraTypeParams) error
 }


### PR DESCRIPTION
In this PR, the following schemas are defined for storing graph channel policy data. NOTE the nodes & channels tables here are only to show how they fit in - the full nodes & channels pictures can be seen [here](https://github.com/lightningnetwork/lnd/pull/9866) and [here](https://github.com/lightningnetwork/lnd/pull/9869).

<img width="699" alt="Screenshot 2025-06-02 at 17 43 35" src="https://github.com/user-attachments/assets/e56bd230-ff0f-4299-b57b-67f0fdfd18f2" />

NOTE: here we only define the schemas and add enough queries so that we can implement the `UpdateEdgePolicy`  method. So with this PR we are not really yet testing reading from these new tables. This is left to follow up PRs since those will be quite a lot of code and I want to keep this PR contained as it already contains new schemas etc. 

Part of https://github.com/lightningnetwork/lnd/issues/9795

See https://github.com/lightningnetwork/lnd/pull/9932 for the full picture that we are aiming at