### PR TITLE
watchtower: fix logging and add comments

### DIFF
--- a/watchtower/lookout/justice_descriptor.go
+++ b/watchtower/lookout/justice_descriptor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnutils"
 	"github.com/lightningnetwork/lnd/watchtower/blob"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb"
 )
@@ -230,6 +231,9 @@ func (p *JusticeDescriptor) CreateJusticeTxn() (*wire.MsgTx, error) {
 	case input.P2WPKHSize:
 		weightEstimate.AddP2WKHOutput()
 
+	// NOTE: P2TR has the same size as P2WSH (34 bytes), their output sizes
+	// are also the same (43 bytes), so here we implicitly catch the P2TR
+	// output case.
 	case input.P2WSHSize:
 		weightEstimate.AddP2WSHOutput()
 
@@ -260,8 +264,9 @@ func (p *JusticeDescriptor) CreateJusticeTxn() (*wire.MsgTx, error) {
 
 	sweepInputs = append(sweepInputs, toLocalInput)
 
-	log.Debugf("Found to local witness output=%#v, stack=%v",
-		toLocalInput.txOut, toLocalInput.witness)
+	log.Debugf("Found to local witness output=%v, stack=%x",
+		lnutils.SpewLogClosure(toLocalInput.txOut),
+		toLocalInput.witness)
 
 	// If the justice kit specifies that we have to sweep the to-remote
 	// output, we'll also try to assemble the output and add it to weight
@@ -273,8 +278,9 @@ func (p *JusticeDescriptor) CreateJusticeTxn() (*wire.MsgTx, error) {
 		}
 		sweepInputs = append(sweepInputs, toRemoteInput)
 
-		log.Debugf("Found to remote witness output=%#v, stack=%v",
-			toRemoteInput.txOut, toRemoteInput.witness)
+		log.Debugf("Found to remote witness output=%v, stack=%x",
+			lnutils.SpewLogClosure(toRemoteInput.txOut),
+			toRemoteInput.witness)
 
 		// Get the weight for the to-remote witness and add that to the
 		// estimator.


### PR DESCRIPTION
Found some weird logging while working on dyn, this PR now fixes it,
Before,
```
2025-06-26 17:49:57.762 [DBG] WTWR justice_descriptor.go:263: Found to local witness output=&wire.TxOut{Value:4194303, PkScript:[]uint8{0x51, 0x20, 0x25, 0x6c, 0x9a, 0x3f, 0xc2, 0xc9, 0x37, 0x8d, 0x46, 0x56, 0x69, 0xf2, 0x35, 0x52, 0x1b, 0xae, 0x9a, 0xa7, 0xee, 0x14, 0xc9, 0xf5, 0x68, 0x83, 0xfd, 0xdf, 0xf7, 0x85, 0x99, 0xc4, 0x73, 0x9a}}, stack=[[9 64 239 233 98 57 8 0 181 241 152 136 30 149 224 106 54 212 107 17 202 245 131 230 142 28 138 142 116 62 232 126 17 51 221 245 25 15 234 189 189 181 155 161 19 206 82 119 165 176 31 117 250 153 187 159 223 213 224 114 63 226 131 212] [32 2 97 175 173 150 74 225 30 0 30 201 74 210 10 129 233 42 12 77 194 230 241 239 137 165 80 53 176 220 2 105 128 117 32 181 72 211 161 224 108 153 149 164 233 148 176 8 197 113 143 202 118 21 159 127 39 17 210 132 6 166 156 113 12 117 207 172] [192 220 160 148 117 17 9 208 189 5 93 3 86 88 116 232 39 109 213 62 146 107 68 227 189 27 182 191 75 193 48 162 121 74 101 117 87 255 157 100 158 253 249 58 33 37 223 20 205 108 69 45 172 184 244 64 86 129 163 152 220 65 186 142 8]]
```

After,
```
2025-06-26 17:47:47.079 [DBG] WTWR justice_descriptor.go:267: Found to local witness output=(*wire.TxOut)(0x140001ce520)({
 Value: (int64) 4194303,
 PkScript: ([]uint8) (len=34 cap=34) {
  00000000  51 20 6c cc 6d 72 66 8f  7f 34 90 db 83 cc 9c 02  |Q l.mrf..4......|
  00000010  88 ca 0e 00 3e 9c 45 ac  b5 82 80 11 8c 44 d8 b4  |....>.E......D..|
  00000020  6a f0                                             |j.|
 }
})
, stack=[e513fc887f5e687eb68c53b322f4db5c9d642fb13ae05443166c1bd94d4a5d57ddf613611c6c580772e769d00f7c1d03a89a79f0e9030fdaca6514bd19c10bf4 20bd86e2bebe413dc9846030f1612e068d064553781fa8be48a88c3d9d8f6f764e7520588648413fae4894f150d44307e911a5b571ccffb9b3d3e8dd7ae4378932b1aaac c0dca094751109d0bd055d03565874e8276dd53e926b44e3bd1bb6bf4bc130a2792879b9d92fa8e166bbe8b260ae0c342e55d30b27f01ae61aecbfe2094e5ec65e]
```