### PR TITLE
itest+lntest: fix flake in `testListSweeps`

### DIFF
--- a/itest/lnd_onchain_test.go
+++ b/itest/lnd_onchain_test.go
@@ -868,27 +868,33 @@ func testListSweeps(ht *lntest.HarnessTest) {
 	ht.AssertNumTxsInMempool(1)
 
 	// List all unconfirmed sweeps that alice's node had broadcast.
-	sweepResp := alice.RPC.ListSweeps(false, -1)
-	txIDs := sweepResp.GetTransactionIds().TransactionIds
-	require.Lenf(ht, txIDs, 1, "number of pending sweeps, starting from "+
-		"height -1")
+	req1 := &walletrpc.ListSweepsRequest{
+		Verbose:     false,
+		StartHeight: -1,
+	}
+	ht.AssertNumSweeps(alice, req1, 1)
 
 	// Now list sweeps from the closing of the first channel. We should
 	// only see the sweep from the second channel and the pending one.
-	sweepResp = alice.RPC.ListSweeps(false, blockHeight)
-	txIDs = sweepResp.GetTransactionIds().TransactionIds
-	require.Lenf(ht, txIDs, 2, "number of sweeps, starting from height %d",
-		blockHeight)
+	req2 := &walletrpc.ListSweepsRequest{
+		Verbose:     false,
+		StartHeight: blockHeight,
+	}
+	ht.AssertNumSweeps(alice, req2, 2)
 
 	// Finally list all sweeps from the closing of the second channel. We
 	// should see all sweeps, including the pending one.
-	sweepResp = alice.RPC.ListSweeps(false, 0)
-	txIDs = sweepResp.GetTransactionIds().TransactionIds
-	require.Lenf(ht, txIDs, 3, "number of sweeps, starting from height 0")
+	req3 := &walletrpc.ListSweepsRequest{
+		Verbose:     false,
+		StartHeight: 0,
+	}
+	ht.AssertNumSweeps(alice, req3, 3)
 
 	// Mine the pending sweep and make sure it is no longer returned.
 	ht.MineBlocksAndAssertNumTxes(1, 1)
-	sweepResp = alice.RPC.ListSweeps(false, -1)
-	txIDs = sweepResp.GetTransactionIds().TransactionIds
-	require.Empty(ht, txIDs, "pending sweep should not be returned")
+	req4 := &walletrpc.ListSweepsRequest{
+		Verbose:     false,
+		StartHeight: -1,
+	}
+	ht.AssertNumSweeps(alice, req4, 0)
 }

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -2059,9 +2059,14 @@ func (h *HarnessTest) CalculateTxesFeeRate(txns []*wire.MsgTx) int64 {
 func (h *HarnessTest) AssertSweepFound(hn *node.HarnessNode,
 	sweep string, verbose bool, startHeight int32) {
 
+	req := &walletrpc.ListSweepsRequest{
+		Verbose:     verbose,
+		StartHeight: startHeight,
+	}
+
 	err := wait.NoError(func() error {
 		// List all sweeps that alice's node had broadcast.
-		sweepResp := hn.RPC.ListSweeps(verbose, startHeight)
+		sweepResp := hn.RPC.ListSweeps(req)
 
 		var found bool
 		if verbose {

--- a/lntest/rpc/wallet_kit.go
+++ b/lntest/rpc/wallet_kit.go
@@ -169,16 +169,12 @@ func (h *HarnessRPC) VerifyMessageWithAddr(
 }
 
 // ListSweeps makes a ListSweeps RPC call to the node's WalletKit client.
-func (h *HarnessRPC) ListSweeps(verbose bool,
-	startHeight int32) *walletrpc.ListSweepsResponse {
+func (h *HarnessRPC) ListSweeps(
+	req *walletrpc.ListSweepsRequest) *walletrpc.ListSweepsResponse {
 
 	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
 	defer cancel()
 
-	req := &walletrpc.ListSweepsRequest{
-		Verbose:     verbose,
-		StartHeight: startHeight,
-	}
 	resp, err := h.WalletKit.ListSweeps(ctxt, req)
 	h.NoError(err, "ListSweeps")
 


### PR DESCRIPTION
Fix the following flake, as seen in this [build](https://github.com/lightningnetwork/lnd/actions/runs/16169173104/job/45638803629?pr=10027),
```
--- FAIL: TestLightningNetworkDaemon/tranche00/03-of-304/btcd/listsweeps (47.51s)
        harness_node.go:395: Starting node (name=Alice) with PID=4268
        harness_node.go:395: Starting node (name=Bob) with PID=4316
        harness_miner.go:193: Mined 0 blocks while waiting for force closed channel to be resolved
        harness_miner.go:193: Mined 0 blocks while waiting for force closed channel to be resolved
        lnd_onchain_test.go:887: 
            	Error Trace:	/Users/runner/work/lnd/lnd/itest/lnd_onchain_test.go:887
            	            				/Users/runner/work/lnd/lnd/lntest/harness.go:315
            	            				/Users/runner/work/lnd/lnd/itest/lnd_test.go:130
            	Error:      	"[b78a7ba3d6227503c5fba5fdf9f85945f7c5d055f15800fab7ab778706a606d9 c7b091333a911c4a8a51c44446470a5f1ef6a388d51ff41bef7764629808abd5]" should have 3 item(s), but has 2
            	Test:       	TestLightningNetworkDaemon/tranche00/03-of-304/btcd/listsweeps
            	Messages:   	number of sweeps, starting from height 0
        harness.go:393: finished test: listsweeps, start height=477, end height=512, mined blocks=35
        harness.go:352: test failed, skipped cleanup
```

We now make sure we assert the `ListSweeps` results in a wait closure.