### PR TITLE
multi: update ChanUpdatesInHorizon and NodeUpdatesInHorizon to return iterators (iter.Seq[T]) 

### DIFF
--- a/discovery/chan_series.go
+++ b/discovery/chan_series.go
@@ -201,7 +201,7 @@ func (c *ChanSeries) UpdatesInHorizon(chain chainhash.Hash,
 		return nil, err
 	}
 
-	for _, nodeAnn := range nodeAnnsInHorizon {
+	for nodeAnn := range nodeAnnsInHorizon {
 		// If this node has not been seen in the above channels, we can
 		// skip sending its NodeAnnouncement.
 		if _, seen := nodesFromChan[nodeAnn.PubKeyBytes]; !seen {

--- a/discovery/chan_series.go
+++ b/discovery/chan_series.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/fn/v2"
 	graphdb "github.com/lightningnetwork/lnd/graph/db"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/netann"
@@ -114,12 +115,13 @@ func (c *ChanSeries) UpdatesInHorizon(chain chainhash.Hash,
 
 	// First, we'll query for all the set of channels that have an update
 	// that falls within the specified horizon.
-	chansInHorizon, err := c.graph.ChanUpdatesInHorizon(
+	chansInHorizonIter, err := c.graph.ChanUpdatesInHorizon(
 		startTime, endTime,
 	)
 	if err != nil {
 		return nil, err
 	}
+	chansInHorizon := fn.Collect(chansInHorizonIter)
 
 	// nodesFromChan records the nodes seen from the channels.
 	nodesFromChan := make(map[[33]byte]struct{}, len(chansInHorizon)*2)

--- a/discovery/syncer_test.go
+++ b/discovery/syncer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"math"
 	"reflect"
 	"sort"
@@ -86,13 +87,20 @@ func (m *mockChannelGraphTimeSeries) HighestChanID(_ context.Context,
 }
 
 func (m *mockChannelGraphTimeSeries) UpdatesInHorizon(chain chainhash.Hash,
-	startTime time.Time, endTime time.Time) ([]lnwire.Message, error) {
+	startTime, endTime time.Time) iter.Seq2[lnwire.Message, error] {
 
-	m.horizonReq <- horizonQuery{
-		chain, startTime, endTime,
+	return func(yield func(lnwire.Message, error) bool) {
+		m.horizonReq <- horizonQuery{
+			chain, startTime, endTime,
+		}
+
+		msgs := <-m.horizonResp
+		for _, msg := range msgs {
+			if !yield(msg, nil) {
+				return
+			}
+		}
 	}
-
-	return <-m.horizonResp, nil
 }
 
 func (m *mockChannelGraphTimeSeries) FilterKnownChanIDs(chain chainhash.Hash,

--- a/discovery/syncer_test.go
+++ b/discovery/syncer_test.go
@@ -94,6 +94,8 @@ func (m *mockChannelGraphTimeSeries) UpdatesInHorizon(chain chainhash.Hash,
 			chain, startTime, endTime,
 		}
 
+		// We'll get the response from the channel, then yield it
+		// immediately.
 		msgs := <-m.horizonResp
 		for _, msg := range msgs {
 			if !yield(msg, nil) {

--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -219,6 +219,12 @@ reader of a payment request.
 - [Introduced](https://github.com/lightningnetwork/lnd/pull/10136) a wallet
   interface to decouple the relationship between `lnd` and `btcwallet`.
 
+- [Refactored](https://github.com/lightningnetwork/lnd/pull/10128) channel graph
+  update iterators to use Go's `iter.Seq2` pattern. The `UpdatesInHorizon`,
+  `NodeUpdatesInHorizon`, and `ChanUpdatesInHorizon` methods now return lazy
+  iterators instead of materializing all updates in memory at once, improving
+  memory efficiency for large graph operations.
+
 ## Breaking Changes
 ## Performance Improvements
 
@@ -300,6 +306,7 @@ reader of a payment request.
 * Erick Cestari
 * Funyug
 * Mohamed Awnallah
+* Olaoluwa Osuntokun
 * Pins
 * Torkel Rogstad
 * Yong Yu

--- a/fn/go.mod
+++ b/fn/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/fn/v2
 
-go 1.19
+go 1.23
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/fn/iter.go
+++ b/fn/iter.go
@@ -1,0 +1,29 @@
+package fn
+
+import "iter"
+
+// Collect drains all of the elements from the passed iterator, returning a
+// slice of the contents.
+func Collect[T any](seq iter.Seq[T]) []T {
+
+	var ret []T
+	for i := range seq {
+		ret = append(ret, i)
+	}
+
+	return ret
+}
+
+// CollectErr drains all of the elements from the passed iterator with error
+// handling, returning a slice of the contents and the first error encountered.
+func CollectErr[T any](seq iter.Seq2[T, error]) ([]T, error) {
+	var ret []T
+	for val, err := range seq {
+		if err != nil {
+			return ret, err
+		}
+		ret = append(ret, val)
+	}
+
+	return ret, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -206,6 +206,9 @@ require (
 // store have been included in a tagged sqldb version.
 replace github.com/lightningnetwork/lnd/sqldb => ./sqldb
 
+// Replace fn package to use local version with iterator Collect function.
+replace github.com/lightningnetwork/lnd/fn/v2 => ./fn
+
 // This replace is for https://github.com/advisories/GHSA-25xm-hr59-7c27
 replace github.com/ulikunitz/xz => github.com/ulikunitz/xz v0.5.11
 

--- a/go.sum
+++ b/go.sum
@@ -374,8 +374,6 @@ github.com/lightningnetwork/lnd/cert v1.2.2 h1:71YK6hogeJtxSxw2teq3eGeuy4rHGKcFf
 github.com/lightningnetwork/lnd/cert v1.2.2/go.mod h1:jQmFn/Ez4zhDgq2hnYSw8r35bqGVxViXhX6Cd7HXM6U=
 github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsDIBjgjWdZgA0=
 github.com/lightningnetwork/lnd/clock v1.1.1/go.mod h1:mGnAhPyjYZQJmebS7aevElXKTFDuO+uNFFfMXK1W8xQ=
-github.com/lightningnetwork/lnd/fn/v2 v2.0.8 h1:r2SLz7gZYQPVc3IZhU82M66guz3Zk2oY+Rlj9QN5S3g=
-github.com/lightningnetwork/lnd/fn/v2 v2.0.8/go.mod h1:TOzwrhjB/Azw1V7aa8t21ufcQmdsQOQMDtxVOQWNl8s=
 github.com/lightningnetwork/lnd/healthcheck v1.2.6 h1:1sWhqr93GdkWy4+6U7JxBfcyZIE78MhIHTJZfPx7qqI=
 github.com/lightningnetwork/lnd/healthcheck v1.2.6/go.mod h1:Mu02um4CWY/zdTOvFje7WJgJcHyX2zq/FG3MhOAiGaQ=
 github.com/lightningnetwork/lnd/kvdb v1.4.16 h1:9BZgWdDfjmHRHLS97cz39bVuBAqMc4/p3HX1xtUdbDI=

--- a/graph/builder.go
+++ b/graph/builder.go
@@ -593,13 +593,13 @@ func (b *Builder) pruneZombieChans() error {
 
 	startTime := time.Unix(0, 0)
 	endTime := time.Now().Add(-1 * chanExpiry)
-	oldEdges, err := b.cfg.Graph.ChanUpdatesInHorizon(startTime, endTime)
+	oldEdgesIter, err := b.cfg.Graph.ChanUpdatesInHorizon(startTime, endTime)
 	if err != nil {
 		return fmt.Errorf("unable to fetch expired channel updates "+
 			"chans: %v", err)
 	}
 
-	for _, u := range oldEdges {
+	for u := range oldEdgesIter {
 		err = filterPruneChans(u.Info, u.Policy1, u.Policy2)
 		if err != nil {
 			return fmt.Errorf("error filtering channels to "+

--- a/graph/builder.go
+++ b/graph/builder.go
@@ -593,13 +593,14 @@ func (b *Builder) pruneZombieChans() error {
 
 	startTime := time.Unix(0, 0)
 	endTime := time.Now().Add(-1 * chanExpiry)
-	oldEdgesIter, err := b.cfg.Graph.ChanUpdatesInHorizon(startTime, endTime)
-	if err != nil {
-		return fmt.Errorf("unable to fetch expired channel updates "+
-			"chans: %v", err)
-	}
+	oldEdgesIter := b.cfg.Graph.ChanUpdatesInHorizon(startTime, endTime)
 
-	for u := range oldEdgesIter {
+	for u, err := range oldEdgesIter {
+		if err != nil {
+			return fmt.Errorf("unable to fetch expired "+
+				"channel updates chans: %v", err)
+		}
+
 		err = filterPruneChans(u.Info, u.Policy1, u.Policy2)
 		if err != nil {
 			return fmt.Errorf("error filtering channels to "+
@@ -619,7 +620,7 @@ func (b *Builder) pruneZombieChans() error {
 		toPrune = append(toPrune, chanID)
 		log.Tracef("Pruning zombie channel with ChannelID(%v)", chanID)
 	}
-	err = b.cfg.Graph.DeleteChannelEdges(
+	err := b.cfg.Graph.DeleteChannelEdges(
 		b.cfg.StrictZombiePruning, true, toPrune...,
 	)
 	if err != nil {

--- a/graph/db/benchmark_test.go
+++ b/graph/db/benchmark_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/batch"
+	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/graph/db/models"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/kvdb/postgres"
@@ -788,9 +789,10 @@ func BenchmarkGraphReadMethods(b *testing.B) {
 		{
 			name: "NodeUpdatesInHorizon",
 			fn: func(b testing.TB, store V1Store) {
-				_, err := store.NodeUpdatesInHorizon(
+				iter := store.NodeUpdatesInHorizon(
 					time.Unix(0, 0), time.Now(),
 				)
+				_, err := fn.CollectErr(iter)
 				require.NoError(b, err)
 			},
 		},
@@ -836,9 +838,10 @@ func BenchmarkGraphReadMethods(b *testing.B) {
 		{
 			name: "ChanUpdatesInHorizon",
 			fn: func(b testing.TB, store V1Store) {
-				_, err := store.ChanUpdatesInHorizon(
+				iter := store.ChanUpdatesInHorizon(
 					time.Unix(0, 0), time.Now(),
 				)
+				_, err := fn.CollectErr(iter)
 				require.NoError(b, err)
 			},
 		},

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -2028,10 +2028,11 @@ func TestChanUpdatesInHorizon(t *testing.T) {
 
 	// If we issue an arbitrary query before any channel updates are
 	// inserted in the database, we should get zero results.
-	chanUpdates, err := graph.ChanUpdatesInHorizon(
+	chanUpdatesIter, err := graph.ChanUpdatesInHorizon(
 		time.Unix(999, 0), time.Unix(9999, 0),
 	)
 	require.NoError(t, err, "unable to updates for updates")
+	chanUpdates := fn.Collect(chanUpdatesIter)
 	if len(chanUpdates) != 0 {
 		t.Fatalf("expected 0 chan updates, instead got %v",
 			len(chanUpdates))
@@ -2144,12 +2145,13 @@ func TestChanUpdatesInHorizon(t *testing.T) {
 		},
 	}
 	for _, queryCase := range queryCases {
-		resp, err := graph.ChanUpdatesInHorizon(
+		respIter, err := graph.ChanUpdatesInHorizon(
 			queryCase.start, queryCase.end,
 		)
 		if err != nil {
 			t.Fatalf("unable to query for updates: %v", err)
 		}
+		resp := fn.Collect(respIter)
 
 		if len(resp) != len(queryCase.resp) {
 			t.Fatalf("expected %v chans, got %v chans",

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -2263,9 +2263,11 @@ func TestNodeUpdatesInHorizon(t *testing.T) {
 		},
 	}
 	for _, queryCase := range queryCases {
-		resp, err := graph.NodeUpdatesInHorizon(
+		respIter, err := graph.NodeUpdatesInHorizon(
 			queryCase.start, queryCase.end,
 		)
+
+		resp := fn.Collect(respIter)
 		require.NoError(t, err)
 		require.Len(t, resp, len(queryCase.resp))
 
@@ -3507,11 +3509,12 @@ func TestNodePruningUpdateIndexDeletion(t *testing.T) {
 	// update time of our test node.
 	startTime := time.Unix(9, 0)
 	endTime := node1.LastUpdate.Add(time.Minute)
-	nodesInHorizon, err := graph.NodeUpdatesInHorizon(startTime, endTime)
+	nodesInHorizonIter, err := graph.NodeUpdatesInHorizon(startTime, endTime)
 	require.NoError(t, err, "unable to fetch nodes in horizon")
 
 	// We should only have a single node, and that node should exactly
 	// match the node we just inserted.
+	nodesInHorizon := fn.Collect(nodesInHorizonIter)
 	if len(nodesInHorizon) != 1 {
 		t.Fatalf("should have 1 nodes instead have: %v",
 			len(nodesInHorizon))
@@ -3525,10 +3528,10 @@ func TestNodePruningUpdateIndexDeletion(t *testing.T) {
 
 	// Now that the node has been deleted, we'll again query the nodes in
 	// the horizon. This time we should have no nodes at all.
-	nodesInHorizon, err = graph.NodeUpdatesInHorizon(startTime, endTime)
+	nodesInHorizonIter, err = graph.NodeUpdatesInHorizon(startTime, endTime)
 	require.NoError(t, err, "unable to fetch nodes in horizon")
 
-	if len(nodesInHorizon) != 0 {
+	if len(fn.Collect(nodesInHorizonIter)) != 0 {
 		t.Fatalf("should have zero nodes instead have: %v",
 			len(nodesInHorizon))
 	}

--- a/graph/db/interfaces.go
+++ b/graph/db/interfaces.go
@@ -2,6 +2,7 @@ package graphdb
 
 import (
 	"context"
+	"iter"
 	"net"
 	"time"
 
@@ -109,8 +110,8 @@ type V1Store interface { //nolint:interfacebloat
 	// an update timestamp within the passed range. This method can be used
 	// by two nodes to quickly determine if they have the same set of up to
 	// date node announcements.
-	NodeUpdatesInHorizon(startTime,
-		endTime time.Time) ([]models.Node, error)
+	NodeUpdatesInHorizon(startTime, endTime time.Time,
+		opts ...IteratorOption) (iter.Seq[models.Node], error)
 
 	// FetchNode attempts to look up a target node by its identity
 	// public key. If the node isn't found in the database, then

--- a/graph/db/interfaces.go
+++ b/graph/db/interfaces.go
@@ -111,7 +111,7 @@ type V1Store interface { //nolint:interfacebloat
 	// by two nodes to quickly determine if they have the same set of up to
 	// date node announcements.
 	NodeUpdatesInHorizon(startTime, endTime time.Time,
-		opts ...IteratorOption) (iter.Seq[models.Node], error)
+		opts ...IteratorOption) iter.Seq2[models.Node, error]
 
 	// FetchNode attempts to look up a target node by its identity
 	// public key. If the node isn't found in the database, then
@@ -221,7 +221,7 @@ type V1Store interface { //nolint:interfacebloat
 	// at least one edge that has an update timestamp within the specified
 	// horizon.
 	ChanUpdatesInHorizon(startTime, endTime time.Time,
-		opts ...IteratorOption) (iter.Seq[ChannelEdge], error)
+		opts ...IteratorOption) iter.Seq2[ChannelEdge, error]
 
 	// FilterKnownChanIDs takes a set of channel IDs and return the subset
 	// of chan ID's that we don't know and are not known zombies of the

--- a/graph/db/interfaces.go
+++ b/graph/db/interfaces.go
@@ -220,8 +220,8 @@ type V1Store interface { //nolint:interfacebloat
 	// ChanUpdatesInHorizon returns all the known channel edges which have
 	// at least one edge that has an update timestamp within the specified
 	// horizon.
-	ChanUpdatesInHorizon(startTime, endTime time.Time) ([]ChannelEdge,
-		error)
+	ChanUpdatesInHorizon(startTime, endTime time.Time,
+		opts ...IteratorOption) (iter.Seq[ChannelEdge], error)
 
 	// FilterKnownChanIDs takes a set of channel IDs and return the subset
 	// of chan ID's that we don't know and are not known zombies of the

--- a/graph/db/options.go
+++ b/graph/db/options.go
@@ -20,6 +20,60 @@ const (
 	DefaultPreAllocCacheNumNodes = 15000
 )
 
+// IteratorOption is a functional option used to change the per-call
+// configuration for iterators.
+type IteratorOption func(*iterConfig)
+
+// iterConfig holds the configuration for graph operations.
+type iterConfig struct {
+	// chanUpdateIterBatchSize is the batch size to use when reading out
+	// channel updates to send a peer a backlog.
+	chanUpdateIterBatchSize int
+
+	// nodeUpdateIterBatchSize is the batch size to use when reading out
+	// node updates to send to a peer backlog.
+	nodeUpdateIterBatchSize int
+
+	// iterPublicNodes is used to make an iterator that only iterates over
+	// public nodes.
+	iterPublicNodes bool
+}
+
+// defaultIteratorConfig returns the default configuration.
+func defaultIteratorConfig() *iterConfig {
+	return &iterConfig{
+		chanUpdateIterBatchSize: 1_000,
+		nodeUpdateIterBatchSize: 1_000,
+	}
+}
+
+// WithChanUpdateIterBatchSize sets the batch size for channel update
+// iterators.
+func WithChanUpdateIterBatchSize(size int) IteratorOption {
+	return func(cfg *iterConfig) {
+		if size > 0 {
+			cfg.chanUpdateIterBatchSize = size
+		}
+	}
+}
+
+// WithNodeUpdateIterBatchSize set the batch size for node ann iterators.
+func WithNodeUpdateIterBatchSize(size int) IteratorOption {
+	return func(cfg *iterConfig) {
+		if size > 0 {
+			cfg.nodeUpdateIterBatchSize = size
+		}
+	}
+}
+
+// WithIterPublicNodesOnly is used to create an iterator that only iterates over
+// public nodes.
+func WithIterPublicNodesOnly() IteratorOption {
+	return func(cfg *iterConfig) {
+		cfg.iterPublicNodes = true
+	}
+}
+
 // chanGraphOptions holds parameters for tuning and customizing the
 // ChannelGraph.
 type chanGraphOptions struct {

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -981,117 +981,250 @@ func (s *SQLStore) ForEachNodeChannel(ctx context.Context, nodePub route.Vertex,
 	}, reset)
 }
 
-// ChanUpdatesInHorizon returns all the known channel edges which have at least
-// one edge that has an update timestamp within the specified horizon.
-//
-// NOTE: This is part of the V1Store interface.
-func (s *SQLStore) ChanUpdatesInHorizon(startTime,
-	endTime time.Time,
-	opts ...IteratorOption) (iter.Seq[ChannelEdge], error) {
+// extractMaxUpdateTime returns the maximum of the two policy update times.
+// This is used for pagination cursor tracking.
+func extractMaxUpdateTime(
+	row sqlc.GetChannelsByPolicyLastUpdateRangeRow) int64 {
+
+	switch {
+	case row.Policy1LastUpdate.Valid && row.Policy2LastUpdate.Valid:
+		return max(row.Policy1LastUpdate.Int64,
+			row.Policy2LastUpdate.Int64)
+	case row.Policy1LastUpdate.Valid:
+		return row.Policy1LastUpdate.Int64
+	case row.Policy2LastUpdate.Valid:
+		return row.Policy2LastUpdate.Int64
+	default:
+		return 0
+	}
+}
+
+// buildChannelFromRow constructs a ChannelEdge from a database row.
+// This includes building the nodes, channel info, and policies.
+func (s *SQLStore) buildChannelFromRow(ctx context.Context, db SQLQueries,
+	row sqlc.GetChannelsByPolicyLastUpdateRangeRow) (ChannelEdge, error) {
+
+	node1, err := buildNode(ctx, s.cfg.QueryCfg, db, row.GraphNode)
+	if err != nil {
+		return ChannelEdge{}, fmt.Errorf("unable to build node1: %w",
+			err)
+	}
+
+	node2, err := buildNode(ctx, s.cfg.QueryCfg, db, row.GraphNode_2)
+	if err != nil {
+		return ChannelEdge{}, fmt.Errorf("unable to build node2: %w",
+			err)
+	}
+
+	channel, err := getAndBuildEdgeInfo(
+		ctx, s.cfg, db,
+		row.GraphChannel, node1.PubKeyBytes,
+		node2.PubKeyBytes,
+	)
+	if err != nil {
+		return ChannelEdge{}, fmt.Errorf("unable to build "+
+			"channel info: %w", err)
+	}
+
+	dbPol1, dbPol2, err := extractChannelPolicies(row)
+	if err != nil {
+		return ChannelEdge{}, fmt.Errorf("unable to extract "+
+			"channel policies: %w", err)
+	}
+
+	p1, p2, err := getAndBuildChanPolicies(
+		ctx, s.cfg.QueryCfg, db, dbPol1, dbPol2, channel.ChannelID,
+		node1.PubKeyBytes, node2.PubKeyBytes,
+	)
+	if err != nil {
+		return ChannelEdge{}, fmt.Errorf("unable to build "+
+			"channel policies: %w", err)
+	}
+
+	return ChannelEdge{
+		Info:    channel,
+		Policy1: p1,
+		Policy2: p2,
+		Node1:   node1,
+		Node2:   node2,
+	}, nil
+}
+
+// updateChanCacheBatch updates the channel cache with multiple edges at once.
+// This method acquires the cache lock only once for the entire batch.
+func (s *SQLStore) updateChanCacheBatch(edgesToCache map[uint64]ChannelEdge) {
+	if len(edgesToCache) == 0 {
+		return
+	}
 
 	s.cacheMu.Lock()
 	defer s.cacheMu.Unlock()
 
-	var (
-		ctx = context.TODO()
-		// To ensure we don't return duplicate ChannelEdges, we'll use
-		// an additional map to keep track of the edges already seen to
-		// prevent re-adding it.
-		edgesSeen    = make(map[uint64]struct{})
-		edgesToCache = make(map[uint64]ChannelEdge)
-		edges        []ChannelEdge
-		hits         int
-	)
-
-	err := s.db.ExecTx(ctx, sqldb.ReadTxOpt(), func(db SQLQueries) error {
-		rows, err := db.GetChannelsByPolicyLastUpdateRange(
-			ctx, sqlc.GetChannelsByPolicyLastUpdateRangeParams{
-				Version:   int16(ProtocolV1),
-				StartTime: sqldb.SQLInt64(startTime.Unix()),
-				EndTime:   sqldb.SQLInt64(endTime.Unix()),
-			},
-		)
-		if err != nil {
-			return err
-		}
-
-		if len(rows) == 0 {
-			return nil
-		}
-
-		// We'll pre-allocate the slices and maps here with a best
-		// effort size in order to avoid unnecessary allocations later
-		// on.
-		uncachedRows := make(
-			[]sqlc.GetChannelsByPolicyLastUpdateRangeRow, 0,
-			len(rows),
-		)
-		edgesToCache = make(map[uint64]ChannelEdge, len(rows))
-		edgesSeen = make(map[uint64]struct{}, len(rows))
-		edges = make([]ChannelEdge, 0, len(rows))
-
-		// Separate cached from non-cached channels since we will only
-		// batch load the data for the ones we haven't cached yet.
-		for _, row := range rows {
-			chanIDInt := byteOrder.Uint64(row.GraphChannel.Scid)
-
-			// Skip duplicates.
-			if _, ok := edgesSeen[chanIDInt]; ok {
-				continue
-			}
-			edgesSeen[chanIDInt] = struct{}{}
-
-			// Check cache first.
-			if channel, ok := s.chanCache.get(chanIDInt); ok {
-				hits++
-				edges = append(edges, channel)
-				continue
-			}
-
-			// Mark this row as one we need to batch load data for.
-			uncachedRows = append(uncachedRows, row)
-		}
-
-		// If there are no uncached rows, then we can return early.
-		if len(uncachedRows) == 0 {
-			return nil
-		}
-
-		// Batch load data for all uncached channels.
-		newEdges, err := batchBuildChannelEdges(
-			ctx, s.cfg, db, uncachedRows,
-		)
-		if err != nil {
-			return fmt.Errorf("unable to batch build channel "+
-				"edges: %w", err)
-		}
-
-		edges = append(edges, newEdges...)
-
-		return nil
-	}, sqldb.NoOpReset)
-	if err != nil {
-		return nil, fmt.Errorf("unable to fetch channels: %w", err)
+	for chanID, edge := range edgesToCache {
+		s.chanCache.insert(chanID, edge)
 	}
+}
 
-	// Insert any edges loaded from disk into the cache.
-	for chanid, channel := range edgesToCache {
-		s.chanCache.insert(chanid, channel)
-	}
+// ChanUpdatesInHorizon returns all the known channel edges which have at least
+// one edge that has an update timestamp within the specified horizon.
+//
+// Iterator Lifecycle:
+// 1. Initialize state (edgesSeen map, cache tracking, pagination cursors)
+// 2. Query batch of channels with policies in time range
+// 3. For each channel: check if seen, check cache, or build from DB
+// 4. Yield channels to caller
+// 5. Update cache after successful batch
+// 6. Repeat with updated pagination cursor until no more results
+//
+// NOTE: This is part of the V1Store interface.
+func (s *SQLStore) ChanUpdatesInHorizon(startTime, endTime time.Time,
+	opts ...IteratorOption) (iter.Seq[ChannelEdge], error) {
 
-	if len(edges) > 0 {
-		log.Debugf("ChanUpdatesInHorizon hit percentage: %.2f (%d/%d)",
-			float64(hits)*100/float64(len(edges)), hits, len(edges))
-	} else {
-		log.Debugf("ChanUpdatesInHorizon returned no edges in "+
-			"horizon (%s, %s)", startTime, endTime)
+	// Apply options.
+	cfg := defaultIteratorConfig()
+	for _, opt := range opts {
+		opt(cfg)
 	}
 
 	return func(yield func(ChannelEdge) bool) {
-		for _, edge := range edges {
-			if !yield(edge) {
+		var (
+			ctx            = context.TODO()
+			edgesSeen      = make(map[uint64]struct{})
+			edgesToCache   = make(map[uint64]ChannelEdge)
+			hits           int
+			total          int
+			lastUpdateTime sql.NullInt64
+			lastID         sql.NullInt64
+			hasMore        = true
+		)
+
+		// Each iteration, we'll read a batch amount of channel updates
+		// (consulting the cache along the way), yield them, then loop
+		// back to decide if we have any more updates to read out.
+		for hasMore {
+			var batch []ChannelEdge
+
+			err := s.db.ExecTx(ctx, sqldb.ReadTxOpt(),
+				func(db SQLQueries) error {
+					//nolint:ll
+					params := sqlc.GetChannelsByPolicyLastUpdateRangeParams{
+						Version: int16(ProtocolV1),
+						StartTime: sqldb.SQLInt64(
+							startTime.Unix(),
+						),
+						EndTime: sqldb.SQLInt64(
+							endTime.Unix(),
+						),
+						LastUpdateTime: lastUpdateTime,
+						LastID:         lastID,
+						MaxResults: sql.NullInt32{
+							Int32: int32(
+								cfg.chanUpdateIterBatchSize,
+							),
+							Valid: true,
+						},
+					}
+					//nolint:ll
+					rows, err := db.GetChannelsByPolicyLastUpdateRange(
+						ctx, params,
+					)
+					if err != nil {
+						return err
+					}
+
+					//nolint:ll
+					hasMore = len(rows) == cfg.chanUpdateIterBatchSize
+
+					//nolint:ll
+					for _, row := range rows {
+						lastUpdateTime = sql.NullInt64{
+							Int64: extractMaxUpdateTime(row),
+							Valid: true,
+						}
+						lastID = sql.NullInt64{
+							Int64: row.GraphChannel.ID,
+							Valid: true,
+						}
+
+						// Skip if we've already
+						// processed this channel.
+						chanIDInt := byteOrder.Uint64(
+							row.GraphChannel.Scid,
+						)
+						_, ok := edgesSeen[chanIDInt]
+						if ok {
+							continue
+						}
+
+						s.cacheMu.RLock()
+						channel, ok := s.chanCache.get(
+							chanIDInt,
+						)
+						s.cacheMu.RUnlock()
+						if ok {
+							hits++
+							total++
+							edgesSeen[chanIDInt] = struct{}{}
+							batch = append(batch, channel)
+
+							continue
+						}
+
+						chanEdge, err := s.buildChannelFromRow(
+							ctx, db, row,
+						)
+						if err != nil {
+							return err
+						}
+
+						edgesSeen[chanIDInt] = struct{}{}
+						edgesToCache[chanIDInt] = chanEdge
+
+						batch = append(batch, chanEdge)
+
+						total++
+					}
+
+					return nil
+				}, func() {
+					batch = nil
+					edgesSeen = make(map[uint64]struct{})
+					edgesToCache = make(
+						map[uint64]ChannelEdge,
+					)
+				})
+
+			if err != nil {
+				log.Errorf("ChanUpdatesInHorizon "+
+					"batch error: %v", err)
+
 				return
 			}
+
+			for _, edge := range batch {
+				if !yield(edge) {
+					return
+				}
+			}
+
+			// Update cache after successful batch yield, setting
+			// the cache lock only once for the entire batch.
+			s.updateChanCacheBatch(edgesToCache)
+			edgesToCache = make(map[uint64]ChannelEdge)
+
+			// If the batch didn't yield anything, then we're done.
+			if len(batch) == 0 {
+				break
+			}
+		}
+
+		if total > 0 {
+			log.Debugf("ChanUpdatesInHorizon hit percentage: "+
+				"%.2f (%d/%d)",
+				float64(hits)*100/float64(total), hits, total)
+		} else {
+			log.Debugf("ChanUpdatesInHorizon returned no edges "+
+				"in horizon (%s, %s)", startTime, endTime)
 		}
 	}, nil
 }

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -933,7 +933,8 @@ func (s *SQLStore) ForEachNodeChannel(ctx context.Context, nodePub route.Vertex,
 //
 // NOTE: This is part of the V1Store interface.
 func (s *SQLStore) ChanUpdatesInHorizon(startTime,
-	endTime time.Time) ([]ChannelEdge, error) {
+	endTime time.Time,
+	opts ...IteratorOption) (iter.Seq[ChannelEdge], error) {
 
 	s.cacheMu.Lock()
 	defer s.cacheMu.Unlock()
@@ -1033,7 +1034,13 @@ func (s *SQLStore) ChanUpdatesInHorizon(startTime,
 			"horizon (%s, %s)", startTime, endTime)
 	}
 
-	return edges, nil
+	return func(yield func(ChannelEdge) bool) {
+		for _, edge := range edges {
+			if !yield(edge) {
+				return
+			}
+		}
+	}, nil
 }
 
 // ForEachNodeCached is similar to forEachNode, but it returns DirectedChannel

--- a/graph/interfaces.go
+++ b/graph/interfaces.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"context"
+	"iter"
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -152,8 +153,9 @@ type DB interface {
 	// ChanUpdatesInHorizon returns all the known channel edges which have
 	// at least one edge that has an update timestamp within the specified
 	// horizon.
-	ChanUpdatesInHorizon(startTime, endTime time.Time) (
-		[]graphdb.ChannelEdge, error)
+	ChanUpdatesInHorizon(startTime, endTime time.Time,
+		opts ...graphdb.IteratorOption) (
+		iter.Seq[graphdb.ChannelEdge], error)
 
 	// DeleteChannelEdges removes edges with the given channel IDs from the
 	// database and marks them as zombies. This ensures that we're unable to

--- a/graph/interfaces.go
+++ b/graph/interfaces.go
@@ -154,8 +154,8 @@ type DB interface {
 	// at least one edge that has an update timestamp within the specified
 	// horizon.
 	ChanUpdatesInHorizon(startTime, endTime time.Time,
-		opts ...graphdb.IteratorOption) (
-		iter.Seq[graphdb.ChannelEdge], error)
+		opts ...graphdb.IteratorOption,
+	) iter.Seq2[graphdb.ChannelEdge, error]
 
 	// DeleteChannelEdges removes edges with the given channel IDs from the
 	// database and marks them as zombies. This ensures that we're unable to


### PR DESCRIPTION
Haven't had an excuse to make an [iterator](https://pkg.go.dev/iter) yet, so I nerd-sniped myself into the creation of this PR. 

This PR does a few things:
  * Updates nodes+chan updates in horizon to return an iterator of the contents.
     * Even though most of the actual values we read out will already be in the channel graph cache, as is we can have a potentially very long running database transactions. 
     * The new iterator versions accept a batch size and read in chunks, yielding out the responses. Callers are mostly unchanged. 
  *  Optimizes public node filtering for nodes in horizon:
     * Before in a new loop after we'd read all the nodes, we'd then check again to see which ones are public. This previously meant a new DB transaction for each node. Now we fold that into the underlying query. 
  * Update the cache incrementally during reading:
     * Before we'd hold the cache mutex the entire time while reading out the entire response. 
     * Now we'll only hold the cache to check if we can serve from it, then we update the cache items at the very end of serving a batch. 

The cache changes now mean that an invocation doesn't have a consistent view of the cache, but for cases like this (serving gossip data to peers, can be lossy), we don't really need a consistent snapshot. This change should reduce over all mutex contention as well. 