### PR TITLE
Refactor link's long methods

### DIFF
--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -109,6 +109,9 @@ circuit. The indices are only available for forwarding events saved after v0.20.
 for payments. Now the payment address is mandatory for the writer and
 reader of a payment request.
 
+- [Refactored](https://github.com/lightningnetwork/lnd/pull/10018) `channelLink`
+  to improve readability and maintainability of the code.
+
 ## Breaking Changes
 ## Performance Improvements
 

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1961,106 +1961,11 @@ func (l *channelLink) handleUpstreamMsg(ctx context.Context,
 		}
 
 	case *lnwire.RevokeAndAck:
-		// We've received a revocation from the remote chain, if valid,
-		// this moves the remote chain forward, and expands our
-		// revocation window.
-
-		// We now process the message and advance our remote commit
-		// chain.
-		fwdPkg, remoteHTLCs, err := l.channel.ReceiveRevocation(msg)
+		err := l.processRemoteRevokeAndAck(ctx, msg)
 		if err != nil {
-			// TODO(halseth): force close?
-			l.failf(
-				LinkFailureError{
-					code:          ErrInvalidRevocation,
-					FailureAction: LinkFailureDisconnect,
-				},
-				"unable to accept revocation: %v", err,
-			)
+			l.log.Errorf("failed to process remote revoke: %v", err)
 			return
 		}
-
-		// The remote party now has a new primary commitment, so we'll
-		// update the contract court to be aware of this new set (the
-		// prior old remote pending).
-		newUpdate := &contractcourt.ContractUpdate{
-			HtlcKey: contractcourt.RemoteHtlcSet,
-			Htlcs:   remoteHTLCs,
-		}
-		err = l.cfg.NotifyContractUpdate(newUpdate)
-		if err != nil {
-			l.log.Errorf("unable to notify contract update: %v",
-				err)
-			return
-		}
-
-		select {
-		case <-l.cg.Done():
-			return
-		default:
-		}
-
-		// If we have a tower client for this channel type, we'll
-		// create a backup for the current state.
-		if l.cfg.TowerClient != nil {
-			state := l.channel.State()
-			chanID := l.ChanID()
-
-			err = l.cfg.TowerClient.BackupState(
-				&chanID, state.RemoteCommitment.CommitHeight-1,
-			)
-			if err != nil {
-				l.failf(LinkFailureError{
-					code: ErrInternalError,
-				}, "unable to queue breach backup: %v", err)
-				return
-			}
-		}
-
-		// If we can send updates then we can process adds in case we
-		// are the exit hop and need to send back resolutions, or in
-		// case there are validity issues with the packets. Otherwise
-		// we defer the action until resume.
-		//
-		// We are free to process the settles and fails without this
-		// check since processing those can't result in further updates
-		// to this channel link.
-		if l.quiescer.CanSendUpdates() {
-			l.processRemoteAdds(fwdPkg)
-		} else {
-			l.quiescer.OnResume(func() {
-				l.processRemoteAdds(fwdPkg)
-			})
-		}
-		l.processRemoteSettleFails(fwdPkg)
-
-		// If the link failed during processing the adds, we must
-		// return to ensure we won't attempted to update the state
-		// further.
-		if l.failed {
-			return
-		}
-
-		// The revocation window opened up. If there are pending local
-		// updates, try to update the commit tx. Pending updates could
-		// already have been present because of a previously failed
-		// update to the commit tx or freshly added in by
-		// processRemoteAdds. Also in case there are no local updates,
-		// but there are still remote updates that are not in the remote
-		// commit tx yet, send out an update.
-		if l.channel.OweCommitment() {
-			if !l.updateCommitTxOrFail(ctx) {
-				return
-			}
-		}
-
-		// Now that we have finished processing the RevokeAndAck, we
-		// can invoke the flushHooks if the channel state is clean.
-		l.RWMutex.Lock()
-		if l.channel.IsChannelClean() {
-			l.flushHooks.invoke()
-		}
-		l.RWMutex.Unlock()
 
 	case *lnwire.UpdateFee:
 		// Check and see if their proposed fee-rate would make us
@@ -4693,6 +4598,111 @@ func (l *channelLink) processRemoteCommitSig(ctx context.Context,
 	// Now that we have finished processing the incoming CommitSig and sent
 	// out our RevokeAndAck, we invoke the flushHooks if the channel state
 	// is clean.
+	l.RWMutex.Lock()
+	if l.channel.IsChannelClean() {
+		l.flushHooks.invoke()
+	}
+	l.RWMutex.Unlock()
+
+	return nil
+}
+
+// processRemoteRevokeAndAck takes a `RevokeAndAck` msg sent from the remote and
+// processes it.
+func (l *channelLink) processRemoteRevokeAndAck(ctx context.Context,
+	msg *lnwire.RevokeAndAck) error {
+
+	// We've received a revocation from the remote chain, if valid, this
+	// moves the remote chain forward, and expands our revocation window.
+
+	// We now process the message and advance our remote commit chain.
+	fwdPkg, remoteHTLCs, err := l.channel.ReceiveRevocation(msg)
+	if err != nil {
+		// TODO(halseth): force close?
+		l.failf(
+			LinkFailureError{
+				code:          ErrInvalidRevocation,
+				FailureAction: LinkFailureDisconnect,
+			},
+			"unable to accept revocation: %v", err,
+		)
+
+		return err
+	}
+
+	// The remote party now has a new primary commitment, so we'll update
+	// the contract court to be aware of this new set (the prior old remote
+	// pending).
+	newUpdate := &contractcourt.ContractUpdate{
+		HtlcKey: contractcourt.RemoteHtlcSet,
+		Htlcs:   remoteHTLCs,
+	}
+	err = l.cfg.NotifyContractUpdate(newUpdate)
+	if err != nil {
+		return fmt.Errorf("unable to notify contract update: %w", err)
+	}
+
+	select {
+	case <-l.cg.Done():
+		return nil
+	default:
+	}
+
+	// If we have a tower client for this channel type, we'll create a
+	// backup for the current state.
+	if l.cfg.TowerClient != nil {
+		state := l.channel.State()
+		chanID := l.ChanID()
+
+		err = l.cfg.TowerClient.BackupState(
+			&chanID, state.RemoteCommitment.CommitHeight-1,
+		)
+		if err != nil {
+			l.failf(LinkFailureError{
+				code: ErrInternalError,
+			}, "unable to queue breach backup: %v", err)
+
+			return err
+		}
+	}
+
+	// If we can send updates then we can process adds in case we are the
+	// exit hop and need to send back resolutions, or in case there are
+	// validity issues with the packets. Otherwise we defer the action until
+	// resume.
+	//
+	// We are free to process the settles and fails without this check since
+	// processing those can't result in further updates to this channel
+	// link.
+	if l.quiescer.CanSendUpdates() {
+		l.processRemoteAdds(fwdPkg)
+	} else {
+		l.quiescer.OnResume(func() {
+			l.processRemoteAdds(fwdPkg)
+		})
+	}
+	l.processRemoteSettleFails(fwdPkg)
+
+	// If the link failed during processing the adds, we must return to
+	// ensure we won't attempted to update the state further.
+	if l.failed {
+		return nil
+	}
+
+	// The revocation window opened up. If there are pending local updates,
+	// try to update the commit tx. Pending updates could already have been
+	// present because of a previously failed update to the commit tx or
+	// freshly added in by processRemoteAdds. Also in case there are no
+	// local updates, but there are still remote updates that are not in the
+	// remote commit tx yet, send out an update.
+	if l.channel.OweCommitment() {
+		if !l.updateCommitTxOrFail(ctx) {
+			return nil
+		}
+	}
+
+	// Now that we have finished processing the RevokeAndAck, we can invoke
+	// the flushHooks if the channel state is clean.
 	l.RWMutex.Lock()
 	if l.channel.IsChannelClean() {
 		l.flushHooks.invoke()

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1307,13 +1307,6 @@ func (l *channelLink) htlcManager(ctx context.Context) {
 	// allow the switch to forward HTLCs in the outbound direction.
 	l.markReestablished()
 
-	// Now that we've received both channel_ready and channel reestablish,
-	// we can go ahead and send the active channel notification. We'll also
-	// defer the inactive notification for when the link exits to ensure
-	// that every active notification is matched by an inactive one.
-	l.cfg.NotifyActiveChannel(l.ChannelPoint())
-	defer l.cfg.NotifyInactiveChannel(l.ChannelPoint())
-
 	// With the channel states synced, we now reset the mailbox to ensure
 	// we start processing all unacked packets in order. This is done here
 	// to ensure that all acknowledgments that occur during channel
@@ -1354,6 +1347,13 @@ func (l *channelLink) htlcManager(ctx context.Context) {
 		l.cg.WgAdd(1)
 		go l.fwdPkgGarbager()
 	}
+
+	// Now that we've received both channel_ready and channel reestablish,
+	// we can go ahead and send the active channel notification. We'll also
+	// defer the inactive notification for when the link exits to ensure
+	// that every active notification is matched by an inactive one.
+	l.cfg.NotifyActiveChannel(l.ChannelPoint())
+	defer l.cfg.NotifyInactiveChannel(l.ChannelPoint())
 
 	for {
 		// We must always check if we failed at some point processing

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1916,66 +1916,32 @@ func (l *channelLink) handleUpstreamMsg(ctx context.Context,
 		return
 	}
 
+	var err error
+
 	switch msg := msg.(type) {
 	case *lnwire.UpdateAddHTLC:
-		err := l.processRemoteUpdateAddHTLC(msg)
-		if err != nil {
-			l.log.Errorf("failed to process remote ADD: %v", err)
-			return
-		}
+		err = l.processRemoteUpdateAddHTLC(msg)
 
 	case *lnwire.UpdateFulfillHTLC:
-		err := l.processRemoteUpdateFulfillHTLC(msg)
-		if err != nil {
-			l.log.Errorf("failed to process remote fulfill: %v",
-				err)
-
-			return
-		}
+		err = l.processRemoteUpdateFulfillHTLC(msg)
 
 	case *lnwire.UpdateFailMalformedHTLC:
-		err := l.processRemoteUpdateFailMalformedHTLC(msg)
-		if err != nil {
-			l.log.Errorf("failed to process remote fail "+
-				"malformed: %v", err)
-
-			return
-		}
+		err = l.processRemoteUpdateFailMalformedHTLC(msg)
 
 	case *lnwire.UpdateFailHTLC:
-		err := l.processRemoteUpdateFailHTLC(msg)
-		if err != nil {
-			l.log.Errorf("failed to process remote fail: %v", err)
-			return
-		}
+		err = l.processRemoteUpdateFailHTLC(msg)
 
 	case *lnwire.CommitSig:
-		err := l.processRemoteCommitSig(ctx, msg)
-		if err != nil {
-			l.log.Errorf("failed to process remote commit sig: %v",
-				err)
-
-			return
-		}
+		err = l.processRemoteCommitSig(ctx, msg)
 
 	case *lnwire.RevokeAndAck:
-		err := l.processRemoteRevokeAndAck(ctx, msg)
-		if err != nil {
-			l.log.Errorf("failed to process remote revoke: %v", err)
-			return
-		}
+		err = l.processRemoteRevokeAndAck(ctx, msg)
 
 	case *lnwire.UpdateFee:
-		err := l.processRemoteUpdateFee(msg)
-		if err != nil {
-			l.log.Errorf("failed to process remote update fee: %v",
-				err)
-
-			return
-		}
+		err = l.processRemoteUpdateFee(msg)
 
 	case *lnwire.Stfu:
-		err := l.handleStfu(msg)
+		err = l.handleStfu(msg)
 		if err != nil {
 			l.stfuFailf("handleStfu: %v", err.Error())
 		}
@@ -1992,6 +1958,11 @@ func (l *channelLink) handleUpstreamMsg(ctx context.Context,
 
 	default:
 		l.log.Warnf("received unknown message of type %T", msg)
+	}
+
+	if err != nil {
+		l.log.Errorf("failed to process remote %v: %v", msg.MsgType(),
+			err)
 	}
 }
 

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1252,8 +1252,6 @@ func (l *channelLink) handleChanSyncErr(err error) {
 // and also the htlc trickle queue+timer for this active channels.
 //
 // NOTE: This MUST be run as a goroutine.
-//
-//nolint:funlen
 func (l *channelLink) htlcManager(ctx context.Context) {
 	defer func() {
 		l.cfg.BatchTicker.Stop()
@@ -1269,8 +1267,6 @@ func (l *channelLink) htlcManager(ctx context.Context) {
 	// matched by an inactive one.
 	l.cfg.NotifyActiveLink(l.ChannelPoint())
 	defer l.cfg.NotifyInactiveLinkEvent(l.ChannelPoint())
-
-	// TODO(roasbeef): need to call wipe chan whenever D/C?
 
 	// If the link is not started for the first time, we need to take extra
 	// steps to resume its state.

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -36,10 +36,6 @@ import (
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
-func init() {
-	prand.Seed(time.Now().UnixNano())
-}
-
 const (
 	// DefaultMaxOutgoingCltvExpiry is the maximum outgoing time lock that
 	// the node accepts for forwarded payments. The value is relative to the

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -3918,7 +3918,10 @@ func (l *channelLink) resumeLink(ctx context.Context) error {
 	// ensure that all acknowledgments that occur during channel
 	// resynchronization have taken affect, causing us only to pull unacked
 	// packets after starting to read from the downstream mailbox.
-	l.mailBox.ResetPackets()
+	err := l.mailBox.ResetPackets()
+	if err != nil {
+		l.log.Errorf("failed to reset packets: %v", err)
+	}
 
 	// If the channel is pending, there's no need to reforwarding packets.
 	if l.ShortChanID() == hop.Source {
@@ -3931,7 +3934,7 @@ func (l *channelLink) resumeLink(ctx context.Context) error {
 	// only attempt to resolve packages if our short chan id indicates that
 	// the channel is not pending, otherwise we should have no htlcs to
 	// reforward.
-	err := l.resolveFwdPkgs(ctx)
+	err = l.resolveFwdPkgs(ctx)
 	switch err {
 	// No error was encountered, success.
 	case nil:
@@ -4316,7 +4319,10 @@ func (l *channelLink) processRemoteCommitSig(ctx context.Context,
 	l.incomingCommitHooks.invoke()
 	l.RWMutex.Unlock()
 
-	l.cfg.Peer.SendMessage(false, nextRevocation)
+	err = l.cfg.Peer.SendMessage(false, nextRevocation)
+	if err != nil {
+		l.log.Errorf("failed to send RevokeAndAck: %v", err)
+	}
 
 	// Notify the incoming htlcs of which the resolutions were locked in.
 	for id, settled := range finalHTLCs {
@@ -4601,7 +4607,10 @@ func (l *channelLink) processLocalUpdateFulfillHTLC(ctx context.Context,
 
 	// Then we send the HTLC settle message to the connected peer so we can
 	// continue the propagation of the settle message.
-	l.cfg.Peer.SendMessage(false, htlc)
+	err = l.cfg.Peer.SendMessage(false, htlc)
+	if err != nil {
+		l.log.Errorf("failed to send UpdateFulfillHTLC: %v", err)
+	}
 
 	// Send a settle event notification to htlcNotifier.
 	l.cfg.HtlcNotifier.NotifySettleEvent(


### PR DESCRIPTION
This PR is mostly about moving code into their dedicated methods so it's easier to observe the overall flow in the link, which prepares the following dynamic commitment PRs.