### PR TITLE
chainfee: method to round up the fee for a given transaction weight

### DIFF
--- a/docs/release-notes/release-notes-0.19.2.md
+++ b/docs/release-notes/release-notes-0.19.2.md
@@ -33,6 +33,10 @@
 
 ## Functional Enhancements
 
+- [Adds](https://github.com/lightningnetwork/lnd/pull/9989) a method 
+  `FeeForWeightRoundUp` to the `chainfee` package which rounds up a calculated 
+  fee value to the nearest satoshi.
+
 ## RPC Additions
 
 ## lncli Additions
@@ -78,4 +82,5 @@ much more slowly.
 ## Tooling and Documentation
 
 # Contributors (Alphabetical Order)
+* hieblmi
 * Yong Yu

--- a/lnwallet/chainfee/rates.go
+++ b/lnwallet/chainfee/rates.go
@@ -71,6 +71,14 @@ func (s SatPerKWeight) FeeForWeight(wu lntypes.WeightUnit) btcutil.Amount {
 	return btcutil.Amount(s) * btcutil.Amount(wu) / 1000
 }
 
+// FeeForWeightRoundUp calculates the fee resulting from this fee rate and the
+// given weight in weight units (wu), rounding up to the nearest satoshi.
+func (s SatPerKWeight) FeeForWeightRoundUp(
+	wu lntypes.WeightUnit) btcutil.Amount {
+
+	return (btcutil.Amount(s)*btcutil.Amount(wu) + 999) / 1000
+}
+
 // FeeForVByte calculates the fee resulting from this fee rate and the given
 // size in vbytes (vb).
 func (s SatPerKWeight) FeeForVByte(vb lntypes.VByte) btcutil.Amount {

--- a/lnwallet/chainfee/rates_test.go
+++ b/lnwallet/chainfee/rates_test.go
@@ -3,6 +3,7 @@ package chainfee
 import (
 	"testing"
 
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,4 +20,14 @@ func TestSatPerVByteConversion(t *testing.T) {
 
 	// 1 sat/vb should be equal to 250 sat/kw.
 	require.Equal(t, SatPerKWeight(250), rate.FeePerKWeight())
+}
+
+// TestFeeForWeightRoundUp checks that the FeeForWeightRoundUp method correctly
+// rounds up the fee for a given weight.
+func TestFeeForWeightRoundUp(t *testing.T) {
+	feeRate := SatPerVByte(1).FeePerKWeight()
+	txWeight := lntypes.WeightUnit(674) // 674 weight units is 168.5 vb.
+
+	require.EqualValues(t, 168, feeRate.FeeForWeight(txWeight))
+	require.EqualValues(t, 169, feeRate.FeeForWeightRoundUp(txWeight))
 }


### PR DESCRIPTION
This PR adds method `FeeForWeightRoundUp` to the `chainfee` package which rounds up a calculated fee value to the nearest satoshi.

This is related to an issue we are seeing in loop: https://github.com/lightninglabs/loop/issues/966