### PR TITLE
chainio: use package logger instead of instance logger

### DIFF
--- a/chainio/dispatcher.go
+++ b/chainio/dispatcher.go
@@ -135,6 +135,14 @@ func (b *BlockbeatDispatcher) Stop() {
 }
 
 func (b *BlockbeatDispatcher) log() btclog.Logger {
+	// There's no guarantee that the `b.beat` is initialized when the
+	// dispatcher shuts down, especially in the case where the node is
+	// running as a remote signer, which doesn't have a chainbackend. In
+	// that case we will use the package logger.
+	if b.beat == nil {
+		return clog
+	}
+
 	return b.beat.logger()
 }
 

--- a/docs/release-notes/release-notes-0.19.2.md
+++ b/docs/release-notes/release-notes-0.19.2.md
@@ -26,6 +26,9 @@
 - [Fixed](https://github.com/lightningnetwork/lnd/pull/9921) a case where the
   spending notification of an output may be missed if wrong height hint is used.
 
+- [Fixed](https://github.com/lightningnetwork/lnd/pull/9962) a case where the
+  node may panic if it's running in the remote signer mode.
+
 # New Features
 
 ## Functional Enhancements


### PR DESCRIPTION
Fixes #9961

There's no guarantee that the `b.beat` is initialized when the dispatcher shuts down, especially in the case of the remote signer where no chainbackend is created.
