### PR TITLE
htlcswitch: exit early if no adds are in the fwd pkg

### DIFF
--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -3624,6 +3624,9 @@ func (l *channelLink) updateChannelFee(ctx context.Context,
 // the switch.
 func (l *channelLink) processRemoteSettleFails(fwdPkg *channeldb.FwdPkg) {
 	if len(fwdPkg.SettleFails) == 0 {
+		l.log.Trace("fwd package has no settle/fails to process " +
+			"exiting early")
+
 		return
 	}
 
@@ -3728,6 +3731,13 @@ func (l *channelLink) processRemoteSettleFails(fwdPkg *channeldb.FwdPkg) {
 //
 //nolint:funlen
 func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg) {
+	// Exit early if there are no adds to process.
+	if len(fwdPkg.Adds) == 0 {
+		l.log.Trace("fwd package has no adds to process exiting early")
+
+		return
+	}
+
 	l.log.Tracef("processing %d remote adds for height %d",
 		len(fwdPkg.Adds), fwdPkg.Height)
 


### PR DESCRIPTION
This lead to the case that we would always record a HTLC
two times in the decayed log (batch-replay bucket) protection which is not necessary
in the first place.

We already do it for the settle/fail package:

https://github.com/lightningnetwork/lnd/blob/4a7cd0095e37c2caf080d39d2f7290a5d38d831e/htlcswitch/link.go#L3626-L3628
