### PR TITLE
[14] graph/db: implement more SQLStore methods

### DIFF
--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -87,6 +87,7 @@ circuit. The indices are only available for forwarding events saved after v0.20.
     * [5](https://github.com/lightningnetwork/lnd/pull/9935)
     * [6](https://github.com/lightningnetwork/lnd/pull/9936)
     * [7](https://github.com/lightningnetwork/lnd/pull/9937)
+    * [8](https://github.com/lightningnetwork/lnd/pull/9938)
 
 ## RPC Updates
 

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -3592,7 +3592,7 @@ func TestDisabledChannelIDs(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	graph := MakeTestGraph(t)
+	graph := MakeTestGraphNew(t)
 
 	// Create first node and add it to the graph.
 	node1 := createTestVertex(t)
@@ -3608,6 +3608,7 @@ func TestDisabledChannelIDs(t *testing.T) {
 
 	// Adding a new channel edge to the graph.
 	edgeInfo, edge1, edge2 := createChannelEdge(node1, node2)
+	node2.LastUpdate = time.Unix(nextUpdateTime(), 0)
 	if err := graph.AddLightningNode(ctx, node2); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}

--- a/sqldb/sqlc/querier.go
+++ b/sqldb/sqlc/querier.go
@@ -60,6 +60,11 @@ type Querier interface {
 	GetPublicV1ChannelsBySCID(ctx context.Context, arg GetPublicV1ChannelsBySCIDParams) ([]Channel, error)
 	GetSCIDByOutpoint(ctx context.Context, arg GetSCIDByOutpointParams) ([]byte, error)
 	GetSourceNodesByVersion(ctx context.Context, version int16) ([]GetSourceNodesByVersionRow, error)
+	// NOTE: this is V1 specific since for V1, disabled is a
+	// simple, single boolean. The proposed V2 policy
+	// structure will have a more complex disabled bit vector
+	// and so the query for V2 may differ.
+	GetV1DisabledSCIDs(ctx context.Context) ([][]byte, error)
 	GetZombieChannel(ctx context.Context, arg GetZombieChannelParams) (ZombieChannel, error)
 	HighestSCID(ctx context.Context, version int16) ([]byte, error)
 	InsertAMPSubInvoice(ctx context.Context, arg InsertAMPSubInvoiceParams) error

--- a/sqldb/sqlc/queries/graph.sql
+++ b/sqldb/sqlc/queries/graph.sql
@@ -573,6 +573,19 @@ JOIN channel_policy_extra_types cpet
 ON cp.id = cpet.channel_policy_id
 WHERE cp.id = $1 OR cp.id = $2;
 
+-- name: GetV1DisabledSCIDs :many
+SELECT c.scid
+FROM channels c
+    JOIN channel_policies cp ON cp.channel_id = c.id
+-- NOTE: this is V1 specific since for V1, disabled is a
+-- simple, single boolean. The proposed V2 policy
+-- structure will have a more complex disabled bit vector
+-- and so the query for V2 may differ.
+WHERE cp.disabled = true
+AND c.version = 1
+GROUP BY c.scid
+HAVING COUNT(*) > 1;
+
 -- name: DeleteChannelPolicyExtraTypes :exec
 DELETE FROM channel_policy_extra_types
 WHERE channel_policy_id = $1;


### PR DESCRIPTION
Here, we implement: 
- FetchChannelEdgesByOutpoint/SCID
- HasChannelEdge
- ChannelID
- FilterKnownChanIDs
- FetchChanInfos
- IsPublicNode
- DisabledChannelIDs

Part of https://github.com/lightningnetwork/lnd/issues/9795
See https://github.com/lightningnetwork/lnd/pull/9932 for the full picture that we are aiming at