### PR TITLE
rpcserver: return consistent grpc NotFound error for GetChaninfo & LookupInvoice

### DIFF
--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -114,6 +114,11 @@ circuit. The indices are only available for forwarding events saved after v0.20.
   [fixed](https://github.com/lightningnetwork/lnd/pull/9572), the affected RPCs
   are `SubscribeChannelGraph`, `GetChanInfo`, `GetNodeInfo` and `DescribeGraph`.
 
+* [Fix a bug](https://github.com/lightningnetwork/lnd/pull/10064) where the
+  `GetChanInfo` was not returning the correct gRPC status code in the cases 
+  where the channel is unknown to the node. The same is done for `LookupInvoice`
+  for the case where the DB is kvdb backed and no invoices have yet been added
+  to the database.
 
 ## lncli Updates
 
@@ -188,5 +193,6 @@ reader of a payment request.
 * Funyug
 * Mohamed Awnallah
 * Pins
+* Torkel Rogstad
 * Yong Yu
 * Ziggie

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -715,6 +715,10 @@ var allTestCases = []*lntest.TestCase{
 		Name:     "peer bootstrapping",
 		TestFunc: testPeerBootstrapping,
 	},
+	{
+		Name:     "grpc not found",
+		TestFunc: testGRPCNotFound,
+	},
 }
 
 // appendPrefixed is used to add a prefix to each test name in the subtests

--- a/lntest/rpc/lnd.go
+++ b/lntest/rpc/lnd.go
@@ -303,6 +303,66 @@ func (h *HarnessRPC) AddInvoiceAssertErr(req *lnrpc.Invoice, errStr string) {
 	require.ErrorContains(h, err, errStr)
 }
 
+// GetChanInfoAssertErr makes an RPC call to GetChanInfo and asserts an error
+// has returned with a specific error message.
+func (h *HarnessRPC) GetChanInfoAssertErr(req *lnrpc.ChanInfoRequest,
+	errStr string) {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	_, err := h.LN.GetChanInfo(ctxt, req)
+	require.ErrorContains(h, err, errStr)
+}
+
+// GetNodeInfoAssertErr makes an RPC call to GetNodeInfo and asserts an error
+// has returned with a specific error message.
+func (h *HarnessRPC) GetNodeInfoAssertErr(req *lnrpc.NodeInfoRequest,
+	errStr string) {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	_, err := h.LN.GetNodeInfo(ctxt, req)
+	require.ErrorContains(h, err, errStr)
+}
+
+// SendCustomMessageAssertErr makes an RPC call to SendCustomMessage and asserts
+// an error has returned with a specific error message.
+func (h *HarnessRPC) SendCustomMessageAssertErr(
+	req *lnrpc.SendCustomMessageRequest, errStr string) {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	_, err := h.LN.SendCustomMessage(ctxt, req)
+	require.ErrorContains(h, err, errStr)
+}
+
+// LookupInvoiceAssertErr makes an RPC call to LookupInvoice and asserts an
+// error has returned with a specific error message.
+func (h *HarnessRPC) LookupInvoiceAssertErr(req *lnrpc.PaymentHash,
+	errStr string) {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	_, err := h.LN.LookupInvoice(ctxt, req)
+	require.ErrorContains(h, err, errStr)
+}
+
+// LookupHTLCResolutionAssertErr makes an RPC call to LookupHTLCResolution and
+// asserts an error has returned with a specific error message.
+func (h *HarnessRPC) LookupHTLCResolutionAssertErr(
+	req *lnrpc.LookupHtlcResolutionRequest, errStr string) {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	_, err := h.LN.LookupHtlcResolution(ctxt, req)
+	require.ErrorContains(h, err, errStr)
+}
+
 // AbandonChannel makes a RPC call to AbandonChannel and asserts.
 func (h *HarnessRPC) AbandonChannel(
 	req *lnrpc.AbandonChannelRequest) *lnrpc.AbandonChannelResponse {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -6989,7 +6989,10 @@ func (r *rpcServer) GetChanInfo(_ context.Context,
 	default:
 		return nil, fmt.Errorf("specify either chan_id or chan_point")
 	}
-	if err != nil {
+	switch {
+	case errors.Is(err, graphdb.ErrEdgeNotFound):
+		return nil, status.Error(codes.NotFound, err.Error())
+	case err != nil:
 		return nil, err
 	}
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -6445,7 +6445,9 @@ func (r *rpcServer) LookupInvoice(ctx context.Context,
 
 	invoice, err := r.server.invoices.LookupInvoice(ctx, payHash)
 	switch {
-	case errors.Is(err, invoices.ErrInvoiceNotFound):
+	case errors.Is(err, invoices.ErrInvoiceNotFound) ||
+		errors.Is(err, invoices.ErrNoInvoicesCreated):
+
 		return nil, status.Error(codes.NotFound, err.Error())
 	case err != nil:
 		return nil, err


### PR DESCRIPTION
Replaces https://github.com/lightningnetwork/lnd/pull/9810
Commit author credit has been retained 👍 

This PR fixes the GetChanInfo endpoint so that it returns the correct grpc status code in the
case where the channel is not found. 

LookupInvoice is also fixed to behave correctly in regards to this grpc status code. 

The GetChanInfo fix is needed for the "remote graph" project so that we can correctly convert `NotFound`
errors back to `graphdb.ErrEdgeNotFound` errors. 