### PR TITLE
lntest: do not do IO under mutex in fee_service

### DIFF
--- a/lntest/fee_service.go
+++ b/lntest/fee_service.go
@@ -115,14 +115,13 @@ func (f *FeeService) Start() error {
 // handleRequest handles a client request for fee estimates.
 func (f *FeeService) handleRequest(w http.ResponseWriter, _ *http.Request) {
 	f.lock.Lock()
-	defer f.lock.Unlock()
-
 	bytes, err := json.Marshal(
 		chainfee.WebAPIResponse{
 			FeeByBlockTarget: f.feeRateMap,
 			MinRelayFeerate:  f.minRelayFeerate,
 		},
 	)
+	f.lock.Unlock()
 	require.NoErrorf(f, err, "cannot serialize estimates")
 
 	_, err = io.WriteString(w, string(bytes))


### PR DESCRIPTION
## Change Description

If HTTP response is consumed slowly, this might block other HTTP requests to the fee service, because the mutex is held.

## Steps to Test
```
make itest
```

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
