### PR TITLE
discovery: fix log line panic

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -2236,7 +2236,7 @@ func (d *AuthenticatedGossiper) isMsgStale(_ context.Context,
 		}
 		if err != nil {
 			log.Debugf("Unable to retrieve channel=%v from graph: "+
-				"%v", chanInfo.ChannelID, err)
+				"%v", msg.ShortChannelID, err)
 			return false
 		}
 


### PR DESCRIPTION
If a method returns an error, we should assume all other parameters to be nil unless the documentation explicitly says otherwise. So here, we fix a log line where a dereference is made to an object that will be nil due to an error being returned.

Panic seen in [this build](https://github.com/lightningnetwork/lnd/actions/runs/15973895448/job/45051241495?pr=10007).