### PR TITLE
lntest: add a flag to export data generated during the test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ clean-itest-logs:
 itest-only: clean-itest-logs db-instance
 	@$(call print, "Running integration tests with ${backend} backend.")
 	date
-	EXEC_SUFFIX=$(EXEC_SUFFIX) scripts/itest_part.sh 0 1 $(SHUFFLE_SEED) $(TEST_FLAGS) $(ITEST_FLAGS) -test.v
+	EXEC_SUFFIX=$(EXEC_SUFFIX) scripts/itest_part.sh 0 1 $(SHUFFLE_SEED) $(BASE_DIR) $(TEST_FLAGS) $(ITEST_FLAGS) -test.v
 	$(COLLECT_ITEST_COVERAGE)
 
 #? itest: Build and run integration tests
@@ -234,7 +234,7 @@ itest-race: build-itest-race itest-only
 itest-parallel: clean-itest-logs build-itest db-instance
 	@$(call print, "Running tests")
 	date
-	EXEC_SUFFIX=$(EXEC_SUFFIX) scripts/itest_parallel.sh $(ITEST_PARALLELISM) $(NUM_ITEST_TRANCHES) $(SHUFFLE_SEED) $(TEST_FLAGS) $(ITEST_FLAGS)
+	EXEC_SUFFIX=$(EXEC_SUFFIX) scripts/itest_parallel.sh $(ITEST_PARALLELISM) $(NUM_ITEST_TRANCHES) $(SHUFFLE_SEED) $(BASE_DIR) $(TEST_FLAGS) $(ITEST_FLAGS)
 	$(COLLECT_ITEST_COVERAGE)
 
 #? itest-clean: Kill all running itest processes

--- a/lntest/node/config.go
+++ b/lntest/node/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"time"
 
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/integration/rpctest"
@@ -28,6 +29,10 @@ const (
 )
 
 var (
+	// baseDirFlag is the default directory where all the node's data are
+	// saved. If not set, a temporary dir will be created.
+	baseDirFlag = flag.String("basedir", ".", "default dir to save data")
+
 	// logOutput is a flag that can be set to append the output from the
 	// seed nodes to log files.
 	logOutput = flag.Bool("logoutput", false,
@@ -159,6 +164,11 @@ type BaseNodeConfig struct {
 	// compiled with all required itest flags.
 	LndBinary string
 
+	// SkipCleanup specifies whether the harness will remove the base dir or
+	// not when the test finishes. When using customized BaseDir, the
+	// cleanup will be skipped.
+	SkipCleanup bool
+
 	// backupDBDir is the path where a database backup is stored, if any.
 	backupDBDir string
 
@@ -222,17 +232,32 @@ func (cfg *BaseNodeConfig) BaseConfig() *BaseNodeConfig {
 
 // GenBaseDir creates a base dir that's used for the test.
 func (cfg *BaseNodeConfig) GenBaseDir() error {
-	if cfg.BaseDir == "" {
+	// Exit early if the BaseDir is already set.
+	if cfg.BaseDir != "" {
+		return nil
+	}
+
+	dirBaseName := fmt.Sprintf("itest-%v-%v-%v-%v", cfg.LogFilenamePrefix,
+		cfg.Name, cfg.NodeID, time.Now().Unix())
+
+	// Create a temporary directory for the node's data and logs. Use dash
+	// suffix as a separator between base name and node ID.
+	if *baseDirFlag == "" {
 		var err error
 
-		// Create a temporary directory for the node's data and logs.
-		// Use dash suffix as a separator between base name and random
-		// suffix.
-		dirBaseName := fmt.Sprintf("lndtest-node-%s-", cfg.Name)
 		cfg.BaseDir, err = os.MkdirTemp("", dirBaseName)
 
 		return err
 	}
+
+	// Create the customized base dir.
+	if err := os.MkdirAll(*baseDirFlag, 0700); err != nil {
+		return err
+	}
+
+	// Use customized base dir and skip the cleanups.
+	cfg.BaseDir = fmt.Sprintf("%s/%s", *baseDirFlag, dirBaseName)
+	cfg.SkipCleanup = true
 
 	return nil
 }

--- a/lntest/node/config.go
+++ b/lntest/node/config.go
@@ -220,6 +220,23 @@ func (cfg *BaseNodeConfig) BaseConfig() *BaseNodeConfig {
 	return cfg
 }
 
+// GenBaseDir creates a base dir that's used for the test.
+func (cfg *BaseNodeConfig) GenBaseDir() error {
+	if cfg.BaseDir == "" {
+		var err error
+
+		// Create a temporary directory for the node's data and logs.
+		// Use dash suffix as a separator between base name and random
+		// suffix.
+		dirBaseName := fmt.Sprintf("lndtest-node-%s-", cfg.Name)
+		cfg.BaseDir, err = os.MkdirTemp("", dirBaseName)
+
+		return err
+	}
+
+	return nil
+}
+
 // GenArgs generates a slice of command line arguments from the lightning node
 // config struct.
 func (cfg *BaseNodeConfig) GenArgs() []string {

--- a/lntest/node/harness_node.go
+++ b/lntest/node/harness_node.go
@@ -93,18 +93,10 @@ type HarnessNode struct {
 // NewHarnessNode creates a new test lightning node instance from the passed
 // config.
 func NewHarnessNode(t *testing.T, cfg *BaseNodeConfig) (*HarnessNode, error) {
-	if cfg.BaseDir == "" {
-		var err error
-
-		// Create a temporary directory for the node's data and logs.
-		// Use dash suffix as a separator between base name and random
-		// suffix.
-		dirBaseName := fmt.Sprintf("lndtest-node-%s-", cfg.Name)
-		cfg.BaseDir, err = os.MkdirTemp("", dirBaseName)
-		if err != nil {
-			return nil, err
-		}
+	if err := cfg.GenBaseDir(); err != nil {
+		return nil, err
 	}
+
 	cfg.DataDir = filepath.Join(cfg.BaseDir, "data")
 	cfg.LogDir = filepath.Join(cfg.BaseDir, "logs")
 	cfg.TLSCertPath = filepath.Join(cfg.BaseDir, "tls.cert")

--- a/lntest/node/harness_node.go
+++ b/lntest/node/harness_node.go
@@ -794,6 +794,13 @@ func (hn *HarnessNode) Shutdown() error {
 	if err := hn.Stop(); err != nil {
 		return err
 	}
+
+	// Exit if we want to skip the cleanup, which happens when a customized
+	// base dir is used.
+	if hn.Cfg.SkipCleanup {
+		return nil
+	}
+
 	if err := hn.cleanup(); err != nil {
 		return err
 	}

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -12,6 +12,7 @@ NUM_ITEST_TRANCHES = 4
 ITEST_PARALLELISM = $(NUM_ITEST_TRANCHES)
 POSTGRES_START_DELAY = 5
 SHUFFLE_SEED = 0
+BASE_DIR = ""
 
 # If rpc option is set also add all extra RPC tags to DEV_TAGS
 ifneq ($(with-rpc),)
@@ -32,6 +33,11 @@ endif
 # Set the seed for shuffling the test cases.
 ifneq ($(shuffleseed),)
 SHUFFLE_SEED = $(shuffleseed)
+endif
+
+# Set the base dir if specified.
+ifneq ($(basedir),)
+BASE_DIR = $(basedir)
 endif
 
 # Windows needs to append a .exe suffix to all executable files, otherwise it

--- a/scripts/itest_part.sh
+++ b/scripts/itest_part.sh
@@ -6,10 +6,11 @@ WORKDIR=$(pwd)/itest
 TRANCHE=$1
 NUM_TRANCHES=$2
 SHUFFLE_SEED_PARAM=$3
+BASE_DIR_PARAM=$4
 
 # Shift the passed parameters by three, giving us all remaining testing flags in
 # the $@ special variable.
-shift 3
+shift 4
 
 # Windows insists on having the .exe suffix for an executable, we need to add
 # that here if necessary.
@@ -18,9 +19,9 @@ LND_EXEC="$WORKDIR"/lnd-itest"$EXEC_SUFFIX"
 BTCD_EXEC="$WORKDIR"/btcd-itest"$EXEC_SUFFIX"
 export GOCOVERDIR="$WORKDIR/cover"
 mkdir -p "$GOCOVERDIR"
-echo $EXEC "$@" -logoutput -logdir=.logs-tranche$TRANCHE -lndexec=$LND_EXEC -btcdexec=$BTCD_EXEC -splittranches=$NUM_TRANCHES -runtranche=$TRANCHE -shuffleseed=$SHUFFLE_SEED_PARAM
+echo $EXEC "$@" -logoutput -logdir=.logs-tranche$TRANCHE -lndexec=$LND_EXEC -btcdexec=$BTCD_EXEC -splittranches=$NUM_TRANCHES -runtranche=$TRANCHE -shuffleseed=$SHUFFLE_SEED_PARAM -basedir=$BASE_DIR_PARAM
 
 # Exit code 255 causes the parallel jobs to abort, so if one part fails the
 # other is aborted too.
 cd "$WORKDIR" || exit 255
-$EXEC "$@" -logoutput -logdir=.logs-tranche$TRANCHE -lndexec=$LND_EXEC -btcdexec=$BTCD_EXEC -splittranches=$NUM_TRANCHES -runtranche=$TRANCHE -shuffleseed=$SHUFFLE_SEED_PARAM || exit 255
+$EXEC "$@" -logoutput -logdir=.logs-tranche$TRANCHE -lndexec=$LND_EXEC -btcdexec=$BTCD_EXEC -splittranches=$NUM_TRANCHES -runtranche=$TRANCHE -shuffleseed=$SHUFFLE_SEED_PARAM -basedir=$BASE_DIR_PARAM || exit 255


### PR DESCRIPTION
Add a new param `basedir` so we can save the node files and analyze them when needed, sth like,
`make itest icase=$icase basedir="your_customized_dir"`

which gives,

```
> tree
.
├── itest-list_payments-Alice-1-1749810982
│   ├── data
│   │   ├── chain
│   │   │   └── bitcoin
│   │   │       └── regtest
│   │   │           ├── admin.macaroon
│   │   │           ├── chainnotifier.macaroon
│   │   │           ├── chan-backup-archives
│   │   │           │   ├── channel.backup-2025-06-13-18-36-29
│   │   │           │   ├── channel.backup-2025-06-13-18-36-30
│   │   │           │   └── channel.backup-2025-06-13-18-36-35
│   │   │           ├── channel.backup
│   │   │           ├── invoice.macaroon
│   │   │           ├── invoices.macaroon
│   │   │           ├── macaroons.db
│   │   │           ├── readonly.macaroon
│   │   │           ├── router.macaroon
│   │   │           ├── signer.macaroon
│   │   │           ├── wallet.db
│   │   │           └── walletkit.macaroon
│   │   ├── graph
│   │   │   └── regtest
│   │   │       ├── channel.db
│   │   │       └── sphinxreplay.db
│   │   └── watchtower
│   │       └── bitcoin
│   │           └── regtest
│   ├── letsencrypt
│   ├── logs
│   │   └── bitcoin
│   │       └── regtest
│   │           └── lnd.log
│   ├── tls.cert
│   └── tls.key
```

Which is what I used to analyze SQL tables.