### PR TITLE
graph/db: only fetch required info for graph cache population

### DIFF
--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -53,6 +53,9 @@ circuit. The indices are only available for forwarding events saved after v0.20.
     byte blobs at the end of gossip messages are valid TLV streams.
   * Various [preparations](https://github.com/lightningnetwork/lnd/pull/9692) 
     of the graph code before the SQL implementation is added.
+  * Only [fetch required 
+    fields](https://github.com/lightningnetwork/lnd/pull/9923) during graph 
+    cache population. 
   * Add graph schemas, queries and CRUD:
     * [1](https://github.com/lightningnetwork/lnd/pull/9866)
 

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -178,7 +178,7 @@ func (c *ChannelGraph) populateCache() error {
 		policy1, policy2 *models.ChannelEdgePolicy) error {
 
 		c.graphCache.AddChannel(
-			info,
+			models.NewCachedEdge(info),
 			models.NewCachedPolicy(policy1),
 			models.NewCachedPolicy(policy2),
 		)
@@ -316,7 +316,7 @@ func (c *ChannelGraph) AddChannelEdge(edge *models.ChannelEdgeInfo,
 	}
 
 	if c.graphCache != nil {
-		c.graphCache.AddChannel(edge, nil, nil)
+		c.graphCache.AddChannel(models.NewCachedEdge(edge), nil, nil)
 	}
 
 	select {
@@ -352,7 +352,7 @@ func (c *ChannelGraph) MarkEdgeLive(chanID uint64) error {
 		info := infos[0]
 
 		c.graphCache.AddChannel(
-			info.Info,
+			models.NewCachedEdge(info.Info),
 			models.NewCachedPolicy(info.Policy1),
 			models.NewCachedPolicy(info.Policy2),
 		)

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -177,7 +177,11 @@ func (c *ChannelGraph) populateCache() error {
 	err = c.V1Store.ForEachChannel(func(info *models.ChannelEdgeInfo,
 		policy1, policy2 *models.ChannelEdgePolicy) error {
 
-		c.graphCache.AddChannel(info, policy1, policy2)
+		c.graphCache.AddChannel(
+			info,
+			models.NewCachedPolicy(policy1),
+			models.NewCachedPolicy(policy2),
+		)
 
 		return nil
 	})
@@ -347,7 +351,11 @@ func (c *ChannelGraph) MarkEdgeLive(chanID uint64) error {
 
 		info := infos[0]
 
-		c.graphCache.AddChannel(info.Info, info.Policy1, info.Policy2)
+		c.graphCache.AddChannel(
+			info.Info,
+			models.NewCachedPolicy(info.Policy1),
+			models.NewCachedPolicy(info.Policy2),
+		)
 	}
 
 	return nil

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -566,12 +566,7 @@ func (c *ChannelGraph) UpdateEdgePolicy(edge *models.ChannelEdgePolicy,
 	}
 
 	if c.graphCache != nil {
-		var isUpdate1 bool
-		if edge.ChannelFlags&lnwire.ChanUpdateDirection == 0 {
-			isUpdate1 = true
-		}
-
-		c.graphCache.UpdatePolicy(edge, from, to, isUpdate1)
+		c.graphCache.UpdatePolicy(edge, from, to)
 	}
 
 	select {

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -566,7 +566,9 @@ func (c *ChannelGraph) UpdateEdgePolicy(edge *models.ChannelEdgePolicy,
 	}
 
 	if c.graphCache != nil {
-		c.graphCache.UpdatePolicy(edge, from, to)
+		c.graphCache.UpdatePolicy(
+			models.NewCachedPolicy(edge), from, to,
+		)
 	}
 
 	select {

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -174,17 +174,14 @@ func (c *ChannelGraph) populateCache() error {
 		return err
 	}
 
-	err = c.V1Store.ForEachChannel(func(info *models.ChannelEdgeInfo,
-		policy1, policy2 *models.ChannelEdgePolicy) error {
+	err = c.V1Store.ForEachChannelCacheable(
+		func(info *models.CachedEdgeInfo,
+			policy1, policy2 *models.CachedEdgePolicy) error {
 
-		c.graphCache.AddChannel(
-			models.NewCachedEdge(info),
-			models.NewCachedPolicy(policy1),
-			models.NewCachedPolicy(policy2),
-		)
+			c.graphCache.AddChannel(info, policy1, policy2)
 
-		return nil
-	})
+			return nil
+		})
 	if err != nil {
 		return err
 	}

--- a/graph/db/graph_cache.go
+++ b/graph/db/graph_cache.go
@@ -185,8 +185,6 @@ func (c *GraphCache) UpdatePolicy(policy *models.CachedEdgePolicy, fromNode,
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
-	isEdge1 := policy.ChannelFlags&lnwire.ChanUpdateDirection == 0
-
 	updatePolicy := func(nodeKey route.Vertex) {
 		if len(c.nodeChannels[nodeKey]) == 0 {
 			log.Warnf("Node=%v not found in graph cache", nodeKey)
@@ -207,7 +205,7 @@ func (c *GraphCache) UpdatePolicy(policy *models.CachedEdgePolicy, fromNode,
 		switch {
 		// This is node 1, and it is edge 1, so this is the outgoing
 		// policy for node 1.
-		case channel.IsNode1 && isEdge1:
+		case channel.IsNode1 && policy.IsNode1():
 			channel.OutPolicySet = true
 			policy.InboundFee.WhenSome(func(fee lnwire.Fee) {
 				channel.InboundFee = fee
@@ -215,7 +213,7 @@ func (c *GraphCache) UpdatePolicy(policy *models.CachedEdgePolicy, fromNode,
 
 		// This is node 2, and it is edge 2, so this is the outgoing
 		// policy for node 2.
-		case !channel.IsNode1 && !isEdge1:
+		case !channel.IsNode1 && !policy.IsNode1():
 			channel.OutPolicySet = true
 			policy.InboundFee.WhenSome(func(fee lnwire.Fee) {
 				channel.InboundFee = fee

--- a/graph/db/graph_cache.go
+++ b/graph/db/graph_cache.go
@@ -264,34 +264,6 @@ func (c *GraphCache) removeChannelIfFound(node route.Vertex, chanID uint64) {
 	delete(c.nodeChannels[node], chanID)
 }
 
-// UpdateChannel updates the channel edge information for a specific edge. We
-// expect the edge to already exist and be known. If it does not yet exist, this
-// call is a no-op.
-func (c *GraphCache) UpdateChannel(info *models.ChannelEdgeInfo) {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
-
-	if len(c.nodeChannels[info.NodeKey1Bytes]) == 0 ||
-		len(c.nodeChannels[info.NodeKey2Bytes]) == 0 {
-
-		return
-	}
-
-	channel, ok := c.nodeChannels[info.NodeKey1Bytes][info.ChannelID]
-	if ok {
-		// We only expect to be called when the channel is already
-		// known.
-		channel.Capacity = info.Capacity
-		channel.OtherNode = info.NodeKey2Bytes
-	}
-
-	channel, ok = c.nodeChannels[info.NodeKey2Bytes][info.ChannelID]
-	if ok {
-		channel.Capacity = info.Capacity
-		channel.OtherNode = info.NodeKey1Bytes
-	}
-}
-
 // getChannels returns a copy of the passed node's channels or nil if there
 // isn't any.
 func (c *GraphCache) getChannels(node route.Vertex) []*DirectedChannel {

--- a/graph/db/graph_cache.go
+++ b/graph/db/graph_cache.go
@@ -115,7 +115,7 @@ func (c *GraphCache) AddNodeFeatures(node route.Vertex,
 // and policy flags automatically. The policy will be set as the outgoing policy
 // on one node and the incoming policy on the peer's side.
 func (c *GraphCache) AddChannel(info *models.ChannelEdgeInfo,
-	policy1 *models.ChannelEdgePolicy, policy2 *models.ChannelEdgePolicy) {
+	policy1, policy2 *models.CachedEdgePolicy) {
 
 	if info == nil {
 		return
@@ -147,21 +147,17 @@ func (c *GraphCache) AddChannel(info *models.ChannelEdgeInfo,
 	// of node 2 then we have the policy 1 as seen from node 1.
 	if policy1 != nil {
 		fromNode, toNode := info.NodeKey1Bytes, info.NodeKey2Bytes
-		if policy1.ToNode != info.NodeKey2Bytes {
+		if !policy1.IsNode1() {
 			fromNode, toNode = toNode, fromNode
 		}
-		c.UpdatePolicy(
-			models.NewCachedPolicy(policy1), fromNode, toNode,
-		)
+		c.UpdatePolicy(policy1, fromNode, toNode)
 	}
 	if policy2 != nil {
 		fromNode, toNode := info.NodeKey2Bytes, info.NodeKey1Bytes
-		if policy2.ToNode != info.NodeKey1Bytes {
+		if policy2.IsNode1() {
 			fromNode, toNode = toNode, fromNode
 		}
-		c.UpdatePolicy(
-			models.NewCachedPolicy(policy2), fromNode, toNode,
-		)
+		c.UpdatePolicy(policy2, fromNode, toNode)
 	}
 }
 

--- a/graph/db/graph_cache.go
+++ b/graph/db/graph_cache.go
@@ -150,14 +150,18 @@ func (c *GraphCache) AddChannel(info *models.ChannelEdgeInfo,
 		if policy1.ToNode != info.NodeKey2Bytes {
 			fromNode, toNode = toNode, fromNode
 		}
-		c.UpdatePolicy(policy1, fromNode, toNode)
+		c.UpdatePolicy(
+			models.NewCachedPolicy(policy1), fromNode, toNode,
+		)
 	}
 	if policy2 != nil {
 		fromNode, toNode := info.NodeKey2Bytes, info.NodeKey1Bytes
 		if policy2.ToNode != info.NodeKey1Bytes {
 			fromNode, toNode = toNode, fromNode
 		}
-		c.UpdatePolicy(policy2, fromNode, toNode)
+		c.UpdatePolicy(
+			models.NewCachedPolicy(policy2), fromNode, toNode,
+		)
 	}
 }
 
@@ -175,7 +179,7 @@ func (c *GraphCache) updateOrAddEdge(node route.Vertex, edge *DirectedChannel) {
 // of the from and to node is not strictly important. But we assume that a
 // channel edge was added beforehand so that the directed channel struct already
 // exists in the cache.
-func (c *GraphCache) UpdatePolicy(policy *models.ChannelEdgePolicy, fromNode,
+func (c *GraphCache) UpdatePolicy(policy *models.CachedEdgePolicy, fromNode,
 	toNode route.Vertex) {
 
 	c.mtx.Lock()
@@ -220,7 +224,7 @@ func (c *GraphCache) UpdatePolicy(policy *models.ChannelEdgePolicy, fromNode,
 		// The other two cases left mean it's the inbound policy for the
 		// node.
 		default:
-			channel.InPolicy = models.NewCachedPolicy(policy)
+			channel.InPolicy = policy
 		}
 	}
 

--- a/graph/db/graph_cache.go
+++ b/graph/db/graph_cache.go
@@ -114,7 +114,7 @@ func (c *GraphCache) AddNodeFeatures(node route.Vertex,
 // and policy 2 does not matter, the directionality is extracted from the info
 // and policy flags automatically. The policy will be set as the outgoing policy
 // on one node and the incoming policy on the peer's side.
-func (c *GraphCache) AddChannel(info *models.ChannelEdgeInfo,
+func (c *GraphCache) AddChannel(info *models.CachedEdgeInfo,
 	policy1, policy2 *models.CachedEdgePolicy) {
 
 	if info == nil {

--- a/graph/db/graph_cache_test.go
+++ b/graph/db/graph_cache_test.go
@@ -61,7 +61,7 @@ func TestGraphCacheAddNode(t *testing.T) {
 		}
 		cache := NewGraphCache(10)
 		cache.AddNodeFeatures(nodeA, lnwire.EmptyFeatureVector())
-		cache.AddChannel(&models.ChannelEdgeInfo{
+		cache.AddChannel(&models.CachedEdgeInfo{
 			ChannelID: 1000,
 			// Those are direction independent!
 			NodeKey1Bytes: pubKey1,

--- a/graph/db/interfaces.go
+++ b/graph/db/interfaces.go
@@ -159,6 +159,22 @@ type V1Store interface { //nolint:interfacebloat
 		*models.ChannelEdgePolicy,
 		*models.ChannelEdgePolicy) error) error
 
+	// ForEachChannelCacheable iterates through all the channel edges stored
+	// within the graph and invokes the passed callback for each edge. The
+	// callback takes two edges as since this is a directed graph, both the
+	// in/out edges are visited. If the callback returns an error, then the
+	// transaction is aborted and the iteration stops early.
+	//
+	// NOTE: If an edge can't be found, or wasn't advertised, then a nil
+	// pointer for that particular channel edge routing policy will be
+	// passed into the callback.
+	//
+	// NOTE: this method is like ForEachChannel but fetches only the data
+	// required for the graph cache.
+	ForEachChannelCacheable(cb func(*models.CachedEdgeInfo,
+		*models.CachedEdgePolicy,
+		*models.CachedEdgePolicy) error) error
+
 	// DisabledChannelIDs returns the channel ids of disabled channels.
 	// A channel is disabled when two of the associated ChanelEdgePolicies
 	// have their disabled bit on.

--- a/graph/db/models/cached_edge_info.go
+++ b/graph/db/models/cached_edge_info.go
@@ -1,0 +1,33 @@
+package models
+
+import "github.com/btcsuite/btcd/btcutil"
+
+// CachedEdgeInfo is a struct that only caches the information of a
+// ChannelEdgeInfo that we actually use for pathfinding and therefore need to
+// store in the cache.
+type CachedEdgeInfo struct {
+	// ChannelID is the unique channel ID for the channel. The first 3
+	// bytes are the block height, the next 3 the index within the block,
+	// and the last 2 bytes are the output index for the channel.
+	ChannelID uint64
+
+	// NodeKey1Bytes is the raw public key of the first node.
+	NodeKey1Bytes [33]byte
+
+	// NodeKey2Bytes is the raw public key of the second node.
+	NodeKey2Bytes [33]byte
+
+	// Capacity is the total capacity of the channel, this is determined by
+	// the value output in the outpoint that created this channel.
+	Capacity btcutil.Amount
+}
+
+// NewCachedEdge creates a new CachedEdgeInfo from the provided ChannelEdgeInfo.
+func NewCachedEdge(edgeInfo *ChannelEdgeInfo) *CachedEdgeInfo {
+	return &CachedEdgeInfo{
+		ChannelID:     edgeInfo.ChannelID,
+		NodeKey1Bytes: edgeInfo.NodeKey1Bytes,
+		NodeKey2Bytes: edgeInfo.NodeKey2Bytes,
+		Capacity:      edgeInfo.Capacity,
+	}
+}

--- a/graph/db/models/cached_edge_policy.go
+++ b/graph/db/models/cached_edge_policy.go
@@ -75,6 +75,18 @@ func (c *CachedEdgePolicy) ComputeFee(
 	return c.FeeBaseMSat + (amt*c.FeeProportionalMillionths)/feeRateParts
 }
 
+// IsDisabled returns true if the channel is disabled in the direction from  the
+// advertising node.
+func (c *CachedEdgePolicy) IsDisabled() bool {
+	return c.ChannelFlags&lnwire.ChanUpdateDisabled != 0
+}
+
+// IsNode1 returns true if this policy was announced by the channel's node_1
+// node.
+func (c *CachedEdgePolicy) IsNode1() bool {
+	return c.ChannelFlags&lnwire.ChanUpdateDirection == 0
+}
+
 // NewCachedPolicy turns a full policy into a minimal one that can be cached.
 func NewCachedPolicy(policy *ChannelEdgePolicy) *CachedEdgePolicy {
 	return &CachedEdgePolicy{

--- a/graph/db/models/cached_edge_policy.go
+++ b/graph/db/models/cached_edge_policy.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
 )
@@ -48,6 +49,9 @@ type CachedEdgePolicy struct {
 	// HTLCs for each millionth of a satoshi forwarded.
 	FeeProportionalMillionths lnwire.MilliSatoshi
 
+	// InboundFee is the fee that the node will charge for incoming HTLCs.
+	InboundFee fn.Option[lnwire.Fee]
+
 	// ToNodePubKey is a function that returns the to node of a policy.
 	// Since we only ever store the inbound policy, this is always the node
 	// that we query the channels for in ForEachChannel(). Therefore, we can
@@ -82,5 +86,6 @@ func NewCachedPolicy(policy *ChannelEdgePolicy) *CachedEdgePolicy {
 		MaxHTLC:                   policy.MaxHTLC,
 		FeeBaseMSat:               policy.FeeBaseMSat,
 		FeeProportionalMillionths: policy.FeeProportionalMillionths,
+		InboundFee:                policy.InboundFee,
 	}
 }

--- a/routing/unified_edges.go
+++ b/routing/unified_edges.go
@@ -360,9 +360,7 @@ func (u *edgeUnifier) getEdgeNetwork(netAmtReceived lnwire.MilliSatoshi,
 		}
 
 		// For network channels, skip the disabled ones.
-		edgeFlags := edge.policy.ChannelFlags
-		isDisabled := edgeFlags&lnwire.ChanUpdateDisabled != 0
-		if isDisabled {
+		if edge.policy.IsDisabled() {
 			log.Debugf("Skipped edge %v due to it being disabled",
 				edge.policy.ChannelID)
 			continue


### PR DESCRIPTION
In this PR, we adjust the various methods of the `GraphCache` such that they all only take the `models.Cached*` versions
of various types (namely `CachedEdgeInfo` and `CachedEdgePolicy`). 
This then allows us to implement a new `ForEachChannelCacheable` method which only requires the 
DB layer to fetch the info needed to construct the cache types. This will be useful when we add the SQL version 
of the graph store so that we can reduce the number of DB round trips. 

Part of https://github.com/lightningnetwork/lnd/issues/9795