### PR TITLE
lnd+itest: plug in graph SQL migration under test tag & add itest

### DIFF
--- a/config_prod.go
+++ b/config_prod.go
@@ -3,9 +3,13 @@
 package lnd
 
 import (
+	"context"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	graphdb "github.com/lightningnetwork/lnd/graph/db"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/sqldb"
+	"github.com/lightningnetwork/lnd/sqldb/sqlc"
 )
 
 // getGraphStore returns a graphdb.V1Store backed by a graphdb.KVStore
@@ -15,4 +19,16 @@ func (d *DefaultDatabaseBuilder) getGraphStore(_ *sqldb.BaseDB,
 	opts ...graphdb.StoreOptionModifier) (graphdb.V1Store, error) {
 
 	return graphdb.NewKVStore(kvBackend, opts...)
+}
+
+// getSQLMigration returns a migration function for the given version.
+//
+// NOTE: this is a no-op for the production build since all migrations that are
+// in production will also be in development builds, and so they are not
+// defined behind a build tag.
+func getSQLMigration(ctx context.Context, version int,
+	kvBackend kvdb.Backend,
+	chain chainhash.Hash) (func(tx *sqlc.Queries) error, bool) {
+
+	return nil, false
 }

--- a/config_test_native_sql.go
+++ b/config_test_native_sql.go
@@ -3,11 +3,15 @@
 package lnd
 
 import (
+	"context"
 	"database/sql"
+	"fmt"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	graphdb "github.com/lightningnetwork/lnd/graph/db"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/sqldb"
+	"github.com/lightningnetwork/lnd/sqldb/sqlc"
 )
 
 // getGraphStore returns a graphdb.V1Store backed by a graphdb.SQLStore
@@ -28,4 +32,28 @@ func (d *DefaultDatabaseBuilder) getGraphStore(baseDB *sqldb.BaseDB,
 		},
 		graphExecutor, opts...,
 	)
+}
+
+// graphSQLMigration is the version number for the graph migration
+// that migrates the KV graph to the native SQL schema.
+const graphSQLMigration = 9
+
+// getSQLMigration returns a migration function for the given version.
+func getSQLMigration(ctx context.Context, version int,
+	kvBackend kvdb.Backend,
+	chain chainhash.Hash) (func(tx *sqlc.Queries) error, bool) {
+
+	if version != graphSQLMigration {
+		return nil, false
+	}
+
+	return func(tx *sqlc.Queries) error {
+		err := graphdb.MigrateGraphToSQL(ctx, kvBackend, tx, chain)
+		if err != nil {
+			return fmt.Errorf("failed to migrate graph to SQL: %w",
+				err)
+		}
+
+		return nil
+	}, true
 }

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -684,6 +684,10 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testInvoiceMigration,
 	},
 	{
+		Name:     "graph migration",
+		TestFunc: testGraphMigration,
+	},
+	{
 		Name:     "payment address mismatch",
 		TestFunc: testWrongPaymentAddr,
 	},

--- a/itest/lnd_graph_migration_test.go
+++ b/itest/lnd_graph_migration_test.go
@@ -1,0 +1,144 @@
+//go:build test_native_sql
+
+package itest
+
+import (
+	"context"
+	"database/sql"
+
+	graphdb "github.com/lightningnetwork/lnd/graph/db"
+	"github.com/lightningnetwork/lnd/graph/db/models"
+	"github.com/lightningnetwork/lnd/lntest"
+	"github.com/lightningnetwork/lnd/lntest/node"
+	"github.com/lightningnetwork/lnd/sqldb"
+	"github.com/stretchr/testify/require"
+)
+
+// testGraphMigration tests that the graph migration from the old KV store to
+// the new native SQL store works as expected.
+func testGraphMigration(ht *lntest.HarnessTest) {
+	ctx := context.Background()
+	alice := ht.NewNodeWithCoins("Alice", nil)
+
+	// Make sure we run the test with SQLite or Postgres.
+	if alice.Cfg.DBBackend != node.BackendSqlite &&
+		alice.Cfg.DBBackend != node.BackendPostgres {
+
+		ht.Skip("node not running with SQLite or Postgres")
+	}
+
+	// Skip the test if the node is already running with native SQL.
+	if alice.Cfg.NativeSQL {
+		ht.Skip("node already running with native SQL")
+	}
+
+	// Spin up a mini network and then connect Alice to it.
+	chans, nodes := ht.CreateSimpleNetwork(
+		[][]string{nil, nil, nil, nil},
+		lntest.OpenChannelParams{Amt: chanAmt},
+	)
+	expNumNodes := len(nodes)
+	expNumChans := len(chans)
+	require.Equal(ht, 5, expNumNodes)
+	require.Equal(ht, 3, expNumChans)
+
+	// Connect Alice to one of the nodes. Alice should now perform a graph
+	// sync with the node.
+	ht.EnsureConnected(alice, nodes[0])
+
+	// Wait for Alice to have a full view of the graph.
+	ht.AssertNumEdges(alice, expNumChans, false)
+
+	// Now stop Alice so we can open the DB for examination.
+	require.NoError(ht, alice.Stop())
+
+	// Open the KV store channel graph DB.
+	db, err := graphdb.NewKVStore(openChannelDB(ht, alice))
+	require.NoError(ht, err)
+
+	// assertDBState is a helper function that asserts the state of the
+	// graph DB.
+	assertDBState := func(db graphdb.V1Store) {
+		var (
+			numNodes int
+			edges    = make(map[uint64]bool)
+		)
+		err := db.ForEachNode(ctx, func(tx graphdb.NodeRTx) error {
+			numNodes++
+
+			// For each node, also count the number of edges.
+			return tx.ForEachChannel(
+				func(info *models.ChannelEdgeInfo,
+					_ *models.ChannelEdgePolicy,
+					_ *models.ChannelEdgePolicy) error {
+
+					edges[info.ChannelID] = true
+					return nil
+				},
+			)
+		})
+		require.NoError(ht, err)
+		require.Equal(ht, expNumNodes, numNodes)
+		require.Equal(ht, expNumChans, len(edges))
+	}
+	assertDBState(db)
+
+	alice.SetExtraArgs([]string{"--db.use-native-sql"})
+
+	// Now run the migration flow three times to ensure that each run is
+	// idempotent.
+	for i := 0; i < 3; i++ {
+		// Start Alice with the native SQL flag set. This will trigger
+		// the migration to run.
+		require.NoError(ht, alice.Start(ht.Context()))
+
+		// At this point the migration should have completed and the
+		// node should be running with native SQL. Now we'll stop Alice
+		// again so we can safely examine the database.
+		require.NoError(ht, alice.Stop())
+
+		// Now we'll open the database with the native SQL backend and
+		// fetch the graph data again to ensure that it was migrated
+		// correctly.
+		sqlInvoiceDB := openNativeSQLGraphDB(ht, alice)
+		assertDBState(sqlInvoiceDB)
+	}
+
+	// Now restart Alice without the --db.use-native-sql flag so we can
+	// check that the KV tombstone was set and that Alice will fail to start.
+	// NOTE: this is the same tombstone used for the invoice migration. Only
+	// one tombstone is needed since we just need one to represent the fact
+	// that the switch to native SQL has been made.
+	require.NoError(ht, alice.Stop())
+	alice.SetExtraArgs(nil)
+
+	// Alice should now fail to start due to the tombstone being set.
+	require.NoError(ht, alice.StartLndCmd(ht.Context()))
+	require.Error(ht, alice.WaitForProcessExit())
+
+	// Start Alice again so the test can complete.
+	alice.SetExtraArgs([]string{"--db.use-native-sql"})
+	require.NoError(ht, alice.Start(ht.Context()))
+}
+
+func openNativeSQLGraphDB(ht *lntest.HarnessTest,
+	hn *node.HarnessNode) graphdb.V1Store {
+
+	db := openNativeSQLDB(ht, hn)
+
+	executor := sqldb.NewTransactionExecutor(
+		db, func(tx *sql.Tx) graphdb.SQLQueries {
+			return db.WithTx(tx)
+		},
+	)
+
+	store, err := graphdb.NewSQLStore(
+		&graphdb.SQLStoreConfig{
+			ChainHash: *ht.Miner().ActiveNet.GenesisHash,
+		},
+		executor,
+	)
+	require.NoError(ht, err)
+
+	return store
+}

--- a/itest/lnd_invoice_migration_test.go
+++ b/itest/lnd_invoice_migration_test.go
@@ -23,6 +23,7 @@ import (
 
 func openChannelDB(ht *lntest.HarnessTest, hn *node.HarnessNode) kvdb.Backend {
 	sqlbase.Init(0)
+
 	var (
 		backend kvdb.Backend
 		err     error

--- a/itest/lnd_invoice_migration_test.go
+++ b/itest/lnd_invoice_migration_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func openChannelDB(ht *lntest.HarnessTest, hn *node.HarnessNode) *channeldb.DB {
+func openChannelDB(ht *lntest.HarnessTest, hn *node.HarnessNode) kvdb.Backend {
 	sqlbase.Init(0)
 	var (
 		backend kvdb.Backend
@@ -53,14 +53,27 @@ func openChannelDB(ht *lntest.HarnessTest, hn *node.HarnessNode) *channeldb.DB {
 		require.NoError(ht, err)
 	}
 
-	db, err := channeldb.CreateWithBackend(backend)
-	require.NoError(ht, err)
-
-	return db
+	return backend
 }
 
 func openNativeSQLInvoiceDB(ht *lntest.HarnessTest,
 	hn *node.HarnessNode) invoices.InvoiceDB {
+
+	db := openNativeSQLDB(ht, hn)
+
+	executor := sqldb.NewTransactionExecutor(
+		db, func(tx *sql.Tx) invoices.SQLInvoiceQueries {
+			return db.WithTx(tx)
+		},
+	)
+
+	return invoices.NewSQLStore(
+		executor, clock.NewDefaultClock(),
+	)
+}
+
+func openNativeSQLDB(ht *lntest.HarnessTest,
+	hn *node.HarnessNode) *sqldb.BaseDB {
 
 	var db *sqldb.BaseDB
 
@@ -90,15 +103,7 @@ func openNativeSQLInvoiceDB(ht *lntest.HarnessTest,
 		db = postgresStore.BaseDB
 	}
 
-	executor := sqldb.NewTransactionExecutor(
-		db, func(tx *sql.Tx) invoices.SQLInvoiceQueries {
-			return db.WithTx(tx)
-		},
-	)
-
-	return invoices.NewSQLStore(
-		executor, clock.NewDefaultClock(),
-	)
+	return db
 }
 
 // clampTime truncates the time of the passed invoice to the microsecond level.
@@ -238,7 +243,8 @@ func testInvoiceMigration(ht *lntest.HarnessTest) {
 	require.NoError(ht, bob.Stop())
 
 	// Open the KV channel DB.
-	db := openChannelDB(ht, bob)
+	db, err := channeldb.CreateWithBackend(openChannelDB(ht, bob))
+	require.NoError(ht, err)
 
 	query := invoices.InvoiceQuery{
 		IndexOffset: 0,

--- a/itest/lnd_misc_test.go
+++ b/itest/lnd_misc_test.go
@@ -1,7 +1,6 @@
 package itest
 
 import (
-	"crypto/rand"
 	"encoding/hex"
 	"fmt"
 	"os"
@@ -1355,12 +1354,9 @@ func testGRPCNotFound(ht *lntest.HarnessTest) {
 		notFoundErr = codes.NotFound.String()
 		unknownPub  = "0286098b97bc843372b4426d4b276cea9aa2f48f0428d6" +
 			"f5b66ae101befc14f8b4"
-		rHash = make([]byte, 32)
+		rHash = ht.Random32Bytes()
 	)
 	unknownPubBytes, err := route.NewVertexFromStr(unknownPub)
-	require.NoError(ht, err)
-
-	_, err = rand.Read(rHash)
 	require.NoError(ht, err)
 
 	alice := ht.NewNode("Alice", []string{

--- a/sqldb/migrations_dev.go
+++ b/sqldb/migrations_dev.go
@@ -8,4 +8,13 @@ var migrationAdditions = []MigrationConfig{
 		Version:       8,
 		SchemaVersion: 7,
 	},
+	{
+		Name:          "kv_graph_migration",
+		Version:       9,
+		SchemaVersion: 7,
+		// A migration function may be attached to this
+		// migration to migrate KV graph to the native SQL
+		// schema. This is optional and can be disabled by the
+		// user if necessary.
+	},
 }


### PR DESCRIPTION
This commit plugs in the graph kvdb-to-sql migration for builds
containing the `test_native_sql` tag. This will allow us to perform
local tests and write itests for the migration without exposing it to
the production release build.

A basic itests for the migration is also added. 

Part of #9795 