### PR TITLE
Catch bad gossip peer and fix `UpdatesInHorizon`

### DIFF
--- a/config.go
+++ b/config.go
@@ -720,6 +720,7 @@ func DefaultConfig() Config {
 			MsgRateBytes:          discovery.DefaultMsgBytesPerSecond,
 			MsgBurstBytes:         discovery.DefaultMsgBytesBurst,
 			FilterConcurrency:     discovery.DefaultFilterConcurrency,
+			BanThreshold:          discovery.DefaultBanThreshold,
 		},
 		Invoices: &lncfg.Invoices{
 			HoldExpiryDelta: lncfg.DefaultHoldInvoiceExpiryDelta,

--- a/discovery/ban.go
+++ b/discovery/ban.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"errors"
+	"math"
 	"sync"
 	"time"
 
@@ -150,6 +151,13 @@ type banman struct {
 
 // newBanman creates a new banman with the default maxBannedPeers.
 func newBanman(banThreshold uint64) *banman {
+	// If the ban threshold is set to 0, we'll use the max value to
+	// effectively disable banning.
+	if banThreshold == 0 {
+		log.Warn("Banning is disabled due to zero banThreshold")
+		banThreshold = math.MaxUint64
+	}
+
 	return &banman{
 		peerBanIndex: lru.NewCache[[33]byte, *cachedBanInfo](
 			maxBannedPeers,

--- a/discovery/ban_test.go
+++ b/discovery/ban_test.go
@@ -12,12 +12,14 @@ import (
 func TestPurgeBanEntries(t *testing.T) {
 	t.Parallel()
 
-	b := newBanman()
+	testBanThreshold := uint64(10)
+
+	b := newBanman(testBanThreshold)
 
 	// Ban a peer by repeatedly incrementing its ban score.
 	peer1 := [33]byte{0x00}
 
-	for i := 0; i < banThreshold; i++ {
+	for range testBanThreshold {
 		b.incrementBanScore(peer1)
 	}
 

--- a/discovery/chan_series.go
+++ b/discovery/chan_series.go
@@ -136,7 +136,21 @@ func (c *ChanSeries) UpdatesInHorizon(chain chainhash.Hash,
 			return nil, err
 		}
 
-		updates = append(updates, chanAnn)
+		// Create a slice to hold the `channel_announcement` and
+		// potentially two `channel_update` msgs.
+		//
+		// NOTE: Based on BOLT7, if a channel_announcement has no
+		// corresponding channel_updates, we must not send the
+		// channel_announcement. Thus we use this slice to decide we
+		// want to send this `channel_announcement` or not. By the end
+		// of the operation, if the len of the slice is 1, we will not
+		// send the `channel_announcement`. Otherwise, when sending the
+		// msgs, the `channel_announcement` must be sent prior to any
+		// corresponding `channel_update` or `node_annoucement`, that's
+		// why we create a slice here to maintain the order.
+		chanUpdates := make([]lnwire.Message, 0, 3)
+		chanUpdates = append(chanUpdates, chanAnn)
+
 		if edge1 != nil {
 			// We don't want to send channel updates that don't
 			// conform to the spec (anymore).
@@ -145,18 +159,28 @@ func (c *ChanSeries) UpdatesInHorizon(chain chainhash.Hash,
 				log.Errorf("not sending invalid channel "+
 					"update %v: %v", edge1, err)
 			} else {
-				updates = append(updates, edge1)
+				chanUpdates = append(chanUpdates, edge1)
 			}
 		}
+
 		if edge2 != nil {
 			err := netann.ValidateChannelUpdateFields(0, edge2)
 			if err != nil {
 				log.Errorf("not sending invalid channel "+
 					"update %v: %v", edge2, err)
 			} else {
-				updates = append(updates, edge2)
+				chanUpdates = append(chanUpdates, edge2)
 			}
 		}
+
+		// If there's no corresponding `channel_update` to send, skip
+		// sending this `channel_announcement`.
+		if len(chanUpdates) < 2 {
+			continue
+		}
+
+		// Append the all the msgs to the slice.
+		updates = append(updates, chanUpdates...)
 	}
 
 	// Next, we'll send out all the node announcements that have an update

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -586,7 +586,7 @@ func New(cfg Config, selfKeyDesc *keychain.KeyDescriptor) *AuthenticatedGossiper
 			maxRejectedUpdates,
 		),
 		chanUpdateRateLimiter: make(map[uint64][2]*rate.Limiter),
-		banman:                newBanman(),
+		banman:                newBanman(DefaultBanThreshold),
 	}
 
 	gossiper.vb = NewValidationBarrier(1000, gossiper.quit)

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -403,6 +403,10 @@ type Config struct {
 	// FilterConcurrency is the maximum number of concurrent gossip filter
 	// applications that can be processed.
 	FilterConcurrency int
+
+	// BanThreshold is the score used to decide whether a given peer is
+	// banned or not.
+	BanThreshold uint64
 }
 
 // processedNetworkMsg is a wrapper around networkMsg and a boolean. It is
@@ -586,7 +590,7 @@ func New(cfg Config, selfKeyDesc *keychain.KeyDescriptor) *AuthenticatedGossiper
 			maxRejectedUpdates,
 		),
 		chanUpdateRateLimiter: make(map[uint64][2]*rate.Limiter),
-		banman:                newBanman(DefaultBanThreshold),
+		banman:                newBanman(cfg.BanThreshold),
 	}
 
 	gossiper.vb = NewValidationBarrier(1000, gossiper.quit)

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -2701,7 +2701,7 @@ func (d *AuthenticatedGossiper) handleChanAnnouncement(ctx context.Context,
 	// ShortChannelID is an alias, then we'll skip validation as it will
 	// not map to a legitimate tx. This is not a DoS vector as only we can
 	// add an alias ChannelAnnouncement from the gossiper.
-	if !(d.cfg.AssumeChannelValid || d.cfg.IsAlias(scid)) { //nolint:nestif
+	if !(d.cfg.AssumeChannelValid || d.cfg.IsAlias(scid)) {
 		op, capacity, script, err := d.validateFundingTransaction(
 			ctx, ann, tapscriptRoot,
 		)

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -995,6 +995,7 @@ func createTestCtx(t *testing.T, startHeight uint32, isChanPeer bool) (
 		GetAlias:              getAlias,
 		FindChannel:           mockFindChannel,
 		ScidCloser:            newMockScidCloser(isChanPeer),
+		BanThreshold:          DefaultBanThreshold,
 	}, selfKeyDesc)
 
 	if err := gossiper.Start(); err != nil {
@@ -4656,7 +4657,7 @@ func TestChanAnnBanningNonChanPeer(t *testing.T) {
 	}
 
 	// Loop 100 times to get nodePeer banned.
-	for i := 0; i < 100; i++ {
+	for i := range DefaultBanThreshold {
 		// Craft a valid channel announcement for a channel we don't
 		// have. We will ensure that it fails validation by modifying
 		// the tx script.
@@ -4746,7 +4747,7 @@ func TestChanAnnBanningChanPeer(t *testing.T) {
 	nodePeer := &mockPeer{remoteKeyPriv1.PubKey(), nil, nil, atomic.Bool{}}
 
 	// Loop 100 times to get nodePeer banned.
-	for i := 0; i < 100; i++ {
+	for i := range DefaultBanThreshold {
 		// Craft a valid channel announcement for a channel we don't
 		// have. We will ensure that it fails validation by modifying
 		// the router.

--- a/discovery/sync_manager.go
+++ b/discovery/sync_manager.go
@@ -211,7 +211,6 @@ type SyncManager struct {
 
 // newSyncManager constructs a new SyncManager backed by the given config.
 func newSyncManager(cfg *SyncManagerCfg) *SyncManager {
-
 	filterConcurrency := cfg.FilterConcurrency
 	if filterConcurrency == 0 {
 		filterConcurrency = DefaultFilterConcurrency

--- a/docs/gossip_rate_limiting.md
+++ b/docs/gossip_rate_limiting.md
@@ -62,6 +62,25 @@ Large routing nodes handling many simultaneous peer connections might benefit
 from increasing this value to 10 or 15, while resource-constrained nodes should
 keep it at the default or even reduce it slightly.
 
+### Preventing Spam: gossip.ban-threshold
+
+To protect your node from spam and misbehaving peers, LND uses a ban score
+system controlled by `gossip.ban-threshold`. Each time a peer sends a gossip
+message that is considered invalid, its ban score is incremented. Once the score
+reaches this threshold, the peer is banned for a default of 48 hours, and your
+node will no longer process gossip messages from them.
+
+A gossip message can be considered invalid for several reasons, including:
+- Invalid signature on the announcement.
+- Stale timestamp, older than what we already have.
+- Too many channel updates for the same channel in a short period.
+- Announcing a channel that is not found on-chain.
+- Announcing a channel that has already been closed.
+- Announcing a channel with an invalid proof.
+
+The default value is 100. Setting this value to 0 disables banning completely,
+which is not recommended for most operators.
+
 ### Understanding Connection Limits: num-restricted-slots
 
 The `num-restricted-slots` configuration deserves special attention because it

--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -96,6 +96,12 @@ circuit. The indices are only available for forwarding events saved after v0.20.
   a canceled invoice. Supports deleting a canceled invoice by providing its
   payment hash.
 
+* A [new config](https://github.com/lightningnetwork/lnd/pull/10102)
+  `gossip.ban-threshold` is added to allow users to configure the ban score
+  threshold for peers. When a peer's ban score exceeds this value, they will be
+  disconnected and banned. Setting the value to 0 effectively disables banning
+  by setting the threshold to the maximum possible value. 
+
 ## lncli Additions
 
 * [`lncli sendpayment` and `lncli queryroutes` now support the

--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -41,6 +41,10 @@
   logger's derived via `WithPrefix` did not inherit change log level changes 
   from their parent loggers. 
 
+- [Fixed](https://github.com/lightningnetwork/lnd/pull/10102) a case that we may
+  send unnecessary `channel_announcement` and `node_announcement` messages when
+  replying to a `gossip_timestamp_filter` query.
+
 # New Features
 
 ## Functional Enhancements

--- a/lncfg/gossip.go
+++ b/lncfg/gossip.go
@@ -39,6 +39,8 @@ type Gossip struct {
 	MsgBurstBytes uint64 `long:"msg-burst-bytes" description:"The maximum burst of outbound gossip data, in bytes, that can be sent at once. This works in conjunction with gossip.msg-rate-bytes as part of a token bucket rate-limiting scheme. This value represents the size of the token bucket. It allows for short, high-speed bursts of traffic, with the long-term rate controlled by gossip.msg-rate-bytes. This value must be larger than the maximum lightning message size (~65KB) to allow sending large gossip messages."`
 
 	FilterConcurrency int `long:"filter-concurrency" description:"The maximum number of concurrent gossip filter applications that can be processed. If not set, defaults to 5."`
+
+	BanThreshold uint64 `long:"ban-threshold" description:"The score at which a peer is banned. A peer's ban score is incremented for each invalid gossip message. Invalid messages include those with bad signatures, stale timestamps, excessive updates, or invalid chain data. Once the score reaches this threshold, the peer is banned."`
 }
 
 // Parse the pubkeys for the pinned syncers.

--- a/lncfg/gossip.go
+++ b/lncfg/gossip.go
@@ -44,7 +44,6 @@ type Gossip struct {
 }
 
 // Parse the pubkeys for the pinned syncers.
-
 func (g *Gossip) Parse() error {
 	pinnedSyncers := make(discovery.PinnedSyncers)
 	for _, pubkeyStr := range g.PinnedSyncersRaw {

--- a/lncfg/gossip.go
+++ b/lncfg/gossip.go
@@ -40,7 +40,7 @@ type Gossip struct {
 
 	FilterConcurrency int `long:"filter-concurrency" description:"The maximum number of concurrent gossip filter applications that can be processed. If not set, defaults to 5."`
 
-	BanThreshold uint64 `long:"ban-threshold" description:"The score at which a peer is banned. A peer's ban score is incremented for each invalid gossip message. Invalid messages include those with bad signatures, stale timestamps, excessive updates, or invalid chain data. Once the score reaches this threshold, the peer is banned."`
+	BanThreshold uint64 `long:"ban-threshold" description:"The score at which a peer is banned. A peer's ban score is incremented for each invalid gossip message. Invalid messages include those with bad signatures, stale timestamps, excessive updates, or invalid chain data. Once the score reaches this threshold, the peer is banned. Set to 0 to disable banning."`
 }
 
 // Parse the pubkeys for the pinned syncers.

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1784,6 +1784,22 @@
 ; See docs/gossip_rate_limiting.md for mor information.
 ; gossip.filter-concurrency=5
 
+; The score at which a peer is banned. Each time a peer sends a gossip message
+; that is considered invalid, its ban score is incremented. Once the score
+; reaches this threshold, the peer is banned for a default of 48 hours, and we
+; will no longer process gossip messages from them. This is a measure to
+; protect the node from spam and misbehaving peers.
+;
+; A gossip message can be considered invalid for several reasons, including:
+; - Invalid signature on the announcement.
+; - Stale timestamp, older than what we already have.
+; - Too many channel updates for the same channel in a short period.
+; - Announcing a channel that is not found on-chain.
+; - Announcing a channel that has already been closed.
+; - Announcing a channel with an invalid proof.
+;
+; gossip.ban-threshold=100
+
 [invoices]
 
 ; If a hold invoice has accepted htlcs that reach their expiry height and are

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1788,7 +1788,8 @@
 ; that is considered invalid, its ban score is incremented. Once the score
 ; reaches this threshold, the peer is banned for a default of 48 hours, and we
 ; will no longer process gossip messages from them. This is a measure to
-; protect the node from spam and misbehaving peers.
+; protect the node from spam and misbehaving peers. Setting this value to 0
+; disables banning completely.
 ;
 ; A gossip message can be considered invalid for several reasons, including:
 ; - Invalid signature on the announcement.

--- a/server.go
+++ b/server.go
@@ -1226,6 +1226,7 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 		MsgRateBytes:            cfg.Gossip.MsgRateBytes,
 		MsgBurstBytes:           cfg.Gossip.MsgBurstBytes,
 		FilterConcurrency:       cfg.Gossip.FilterConcurrency,
+		BanThreshold:            cfg.Gossip.BanThreshold,
 	}, nodeKeyDesc)
 
 	accessCfg := &accessManConfig{


### PR DESCRIPTION
This PR adds two changes,
- update `UpdatesInHorizon` to be more robust about invalid announcements.
- record bad peers when processing invalid `channel_update`.