### PR TITLE
docs: move v0.19.3 items to correct file

### DIFF
--- a/docs/release-notes/release-notes-0.19.3.md
+++ b/docs/release-notes/release-notes-0.19.3.md
@@ -25,6 +25,14 @@
   messages simultaneously. The fix ensures only a single goroutine processes the
   backlog at any given time using an atomic flag.
 
+- [Fix](https://github.com/lightningnetwork/lnd/pull/10107) a bug where child
+  logger's derived via `WithPrefix` did not inherit change log level changes
+  from their parent loggers.
+
+- Fixed a [deadlock](https://github.com/lightningnetwork/lnd/pull/10108) that
+  can cause contract resolvers to be stuck at marking the channel force close as
+  being complete.
+
 - [Fixed a bug in `btcwallet` that caused issues with Tapscript addresses being
   imported in a watch-only (e.g. remote-signing)
   setup](https://github.com/lightningnetwork/lnd/pull/10119).
@@ -37,6 +45,10 @@
 # New Features
 
 ## Functional Enhancements
+
+* The default value for `gossip.msg-rate-bytes` has been
+  [increased](https://github.com/lightningnetwork/lnd/pull/10096) from 100KB to
+  1MB, and `gossip.msg-burst-bytes` has been increased from 200KB to 2MB.
 
 - Previously, when sweeping non-time sensitive anchor outputs, they might be
   grouped with other non-time sensitive outputs such as `to_local` outputs,
@@ -79,6 +91,7 @@
 
 # Contributors (Alphabetical Order)
 
+* Elle Mouton
 * Olaoluwa Osuntokun
 * Oliver Gugger
 * Yong Yu

--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -37,13 +37,6 @@
   known TLV fields were incorrectly encoded into the `ExtraData` field of
   messages in the dynamic commitment set.
 
-- Fixed a [deadlock](https://github.com/lightningnetwork/lnd/pull/10108) that
-  can cause contract resolvers to be stuck at marking the channel force close as
-  being complete.
- 
-- [Fix](https://github.com/lightningnetwork/lnd/pull/10107) a bug where child 
-  logger's derived via `WithPrefix` did not inherit change log level changes 
-  from their parent loggers. 
 
 # New Features
 
@@ -85,11 +78,6 @@ circuit. The indices are only available for forwarding events saved after v0.20.
   protocols like dynamic commitments by restricting that the operation must
   finish under this timeout value. Consider using a larger timeout value if you
   have a slow network.
-
-* The default value for `gossip.msg-rate-bytes` has been
-  [increased](https://github.com/lightningnetwork/lnd/pull/10096) from 100KB to
-  1MB, and `gossip.msg-burst-bytes` has been increased from 200KB to 2MB.
-
 
 * Added [`deletecanceledinvoices`](
   https://github.com/lightningnetwork/lnd/pull/9625) RPC to allow the removal of


### PR DESCRIPTION
Moves the PRs that are going to be shipped with v0.19.3 into the correct release notes file.

See https://github.com/lightningnetwork/lnd/pull/10134 for more details.
