### PR TITLE
[11] graph/db: Implement various "ForEach" methods on the graph SQLStore

### DIFF
--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -77,6 +77,7 @@ circuit. The indices are only available for forwarding events saved after v0.20.
     * [2](https://github.com/lightningnetwork/lnd/pull/9869)
     * [3](https://github.com/lightningnetwork/lnd/pull/9887)
     * [4](https://github.com/lightningnetwork/lnd/pull/9931)
+    * [5](https://github.com/lightningnetwork/lnd/pull/9935)
 
 ## RPC Updates
 

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -3041,7 +3041,7 @@ func TestIncompleteChannelPolicies(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	graph := MakeTestGraph(t)
+	graph := MakeTestGraphNew(t)
 
 	// Create two nodes.
 	node1 := createTestVertex(t)
@@ -4110,7 +4110,7 @@ func TestBatchedUpdateEdgePolicy(t *testing.T) {
 // BenchmarkForEachChannel is a benchmark test that measures the number of
 // allocations and the total memory consumed by the full graph traversal.
 func BenchmarkForEachChannel(b *testing.B) {
-	graph := MakeTestGraph(b)
+	graph := MakeTestGraphNew(b)
 
 	const numNodes = 100
 	const numChannels = 4

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -1436,7 +1436,7 @@ func TestGraphTraversalCacheable(t *testing.T) {
 func TestGraphCacheTraversal(t *testing.T) {
 	t.Parallel()
 
-	graph := MakeTestGraph(t)
+	graph := MakeTestGraphNew(t)
 
 	// We'd like to test some of the graph traversal capabilities within
 	// the DB, so we'll create a series of fake nodes to insert into the

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -2069,16 +2069,15 @@ func TestChanUpdatesInHorizon(t *testing.T) {
 
 			assertEdgeInfoEqual(t, chanExp.Info, chanRet.Info)
 
-			err := compareEdgePolicies(
+			err = compareEdgePolicies(
 				chanExp.Policy1, chanRet.Policy1,
 			)
-			if err != nil {
-				t.Fatal(err)
-			}
-			compareEdgePolicies(chanExp.Policy2, chanRet.Policy2)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+
+			err = compareEdgePolicies(
+				chanExp.Policy2, chanRet.Policy2,
+			)
+			require.NoError(t, err)
 		}
 	}
 }

--- a/graph/db/notifications.go
+++ b/graph/db/notifications.go
@@ -473,6 +473,11 @@ func EncodeHexColor(color color.RGBA) string {
 // DecodeHexColor takes a hex color string like "#rrggbb" and returns a
 // color.RGBA.
 func DecodeHexColor(hex string) (color.RGBA, error) {
+	if len(hex) != 7 || hex[0] != '#' {
+		return color.RGBA{}, fmt.Errorf("invalid hex color string: %s",
+			hex)
+	}
+
 	r, err := strconv.ParseUint(hex[1:3], 16, 8)
 	if err != nil {
 		return color.RGBA{}, fmt.Errorf("invalid red component: %w",

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -934,9 +934,12 @@ func buildNode(ctx context.Context, db SQLQueries, dbNode *sqlc.Node) (
 	node.LastUpdate = time.Unix(dbNode.LastUpdate.Int64, 0)
 
 	var err error
-	node.Color, err = DecodeHexColor(dbNode.Color.String)
-	if err != nil {
-		return nil, fmt.Errorf("unable to decode color: %w", err)
+	if dbNode.Color.Valid {
+		node.Color, err = DecodeHexColor(dbNode.Color.String)
+		if err != nil {
+			return nil, fmt.Errorf("unable to decode color: %w",
+				err)
+		}
 	}
 
 	// Fetch the node's features.

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -1702,7 +1702,10 @@ func getAndBuildEdgeInfo(ctx context.Context, db SQLQueries,
 		ExtraOpaqueData:  recs,
 	}
 
-	if dbChan.Bitcoin1Signature != nil {
+	// We always set all the signatures at the same time, so we can
+	// safely check if one signature is present to determine if we have the
+	// rest of the signatures for the auth proof.
+	if len(dbChan.Bitcoin1Signature) > 0 {
 		channel.AuthProof = &models.ChannelAuthProof{
 			NodeSig1Bytes:    dbChan.Node1Signature,
 			NodeSig2Bytes:    dbChan.Node2Signature,

--- a/graph/notifications_test.go
+++ b/graph/notifications_test.go
@@ -991,7 +991,9 @@ func TestChannelCloseNotification(t *testing.T) {
 // TestEncodeHexColor tests that the string used to represent a node color is
 // correctly encoded.
 func TestEncodeHexColor(t *testing.T) {
-	var colorTestCases = []struct {
+	t.Parallel()
+
+	var tests = []struct {
 		R       uint8
 		G       uint8
 		B       uint8
@@ -1006,14 +1008,32 @@ func TestEncodeHexColor(t *testing.T) {
 		{1, 2, 3, "#", false},
 	}
 
-	for _, tc := range colorTestCases {
-		encoded := graphdb.EncodeHexColor(
-			color.RGBA{tc.R, tc.G, tc.B, 0},
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("R:%d,G:%d,B:%d", test.R, test.G, test.B),
+			func(t *testing.T) {
+				expColor := color.RGBA{
+					R: test.R,
+					G: test.G,
+					B: test.B,
+				}
+
+				encoded := graphdb.EncodeHexColor(expColor)
+
+				if test.isValid {
+					require.Equal(t, test.encoded, encoded)
+				}
+
+				decoded, err := graphdb.DecodeHexColor(
+					test.encoded,
+				)
+				if test.isValid {
+					require.NoError(t, err)
+					require.Equal(t, expColor, decoded)
+				} else {
+					require.Error(t, err)
+				}
+			},
 		)
-		if (encoded == tc.encoded) != tc.isValid {
-			t.Fatalf("incorrect color encoding, "+
-				"want: %v, got: %v", tc.encoded, encoded)
-		}
 	}
 }
 

--- a/sqldb/sqlc/querier.go
+++ b/sqldb/sqlc/querier.go
@@ -48,6 +48,7 @@ type Querier interface {
 	GetNodeByPubKey(ctx context.Context, arg GetNodeByPubKeyParams) (Node, error)
 	GetNodeFeatures(ctx context.Context, nodeID int64) ([]NodeFeature, error)
 	GetNodeFeaturesByPubKey(ctx context.Context, arg GetNodeFeaturesByPubKeyParams) ([]int32, error)
+	GetNodeIDByPubKey(ctx context.Context, arg GetNodeIDByPubKeyParams) (int64, error)
 	GetNodesByLastUpdateRange(ctx context.Context, arg GetNodesByLastUpdateRangeParams) ([]Node, error)
 	GetSourceNodesByVersion(ctx context.Context, version int16) ([]GetSourceNodesByVersionRow, error)
 	HighestSCID(ctx context.Context, version int16) ([]byte, error)
@@ -64,6 +65,7 @@ type Querier interface {
 	InsertNodeAddress(ctx context.Context, arg InsertNodeAddressParams) error
 	InsertNodeFeature(ctx context.Context, arg InsertNodeFeatureParams) error
 	ListChannelsByNodeID(ctx context.Context, arg ListChannelsByNodeIDParams) ([]ListChannelsByNodeIDRow, error)
+	ListNodeIDsAndPubKeys(ctx context.Context, arg ListNodeIDsAndPubKeysParams) ([]ListNodeIDsAndPubKeysRow, error)
 	ListNodesPaginated(ctx context.Context, arg ListNodesPaginatedParams) ([]Node, error)
 	NextInvoiceSettleIndex(ctx context.Context) (int64, error)
 	OnAMPSubInvoiceCanceled(ctx context.Context, arg OnAMPSubInvoiceCanceledParams) error

--- a/sqldb/sqlc/querier.go
+++ b/sqldb/sqlc/querier.go
@@ -64,6 +64,7 @@ type Querier interface {
 	InsertNodeAddress(ctx context.Context, arg InsertNodeAddressParams) error
 	InsertNodeFeature(ctx context.Context, arg InsertNodeFeatureParams) error
 	ListChannelsByNodeID(ctx context.Context, arg ListChannelsByNodeIDParams) ([]ListChannelsByNodeIDRow, error)
+	ListNodesPaginated(ctx context.Context, arg ListNodesPaginatedParams) ([]Node, error)
 	NextInvoiceSettleIndex(ctx context.Context) (int64, error)
 	OnAMPSubInvoiceCanceled(ctx context.Context, arg OnAMPSubInvoiceCanceledParams) error
 	OnAMPSubInvoiceCreated(ctx context.Context, arg OnAMPSubInvoiceCreatedParams) error

--- a/sqldb/sqlc/queries/graph.sql
+++ b/sqldb/sqlc/queries/graph.sql
@@ -27,6 +27,13 @@ FROM nodes
 WHERE pub_key = $1
   AND version = $2;
 
+-- name: ListNodesPaginated :many
+SELECT *
+FROM nodes
+WHERE version = $1 AND id > $2
+ORDER BY id
+LIMIT $3;
+
 -- name: DeleteNodeByPubKey :execresult
 DELETE FROM nodes
 WHERE pub_key = $1
@@ -194,7 +201,6 @@ ORDER BY scid DESC
 LIMIT 1;
 
 -- name: ListChannelsByNodeID :many
-
 SELECT sqlc.embed(c),
     n1.pub_key AS node1_pubkey,
     n2.pub_key AS node2_pubkey,

--- a/sqldb/sqlc/queries/graph.sql
+++ b/sqldb/sqlc/queries/graph.sql
@@ -27,10 +27,23 @@ FROM nodes
 WHERE pub_key = $1
   AND version = $2;
 
+-- name: GetNodeIDByPubKey :one
+SELECT id
+FROM nodes
+WHERE pub_key = $1
+  AND version = $2;
+
 -- name: ListNodesPaginated :many
 SELECT *
 FROM nodes
 WHERE version = $1 AND id > $2
+ORDER BY id
+LIMIT $3;
+
+-- name: ListNodeIDsAndPubKeys :many
+SELECT id, pub_key
+FROM nodes
+WHERE version = $1  AND id > $2
 ORDER BY id
 LIMIT $3;
 


### PR DESCRIPTION
In this PR, the following methods are implemented on the graph SQLStore:

- ForEachNode
- ForEachNodeDirectedChannel
- ForEachNodeCacheable
- ForEachNodeChannel

Part of #9795 
See https://github.com/lightningnetwork/lnd/pull/9932 for the full picture that we are aiming at