### PR TITLE
graph/db+sqldb: different defaults for SQLite and Postgres query options

### DIFF
--- a/config_builder.go
+++ b/config_builder.go
@@ -1130,9 +1130,8 @@ func (d *DefaultDatabaseBuilder) BuildDatabase(
 					continue
 				}
 
-				migFn, ok := getSQLMigration(
+				migFn, ok := d.getSQLMigration(
 					ctx, version, dbs.ChanStateDB.Backend,
-					*d.cfg.ActiveNetParams.GenesisHash,
 				)
 				if !ok {
 					continue

--- a/config_prod.go
+++ b/config_prod.go
@@ -5,7 +5,6 @@ package lnd
 import (
 	"context"
 
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	graphdb "github.com/lightningnetwork/lnd/graph/db"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/sqldb"
@@ -30,9 +29,9 @@ func (d *DefaultDatabaseBuilder) getGraphStore(_ *sqldb.BaseDB,
 // NOTE: this is a no-op for the production build since all migrations that are
 // in production will also be in development builds, and so they are not
 // defined behind a build tag.
-func getSQLMigration(ctx context.Context, version int,
-	kvBackend kvdb.Backend,
-	chain chainhash.Hash) (func(tx *sqlc.Queries) error, bool) {
+func (d *DefaultDatabaseBuilder) getSQLMigration(ctx context.Context,
+	version int, kvBackend kvdb.Backend) (func(tx *sqlc.Queries) error,
+	bool) {
 
 	return nil, false
 }

--- a/config_test_native_sql.go
+++ b/config_test_native_sql.go
@@ -7,7 +7,6 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	graphdb "github.com/lightningnetwork/lnd/graph/db"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lncfg"
@@ -50,15 +49,23 @@ func (d *DefaultDatabaseBuilder) getGraphStore(baseDB *sqldb.BaseDB,
 const graphSQLMigration = 9
 
 // getSQLMigration returns a migration function for the given version.
-func getSQLMigration(ctx context.Context, version int,
-	kvBackend kvdb.Backend,
-	chain chainhash.Hash) (func(tx *sqlc.Queries) error, bool) {
+func (d *DefaultDatabaseBuilder) getSQLMigration(ctx context.Context,
+	version int, kvBackend kvdb.Backend) (func(tx *sqlc.Queries) error,
+	bool) {
+
+	cfg := &graphdb.SQLStoreConfig{
+		ChainHash: *d.cfg.ActiveNetParams.GenesisHash,
+		QueryCfg:  &d.cfg.DB.Sqlite.QueryConfig,
+	}
+	if d.cfg.DB.Backend == lncfg.PostgresBackend {
+		cfg.QueryCfg = &d.cfg.DB.Postgres.QueryConfig
+	}
 
 	switch version {
 	case graphSQLMigration:
 		return func(tx *sqlc.Queries) error {
 			err := graphdb.MigrateGraphToSQL(
-				ctx, kvBackend, tx, chain,
+				ctx, cfg, kvBackend, tx,
 			)
 			if err != nil {
 				return fmt.Errorf("failed to migrate graph "+

--- a/config_test_native_sql.go
+++ b/config_test_native_sql.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	graphdb "github.com/lightningnetwork/lnd/graph/db"
 	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/sqldb"
 	"github.com/lightningnetwork/lnd/sqldb/sqlc"
 )
@@ -30,10 +31,15 @@ func (d *DefaultDatabaseBuilder) getGraphStore(baseDB *sqldb.BaseDB,
 		},
 	)
 
+	queryConfig := d.cfg.DB.Sqlite.QueryConfig
+	if d.cfg.DB.Backend == lncfg.PostgresBackend {
+		queryConfig = d.cfg.DB.Postgres.QueryConfig
+	}
+
 	return graphdb.NewSQLStore(
 		&graphdb.SQLStoreConfig{
 			ChainHash: *d.cfg.ActiveNetParams.GenesisHash,
-			QueryCfg:  sqldb.DefaultQueryConfig(),
+			QueryCfg:  &queryConfig,
 		},
 		graphExecutor, opts...,
 	)

--- a/graph/builder.go
+++ b/graph/builder.go
@@ -1037,9 +1037,6 @@ func (b *Builder) AddEdge(ctx context.Context, edge *models.ChannelEdgeInfo,
 // Chain View is updated with the new edge if it is successfully added to the
 // graph. We only persist the channel if we currently dont have it at all in
 // our graph.
-//
-// TODO(elle): this currently also does funding-transaction validation. But this
-// should be moved to the gossiper instead.
 func (b *Builder) addEdge(ctx context.Context, edge *models.ChannelEdgeInfo,
 	op ...batch.SchedulerOption) error {
 

--- a/graph/db/benchmark_test.go
+++ b/graph/db/benchmark_test.go
@@ -449,10 +449,12 @@ func TestPopulateViaMigration(t *testing.T) {
 	log.SetLevel(btclog.LevelDebug)
 
 	var (
+		cfg     = sqldb.DefaultSQLiteConfig()
 		srcKVDB = kvdbSqlite(t, kvdbSqlitePath, kvdbSqliteFile)
 		dstSQL  = sqlSQLite(t, nativeSQLSqlitePath, nativeSQLSqliteFile)
 	)
 	if testPostgres {
+		cfg = sqldb.DefaultPostgresConfig()
 		srcKVDB = kvdbPostgres(t, kvdbPostgresDNS)
 		dstSQL = sqlPostgres(t, nativeSQLPostgresDNS)
 	}
@@ -462,7 +464,10 @@ func TestPopulateViaMigration(t *testing.T) {
 	err := dstSQL.ExecTx(
 		ctx, sqldb.WriteTxOpt(), func(queries SQLQueries) error {
 			return MigrateGraphToSQL(
-				ctx, srcKVDB, queries, dbTestChain,
+				ctx, &SQLStoreConfig{
+					QueryCfg:  cfg,
+					ChainHash: dbTestChain,
+				}, srcKVDB, queries,
 			)
 		}, func() {},
 	)

--- a/graph/db/sql_migration.go
+++ b/graph/db/sql_migration.go
@@ -603,6 +603,7 @@ func migratePruneLog(ctx context.Context, kvBackend kvdb.Backend,
 		hash *chainhash.Hash) error {
 
 		count++
+		chunk++
 
 		// Keep track of the prune tip height and hash.
 		if height > pruneTipHeight {
@@ -786,6 +787,7 @@ func migrateClosedSCIDIndex(ctx context.Context, kvBackend kvdb.Backend,
 	)
 	migrateSingleClosedSCID := func(scid lnwire.ShortChannelID) error {
 		count++
+		chunk++
 
 		chanIDB := channelIDToBytes(scid.ToUint64())
 		err := sqlDB.InsertClosedChannel(ctx, chanIDB)
@@ -874,6 +876,7 @@ func migrateZombieIndex(ctx context.Context, kvBackend kvdb.Backend,
 		}
 
 		count++
+		chunk++
 
 		err = sqlDB.UpsertZombieChannel(
 			ctx, sqlc.UpsertZombieChannelParams{

--- a/graph/db/sql_migration.go
+++ b/graph/db/sql_migration.go
@@ -26,8 +26,8 @@ import (
 // NOTE: this is currently not called from any code path. It is called via tests
 // only for now and will be called from the main lnd binary once the
 // migration is fully implemented and tested.
-func MigrateGraphToSQL(ctx context.Context, kvBackend kvdb.Backend,
-	sqlDB SQLQueries, chain chainhash.Hash) error {
+func MigrateGraphToSQL(ctx context.Context, cfg *SQLStoreConfig,
+	kvBackend kvdb.Backend, sqlDB SQLQueries) error {
 
 	log.Infof("Starting migration of the graph store from KV to SQL")
 	t0 := time.Now()
@@ -43,7 +43,8 @@ func MigrateGraphToSQL(ctx context.Context, kvBackend kvdb.Backend,
 	}
 
 	// 1) Migrate all the nodes.
-	if err := migrateNodes(ctx, kvBackend, sqlDB); err != nil {
+	err = migrateNodes(ctx, cfg.QueryCfg, kvBackend, sqlDB)
+	if err != nil {
 		return fmt.Errorf("could not migrate nodes: %w", err)
 	}
 
@@ -53,7 +54,7 @@ func MigrateGraphToSQL(ctx context.Context, kvBackend kvdb.Backend,
 	}
 
 	// 3) Migrate all the channels and channel policies.
-	err = migrateChannelsAndPolicies(ctx, kvBackend, sqlDB, chain)
+	err = migrateChannelsAndPolicies(ctx, cfg, kvBackend, sqlDB)
 	if err != nil {
 		return fmt.Errorf("could not migrate channels and policies: %w",
 			err)
@@ -108,8 +109,8 @@ func checkGraphExists(db kvdb.Backend) (bool, error) {
 // migrateNodes migrates all nodes from the KV backend to the SQL database.
 // This includes doing a sanity check after each migration to ensure that the
 // migrated node matches the original node.
-func migrateNodes(ctx context.Context, kvBackend kvdb.Backend,
-	sqlDB SQLQueries) error {
+func migrateNodes(ctx context.Context, cfg *sqldb.QueryConfig,
+	kvBackend kvdb.Backend, sqlDB SQLQueries) error {
 
 	// Keep track of the number of nodes migrated and the number of
 	// nodes skipped due to errors.
@@ -192,7 +193,7 @@ func migrateNodes(ctx context.Context, kvBackend kvdb.Backend,
 				pub, id, dbNode.ID)
 		}
 
-		migratedNode, err := buildNode(ctx, sqlDB, dbNode)
+		migratedNode, err := buildNode(ctx, cfg, sqlDB, dbNode)
 		if err != nil {
 			return fmt.Errorf("could not build migrated node "+
 				"from dbNode(db id: %d, node pub: %x): %w",
@@ -320,8 +321,8 @@ func migrateSourceNode(ctx context.Context, kvdb kvdb.Backend,
 
 // migrateChannelsAndPolicies migrates all channels and their policies
 // from the KV backend to the SQL database.
-func migrateChannelsAndPolicies(ctx context.Context, kvBackend kvdb.Backend,
-	sqlDB SQLQueries, chain chainhash.Hash) error {
+func migrateChannelsAndPolicies(ctx context.Context, cfg *SQLStoreConfig,
+	kvBackend kvdb.Backend, sqlDB SQLQueries) error {
 
 	var (
 		channelCount       uint64
@@ -373,9 +374,10 @@ func migrateChannelsAndPolicies(ctx context.Context, kvBackend kvdb.Backend,
 		// info, but rather rely on the chain hash LND is running with.
 		// So this is our way of ensuring that LND is running on the
 		// correct network at migration time.
-		if channel.ChainHash != chain {
+		if channel.ChainHash != cfg.ChainHash {
 			return fmt.Errorf("channel %d has chain hash %s, "+
-				"expected %s", scid, channel.ChainHash, chain)
+				"expected %s", scid, channel.ChainHash,
+				cfg.ChainHash)
 		}
 
 		// Sanity check to ensure that the channel has valid extra
@@ -413,7 +415,8 @@ func migrateChannelsAndPolicies(ctx context.Context, kvBackend kvdb.Backend,
 		chunk++
 
 		err = migrateSingleChannel(
-			ctx, sqlDB, channel, policy1, policy2, migChanPolicy,
+			ctx, cfg, sqlDB, channel, policy1, policy2,
+			migChanPolicy,
 		)
 		if err != nil {
 			return fmt.Errorf("could not migrate channel %d: %w",
@@ -448,8 +451,8 @@ func migrateChannelsAndPolicies(ctx context.Context, kvBackend kvdb.Backend,
 	return nil
 }
 
-func migrateSingleChannel(ctx context.Context, sqlDB SQLQueries,
-	channel *models.ChannelEdgeInfo,
+func migrateSingleChannel(ctx context.Context, cfg *SQLStoreConfig,
+	sqlDB SQLQueries, channel *models.ChannelEdgeInfo,
 	policy1, policy2 *models.ChannelEdgePolicy,
 	migChanPolicy func(*models.ChannelEdgePolicy) error) error {
 
@@ -508,7 +511,7 @@ func migrateSingleChannel(ctx context.Context, sqlDB SQLQueries,
 	}
 
 	migChan, migPol1, migPol2, err := getAndBuildChanAndPolicies(
-		ctx, sqlDB, row, channel.ChainHash,
+		ctx, cfg, sqlDB, row,
 	)
 	if err != nil {
 		return fmt.Errorf("could not build migrated channel and "+
@@ -703,9 +706,9 @@ func migratePruneLog(ctx context.Context, kvBackend kvdb.Backend,
 // getAndBuildChanAndPolicies is a helper that builds the channel edge info
 // and policies from the given row returned by the SQL query
 // GetChannelBySCIDWithPolicies.
-func getAndBuildChanAndPolicies(ctx context.Context, db SQLQueries,
-	row sqlc.GetChannelBySCIDWithPoliciesRow,
-	chain chainhash.Hash) (*models.ChannelEdgeInfo,
+func getAndBuildChanAndPolicies(ctx context.Context, cfg *SQLStoreConfig,
+	db SQLQueries,
+	row sqlc.GetChannelBySCIDWithPoliciesRow) (*models.ChannelEdgeInfo,
 	*models.ChannelEdgePolicy, *models.ChannelEdgePolicy, error) {
 
 	node1, node2, err := buildNodeVertices(
@@ -716,7 +719,7 @@ func getAndBuildChanAndPolicies(ctx context.Context, db SQLQueries,
 	}
 
 	edge, err := getAndBuildEdgeInfo(
-		ctx, db, chain, row.GraphChannel, node1, node2,
+		ctx, cfg, db, row.GraphChannel, node1, node2,
 	)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("unable to build channel "+
@@ -730,7 +733,8 @@ func getAndBuildChanAndPolicies(ctx context.Context, db SQLQueries,
 	}
 
 	policy1, policy2, err := getAndBuildChanPolicies(
-		ctx, db, dbPol1, dbPol2, edge.ChannelID, node1, node2,
+		ctx, cfg.QueryCfg, db, dbPol1, dbPol2, edge.ChannelID, node1,
+		node2,
 	)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("unable to build channel "+

--- a/graph/db/test_postgres.go
+++ b/graph/db/test_postgres.go
@@ -43,7 +43,7 @@ func NewTestDBWithFixture(t testing.TB,
 	store, err := NewSQLStore(
 		&SQLStoreConfig{
 			ChainHash: *chaincfg.MainNetParams.GenesisHash,
-			QueryCfg:  sqldb.DefaultQueryConfig(),
+			QueryCfg:  sqldb.DefaultPostgresConfig(),
 		}, querier,
 	)
 	require.NoError(t, err)

--- a/graph/db/test_sqlite.go
+++ b/graph/db/test_sqlite.go
@@ -28,7 +28,7 @@ func NewTestDBWithFixture(t testing.TB, _ *sqldb.TestPgFixture) V1Store {
 	store, err := NewSQLStore(
 		&SQLStoreConfig{
 			ChainHash: *chaincfg.MainNetParams.GenesisHash,
-			QueryCfg:  sqldb.DefaultQueryConfig(),
+			QueryCfg:  sqldb.DefaultSQLiteConfig(),
 		}, newBatchQuerier(t),
 	)
 	require.NoError(t, err)

--- a/itest/lnd_graph_migration_test.go
+++ b/itest/lnd_graph_migration_test.go
@@ -142,10 +142,15 @@ func openNativeSQLGraphDB(ht *lntest.HarnessTest,
 		},
 	)
 
+	queryCfg := sqldb.DefaultSQLiteConfig()
+	if hn.Cfg.DBBackend != node.BackendSqlite {
+		queryCfg = sqldb.DefaultPostgresConfig()
+	}
+
 	store, err := graphdb.NewSQLStore(
 		&graphdb.SQLStoreConfig{
 			ChainHash: *ht.Miner().ActiveNet.GenesisHash,
-			QueryCfg:  sqldb.DefaultQueryConfig(),
+			QueryCfg:  queryCfg,
 		},
 		executor,
 	)

--- a/lncfg/db.go
+++ b/lncfg/db.go
@@ -143,6 +143,9 @@ func (db *DB) Validate() error {
 		}
 
 	case SqliteBackend:
+		if err := db.Sqlite.Validate(); err != nil {
+			return err
+		}
 	case PostgresBackend:
 		if err := db.Postgres.Validate(); err != nil {
 			return err

--- a/lncfg/db.go
+++ b/lncfg/db.go
@@ -115,10 +115,18 @@ func DefaultDB() *DB {
 		},
 		Postgres: &sqldb.PostgresConfig{
 			MaxConnections: defaultPostgresMaxConnections,
+			QueryConfig: sqldb.QueryConfig{
+				MaxBatchSize: 250,
+				MaxPageSize:  10000,
+			},
 		},
 		Sqlite: &sqldb.SqliteConfig{
 			MaxConnections: defaultSqliteMaxConnections,
 			BusyTimeout:    defaultSqliteBusyTimeout,
+			QueryConfig: sqldb.QueryConfig{
+				MaxBatchSize: 250,
+				MaxPageSize:  10000,
+			},
 		},
 		UseNativeSQL:           false,
 		SkipNativeSQLMigration: false,

--- a/lncfg/db.go
+++ b/lncfg/db.go
@@ -115,18 +115,12 @@ func DefaultDB() *DB {
 		},
 		Postgres: &sqldb.PostgresConfig{
 			MaxConnections: defaultPostgresMaxConnections,
-			QueryConfig: sqldb.QueryConfig{
-				MaxBatchSize: 250,
-				MaxPageSize:  10000,
-			},
+			QueryConfig:    *sqldb.DefaultPostgresConfig(),
 		},
 		Sqlite: &sqldb.SqliteConfig{
 			MaxConnections: defaultSqliteMaxConnections,
 			BusyTimeout:    defaultSqliteBusyTimeout,
-			QueryConfig: sqldb.QueryConfig{
-				MaxBatchSize: 250,
-				MaxPageSize:  10000,
-			},
+			QueryConfig:    *sqldb.DefaultSQLiteConfig(),
 		},
 		UseNativeSQL:           false,
 		SkipNativeSQLMigration: false,

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1601,6 +1601,12 @@
 ; Whether to skip executing schema migrations.
 ; db.postgres.skipmigrations=false
 
+; The maximum number of elements to use in a native-SQL batch query IN clause.
+; db.postgres.query.max-batch-size=5000
+
+; The maximum number of records to fetch at a time in a paginated query during
+; native-SQL calls.
+; db.postgres.query.max-page-size=10500
 
 [sqlite]
 
@@ -1616,6 +1622,13 @@
 
 ; The maximum amount of time to wait to execute a query if the db is locked.
 ; db.sqlite.busytimeout=5s
+
+; The maximum number of elements to use in a native-SQL batch query IN clause.
+; db.sqlite.query.max-batch-size=250
+
+; The maximum number of records to fetch at a time in a paginated query during
+; native-SQL calls.
+; db.sqlite.query.max-page-size=100
 
 ; Raw pragma option pairs to be used when opening the sqlite db. The flag
 ; can be specified multiple times to set multiple options.

--- a/sqldb/config.go
+++ b/sqldb/config.go
@@ -31,6 +31,15 @@ type SqliteConfig struct {
 	QueryConfig    `group:"query" namespace:"query"`
 }
 
+// Validate checks that the SqliteConfig values are valid.
+func (p *SqliteConfig) Validate() error {
+	if err := p.QueryConfig.Validate(true); err != nil {
+		return fmt.Errorf("invalid query config: %w", err)
+	}
+
+	return nil
+}
+
 // PostgresConfig holds the postgres database configuration.
 //
 //nolint:ll
@@ -42,6 +51,7 @@ type PostgresConfig struct {
 	QueryConfig    `group:"query" namespace:"query"`
 }
 
+// Validate checks that the PostgresConfig values are valid.
 func (p *PostgresConfig) Validate() error {
 	if p.Dsn == "" {
 		return fmt.Errorf("DSN is required")
@@ -51,6 +61,10 @@ func (p *PostgresConfig) Validate() error {
 	_, err := url.Parse(p.Dsn)
 	if err != nil {
 		return fmt.Errorf("invalid DSN: %w", err)
+	}
+
+	if err := p.QueryConfig.Validate(false); err != nil {
+		return fmt.Errorf("invalid query config: %w", err)
 	}
 
 	return nil

--- a/sqldb/config.go
+++ b/sqldb/config.go
@@ -28,6 +28,7 @@ type SqliteConfig struct {
 	MaxConnections int           `long:"maxconnections" description:"The maximum number of open connections to the database. Set to zero for unlimited."`
 	PragmaOptions  []string      `long:"pragmaoptions" description:"A list of pragma options to set on a database connection. For example, 'auto_vacuum=incremental'. Note that the flag must be specified multiple times if multiple options are to be set."`
 	SkipMigrations bool          `long:"skipmigrations" description:"Skip applying migrations on startup."`
+	QueryConfig    `group:"query" namespace:"query"`
 }
 
 // PostgresConfig holds the postgres database configuration.
@@ -38,6 +39,7 @@ type PostgresConfig struct {
 	Timeout        time.Duration `long:"timeout" description:"Database connection timeout. Set to zero to disable."`
 	MaxConnections int           `long:"maxconnections" description:"The maximum number of open connections to the database. Set to zero for unlimited."`
 	SkipMigrations bool          `long:"skipmigrations" description:"Skip applying migrations on startup."`
+	QueryConfig    `group:"query" namespace:"query"`
 }
 
 func (p *PostgresConfig) Validate() error {

--- a/sqldb/paginate.go
+++ b/sqldb/paginate.go
@@ -6,20 +6,19 @@ import (
 )
 
 // QueryConfig holds configuration values for SQL queries.
+//
+//nolint:ll
 type QueryConfig struct {
 	// MaxBatchSize is the maximum number of items included in a batch
 	// query IN clauses list.
-	MaxBatchSize int
+	MaxBatchSize int `long:"max-batch-size" description:"The maximum number of items to include in a batch query IN clause. This is used for queries that fetch results based on a list of identifiers."`
 
 	// MaxPageSize is the maximum number of items returned in a single page
 	// of results. This is used for paginated queries.
-	MaxPageSize int32
+	MaxPageSize int32 `long:"max-page-size" description:"The maximum number of items to return in a single page of results. This is used for paginated queries."`
 }
 
 // DefaultQueryConfig returns a default configuration for SQL queries.
-//
-// TODO(elle): make configurable & have different defaults for SQLite and
-// Postgres.
 func DefaultQueryConfig() *QueryConfig {
 	return &QueryConfig{
 		MaxBatchSize: 250,

--- a/sqldb/paginate.go
+++ b/sqldb/paginate.go
@@ -72,14 +72,6 @@ func (c *QueryConfig) Validate(sqlite bool) error {
 	return nil
 }
 
-// DefaultQueryConfig returns a default configuration for SQL queries.
-func DefaultQueryConfig() *QueryConfig {
-	return &QueryConfig{
-		MaxBatchSize: 250,
-		MaxPageSize:  10000,
-	}
-}
-
 // DefaultSQLiteConfig returns a default configuration for SQL queries to a
 // SQLite backend.
 func DefaultSQLiteConfig() *QueryConfig {

--- a/sqldb/paginate.go
+++ b/sqldb/paginate.go
@@ -15,6 +15,20 @@ const (
 	// included in a batch query IN clause for Postgres. This was determined
 	// using the TestSQLSliceQueries test.
 	maxPostgresBatchSize = 65535
+
+	// defaultSQLitePageSize is the default page size for SQLite queries.
+	defaultSQLitePageSize = 100
+
+	// defaultPostgresPageSize is the default page size for Postgres
+	// queries.
+	defaultPostgresPageSize = 10500
+
+	// defaultSQLiteBatchSize is the default batch size for SQLite queries.
+	defaultSQLiteBatchSize = 250
+
+	// defaultPostgresBatchSize is the default batch size for Postgres
+	// queries.
+	defaultPostgresBatchSize = 5000
 )
 
 // QueryConfig holds configuration values for SQL queries.
@@ -63,6 +77,24 @@ func DefaultQueryConfig() *QueryConfig {
 	return &QueryConfig{
 		MaxBatchSize: 250,
 		MaxPageSize:  10000,
+	}
+}
+
+// DefaultSQLiteConfig returns a default configuration for SQL queries to a
+// SQLite backend.
+func DefaultSQLiteConfig() *QueryConfig {
+	return &QueryConfig{
+		MaxBatchSize: defaultSQLiteBatchSize,
+		MaxPageSize:  defaultSQLitePageSize,
+	}
+}
+
+// DefaultPostgresConfig returns a default configuration for SQL queries to a
+// Postgres backend.
+func DefaultPostgresConfig() *QueryConfig {
+	return &QueryConfig{
+		MaxBatchSize: defaultPostgresBatchSize,
+		MaxPageSize:  defaultPostgresPageSize,
 	}
 }
 

--- a/sqldb/paginate_test.go
+++ b/sqldb/paginate_test.go
@@ -22,7 +22,7 @@ func TestExecuteBatchQuery(t *testing.T) {
 
 	t.Run("empty input returns nil", func(t *testing.T) {
 		var (
-			cfg        = DefaultQueryConfig()
+			cfg        = DefaultSQLiteConfig()
 			inputItems []int
 		)
 
@@ -144,7 +144,7 @@ func TestExecuteBatchQuery(t *testing.T) {
 
 	t.Run("query function error is propagated", func(t *testing.T) {
 		var (
-			cfg        = DefaultQueryConfig()
+			cfg        = DefaultSQLiteConfig()
 			inputItems = []int{1, 2, 3}
 		)
 
@@ -174,7 +174,7 @@ func TestExecuteBatchQuery(t *testing.T) {
 
 	t.Run("callback error is propagated", func(t *testing.T) {
 		var (
-			cfg        = DefaultQueryConfig()
+			cfg        = DefaultSQLiteConfig()
 			inputItems = []int{1, 2, 3}
 		)
 
@@ -307,7 +307,7 @@ func TestSQLSliceQueries(t *testing.T) {
 
 	err := ExecuteBatchQuery(
 		ctx,
-		DefaultQueryConfig(),
+		DefaultSQLiteConfig(),
 		queryParams,
 		func(s string) string {
 			return s

--- a/sqldb/paginate_test.go
+++ b/sqldb/paginate_test.go
@@ -281,11 +281,17 @@ func TestSQLSliceQueries(t *testing.T) {
 			break
 		}
 
-		x *= 10
+		// If it succeeded, we expect it to be under the maximum that
+		// we expect for this DB.
+		if isSQLite {
+			require.LessOrEqual(t, x, maxSQLiteBatchSize,
+				"SQLite should not exceed 32766 parameters")
+		} else {
+			require.LessOrEqual(t, x, maxPostgresBatchSize,
+				"Postgres should not exceed 65535 parameters")
+		}
 
-		// Just to make sure that the test doesn't carry on too long,
-		// we assert that we don't exceed a reasonable limit.
-		require.LessOrEqual(t, x, 100000)
+		x *= 10
 	}
 
 	// Now that we have found the limit that the raw query can handle, we


### PR DESCRIPTION
This PR does 2 things related to the `sqldb.QueryConfig`: 

1) plugs these values in to the main SQLite and Postgres config structs & makes the values configurable 
2) adds a benchmark which aided in finding better default values to use for sqlite and postgres for the query options. 

Part of #9795 

#  Benchmark improvements: 

### SQLite
```
name                                                    old time/op  new time/op  delta
GraphReadMethods/ForEachNode-native-sqlite-10            269ms ± 1%   200ms ± 3%  -25.86%  (p=0.008 n=5+5)
GraphReadMethods/ForEachChannel-native-sqlite-10         1.53s ±12%   1.40s ± 1%   -8.58%  (p=0.016 n=5+4)
GraphReadMethods/NodeUpdatesInHorizon-native-sqlite-10   238ms ± 2%   239ms ± 4%     ~     (p=0.841 n=5+5)
GraphReadMethods/ForEachNodeCacheable-native-sqlite-10   136ms ± 1%   114ms ± 5%  -15.92%  (p=0.008 n=5+5)
GraphReadMethods/ForEachNodeCached-native-sqlite-10      10.5s ± 5%    7.2s ± 1%  -31.26%  (p=0.008 n=5+5)
GraphReadMethods/ChanUpdatesInHorizon-native-sqlite-10   1.99s ± 3%   1.98s ± 4%     ~     (p=1.000 n=5+5)
```

### Postgres
```
name                                                      old time/op  new time/op  delta
GraphReadMethods/ForEachNode-native-postgres-10           91.1ms ± 1%  91.9ms ± 1%     ~     (p=0.111 n=5+4)
GraphReadMethods/ForEachChannel-native-postgres-10         601ms ± 5%   419ms ± 2%  -30.24%  (p=0.008 n=5+5)
GraphReadMethods/NodeUpdatesInHorizon-native-postgres-10  81.1ms ± 3%  79.5ms ± 5%     ~     (p=0.222 n=5+5)
GraphReadMethods/ForEachNodeCacheable-native-postgres-10  59.4ms ±10%  51.1ms ± 5%  -14.07%  (p=0.008 n=5+5)
GraphReadMethods/ForEachNodeCached-native-postgres-10      1.13s ± 4%   0.88s ± 2%  -22.10%  (p=0.008 n=5+5)
GraphReadMethods/ChanUpdatesInHorizon-native-postgres-10   784ms ± 3%   629ms ± 2%  -19.78%  (p=0.008 n=5+5)
```