### PR TITLE
CI: add pgp keys expiry check

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,22 @@ env:
   GO_VERSION: 1.23.12
 
 jobs:
+  ########################
+  # Check release signing keys
+  ########################
+  pgp-key-expiration-check:
+    name: Check release signing key expirations
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+
+      - name: Check PGP key expirations
+        run: scripts/check-pgp-expiry.sh
+
+  ########################
+  # Create release
+  ########################
   main:
     name: Release build
     runs-on: ubuntu-latest

--- a/scripts/check-pgp-expiry.sh
+++ b/scripts/check-pgp-expiry.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# Validates PGP keys in the scripts/keys directory by checking their expiration
+# status and signing capabilities. It iterates through all .asc files and uses
+# GPG to parse key information.
+
+set -euo pipefail
+shopt -s nullglob
+
+error() {
+    RED='\033[0;31m'
+    NC='\033[0m' # No Color
+    echo -e "${RED}ERROR: $1${NC}"
+    exit_code=1
+}
+
+# Check if a key has expired or is expiring soon
+# Args: $1 = expiry timestamp, $2 = key_info
+# Returns: 0 if key is valid or has no expiry, 1 if expired/expiring soon
+check_key_expiry() {
+    local expiry="$1"
+    local key_info="$2"
+
+    # If expiry is empty, the key does not expire.
+    if [[ -z "$expiry" ]]; then
+        echo "INFO: $key_info does not expire"
+        return 0
+    fi
+
+    # Convert expiry timestamp to human readable date for logging.
+    local expiry_date
+    if ! expiry_date=$(date -d "@$expiry" "+%Y-%m-%d" 2>/dev/null \
+        || date -r "$expiry" "+%Y-%m-%d" 2>/dev/null); then
+        error "Invalid expiry timestamp for $key_info $expiry"
+        return 1
+    fi
+
+    if (( expiry < $(date +%s) )); then
+        echo "WARN: $key_info has already expired ($expiry_date)"
+        return 1
+    fi
+
+    if (( expiry < EXPIRE_THRESHOLD )); then
+        echo "WARN: $key_info expires soon ($expiry_date)"
+        return 1
+    fi
+
+    echo "INFO: $key_info is valid until $expiry_date"
+    return 0
+}
+
+echo
+echo "Starting PGP key validation..."
+
+KEY_DIR="./scripts/keys"
+if [[ ! -d "$KEY_DIR" ]]; then
+    error "Directory $KEY_DIR does not exist"
+    exit $exit_code
+fi
+
+key_files=("$KEY_DIR"/*.asc)
+if (( ${#key_files[@]} == 0 )); then
+    error "No PGP keys found in $KEY_DIR"
+    exit $exit_code
+fi
+
+# 2 weeks = 14 days * (24 hours * 60 minutes * 60 seconds).
+EXPIRE_THRESHOLD=$(($(date +%s) + 14 * 86400))
+exit_code=0
+
+echo "Found ${#key_files[@]} key file(s) in $KEY_DIR"
+echo
+
+for key_file in "${key_files[@]}"; do
+    echo "────────────────────────────────────────────────────────────────────"
+    echo "Checking $(basename "$key_file")..."
+
+    gpg_output=$(gpg --with-colons --import-options show-only \
+      --import "$key_file" 2>&1 | grep -E '^(pub|sub):')
+
+    key_name=$(basename "$key_file")
+
+    # Parse GPG output line by line to find key type, id, expiry and
+    # capabilities.
+    valid_sign_key_found=false
+    while IFS=: read -r type _ _ _ id _ expiry _ _ _ _ capabilities _; do
+        if [[ "$valid_sign_key_found" == true ]]; then
+            # If we already found a valid signing key, skip further checks for
+            # this keychain.
+            break
+        fi
+
+        key_info="$type:$id ($capabilities)"
+
+        # Check primary key expiry.
+        if [[ "$type" == "pub" ]] &&
+            ! check_key_expiry "$expiry" "$key_info"; then
+            error "$key_info primary key is invalid"
+            break
+        fi
+
+        # Filter out keys that cannot sign releases.
+        if ! [[ "$capabilities" =~ [sS] ]]; then
+            continue
+        fi
+
+        # Check sub key expiry.
+        if [[ "$type" == "sub" ]] &&
+            ! check_key_expiry "$expiry" "$key_info"; then
+            continue
+        fi
+
+        # If we reach here, we have a valid signing key.
+        valid_sign_key_found=true
+    done <<< "$gpg_output"
+
+    if [[ "$valid_sign_key_found" == false ]]; then
+        error "$key_name does not have any valid sign key"
+    fi
+done
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+if [[ $exit_code -eq 0 ]]; then
+    echo "All PGP keys are valid and ready for use!"
+else
+    error "Some PGP keys have issues that need attention."
+fi
+
+exit $exit_code


### PR DESCRIPTION
## Description

Closes #6281. This PR adds a new job to the CI pipeline that verifies the expiration of PGP keys. The job will fail if no valid signing-capable primary or subkey is found.

And, since we have some expired keys, the job is currently failing.


## How to Test

Run the script manually:

```bash
bash scripts/check-pgp-expiry.sh
```

Or simulate the CI job locally using:

```bash
act -j pgp-key-expiration-check
```

To inspect the expiration dates for debugging, use:

```bash
gpg --with-colons --import-options show-only --import "$key_file"
```

Output:
```
➜  lnd git:(check-pgp-keys-expiry) scripts/check-pgp-expiry.sh

Starting PGP key validation...
Found 14 key file(s) in ./scripts/keys

────────────────────────────────────────────────────────────────────
Checking bhandras.asc...
INFO: pub:80E5375C094198D8 (scESC) is valid until 2027-06-06
────────────────────────────────────────────────────────────────────
Checking carlaKC.asc...
INFO: pub:4CA7FE54A6213C91 (scESC) is valid until 2034-05-05
────────────────────────────────────────────────────────────────────
Checking ellemouton.asc...
INFO: pub:D7D916376026F177 (scSC) is valid until 2026-06-21
────────────────────────────────────────────────────────────────────
Checking ffranr.asc...
WARN: pub:B1F8848557AA29D2 (sc) has already expired (2024-10-05)
ERROR: pub:B1F8848557AA29D2 (sc) primary key is invalid
ERROR: ffranr.asc does not have any valid sign key
────────────────────────────────────────────────────────────────────
Checking guggero.asc...
INFO: pub:8E4256593F177720 (scESC) is valid until 2034-04-28
────────────────────────────────────────────────────────────────────
Checking hieblmi.asc...
WARN: pub:F82D456EA023C9BF (sc) has already expired (2024-06-01)
ERROR: pub:F82D456EA023C9BF (sc) primary key is invalid
ERROR: hieblmi.asc does not have any valid sign key
────────────────────────────────────────────────────────────────────
Checking positiveblue.asc...
INFO: pub:E9FE7FE00AD163A4 (cC) does not expire
WARN: sub:4FFF2510928804DC (s) has already expired (2022-09-23)
ERROR: positiveblue.asc does not have any valid sign key
────────────────────────────────────────────────────────────────────
Checking proofofkeags.asc...
INFO: pub:FA7E65C951F12439 (scESC) is valid until 2027-05-28
────────────────────────────────────────────────────────────────────
Checking roasbeef.asc...
INFO: pub:DC42612E89237182 (scESCA) does not expire
────────────────────────────────────────────────────────────────────
Checking sputn1ck.asc...
WARN: pub:671103D881A5F0E4 (sc) has already expired (2024-01-05)
ERROR: pub:671103D881A5F0E4 (sc) primary key is invalid
ERROR: sputn1ck.asc does not have any valid sign key
────────────────────────────────────────────────────────────────────
Checking suheb.asc...
INFO: pub:00C9E2BC2E45666F (scESC) is valid until 2025-10-01
────────────────────────────────────────────────────────────────────
Checking ViktorTigerstrom.asc...
WARN: pub:B984570980684DCC (sc) has already expired (2025-06-05)
ERROR: pub:B984570980684DCC (sc) primary key is invalid
ERROR: ViktorTigerstrom.asc does not have any valid sign key
────────────────────────────────────────────────────────────────────
Checking yyforyongyu.asc...
INFO: pub:9BCD95C4FF296868 (scESC) is valid until 2036-07-14
────────────────────────────────────────────────────────────────────
Checking ziggie1984.asc...
INFO: pub:1AFF9C4DCED6D666 (scESC) is valid until 2025-11-30
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
ERROR: Some PGP keys have issues that need attention.
```