### PR TITLE
server: don't mention aux controllers in error message

### DIFF
--- a/server.go
+++ b/server.go
@@ -634,8 +634,9 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 	if cfg.ProtocolOptions.TaprootOverlayChans &&
 		implCfg.AuxFundingController.IsNone() {
 
-		return nil, fmt.Errorf("taproot overlay flag set, but not " +
-			"aux controllers")
+		return nil, fmt.Errorf("taproot overlay flag set, but " +
+			"overlay channels are not supported " +
+			"in a standalone lnd build")
 	}
 
 	//nolint:ll


### PR DESCRIPTION
This error is returned when one attempts to use Taproot overlay channels without the necessary auxiliary funding controller being supplied. In practice, when running lnd via litd, the latter will always supply 'tapd' as the aux funding controller, but a standalone lnd has no knowledge of that.

The previous message sort of reads like the lnd user has forgotten to set some available option or flag, but nothing or the sort actually exists. The update makes it clearer that the feature isn't available in the standalone build.
