### PR TITLE
walletrpc: allow conf_target=1 in EstimateFee and FundPsbt

### DIFF
--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -45,6 +45,10 @@
 
 ## Functional Enhancements
 
+* RPCs `walletrpc.EstimateFee` and `walletrpc.FundPsbt` now
+   [allow](https://github.com/lightningnetwork/lnd/pull/10087)
+  `conf_target=1`. Previously they required `conf_target >= 2`.
+
 ## RPC Additions
 * When querying [`ForwardingEvents`](https://github.com/lightningnetwork/lnd/pull/9813)
 logs, the response now include the incoming and outgoing htlc indices of the payment 

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -731,6 +731,10 @@ var allTestCases = []*lntest.TestCase{
 		Name:     "delete canceled invoice",
 		TestFunc: testDeleteCanceledInvoice,
 	},
+	{
+		Name:     "estimate fee",
+		TestFunc: testEstimateFee,
+	},
 }
 
 // appendPrefixed is used to add a prefix to each test name in the subtests

--- a/itest/lnd_psbt_test.go
+++ b/itest/lnd_psbt_test.go
@@ -1253,8 +1253,8 @@ func fundPsbtCoinSelect(t testing.TB, node *node.HarnessNode,
 		Template: &walletrpc.FundPsbtRequest_CoinSelect{
 			CoinSelect: cs,
 		},
-		Fees: &walletrpc.FundPsbtRequest_SatPerVbyte{
-			SatPerVbyte: 50,
+		Fees: &walletrpc.FundPsbtRequest_TargetConf{
+			TargetConf: 1,
 		},
 	})
 

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -1555,9 +1555,9 @@ func (w *WalletKit) FundPsbt(_ context.Context,
 	// Estimate the fee by the target number of blocks to confirmation.
 	case req.GetTargetConf() != 0:
 		targetConf := req.GetTargetConf()
-		if targetConf < 2 {
+		if targetConf < 1 {
 			return nil, fmt.Errorf("confirmation target must be " +
-				"greater than 1")
+				"greater than 0")
 		}
 
 		feeSatPerKW, err = w.cfg.FeeEstimator.EstimateFeePerKW(

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -843,12 +843,10 @@ func (w *WalletKit) SendOutputs(ctx context.Context,
 func (w *WalletKit) EstimateFee(ctx context.Context,
 	req *EstimateFeeRequest) (*EstimateFeeResponse, error) {
 
-	switch {
-	// A confirmation target of zero doesn't make any sense. Similarly, we
-	// reject confirmation targets of 1 as they're unreasonable.
-	case req.ConfTarget == 0 || req.ConfTarget == 1:
+	// A confirmation target of zero or lower doesn't make any sense.
+	if req.ConfTarget <= 0 {
 		return nil, fmt.Errorf("confirmation target must be greater " +
-			"than 1")
+			"than 0")
 	}
 
 	satPerKw, err := w.cfg.FeeEstimator.EstimateFeePerKW(


### PR DESCRIPTION
## Change Description

Previously `walletrpc.EstimateFee` and `walletrpc.FundPsbt` used to fail if conf_target is 1.
This was discussed before in https://github.com/lightningnetwork/lnd/pull/9611

In this PR value 1 is allowed. An itest is added.

## Steps to Test

```
make itest icase='estimate_fee'
make itest icase='fund_psbt'
```

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
