### PR TITLE
wallet: fix imported tapscript address behavior in watch-only mode

### DIFF
--- a/docs/release-notes/release-notes-0.19.3.md
+++ b/docs/release-notes/release-notes-0.19.3.md
@@ -25,6 +25,10 @@
   messages simultaneously. The fix ensures only a single goroutine processes the
   backlog at any given time using an atomic flag.
 
+- [Fixed a bug in `btcwallet` that caused issues with Tapscript addresses being
+  imported in a watch-only (e.g. remote-signing)
+  setup](https://github.com/lightningnetwork/lnd/pull/10119).
+
 # New Features
 
 ## Functional Enhancements
@@ -71,4 +75,5 @@
 # Contributors (Alphabetical Order)
 
 * Olaoluwa Osuntokun
+* Oliver Gugger
 * Yong Yu

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/btcsuite/btclog v0.0.0-20241003133417-09c4e92e319c
 	github.com/btcsuite/btclog/v2 v2.0.1-0.20250728225537-6090e87c6c5b
-	github.com/btcsuite/btcwallet v0.16.14
+	github.com/btcsuite/btcwallet v0.16.15-0.20250805011126-a3632ae48ab3
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.3.5
 	github.com/btcsuite/btcwallet/wallet/txrules v1.2.2
 	github.com/btcsuite/btcwallet/walletdb v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/btcsuite/btclog v0.0.0-20241003133417-09c4e92e319c/go.mod h1:w7xnGOhw
 github.com/btcsuite/btclog/v2 v2.0.1-0.20250728225537-6090e87c6c5b h1:MQ+Q6sDy37V1wP1Yu79A5KqJutolqUGwA99UZWQDWZM=
 github.com/btcsuite/btclog/v2 v2.0.1-0.20250728225537-6090e87c6c5b/go.mod h1:XItGUfVOxotJL8kkuk2Hj3EVow5KCugXl3wWfQ6K0AE=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
-github.com/btcsuite/btcwallet v0.16.14 h1:CofysgmI1ednkLsXontAdBoXJkbiim7unXnFKhLLjnE=
-github.com/btcsuite/btcwallet v0.16.14/go.mod h1:H6dfoZcWPonM2wbVsR2ZBY0PKNZKdQyLAmnX8vL9JFA=
+github.com/btcsuite/btcwallet v0.16.15-0.20250805011126-a3632ae48ab3 h1:MAjNRpj3XhCOrhchq4wq0qI34TIBX/DCnT6OLWejx68=
+github.com/btcsuite/btcwallet v0.16.15-0.20250805011126-a3632ae48ab3/go.mod h1:H6dfoZcWPonM2wbVsR2ZBY0PKNZKdQyLAmnX8vL9JFA=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.5 h1:Rr0njWI3r341nhSPesKQ2JF+ugDSzdPoeckS75SeDZk=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.5/go.mod h1:+tXJ3Ym0nlQc/iHSwW1qzjmPs3ev+UVWMbGgfV1OZqU=
 github.com/btcsuite/btcwallet/wallet/txrules v1.2.2 h1:YEO+Lx1ZJJAtdRrjuhXjWrYsmAk26wLTlNzxt2q0lhk=

--- a/itest/lnd_psbt_test.go
+++ b/itest/lnd_psbt_test.go
@@ -1060,6 +1060,14 @@ func testFundPsbt(ht *lntest.HarnessTest) {
 	alice := ht.NewNodeWithCoins("Alice", nil)
 	bob := ht.NewNodeWithCoins("Bob", nil)
 
+	runFundPsbt(ht, alice, bob)
+}
+
+// runFundPsbt tests the FundPsbt RPC use case where we want to fund a PSBT
+// that already has an input specified. This is a pay-join scenario where Bob
+// wants to send Alice some coins, but he wants to do so in a way that doesn't
+// reveal the full amount he is sending.
+func runFundPsbt(ht *lntest.HarnessTest, alice, bob *node.HarnessNode) {
 	// We test a pay-join between Alice and Bob. Bob wants to send Alice
 	// 5 million Satoshis in a non-obvious way. So Bob selects a UTXO that's
 	// bigger than 5 million Satoshis and expects the change minus the send

--- a/itest/lnd_remote_signer_test.go
+++ b/itest/lnd_remote_signer_test.go
@@ -28,6 +28,10 @@ var remoteSignerTestCases = []*lntest.TestCase{
 		TestFunc: testRemoteSignerAccountImport,
 	},
 	{
+		Name:     "tapscript import",
+		TestFunc: testRemoteSignerTapscriptImport,
+	},
+	{
 		Name:     "channel open",
 		TestFunc: testRemoteSignerChannelOpen,
 	},
@@ -221,6 +225,24 @@ func testRemoteSignerAccountImport(ht *lntest.HarnessTest) {
 				tt, walletrpc.AddressType_WITNESS_PUBKEY_HASH,
 				carol, wo,
 			)
+		},
+	}
+
+	_, watchOnly, carol := prepareRemoteSignerTest(ht, tc)
+	tc.fn(ht, watchOnly, carol)
+}
+
+func testRemoteSignerTapscriptImport(ht *lntest.HarnessTest) {
+	tc := remoteSignerTestCase{
+		name:      "tapscript import",
+		sendCoins: true,
+		fn: func(tt *lntest.HarnessTest, wo, carol *node.HarnessNode) {
+			testTaprootImportTapscriptFullTree(ht, wo)
+			testTaprootImportTapscriptPartialReveal(ht, wo)
+			testTaprootImportTapscriptRootHashOnly(ht, wo)
+			testTaprootImportTapscriptFullKey(ht, wo)
+
+			testTaprootImportTapscriptFullKeyFundPsbt(ht, wo)
 		},
 	}
 

--- a/itest/lnd_remote_signer_test.go
+++ b/itest/lnd_remote_signer_test.go
@@ -328,6 +328,11 @@ func testRemoteSignerPSBT(ht *lntest.HarnessTest) {
 			// that aren't in the wallet. But we also want to make
 			// sure we can fund and then sign PSBTs from our wallet.
 			runFundAndSignPsbt(ht, wo)
+
+			// We also have a more specific funding test that does
+			// a pay-join payment with Carol.
+			ht.FundCoins(btcutil.SatoshiPerBitcoin, carol)
+			runFundPsbt(ht, wo, carol)
 		},
 	}
 


### PR DESCRIPTION
Depends on https://github.com/btcsuite/btcwallet/pull/1022.

Demonstrates the base issue that causes https://github.com/lightninglabs/lightning-terminal/issues/1123 and https://github.com/lightningnetwork/lnd/issues/10120.
Not yet sure what the issue is, perhaps this demonstration case can help find it.
@yyforyongyu you're digging deep into the wallet, perhaps you have an idea?

To see the difference between running the test in a normal setup and in a remote-signing one, you can run:

**Normal**:
```shell
$ make itest icase=taproot_import_scripts

--- PASS: TestLightningNetworkDaemon (5.76s)
    --- PASS: TestLightningNetworkDaemon/tranche00/118-of-302/btcd/taproot_import_scripts (4.57s)
PASS
```

**With a remote signer**:
```shell
$ make itest icase=remote_signer-tapscript_import

    lnd_taproot_test.go:1161: p2tr outpoint: e05bd624e15ca2227390dfac5f25ff8a86d2272bf4f598e514b0bc56a1cf016c:1
    harness_assertion.go:2617: 
                Error Trace:    /home/guggero/projects/go/src/github.com/lightningnetwork/lnd/lntest/harness_assertion.go:2617
                                                        /home/guggero/projects/go/src/github.com/lightningnetwork/lnd/itest/lnd_taproot_test.go:1166
                                                        /home/guggero/projects/go/src/github.com/lightningnetwork/lnd/itest/lnd_remote_signer_test.go:240
                                                        /home/guggero/projects/go/src/github.com/lightningnetwork/lnd/itest/lnd_remote_signer_test.go:250
                                                        /home/guggero/projects/go/src/github.com/lightningnetwork/lnd/lntest/harness.go:315
                                                        /home/guggero/projects/go/src/github.com/lightningnetwork/lnd/itest/lnd_test.go:130
                Error:          Received unexpected error:
                                tx with hash 6c01cfa156bcb014e598f5f42b27d2868aff255facdf907322a25ce124d65be0 not found
                Test:           TestLightningNetworkDaemon/tranche00/227-of-302/btcd/remote_signer-tapscript_import
                Messages:       outpoint txid_bytes:"l\x01ϡV\xbc\xb0\x14\xe5\x98\xf5\xf4+'҆\x8a\xff%_\xacߐs\"\xa2\\\xe1$\xd6[\xe0"  output_index:1 not found in WatchOnly's wallet

```

EDIT: This behavior is fixed with https://github.com/btcsuite/btcwallet/pull/1022, so we update to that PR here.