### PR TITLE
Allow zero amount paths with MinHTLC policies

### DIFF
--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -25,6 +25,8 @@
   https://github.com/lightningnetwork/lnd/pull/9815). This ensures the original
   announcement remains unchanged until the new one is fully signed and
   validated.
+- [Fixed creation of invoices with zero amount and blinded paths](
+  https://github.com/lightningnetwork/lnd/pull/10029).
 
 # New Features
 
@@ -170,5 +172,6 @@ reader of a payment request.
 * Erick Cestari
 * Funyug
 * Mohamed Awnallah
+* Maurice Poirrier
 * Pins
 * Ziggie


### PR DESCRIPTION
## Change Description
Skip returning error when building blinded paths amount is zero and channel has a greater `MinHTLC` policy. This fixes #9256 

Previously, building blinded paths would fail when `ValueMsat` was 0 (zero amount payments) and intermediate channels had `MinHTLC` policies greater than zero. This prevented creation of blinded path invoices for zero amount payments.

The fix adds a condition to skip MinHTLC validation during path construction when `ValueMsat` is 0, since zero amount indicates the sender will decide the final payment amount. MinHTLC constraints will still be validated at payment time from the sender's perspective.

## Steps to Test
Added a test `make unit pkg=routing/blindedpath case=TestBuildBlindedPathZeroAmount` and can be tested on a regtest network running `licli addinvoice --blind --amt 0 `

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
