### PR TITLE
bugfix payment lifecycle payment attempts

### DIFF
--- a/docs/release-notes/release-notes-0.19.2.md
+++ b/docs/release-notes/release-notes-0.19.2.md
@@ -113,5 +113,10 @@ much more slowly.
 ## Tooling and Documentation
 
 # Contributors (Alphabetical Order)
+
+* Calvin Zachman 
+* George Tsagkarelis
 * hieblmi
+* Oliver Gugger
 * Yong Yu
+* Ziggie

--- a/docs/release-notes/release-notes-0.19.3.md
+++ b/docs/release-notes/release-notes-0.19.3.md
@@ -29,6 +29,11 @@
   imported in a watch-only (e.g. remote-signing)
   setup](https://github.com/lightningnetwork/lnd/pull/10119).
 
+- [Fixed](https://github.com/lightningnetwork/lnd/pull/10125) a case in the
+  payment lifecycle where we would retry the same route over and over again in
+  situations where the sending amount would violate the channel policy
+  restriction (min,max HTLC).
+
 # New Features
 
 ## Functional Enhancements
@@ -77,3 +82,4 @@
 * Olaoluwa Osuntokun
 * Oliver Gugger
 * Yong Yu
+* Ziggie

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -243,6 +243,10 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testWumboChannels,
 	},
 	{
+		Name:     "max htlc path payment",
+		TestFunc: testMaxHtlcPathPayment,
+	},
+	{
 		Name:     "max htlc pathfind",
 		TestFunc: testMaxHtlcPathfind,
 	},

--- a/itest/lnd_max_htlc_path_test.go
+++ b/itest/lnd_max_htlc_path_test.go
@@ -1,0 +1,74 @@
+package itest
+
+import (
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
+	"github.com/lightningnetwork/lnd/lntest"
+)
+
+// testMaxHtlcPathPayment tests that when a payment is attempted, the path
+// finding logic correctly takes into account the max_htlc value of the first
+// channel.
+func testMaxHtlcPathPayment(ht *lntest.HarnessTest) {
+	// Create a channel Alice->Bob.
+	chanPoints, nodes := ht.CreateSimpleNetwork(
+		[][]string{nil, nil}, lntest.OpenChannelParams{
+			Amt: 1000000,
+		},
+	)
+	alice, bob := nodes[0], nodes[1]
+	chanPoint := chanPoints[0]
+
+	// Alice and Bob should have one channel open with each other now.
+	ht.AssertNodeNumChannels(alice, 1)
+	ht.AssertNodeNumChannels(bob, 1)
+
+	// Define a max_htlc value that is lower than the default.
+	const (
+		maxHtlcMsat   = 50000000
+		minHtlcMsat   = 1000
+		timeLockDelta = 80
+		baseFeeMsat   = 0
+		feeRate       = 0
+	)
+
+	// Update Alice's channel policy to set the new max_htlc value.
+	req := &lnrpc.PolicyUpdateRequest{
+		Scope: &lnrpc.PolicyUpdateRequest_ChanPoint{
+			ChanPoint: chanPoint,
+		},
+		MaxHtlcMsat:   maxHtlcMsat,
+		MinHtlcMsat:   minHtlcMsat,
+		BaseFeeMsat:   baseFeeMsat,
+		FeeRate:       feeRate,
+		TimeLockDelta: timeLockDelta,
+	}
+	alice.RPC.UpdateChannelPolicy(req)
+
+	expectedPolicy := &lnrpc.RoutingPolicy{
+		FeeBaseMsat:      baseFeeMsat,
+		FeeRateMilliMsat: feeRate,
+		TimeLockDelta:    timeLockDelta,
+		MinHtlc:          minHtlcMsat,
+		MaxHtlcMsat:      maxHtlcMsat,
+	}
+
+	// Wait for the policy update to propagate to Bob.
+	ht.AssertChannelPolicyUpdate(
+		bob, alice, expectedPolicy, chanPoint, false,
+	)
+
+	// Create an invoice for an amount greater than the max htlc value.
+	invoiceAmt := int64(maxHtlcMsat + 10_000_000)
+	invoice := &lnrpc.Invoice{ValueMsat: invoiceAmt}
+	resp := bob.RPC.AddInvoice(invoice)
+
+	// Attempt to pay the invoice from Alice. The payment should be
+	// splitted into two parts, one for the max_htlc value and one for the
+	// remaining amount and succeed.
+	payReq := &routerrpc.SendPaymentRequest{
+		PaymentRequest: resp.PaymentRequest,
+		FeeLimitMsat:   noFeeLimitMsat,
+	}
+	ht.SendPaymentAssertSettled(alice, payReq)
+}

--- a/routing/integrated_routing_context_test.go
+++ b/routing/integrated_routing_context_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
-	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/lightningnetwork/lnd/zpay32"
 	"github.com/stretchr/testify/require"
 )
@@ -36,8 +35,8 @@ func (m *mockBandwidthHints) availableChanBandwidth(channelID uint64,
 	return balance, ok
 }
 
-func (m *mockBandwidthHints) firstHopCustomBlob() fn.Option[tlv.Blob] {
-	return fn.None[tlv.Blob]()
+func (m *mockBandwidthHints) isCustomHTLCPayment() bool {
+	return false
 }
 
 // integratedRoutingContext defines the context in which integrated routing

--- a/routing/unified_edges.go
+++ b/routing/unified_edges.go
@@ -265,12 +265,13 @@ func (u *edgeUnifier) getEdgeLocal(netAmtReceived lnwire.MilliSatoshi,
 		// Add inbound fee to get to the amount that is sent over the
 		// local channel.
 		amt := netAmtReceived + lnwire.MilliSatoshi(inboundFee)
-
 		// Check valid amount range for the channel. We skip this test
-		// for payments with custom HTLC data, as the amount sent on
-		// the BTC layer may differ from the amount that is actually
-		// forwarded in custom channels.
-		if bandwidthHints.firstHopCustomBlob().IsNone() &&
+
+		// for payments with custom htlc data we skip the amount range
+		// check because the amt of the payment does not relate to the
+		// actual amount carried by the HTLC but instead is encoded in
+		// the blob data.
+		if !bandwidthHints.isCustomHTLCPayment() &&
 			!edge.amtInRange(amt) {
 
 			log.Debugf("Amount %v not in range for edge %v",


### PR DESCRIPTION
## Problem description:

Looking through some logs of bigger node-runners I saw a lot of these messages:

```
 policy for local forward not satisfied
```

Making some local testing I realized that LND will easily end up in a 1 min endless loop always trying the same channel because local failures are currently not registered in the Mission-Control setup.

See here:

```
 2025-08-02 16:04:49.472 [ERR] HSWC: Link 182:1:0 policy for local forward not satisfied
2025-08-02 16:04:49.472 [ERR] CRTR: Failed sending attempt 1724 for payment c5c98d82996f4a03d73aa85e10831ef6c0e2bf3b498af455fd073cf6d5c3d745 to switch: htlc exceeds maximum policy amount
2025-08-02 16:04:49.472 [ERR] CRTR: Channel update of ourselves received
2025-08-02 16:04:49.472 [WRN] CRTR: Routing failure for local channel {<nil> 200111116320768} occurred
2025-08-02 16:04:49.472 [WRN] CRTR: Attempt 1724 for payment c5c98d82996f4a03d73aa85e10831ef6c0e2bf3b498af455fd073cf6d5c3d745 failed: htlc exceeds maximum policy amount
2025-08-02 16:04:49.534 [DBG] CRTR: Payment c5c98d82996f4a03d73aa85e10831ef6c0e2bf3b498af455fd073cf6d5c3d745: status=In Flight, active_shards=0, rem_value=200000000 mSAT, fee_limit=10000000 mSAT
2025-08-02 16:04:49.534 [DBG] CRTR: PaymentSession(c5c98d82996f4a03d73aa85e10831ef6c0e2bf3b498af455fd073cf6d5c3d745): pathfinding for amt=200000000 mSAT
2025-08-02 16:04:49.535 [DBG] CRTR: Pathfinding absolute attempt cost: 300 sats
2025-08-02 16:04:49.535 [DBG] CRTR: Found route: probability=0.95, hops=1, fee=0 mSAT
2025-08-02 16:04:49.535 [DBG] CRTR: Pathfinding perf metrics: nodes=1, edges=1, time=99.334µs
2025-08-02 16:04:49.576 [DBG] CRTR: Sending HTLC attempt(id=1725, total_amt=200000000 mSAT, first_hop_amt={200000000}) for payment c5c98d82996f4a03d73aa85e10831ef6c0e2bf3b498af455fd073cf6d5c3d745
2025-08-02 16:04:49.576 [WRN] HSWC: ChannelLink(ff0e5465034e8184a841bb7fe910d532100cd9a95952355896b0a702016d55fb:0): outgoing htlc(c5c98d82996f4a03d73aa85e10831ef6c0e2bf3b498af455fd073cf6d5c3d745) is too large: max_htlc=20000000 mSAT, htlc_value=200000000 mSAT
2025-08-02 16:04:49.576 [ERR] HSWC: Link 182:1:0 policy for local forward not satisfied
2025-08-02 16:04:49.576 [ERR] CRTR: Failed sending attempt 1725 for payment c5c98d82996f4a03d73aa85e10831ef6c0e2bf3b498af455fd073cf6d5c3d745 to switch: htlc exceeds maximum policy amount
2025-08-02 16:04:49.576 [ERR] CRTR: Channel update of ourselves received
2025-08-02 16:04:49.576 [WRN] CRTR: Routing failure for local channel {<nil> 200111116320768} occurred
2025-08-02 16:04:49.576 [WRN] CRTR: Attempt 1725 for payment c5c98d82996f4a03d73aa85e10831ef6c0e2bf3b498af455fd073cf6d5c3d745 failed: htlc exceeds maximum policy amount
2025-08-02 16:04:49.640 [DBG] CRTR: Payment c5c98d82996f4a03d73aa85e10831ef6c0e2bf3b498af455fd073cf6d5c3d745: status=In Flight, active_shards=0, rem_value=200000000 mSAT, fee_limit=10000000 mSAT
2025-08-02 16:04:49.640 [DBG] CRTR: PaymentSession(c5c98d82996f4a03d73aa85e10831ef6c0e2bf3b498af455fd073cf6d5c3d745): pathfinding for amt=200000000 mSAT
2025-08-02 16:04:49.640 [DBG] CRTR: Pathfinding absolute attempt cost: 300 sats
2025-08-02 16:04:49.640 [DBG] CRTR: Found route: probability=0.95, hops=1, fee=0 mSAT
2025-08-02 16:04:49.640 [DBG] CRTR: Pathfinding perf metrics: nodes=1, edges=1, time=96.125µs
2025-08-02 16:04:49.683 [DBG] CRTR: Sending HTLC attempt(id=1726, total_amt=200000000 mSAT, first_hop_amt={200000000}) for payment c5c98d82996f4a03d73aa85e10831ef6c0e2bf3b498af455fd073cf6d5c3d745
2025-08-02 16:04:49.683 [WRN] HSWC: ChannelLink(ff0e5465034e8184a841bb7fe910d532100cd9a95952355896b0a702016d55fb:0): outgoing htlc(c5c98d82996f4a03d73aa85e10831ef6c0e2bf3b498af455fd073cf6d5c3d745) is too large: max_htlc=20000000 mSAT, htlc_value=200000000 mSAT
```

## Problem was introduced here:

https://github.com/lightningnetwork/lnd/pull/9049

but only since https://github.com/lightningnetwork/lnd/pull/8390 (LND 19) this bug would be triggered.

Code part:
https://github.com/lightningnetwork/lnd/blob/37523b6cb708d6df3cbca50da3399f3ab5ad2a7a/routing/unified_edges.go#L273




## Codewise the following happens:

1. Payment is sent (we do not check for the policy for the payment)
https://github.com/lightningnetwork/lnd/blob/37523b6cb708d6df3cbca50da3399f3ab5ad2a7a/routing/unified_edges.go#L273

because the EndorsementBit is always set in the payment firstHop data here:

https://github.com/lightningnetwork/lnd/blob/37523b6cb708d6df3cbca50da3399f3ab5ad2a7a/lnrpc/routerrpc/router_backend.go#L936-L949

2. When the payment fails we do not update any mission control so we keep trying the same channel again and again:

https://github.com/lightningnetwork/lnd/blob/37523b6cb708d6df3cbca50da3399f3ab5ad2a7a/routing/result_interpretation.go#L209-L235

4. => eventually failing the payment after the timeout period.

https://github.com/lightningnetwork/lnd/blob/37523b6cb708d6df3cbca50da3399f3ab5ad2a7a/lnrpc/routerrpc/router_server.go#L358


## This is just a preliminary commit to discuss potential fixes:

1. Make sure we only skip the amount check when the `TrafficShaper` signals it
2. Remove Policy check for sends
6. Other options ?



