### PR TITLE
graph/db: fix potential policy swop

### DIFF
--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -1188,7 +1188,7 @@ func (s *SQLStore) ForEachNodeCached(ctx context.Context,
 				var cachedInPolicy *models.CachedEdgePolicy
 				if inPolicy != nil {
 					cachedInPolicy = models.NewCachedPolicy(
-						p2,
+						inPolicy,
 					)
 					cachedInPolicy.ToNodePubKey =
 						toNodeCallback
@@ -1197,11 +1197,13 @@ func (s *SQLStore) ForEachNodeCached(ctx context.Context,
 				}
 
 				var inboundFee lnwire.Fee
-				outPolicy.InboundFee.WhenSome(
-					func(fee lnwire.Fee) {
-						inboundFee = fee
-					},
-				)
+				if outPolicy != nil {
+					outPolicy.InboundFee.WhenSome(
+						func(fee lnwire.Fee) {
+							inboundFee = fee
+						},
+					)
+				}
 
 				directedChannel := &DirectedChannel{
 					ChannelID: e.ChannelID,
@@ -1209,7 +1211,7 @@ func (s *SQLStore) ForEachNodeCached(ctx context.Context,
 						e.NodeKey1Bytes,
 					OtherNode:    e.NodeKey2Bytes,
 					Capacity:     e.Capacity,
-					OutPolicySet: p1 != nil,
+					OutPolicySet: outPolicy != nil,
 					InPolicy:     cachedInPolicy,
 					InboundFee:   inboundFee,
 				}


### PR DESCRIPTION
Here, we fix a bug that could lead to a nil pointer dereference.

NOTE: this code isn't "live" yet, so should not affect any production release. 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x8c pc=0x1056c3a78]

goroutine 4078542 [running]:
github.com/lightningnetwork/lnd/graph/db.(*SQLStore).ForEachNodeCached.func1.1(0x2, {0x2, 0x0, 0x7, 0x2f, 0xd3, 0x1, 0xcb, 0x4a, 0x68, ...})
        /Users/elle/LL/lnd/graph/db/sql_store.go:1259 +0x648
github.com/lightningnetwork/lnd/graph/db.forEachNodeCacheable({0x105b92578, 0x106299a40}, {0x105ba98c0, 0x14000b80050}, 0x14000047b40)
        /Users/elle/LL/lnd/graph/db/sql_store.go:3210 +0x170
github.com/lightningnetwork/lnd/graph/db.(*SQLStore).ForEachNodeCached.func1({0x105ba98c0?, 0x14000b80050?})
        /Users/elle/LL/lnd/graph/db/sql_store.go:1177 +0x6c

```