### PR TITLE
lntest: enable neutrino testing with bitcoind

### DIFF
--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -131,6 +131,8 @@ circuit. The indices are only available for forwarding events saved after v0.20.
 
 ## Tooling and Documentation
 
+* lntest: [enable neutrino testing with bitcoind](https://github.com/lightningnetwork/lnd/pull/9977)
+
 # Contributors (Alphabetical Order)
 
 * Abdulkbk

--- a/lntest/bitcoind_common.go
+++ b/lntest/bitcoind_common.go
@@ -85,6 +85,11 @@ func (b BitcoindBackendConfig) Name() string {
 	return "bitcoind"
 }
 
+// P2PAddr return bitcoin p2p ip:port.
+func (b BitcoindBackendConfig) P2PAddr() (string, error) {
+	return fmt.Sprintf("127.0.0.1:%d", b.p2pPort), nil
+}
+
 // newBackend starts a bitcoind node with the given extra parameters and returns
 // a BitcoindBackendConfig for that node.
 func newBackend(miner string, netParams *chaincfg.Params, extraArgs []string,

--- a/lntest/bitcoind_common.go
+++ b/lntest/bitcoind_common.go
@@ -131,6 +131,8 @@ func newBackend(miner string, netParams *chaincfg.Params, extraArgs []string,
 		"-debug",
 		"-debugexclude=libevent",
 		"-debuglogfile=" + logFile,
+		"-blockfilterindex",
+		"-peerblockfilters",
 	}
 	cmdArgs = append(cmdArgs, extraArgs...)
 	bitcoind := exec.Command("bitcoind", cmdArgs...)

--- a/lntest/bitcoind_common.go
+++ b/lntest/bitcoind_common.go
@@ -124,7 +124,7 @@ func newBackend(miner string, netParams *chaincfg.Params, extraArgs []string,
 			"d$507c670e800a95284294edb5773b05544b" +
 			"220110063096c221be9933c82d38e1",
 		fmt.Sprintf("-rpcport=%d", rpcPort),
-		fmt.Sprintf("-port=%d", p2pPort),
+		fmt.Sprintf("-bind=127.0.0.1:%d", p2pPort),
 		fmt.Sprintf("-bind=127.0.0.1:%d=onion", torBindPort),
 		"-zmqpubrawblock=" + zmqBlockAddr,
 		"-zmqpubrawtx=" + zmqTxAddr,

--- a/lntest/btcd.go
+++ b/lntest/btcd.go
@@ -74,6 +74,11 @@ func (b BtcdBackendConfig) Name() string {
 	return "btcd"
 }
 
+// P2PAddr return bitcoin p2p ip:port.
+func (b BtcdBackendConfig) P2PAddr() (string, error) {
+	return b.harness.P2PAddress(), nil
+}
+
 // NewBackend starts a new rpctest.Harness and returns a BtcdBackendConfig for
 // that node. miner should be set to the P2P address of the miner to connect
 // to.

--- a/lntest/neutrino.go
+++ b/lntest/neutrino.go
@@ -54,6 +54,11 @@ func (b NeutrinoBackendConfig) Name() string {
 	return NeutrinoBackendName
 }
 
+// P2PAddr return bitcoin p2p ip:port.
+func (b NeutrinoBackendConfig) P2PAddr() (string, error) {
+	return b.minerAddr, nil
+}
+
 // NewBackend starts and returns a NeutrinoBackendConfig for the node.
 func NewBackend(miner string, _ *chaincfg.Params) (
 	*NeutrinoBackendConfig, func() error, error) {

--- a/lntest/node/config.go
+++ b/lntest/node/config.go
@@ -114,6 +114,9 @@ type BackendConfig interface {
 	// Credentials returns the rpc username, password and host for the
 	// backend.
 	Credentials() (string, string, string, error)
+
+	// P2PAddr return bitcoin p2p ip:port.
+	P2PAddr() (string, error)
 }
 
 // BaseNodeConfig is the base node configuration.


### PR DESCRIPTION
## Change Description

Previously, Neutrino could be enabled via the `neutrino` build tag, which affected all LND nodes involved in an itest and required using a `btcd` miner as the source of compact block headers. This PR introduces a more flexible setup: it is now possible to run some LND nodes with a regular `bitcoind` backend, while others use Neutrino with `bitcoind`'s P2P interface as the source of compact block headers. This allows testing more complex scenarios where some nodes have a local `bitcoind` instance, while others rely on Neutrino for lightweight syncing.

## Steps to Test

```bash
make itest
```

The change is fully backwards compatible, and all existing itests should continue to pass.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
