### PR TITLE
Use spent height as the rescan start height in `RegisterSpendNtfn`

### DIFF
--- a/chainntnfs/bitcoindnotify/bitcoind.go
+++ b/chainntnfs/bitcoindnotify/bitcoind.go
@@ -837,7 +837,11 @@ func (b *BitcoindNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
 		chainntnfs.Log.Debugf("Outpoint(%v) has spent at height %v",
 			outpoint, spentHeight)
 
-		if spentHeight > ntfn.HistoricalDispatch.StartHeight {
+		// Since the tx has already been spent at spentHeight, the
+		// heightHint specified by the caller is no longer relevant. We
+		// now update the starting height to be the spent height to make
+		// sure we won't miss it in the rescan.
+		if spentHeight != ntfn.HistoricalDispatch.StartHeight {
 			ntfn.HistoricalDispatch.StartHeight = spentHeight
 		}
 	}

--- a/chainntnfs/bitcoindnotify/bitcoind.go
+++ b/chainntnfs/bitcoindnotify/bitcoind.go
@@ -833,8 +833,12 @@ func (b *BitcoindNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
 			return nil, err
 		}
 
-		if uint32(blockHeight) > ntfn.HistoricalDispatch.StartHeight {
-			ntfn.HistoricalDispatch.StartHeight = uint32(blockHeight)
+		spentHeight := uint32(blockHeight)
+		chainntnfs.Log.Debugf("Outpoint(%v) has spent at height %v",
+			outpoint, spentHeight)
+
+		if spentHeight > ntfn.HistoricalDispatch.StartHeight {
+			ntfn.HistoricalDispatch.StartHeight = spentHeight
 		}
 	}
 

--- a/chainntnfs/btcdnotify/btcd.go
+++ b/chainntnfs/btcdnotify/btcd.go
@@ -933,15 +933,21 @@ func (b *BtcdNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
 				"block %v: %v", blockHash, err)
 		}
 
-		if uint32(blockHeader.Height) > ntfn.HistoricalDispatch.StartHeight {
+		spentHeight := uint32(blockHeader.Height)
+		chainntnfs.Log.Debugf("Outpoint(%v) has spent at height %v",
+			outpoint, spentHeight)
+
+		if spentHeight > ntfn.HistoricalDispatch.StartHeight {
 			startHash, err = b.chainConn.GetBlockHash(
-				int64(blockHeader.Height),
+				int64(spentHeight),
 			)
 			if err != nil {
 				return nil, fmt.Errorf("unable to get block "+
 					"hash for height %d: %v",
 					blockHeader.Height, err)
 			}
+
+			ntfn.HistoricalDispatch.StartHeight = spentHeight
 		}
 	}
 

--- a/chainntnfs/btcdnotify/btcd.go
+++ b/chainntnfs/btcdnotify/btcd.go
@@ -937,7 +937,11 @@ func (b *BtcdNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
 		chainntnfs.Log.Debugf("Outpoint(%v) has spent at height %v",
 			outpoint, spentHeight)
 
-		if spentHeight > ntfn.HistoricalDispatch.StartHeight {
+		// Since the tx has already been spent at spentHeight, the
+		// heightHint specified by the caller is no longer relevant. We
+		// now update the starting height to be the spent height to make
+		// sure we won't miss it in the rescan.
+		if spentHeight != ntfn.HistoricalDispatch.StartHeight {
 			startHash, err = b.chainConn.GetBlockHash(
 				int64(spentHeight),
 			)

--- a/docs/release-notes/release-notes-0.19.2.md
+++ b/docs/release-notes/release-notes-0.19.2.md
@@ -23,6 +23,9 @@
 - [Use](https://github.com/lightningnetwork/lnd/pull/9889) `BigSizeT` instead of
   `uint16` for the htlc index that's used in the revocation log.
 
+- [Fixed](https://github.com/lightningnetwork/lnd/pull/9921) a case where the
+  spending notification of an output may be missed if wrong height hint is used.
+
 # New Features
 
 ## Functional Enhancements


### PR DESCRIPTION
While debugging #9917 I realized the rescan start height could be a bit off when the output has already been spent. We now fix it by always using the spent height as the rescan start height if the output has already spent, even if the caller is specifying a different height hint.