### PR TITLE
Skip unnecessary disconnect and wait for disconnect to finish in shutdown

### DIFF
--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -769,7 +769,9 @@ func NewBrontide(cfg Config) *Brontide {
 // Start starts all helper goroutines the peer needs for normal operations.  In
 // the case this peer has already been started, then this function is a noop.
 func (p *Brontide) Start() error {
-	if atomic.AddInt32(&p.started, 1) != 1 {
+	if !atomic.CompareAndSwapInt32(&p.started, 0, 1) {
+		p.log.Warn("already started")
+
 		return nil
 	}
 

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -1595,6 +1595,8 @@ func (p *Brontide) WaitForDisconnect(ready chan struct{}) {
 
 	case <-p.cg.Done():
 		p.log.Trace("peer quit, exit waiting for signal ready")
+
+		return
 	}
 
 	p.cg.WgWait()

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -1574,17 +1574,27 @@ func (p *Brontide) maybeSendChannelUpdates() {
 // calling Disconnect will signal the quit channel and the method will not
 // block, since no goroutines were spawned.
 func (p *Brontide) WaitForDisconnect(ready chan struct{}) {
+	p.log.Trace("waiting for disconnect")
+	defer p.log.Trace("peer disconnected")
+
 	// Before we try to call the `Wait` goroutine, we'll make sure the main
 	// set of goroutines are already active.
 	select {
 	case <-p.startReady:
+		p.log.Trace("startReady received, waiting for signal ready")
+
 	case <-p.cg.Done():
+		p.log.Trace("-peer quit, exit waiting for signal startReady")
+
 		return
 	}
 
 	select {
 	case <-ready:
+		p.log.Trace("ready received, waiting goroutines to finish")
+
 	case <-p.cg.Done():
+		p.log.Trace("peer quit, exit waiting for signal ready")
 	}
 
 	p.cg.WgWait()
@@ -1599,6 +1609,9 @@ func (p *Brontide) WaitForDisconnect(ready chan struct{}) {
 // the peer has finished starting up before calling this method.
 func (p *Brontide) Disconnect(reason error) {
 	if !atomic.CompareAndSwapInt32(&p.disconnect, 0, 1) {
+		p.log.Warnf("got disconnect reason [%v], but peer already "+
+			"disconnected", reason)
+
 		return
 	}
 
@@ -1609,11 +1622,13 @@ func (p *Brontide) Disconnect(reason error) {
 	// started, otherwise we will skip reading it as this chan won't be
 	// closed, hence blocks forever.
 	if atomic.LoadInt32(&p.started) == 1 {
-		p.log.Debugf("Peer hasn't finished starting up yet, waiting " +
-			"on startReady signal before closing connection")
+		p.log.Debug("waiting on startReady signal before closing " +
+			"connection")
 
 		select {
 		case <-p.startReady:
+			p.log.Debug("startReady received")
+
 		case <-p.cg.Done():
 			return
 		}
@@ -2065,7 +2080,8 @@ out:
 			}
 		}
 		if err != nil {
-			p.log.Infof("unable to read message from peer: %v", err)
+			p.log.Debugf("unable to read message from peer: %v",
+				err)
 
 			// If we could not read our peer's message due to an
 			// unknown type or invalid alias, we continue processing
@@ -2187,8 +2203,7 @@ out:
 				err := p.resendChanSyncMsg(targetChan)
 				if err != nil {
 					// TODO(halseth): send error to peer?
-					p.log.Errorf("resend failed: %v",
-						err)
+					p.log.Errorf("resend failed: %v", err)
 				}
 			}
 

--- a/server.go
+++ b/server.go
@@ -5192,7 +5192,12 @@ func (s *server) DisconnectPeer(pubKey *btcec.PublicKey) error {
 	//
 	// NOTE: We call it in a goroutine to avoid blocking the main server
 	// goroutine because we might hold the server's mutex.
-	go peer.Disconnect(fmt.Errorf("server: DisconnectPeer called"))
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+
+		peer.Disconnect(fmt.Errorf("server: DisconnectPeer called"))
+	}()
 
 	return nil
 }


### PR DESCRIPTION
Was debugging reconnection behavior in quiescence and found a few behaviors that can be improved:
- when peer is already disconnected, no need to disconnect again.
- fixed a case the peer may be stuck in `WaitForDisconnect`
- similar to this [comment](https://github.com/lightningnetwork/lnd/pull/10012#issuecomment-3028079734), we want to make sure we wait for goroutines to finish when shutting down.