### PR TITLE
sweep: fix expected spending events being missed

### DIFF
--- a/server.go
+++ b/server.go
@@ -1304,6 +1304,7 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 		Estimator:  cc.FeeEstimator,
 		Notifier:   cc.ChainNotifier,
 		AuxSweeper: s.implCfg.AuxSweeper,
+		ChainIO:    cc.ChainIO,
 	})
 
 	s.sweeper = sweep.New(&sweep.UtxoSweeperConfig{

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -112,8 +112,8 @@ const (
 	// error, which means they cannot be retried with increased budget.
 	TxFatal
 
-	// sentinalEvent is used to check if an event is unknown.
-	sentinalEvent
+	// sentinelEvent is used to check if an event is unknown.
+	sentinelEvent
 )
 
 // String returns a human-readable string for the event.
@@ -138,13 +138,13 @@ func (e BumpEvent) String() string {
 
 // Unknown returns true if the event is unknown.
 func (e BumpEvent) Unknown() bool {
-	return e >= sentinalEvent
+	return e >= sentinelEvent
 }
 
 // BumpRequest is used by the caller to give the Bumper the necessary info to
 // create and manage potential fee bumps for a set of inputs.
 type BumpRequest struct {
-	// Budget givens the total amount that can be used as fees by these
+	// Budget gives the total amount that can be used as fees by these
 	// inputs.
 	Budget btcutil.Amount
 
@@ -594,7 +594,7 @@ func (t *TxPublisher) createRBFCompliantTx(
 				// used up the budget, we will return an error
 				// indicating this tx cannot be made. The
 				// sweeper should handle this error and try to
-				// cluster these inputs differetly.
+				// cluster these inputs differently.
 				increased, err = f.Increment()
 				if err != nil {
 					return nil, err
@@ -1337,7 +1337,7 @@ func (t *TxPublisher) createAndPublishTx(
 	// the fee bumper retry it at next block.
 	//
 	// NOTE: we may get this error if we've bypassed the mempool check,
-	// which means we are suing neutrino backend.
+	// which means we are using neutrino backend.
 	if errors.Is(result.Err, chain.ErrInsufficientFee) ||
 		errors.Is(result.Err, lnwallet.ErrMempoolFee) {
 

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -1467,7 +1467,7 @@ func (t *TxPublisher) getSpentInputs(
 		// Remove the subscription when exit.
 		defer spendEvent.Cancel()
 
-		// Do a non-blocking read to see if the output has been spent.
+		// Do a blocking read to receive the spent event.
 		select {
 		case spend, ok := <-spendEvent.Spend:
 			if !ok {
@@ -1482,10 +1482,6 @@ func (t *TxPublisher) getSpentInputs(
 				spendingTx.TxHash())
 
 			spentInputs[op] = spendingTx
-
-		// Move to the next input.
-		default:
-			log.Tracef("Input %v not spent yet", op)
 		}
 	}
 

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -74,7 +74,7 @@ func TestBumpResultValidate(t *testing.T) {
 	// Unknown event type will give an error.
 	b = BumpResult{
 		Tx:    &wire.MsgTx{},
-		Event: sentinalEvent,
+		Event: sentinelEvent,
 	}
 	require.ErrorIs(t, b.Validate(), ErrInvalidBumpResult)
 
@@ -465,7 +465,7 @@ func TestCreateAndCheckTx(t *testing.T) {
 	//
 	// NOTE: we are not testing the utility of creating valid txes here, so
 	// this is fine to be mocked. This behaves essentially as skipping the
-	// Signer check and alaways assume the tx has a valid sig.
+	// Signer check and always assume the tx has a valid sig.
 	script := &input.Script{}
 	m.signer.On("ComputeInputScript", mock.Anything,
 		mock.Anything).Return(script, nil)
@@ -558,7 +558,7 @@ func TestCreateRBFCompliantTx(t *testing.T) {
 	//
 	// NOTE: we are not testing the utility of creating valid txes here, so
 	// this is fine to be mocked. This behaves essentially as skipping the
-	// Signer check and alaways assume the tx has a valid sig.
+	// Signer check and always assume the tx has a valid sig.
 	script := &input.Script{}
 	m.signer.On("ComputeInputScript", mock.Anything,
 		mock.Anything).Return(script, nil)
@@ -1128,9 +1128,9 @@ func TestBroadcastImmediate(t *testing.T) {
 	require.Empty(t, tp.subscriberChans.Len())
 }
 
-// TestCreateAnPublishFail checks all the error cases are handled properly in
-// the method createAndPublish.
-func TestCreateAnPublishFail(t *testing.T) {
+// TestCreateAndPublishFail checks all the error cases are handled properly in
+// the method createAndPublishTx.
+func TestCreateAndPublishFail(t *testing.T) {
 	t.Parallel()
 
 	// Create a publisher using the mocks.
@@ -1160,7 +1160,7 @@ func TestCreateAnPublishFail(t *testing.T) {
 	//
 	// NOTE: we are not testing the utility of creating valid txes here, so
 	// this is fine to be mocked. This behaves essentially as skipping the
-	// Signer check and alaways assume the tx has a valid sig.
+	// Signer check and always assume the tx has a valid sig.
 	script := &input.Script{}
 	m.signer.On("ComputeInputScript", mock.Anything,
 		mock.Anything).Return(script, nil)
@@ -1198,9 +1198,9 @@ func TestCreateAnPublishFail(t *testing.T) {
 	require.True(t, resultOpt.IsNone())
 }
 
-// TestCreateAnPublishSuccess checks the expected result is returned from the
-// method createAndPublish.
-func TestCreateAnPublishSuccess(t *testing.T) {
+// TestCreateAndPublishSuccess checks the expected result is returned from the
+// method createAndPublishTx.
+func TestCreateAndPublishSuccess(t *testing.T) {
 	t.Parallel()
 
 	// Create a publisher using the mocks.
@@ -1226,7 +1226,7 @@ func TestCreateAnPublishSuccess(t *testing.T) {
 	//
 	// NOTE: we are not testing the utility of creating valid txes here, so
 	// this is fine to be mocked. This behaves essentially as skipping the
-	// Signer check and alaways assume the tx has a valid sig.
+	// Signer check and always assume the tx has a valid sig.
 	script := &input.Script{}
 	m.signer.On("ComputeInputScript", mock.Anything,
 		mock.Anything).Return(script, nil)
@@ -1453,7 +1453,7 @@ func TestHandleFeeBumpTx(t *testing.T) {
 	//
 	// NOTE: we are not testing the utility of creating valid txes here, so
 	// this is fine to be mocked. This behaves essentially as skipping the
-	// Signer check and alaways assume the tx has a valid sig.
+	// Signer check and always assume the tx has a valid sig.
 	script := &input.Script{}
 	m.signer.On("ComputeInputScript", mock.Anything,
 		mock.Anything).Return(script, nil)
@@ -1854,7 +1854,7 @@ func TestHandleInitialBroadcastSuccess(t *testing.T) {
 	//
 	// NOTE: we are not testing the utility of creating valid txes here, so
 	// this is fine to be mocked. This behaves essentially as skipping the
-	// Signer check and alaways assume the tx has a valid sig.
+	// Signer check and always assume the tx has a valid sig.
 	script := &input.Script{}
 	m.signer.On("ComputeInputScript", mock.Anything,
 		mock.Anything).Return(script, nil)
@@ -1940,7 +1940,7 @@ func TestHandleInitialBroadcastFail(t *testing.T) {
 	//
 	// NOTE: we are not testing the utility of creating valid txes here, so
 	// this is fine to be mocked. This behaves essentially as skipping the
-	// Signer check and alaways assume the tx has a valid sig.
+	// Signer check and always assume the tx has a valid sig.
 	script := &input.Script{}
 	m.signer.On("ComputeInputScript", mock.Anything,
 		mock.Anything).Return(script, nil)


### PR DESCRIPTION
Fix the issue #10051. What happened there was,
- a sweeping tx was created during a restart, which put `CommitmentAnchor` and `CommitmentTimeLock` in the same group, while the anchor has already been spent.
- This is usually fine as we would detect that the anchor input is spent, and retry sweeping the to_local output.

However, from the logs there, the spending event was not notified quickly enough here, causing us to think there's no spent of the anchor input,
https://github.com/lightningnetwork/lnd/blob/ea32aac7704dc9ede3b62ba15e1f772123c6555b/sweep/fee_bumper.go#L1433-L1453

We now fix it by calling `GetUtxo` first to check whether a given input is spent or not, and if it is, we will then do a block reading on the spending notification to receive a spending event.