### PR TITLE
[16] graph/db: SQL closed SCIDs table and last few methods

### DIFF
--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -89,6 +89,7 @@ circuit. The indices are only available for forwarding events saved after v0.20.
     * [7](https://github.com/lightningnetwork/lnd/pull/9937)
     * [8](https://github.com/lightningnetwork/lnd/pull/9938)
     * [9](https://github.com/lightningnetwork/lnd/pull/9939)
+    * [10](https://github.com/lightningnetwork/lnd/pull/9971)
 
 ## RPC Updates
 

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -4325,7 +4325,7 @@ func TestGraphLoading(t *testing.T) {
 func TestClosedScid(t *testing.T) {
 	t.Parallel()
 
-	graph := MakeTestGraph(t)
+	graph := MakeTestGraphNew(t)
 
 	scid := lnwire.ShortChannelID{}
 

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -1128,7 +1128,7 @@ func TestAddEdgeProof(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	graph := MakeTestGraph(t)
+	graph := MakeTestGraphNew(t)
 
 	// Add an edge with no proof.
 	node1 := createTestVertex(t)

--- a/graph/db/kv_store.go
+++ b/graph/db/kv_store.go
@@ -2150,8 +2150,8 @@ func (c *KVStore) ChanUpdatesInHorizon(startTime,
 	}
 
 	if len(edgesInHorizon) > 0 {
-		log.Debugf("ChanUpdatesInHorizon hit percentage: %f (%d/%d)",
-			float64(hits)/float64(len(edgesInHorizon)), hits,
+		log.Debugf("ChanUpdatesInHorizon hit percentage: %.2f (%d/%d)",
+			float64(hits)*100/float64(len(edgesInHorizon)), hits,
 			len(edgesInHorizon))
 	} else {
 		log.Debugf("ChanUpdatesInHorizon returned no edges in "+

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -1395,7 +1395,7 @@ func (s *SQLStore) ForEachChannel(cb func(*models.ChannelEdgeInfo,
 	}
 
 	return s.db.ExecTx(ctx, sqldb.ReadTxOpt(), func(db SQLQueries) error {
-		var lastID int64
+		lastID := int64(-1)
 		for {
 			//nolint:ll
 			rows, err := db.ListChannelsWithPoliciesPaginated(
@@ -2957,7 +2957,7 @@ func forEachNodeDirectedChannel(ctx context.Context, db SQLQueries,
 func forEachNodeCacheable(ctx context.Context, db SQLQueries,
 	cb func(nodeID int64, nodePub route.Vertex) error) error {
 
-	var lastID int64
+	lastID := int64(-1)
 
 	for {
 		nodes, err := db.ListNodeIDsAndPubKeys(

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -137,6 +137,12 @@ type SQLQueries interface {
 	GetPruneTip(ctx context.Context) (sqlc.PruneLog, error)
 	UpsertPruneLogEntry(ctx context.Context, arg sqlc.UpsertPruneLogEntryParams) error
 	DeletePruneLogEntriesInRange(ctx context.Context, arg sqlc.DeletePruneLogEntriesInRangeParams) error
+
+	/*
+		Closed SCID table queries.
+	*/
+	InsertClosedChannel(ctx context.Context, scid []byte) error
+	IsClosedChannel(ctx context.Context, scid []byte) (bool, error)
 }
 
 // BatchedSQLQueries is a version of SQLQueries that's capable of batched
@@ -2622,6 +2628,50 @@ func (s *SQLStore) AddEdgeProof(scid lnwire.ShortChannelID,
 	}
 
 	return nil
+}
+
+// PutClosedScid stores a SCID for a closed channel in the database. This is so
+// that we can ignore channel announcements that we know to be closed without
+// having to validate them and fetch a block.
+//
+// NOTE: part of the V1Store interface.
+func (s *SQLStore) PutClosedScid(scid lnwire.ShortChannelID) error {
+	var (
+		ctx     = context.TODO()
+		chanIDB = channelIDToBytes(scid.ToUint64())
+	)
+
+	return s.db.ExecTx(ctx, sqldb.WriteTxOpt(), func(db SQLQueries) error {
+		return db.InsertClosedChannel(ctx, chanIDB[:])
+	}, sqldb.NoOpReset)
+}
+
+// IsClosedScid checks whether a channel identified by the passed in scid is
+// closed. This helps avoid having to perform expensive validation checks.
+//
+// NOTE: part of the V1Store interface.
+func (s *SQLStore) IsClosedScid(scid lnwire.ShortChannelID) (bool, error) {
+	var (
+		ctx      = context.TODO()
+		isClosed bool
+		chanIDB  = channelIDToBytes(scid.ToUint64())
+	)
+	err := s.db.ExecTx(ctx, sqldb.ReadTxOpt(), func(db SQLQueries) error {
+		var err error
+		isClosed, err = db.IsClosedChannel(ctx, chanIDB[:])
+		if err != nil {
+			return fmt.Errorf("unable to fetch closed channel: %w",
+				err)
+		}
+
+		return nil
+	}, sqldb.NoOpReset)
+	if err != nil {
+		return false, fmt.Errorf("unable to fetch closed channel: %w",
+			err)
+	}
+
+	return isClosed, nil
 }
 
 // forEachNodeDirectedChannel iterates through all channels of a given

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -1103,8 +1103,8 @@ func (s *SQLStore) ChanUpdatesInHorizon(startTime,
 	}
 
 	if len(edges) > 0 {
-		log.Debugf("ChanUpdatesInHorizon hit percentage: %f (%d/%d)",
-			float64(hits)/float64(len(edges)), hits, len(edges))
+		log.Debugf("ChanUpdatesInHorizon hit percentage: %.2f (%d/%d)",
+			float64(hits)*100/float64(len(edges)), hits, len(edges))
 	} else {
 		log.Debugf("ChanUpdatesInHorizon returned no edges in "+
 			"horizon (%s, %s)", startTime, endTime)

--- a/sqldb/sqlc/graph.sql.go
+++ b/sqldb/sqlc/graph.sql.go
@@ -26,6 +26,34 @@ func (q *Queries) AddSourceNode(ctx context.Context, nodeID int64) error {
 	return err
 }
 
+const addV1ChannelProof = `-- name: AddV1ChannelProof :execresult
+UPDATE channels
+SET node_1_signature = $2,
+    node_2_signature = $3,
+    bitcoin_1_signature = $4,
+    bitcoin_2_signature = $5
+WHERE scid = $1
+  AND version = 1
+`
+
+type AddV1ChannelProofParams struct {
+	Scid              []byte
+	Node1Signature    []byte
+	Node2Signature    []byte
+	Bitcoin1Signature []byte
+	Bitcoin2Signature []byte
+}
+
+func (q *Queries) AddV1ChannelProof(ctx context.Context, arg AddV1ChannelProofParams) (sql.Result, error) {
+	return q.db.ExecContext(ctx, addV1ChannelProof,
+		arg.Scid,
+		arg.Node1Signature,
+		arg.Node2Signature,
+		arg.Bitcoin1Signature,
+		arg.Bitcoin2Signature,
+	)
+}
+
 const countZombieChannels = `-- name: CountZombieChannels :one
 SELECT COUNT(*)
 FROM zombie_channels

--- a/sqldb/sqlc/migrations/000007_graph.down.sql
+++ b/sqldb/sqlc/migrations/000007_graph.down.sql
@@ -29,3 +29,4 @@ DROP TABLE IF EXISTS nodes;
 DROP TABLE IF EXISTS channel_policy_extra_types;
 DROP TABLE IF EXISTS zombie_channels;
 DROP TABLE IF EXISTS prune_log;
+DROP TABLE IF EXISTS closed_scids;

--- a/sqldb/sqlc/migrations/000007_graph.up.sql
+++ b/sqldb/sqlc/migrations/000007_graph.up.sql
@@ -332,3 +332,8 @@ CREATE TABLE IF NOT EXISTS prune_log (
     -- The block hash that the prune was performed at.
     block_hash BLOB NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS closed_scids (
+    -- The short channel id of the channel.
+    scid BLOB PRIMARY KEY
+);

--- a/sqldb/sqlc/models.go
+++ b/sqldb/sqlc/models.go
@@ -78,6 +78,10 @@ type ChannelPolicyExtraType struct {
 	Value           []byte
 }
 
+type ClosedScid struct {
+	Scid []byte
+}
+
 type Invoice struct {
 	ID                 int64
 	Hash               []byte

--- a/sqldb/sqlc/querier.go
+++ b/sqldb/sqlc/querier.go
@@ -12,6 +12,7 @@ import (
 
 type Querier interface {
 	AddSourceNode(ctx context.Context, nodeID int64) error
+	AddV1ChannelProof(ctx context.Context, arg AddV1ChannelProofParams) (sql.Result, error)
 	ClearKVInvoiceHashIndex(ctx context.Context) error
 	CountZombieChannels(ctx context.Context, version int16) (int64, error)
 	CreateChannel(ctx context.Context, arg CreateChannelParams) (int64, error)

--- a/sqldb/sqlc/querier.go
+++ b/sqldb/sqlc/querier.go
@@ -80,6 +80,7 @@ type Querier interface {
 	InsertAMPSubInvoiceHTLC(ctx context.Context, arg InsertAMPSubInvoiceHTLCParams) error
 	InsertChanPolicyExtraType(ctx context.Context, arg InsertChanPolicyExtraTypeParams) error
 	InsertChannelFeature(ctx context.Context, arg InsertChannelFeatureParams) error
+	InsertClosedChannel(ctx context.Context, scid []byte) error
 	InsertInvoice(ctx context.Context, arg InsertInvoiceParams) (int64, error)
 	InsertInvoiceFeature(ctx context.Context, arg InsertInvoiceFeatureParams) error
 	InsertInvoiceHTLC(ctx context.Context, arg InsertInvoiceHTLCParams) (int64, error)
@@ -88,6 +89,7 @@ type Querier interface {
 	InsertMigratedInvoice(ctx context.Context, arg InsertMigratedInvoiceParams) (int64, error)
 	InsertNodeAddress(ctx context.Context, arg InsertNodeAddressParams) error
 	InsertNodeFeature(ctx context.Context, arg InsertNodeFeatureParams) error
+	IsClosedChannel(ctx context.Context, scid []byte) (bool, error)
 	IsPublicV1Node(ctx context.Context, pubKey []byte) (bool, error)
 	IsZombieChannel(ctx context.Context, arg IsZombieChannelParams) (bool, error)
 	ListChannelsByNodeID(ctx context.Context, arg ListChannelsByNodeIDParams) ([]ListChannelsByNodeIDRow, error)

--- a/sqldb/sqlc/queries/graph.sql
+++ b/sqldb/sqlc/queries/graph.sql
@@ -208,6 +208,15 @@ INSERT INTO channels (
 )
 RETURNING id;
 
+-- name: AddV1ChannelProof :execresult
+UPDATE channels
+SET node_1_signature = $2,
+    node_2_signature = $3,
+    bitcoin_1_signature = $4,
+    bitcoin_2_signature = $5
+WHERE scid = $1
+  AND version = 1;
+
 -- name: GetChannelsBySCIDRange :many
 SELECT sqlc.embed(c),
     n1.pub_key AS node1_pub_key,

--- a/sqldb/sqlc/queries/graph.sql
+++ b/sqldb/sqlc/queries/graph.sql
@@ -709,3 +709,20 @@ LIMIT 1;
 DELETE FROM prune_log
 WHERE block_height >= @start_height
   AND block_height <= @end_height;
+
+/* ─────────────────────────────────────────────
+   closed_scid table queries
+   ────────────────────────────────────────────-
+*/
+
+-- name: InsertClosedChannel :exec
+INSERT INTO closed_scids (scid)
+VALUES ($1)
+ON CONFLICT (scid) DO NOTHING;
+
+-- name: IsClosedChannel :one
+SELECT EXISTS (
+    SELECT 1
+    FROM closed_scids
+    WHERE scid = $1
+);


### PR DESCRIPTION
In this PR, we do a few things:

1) we define the SQL schema of the `closed_scid` index. This lets us then implement the following methods:
`PutClosedScid`, `IsClosedScid`
2) We also let the SQLStore implement the last couple of V1Store methods: `ForEachChannelCacheable`, `AddEdgeProof`, `GraphSession`


Part of https://github.com/lightningnetwork/lnd/issues/9795
See https://github.com/lightningnetwork/lnd/pull/9932 for the full picture that we are aiming at