### PR TITLE
fix switch deadlock

### DIFF
--- a/docs/release-notes/release-notes-0.19.2.md
+++ b/docs/release-notes/release-notes-0.19.2.md
@@ -37,6 +37,8 @@
   could lead to a memory issues due to a goroutine leak in the peer/gossiper
   code.
 
+- [Fixed](https://github.com/lightningnetwork/lnd/pull/10035) a deadlock (writer starvation) in the switch.
+
 # New Features
 
 ## Functional Enhancements

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -880,7 +880,6 @@ func (s *Switch) getLocalLink(pkt *htlcPacket, htlc *lnwire.UpdateAddHTLC) (
 	// Try to find links by node destination.
 	s.indexMtx.RLock()
 	link, err := s.getLinkByShortID(pkt.outgoingChanID)
-	defer s.indexMtx.RUnlock()
 	if err != nil {
 		// If the link was not found for the outgoingChanID, an outside
 		// subsystem may be using the confirmed SCID of a zero-conf
@@ -892,6 +891,7 @@ func (s *Switch) getLocalLink(pkt *htlcPacket, htlc *lnwire.UpdateAddHTLC) (
 		// do that upon receiving the packet.
 		baseScid, ok := s.baseIndex[pkt.outgoingChanID]
 		if !ok {
+			s.indexMtx.RUnlock()
 			log.Errorf("Link %v not found", pkt.outgoingChanID)
 			return nil, NewLinkError(&lnwire.FailUnknownNextPeer{})
 		}
@@ -900,10 +900,15 @@ func (s *Switch) getLocalLink(pkt *htlcPacket, htlc *lnwire.UpdateAddHTLC) (
 		// link.
 		link, err = s.getLinkByShortID(baseScid)
 		if err != nil {
+			s.indexMtx.RUnlock()
 			log.Errorf("Link %v not found", baseScid)
 			return nil, NewLinkError(&lnwire.FailUnknownNextPeer{})
 		}
 	}
+	// We finished looking up the indexes, so we can unlock the mutex before
+	// performing the link operations which might also acquire the lock
+	// in case e.g. failAliasUpdate is called.
+	s.indexMtx.RUnlock()
 
 	if !link.EligibleToForward() {
 		log.Errorf("Link %v is not available to forward",
@@ -928,6 +933,7 @@ func (s *Switch) getLocalLink(pkt *htlcPacket, htlc *lnwire.UpdateAddHTLC) (
 			"satisfied", pkt.outgoingChanID)
 		return nil, htlcErr
 	}
+
 	return link, nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/10008

In the issue above we had a writer starvation because although we only aquire the RLock in:

`getLocalLink ` which if the balance is not enough creates a failUpdate (which also needs the RLock) so far so good that would not deadlock, however there is a chance a writer regssiters in between and if that happens we have a writer starvation and the parts of the system will deadlock.

In a above case the server mutex is locked and it will cause almost the whole system to lock down.


Important goroutine dump logs:

Here the `getLocalLink` call:

```
goroutine 216074 [sync.RWMutex.RLock, 4 minutes]: 1 times: [[216074]
sync.runtime_SemacquireRWMutexR(0xc2120595219f4ec4?, 0xc0?, 0x4691180?)
        runtime/sema.go:100 +0x25
sync.(*RWMutex).RLock(...)
        sync/rwmutex.go:72
github.com/lightningnetwork/lnd/htlcswitch.(*Switch).failAliasUpdate(0xc00c3d2700, {0x0, 0x0, 0x0}, 0x0)
        github.com/lightningnetwork/lnd/htlcswitch/switch.go:2667 +0x65
github.com/lightningnetwork/lnd/htlcswitch.(*channelLink).createFailureWithUpdate(0xc010837808, 0xa7?, {0x0?, 0x20?, 0x0?}, 0x2a6a308)
        github.com/lightningnetwork/lnd/htlcswitch/link.go:874 +0x56
github.com/lightningnetwork/lnd/htlcswitch.(*channelLink).canSendHtlc(0xc010837808, {0x3e8, 0x2faf080, 0x0, 0x118, {0x0, 0xffffff4c}, 0x90}, {0xf0, 0xec, ...}, ...)
        github.com/lightningnetwork/lnd/htlcswitch/link.go:3400 +0x1fb
github.com/lightningnetwork/lnd/htlcswitch.(*channelLink).CheckHtlcTransit(0xc010837808, {0xf0, 0xec, 0xf7, 0x6d, 0x82, 0xa5, 0xb3, 0x7d, 0x0, ...}, ...)
        github.com/lightningnetwork/lnd/htlcswitch/link.go:3359 +0x191
github.com/lightningnetwork/lnd/htlcswitch.(*Switch).getLocalLink(0xc00c3d2700, 0xc0051b32c0, 0xc0130a5208)
        github.com/lightningnetwork/lnd/htlcswitch/switch.go:922 +0x227
github.com/lightningnetwork/lnd/htlcswitch.(*Switch).SendHTLC(0xc00c3d2700, {0xee84330?, 0xc5fe98d3?, 0xe90e?}, 0x3a1468f, 0xc0130a5208)
        github.com/lightningnetwork/lnd/htlcswitch/switch.go:565 +0xd8
github.com/lightningnetwork/lnd/routing.(*paymentLifecycle).sendAttempt(0xc00597bc00, 0xc0050b0e08)
        github.com/lightningnetwork/lnd/routing/payment_lifecycle.go:695 +0x4b0
github.com/lightningnetwork/lnd/routing.(*paymentLifecycle).resumePayment(0xc00597bc00, {0x2d64880, 0xc014ebfb20})
        github.com/lightningnetwork/lnd/routing/payment_lifecycle.go:308 +0x387
github.com/lightningnetwork/lnd/routing.(*ChannelRouter).sendPayment(0xc0016261b0, {0x2d646f0?, 0x46bb800?}, 0x18376, {0xf0, 0xec, 0xf7, 0x6d, 0x82, 0xa5, ...}, ...)
        github.com/lightningnetwork/lnd/routing/router.go:1271 +0x2e9
github.com/lightningnetwork/lnd/routing.(*ChannelRouter).SendPaymentAsync.func1()
        github.com/lightningnetwork/lnd/routing/router.go:916 +0x23e
created by github.com/lightningnetwork/lnd/routing.(*ChannelRouter).SendPaymentAsync in goroutine 216016
        github.com/lightningnetwork/lnd/routing/router.go:910 +0xec
```

It clearly locks at the switch read mutex.

Which means this lock was registered before:

```
goroutine 220562 [sync.RWMutex.Lock, 4 minutes]: 1 times: [[220562]
sync.runtime_SemacquireRWMutex(0x62e8e0?, 0xf8?, 0x7fdef424c928?)
        runtime/sema.go:105 +0x25
sync.(*RWMutex).Lock(0x7ff4fd90ea68?)
        sync/rwmutex.go:153 +0x6a
github.com/lightningnetwork/lnd/htlcswitch.(*Switch).RemoveLink(0xc00c3d2700, {0x3, 0xfa, 0x5, 0xc5, 0x14, 0x84, 0xc3, 0xac, 0xa, ...})
        github.com/lightningnetwork/lnd/htlcswitch/switch.go:2342 +0x38
github.com/lightningnetwork/lnd/peer.(*Brontide).addLink(0xc010935688, 0xc002f4d0b0, 0xc0071aefc0, 0xc002f4d230, 0xc011817770, 0x1, {0x0, {{0x0, 0x0, 0x0, ...}, ...}})
        github.com/lightningnetwork/lnd/peer/brontide.go:1470 +0x993
github.com/lightningnetwork/lnd/peer.(*Brontide).loadActiveChannels(0xc010935688, {0xc012f396c8, 0x1, 0xc01096f300?})
        github.com/lightningnetwork/lnd/peer/brontide.go:1331 +0x1568
github.com/lightningnetwork/lnd/peer.(*Brontide).Start(0xc010935688)
        github.com/lightningnetwork/lnd/peer/brontide.go:884 +0x772
github.com/lightningnetwork/lnd.(*server).peerInitializer(0xc000d09508, 0xc010935688)
        github.com/lightningnetwork/lnd/server.go:4588 +0x238
created by github.com/lightningnetwork/lnd.(*server).peerConnected in goroutine 220546
        github.com/lightningnetwork/lnd/server.go:4505 +0xdff
```

which also holds the server mutex that's why all the P2P connection bork.