### PR TITLE
server: ensure newer node announcement timestamp

### DIFF
--- a/server.go
+++ b/server.go
@@ -950,9 +950,35 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 	if err != nil {
 		return nil, err
 	}
+
+	// TODO(elle): All previously persisted node announcement fields (ie,
+	//  not just LastUpdate) should be consulted here to ensure that we
+	//  aren't overwriting any fields that may have been set during the
+	//  last run of lnd.
+	nodeLastUpdate := time.Now()
+	srcNode, err := dbs.GraphDB.SourceNode(ctx)
+	switch {
+	// If we have a source node persisted in the DB already, then we just
+	// need to make sure that the new LastUpdate time is at least one
+	// second after the last update time.
+	case err == nil:
+		if srcNode.LastUpdate.Second() >= nodeLastUpdate.Second() {
+			nodeLastUpdate = srcNode.LastUpdate.Add(time.Second)
+		}
+
+	// If we don't have a source node persisted in the DB, then we'll
+	// create a new one with the current time as the LastUpdate.
+	case errors.Is(err, graphdb.ErrSourceNodeNotSet):
+
+	// If the above cases are not matched, then we have an unhandled non
+	// nil error.
+	default:
+		return nil, fmt.Errorf("unable to fetch source node: %w", err)
+	}
+
 	selfNode := &models.LightningNode{
 		HaveNodeAnnouncement: true,
-		LastUpdate:           time.Now(),
+		LastUpdate:           nodeLastUpdate,
 		Addresses:            selfAddrs,
 		Alias:                nodeAlias.String(),
 		Features:             s.featureMgr.Get(feature.SetNodeAnn),


### PR DESCRIPTION
On startup, we currently blindly overwrite our node announcement info for our source node. This includes overwriting the existing LastUpdate timestamp. This can cause an issue with our new SQL backends in the case that the new timestamp is not greater than the previously written timestamp. So here, we first fetch the source node and make sure to use a timestamp that is greater than the previosly set one.

Fixes https://github.com/lightningnetwork/lnd/issues/9999