### PR TITLE
graph/db: let FetchChannelEdgesByID behave as promised

### DIFF
--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -451,8 +451,14 @@ func TestEdgeInsertionDeletion(t *testing.T) {
 	// properly deleted.
 	_, _, _, err = graph.FetchChannelEdgesByOutpoint(&outpoint)
 	require.ErrorIs(t, err, ErrEdgeNotFound)
-	_, _, _, err = graph.FetchChannelEdgesByID(chanID)
+
+	// Assert that if the edge is a zombie, then FetchChannelEdgesByID
+	// still returns a populated models.ChannelEdgeInfo as its comment
+	// description promises.
+	edge, _, _, err := graph.FetchChannelEdgesByID(chanID)
 	require.ErrorIs(t, err, ErrZombieEdge)
+	require.NotNil(t, edge)
+
 	isZombie, _, _, err := graph.IsZombieEdge(chanID)
 	require.NoError(t, err)
 	require.True(t, isZombie)


### PR DESCRIPTION
The comment of FetchChannelEdgesByID says that if the ErrZombieEdge error is returned, then the ChannelEdgeInfo return parameter will also still be populated and returned (ie, wont be nil). This commit updates the SQLStore implementation of FetchChannelEdgesByID to do this. This is needed to prevent nil dereference panics at any call-sites that depend on the method working as it describes.

fixes https://github.com/lightningnetwork/lnd/issues/10005
