### PR TITLE
Fix `ExtraData` field and use `BigSize` encodine

### DIFF
--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -29,6 +29,10 @@
 - Fixed [shutdown deadlock](https://github.com/lightningnetwork/lnd/pull/10042)
   when we fail starting up LND before we startup the chanbackup sub-server.
 
+- [Fixed](https://github.com/lightningnetwork/lnd/pull/10027) an issue where
+  known TLV fields were incorrectly encoded into the `ExtraData` field of
+  messages in the dynamic commitment set.
+
 # New Features
 
 ## Functional Enhancements

--- a/lnwire/dyn_ack_test.go
+++ b/lnwire/dyn_ack_test.go
@@ -1,0 +1,84 @@
+package lnwire
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnutils"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDynAckEncodeDecode checks that the Encode and Decode methods for DynAck
+// work as expected.
+func TestDynAckEncodeDecode(t *testing.T) {
+	t.Parallel()
+
+	// Generate random channel ID.
+	chanIDBytes, err := generateRandomBytes(32)
+	require.NoError(t, err)
+
+	var chanID ChannelID
+	copy(chanID[:], chanIDBytes)
+
+	// Generate random sig.
+	sigBytes, err := generateRandomBytes(64)
+	require.NoError(t, err)
+
+	var sig Sig
+	copy(sig.bytes[:], sigBytes)
+
+	// Create test data for the TLVs. The actual value doesn't matter, as we
+	// only care about that the raw bytes can be decoded into a msg, and the
+	// msg can be encoded into the exact same raw bytes.
+	testTlvData := []byte{
+		// ExtraData - unknown tlv record.
+		//
+		// NOTE: This record is optional and occupies the type 1.
+		0x1,        // type.
+		0x2,        // length.
+		0x79, 0x79, // value.
+
+		// LocalNonce tlv.
+		0x14,                               // type.
+		0x42,                               // length.
+		0x2c, 0xd4, 0x53, 0x7d, 0xaa, 0x7b, // value.
+		0x7e, 0xae, 0x18, 0x32, 0xa6, 0xc4, 0x29, 0xe9, 0xe0, 0x91,
+		0x32, 0x7a, 0xaf, 0xd1, 0x1c, 0x2b, 0x04, 0xa0, 0x4d, 0xb5,
+		0x6a, 0x6f, 0x8b, 0x6c, 0xdc, 0xd1, 0x80, 0x2d, 0xff, 0x72,
+		0xd8, 0x3c, 0xfc, 0x01, 0x6e, 0x7c, 0x1a, 0xc8, 0x5e, 0x3a,
+		0x16, 0x98, 0xbc, 0x9b, 0x6e, 0x22, 0x58, 0x96, 0x96, 0xad,
+		0x88, 0xbf, 0xff, 0x59, 0x90, 0xbd, 0x36, 0x0b, 0x0b, 0x4d,
+
+		// ExtraData - unknown tlv.
+		0x6f,       // type.
+		0x2,        // length.
+		0x79, 0x79, // value.
+	}
+
+	msg := &DynAck{}
+
+	// Pre-allocate a new slice with enough capacity for all three parts for
+	// efficiency.
+	totalLen := len(chanIDBytes) + len(sigBytes) + len(testTlvData)
+	rawBytes := make([]byte, 0, totalLen)
+
+	// Append each slice to the new rawBytes slice.
+	rawBytes = append(rawBytes, chanIDBytes...)
+	rawBytes = append(rawBytes, sigBytes...)
+	rawBytes = append(rawBytes, testTlvData...)
+
+	// Decode the raw bytes.
+	r := bytes.NewBuffer(rawBytes)
+	err = msg.Decode(r, 0)
+	require.NoError(t, err)
+
+	t.Logf("Encoded msg is %v", lnutils.SpewLogClosure(msg))
+
+	// Encode the msg into raw bytes and assert the encoded bytes equal to
+	// the rawBytes.
+	w := new(bytes.Buffer)
+	err = msg.Encode(w, 0)
+	require.NoError(t, err)
+
+	require.Equal(t, rawBytes, w.Bytes())
+}

--- a/lnwire/dyn_commit.go
+++ b/lnwire/dyn_commit.go
@@ -110,24 +110,16 @@ func (dc *DynCommit) Decode(r io.Reader, _ uint32) error {
 	// Check the results of the TLV Stream decoding and appropriately set
 	// message fields.
 	if _, ok := knownRecords[dc.DustLimit.TlvType()]; ok {
-		var rec tlv.RecordT[tlv.TlvType0, tlv.BigSizeT[btcutil.Amount]]
-		rec.Val = dustLimit.Val
-		dc.DustLimit = tlv.SomeRecordT(rec)
+		dc.DustLimit = tlv.SomeRecordT(dustLimit)
 	}
 	if _, ok := knownRecords[dc.MaxValueInFlight.TlvType()]; ok {
-		var rec tlv.RecordT[tlv.TlvType2, MilliSatoshi]
-		rec.Val = maxValue.Val
-		dc.MaxValueInFlight = tlv.SomeRecordT(rec)
+		dc.MaxValueInFlight = tlv.SomeRecordT(maxValue)
 	}
 	if _, ok := knownRecords[dc.HtlcMinimum.TlvType()]; ok {
-		var rec tlv.RecordT[tlv.TlvType4, MilliSatoshi]
-		rec.Val = htlcMin.Val
-		dc.HtlcMinimum = tlv.SomeRecordT(rec)
+		dc.HtlcMinimum = tlv.SomeRecordT(htlcMin)
 	}
 	if _, ok := knownRecords[dc.ChannelReserve.TlvType()]; ok {
-		var rec tlv.RecordT[tlv.TlvType6, tlv.BigSizeT[btcutil.Amount]]
-		rec.Val = reserve.Val
-		dc.ChannelReserve = tlv.SomeRecordT(rec)
+		dc.ChannelReserve = tlv.SomeRecordT(reserve)
 	}
 	if _, ok := knownRecords[dc.CsvDelay.TlvType()]; ok {
 		dc.CsvDelay = tlv.SomeRecordT(csvDelay)

--- a/lnwire/dyn_commit.go
+++ b/lnwire/dyn_commit.go
@@ -75,10 +75,10 @@ func (dc *DynCommit) Decode(r io.Reader, _ uint32) error {
 	}
 
 	// Prepare receiving buffers to be filled by TLV extraction.
-	var dustLimit tlv.RecordT[tlv.TlvType0, uint64]
+	var dustLimit tlv.RecordT[tlv.TlvType0, tlv.BigSizeT[btcutil.Amount]]
 	var maxValue tlv.RecordT[tlv.TlvType2, uint64]
 	var htlcMin tlv.RecordT[tlv.TlvType4, uint64]
-	var reserve tlv.RecordT[tlv.TlvType6, uint64]
+	var reserve tlv.RecordT[tlv.TlvType6, tlv.BigSizeT[btcutil.Amount]]
 	csvDelay := dc.CsvDelay.Zero()
 	maxHtlcs := dc.MaxAcceptedHTLCs.Zero()
 	chanType := dc.ChannelType.Zero()
@@ -94,8 +94,8 @@ func (dc *DynCommit) Decode(r io.Reader, _ uint32) error {
 	// Check the results of the TLV Stream decoding and appropriately set
 	// message fields.
 	if val, ok := typeMap[dc.DustLimit.TlvType()]; ok && val == nil {
-		var rec tlv.RecordT[tlv.TlvType0, btcutil.Amount]
-		rec.Val = btcutil.Amount(dustLimit.Val)
+		var rec tlv.RecordT[tlv.TlvType0, tlv.BigSizeT[btcutil.Amount]]
+		rec.Val = dustLimit.Val
 		dc.DustLimit = tlv.SomeRecordT(rec)
 	}
 	if val, ok := typeMap[dc.MaxValueInFlight.TlvType()]; ok && val == nil {
@@ -109,8 +109,8 @@ func (dc *DynCommit) Decode(r io.Reader, _ uint32) error {
 		dc.HtlcMinimum = tlv.SomeRecordT(rec)
 	}
 	if val, ok := typeMap[dc.ChannelReserve.TlvType()]; ok && val == nil {
-		var rec tlv.RecordT[tlv.TlvType6, btcutil.Amount]
-		rec.Val = btcutil.Amount(reserve.Val)
+		var rec tlv.RecordT[tlv.TlvType6, tlv.BigSizeT[btcutil.Amount]]
+		rec.Val = reserve.Val
 		dc.ChannelReserve = tlv.SomeRecordT(rec)
 	}
 	if val, ok := typeMap[dc.CsvDelay.TlvType()]; ok && val == nil {

--- a/lnwire/dyn_commit.go
+++ b/lnwire/dyn_commit.go
@@ -76,8 +76,8 @@ func (dc *DynCommit) Decode(r io.Reader, _ uint32) error {
 
 	// Prepare receiving buffers to be filled by TLV extraction.
 	var dustLimit tlv.RecordT[tlv.TlvType0, tlv.BigSizeT[btcutil.Amount]]
-	var maxValue tlv.RecordT[tlv.TlvType2, uint64]
-	var htlcMin tlv.RecordT[tlv.TlvType4, uint64]
+	var maxValue tlv.RecordT[tlv.TlvType2, MilliSatoshi]
+	var htlcMin tlv.RecordT[tlv.TlvType4, MilliSatoshi]
 	var reserve tlv.RecordT[tlv.TlvType6, tlv.BigSizeT[btcutil.Amount]]
 	csvDelay := dc.CsvDelay.Zero()
 	maxHtlcs := dc.MaxAcceptedHTLCs.Zero()
@@ -100,12 +100,12 @@ func (dc *DynCommit) Decode(r io.Reader, _ uint32) error {
 	}
 	if val, ok := typeMap[dc.MaxValueInFlight.TlvType()]; ok && val == nil {
 		var rec tlv.RecordT[tlv.TlvType2, MilliSatoshi]
-		rec.Val = MilliSatoshi(maxValue.Val)
+		rec.Val = maxValue.Val
 		dc.MaxValueInFlight = tlv.SomeRecordT(rec)
 	}
 	if val, ok := typeMap[dc.HtlcMinimum.TlvType()]; ok && val == nil {
 		var rec tlv.RecordT[tlv.TlvType4, MilliSatoshi]
-		rec.Val = MilliSatoshi(htlcMin.Val)
+		rec.Val = htlcMin.Val
 		dc.HtlcMinimum = tlv.SomeRecordT(rec)
 	}
 	if val, ok := typeMap[dc.ChannelReserve.TlvType()]; ok && val == nil {

--- a/lnwire/dyn_commit_test.go
+++ b/lnwire/dyn_commit_test.go
@@ -1,0 +1,116 @@
+package lnwire
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnutils"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDynCommitEncodeDecode checks that the Encode and Decode methods for
+// DynCommit work as expected.
+func TestDynCommitEncodeDecode(t *testing.T) {
+	t.Parallel()
+
+	// Generate random channel ID.
+	chanIDBytes, err := generateRandomBytes(32)
+	require.NoError(t, err)
+
+	var chanID ChannelID
+	copy(chanID[:], chanIDBytes)
+
+	// Generate random sig.
+	sigBytes, err := generateRandomBytes(64)
+	require.NoError(t, err)
+
+	var sig Sig
+	copy(sig.bytes[:], sigBytes)
+
+	// Create test data for the TLVs. The actual value doesn't matter, as we
+	// only care about that the raw bytes can be decoded into a msg, and the
+	// msg can be encoded into the exact same raw bytes.
+	testTlvData := []byte{
+		// DustLimit tlv.
+		0x0,                        // type.
+		0x5,                        // length.
+		0xfe, 0x0, 0xf, 0x42, 0x40, // value (BigSize: 1_000_000).
+
+		// ExtraData - unknown tlv record.
+		//
+		// NOTE: This record is optional and occupies the type 1.
+		0x1,        // type.
+		0x2,        // length.
+		0x79, 0x79, // value.
+
+		// MaxValueInFlight tlv.
+		0x2,                        // type.
+		0x5,                        // length.
+		0xfe, 0x0, 0xf, 0x42, 0x40, // value (BigSize: 1_000_000).
+
+		// HtlcMinimum tlv.
+		0x4,                        // type.
+		0x5,                        // length.
+		0xfe, 0x0, 0xf, 0x42, 0x40, // value (BigSize: 1_000_000).
+		//
+		// ChannelReserve tlv.
+		0x6,                        // type.
+		0x5,                        // length.
+		0xfe, 0x0, 0xf, 0x42, 0x40, // value (BigSize: 1_000_000).
+
+		// CsvDelay tlv.
+		0x8,      // type.
+		0x2,      // length.
+		0x0, 0x8, // value.
+
+		// MaxAcceptedHTLCs tlv.
+		0xa,      // type.
+		0x2,      // length.
+		0x0, 0x8, // value.
+
+		// ChannelType tlv is empty.
+		//
+		// LocalNonce tlv.
+		0x14,                               // type.
+		0x42,                               // length.
+		0x2c, 0xd4, 0x53, 0x7d, 0xaa, 0x7b, // value.
+		0x7e, 0xae, 0x18, 0x32, 0xa6, 0xc4, 0x29, 0xe9, 0xe0, 0x91,
+		0x32, 0x7a, 0xaf, 0xd1, 0x1c, 0x2b, 0x04, 0xa0, 0x4d, 0xb5,
+		0x6a, 0x6f, 0x8b, 0x6c, 0xdc, 0xd1, 0x80, 0x2d, 0xff, 0x72,
+		0xd8, 0x3c, 0xfc, 0x01, 0x6e, 0x7c, 0x1a, 0xc8, 0x5e, 0x3a,
+		0x16, 0x98, 0xbc, 0x9b, 0x6e, 0x22, 0x58, 0x96, 0x96, 0xad,
+		0x88, 0xbf, 0xff, 0x59, 0x90, 0xbd, 0x36, 0x0b, 0x0b, 0x4d,
+
+		// ExtraData - unknown tlv record.
+		0x6f,       // type.
+		0x2,        // length.
+		0x79, 0x79, // value.
+	}
+
+	msg := &DynCommit{}
+
+	// Pre-allocate a new slice with enough capacity for all three parts for
+	// efficiency.
+	totalLen := len(chanIDBytes) + len(sigBytes) + len(testTlvData)
+	rawBytes := make([]byte, 0, totalLen)
+
+	// Append each slice to the new rawBytes slice.
+	rawBytes = append(rawBytes, chanIDBytes...)
+	rawBytes = append(rawBytes, sigBytes...)
+	rawBytes = append(rawBytes, testTlvData...)
+
+	// Decode the raw bytes.
+	r := bytes.NewBuffer(rawBytes)
+	err = msg.Decode(r, 0)
+	require.NoError(t, err)
+
+	t.Logf("Encoded msg is %v", lnutils.SpewLogClosure(msg))
+
+	// Encode the msg into raw bytes and assert the encoded bytes equal to
+	// the rawBytes.
+	w := new(bytes.Buffer)
+	err = msg.Encode(w, 0)
+	require.NoError(t, err)
+
+	require.Equal(t, rawBytes, w.Bytes())
+}

--- a/lnwire/dyn_propose.go
+++ b/lnwire/dyn_propose.go
@@ -130,27 +130,19 @@ func (dp *DynPropose) Decode(r io.Reader, _ uint32) error {
 	// Check the results of the TLV Stream decoding and appropriately set
 	// message fields.
 	if _, ok := knownRecords[dp.DustLimit.TlvType()]; ok {
-		var rec tlv.RecordT[tlv.TlvType0, tlv.BigSizeT[btcutil.Amount]]
-		rec.Val = dustLimit.Val
-		dp.DustLimit = tlv.SomeRecordT(rec)
+		dp.DustLimit = tlv.SomeRecordT(dustLimit)
 	}
 
 	if _, ok := knownRecords[dp.MaxValueInFlight.TlvType()]; ok {
-		var rec tlv.RecordT[tlv.TlvType2, MilliSatoshi]
-		rec.Val = maxValue.Val
-		dp.MaxValueInFlight = tlv.SomeRecordT(rec)
+		dp.MaxValueInFlight = tlv.SomeRecordT(maxValue)
 	}
 
 	if _, ok := knownRecords[dp.HtlcMinimum.TlvType()]; ok {
-		var rec tlv.RecordT[tlv.TlvType4, MilliSatoshi]
-		rec.Val = htlcMin.Val
-		dp.HtlcMinimum = tlv.SomeRecordT(rec)
+		dp.HtlcMinimum = tlv.SomeRecordT(htlcMin)
 	}
 
 	if _, ok := knownRecords[dp.ChannelReserve.TlvType()]; ok {
-		var rec tlv.RecordT[tlv.TlvType6, tlv.BigSizeT[btcutil.Amount]]
-		rec.Val = reserve.Val
-		dp.ChannelReserve = tlv.SomeRecordT(rec)
+		dp.ChannelReserve = tlv.SomeRecordT(reserve)
 	}
 
 	if _, ok := knownRecords[dp.CsvDelay.TlvType()]; ok {

--- a/lnwire/dyn_propose.go
+++ b/lnwire/dyn_propose.go
@@ -17,7 +17,9 @@ type DynPropose struct {
 
 	// DustLimit, if not nil, proposes a change to the dust_limit_satoshis
 	// for the sender's commitment transaction.
-	DustLimit tlv.OptionalRecordT[tlv.TlvType0, btcutil.Amount]
+	DustLimit tlv.OptionalRecordT[
+		tlv.TlvType0, tlv.BigSizeT[btcutil.Amount],
+	]
 
 	// MaxValueInFlight, if not nil, proposes a change to the
 	// max_htlc_value_in_flight_msat limit of the sender.
@@ -29,7 +31,9 @@ type DynPropose struct {
 
 	// ChannelReserve, if not nil, proposes a change to the
 	// channel_reserve_satoshis requirement of the recipient.
-	ChannelReserve tlv.OptionalRecordT[tlv.TlvType6, btcutil.Amount]
+	ChannelReserve tlv.OptionalRecordT[
+		tlv.TlvType6, tlv.BigSizeT[btcutil.Amount],
+	]
 
 	// CsvDelay, if not nil, proposes a change to the to_self_delay
 	// requirement of the recipient.
@@ -98,10 +102,10 @@ func (dp *DynPropose) Decode(r io.Reader, _ uint32) error {
 	}
 
 	// Prepare receiving buffers to be filled by TLV extraction.
-	var dustLimit tlv.RecordT[tlv.TlvType0, uint64]
+	var dustLimit tlv.RecordT[tlv.TlvType0, tlv.BigSizeT[btcutil.Amount]]
 	var maxValue tlv.RecordT[tlv.TlvType2, uint64]
 	var htlcMin tlv.RecordT[tlv.TlvType4, uint64]
-	var reserve tlv.RecordT[tlv.TlvType6, uint64]
+	var reserve tlv.RecordT[tlv.TlvType6, tlv.BigSizeT[btcutil.Amount]]
 	csvDelay := dp.CsvDelay.Zero()
 	maxHtlcs := dp.MaxAcceptedHTLCs.Zero()
 	chanType := dp.ChannelType.Zero()
@@ -117,8 +121,8 @@ func (dp *DynPropose) Decode(r io.Reader, _ uint32) error {
 	// Check the results of the TLV Stream decoding and appropriately set
 	// message fields.
 	if val, ok := typeMap[dp.DustLimit.TlvType()]; ok && val == nil {
-		var rec tlv.RecordT[tlv.TlvType0, btcutil.Amount]
-		rec.Val = btcutil.Amount(dustLimit.Val)
+		var rec tlv.RecordT[tlv.TlvType0, tlv.BigSizeT[btcutil.Amount]]
+		rec.Val = dustLimit.Val
 		dp.DustLimit = tlv.SomeRecordT(rec)
 	}
 	if val, ok := typeMap[dp.MaxValueInFlight.TlvType()]; ok && val == nil {
@@ -132,8 +136,8 @@ func (dp *DynPropose) Decode(r io.Reader, _ uint32) error {
 		dp.HtlcMinimum = tlv.SomeRecordT(rec)
 	}
 	if val, ok := typeMap[dp.ChannelReserve.TlvType()]; ok && val == nil {
-		var rec tlv.RecordT[tlv.TlvType6, btcutil.Amount]
-		rec.Val = btcutil.Amount(reserve.Val)
+		var rec tlv.RecordT[tlv.TlvType6, tlv.BigSizeT[btcutil.Amount]]
+		rec.Val = reserve.Val
 		dp.ChannelReserve = tlv.SomeRecordT(rec)
 	}
 	if val, ok := typeMap[dp.CsvDelay.TlvType()]; ok && val == nil {
@@ -187,11 +191,10 @@ func dynProposeRecords(dp *DynPropose) []tlv.RecordProducer {
 	recordProducers := make([]tlv.RecordProducer, 0, 7)
 
 	dp.DustLimit.WhenSome(
-		func(dl tlv.RecordT[tlv.TlvType0, btcutil.Amount]) {
-			rec := tlv.NewPrimitiveRecord[tlv.TlvType0](
-				uint64(dl.Val),
-			)
-			recordProducers = append(recordProducers, &rec)
+		func(dl tlv.RecordT[tlv.TlvType0,
+			tlv.BigSizeT[btcutil.Amount]]) {
+
+			recordProducers = append(recordProducers, &dl)
 		},
 	)
 	dp.MaxValueInFlight.WhenSome(
@@ -211,11 +214,10 @@ func dynProposeRecords(dp *DynPropose) []tlv.RecordProducer {
 		},
 	)
 	dp.ChannelReserve.WhenSome(
-		func(reserve tlv.RecordT[tlv.TlvType6, btcutil.Amount]) {
-			rec := tlv.NewPrimitiveRecord[tlv.TlvType6](
-				uint64(reserve.Val),
-			)
-			recordProducers = append(recordProducers, &rec)
+		func(reserve tlv.RecordT[tlv.TlvType6,
+			tlv.BigSizeT[btcutil.Amount]]) {
+
+			recordProducers = append(recordProducers, &reserve)
 		},
 	)
 	dp.CsvDelay.WhenSome(

--- a/lnwire/dyn_propose.go
+++ b/lnwire/dyn_propose.go
@@ -112,8 +112,8 @@ func (dp *DynPropose) Decode(r io.Reader, _ uint32) error {
 
 	// Prepare receiving buffers to be filled by TLV extraction.
 	var dustLimit tlv.RecordT[tlv.TlvType0, tlv.BigSizeT[btcutil.Amount]]
-	var maxValue tlv.RecordT[tlv.TlvType2, uint64]
-	var htlcMin tlv.RecordT[tlv.TlvType4, uint64]
+	var maxValue tlv.RecordT[tlv.TlvType2, MilliSatoshi]
+	var htlcMin tlv.RecordT[tlv.TlvType4, MilliSatoshi]
 	var reserve tlv.RecordT[tlv.TlvType6, tlv.BigSizeT[btcutil.Amount]]
 	csvDelay := dp.CsvDelay.Zero()
 	maxHtlcs := dp.MaxAcceptedHTLCs.Zero()
@@ -137,14 +137,14 @@ func (dp *DynPropose) Decode(r io.Reader, _ uint32) error {
 	}
 	if val, ok := typeMap[dp.MaxValueInFlight.TlvType()]; ok && val == nil {
 		var rec tlv.RecordT[tlv.TlvType2, MilliSatoshi]
-		rec.Val = MilliSatoshi(maxValue.Val)
+		rec.Val = maxValue.Val
 		dp.MaxValueInFlight = tlv.SomeRecordT(rec)
 
 		delete(typeMap, dp.MaxValueInFlight.TlvType())
 	}
 	if val, ok := typeMap[dp.HtlcMinimum.TlvType()]; ok && val == nil {
 		var rec tlv.RecordT[tlv.TlvType4, MilliSatoshi]
-		rec.Val = MilliSatoshi(htlcMin.Val)
+		rec.Val = htlcMin.Val
 		dp.HtlcMinimum = tlv.SomeRecordT(rec)
 
 		delete(typeMap, dp.HtlcMinimum.TlvType())
@@ -226,18 +226,12 @@ func dynProposeRecords(dp *DynPropose) []tlv.RecordProducer {
 	)
 	dp.MaxValueInFlight.WhenSome(
 		func(mvif tlv.RecordT[tlv.TlvType2, MilliSatoshi]) {
-			rec := tlv.NewPrimitiveRecord[tlv.TlvType2](
-				uint64(mvif.Val),
-			)
-			recordProducers = append(recordProducers, &rec)
+			recordProducers = append(recordProducers, &mvif)
 		},
 	)
 	dp.HtlcMinimum.WhenSome(
 		func(hm tlv.RecordT[tlv.TlvType4, MilliSatoshi]) {
-			rec := tlv.NewPrimitiveRecord[tlv.TlvType4](
-				uint64(hm.Val),
-			)
-			recordProducers = append(recordProducers, &rec)
+			recordProducers = append(recordProducers, &hm)
 		},
 	)
 	dp.ChannelReserve.WhenSome(

--- a/lnwire/dyn_propose_test.go
+++ b/lnwire/dyn_propose_test.go
@@ -1,0 +1,86 @@
+package lnwire
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDynProposeEncodeDecode checks that the Encode and Decode methods work as
+// expected.
+func TestDynProposeEncodeDecode(t *testing.T) {
+	t.Parallel()
+
+	// Generate random channel ID.
+	chanIDBytes, err := generateRandomBytes(32)
+	require.NoError(t, err)
+
+	var chanID ChannelID
+	copy(chanID[:], chanIDBytes)
+
+	// Create test data for the TLVs. The actual value doesn't matter, as we
+	// only care about that the raw bytes can be decoded into a msg, and the
+	// msg can be encoded into the exact same raw bytes.
+	testTlvData := []byte{
+		// DustLimit tlv.
+		0x0,                        // type.
+		0x5,                        // length.
+		0xfe, 0x0, 0xf, 0x42, 0x40, // value (BigSize:  1_000_000).
+
+		// ExtraData - unknown tlv record.
+		//
+		// NOTE: This record is optional and occupies the type 1.
+		0x1,        // type.
+		0x2,        // length.
+		0x79, 0x79, // value.
+
+		// MaxValueInFlight tlv.
+		0x2,                        // type.
+		0x5,                        // length.
+		0xfe, 0x0, 0xf, 0x42, 0x40, // value (BigSize: 1_000_000).
+
+		// HtlcMinimum tlv.
+		0x4,                        // type.
+		0x5,                        // length.
+		0xfe, 0x0, 0xf, 0x42, 0x40, // value (BigSize: 1_000_000).
+		//
+		// ChannelReserve tlv.
+		0x6,                        // type.
+		0x5,                        // length.
+		0xfe, 0x0, 0xf, 0x42, 0x40, // value (BigSize: 1_000_000).
+
+		// CsvDelay tlv.
+		0x8,      // type.
+		0x2,      // length.
+		0x0, 0x8, // value.
+
+		// MaxAcceptedHTLCs tlv.
+		0xa,      // type.
+		0x2,      // length.
+		0x0, 0x8, // value.
+
+		// ChannelType tlv is empty.
+		//
+		// ExtraData - unknown tlv record.
+		0x6f,       // type.
+		0x2,        // length.
+		0x79, 0x79, // value.
+	}
+
+	msg := &DynPropose{}
+
+	rawBytes := make([]byte, 0, len(chanIDBytes)+len(testTlvData))
+	rawBytes = append(rawBytes, chanIDBytes...)
+	rawBytes = append(rawBytes, testTlvData...)
+
+	r := bytes.NewBuffer(rawBytes)
+	err = msg.Decode(r, 0)
+	require.NoError(t, err)
+
+	w := new(bytes.Buffer)
+	err = msg.Encode(w, 0)
+	require.NoError(t, err)
+
+	require.Equal(t, rawBytes, w.Bytes())
+}

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -5,10 +5,8 @@ import (
 	crand "crypto/rand"
 	"encoding/hex"
 	"math"
-	"math/rand"
 	"net"
 	"testing"
-	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
@@ -248,8 +246,4 @@ func TestLightningWireProtocol(t *testing.T) {
 			)
 		}))
 	}
-}
-
-func init() {
-	rand.Seed(time.Now().Unix())
 }

--- a/lnwire/test_message.go
+++ b/lnwire/test_message.go
@@ -881,10 +881,7 @@ func (dp *DynPropose) RandTestMessage(t *rapid.T) Message {
 		}
 	}
 
-	extraData := RandExtraOpaqueData(t, ignoreRecords)
-	if len(extraData) > 0 {
-		msg.ExtraData = extraData
-	}
+	msg.ExtraData = RandExtraOpaqueData(t, ignoreRecords)
 
 	return msg
 }

--- a/lnwire/test_message.go
+++ b/lnwire/test_message.go
@@ -796,9 +796,10 @@ func (da *DynAck) RandTestMessage(t *rapid.T) Message {
 	}
 
 	includeLocalNonce := rapid.Bool().Draw(t, "includeLocalNonce")
-
 	if includeLocalNonce {
-		msg.LocalNonce = fn.Some(RandMusig2Nonce(t))
+		nonce := RandMusig2Nonce(t)
+		rec := tlv.NewRecordT[tlv.TlvType14](nonce)
+		msg.LocalNonce = tlv.SomeRecordT(rec)
 	}
 
 	// Create a tlv type lists to hold all known records which will be

--- a/lnwire/test_message.go
+++ b/lnwire/test_message.go
@@ -792,8 +792,7 @@ var _ TestMessage = (*DynAck)(nil)
 // This is part of the TestMessage interface.
 func (da *DynAck) RandTestMessage(t *rapid.T) Message {
 	msg := &DynAck{
-		ChanID:    RandChannelID(t),
-		ExtraData: RandExtraOpaqueData(t, nil),
+		ChanID: RandChannelID(t),
 	}
 
 	includeLocalNonce := rapid.Bool().Draw(t, "includeLocalNonce")
@@ -801,6 +800,18 @@ func (da *DynAck) RandTestMessage(t *rapid.T) Message {
 	if includeLocalNonce {
 		msg.LocalNonce = fn.Some(RandMusig2Nonce(t))
 	}
+
+	// Create a tlv type lists to hold all known records which will be
+	// ignored when creating ExtraData records.
+	ignoreRecords := fn.NewSet[uint64]()
+	for i := range uint64(15) {
+		// Ignore known records.
+		if i%2 == 0 {
+			ignoreRecords.Add(i)
+		}
+	}
+
+	msg.ExtraData = RandExtraOpaqueData(t, ignoreRecords)
 
 	return msg
 }

--- a/lnwire/test_message.go
+++ b/lnwire/test_message.go
@@ -1004,11 +1004,21 @@ func (dc *DynCommit) RandTestMessage(t *rapid.T) Message {
 		dp.ChannelType = tlv.SomeRecordT(chanType)
 	}
 
+	includeLocalNonce := rapid.Bool().Draw(t, "includeLocalNonce")
+	if includeLocalNonce {
+		nonce := RandMusig2Nonce(t)
+		rec := tlv.NewRecordT[tlv.TlvType14](nonce)
+		da.LocalNonce = tlv.SomeRecordT(rec)
+	}
+
 	// Create a tlv type lists to hold all known records which will be
 	// ignored when creating ExtraData records.
 	ignoreRecords := fn.NewSet[uint64]()
-	for i := range uint64(13) {
-		ignoreRecords.Add(i)
+	for i := range uint64(15) {
+		// Ignore known records.
+		if i%2 == 0 {
+			ignoreRecords.Add(i)
+		}
 	}
 	msg := &DynCommit{
 		DynPropose: *dp,

--- a/lnwire/test_message.go
+++ b/lnwire/test_message.go
@@ -833,9 +833,9 @@ func (dp *DynPropose) RandTestMessage(t *rapid.T) Message {
 
 	// Generate random values for each included field
 	if includeDustLimit {
-		var rec tlv.RecordT[tlv.TlvType0, btcutil.Amount]
+		var rec tlv.RecordT[tlv.TlvType0, tlv.BigSizeT[btcutil.Amount]]
 		val := btcutil.Amount(rapid.Uint32().Draw(t, "dustLimit"))
-		rec.Val = val
+		rec.Val = tlv.NewBigSizeT(val)
 		msg.DustLimit = tlv.SomeRecordT(rec)
 	}
 
@@ -847,9 +847,9 @@ func (dp *DynPropose) RandTestMessage(t *rapid.T) Message {
 	}
 
 	if includeChannelReserve {
-		var rec tlv.RecordT[tlv.TlvType6, btcutil.Amount]
+		var rec tlv.RecordT[tlv.TlvType6, tlv.BigSizeT[btcutil.Amount]]
 		val := btcutil.Amount(rapid.Uint32().Draw(t, "channelReserve"))
-		rec.Val = val
+		rec.Val = tlv.NewBigSizeT(val)
 		msg.ChannelReserve = tlv.SomeRecordT(rec)
 	}
 
@@ -942,9 +942,9 @@ func (dc *DynCommit) RandTestMessage(t *rapid.T) Message {
 
 	// Generate random values for each included field
 	if includeDustLimit {
-		var rec tlv.RecordT[tlv.TlvType0, btcutil.Amount]
+		var rec tlv.RecordT[tlv.TlvType0, tlv.BigSizeT[btcutil.Amount]]
 		val := btcutil.Amount(rapid.Uint32().Draw(t, "dustLimit"))
-		rec.Val = val
+		rec.Val = tlv.NewBigSizeT(val)
 		dp.DustLimit = tlv.SomeRecordT(rec)
 	}
 
@@ -956,9 +956,9 @@ func (dc *DynCommit) RandTestMessage(t *rapid.T) Message {
 	}
 
 	if includeChannelReserve {
-		var rec tlv.RecordT[tlv.TlvType6, btcutil.Amount]
+		var rec tlv.RecordT[tlv.TlvType6, tlv.BigSizeT[btcutil.Amount]]
 		val := btcutil.Amount(rapid.Uint32().Draw(t, "channelReserve"))
-		rec.Val = val
+		rec.Val = tlv.NewBigSizeT(val)
 		dp.ChannelReserve = tlv.SomeRecordT(rec)
 	}
 

--- a/lnwire/test_message.go
+++ b/lnwire/test_message.go
@@ -1025,10 +1025,7 @@ func (dc *DynCommit) RandTestMessage(t *rapid.T) Message {
 		DynAck:     *da,
 	}
 
-	extraData := RandExtraOpaqueData(t, ignoreRecords)
-	if len(extraData) > 0 {
-		msg.ExtraData = extraData
-	}
+	msg.ExtraData = RandExtraOpaqueData(t, ignoreRecords)
 
 	return msg
 }


### PR DESCRIPTION
This PR changes the encoding from `btcutil.Amount` to `BigSize` for efficiency. It also fixes the wrong encoding used in the dyn msg set. For instance, the extra data field is meant to hold extra data, but it actually holds the full tlv data,

before this change, notice the `ExtraData` holds `LocalNonce`,
```
dyn_ack_test.go:68: Encoded msg is (*lnwire.DynAck)(0x140002beea0)({
         ChanID: (lnwire.ChannelID) (len=32 cap=32) 777b0cfd56e5b84a4bbe87f209b9eeb9218208e9a403c75e03d2981ecd91cf79,
         Sig: (lnwire.Sig) {
          bytes: ([64]uint8) (len=64 cap=64) {
           00000000  b0 54 0e e8 6d 02 d1 e6  8f d9 95 a9 9d 49 60 5d  |.T..m........I`]|
           00000010  eb 8e aa 16 4c 7d 26 47  60 10 b2 06 bd 97 8a 3e  |....L}&G`......>|
           00000020  b2 73 05 c0 be 0c 14 ed  fd 64 b4 79 a0 7e 22 15  |.s.......d.y.~".|
           00000030  96 f1 12 86 4f 2f f9 c1  ae d6 68 0d e6 29 68 26  |....O/....h..)h&|
          },
          sigType: (lnwire.sigType) 0
         },
         LocalNonce: (fn.Option[github.com/lightningnetwork/lnd/lnwire.Musig2Nonce]) {
          isSome: (bool) true,
          some: (lnwire.Musig2Nonce) (len=66 cap=66) {
           00000000  2c d4 53 7d aa 7b 7e ae  18 32 a6 c4 29 e9 e0 91  |,.S}.{~..2..)...|
           00000010  32 7a af d1 1c 2b 04 a0  4d b5 6a 6f 8b 6c dc d1  |2z...+..M.jo.l..|
           00000020  80 2d ff 72 d8 3c fc 01  6e 7c 1a c8 5e 3a 16 98  |.-.r.<..n|..^:..|
           00000030  bc 9b 6e 22 58 96 96 ad  88 bf ff 59 90 bd 36 0b  |..n"X......Y..6.|
           00000040  0b 4d                                             |.M|
          }
         },
         ExtraData: (lnwire.ExtraOpaqueData) (len=72 cap=512) {
          00000000  00 42 2c d4 53 7d aa 7b  7e ae 18 32 a6 c4 29 e9  |.B,.S}.{~..2..).|
          00000010  e0 91 32 7a af d1 1c 2b  04 a0 4d b5 6a 6f 8b 6c  |..2z...+..M.jo.l|
          00000020  dc d1 80 2d ff 72 d8 3c  fc 01 6e 7c 1a c8 5e 3a  |...-.r.<..n|..^:|
          00000030  16 98 bc 9b 6e 22 58 96  96 ad 88 bf ff 59 90 bd  |....n"X......Y..|
          00000040  36 0b 0b 4d 6f 02 79 79                           |6..Mo.yy|
         }
        })
```

after,
```
dyn_ack_test.go:68: Encoded msg is (*lnwire.DynAck)(0x1400033eea0)({
         ChanID: (lnwire.ChannelID) (len=32 cap=32) 24481a8ac033dc870a059ca802707b72222ecd6e4641578aea581f4b972dd70b,
         Sig: (lnwire.Sig) {
          bytes: ([64]uint8) (len=64 cap=64) {
           00000000  7b ab c5 37 d9 bd c1 cd  0b d9 88 ff 11 9b e1 21  |{..7...........!|
           00000010  c1 af ce b0 2c 34 e3 32  27 25 bd 0c a0 19 80 65  |....,4.2'%.....e|
           00000020  da 35 c3 37 d0 41 ff ce  13 a4 fd f2 4c d2 4c d9  |.5.7.A......L.L.|
           00000030  8b 37 57 80 38 6d e0 6a  56 9b bb c3 c4 1f e1 b7  |.7W.8m.jV.......|
          },
          sigType: (lnwire.sigType) 0
         },
         LocalNonce: (fn.Option[github.com/lightningnetwork/lnd/lnwire.Musig2Nonce]) {
          isSome: (bool) true,
          some: (lnwire.Musig2Nonce) (len=66 cap=66) {
           00000000  2c d4 53 7d aa 7b 7e ae  18 32 a6 c4 29 e9 e0 91  |,.S}.{~..2..)...|
           00000010  32 7a af d1 1c 2b 04 a0  4d b5 6a 6f 8b 6c dc d1  |2z...+..M.jo.l..|
           00000020  80 2d ff 72 d8 3c fc 01  6e 7c 1a c8 5e 3a 16 98  |.-.r.<..n|..^:..|
           00000030  bc 9b 6e 22 58 96 96 ad  88 bf ff 59 90 bd 36 0b  |..n"X......Y..6.|
           00000040  0b 4d                                             |.M|
          }
         },
         ExtraData: (lnwire.ExtraOpaqueData) (len=4 cap=64) {
          00000000  6f 02 79 79                                       |o.yy|
         }
        })
```

I think we may have other places use the wrong encoding, will check.