### PR TITLE
cmd/wtclient: add usage info for session and terminate commands

### DIFF
--- a/cmd/commands/wtclient.go
+++ b/cmd/commands/wtclient.go
@@ -376,7 +376,8 @@ func policy(ctx *cli.Context) error {
 }
 
 var sessionCommands = cli.Command{
-	Name: "session",
+	Name:  "session",
+	Usage: "Interact with watchtower client sessions.",
 	Subcommands: []cli.Command{
 		terminateSessionCommand,
 	},
@@ -384,6 +385,7 @@ var sessionCommands = cli.Command{
 
 var terminateSessionCommand = cli.Command{
 	Name:      "terminate",
+	Usage:     "Terminate a watchtower client session.",
 	ArgsUsage: "id",
 	Action:    actionDecorator(terminateSession),
 }


### PR DESCRIPTION
## Change Description
Just add the usage info to the terminal and session commands inside the wtclient. Solves https://github.com/lightningnetwork/lnd/issues/9583.

## Steps to Test
```
$ make
$ ./lncli-debug wtclient -h
...
   session     Interact with watchtower client sessions.
...

$ ./lncli-debug wtclient session -h
...
   terminate  Terminate a watchtower client session.
...

$ ./lncli-debug wtclient session terminate -h
NAME:
   lncli wtclient session terminate - Terminate a watchtower client session.

USAGE:
   lncli wtclient session terminate id

```

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
