### PR TITLE
accessman: fix logging in removePeerAccess

### DIFF
--- a/accessman.go
+++ b/accessman.go
@@ -611,8 +611,12 @@ func (a *accessMan) addPeerAccess(remotePub *btcec.PublicKey,
 
 // removePeerAccess removes the peer's access from the maps. This should be
 // called when the peer has been disconnected.
-func (a *accessMan) removePeerAccess(peerPubKey string) {
-	ctx := btclog.WithCtx(context.TODO(), "peer", peerPubKey)
+func (a *accessMan) removePeerAccess(peerPub *btcec.PublicKey) {
+	peerPubKey := string(peerPub.SerializeCompressed())
+
+	ctx := btclog.WithCtx(
+		context.TODO(), lnutils.LogPubKey("peer", peerPub),
+	)
 	acsmLog.DebugS(ctx, "Removing access:")
 
 	a.banScoreMtx.Lock()

--- a/server.go
+++ b/server.go
@@ -4975,8 +4975,7 @@ func (s *server) removePeer(p *peer.Brontide) {
 	}
 
 	// Remove the peer's access permission from the access manager.
-	peerPubStr := string(p.IdentityKey().SerializeCompressed())
-	s.peerAccessMan.removePeerAccess(peerPubStr)
+	s.peerAccessMan.removePeerAccess(p.IdentityKey())
 
 	// Copy the peer's error buffer across to the server if it has any items
 	// in it so that we can restore peer errors across connections.


### PR DESCRIPTION
## Change Description
Peer pubkey was logged as raw bytes instead of hex:

```
2025-06-23 22:47:25.580 [DBG] ACSM: Removing access: peer=^B<82>^<D9>l<B9>^P<CD>*
Fi1<95><F2><BE>|<FE><BD>恟Z<FE>Wg<B2><EF>z'<BC><B9>$
2025-06-23 22:47:25.580 [DBG] ACSM: Decremented restricted slots peer=^B<82>^<D9>l<B9>^P<CD>*
Fi1<95><F2><BE>|<FE><BD>恟Z<FE>Wg<B2><EF>z'<BC><B9>$ old_restricted=3 new_restricted=2
2025-06-23 22:47:25.580 [DBG] ACSM: Chan info not found during removal: peer=^B<82>^<D9>l<B9>^P<CD>*
Fi1<95><F2><BE>|<FE><BD>恟Z<FE>Wg<B2><EF>z'<BC><B9>$
```

After this fix it is logged properly:

```
2025-06-23 23:17:06.244 [DBG] ACSM: Removing access: peer=021ead97a963
2025-06-23 23:17:06.244 [DBG] ACSM: Decremented restricted slots peer=021ead97a963 old_restricted=4 new_restricted=3
2025-06-23 23:17:06.244 [DBG] ACSM: Chan info not found during removal: peer=021ead97a963
```

## Steps to Test

I found this debug log in one of my itests during shutdown. I think it always appears there.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
