### PR TITLE
itest coverage increase following the spec update regarding MPP payments

### DIFF
--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -93,6 +93,10 @@ circuit. The indices are only available for forwarding events saved after v0.20.
 
 ## Code Health
 
+- [Increase itest coverage](https://github.com/lightningnetwork/lnd/pull/9990)
+for payments. Now the payment address is mandatory for the writer and
+reader of a payment request.
+
 ## Breaking Changes
 ## Performance Improvements
 
@@ -149,3 +153,4 @@ circuit. The indices are only available for forwarding events saved after v0.20.
 * Funyug
 * Mohamed Awnallah
 * Pins
+* Ziggie

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -1038,7 +1038,11 @@ func (i *InvoiceRegistry) notifyExitHopHtlcLocked(
 	)
 	switch {
 	case errors.Is(err, ErrInvoiceNotFound) ||
-		errors.Is(err, ErrNoInvoicesCreated):
+		errors.Is(err, ErrNoInvoicesCreated) ||
+		errors.Is(err, ErrInvRefEquivocation):
+
+		log.Debugf("Invoice not found with error: %v, failing htlc",
+			err)
 
 		// If the invoice was not found, return a failure resolution
 		// with an invoice not found result.

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -684,6 +684,10 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testInvoiceMigration,
 	},
 	{
+		Name:     "payment address mismatch",
+		TestFunc: testWrongPaymentAddr,
+	},
+	{
 		Name:     "fee replacement",
 		TestFunc: testFeeReplacement,
 	},


### PR DESCRIPTION
I added an additional test regarding MPP payments based on the new spec requiring the payment address to be set for the writer and the reader of an invoice.