### PR TITLE
graph/db: use `/*SLICE:<field_name>*/` to optimise various graph queries

### DIFF
--- a/config_test_native_sql.go
+++ b/config_test_native_sql.go
@@ -32,7 +32,8 @@ func (d *DefaultDatabaseBuilder) getGraphStore(baseDB *sqldb.BaseDB,
 
 	return graphdb.NewSQLStore(
 		&graphdb.SQLStoreConfig{
-			ChainHash: *d.cfg.ActiveNetParams.GenesisHash,
+			ChainHash:     *d.cfg.ActiveNetParams.GenesisHash,
+			PaginationCfg: sqldb.DefaultPagedQueryConfig(),
 		},
 		graphExecutor, opts...,
 	)

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -93,7 +93,7 @@ type SQLQueries interface {
 	CreateChannel(ctx context.Context, arg sqlc.CreateChannelParams) (int64, error)
 	AddV1ChannelProof(ctx context.Context, arg sqlc.AddV1ChannelProofParams) (sql.Result, error)
 	GetChannelBySCID(ctx context.Context, arg sqlc.GetChannelBySCIDParams) (sqlc.GraphChannel, error)
-	GetChannelByOutpoint(ctx context.Context, outpoint string) (sqlc.GetChannelByOutpointRow, error)
+	GetChannelsByOutpoints(ctx context.Context, outpoints []string) ([]sqlc.GetChannelsByOutpointsRow, error)
 	GetChannelsBySCIDRange(ctx context.Context, arg sqlc.GetChannelsBySCIDRangeParams) ([]sqlc.GetChannelsBySCIDRangeRow, error)
 	GetChannelBySCIDWithPolicies(ctx context.Context, arg sqlc.GetChannelBySCIDWithPoliciesParams) (sqlc.GetChannelBySCIDWithPoliciesRow, error)
 	GetChannelAndNodesBySCID(ctx context.Context, arg sqlc.GetChannelAndNodesBySCIDParams) (sqlc.GetChannelAndNodesBySCIDRow, error)
@@ -2365,22 +2365,9 @@ func (s *SQLStore) PruneGraph(spentOutputs []*wire.OutPoint,
 		prunedNodes []route.Vertex
 	)
 	err := s.db.ExecTx(ctx, sqldb.WriteTxOpt(), func(db SQLQueries) error {
-		for _, outpoint := range spentOutputs {
-			// TODO(elle): potentially optimize this by using
-			//  sqlc.slice() once that works for both SQLite and
-			//  Postgres.
-			//
-			// NOTE: this fetches channels for all protocol
-			// versions.
-			row, err := db.GetChannelByOutpoint(
-				ctx, outpoint.String(),
-			)
-			if errors.Is(err, sql.ErrNoRows) {
-				continue
-			} else if err != nil {
-				return fmt.Errorf("unable to fetch channel: %w",
-					err)
-			}
+		// Define the callback function for processing each channel.
+		channelCallback := func(ctx context.Context,
+			row sqlc.GetChannelsByOutpointsRow) error {
 
 			node1, node2, err := buildNodeVertices(
 				row.Node1Pubkey, row.Node2Pubkey,
@@ -2404,9 +2391,19 @@ func (s *SQLStore) PruneGraph(spentOutputs []*wire.OutPoint,
 			}
 
 			closedChans = append(closedChans, info)
+
+			return nil
 		}
 
-		err := db.UpsertPruneLogEntry(
+		err := s.forEachChanInOutpoints(
+			ctx, db, spentOutputs, channelCallback,
+		)
+		if err != nil {
+			return fmt.Errorf("unable to fetch channels by "+
+				"outpoints: %w", err)
+		}
+
+		err = db.UpsertPruneLogEntry(
 			ctx, sqlc.UpsertPruneLogEntryParams{
 				BlockHash:   blockHash[:],
 				BlockHeight: int64(blockHeight),
@@ -2440,6 +2437,35 @@ func (s *SQLStore) PruneGraph(spentOutputs []*wire.OutPoint,
 	}
 
 	return closedChans, prunedNodes, nil
+}
+
+// forEachChanInOutpoints is a helper function that executes a paginated
+// query to fetch channels by their outpoints and applies the given call-back
+// to each.
+//
+// NOTE: this fetches channels for all protocol versions.
+func (s *SQLStore) forEachChanInOutpoints(ctx context.Context, db SQLQueries,
+	outpoints []*wire.OutPoint, cb func(ctx context.Context,
+		row sqlc.GetChannelsByOutpointsRow) error) error {
+
+	// Create a wrapper that uses the transaction's db instance to execute
+	// the query.
+	queryWrapper := func(ctx context.Context,
+		pageOutpoints []string) ([]sqlc.GetChannelsByOutpointsRow,
+		error) {
+
+		return db.GetChannelsByOutpoints(ctx, pageOutpoints)
+	}
+
+	// Define the conversion function from Outpoint to string.
+	outpointToString := func(outpoint *wire.OutPoint) string {
+		return outpoint.String()
+	}
+
+	return sqldb.ExecutePagedQuery(
+		ctx, s.cfg.PaginationCfg, outpoints, outpointToString,
+		queryWrapper, cb,
+	)
 }
 
 // ChannelView returns the verifiable edge information for each active channel

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -97,6 +97,7 @@ type SQLQueries interface {
 	GetChannelsByOutpoints(ctx context.Context, outpoints []string) ([]sqlc.GetChannelsByOutpointsRow, error)
 	GetChannelsBySCIDRange(ctx context.Context, arg sqlc.GetChannelsBySCIDRangeParams) ([]sqlc.GetChannelsBySCIDRangeRow, error)
 	GetChannelBySCIDWithPolicies(ctx context.Context, arg sqlc.GetChannelBySCIDWithPoliciesParams) (sqlc.GetChannelBySCIDWithPoliciesRow, error)
+	GetChannelsBySCIDWithPolicies(ctx context.Context, arg sqlc.GetChannelsBySCIDWithPoliciesParams) ([]sqlc.GetChannelsBySCIDWithPoliciesRow, error)
 	GetChannelAndNodesBySCID(ctx context.Context, arg sqlc.GetChannelAndNodesBySCIDParams) (sqlc.GetChannelAndNodesBySCIDRow, error)
 	GetChannelFeaturesAndExtras(ctx context.Context, channelID int64) ([]sqlc.GetChannelFeaturesAndExtrasRow, error)
 	HighestSCID(ctx context.Context, version int16) ([]byte, error)
@@ -2170,27 +2171,11 @@ func (s *SQLStore) IsPublicNode(pubKey [33]byte) (bool, error) {
 func (s *SQLStore) FetchChanInfos(chanIDs []uint64) ([]ChannelEdge, error) {
 	var (
 		ctx   = context.TODO()
-		edges []ChannelEdge
+		edges = make(map[uint64]ChannelEdge)
 	)
 	err := s.db.ExecTx(ctx, sqldb.ReadTxOpt(), func(db SQLQueries) error {
-		for _, chanID := range chanIDs {
-			chanIDB := channelIDToBytes(chanID)
-
-			// TODO(elle): potentially optimize this by using
-			//  sqlc.slice() once that works for both SQLite and
-			//  Postgres.
-			row, err := db.GetChannelBySCIDWithPolicies(
-				ctx, sqlc.GetChannelBySCIDWithPoliciesParams{
-					Scid:    chanIDB,
-					Version: int16(ProtocolV1),
-				},
-			)
-			if errors.Is(err, sql.ErrNoRows) {
-				continue
-			} else if err != nil {
-				return fmt.Errorf("unable to fetch channel: %w",
-					err)
-			}
+		chanCallBack := func(ctx context.Context,
+			row sqlc.GetChannelsBySCIDWithPoliciesRow) error {
 
 			node1, node2, err := buildNodes(
 				ctx, db, row.GraphNode, row.GraphNode_2,
@@ -2225,24 +2210,64 @@ func (s *SQLStore) FetchChanInfos(chanIDs []uint64) ([]ChannelEdge, error) {
 					"policies: %w", err)
 			}
 
-			edges = append(edges, ChannelEdge{
+			edges[edge.ChannelID] = ChannelEdge{
 				Info:    edge,
 				Policy1: p1,
 				Policy2: p2,
 				Node1:   node1,
 				Node2:   node2,
-			})
+			}
+
+			return nil
 		}
 
-		return nil
+		return s.forEachChanWithPoliciesInSCIDList(
+			ctx, db, chanCallBack, chanIDs,
+		)
 	}, func() {
-		edges = nil
+		clear(edges)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch channels: %w", err)
 	}
 
-	return edges, nil
+	res := make([]ChannelEdge, 0, len(edges))
+	for _, chanID := range chanIDs {
+		edge, ok := edges[chanID]
+		if !ok {
+			continue
+		}
+
+		res = append(res, edge)
+	}
+
+	return res, nil
+}
+
+// forEachChanWithPoliciesInSCIDList is a wrapper around the
+// GetChannelsBySCIDWithPolicies query that allows us to iterate through
+// channels in a paginated manner.
+func (s *SQLStore) forEachChanWithPoliciesInSCIDList(ctx context.Context,
+	db SQLQueries, cb func(ctx context.Context,
+		row sqlc.GetChannelsBySCIDWithPoliciesRow) error,
+	chanIDs []uint64) error {
+
+	queryWrapper := func(ctx context.Context,
+		scids [][]byte) ([]sqlc.GetChannelsBySCIDWithPoliciesRow,
+		error) {
+
+		return db.GetChannelsBySCIDWithPolicies(
+			ctx, sqlc.GetChannelsBySCIDWithPoliciesParams{
+				Version: int16(ProtocolV1),
+				Scids:   scids,
+			},
+		)
+	}
+
+	return sqldb.ExecutePagedQuery(
+		ctx, s.cfg.PaginationCfg, chanIDs, channelIDToBytes,
+		queryWrapper, cb,
+	)
 }
 
 // FilterKnownChanIDs takes a set of channel IDs and return the subset of chan
@@ -4300,6 +4325,50 @@ func extractChannelPolicies(row any) (*sqlc.GraphChannelPolicy,
 
 	var policy1, policy2 *sqlc.GraphChannelPolicy
 	switch r := row.(type) {
+	case sqlc.GetChannelsBySCIDWithPoliciesRow:
+		if r.Policy1ID.Valid {
+			policy1 = &sqlc.GraphChannelPolicy{
+				ID:                      r.Policy1ID.Int64,
+				Version:                 r.Policy1Version.Int16,
+				ChannelID:               r.GraphChannel.ID,
+				NodeID:                  r.Policy1NodeID.Int64,
+				Timelock:                r.Policy1Timelock.Int32,
+				FeePpm:                  r.Policy1FeePpm.Int64,
+				BaseFeeMsat:             r.Policy1BaseFeeMsat.Int64,
+				MinHtlcMsat:             r.Policy1MinHtlcMsat.Int64,
+				MaxHtlcMsat:             r.Policy1MaxHtlcMsat,
+				LastUpdate:              r.Policy1LastUpdate,
+				InboundBaseFeeMsat:      r.Policy1InboundBaseFeeMsat,
+				InboundFeeRateMilliMsat: r.Policy1InboundFeeRateMilliMsat,
+				Disabled:                r.Policy1Disabled,
+				MessageFlags:            r.Policy1MessageFlags,
+				ChannelFlags:            r.Policy1ChannelFlags,
+				Signature:               r.Policy1Signature,
+			}
+		}
+		if r.Policy2ID.Valid {
+			policy2 = &sqlc.GraphChannelPolicy{
+				ID:                      r.Policy2ID.Int64,
+				Version:                 r.Policy2Version.Int16,
+				ChannelID:               r.GraphChannel.ID,
+				NodeID:                  r.Policy2NodeID.Int64,
+				Timelock:                r.Policy2Timelock.Int32,
+				FeePpm:                  r.Policy2FeePpm.Int64,
+				BaseFeeMsat:             r.Policy2BaseFeeMsat.Int64,
+				MinHtlcMsat:             r.Policy2MinHtlcMsat.Int64,
+				MaxHtlcMsat:             r.Policy2MaxHtlcMsat,
+				LastUpdate:              r.Policy2LastUpdate,
+				InboundBaseFeeMsat:      r.Policy2InboundBaseFeeMsat,
+				InboundFeeRateMilliMsat: r.Policy2InboundFeeRateMilliMsat,
+				Disabled:                r.Policy2Disabled,
+				MessageFlags:            r.Policy2MessageFlags,
+				ChannelFlags:            r.Policy2ChannelFlags,
+				Signature:               r.Policy2Signature,
+			}
+		}
+
+		return policy1, policy2, nil
+
 	case sqlc.GetChannelByOutpointWithPoliciesRow:
 		if r.Policy1ID.Valid {
 			policy1 = &sqlc.GraphChannelPolicy{

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -182,6 +182,9 @@ type SQLStoreConfig struct {
 	// ChainHash is the genesis hash for the chain that all the gossip
 	// messages in this store are aimed at.
 	ChainHash chainhash.Hash
+
+	// PaginationCfg is the configuration for paginated queries.
+	PaginationCfg *sqldb.PagedQueryConfig
 }
 
 // NewSQLStore creates a new SQLStore instance given an open BatchedSQLQueries

--- a/graph/db/test_postgres.go
+++ b/graph/db/test_postgres.go
@@ -19,7 +19,9 @@ func NewTestDB(t testing.TB) V1Store {
 
 // NewTestDBFixture creates a new sqldb.TestPgFixture for testing purposes.
 func NewTestDBFixture(t *testing.T) *sqldb.TestPgFixture {
-	pgFixture := sqldb.NewTestPgFixture(t, sqldb.DefaultPostgresFixtureLifetime)
+	pgFixture := sqldb.NewTestPgFixture(
+		t, sqldb.DefaultPostgresFixtureLifetime,
+	)
 	t.Cleanup(func() {
 		pgFixture.TearDown(t)
 	})
@@ -28,7 +30,9 @@ func NewTestDBFixture(t *testing.T) *sqldb.TestPgFixture {
 
 // NewTestDBWithFixture is a helper function that creates a SQLStore backed by a
 // SQL database for testing.
-func NewTestDBWithFixture(t testing.TB, pgFixture *sqldb.TestPgFixture) V1Store {
+func NewTestDBWithFixture(t testing.TB,
+	pgFixture *sqldb.TestPgFixture) V1Store {
+
 	var querier BatchedSQLQueries
 	if pgFixture == nil {
 		querier = newBatchQuerier(t)
@@ -38,7 +42,8 @@ func NewTestDBWithFixture(t testing.TB, pgFixture *sqldb.TestPgFixture) V1Store 
 
 	store, err := NewSQLStore(
 		&SQLStoreConfig{
-			ChainHash: *chaincfg.MainNetParams.GenesisHash,
+			ChainHash:     *chaincfg.MainNetParams.GenesisHash,
+			PaginationCfg: sqldb.DefaultPagedQueryConfig(),
 		}, querier,
 	)
 	require.NoError(t, err)

--- a/graph/db/test_sqlite.go
+++ b/graph/db/test_sqlite.go
@@ -27,7 +27,8 @@ func NewTestDBFixture(_ *testing.T) *sqldb.TestPgFixture {
 func NewTestDBWithFixture(t testing.TB, _ *sqldb.TestPgFixture) V1Store {
 	store, err := NewSQLStore(
 		&SQLStoreConfig{
-			ChainHash: *chaincfg.MainNetParams.GenesisHash,
+			ChainHash:     *chaincfg.MainNetParams.GenesisHash,
+			PaginationCfg: sqldb.DefaultPagedQueryConfig(),
 		}, newBatchQuerier(t),
 	)
 	require.NoError(t, err)

--- a/itest/lnd_graph_migration_test.go
+++ b/itest/lnd_graph_migration_test.go
@@ -144,7 +144,8 @@ func openNativeSQLGraphDB(ht *lntest.HarnessTest,
 
 	store, err := graphdb.NewSQLStore(
 		&graphdb.SQLStoreConfig{
-			ChainHash: *ht.Miner().ActiveNet.GenesisHash,
+			ChainHash:     *ht.Miner().ActiveNet.GenesisHash,
+			PaginationCfg: sqldb.DefaultPagedQueryConfig(),
 		},
 		executor,
 	)

--- a/scripts/gen_sqlc_docker.sh
+++ b/scripts/gen_sqlc_docker.sh
@@ -47,3 +47,25 @@ docker run \
   -v "$DIR/../:/build" \
   -w /build \
   "sqlc/sqlc:${SQLC_VERSION}" generate
+
+# Because we're using the Postgres dialect of sqlc, we can't use sqlc.slice()
+# normally, because sqlc just thinks it can pass the Golang slice directly to
+# the database driver. So it doesn't put the /*SLICE:<field_name>*/ workaround
+# comment into the actual SQL query. But we add the comment ourselves and now
+# just need to replace the '$X/*SLICE:<field_name>*/' placeholders with the
+# actual placeholder that's going to be replaced by the sqlc generated code.
+echo "Applying sqlc.slice() workaround..."
+for file in sqldb/sqlc/*.sql.go; do
+  echo "Patching $file"
+
+  # First, we replace the `$X/*SLICE:<field_name>*/` placeholders with
+  # the actual placeholder that sqlc will use: `/*SLICE:<field_name>*/?`.
+  sed -i.bak -E 's/\$([0-9]+)\/\*SLICE:([a-zA-Z_][a-zA-Z0-9_]*)\*\//\/\*SLICE:\2\*\/\?/g' "$file"
+
+  # Then, we replace the `strings.Repeat(",?", len(arg.<golang_name>))[1:]` with
+  # a function call that generates the correct number of placeholders:
+  # `makeQueryParams(len(queryParams), len(arg.<golang_name>))`.
+  sed -i.bak -E 's/strings\.Repeat\(",\?", len\(([^)]+)\)\)\[1:\]/makeQueryParams(len(queryParams), len(\1))/g' "$file"
+
+  rm "$file.bak"
+done

--- a/sqldb/paginate.go
+++ b/sqldb/paginate.go
@@ -1,0 +1,76 @@
+package sqldb
+
+import (
+	"context"
+	"fmt"
+)
+
+// PagedQueryFunc represents a function that takes a slice of converted items
+// and returns results.
+type PagedQueryFunc[T any, R any] func(context.Context, []T) ([]R, error)
+
+// ItemCallbackFunc represents a function that processes individual results.
+type ItemCallbackFunc[R any] func(context.Context, R) error
+
+// ConvertFunc represents a function that converts from input type to query type
+type ConvertFunc[I any, T any] func(I) T
+
+// PagedQueryConfig holds configuration values for calls to ExecutePagedQuery.
+type PagedQueryConfig struct {
+	PageSize int
+}
+
+// DefaultPagedQueryConfig returns a default configuration
+func DefaultPagedQueryConfig() *PagedQueryConfig {
+	return &PagedQueryConfig{
+		PageSize: 1000,
+	}
+}
+
+// ExecutePagedQuery executes a paginated query over a slice of input items.
+// It converts the input items to a query type using the provided convertFunc,
+// executes the query using the provided queryFunc, and applies the callback
+// to each result.
+func ExecutePagedQuery[I any, T any, R any](ctx context.Context,
+	cfg *PagedQueryConfig, inputItems []I, convertFunc ConvertFunc[I, T],
+	queryFunc PagedQueryFunc[T, R], callback ItemCallbackFunc[R]) error {
+
+	if len(inputItems) == 0 {
+		return nil
+	}
+
+	// Process items in pages.
+	for i := 0; i < len(inputItems); i += cfg.PageSize {
+		// Calculate the end index for this page.
+		end := i + cfg.PageSize
+		if end > len(inputItems) {
+			end = len(inputItems)
+		}
+
+		// Get the page slice of input items.
+		inputPage := inputItems[i:end]
+
+		// Convert only the items needed for this page.
+		convertedPage := make([]T, len(inputPage))
+		for j, inputItem := range inputPage {
+			convertedPage[j] = convertFunc(inputItem)
+		}
+
+		// Execute the query for this page.
+		results, err := queryFunc(ctx, convertedPage)
+		if err != nil {
+			return fmt.Errorf("query failed for page "+
+				"starting at %d: %w", i, err)
+		}
+
+		// Apply the callback to each result.
+		for _, result := range results {
+			if err := callback(ctx, result); err != nil {
+				return fmt.Errorf("callback failed for "+
+					"result: %w", err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/sqldb/paginate_test.go
+++ b/sqldb/paginate_test.go
@@ -1,0 +1,236 @@
+package sqldb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestExecutePagedQuery tests the ExecutePagedQuery function which processes
+// items in pages, allowing for efficient querying and processing of large
+// datasets.
+func TestExecutePagedQuery(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("empty input returns nil", func(t *testing.T) {
+		var (
+			cfg        = DefaultPagedQueryConfig()
+			inputItems []int
+		)
+
+		convertFunc := func(i int) string {
+			return fmt.Sprintf("%d", i)
+		}
+
+		queryFunc := func(ctx context.Context, items []string) (
+			[]string, error) {
+
+			require.Fail(t, "queryFunc should not be called "+
+				"with empty input")
+			return nil, nil
+		}
+		callback := func(ctx context.Context, result string) error {
+			require.Fail(t, "callback should not be called with "+
+				"empty input")
+
+			return nil
+		}
+
+		err := ExecutePagedQuery(
+			ctx, cfg, inputItems, convertFunc, queryFunc, callback,
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("single page processes all items", func(t *testing.T) {
+		var (
+			convertedItems  []string
+			callbackResults []string
+			inputItems      = []int{1, 2, 3, 4, 5}
+			cfg             = &PagedQueryConfig{
+				PageSize: 10,
+			}
+		)
+
+		convertFunc := func(i int) string {
+			return fmt.Sprintf("converted_%d", i)
+		}
+
+		queryFunc := func(ctx context.Context,
+			items []string) ([]string, error) {
+
+			convertedItems = append(convertedItems, items...)
+			results := make([]string, len(items))
+			for i, item := range items {
+				results[i] = fmt.Sprintf("result_%s", item)
+			}
+
+			return results, nil
+		}
+
+		callback := func(ctx context.Context, result string) error {
+			callbackResults = append(callbackResults, result)
+			return nil
+		}
+
+		err := ExecutePagedQuery(
+			ctx, cfg, inputItems, convertFunc, queryFunc, callback,
+		)
+		require.NoError(t, err)
+
+		require.Equal(t, []string{
+			"converted_1", "converted_2", "converted_3",
+			"converted_4", "converted_5",
+		}, convertedItems)
+
+		require.Equal(t, []string{
+			"result_converted_1", "result_converted_2",
+			"result_converted_3", "result_converted_4",
+			"result_converted_5",
+		}, callbackResults)
+	})
+
+	t.Run("multiple pages process correctly", func(t *testing.T) {
+		var (
+			queryCallCount int
+			pageSizes      []int
+			allResults     []string
+			inputItems     = []int{1, 2, 3, 4, 5, 6, 7, 8}
+			cfg            = &PagedQueryConfig{
+				PageSize: 3,
+			}
+		)
+
+		convertFunc := func(i int) string {
+			return fmt.Sprintf("item_%d", i)
+		}
+
+		queryFunc := func(ctx context.Context,
+			items []string) ([]string, error) {
+
+			queryCallCount++
+			pageSizes = append(pageSizes, len(items))
+			results := make([]string, len(items))
+			for i, item := range items {
+				results[i] = fmt.Sprintf("result_%s", item)
+			}
+
+			return results, nil
+		}
+
+		callback := func(ctx context.Context, result string) error {
+			allResults = append(allResults, result)
+			return nil
+		}
+
+		err := ExecutePagedQuery(
+			ctx, cfg, inputItems, convertFunc, queryFunc, callback,
+		)
+		require.NoError(t, err)
+
+		// Should have 3 pages: [1,2,3], [4,5,6], [7,8]
+		require.Equal(t, 3, queryCallCount)
+		require.Equal(t, []int{3, 3, 2}, pageSizes)
+		require.Len(t, allResults, 8)
+	})
+
+	t.Run("query function error is propagated", func(t *testing.T) {
+		var (
+			cfg        = DefaultPagedQueryConfig()
+			inputItems = []int{1, 2, 3}
+		)
+
+		convertFunc := func(i int) string {
+			return fmt.Sprintf("%d", i)
+		}
+
+		queryFunc := func(ctx context.Context,
+			items []string) ([]string, error) {
+
+			return nil, errors.New("query failed")
+		}
+
+		callback := func(ctx context.Context, result string) error {
+			require.Fail(t, "callback should not be called when "+
+				"query fails")
+
+			return nil
+		}
+
+		err := ExecutePagedQuery(
+			ctx, cfg, inputItems, convertFunc, queryFunc, callback,
+		)
+		require.ErrorContains(t, err, "query failed for page "+
+			"starting at 0: query failed")
+	})
+
+	t.Run("callback error is propagated", func(t *testing.T) {
+		var (
+			cfg        = DefaultPagedQueryConfig()
+			inputItems = []int{1, 2, 3}
+		)
+
+		convertFunc := func(i int) string {
+			return fmt.Sprintf("%d", i)
+		}
+
+		queryFunc := func(ctx context.Context,
+			items []string) ([]string, error) {
+
+			return items, nil
+		}
+
+		callback := func(ctx context.Context, result string) error {
+			if result == "2" {
+				return errors.New("callback failed")
+			}
+			return nil
+		}
+
+		err := ExecutePagedQuery(
+			ctx, cfg, inputItems, convertFunc, queryFunc, callback,
+		)
+		require.ErrorContains(t, err, "callback failed for result: "+
+			"callback failed")
+	})
+
+	t.Run("query error in second page is propagated", func(t *testing.T) {
+		var (
+			inputItems = []int{1, 2, 3, 4}
+			cfg        = &PagedQueryConfig{
+				PageSize: 2,
+			}
+			queryCallCount int
+		)
+
+		convertFunc := func(i int) string {
+			return fmt.Sprintf("%d", i)
+		}
+
+		queryFunc := func(ctx context.Context,
+			items []string) ([]string, error) {
+
+			queryCallCount++
+			if queryCallCount == 2 {
+				return nil, fmt.Errorf("second page failed")
+			}
+
+			return items, nil
+		}
+
+		callback := func(ctx context.Context, result string) error {
+			return nil
+		}
+
+		err := ExecutePagedQuery(
+			ctx, cfg, inputItems, convertFunc, queryFunc, callback,
+		)
+		require.ErrorContains(t, err, "query failed for page "+
+			"starting at 2: second page failed")
+	})
+}

--- a/sqldb/postgres_test.go
+++ b/sqldb/postgres_test.go
@@ -7,6 +7,14 @@ import (
 	"testing"
 )
 
+// isSQLite is false if the build tag is set to test_db_postgres. It is used in
+// tests that compile for both SQLite and Postgres databases to determine
+// which database implementation is being used.
+//
+// TODO(elle): once we've updated to using sqldbv2, we can remove this since
+// then we will have access to the DatabaseType on the BaseDB struct at runtime.
+const isSQLite = false
+
 // NewTestDB is a helper function that creates a Postgres database for testing.
 func NewTestDB(t *testing.T) *PostgresStore {
 	pgFixture := NewTestPgFixture(t, DefaultPostgresFixtureLifetime)

--- a/sqldb/sqlc/db_custom.go
+++ b/sqldb/sqlc/db_custom.go
@@ -1,0 +1,39 @@
+package sqlc
+
+import (
+	"fmt"
+	"strings"
+)
+
+// makeQueryParams generates a string of query parameters for a SQL query. It is
+// meant to replace the `?` placeholders in a SQL query with numbered parameters
+// like `$1`, `$2`, etc. This is required for the sqlc /*SLICE:<field_name>*/
+// workaround. See scripts/gen_sqlc_docker.sh for more details.
+func makeQueryParams(numTotalArgs, numListArgs int) string {
+	if numListArgs == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+
+	// Pre-allocate a rough estimation of the buffer size to avoid
+	// re-allocations. A parameter like $1000, takes 6 bytes.
+	b.Grow(numListArgs * 6)
+
+	diff := numTotalArgs - numListArgs
+	for i := 0; i < numListArgs; i++ {
+		if i > 0 {
+			// We don't need to check the error here because the
+			// WriteString method of strings.Builder always returns
+			// nil.
+			_, _ = b.WriteString(",")
+		}
+
+		// We don't need to check the error here because the
+		// Write method (called by fmt.Fprintf) of strings.Builder
+		// always returns nil.
+		_, _ = fmt.Fprintf(&b, "$%d", i+diff+1)
+	}
+
+	return b.String()
+}

--- a/sqldb/sqlc/db_custom_test.go
+++ b/sqldb/sqlc/db_custom_test.go
@@ -1,0 +1,67 @@
+package sqlc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// BenchmarkMakeQueryParams benchmarks the makeQueryParams function for
+// various argument sizes. This helps to ensure the function performs
+// efficiently when generating SQL query parameter strings for different
+// input sizes.
+func BenchmarkMakeQueryParams(b *testing.B) {
+	cases := []struct {
+		totalArgs int
+		listArgs  int
+	}{
+		{totalArgs: 5, listArgs: 2},
+		{totalArgs: 10, listArgs: 3},
+		{totalArgs: 50, listArgs: 10},
+		{totalArgs: 100, listArgs: 20},
+	}
+
+	for _, c := range cases {
+		name := fmt.Sprintf(
+			"totalArgs=%d/listArgs=%d", c.totalArgs,
+			c.listArgs,
+		)
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = makeQueryParams(
+					c.totalArgs, c.listArgs,
+				)
+			}
+		})
+	}
+}
+
+// TestMakeQueryParams tests the makeQueryParams function for various
+// argument sizes and verifies the output matches the expected SQL
+// parameter string. The function is assumed to generate a comma-separated
+// list of parameters in the form $N for use in SQL queries.
+func TestMakeQueryParams(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		totalArgs int
+		listArgs  int
+		expected  string
+	}{
+		{totalArgs: 5, listArgs: 2, expected: "$4,$5"},
+		{totalArgs: 10, listArgs: 3, expected: "$8,$9,$10"},
+		{totalArgs: 1, listArgs: 1, expected: "$1"},
+		{totalArgs: 3, listArgs: 0, expected: ""},
+		{totalArgs: 4, listArgs: 4, expected: "$1,$2,$3,$4"},
+	}
+
+	for _, tc := range testCases {
+		result := makeQueryParams(tc.totalArgs, tc.listArgs)
+		require.Equal(
+			t, tc.expected, result,
+			"unexpected result for totalArgs=%d, "+
+				"listArgs=%d", tc.totalArgs, tc.listArgs,
+		)
+	}
+}

--- a/sqldb/sqlc/graph.sql.go
+++ b/sqldb/sqlc/graph.sql.go
@@ -358,46 +358,6 @@ func (q *Queries) GetChannelAndNodesBySCID(ctx context.Context, arg GetChannelAn
 	return i, err
 }
 
-const getChannelByOutpoint = `-- name: GetChannelByOutpoint :one
-SELECT
-    c.id, c.version, c.scid, c.node_id_1, c.node_id_2, c.outpoint, c.capacity, c.bitcoin_key_1, c.bitcoin_key_2, c.node_1_signature, c.node_2_signature, c.bitcoin_1_signature, c.bitcoin_2_signature,
-    n1.pub_key AS node1_pubkey,
-    n2.pub_key AS node2_pubkey
-FROM graph_channels c
-    JOIN graph_nodes n1 ON c.node_id_1 = n1.id
-    JOIN graph_nodes n2 ON c.node_id_2 = n2.id
-WHERE c.outpoint = $1
-`
-
-type GetChannelByOutpointRow struct {
-	GraphChannel GraphChannel
-	Node1Pubkey  []byte
-	Node2Pubkey  []byte
-}
-
-func (q *Queries) GetChannelByOutpoint(ctx context.Context, outpoint string) (GetChannelByOutpointRow, error) {
-	row := q.db.QueryRowContext(ctx, getChannelByOutpoint, outpoint)
-	var i GetChannelByOutpointRow
-	err := row.Scan(
-		&i.GraphChannel.ID,
-		&i.GraphChannel.Version,
-		&i.GraphChannel.Scid,
-		&i.GraphChannel.NodeID1,
-		&i.GraphChannel.NodeID2,
-		&i.GraphChannel.Outpoint,
-		&i.GraphChannel.Capacity,
-		&i.GraphChannel.BitcoinKey1,
-		&i.GraphChannel.BitcoinKey2,
-		&i.GraphChannel.Node1Signature,
-		&i.GraphChannel.Node2Signature,
-		&i.GraphChannel.Bitcoin1Signature,
-		&i.GraphChannel.Bitcoin2Signature,
-		&i.Node1Pubkey,
-		&i.Node2Pubkey,
-	)
-	return i, err
-}
-
 const getChannelByOutpointWithPolicies = `-- name: GetChannelByOutpointWithPolicies :one
 SELECT
     c.id, c.version, c.scid, c.node_id_1, c.node_id_2, c.outpoint, c.capacity, c.bitcoin_key_1, c.bitcoin_key_2, c.node_1_signature, c.node_2_signature, c.bitcoin_1_signature, c.bitcoin_2_signature,

--- a/sqldb/sqlc/querier.go
+++ b/sqldb/sqlc/querier.go
@@ -18,8 +18,8 @@ type Querier interface {
 	CreateChannel(ctx context.Context, arg CreateChannelParams) (int64, error)
 	CreateChannelExtraType(ctx context.Context, arg CreateChannelExtraTypeParams) error
 	DeleteCanceledInvoices(ctx context.Context) (sql.Result, error)
-	DeleteChannel(ctx context.Context, id int64) error
 	DeleteChannelPolicyExtraTypes(ctx context.Context, channelPolicyID int64) error
+	DeleteChannels(ctx context.Context, ids []int64) error
 	DeleteExtraNodeType(ctx context.Context, arg DeleteExtraNodeTypeParams) error
 	DeleteInvoice(ctx context.Context, arg DeleteInvoiceParams) (sql.Result, error)
 	DeleteNode(ctx context.Context, id int64) error

--- a/sqldb/sqlc/querier.go
+++ b/sqldb/sqlc/querier.go
@@ -44,6 +44,7 @@ type Querier interface {
 	GetChannelsByOutpoints(ctx context.Context, outpoints []string) ([]GetChannelsByOutpointsRow, error)
 	GetChannelsByPolicyLastUpdateRange(ctx context.Context, arg GetChannelsByPolicyLastUpdateRangeParams) ([]GetChannelsByPolicyLastUpdateRangeRow, error)
 	GetChannelsBySCIDRange(ctx context.Context, arg GetChannelsBySCIDRangeParams) ([]GetChannelsBySCIDRangeRow, error)
+	GetChannelsBySCIDWithPolicies(ctx context.Context, arg GetChannelsBySCIDWithPoliciesParams) ([]GetChannelsBySCIDWithPoliciesRow, error)
 	GetChannelsBySCIDs(ctx context.Context, arg GetChannelsBySCIDsParams) ([]GraphChannel, error)
 	GetDatabaseVersion(ctx context.Context) (int32, error)
 	GetExtraNodeTypes(ctx context.Context, nodeID int64) ([]GraphNodeExtraType, error)

--- a/sqldb/sqlc/querier.go
+++ b/sqldb/sqlc/querier.go
@@ -44,6 +44,7 @@ type Querier interface {
 	GetChannelsByOutpoints(ctx context.Context, outpoints []string) ([]GetChannelsByOutpointsRow, error)
 	GetChannelsByPolicyLastUpdateRange(ctx context.Context, arg GetChannelsByPolicyLastUpdateRangeParams) ([]GetChannelsByPolicyLastUpdateRangeRow, error)
 	GetChannelsBySCIDRange(ctx context.Context, arg GetChannelsBySCIDRangeParams) ([]GetChannelsBySCIDRangeRow, error)
+	GetChannelsBySCIDs(ctx context.Context, arg GetChannelsBySCIDsParams) ([]GraphChannel, error)
 	GetDatabaseVersion(ctx context.Context) (int32, error)
 	GetExtraNodeTypes(ctx context.Context, nodeID int64) ([]GraphNodeExtraType, error)
 	// This method may return more than one invoice if filter using multiple fields

--- a/sqldb/sqlc/querier.go
+++ b/sqldb/sqlc/querier.go
@@ -42,6 +42,7 @@ type Querier interface {
 	GetChannelFeaturesAndExtras(ctx context.Context, channelID int64) ([]GetChannelFeaturesAndExtrasRow, error)
 	GetChannelPolicyByChannelAndNode(ctx context.Context, arg GetChannelPolicyByChannelAndNodeParams) (GraphChannelPolicy, error)
 	GetChannelPolicyExtraTypes(ctx context.Context, arg GetChannelPolicyExtraTypesParams) ([]GetChannelPolicyExtraTypesRow, error)
+	GetChannelsByOutpoints(ctx context.Context, outpoints []string) ([]GetChannelsByOutpointsRow, error)
 	GetChannelsByPolicyLastUpdateRange(ctx context.Context, arg GetChannelsByPolicyLastUpdateRangeParams) ([]GetChannelsByPolicyLastUpdateRangeRow, error)
 	GetChannelsBySCIDRange(ctx context.Context, arg GetChannelsBySCIDRangeParams) ([]GetChannelsBySCIDRangeRow, error)
 	GetDatabaseVersion(ctx context.Context) (int32, error)

--- a/sqldb/sqlc/querier.go
+++ b/sqldb/sqlc/querier.go
@@ -35,7 +35,6 @@ type Querier interface {
 	FilterInvoices(ctx context.Context, arg FilterInvoicesParams) ([]Invoice, error)
 	GetAMPInvoiceID(ctx context.Context, setID []byte) (int64, error)
 	GetChannelAndNodesBySCID(ctx context.Context, arg GetChannelAndNodesBySCIDParams) (GetChannelAndNodesBySCIDRow, error)
-	GetChannelByOutpoint(ctx context.Context, outpoint string) (GetChannelByOutpointRow, error)
 	GetChannelByOutpointWithPolicies(ctx context.Context, arg GetChannelByOutpointWithPoliciesParams) (GetChannelByOutpointWithPoliciesRow, error)
 	GetChannelBySCID(ctx context.Context, arg GetChannelBySCIDParams) (GraphChannel, error)
 	GetChannelBySCIDWithPolicies(ctx context.Context, arg GetChannelBySCIDWithPoliciesParams) (GetChannelBySCIDWithPoliciesRow, error)

--- a/sqldb/sqlc/queries/graph.sql
+++ b/sqldb/sqlc/queries/graph.sql
@@ -569,8 +569,9 @@ WHERE c.version = $1 AND c.id > $2
 ORDER BY c.id
 LIMIT $3;
 
--- name: DeleteChannel :exec
-DELETE FROM graph_channels WHERE id = $1;
+-- name: DeleteChannels :exec
+DELETE FROM graph_channels
+WHERE id IN (sqlc.slice('ids')/*SLICE:ids*/);
 
 /* ─────────────────────────────────────────────
    graph_channel_features table queries

--- a/sqldb/sqlc/queries/graph.sql
+++ b/sqldb/sqlc/queries/graph.sql
@@ -231,6 +231,17 @@ WHERE scid >= @start_scid
 SELECT * FROM graph_channels
 WHERE scid = $1 AND version = $2;
 
+-- name: GetChannelsByOutpoints :many
+SELECT
+    sqlc.embed(c),
+    n1.pub_key AS node1_pubkey,
+    n2.pub_key AS node2_pubkey
+FROM graph_channels c
+    JOIN graph_nodes n1 ON c.node_id_1 = n1.id
+    JOIN graph_nodes n2 ON c.node_id_2 = n2.id
+WHERE c.outpoint IN
+    (sqlc.slice('outpoints')/*SLICE:outpoints*/);
+
 -- name: GetChannelByOutpoint :one
 SELECT
     sqlc.embed(c),

--- a/sqldb/sqlc/queries/graph.sql
+++ b/sqldb/sqlc/queries/graph.sql
@@ -242,16 +242,6 @@ FROM graph_channels c
 WHERE c.outpoint IN
     (sqlc.slice('outpoints')/*SLICE:outpoints*/);
 
--- name: GetChannelByOutpoint :one
-SELECT
-    sqlc.embed(c),
-    n1.pub_key AS node1_pubkey,
-    n2.pub_key AS node2_pubkey
-FROM graph_channels c
-    JOIN graph_nodes n1 ON c.node_id_1 = n1.id
-    JOIN graph_nodes n2 ON c.node_id_2 = n2.id
-WHERE c.outpoint = $1;
-
 -- name: GetChannelAndNodesBySCID :one
 SELECT
     c.*,

--- a/sqldb/sqlc/queries/graph.sql
+++ b/sqldb/sqlc/queries/graph.sql
@@ -283,6 +283,57 @@ WHERE cet.channel_id = $1;
 SELECT scid from graph_channels
 WHERE outpoint = $1 AND version = $2;
 
+-- name: GetChannelsBySCIDWithPolicies :many
+SELECT
+    sqlc.embed(c),
+    sqlc.embed(n1),
+    sqlc.embed(n2),
+
+    -- Policy 1
+    cp1.id AS policy1_id,
+    cp1.node_id AS policy1_node_id,
+    cp1.version AS policy1_version,
+    cp1.timelock AS policy1_timelock,
+    cp1.fee_ppm AS policy1_fee_ppm,
+    cp1.base_fee_msat AS policy1_base_fee_msat,
+    cp1.min_htlc_msat AS policy1_min_htlc_msat,
+    cp1.max_htlc_msat AS policy1_max_htlc_msat,
+    cp1.last_update AS policy1_last_update,
+    cp1.disabled AS policy1_disabled,
+    cp1.inbound_base_fee_msat AS policy1_inbound_base_fee_msat,
+    cp1.inbound_fee_rate_milli_msat AS policy1_inbound_fee_rate_milli_msat,
+    cp1.message_flags AS policy1_message_flags,
+    cp1.channel_flags AS policy1_channel_flags,
+    cp1.signature AS policy1_signature,
+
+    -- Policy 2
+    cp2.id AS policy2_id,
+    cp2.node_id AS policy2_node_id,
+    cp2.version AS policy2_version,
+    cp2.timelock AS policy2_timelock,
+    cp2.fee_ppm AS policy2_fee_ppm,
+    cp2.base_fee_msat AS policy2_base_fee_msat,
+    cp2.min_htlc_msat AS policy2_min_htlc_msat,
+    cp2.max_htlc_msat AS policy2_max_htlc_msat,
+    cp2.last_update AS policy2_last_update,
+    cp2.disabled AS policy2_disabled,
+    cp2.inbound_base_fee_msat AS policy2_inbound_base_fee_msat,
+    cp2.inbound_fee_rate_milli_msat AS policy2_inbound_fee_rate_milli_msat,
+    cp2.message_flags AS policy_2_message_flags,
+    cp2.channel_flags AS policy_2_channel_flags,
+    cp2.signature AS policy2_signature
+
+FROM graph_channels c
+    JOIN graph_nodes n1 ON c.node_id_1 = n1.id
+    JOIN graph_nodes n2 ON c.node_id_2 = n2.id
+    LEFT JOIN graph_channel_policies cp1
+        ON cp1.channel_id = c.id AND cp1.node_id = c.node_id_1 AND cp1.version = c.version
+    LEFT JOIN graph_channel_policies cp2
+        ON cp2.channel_id = c.id AND cp2.node_id = c.node_id_2 AND cp2.version = c.version
+WHERE
+    c.version = @version
+  AND c.scid IN (sqlc.slice('scids')/*SLICE:scids*/);
+
 -- name: GetChannelsByPolicyLastUpdateRange :many
 SELECT
     sqlc.embed(c),

--- a/sqldb/sqlc/queries/graph.sql
+++ b/sqldb/sqlc/queries/graph.sql
@@ -231,6 +231,11 @@ WHERE scid >= @start_scid
 SELECT * FROM graph_channels
 WHERE scid = $1 AND version = $2;
 
+-- name: GetChannelsBySCIDs :many
+SELECT * FROM graph_channels
+WHERE version = @version
+  AND scid IN (sqlc.slice('scids')/*SLICE:scids*/);
+
 -- name: GetChannelsByOutpoints :many
 SELECT
     sqlc.embed(c),

--- a/sqldb/sqlite_test.go
+++ b/sqldb/sqlite_test.go
@@ -7,6 +7,14 @@ import (
 	"testing"
 )
 
+// isSQLite is true if the build tag is set to test_db_sqlite. It is used in
+// tests that compile for both SQLite and Postgres databases to determine
+// which database implementation is being used.
+//
+// TODO(elle): once we've updated to using sqldbv2, we can remove this since
+// then we will have access to the DatabaseType on the BaseDB struct at runtime.
+const isSQLite = true
+
 // NewTestDB is a helper function that creates an SQLite database for testing.
 func NewTestDB(t *testing.T) *SqliteStore {
 	return NewTestSqliteDB(t)


### PR DESCRIPTION
In this PR, the `/*SLICE:<field_name>*/` directive is made use of so that we can perform
`WHERE x IN <list of x type>` SQL queries. This then allows us to perform fewer DB calls. 

We dont want to give our SQL lib an unbound number of items in the parameter though so this
PR also adds an `ExecutePagedQuery` helper that gives us the ability to call these new types of
SQL queries in a paginated fashion,. 