### PR TITLE
itest: fix flake in `sweep_cpfp_anchor_incoming_timeout`

### DIFF
--- a/itest/lnd_sweep_test.go
+++ b/itest/lnd_sweep_test.go
@@ -766,14 +766,6 @@ func testSweepHTLCs(ht *lntest.HarnessTest) {
 	// - when sweeping HTLCs, he needs one utxo for each sweep.
 	numUTXOs := 2
 
-	// Bob should have enough wallet UTXOs here to sweep the HTLC in the
-	// end of this test. However, due to a known issue, Bob's wallet may
-	// report there's no UTXO available. For details,
-	// - https://github.com/lightningnetwork/lnd/issues/8786
-	//
-	// TODO(yy): remove this extra UTXO once the issue is resolved.
-	numUTXOs++
-
 	// For neutrino backend, we need two more UTXOs for Bob to create his
 	// sweeping txns.
 	if ht.IsNeutrinoBackend() {
@@ -1801,14 +1793,6 @@ func testFeeReplacement(ht *lntest.HarnessTest) {
 	// - when sweeping anchors, he needs one utxo for each sweep.
 	// - when sweeping HTLCs, he needs one utxo for each sweep.
 	numUTXOs := 2
-
-	// Bob should have enough wallet UTXOs here to sweep the HTLC in the
-	// end of this test. However, due to a known issue, Bob's wallet may
-	// report there's no UTXO available. For details,
-	// - https://github.com/lightningnetwork/lnd/issues/8786
-	//
-	// TODO(yy): remove this extra UTXO once the issue is resolved.
-	numUTXOs++
 
 	// For neutrino backend, we need two more UTXOs for Bob to create his
 	// sweeping txns.

--- a/itest/lnd_sweep_test.go
+++ b/itest/lnd_sweep_test.go
@@ -665,6 +665,26 @@ func testSweepCPFPAnchorIncomingTimeout(ht *lntest.HarnessTest) {
 	// needed to clean up the mempool.
 	ht.MineBlocksAndAssertNumTxes(1, 2)
 
+	// We mined a block above, which confirmed Bob's force closing tx and
+	// his anchor sweeping tx. Bob should now have a new change output
+	// created from that sweeping tx, which can be used as the input to
+	// sweep his HTLC.
+	// Also in the above mined block, the HTLC will be offered to Bob's
+	// sweeper for sweeping, which requires a wallet utxo since it's a
+	// zero fee HTLC.
+	// There's the possible race that,
+	// - btcwallet is processing this block, and marking the change output
+	//   as confirmed.
+	// - btcwallet notifies LND about the new block.
+	// If the block notification comes first, LND's sweeper will not be
+	// able to sweep this HTLC as it thinks the wallet UTXO is still
+	// unconfirmed.
+	// TODO(yy): To fix the above issue, we need to make sure btcwallet
+	// should update its internal state first before notifying the new
+	// block, which is scheduled to be fixed during the btcwallet SQLizing
+	// saga.
+	ht.MineEmptyBlocks(1)
+
 	// The above mined block should confirm Bob's force close tx, and his
 	// contractcourt will offer the HTLC to his sweeper. We are not testing
 	// the HTLC sweeping behaviors so we just perform a simple check and


### PR DESCRIPTION
Removed finished TODOs and fixed the itest flake found in several CIs, e.g., this [one](https://github.com/lightningnetwork/lnd/actions/runs/15774978611/job/44467279473?pr=9967),
```
--- FAIL: TestLightningNetworkDaemon/tranche01/64-of-298/bitcoind/sweep_cpfp_anchor_incoming_timeout (202.59s)
        harness_node.go:403: Starting node (name=Alice) with PID=53262
        harness_node.go:403: Starting node (name=Bob) with PID=55151
        harness_node.go:403: Starting node (name=Carol) with PID=55931
        lnd_sweep_test.go:608: Bob(position=3): txWeight=722 wu, expected: [fee=7686, feerate=10645 sat/kw], got: [fee=7692, feerate=10654] in tx 0988fecd73248a91ac56645dd78f0e2c9b0470443ba221c97578e2fe12583171
        lnd_sweep_test.go:608: Bob(position=2): txWeight=722 wu, expected: [fee=13567, feerate=18791 sat/kw], got: [fee=13571, feerate=18796] in tx e8a0461faf32902d743ff3107080c9117f0625a94deea11e3d7ae7742b1f9fed
        lnd_sweep_test.go:608: Bob(position=1): txWeight=722 wu, expected: [fee=19448, feerate=26936 sat/kw], got: [fee=19451, feerate=26940] in tx 85ee39501c7047680d045c7fa05a4c1cdf9ea9cee09ff8a89207a3d6f307915d
        miner.go:223: 
            	Error Trace:	/home/runner/work/lnd/lnd/lntest/miner/miner.go:223
            	            				/home/runner/work/lnd/lnd/lntest/harness_miner.go:222
            	            				/home/runner/work/lnd/lnd/lntest/harness_miner.go:104
            	            				/home/runner/work/lnd/lnd/itest/lnd_sweep_test.go:673
            	            				/home/runner/work/lnd/lnd/lntest/harness.go:303
            	            				/home/runner/work/lnd/lnd/itest/lnd_test.go:130
            	Error:      	Received unexpected error:
            	            	want 1, got 0 in mempool: []
            	Test:       	TestLightningNetworkDaemon/tranche01/64-of-298/bitcoind/sweep_cpfp_anchor_incoming_timeout
            	Messages:   	assert tx in mempool timeout
        harness.go:381: finished test: sweep_cpfp_anchor_incoming_timeout, start height=785, end height=827, mined blocks=42
```