### PR TITLE
graph/db: do nil check on ChannelEdgePolicy 

### DIFF
--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -351,10 +351,16 @@ func (c *ChannelGraph) MarkEdgeLive(chanID uint64) error {
 
 		info := infos[0]
 
+		var policy1, policy2 *models.CachedEdgePolicy
+		if info.Policy1 != nil {
+			policy1 = models.NewCachedPolicy(info.Policy1)
+		}
+		if info.Policy2 != nil {
+			policy2 = models.NewCachedPolicy(info.Policy2)
+		}
+
 		c.graphCache.AddChannel(
-			models.NewCachedEdge(info.Info),
-			models.NewCachedPolicy(info.Policy1),
-			models.NewCachedPolicy(info.Policy2),
+			models.NewCachedEdge(info.Info), policy1, policy2,
 		)
 	}
 

--- a/graph/db/kv_store.go
+++ b/graph/db/kv_store.go
@@ -530,18 +530,12 @@ func (c *KVStore) ForEachChannelCacheable(cb func(*models.CachedEdgeInfo,
 					cachedPolicy1 = models.NewCachedPolicy(
 						policy1,
 					)
-				} else {
-					log.Warnf("ChannelEdgePolicy not "+
-						"found using %v", key1)
 				}
 
 				if policy2 != nil {
 					cachedPolicy2 = models.NewCachedPolicy(
 						policy2,
 					)
-				} else {
-					log.Warnf("ChannelEdgePolicy not "+
-						"found using %v", key2)
 				}
 
 				return cb(


### PR DESCRIPTION
Similarly to https://github.com/lightningnetwork/lnd/pull/9951, here we make sure to do a nil 
check on ChannelEdgePolicy pointers before dereferencing them. In the graph/db code, we should
always expect a ChannelEdgePolicy to potentially be nil. 

The second commit addresses [this](https://github.com/lightningnetwork/lnd/pull/9951/files#r2149940819) comment
from the review of that PR. 