### PR TITLE
graph/db: fix sql test compilation

### DIFF
--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -4350,15 +4350,6 @@ func TestGraphLoading(t *testing.T) {
 	// Next, create the graph for the first time.
 	graphStore := NewTestDB(t)
 
-	// Temporarily add a manual skip for this test, until all the methods
-	// it uses have been implemented on the SQLStore struct. We have to
-	// manually add this skip because it is the only test that doesn't use
-	// the MakeTestGraph helper to create the graph store.
-	_, ok := graphStore.(*KVStore)
-	if !ok {
-		t.Skipf("Skipping TestGraphLoading for non-bbolt graph store")
-	}
-
 	graph, err := NewChannelGraph(graphStore)
 	require.NoError(t, err)
 	require.NoError(t, graph.Start())

--- a/graph/db/sql_migration_test.go
+++ b/graph/db/sql_migration_test.go
@@ -345,8 +345,9 @@ func (c chanSet) CountPolicies() int {
 // fetchAllChannelsAndPolicies retrieves all channels and their policies
 // from the given store and returns them sorted by their channel ID.
 func fetchAllChannelsAndPolicies(t *testing.T, store V1Store) chanSet {
+	ctx := context.Background()
 	channels := make(chanSet, 0)
-	err := store.ForEachChannel(func(info *models.ChannelEdgeInfo,
+	err := store.ForEachChannel(ctx, func(info *models.ChannelEdgeInfo,
 		p1 *models.ChannelEdgePolicy,
 		p2 *models.ChannelEdgePolicy) error {
 


### PR DESCRIPTION
Due to the merge of https://github.com/lightningnetwork/lnd/pull/10043, there is a compilation issue for the sqlite/postgres graph tests since the latest CI run of 10043 was completed before the merge of https://github.com/lightningnetwork/lnd/pull/10050)