### PR TITLE
chainreg: use new lseed service

### DIFF
--- a/chainreg/chainregistry.go
+++ b/chainreg/chainregistry.go
@@ -878,8 +878,8 @@ var (
 	ChainDNSSeeds = map[chainhash.Hash][][2]string{
 		BitcoinMainnetGenesis: {
 			{
-				"nodes.lightning.directory",
-				"soa.nodes.lightning.directory",
+				"nodes.lightning.wiki",
+				"soa.nodes.lightning.wiki",
 			},
 			{
 				"lseed.bitcoinstats.com",
@@ -888,14 +888,22 @@ var (
 
 		BitcoinTestnetGenesis: {
 			{
-				"test.nodes.lightning.directory",
-				"soa.nodes.lightning.directory",
+				"test.nodes.lightning.wiki",
+				"soa.nodes.lightning.wiki",
+			},
+		},
+
+		BitcoinTestnet4Genesis: {
+			{
+				"test4.nodes.lightning.wiki",
+				"soa.nodes.lightning.wiki",
 			},
 		},
 
 		BitcoinSignetGenesis: {
 			{
-				"ln.signet.secp.tech",
+				"signet.nodes.lightning.wiki",
+				"soa.nodes.lightning.wiki",
 			},
 		},
 	}

--- a/docs/release-notes/release-notes-0.19.2.md
+++ b/docs/release-notes/release-notes-0.19.2.md
@@ -37,6 +37,11 @@
   `FeeForWeightRoundUp` to the `chainfee` package which rounds up a calculated 
   fee value to the nearest satoshi.
 
+- [Update](https://github.com/lightningnetwork/lnd/pull/9996) lnd to point at
+  the new deployment of the lightning seed service which is used to provide
+  candidate peers during initial network bootstrap. The lseed service now
+  supports `testnet4` and `signet` networks as well.
+
 ## RPC Additions
 
 ## lncli Additions


### PR DESCRIPTION
## Change Description
This points **_lnd_** at the new deployment of the **_lseed_** service used to provide candidate peers during initial network bootstrap. We also add lightning seed hostnames for the `testnet4` network.

## Steps to Test
- Start up an lnd with this change. Or update your `lnd.conf` file to point your node at the new service as demonstrated [here](https://github.com/lightningnetwork/lnd/blob/v0.19.1-beta/sample-lnd.conf#L709).
- And/or manually interact with the **_lseed_** service:
```
# Manually query the lightning seed service:
dig nodes.lightning.wiki SRV
dig test.nodes.lightning.wiki SRV
dig test4.nodes.lightning.wiki SRV
dig signet.nodes.lightning.wiki SRV

# Obtain network address of a peer from lseed service:
dig ln1q00n7z3066l22s56t9jxrnncfjfzk2vp4ks6lzw0alxeena3dst2wxe8xyt.nodes.lightning.wiki

# Convert node hostname to node ID public key (bech32 decode):
ln1q00n7z3066l22s56t9jxrnncfjfzk2vp4ks6lzw0alxeena3dst2wxe8xyt --> 03df3f0a2fd6bea5429a596461ce784c922b2981ada1af89cfefcd9ccfb16c16a7

```

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
