### PR TITLE
Async graph cache load

### DIFF
--- a/config_builder.go
+++ b/config_builder.go
@@ -1034,6 +1034,9 @@ func (d *DefaultDatabaseBuilder) BuildDatabase(
 
 	chanGraphOpts := []graphdb.ChanGraphOption{
 		graphdb.WithUseGraphCache(!cfg.DB.NoGraphCache),
+		graphdb.WithAsyncGraphCachePopulation(
+			!cfg.DB.SyncGraphCacheLoad,
+		),
 	}
 
 	// We want to pre-allocate the channel graph cache according to what we

--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -127,7 +127,14 @@ reader of a payment request.
   to improve readability and maintainability of the code.
 
 ## Breaking Changes
+
 ## Performance Improvements
+
+* Let the channel graph cache be populated asynchronously on startup. While the 
+  cache is being populated, the graph is still available for queries, but
+  all read queries will be served from the database until the cache is fully 
+  populated. This new behaviour can be opted out of via the new 
+  `--db.sync-graph-cache-load` option.
 
 ## Deprecations
 

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -31,6 +31,8 @@ type ChannelGraph struct {
 	started atomic.Bool
 	stopped atomic.Bool
 
+	opts *chanGraphOptions
+
 	// cacheLoaded is true if the initial graphCache population has
 	// finished. We use this to ensure that when performing any reads,
 	// we only read from the graphCache if it has been fully populated.
@@ -54,6 +56,7 @@ func NewChannelGraph(v1Store V1Store,
 	}
 
 	g := &ChannelGraph{
+		opts:            opts,
 		V1Store:         v1Store,
 		topologyManager: newTopologyManager(),
 		quit:            make(chan struct{}),
@@ -78,8 +81,21 @@ func (c *ChannelGraph) Start() error {
 	log.Debugf("ChannelGraph starting")
 	defer log.Debug("ChannelGraph started")
 
-	if err := c.populateCache(); err != nil {
-		return fmt.Errorf("could not populate the graph cache: %w", err)
+	if c.opts.asyncGraphCachePopulation {
+		c.wg.Add(1)
+		go func() {
+			defer c.wg.Done()
+
+			if err := c.populateCache(); err != nil {
+				log.Errorf("Could not populate the graph "+
+					"cache: %v", err)
+			}
+		}()
+	} else {
+		if err := c.populateCache(); err != nil {
+			return fmt.Errorf("could not populate the graph "+
+				"cache: %w", err)
+		}
 	}
 
 	c.wg.Add(1)

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -78,11 +78,8 @@ func (c *ChannelGraph) Start() error {
 	log.Debugf("ChannelGraph starting")
 	defer log.Debug("ChannelGraph started")
 
-	if c.graphCache != nil {
-		if err := c.populateCache(); err != nil {
-			return fmt.Errorf("could not populate the graph "+
-				"cache: %w", err)
-		}
+	if err := c.populateCache(); err != nil {
+		return fmt.Errorf("could not populate the graph cache: %w", err)
 	}
 
 	c.wg.Add(1)
@@ -161,9 +158,13 @@ func (c *ChannelGraph) handleTopologySubscriptions() {
 }
 
 // populateCache loads the entire channel graph into the in-memory graph cache.
-//
-// NOTE: This should only be called if the graphCache has been constructed.
 func (c *ChannelGraph) populateCache() error {
+	if c.graphCache == nil {
+		log.Info("In-memory channel graph cache disabled")
+
+		return nil
+	}
+
 	startTime := time.Now()
 	log.Info("Populating in-memory channel graph, this might take a " +
 		"while...")

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/graph/db/models"
 	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/stretchr/testify/require"
@@ -102,7 +103,7 @@ func TestNodeInsertionAndDeletion(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	graph := MakeTestGraph(t)
+	graph := MakeTestGraph(t, WithSyncGraphCachePopulation())
 
 	// We'd like to test basic insertion/deletion for vertexes from the
 	// graph, so we'll create a test vertex to start with.
@@ -260,7 +261,7 @@ func TestPartialNode(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	graph := MakeTestGraph(t)
+	graph := MakeTestGraph(t, WithSyncGraphCachePopulation())
 
 	// To insert a partial node, we need to add a channel edge that has
 	// node keys for nodes we are not yet aware
@@ -386,7 +387,7 @@ func TestEdgeInsertionDeletion(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	graph := MakeTestGraph(t)
+	graph := MakeTestGraph(t, WithSyncGraphCachePopulation())
 
 	// We'd like to test the insertion/deletion of edges, so we create two
 	// vertexes to connect.
@@ -511,7 +512,7 @@ func TestDisconnectBlockAtHeight(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	graph := MakeTestGraph(t)
+	graph := MakeTestGraph(t, WithSyncGraphCachePopulation())
 
 	sourceNode := createTestVertex(t)
 	if err := graph.SetSourceNode(ctx, sourceNode); err != nil {
@@ -802,7 +803,7 @@ func TestEdgeInfoUpdates(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	graph := MakeTestGraph(t)
+	graph := MakeTestGraph(t, WithSyncGraphCachePopulation())
 
 	// We'd like to test the update of edges inserted into the database, so
 	// we create two vertexes to connect.
@@ -4350,7 +4351,9 @@ func TestGraphLoading(t *testing.T) {
 		t.Skipf("Skipping TestGraphLoading for non-bbolt graph store")
 	}
 
-	graph, err := NewChannelGraph(graphStore)
+	graph, err := NewChannelGraph(
+		graphStore, WithSyncGraphCachePopulation(),
+	)
 	require.NoError(t, err)
 	require.NoError(t, graph.Start())
 	t.Cleanup(func() {
@@ -4364,7 +4367,9 @@ func TestGraphLoading(t *testing.T) {
 
 	// Recreate the graph. This should cause the graph cache to be
 	// populated.
-	graphReloaded, err := NewChannelGraph(graphStore)
+	graphReloaded, err := NewChannelGraph(
+		graphStore, WithSyncGraphCachePopulation(),
+	)
 	require.NoError(t, err)
 	require.NoError(t, graphReloaded.Start())
 	t.Cleanup(func() {
@@ -4381,6 +4386,97 @@ func TestGraphLoading(t *testing.T) {
 		t, graph.graphCache.nodeFeatures,
 		graphReloaded.graphCache.nodeFeatures,
 	)
+}
+
+// TestAsyncGraphCache tests the behaviour of the ChannelGraph when the graph
+// cache is populated asynchronously.
+func TestAsyncGraphCache(t *testing.T) {
+	t.Parallel()
+
+	const (
+		numNodes    = 100
+		numChannels = 3
+	)
+
+	// Next, create the graph for the first time.
+	graphStore := NewTestDB(t)
+
+	// The first time we spin up the graph, we Start is as normal and fill
+	// it with test data. This will ensure that the graph cache has
+	// something to load on the next Start.
+	graph, err := NewChannelGraph(graphStore)
+	require.NoError(t, err)
+	require.NoError(t, graph.Start())
+	channels, nodes := fillTestGraph(t, graph, numNodes, numChannels)
+
+	assertGraphState := func() {
+		var (
+			numNodes  int
+			chanIndex = make(map[uint64]struct{}, numChannels)
+		)
+		// We query the graph for all nodes and channels, and
+		// assert that we get the expected number of nodes and
+		// channels.
+		err = graph.ForEachNodeCached(
+			func(node route.Vertex,
+				chans map[uint64]*DirectedChannel) error {
+
+				numNodes++
+				for chanID := range chans {
+					chanIndex[chanID] = struct{}{}
+				}
+
+				return nil
+			},
+		)
+		require.NoError(t, err)
+
+		require.Equal(t, len(nodes), numNodes)
+		require.Equal(t, len(channels), len(chanIndex))
+	}
+
+	assertGraphState()
+
+	// Now we stop the graph.
+	require.NoError(t, graph.Stop())
+
+	// Recreate it but don't start it yet.
+	graph, err = NewChannelGraph(graphStore)
+	require.NoError(t, err)
+
+	// Spin off a goroutine that starts to make queries to the ChannelGraph.
+	// We start this before we start the graph, so that we can ensure that
+	// the queries are made while the graph cache is being populated.
+	var (
+		wg      sync.WaitGroup
+		numRuns = 10
+	)
+	for i := 0; i < numRuns; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			assertGraphState()
+		}()
+	}
+
+	require.NoError(t, graph.Start())
+	t.Cleanup(func() {
+		require.NoError(t, graph.Stop())
+	})
+
+	// Wait for the cache to be fully populated.
+	err = wait.Predicate(func() bool {
+		return graph.cacheLoaded.Load()
+	}, wait.DefaultTimeout)
+	require.NoError(t, err)
+
+	// And then assert that all the expected nodes and channels are
+	// present in the graph cache.
+	for _, node := range nodes {
+		_, ok := graph.graphCache.nodeChannels[node.PubKeyBytes]
+		require.True(t, ok)
+	}
 }
 
 // TestClosedScid tests that we can correctly insert a SCID into the index of

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -1330,10 +1330,15 @@ func TestForEachSourceNodeChannel(t *testing.T) {
 	require.Empty(t, expectedSrcChans)
 }
 
+// TestGraphTraversal tests that we can traverse the graph and find all
+// nodes and channels that we expect to find.
 func TestGraphTraversal(t *testing.T) {
 	t.Parallel()
 
-	graph := MakeTestGraph(t)
+	// If we turn the channel graph cache _off_, then iterate through the
+	// set of channels (to force the fall back), we should find all the
+	// channel as well as the nodes included.
+	graph := MakeTestGraph(t, WithUseGraphCache(false))
 
 	// We'd like to test some of the graph traversal capabilities within
 	// the DB, so we'll create a series of fake nodes to insert into the
@@ -1348,10 +1353,6 @@ func TestGraphTraversal(t *testing.T) {
 		nodeIndex[node.PubKeyBytes] = struct{}{}
 	}
 
-	// If we turn the channel graph cache _off_, then iterate through the
-	// set of channels (to force the fall back), we should find all the
-	// channel as well as the nodes included.
-	graph.graphCache = nil
 	err := graph.ForEachNodeCached(func(node route.Vertex,
 		chans map[uint64]*DirectedChannel) error {
 
@@ -4247,17 +4248,16 @@ func BenchmarkForEachChannel(b *testing.B) {
 	}
 }
 
-// TestGraphCacheForEachNodeChannel tests that the forEachNodeDirectedChannel
+// TestForEachNodeDirectedChannel tests that the ForEachNodeDirectedChannel
 // method works as expected, and is able to handle nil self edges.
-func TestGraphCacheForEachNodeChannel(t *testing.T) {
+func TestForEachNodeDirectedChannel(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	graph := MakeTestGraph(t)
-
 	// Unset the channel graph cache to simulate the user running with the
-	// option turned off.
-	graph.graphCache = nil
+	// option turned off. This forces the V1Store ForEachNodeDirectedChannel
+	// to be queried instead of the graph cache's ForEachChannel method.
+	graph := MakeTestGraph(t, WithUseGraphCache(false))
 
 	node1 := createTestVertex(t)
 	require.NoError(t, graph.AddLightningNode(ctx, node1))

--- a/graph/db/options.go
+++ b/graph/db/options.go
@@ -31,14 +31,20 @@ type chanGraphOptions struct {
 	// preAllocCacheNumNodes is the number of nodes we expect to be in the
 	// graph cache, so we can pre-allocate the map accordingly.
 	preAllocCacheNumNodes int
+
+	// asyncGraphCachePopulation indicates whether the graph cache
+	// should be populated asynchronously or if the Start method should
+	// block until the cache is fully populated.
+	asyncGraphCachePopulation bool
 }
 
 // defaultChanGraphOptions returns a new chanGraphOptions instance populated
 // with default values.
 func defaultChanGraphOptions() *chanGraphOptions {
 	return &chanGraphOptions{
-		useGraphCache:         true,
-		preAllocCacheNumNodes: DefaultPreAllocCacheNumNodes,
+		useGraphCache:             true,
+		asyncGraphCachePopulation: true,
+		preAllocCacheNumNodes:     DefaultPreAllocCacheNumNodes,
 	}
 }
 
@@ -58,6 +64,25 @@ func WithUseGraphCache(use bool) ChanGraphOption {
 func WithPreAllocCacheNumNodes(n int) ChanGraphOption {
 	return func(o *chanGraphOptions) {
 		o.preAllocCacheNumNodes = n
+	}
+}
+
+// WithAsyncGraphCachePopulation sets whether the graph cache should be
+// populated asynchronously or if the Start method should block until the
+// cache is fully populated.
+func WithAsyncGraphCachePopulation(async bool) ChanGraphOption {
+	return func(o *chanGraphOptions) {
+		o.asyncGraphCachePopulation = async
+	}
+}
+
+// WithSyncGraphCachePopulation will cause the ChannelGraph to block
+// until the graph cache is fully populated before returning from the Start
+// method. This is useful for tests that need to ensure the graph cache is
+// fully populated before proceeding with further operations.
+func WithSyncGraphCachePopulation() ChanGraphOption {
+	return func(o *chanGraphOptions) {
+		o.asyncGraphCachePopulation = false
 	}
 }
 

--- a/lncfg/db.go
+++ b/lncfg/db.go
@@ -92,6 +92,8 @@ type DB struct {
 
 	NoGraphCache bool `long:"no-graph-cache" description:"Don't use the in-memory graph cache for path finding. Much slower but uses less RAM. Can only be used with a bolt database backend."`
 
+	SyncGraphCacheLoad bool `long:"sync-graph-cache-load" description:"Force synchronous loading of the graph cache. This will block the startup until the graph cache is fully loaded into memory. This is useful if any bugs appear with the new async loading feature of the graph cache."`
+
 	PruneRevocation bool `long:"prune-revocation" description:"Run the optional migration that prunes the revocation logs to save disk space."`
 
 	NoRevLogAmtData bool `long:"no-rev-log-amt-data" description:"If set, the to-local and to-remote output amounts of revoked commitment transactions will not be stored in the revocation log. Note that once this data is lost, a watchtower client will not be able to back up the revoked state."`

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1471,6 +1471,12 @@
 ; less RAM. Can only be used with a bolt database backend.
 ; db.no-graph-cache=false
 
+; Block the start-up of LND until the graph cache has been fully populated.
+; If not set, the graph cache will be populated asynchronously and any read
+; calls made before the cache is fully populated will fall back to the
+; database.
+; db.sync-graph-cache-load=false
+
 ; Specify whether the optional migration for pruning old revocation logs
 ; should be applied. This migration will only save disk space if there are open
 ; channels prior to lnd@v0.15.0.


### PR DESCRIPTION
Let the channel graph cache be populated asynchronously on startup. While the 
cache is being populated, the graph is still available for queries, but
all read queries will be served from the database until the cache is fully 
populated. This new behaviour can be opted out of via the new 
`--db.sync-graph-cache-load` option.

Fixes #6187 
Replaces #8919