### PR TITLE
graph/db: use batch validation to improve SQL migration performance

### DIFF
--- a/graph/db/benchmark_test.go
+++ b/graph/db/benchmark_test.go
@@ -788,13 +788,13 @@ func BenchmarkFindOptimalSQLQueryConfig(b *testing.B) {
 	// Set the various page sizes we want to test.
 	//
 	// NOTE: these are the sqlite paging testing values.
-	testSizes := []int{20, 50, 100, 150, 500}
+	testSizes := []uint32{20, 50, 100, 150, 500}
 
 	configOption := "MaxPageSize"
 	if testBatching {
 		configOption = "MaxBatchSize"
 
-		testSizes = []int{
+		testSizes = []uint32{
 			50, 100, 150, 200, 250, 300, 350,
 		}
 	}
@@ -806,10 +806,10 @@ func BenchmarkFindOptimalSQLQueryConfig(b *testing.B) {
 		// Set the various page sizes we want to test.
 		//
 		// NOTE: these are the postgres paging values.
-		testSizes = []int{5000, 7000, 10000, 12000}
+		testSizes = []uint32{5000, 7000, 10000, 12000}
 
 		if testBatching {
-			testSizes = []int{
+			testSizes = []uint32{
 				1000, 2000, 5000, 7000, 10000,
 			}
 		}
@@ -828,7 +828,7 @@ func BenchmarkFindOptimalSQLQueryConfig(b *testing.B) {
 				if testBatching {
 					cfg.MaxBatchSize = size
 				} else {
-					cfg.MaxPageSize = int32(size)
+					cfg.MaxPageSize = size
 				}
 
 				store := connectNativeSQLite(

--- a/graph/db/benchmark_test.go
+++ b/graph/db/benchmark_test.go
@@ -431,9 +431,6 @@ func TestPopulateDBs(t *testing.T) {
 // postgres backend instead of the kvdb-sqlite backend.
 //
 // NOTE: this is a helper test and is not run by default.
-//
-// TODO(elle): this test reveals tht there may be an issue with the postgres
-// migration as it is super slow.
 func TestPopulateViaMigration(t *testing.T) {
 	t.Skipf("Skipping local helper test")
 

--- a/graph/db/sql_migration.go
+++ b/graph/db/sql_migration.go
@@ -283,7 +283,7 @@ func migrateNodes(ctx context.Context, cfg *sqldb.QueryConfig,
 		batch[id] = node
 
 		// Validate batch when full.
-		if len(batch) >= cfg.MaxBatchSize {
+		if len(batch) >= int(cfg.MaxBatchSize) {
 			err := validateBatch()
 			if err != nil {
 				return fmt.Errorf("batch validation failed: %w",
@@ -548,7 +548,7 @@ func migrateChannelsAndPolicies(ctx context.Context, cfg *SQLStoreConfig,
 			dbInfo:  dbChanInfo,
 		}
 
-		if len(batch) >= cfg.QueryCfg.MaxBatchSize {
+		if len(batch) >= int(cfg.QueryCfg.MaxBatchSize) {
 			// Do batch validation.
 			err := validateMigratedChannels(ctx, cfg, sqlDB, batch)
 			if err != nil {
@@ -902,7 +902,7 @@ func migratePruneLog(ctx context.Context, cfg *sqldb.QueryConfig,
 			batch[height] = *hash
 
 			// Validate batch when full.
-			if len(batch) >= cfg.MaxBatchSize {
+			if len(batch) >= int(cfg.MaxBatchSize) {
 				err := validateBatch()
 				if err != nil {
 					return fmt.Errorf("batch "+
@@ -1070,7 +1070,7 @@ func migrateClosedSCIDIndex(ctx context.Context, cfg *sqldb.QueryConfig,
 		batch = append(batch, chanIDB)
 
 		// Validate batch when full.
-		if len(batch) >= cfg.MaxBatchSize {
+		if len(batch) >= int(cfg.MaxBatchSize) {
 			err := validateBatch()
 			if err != nil {
 				return fmt.Errorf("batch validation failed: %w",
@@ -1251,7 +1251,7 @@ func migrateZombieIndex(ctx context.Context, cfg *sqldb.QueryConfig,
 		}
 
 		// Validate batch when full.
-		if len(batch) >= cfg.MaxBatchSize {
+		if len(batch) >= int(cfg.MaxBatchSize) {
 			err := validateBatch()
 			if err != nil {
 				return fmt.Errorf("batch validation failed: %w",

--- a/graph/db/sql_migration.go
+++ b/graph/db/sql_migration.go
@@ -118,6 +118,8 @@ func migrateNodes(ctx context.Context, cfg *sqldb.QueryConfig,
 	// Keep track of the number of nodes migrated and the number of
 	// nodes skipped due to errors.
 	var (
+		totalTime = time.Now()
+
 		count   uint64
 		skipped uint64
 
@@ -317,8 +319,9 @@ func migrateNodes(ctx context.Context, cfg *sqldb.QueryConfig,
 		}
 	}
 
-	log.Infof("Migrated %d nodes from KV to SQL (skipped %d nodes due to "+
-		"invalid TLV streams)", count, skipped)
+	log.Infof("Migrated %d nodes from KV to SQL in %v (skipped %d nodes "+
+		"due to invalid TLV streams)", count, time.Since(totalTime),
+		skipped)
 
 	return nil
 }
@@ -421,6 +424,8 @@ func migrateChannelsAndPolicies(ctx context.Context, cfg *SQLStoreConfig,
 	kvBackend kvdb.Backend, sqlDB SQLQueries) error {
 
 	var (
+		totalTime = time.Now()
+
 		channelCount       uint64
 		skippedChanCount   uint64
 		policyCount        uint64
@@ -588,10 +593,10 @@ func migrateChannelsAndPolicies(ctx context.Context, cfg *SQLStoreConfig,
 		batch = make(map[int64]*migChanInfo, cfg.QueryCfg.MaxBatchSize)
 	}
 
-	log.Infof("Migrated %d channels and %d policies from KV to SQL "+
+	log.Infof("Migrated %d channels and %d policies from KV to SQL in %s"+
 		"(skipped %d channels and %d policies due to invalid TLV "+
-		"streams)", channelCount, policyCount, skippedChanCount,
-		skippedPolicyCount)
+		"streams)", channelCount, policyCount, time.Since(totalTime),
+		skippedChanCount, skippedPolicyCount)
 
 	return nil
 }
@@ -804,6 +809,8 @@ func migratePruneLog(ctx context.Context, cfg *sqldb.QueryConfig,
 	kvBackend kvdb.Backend, sqlDB SQLQueries) error {
 
 	var (
+		totalTime = time.Now()
+
 		count          uint64
 		pruneTipHeight uint32
 		pruneTipHash   chainhash.Hash
@@ -958,9 +965,9 @@ func migratePruneLog(ctx context.Context, cfg *sqldb.QueryConfig,
 			chainhash.Hash(pruneTip.BlockHash))
 	}
 
-	log.Infof("Migrated %d prune log entries from KV to SQL. The prune "+
-		"tip is: height %d, hash: %s", count, pruneTipHeight,
-		pruneTipHash)
+	log.Infof("Migrated %d prune log entries from KV to SQL in %s. "+
+		"The prune tip is: height %d, hash: %s", count,
+		time.Since(totalTime), pruneTipHeight, pruneTipHash)
 
 	return nil
 }
@@ -1001,6 +1008,8 @@ func migrateClosedSCIDIndex(ctx context.Context, cfg *sqldb.QueryConfig,
 	kvBackend kvdb.Backend, sqlDB SQLQueries) error {
 
 	var (
+		totalTime = time.Now()
+
 		count uint64
 
 		t0    = time.Now()
@@ -1097,7 +1106,8 @@ func migrateClosedSCIDIndex(ctx context.Context, cfg *sqldb.QueryConfig,
 		}
 	}
 
-	log.Infof("Migrated %d closed SCIDs from KV to SQL", count)
+	log.Infof("Migrated %d closed SCIDs from KV to SQL in %s", count,
+		time.Since(totalTime))
 
 	return nil
 }
@@ -1115,6 +1125,8 @@ func migrateZombieIndex(ctx context.Context, cfg *sqldb.QueryConfig,
 	kvBackend kvdb.Backend, sqlDB SQLQueries) error {
 
 	var (
+		totalTime = time.Now()
+
 		count uint64
 
 		t0    = time.Now()
@@ -1272,7 +1284,8 @@ func migrateZombieIndex(ctx context.Context, cfg *sqldb.QueryConfig,
 		}
 	}
 
-	log.Infof("Migrated %d zombie channels from KV to SQL", count)
+	log.Infof("Migrated %d zombie channels from KV to SQL in %s", count,
+		time.Since(totalTime))
 
 	return nil
 }

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -133,6 +133,7 @@ type SQLQueries interface {
 	*/
 	UpsertZombieChannel(ctx context.Context, arg sqlc.UpsertZombieChannelParams) error
 	GetZombieChannel(ctx context.Context, arg sqlc.GetZombieChannelParams) (sqlc.GraphZombieChannel, error)
+	GetZombieChannelsSCIDs(ctx context.Context, arg sqlc.GetZombieChannelsSCIDsParams) ([]sqlc.GraphZombieChannel, error)
 	CountZombieChannels(ctx context.Context, version int16) (int64, error)
 	DeleteZombieChannel(ctx context.Context, arg sqlc.DeleteZombieChannelParams) (sql.Result, error)
 	IsZombieChannel(ctx context.Context, arg sqlc.IsZombieChannelParams) (bool, error)

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -151,6 +151,7 @@ type SQLQueries interface {
 	*/
 	InsertClosedChannel(ctx context.Context, scid []byte) error
 	IsClosedChannel(ctx context.Context, scid []byte) (bool, error)
+	GetClosedChannelsSCIDs(ctx context.Context, scids [][]byte) ([][]byte, error)
 }
 
 // BatchedSQLQueries is a version of SQLQueries that's capable of batched

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -55,6 +55,7 @@ type SQLQueries interface {
 	*/
 	UpsertNode(ctx context.Context, arg sqlc.UpsertNodeParams) (int64, error)
 	GetNodeByPubKey(ctx context.Context, arg sqlc.GetNodeByPubKeyParams) (sqlc.GraphNode, error)
+	GetNodesByIDs(ctx context.Context, ids []int64) ([]sqlc.GraphNode, error)
 	GetNodeIDByPubKey(ctx context.Context, arg sqlc.GetNodeIDByPubKeyParams) (int64, error)
 	GetNodesByLastUpdateRange(ctx context.Context, arg sqlc.GetNodesByLastUpdateRangeParams) ([]sqlc.GraphNode, error)
 	ListNodesPaginated(ctx context.Context, arg sqlc.ListNodesPaginatedParams) ([]sqlc.GraphNode, error)

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -98,6 +98,7 @@ type SQLQueries interface {
 	GetChannelsBySCIDRange(ctx context.Context, arg sqlc.GetChannelsBySCIDRangeParams) ([]sqlc.GetChannelsBySCIDRangeRow, error)
 	GetChannelBySCIDWithPolicies(ctx context.Context, arg sqlc.GetChannelBySCIDWithPoliciesParams) (sqlc.GetChannelBySCIDWithPoliciesRow, error)
 	GetChannelsBySCIDWithPolicies(ctx context.Context, arg sqlc.GetChannelsBySCIDWithPoliciesParams) ([]sqlc.GetChannelsBySCIDWithPoliciesRow, error)
+	GetChannelsByIDs(ctx context.Context, ids []int64) ([]sqlc.GetChannelsByIDsRow, error)
 	GetChannelAndNodesBySCID(ctx context.Context, arg sqlc.GetChannelAndNodesBySCIDParams) (sqlc.GetChannelAndNodesBySCIDRow, error)
 	HighestSCID(ctx context.Context, version int16) ([]byte, error)
 	ListChannelsByNodeID(ctx context.Context, arg sqlc.ListChannelsByNodeIDParams) ([]sqlc.ListChannelsByNodeIDRow, error)
@@ -4519,6 +4520,51 @@ func extractChannelPolicies(row any) (*sqlc.GraphChannelPolicy,
 		}
 
 		return policy1, policy2, nil
+
+	case sqlc.GetChannelsByIDsRow:
+		if r.Policy1ID.Valid {
+			policy1 = &sqlc.GraphChannelPolicy{
+				ID:                      r.Policy1ID.Int64,
+				Version:                 r.Policy1Version.Int16,
+				ChannelID:               r.GraphChannel.ID,
+				NodeID:                  r.Policy1NodeID.Int64,
+				Timelock:                r.Policy1Timelock.Int32,
+				FeePpm:                  r.Policy1FeePpm.Int64,
+				BaseFeeMsat:             r.Policy1BaseFeeMsat.Int64,
+				MinHtlcMsat:             r.Policy1MinHtlcMsat.Int64,
+				MaxHtlcMsat:             r.Policy1MaxHtlcMsat,
+				LastUpdate:              r.Policy1LastUpdate,
+				InboundBaseFeeMsat:      r.Policy1InboundBaseFeeMsat,
+				InboundFeeRateMilliMsat: r.Policy1InboundFeeRateMilliMsat,
+				Disabled:                r.Policy1Disabled,
+				MessageFlags:            r.Policy1MessageFlags,
+				ChannelFlags:            r.Policy1ChannelFlags,
+				Signature:               r.Policy1Signature,
+			}
+		}
+		if r.Policy2ID.Valid {
+			policy2 = &sqlc.GraphChannelPolicy{
+				ID:                      r.Policy2ID.Int64,
+				Version:                 r.Policy2Version.Int16,
+				ChannelID:               r.GraphChannel.ID,
+				NodeID:                  r.Policy2NodeID.Int64,
+				Timelock:                r.Policy2Timelock.Int32,
+				FeePpm:                  r.Policy2FeePpm.Int64,
+				BaseFeeMsat:             r.Policy2BaseFeeMsat.Int64,
+				MinHtlcMsat:             r.Policy2MinHtlcMsat.Int64,
+				MaxHtlcMsat:             r.Policy2MaxHtlcMsat,
+				LastUpdate:              r.Policy2LastUpdate,
+				InboundBaseFeeMsat:      r.Policy2InboundBaseFeeMsat,
+				InboundFeeRateMilliMsat: r.Policy2InboundFeeRateMilliMsat,
+				Disabled:                r.Policy2Disabled,
+				MessageFlags:            r.Policy2MessageFlags,
+				ChannelFlags:            r.Policy2ChannelFlags,
+				Signature:               r.Policy2Signature,
+			}
+		}
+
+		return policy1, policy2, nil
+
 	default:
 		return nil, nil, fmt.Errorf("unexpected row type in "+
 			"extractChannelPolicies: %T", r)

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -142,6 +142,7 @@ type SQLQueries interface {
 	*/
 	GetPruneTip(ctx context.Context) (sqlc.GraphPruneLog, error)
 	GetPruneHashByHeight(ctx context.Context, blockHeight int64) ([]byte, error)
+	GetPruneEntriesForHeights(ctx context.Context, heights []int64) ([]sqlc.GraphPruneLog, error)
 	UpsertPruneLogEntry(ctx context.Context, arg sqlc.UpsertPruneLogEntryParams) error
 	DeletePruneLogEntriesInRange(ctx context.Context, arg sqlc.DeletePruneLogEntriesInRangeParams) error
 

--- a/sqldb/paginate.go
+++ b/sqldb/paginate.go
@@ -37,11 +37,11 @@ const (
 type QueryConfig struct {
 	// MaxBatchSize is the maximum number of items included in a batch
 	// query IN clauses list.
-	MaxBatchSize int `long:"max-batch-size" description:"The maximum number of items to include in a batch query IN clause. This is used for queries that fetch results based on a list of identifiers."`
+	MaxBatchSize uint32 `long:"max-batch-size" description:"The maximum number of items to include in a batch query IN clause. This is used for queries that fetch results based on a list of identifiers."`
 
 	// MaxPageSize is the maximum number of items returned in a single page
 	// of results. This is used for paginated queries.
-	MaxPageSize int32 `long:"max-page-size" description:"The maximum number of items to return in a single page of results. This is used for paginated queries."`
+	MaxPageSize uint32 `long:"max-page-size" description:"The maximum number of items to return in a single page of results. This is used for paginated queries."`
 }
 
 // Validate checks that the QueryConfig values are valid.
@@ -121,9 +121,9 @@ func ExecuteBatchQuery[I any, T any, R any](ctx context.Context,
 	}
 
 	// Process items in pages.
-	for i := 0; i < len(inputItems); i += cfg.MaxBatchSize {
+	for i := 0; i < len(inputItems); i += int(cfg.MaxBatchSize) {
 		// Calculate the end index for this page.
-		end := i + cfg.MaxBatchSize
+		end := i + int(cfg.MaxBatchSize)
 		if end > len(inputItems) {
 			end = len(inputItems)
 		}
@@ -189,7 +189,7 @@ func ExecutePaginatedQuery[C any, T any](ctx context.Context, cfg *QueryConfig,
 
 	for {
 		// Fetch the next page.
-		items, err := queryFunc(ctx, cursor, cfg.MaxPageSize)
+		items, err := queryFunc(ctx, cursor, int32(cfg.MaxPageSize))
 		if err != nil {
 			return fmt.Errorf("failed to fetch page with "+
 				"cursor %v: %w", cursor, err)
@@ -265,7 +265,7 @@ func ExecuteCollectAndBatchWithSharedDataQuery[C any, T any, I any, D any](
 
 	for {
 		// Step 1: Fetch the next page of items.
-		items, err := pageQueryFunc(ctx, cursor, cfg.MaxPageSize)
+		items, err := pageQueryFunc(ctx, cursor, int32(cfg.MaxPageSize))
 		if err != nil {
 			return fmt.Errorf("failed to fetch page with "+
 				"cursor %v: %w", cursor, err)

--- a/sqldb/paginate_test.go
+++ b/sqldb/paginate_test.go
@@ -341,7 +341,7 @@ func TestExecutePaginatedQuery(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		pageSize      int32
+		pageSize      uint32
 		allItems      []testItem
 		initialCursor int64
 		queryError    error
@@ -592,7 +592,7 @@ func TestExecuteCollectAndBatchWithSharedDataQuery(t *testing.T) {
 
 	tests := []struct {
 		name                   string
-		maxPageSize            int32
+		maxPageSize            uint32
 		allRows                []channelRow
 		initialCursor          int64
 		pageQueryError         error

--- a/sqldb/sqlc/querier.go
+++ b/sqldb/sqlc/querier.go
@@ -71,6 +71,7 @@ type Querier interface {
 	GetNodeIDByPubKey(ctx context.Context, arg GetNodeIDByPubKeyParams) (int64, error)
 	GetNodesByIDs(ctx context.Context, ids []int64) ([]GraphNode, error)
 	GetNodesByLastUpdateRange(ctx context.Context, arg GetNodesByLastUpdateRangeParams) ([]GraphNode, error)
+	GetPruneEntriesForHeights(ctx context.Context, heights []int64) ([]GraphPruneLog, error)
 	GetPruneHashByHeight(ctx context.Context, blockHeight int64) ([]byte, error)
 	GetPruneTip(ctx context.Context) (GraphPruneLog, error)
 	GetPublicV1ChannelsBySCID(ctx context.Context, arg GetPublicV1ChannelsBySCIDParams) ([]GraphChannel, error)

--- a/sqldb/sqlc/querier.go
+++ b/sqldb/sqlc/querier.go
@@ -42,6 +42,7 @@ type Querier interface {
 	GetChannelFeaturesBatch(ctx context.Context, chanIds []int64) ([]GraphChannelFeature, error)
 	GetChannelPolicyByChannelAndNode(ctx context.Context, arg GetChannelPolicyByChannelAndNodeParams) (GraphChannelPolicy, error)
 	GetChannelPolicyExtraTypesBatch(ctx context.Context, policyIds []int64) ([]GetChannelPolicyExtraTypesBatchRow, error)
+	GetChannelsByIDs(ctx context.Context, ids []int64) ([]GetChannelsByIDsRow, error)
 	GetChannelsByOutpoints(ctx context.Context, outpoints []string) ([]GetChannelsByOutpointsRow, error)
 	GetChannelsByPolicyLastUpdateRange(ctx context.Context, arg GetChannelsByPolicyLastUpdateRangeParams) ([]GetChannelsByPolicyLastUpdateRangeRow, error)
 	GetChannelsBySCIDRange(ctx context.Context, arg GetChannelsBySCIDRangeParams) ([]GetChannelsBySCIDRangeRow, error)

--- a/sqldb/sqlc/querier.go
+++ b/sqldb/sqlc/querier.go
@@ -48,6 +48,7 @@ type Querier interface {
 	GetChannelsBySCIDRange(ctx context.Context, arg GetChannelsBySCIDRangeParams) ([]GetChannelsBySCIDRangeRow, error)
 	GetChannelsBySCIDWithPolicies(ctx context.Context, arg GetChannelsBySCIDWithPoliciesParams) ([]GetChannelsBySCIDWithPoliciesRow, error)
 	GetChannelsBySCIDs(ctx context.Context, arg GetChannelsBySCIDsParams) ([]GraphChannel, error)
+	GetClosedChannelsSCIDs(ctx context.Context, scids [][]byte) ([][]byte, error)
 	GetDatabaseVersion(ctx context.Context) (int32, error)
 	GetExtraNodeTypes(ctx context.Context, nodeID int64) ([]GraphNodeExtraType, error)
 	// This method may return more than one invoice if filter using multiple fields

--- a/sqldb/sqlc/querier.go
+++ b/sqldb/sqlc/querier.go
@@ -68,6 +68,7 @@ type Querier interface {
 	GetNodeFeaturesBatch(ctx context.Context, ids []int64) ([]GraphNodeFeature, error)
 	GetNodeFeaturesByPubKey(ctx context.Context, arg GetNodeFeaturesByPubKeyParams) ([]int32, error)
 	GetNodeIDByPubKey(ctx context.Context, arg GetNodeIDByPubKeyParams) (int64, error)
+	GetNodesByIDs(ctx context.Context, ids []int64) ([]GraphNode, error)
 	GetNodesByLastUpdateRange(ctx context.Context, arg GetNodesByLastUpdateRangeParams) ([]GraphNode, error)
 	GetPruneHashByHeight(ctx context.Context, blockHeight int64) ([]byte, error)
 	GetPruneTip(ctx context.Context) (GraphPruneLog, error)

--- a/sqldb/sqlc/querier.go
+++ b/sqldb/sqlc/querier.go
@@ -84,6 +84,7 @@ type Querier interface {
 	// and so the query for V2 may differ.
 	GetV1DisabledSCIDs(ctx context.Context) ([][]byte, error)
 	GetZombieChannel(ctx context.Context, arg GetZombieChannelParams) (GraphZombieChannel, error)
+	GetZombieChannelsSCIDs(ctx context.Context, arg GetZombieChannelsSCIDsParams) ([]GraphZombieChannel, error)
 	HighestSCID(ctx context.Context, version int16) ([]byte, error)
 	InsertAMPSubInvoice(ctx context.Context, arg InsertAMPSubInvoiceParams) error
 	InsertAMPSubInvoiceHTLC(ctx context.Context, arg InsertAMPSubInvoiceHTLCParams) error

--- a/sqldb/sqlc/queries/graph.sql
+++ b/sqldb/sqlc/queries/graph.sql
@@ -952,6 +952,12 @@ FROM graph_prune_log
 ORDER BY block_height DESC
 LIMIT 1;
 
+-- name: GetPruneEntriesForHeights :many
+SELECT block_height, block_hash
+FROM graph_prune_log
+WHERE block_height
+   IN (sqlc.slice('heights')/*SLICE:heights*/);
+
 -- name: GetPruneHashByHeight :one
 SELECT block_hash
 FROM graph_prune_log

--- a/sqldb/sqlc/queries/graph.sql
+++ b/sqldb/sqlc/queries/graph.sql
@@ -335,6 +335,59 @@ WHERE
     c.version = @version
   AND c.scid IN (sqlc.slice('scids')/*SLICE:scids*/);
 
+-- name: GetChannelsByIDs :many
+SELECT
+    sqlc.embed(c),
+
+    -- Minimal node data.
+    n1.id AS node1_id,
+    n1.pub_key AS node1_pub_key,
+    n2.id AS node2_id,
+    n2.pub_key AS node2_pub_key,
+
+    -- Policy 1
+    cp1.id AS policy1_id,
+    cp1.node_id AS policy1_node_id,
+    cp1.version AS policy1_version,
+    cp1.timelock AS policy1_timelock,
+    cp1.fee_ppm AS policy1_fee_ppm,
+    cp1.base_fee_msat AS policy1_base_fee_msat,
+    cp1.min_htlc_msat AS policy1_min_htlc_msat,
+    cp1.max_htlc_msat AS policy1_max_htlc_msat,
+    cp1.last_update AS policy1_last_update,
+    cp1.disabled AS policy1_disabled,
+    cp1.inbound_base_fee_msat AS policy1_inbound_base_fee_msat,
+    cp1.inbound_fee_rate_milli_msat AS policy1_inbound_fee_rate_milli_msat,
+    cp1.message_flags AS policy1_message_flags,
+    cp1.channel_flags AS policy1_channel_flags,
+    cp1.signature AS policy1_signature,
+
+    -- Policy 2
+    cp2.id AS policy2_id,
+    cp2.node_id AS policy2_node_id,
+    cp2.version AS policy2_version,
+    cp2.timelock AS policy2_timelock,
+    cp2.fee_ppm AS policy2_fee_ppm,
+    cp2.base_fee_msat AS policy2_base_fee_msat,
+    cp2.min_htlc_msat AS policy2_min_htlc_msat,
+    cp2.max_htlc_msat AS policy2_max_htlc_msat,
+    cp2.last_update AS policy2_last_update,
+    cp2.disabled AS policy2_disabled,
+    cp2.inbound_base_fee_msat AS policy2_inbound_base_fee_msat,
+    cp2.inbound_fee_rate_milli_msat AS policy2_inbound_fee_rate_milli_msat,
+    cp2.message_flags AS policy2_message_flags,
+    cp2.channel_flags AS policy2_channel_flags,
+    cp2.signature AS policy2_signature
+
+FROM graph_channels c
+    JOIN graph_nodes n1 ON c.node_id_1 = n1.id
+    JOIN graph_nodes n2 ON c.node_id_2 = n2.id
+    LEFT JOIN graph_channel_policies cp1
+        ON cp1.channel_id = c.id AND cp1.node_id = c.node_id_1 AND cp1.version = c.version
+    LEFT JOIN graph_channel_policies cp2
+        ON cp2.channel_id = c.id AND cp2.node_id = c.node_id_2 AND cp2.version = c.version
+WHERE c.id IN (sqlc.slice('ids')/*SLICE:ids*/);
+
 -- name: GetChannelsByPolicyLastUpdateRange :many
 SELECT
     sqlc.embed(c),

--- a/sqldb/sqlc/queries/graph.sql
+++ b/sqldb/sqlc/queries/graph.sql
@@ -908,6 +908,12 @@ DO UPDATE SET
     node_key_1 = COALESCE(EXCLUDED.node_key_1, graph_zombie_channels.node_key_1),
     node_key_2 = COALESCE(EXCLUDED.node_key_2, graph_zombie_channels.node_key_2);
 
+-- name: GetZombieChannelsSCIDs :many
+SELECT *
+FROM graph_zombie_channels
+WHERE version = @version
+  AND scid IN (sqlc.slice('scids')/*SLICE:scids*/);
+
 -- name: DeleteZombieChannel :execresult
 DELETE FROM graph_zombie_channels
 WHERE scid = $1

--- a/sqldb/sqlc/queries/graph.sql
+++ b/sqldb/sqlc/queries/graph.sql
@@ -984,3 +984,8 @@ SELECT EXISTS (
     FROM graph_closed_scids
     WHERE scid = $1
 );
+
+-- name: GetClosedChannelsSCIDs :many
+SELECT scid
+FROM graph_closed_scids
+WHERE scid IN (sqlc.slice('scids')/*SLICE:scids*/);

--- a/sqldb/sqlc/queries/graph.sql
+++ b/sqldb/sqlc/queries/graph.sql
@@ -21,6 +21,11 @@ WHERE graph_nodes.last_update IS NULL
     OR EXCLUDED.last_update > graph_nodes.last_update
 RETURNING id;
 
+-- name: GetNodesByIDs :many
+SELECT *
+FROM graph_nodes
+WHERE id IN (sqlc.slice('ids')/*SLICE:ids*/);
+
 -- name: GetNodeByPubKey :one
 SELECT *
 FROM graph_nodes


### PR DESCRIPTION
Part of #9795 

This PR updates the graph SQL migration code to make use of batch fetching for validation instead of validating records one-by-one. This is especially important for when a postgres backend is being used. 

## Performance:
With this PR, the migration for a mainnet backend with
- 16216 nodes,
- 51239 channels
- 82029 policies
- 361511 prune log entries
- 17931 closed SCID index entries 
- 238183 zombie channel index entries 

Takes ~ 50 seconds on SQLite & 1m35s on Postgres 

(before this PR, it would take >11m on postgres)