### PR TITLE
[2/2] discovery+lnwire: add support for DNS host name in `NodeAnnouncement` msg using a new `external-dns-address` config field

### DIFF
--- a/chanbackup/backup_test.go
+++ b/chanbackup/backup_test.go
@@ -161,6 +161,7 @@ func TestFetchStaticChanBackups(t *testing.T) {
 	chanSource.addAddrsForNode(randomChan2.IdentityPub, []net.Addr{addr2})
 	chanSource.addAddrsForNode(randomChan2.IdentityPub, []net.Addr{addr3})
 	chanSource.addAddrsForNode(randomChan2.IdentityPub, []net.Addr{addr4})
+	chanSource.addAddrsForNode(randomChan2.IdentityPub, []net.Addr{addr5})
 
 	// With the channel source populated, we'll now attempt to create a set
 	// of backups for all the channels. This should succeed, as all items

--- a/chanbackup/multi_test.go
+++ b/chanbackup/multi_test.go
@@ -23,7 +23,7 @@ func TestMultiPackUnpack(t *testing.T) {
 		}
 
 		single := NewSingle(
-			channel, []net.Addr{addr1, addr2, addr3, addr4},
+			channel, []net.Addr{addr1, addr2, addr3, addr4, addr5},
 		)
 
 		originalSingles = append(originalSingles, single)

--- a/chanbackup/single_test.go
+++ b/chanbackup/single_test.go
@@ -41,7 +41,11 @@ var (
 		OnionService: "3g2upl4pq6kufc4m.onion",
 		Port:         9735,
 	}
-	addr4 = &lnwire.OpaqueAddrs{
+	addr4 = &lnwire.DNSAddress{
+		Hostname: "example.com",
+		Port:     8080,
+	}
+	addr5 = &lnwire.OpaqueAddrs{
 		// The first byte must be an address type we are not yet aware
 		// of for it to be a valid OpaqueAddrs.
 		Payload: []byte{math.MaxUint8, 1, 2, 3, 4},
@@ -320,7 +324,7 @@ func TestSinglePackUnpack(t *testing.T) {
 	require.NoError(t, err, "unable to gen open channel")
 
 	singleChanBackup := NewSingle(
-		channel, []net.Addr{addr1, addr2, addr3, addr4},
+		channel, []net.Addr{addr1, addr2, addr3, addr4, addr5},
 	)
 
 	keyRing := &lnencrypt.MockKeyRing{}
@@ -647,7 +651,7 @@ func TestSingleUnconfirmedChannel(t *testing.T) {
 	channel.FundingBroadcastHeight = fundingBroadcastHeight
 
 	singleChanBackup := NewSingle(
-		channel, []net.Addr{addr1, addr2, addr3, addr4},
+		channel, []net.Addr{addr1, addr2, addr3, addr4, addr5},
 	)
 	keyRing := &lnencrypt.MockKeyRing{}
 

--- a/discovery/chan_series.go
+++ b/discovery/chan_series.go
@@ -192,6 +192,13 @@ func (c *ChanSeries) UpdatesInHorizon(chain chainhash.Hash,
 			return nil, err
 		}
 
+		if err := netann.ValidateNodeAnnFields(nodeUpdate); err != nil {
+			log.Debugf("Skipping forwarding invalid node "+
+				"announcement %x: %v", nodeAnn.PubKeyBytes, err)
+
+			continue
+		}
+
 		updates = append(updates, nodeUpdate)
 	}
 
@@ -243,6 +250,7 @@ func (c *ChanSeries) FilterChannelRange(_ chainhash.Hash, startHeight,
 // to reply to a QueryShortChanIDs message sent by a remote peer. The response
 // will contain a unique set of ChannelAnnouncements, the latest ChannelUpdate
 // for each of the announcements, and a unique set of NodeAnnouncements.
+// Invalid node announcements are skipped and logged for debugging purposes.
 //
 // NOTE: This is part of the ChannelGraphTimeSeries interface.
 func (c *ChanSeries) FetchChanAnns(chain chainhash.Hash,
@@ -296,8 +304,15 @@ func (c *ChanSeries) FetchChanAnns(chain chainhash.Hash,
 					return nil, err
 				}
 
-				chanAnns = append(chanAnns, nodeAnn)
-				nodePubsSent[nodePub] = struct{}{}
+				err = netann.ValidateNodeAnnFields(nodeAnn)
+				if err != nil {
+					log.Debugf("Skipping forwarding "+
+						"invalid node announcement "+
+						"%x: %v", nodeAnn.NodeID, err)
+				} else {
+					chanAnns = append(chanAnns, nodeAnn)
+					nodePubsSent[nodePub] = struct{}{}
+				}
 			}
 		}
 		if edge2 != nil {
@@ -315,8 +330,15 @@ func (c *ChanSeries) FetchChanAnns(chain chainhash.Hash,
 					return nil, err
 				}
 
-				chanAnns = append(chanAnns, nodeAnn)
-				nodePubsSent[nodePub] = struct{}{}
+				err = netann.ValidateNodeAnnFields(nodeAnn)
+				if err != nil {
+					log.Debugf("Skipping forwarding "+
+						"invalid node announcement "+
+						"%x: %v", nodeAnn.NodeID, err)
+				} else {
+					chanAnns = append(chanAnns, nodeAnn)
+					nodePubsSent[nodePub] = struct{}{}
+				}
 			}
 		}
 	}

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -2220,7 +2220,9 @@ func (d *AuthenticatedGossiper) processZombieUpdate(_ context.Context,
 }
 
 // fetchNodeAnn fetches the latest signed node announcement from our point of
-// view for the node with the given public key.
+// view for the node with the given public key. It also validates the node
+// announcement fields and returns an error if they are invalid to prevent
+// forwarding invalid node announcements to our peers.
 func (d *AuthenticatedGossiper) fetchNodeAnn(ctx context.Context,
 	pubKey [33]byte) (*lnwire.NodeAnnouncement, error) {
 
@@ -2229,7 +2231,12 @@ func (d *AuthenticatedGossiper) fetchNodeAnn(ctx context.Context,
 		return nil, err
 	}
 
-	return node.NodeAnnouncement(true)
+	nodeAnn, err := node.NodeAnnouncement(true)
+	if err != nil {
+		return nil, err
+	}
+
+	return nodeAnn, netann.ValidateNodeAnnFields(nodeAnn)
 }
 
 // isMsgStale determines whether a message retrieved from the backing

--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -198,6 +198,14 @@ reader of a payment request.
 * [Require invoices to include a payment address or blinded paths](https://github.com/lightningnetwork/lnd/pull/9752) 
   to comply with updated BOLT 11 specifications before sending payments.
 
+* [Support DNS address in
+  node announcement msg](https://github.com/lightningnetwork/lnd/pull/10159):
+  This update allows users to announce their LND node using a DNS address in
+  the node announcement message, by configuring `external-dns-address` field in
+  the LND config file.
+  **Note:** According to BOLT 07, only one DNS address may be announced per
+  node.
+
 ## Testing
 
 * Previously, automatic peer bootstrapping was disabled for simnet, signet and

--- a/graph/db/addr_test.go
+++ b/graph/db/addr_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/tor"
 	"github.com/stretchr/testify/require"
 )
@@ -38,6 +39,18 @@ var (
 		OnionService: "vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd.onion", //nolint:ll
 		Port:         80,
 	}
+
+	testOpaqueAddr = &lnwire.OpaqueAddrs{
+		// NOTE: the first byte is a protocol level address type. So
+		// for we set it to 0xff to guarantee that we do not know this
+		// type yet.
+		Payload: []byte{0xff, 0x02, 0x03, 0x04, 0x05, 0x06},
+	}
+
+	testDNSAddr = &lnwire.DNSAddress{
+		Hostname: "example.com",
+		Port:     8080,
+	}
 )
 
 var addrTests = []struct {
@@ -56,6 +69,12 @@ var addrTests = []struct {
 	},
 	{
 		expAddr: testOnionV3Addr,
+	},
+	{
+		expAddr: testOpaqueAddr,
+	},
+	{
+		expAddr: testDNSAddr,
 	},
 
 	// Invalid addresses.

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -39,7 +39,10 @@ var (
 		"[2001:db8:85a3:0:0:8a2e:370:7334]:80")
 	testAddrs      = []net.Addr{testAddr, anotherAddr}
 	testOpaqueAddr = &lnwire.OpaqueAddrs{
-		Payload: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
+		// NOTE: the first byte is a protocol level address type. So
+		// for we set it to 0xff to guarantee that we do not know this
+		// type yet.
+		Payload: []byte{0xff, 0x02, 0x03, 0x04, 0x05, 0x06},
 	}
 
 	testRBytes, _ = hex.DecodeString("8ce2bc69281ce27da07e6683571319d18" +

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -37,13 +37,7 @@ var (
 		Port: 9000}
 	anotherAddr, _ = net.ResolveTCPAddr("tcp",
 		"[2001:db8:85a3:0:0:8a2e:370:7334]:80")
-	testAddrs      = []net.Addr{testAddr, anotherAddr}
-	testOpaqueAddr = &lnwire.OpaqueAddrs{
-		// NOTE: the first byte is a protocol level address type. So
-		// for we set it to 0xff to guarantee that we do not know this
-		// type yet.
-		Payload: []byte{0xff, 0x02, 0x03, 0x04, 0x05, 0x06},
-	}
+	testAddrs = []net.Addr{testAddr, anotherAddr}
 
 	testRBytes, _ = hex.DecodeString("8ce2bc69281ce27da07e6683571319d18" +
 		"e949ddfa2965fb6caa1bf0314f882d7")
@@ -211,6 +205,8 @@ func TestNodeInsertionAndDeletion(t *testing.T) {
 		// Add one v2 and one v3 onion address.
 		testOnionV2Addr,
 		testOnionV3Addr,
+		// Add a DNS host address.
+		testDNSAddr,
 		// Make sure to also test the opaque address type.
 		testOpaqueAddr,
 	}

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -3520,6 +3520,7 @@ const (
 	addressTypeIPv6   dbAddressType = 2
 	addressTypeTorV2  dbAddressType = 3
 	addressTypeTorV3  dbAddressType = 4
+	addressTypeDNS    dbAddressType = 5
 	addressTypeOpaque dbAddressType = math.MaxInt8
 )
 
@@ -3547,6 +3548,7 @@ func upsertNodeAddresses(ctx context.Context, db SQLQueries, nodeID int64,
 		addressTypeIPv6:   {},
 		addressTypeTorV2:  {},
 		addressTypeTorV3:  {},
+		addressTypeDNS:    {},
 		addressTypeOpaque: {},
 	}
 	addAddr := func(t dbAddressType, addr net.Addr) {
@@ -3575,6 +3577,9 @@ func upsertNodeAddresses(ctx context.Context, db SQLQueries, nodeID int64,
 				return fmt.Errorf("invalid length for a tor " +
 					"address")
 			}
+
+		case *lnwire.DNSAddress:
+			addAddr(addressTypeDNS, addr)
 
 		case *lnwire.OpaqueAddrs:
 			addAddr(addressTypeOpaque, addr)
@@ -4648,6 +4653,23 @@ func parseAddress(addrType dbAddressType, address string) (net.Addr, error) {
 		return &tor.OnionAddr{
 			OnionService: service,
 			Port:         port,
+		}, nil
+
+	case addressTypeDNS:
+		hostname, portStr, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, fmt.Errorf("unable to split DNS "+
+				"address: %v", address)
+		}
+
+		port, err := strconv.Atoi(portStr)
+		if err != nil {
+			return nil, err
+		}
+
+		return &lnwire.DNSAddress{
+			Hostname: hostname,
+			Port:     uint16(port),
 		}, nil
 
 	case addressTypeOpaque:

--- a/itest/lnd_channel_graph_test.go
+++ b/itest/lnd_channel_graph_test.go
@@ -441,6 +441,7 @@ func testUpdateNodeAnnouncement(ht *lntest.HarnessTest) {
 	for _, addr := range extraAddrs {
 		lndArgs = append(lndArgs, "--externalip="+addr)
 	}
+	lndArgs = append(lndArgs, "--external-dns-address="+"example.com")
 	dave := ht.NewNode("Dave", lndArgs)
 
 	// assertNodeAnn is a helper closure that checks a given node update
@@ -471,6 +472,21 @@ func testUpdateNodeAnnouncement(ht *lntest.HarnessTest) {
 	// Get dave default information so we can compare it lately with the
 	// broadcast updates.
 	resp := dave.RPC.GetInfo()
+
+	// Assert that the URIs contain example.com as configured via
+	// --external-dns-address.
+	foundDNSAddress := false
+	for _, uri := range resp.GetUris() {
+		if strings.Contains(uri, "example.com") {
+			foundDNSAddress = true
+			break
+		}
+	}
+	require.True(
+		ht, foundDNSAddress,
+		"example.com should be present in node URIs",
+	)
+
 	defaultAddrs := make([]*lnrpc.NodeAddress, 0, len(resp.Uris))
 	for _, uri := range resp.GetUris() {
 		values := strings.Split(uri, "@")

--- a/lnwire/dns_addr.go
+++ b/lnwire/dns_addr.go
@@ -1,9 +1,17 @@
 package lnwire
 
 import (
+	"errors"
+	"fmt"
 	"net"
 	"strconv"
 )
+
+// ErrEmptyDNSHostname is returned when a DNS hostname is empty.
+var ErrEmptyDNSHostname = errors.New("hostname cannot be empty")
+
+// ErrZeroPort is returned when a DNS port is zero.
+var ErrZeroPort = errors.New("port cannot be zero")
 
 // DNSAddress is used to represent a DNS address of a node.
 type DNSAddress struct {
@@ -28,4 +36,41 @@ func (d *DNSAddress) Network() string {
 // String returns the address in the form "hostname:port".
 func (d *DNSAddress) String() string {
 	return net.JoinHostPort(d.Hostname, strconv.Itoa(int(d.Port)))
+}
+
+// ValidateDNSAddr validates that the DNS hostname is not empty and contains
+// only ASCII characters and of max length 255 characters and port is non zero
+// according to BOLT #7.
+func ValidateDNSAddr(hostname string, port uint16) error {
+	if hostname == "" {
+		return ErrEmptyDNSHostname
+	}
+
+	// Per BOLT 7, ports must not be zero for type 5 address (DNS address).
+	if port == 0 {
+		return ErrZeroPort
+	}
+
+	if len(hostname) > 255 {
+		return fmt.Errorf("DNS hostname length %d, exceeds limit of "+
+			"255 bytes", len(hostname))
+	}
+
+	// Check if hostname contains only ASCII characters.
+	for i, r := range hostname {
+		// Check for valid hostname characters, excluding ASCII control
+		// characters (0-31), spaces, underscores, delete character
+		// (127), and the special characters (like /, \, @, #, $, etc.).
+		if !((r >= 'a' && r <= 'z') ||
+			(r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') ||
+			r == '-' ||
+			r == '.') {
+
+			return fmt.Errorf("hostname '%s' contains invalid "+
+				"character '%c' at position %d", hostname, r, i)
+		}
+	}
+
+	return nil
 }

--- a/lnwire/dns_addr.go
+++ b/lnwire/dns_addr.go
@@ -1,0 +1,31 @@
+package lnwire
+
+import (
+	"net"
+	"strconv"
+)
+
+// DNSAddress is used to represent a DNS address of a node.
+type DNSAddress struct {
+	// Hostname is the DNS hostname of the address. This MUST only contain
+	// ASCII characters as per Bolt #7. The maximum length that this may
+	// be is 255 bytes.
+	Hostname string
+
+	// Port is the port number of the address.
+	Port uint16
+}
+
+// A compile-time check to ensure that DNSAddress implements the net.Addr
+// interface.
+var _ net.Addr = (*DNSAddress)(nil)
+
+// Network returns the network that this address uses, which is "tcp".
+func (d *DNSAddress) Network() string {
+	return "tcp"
+}
+
+// String returns the address in the form "hostname:port".
+func (d *DNSAddress) String() string {
+	return net.JoinHostPort(d.Hostname, strconv.Itoa(int(d.Port)))
+}

--- a/lnwire/lnwire.go
+++ b/lnwire/lnwire.go
@@ -719,174 +719,9 @@ func ReadElement(r io.Reader, element interface{}) error {
 		}
 
 	case *[]net.Addr:
-		// First, we'll read the number of total bytes that have been
-		// used to encode the set of addresses.
-		var numAddrsBytes [2]byte
-		if _, err = io.ReadFull(r, numAddrsBytes[:]); err != nil {
-			return err
-		}
-		addrsLen := binary.BigEndian.Uint16(numAddrsBytes[:])
-
-		// With the number of addresses, read, we'll now pull in the
-		// buffer of the encoded addresses into memory.
-		addrs := make([]byte, addrsLen)
-		if _, err := io.ReadFull(r, addrs[:]); err != nil {
-			return err
-		}
-		addrBuf := bytes.NewReader(addrs)
-
-		// Finally, we'll parse the remaining address payload in
-		// series, using the first byte to denote how to decode the
-		// address itself.
-		var (
-			addresses     []net.Addr
-			addrBytesRead uint16
-		)
-
-		for addrBytesRead < addrsLen {
-			var descriptor [1]byte
-			if _, err = io.ReadFull(addrBuf, descriptor[:]); err != nil {
-				return err
-			}
-
-			addrBytesRead++
-
-			var address net.Addr
-			switch aType := addressType(descriptor[0]); aType {
-			case noAddr:
-				continue
-
-			case tcp4Addr:
-				var ip [4]byte
-				if _, err := io.ReadFull(addrBuf, ip[:]); err != nil {
-					return err
-				}
-
-				var port [2]byte
-				if _, err := io.ReadFull(addrBuf, port[:]); err != nil {
-					return err
-				}
-
-				address = &net.TCPAddr{
-					IP:   net.IP(ip[:]),
-					Port: int(binary.BigEndian.Uint16(port[:])),
-				}
-				addrBytesRead += tcp4AddrLen
-
-			case tcp6Addr:
-				var ip [16]byte
-				if _, err := io.ReadFull(addrBuf, ip[:]); err != nil {
-					return err
-				}
-
-				var port [2]byte
-				if _, err := io.ReadFull(addrBuf, port[:]); err != nil {
-					return err
-				}
-
-				address = &net.TCPAddr{
-					IP:   net.IP(ip[:]),
-					Port: int(binary.BigEndian.Uint16(port[:])),
-				}
-				addrBytesRead += tcp6AddrLen
-
-			case v2OnionAddr:
-				var h [tor.V2DecodedLen]byte
-				if _, err := io.ReadFull(addrBuf, h[:]); err != nil {
-					return err
-				}
-
-				var p [2]byte
-				if _, err := io.ReadFull(addrBuf, p[:]); err != nil {
-					return err
-				}
-
-				onionService := tor.Base32Encoding.EncodeToString(h[:])
-				onionService += tor.OnionSuffix
-				port := int(binary.BigEndian.Uint16(p[:]))
-
-				address = &tor.OnionAddr{
-					OnionService: onionService,
-					Port:         port,
-				}
-				addrBytesRead += v2OnionAddrLen
-
-			case v3OnionAddr:
-				var h [tor.V3DecodedLen]byte
-				if _, err := io.ReadFull(addrBuf, h[:]); err != nil {
-					return err
-				}
-
-				var p [2]byte
-				if _, err := io.ReadFull(addrBuf, p[:]); err != nil {
-					return err
-				}
-
-				onionService := tor.Base32Encoding.EncodeToString(h[:])
-				onionService += tor.OnionSuffix
-				port := int(binary.BigEndian.Uint16(p[:]))
-
-				address = &tor.OnionAddr{
-					OnionService: onionService,
-					Port:         port,
-				}
-				addrBytesRead += v3OnionAddrLen
-
-			case dnsAddr:
-				var hostnameLen [1]byte
-				_, err := io.ReadFull(addrBuf, hostnameLen[:])
-				if err != nil {
-					return err
-				}
-
-				hostname := make([]byte, hostnameLen[0])
-				_, err = io.ReadFull(addrBuf, hostname)
-				if err != nil {
-					return err
-				}
-
-				var port [2]byte
-				_, err = io.ReadFull(addrBuf, port[:])
-				if err != nil {
-					return err
-				}
-
-				address = &DNSAddress{
-					Hostname: string(hostname),
-					Port: binary.BigEndian.Uint16(
-						port[:],
-					),
-				}
-				addrBytesRead += dnsAddrOverhead +
-					uint16(len(hostname))
-
-			default:
-				// If we don't understand this address type,
-				// we just store it along with the remaining
-				// address bytes as type OpaqueAddrs. We need
-				// to hold onto the bytes so that we can still
-				// write them back to the wire when we
-				// propagate this message.
-				payloadLen := 1 + addrsLen - addrBytesRead
-				payload := make([]byte, payloadLen)
-
-				// First write a byte for the address type that
-				// we already read.
-				payload[0] = byte(aType)
-
-				// Now append the rest of the address bytes.
-				_, err := io.ReadFull(addrBuf, payload[1:])
-				if err != nil {
-					return err
-				}
-
-				address = &OpaqueAddrs{
-					Payload: payload,
-				}
-				addrBytesRead = addrsLen
-			}
-
-			addresses = append(addresses, address)
+		addresses, err := ReadAddresses(r)
+		if err != nil {
+			return fmt.Errorf("unable to read addresses: %w", err)
 		}
 
 		*e = addresses
@@ -948,4 +783,181 @@ func ReadElements(r io.Reader, elements ...interface{}) error {
 		}
 	}
 	return nil
+}
+
+// ReadAddresses reads encoded network addresses.
+//
+//nolint:funlen
+func ReadAddresses(r io.Reader) ([]net.Addr, error) {
+	// First, we'll read the number of total bytes that have been
+	// used to encode the set of addresses.
+	var numAddrsBytes [2]byte
+	if _, err := io.ReadFull(r, numAddrsBytes[:]); err != nil {
+		return nil, err
+	}
+	addrsLen := binary.BigEndian.Uint16(numAddrsBytes[:])
+
+	// With the number of addresses, read, we'll now pull in the
+	// buffer of the encoded addresses into memory.
+	addrs := make([]byte, addrsLen)
+	if _, err := io.ReadFull(r, addrs); err != nil {
+		return nil, err
+	}
+	addrBuf := bytes.NewReader(addrs)
+
+	// Finally, we'll parse the remaining address payload in
+	// series, using the first byte to denote how to decode the
+	// address itself.
+	var (
+		addresses     []net.Addr
+		addrBytesRead uint16
+	)
+
+	for addrBytesRead < addrsLen {
+		var descriptor [1]byte
+		if _, err := io.ReadFull(addrBuf, descriptor[:]); err != nil {
+			return nil, err
+		}
+
+		addrBytesRead++
+
+		var address net.Addr
+		switch aType := addressType(descriptor[0]); aType {
+		case noAddr:
+			continue
+
+		case tcp4Addr:
+			var ip [4]byte
+			if _, err := io.ReadFull(addrBuf, ip[:]); err != nil {
+				return nil, err
+			}
+
+			var port [2]byte
+			if _, err := io.ReadFull(addrBuf, port[:]); err != nil {
+				return nil, err
+			}
+
+			address = &net.TCPAddr{
+				IP:   net.IP(ip[:]),
+				Port: int(binary.BigEndian.Uint16(port[:])),
+			}
+			addrBytesRead += tcp4AddrLen
+
+		case tcp6Addr:
+			var ip [16]byte
+			if _, err := io.ReadFull(addrBuf, ip[:]); err != nil {
+				return nil, err
+			}
+
+			var port [2]byte
+			if _, err := io.ReadFull(addrBuf, port[:]); err != nil {
+				return nil, err
+			}
+
+			address = &net.TCPAddr{
+				IP:   net.IP(ip[:]),
+				Port: int(binary.BigEndian.Uint16(port[:])),
+			}
+			addrBytesRead += tcp6AddrLen
+
+		case v2OnionAddr:
+			var h [tor.V2DecodedLen]byte
+			if _, err := io.ReadFull(addrBuf, h[:]); err != nil {
+				return nil, err
+			}
+
+			var p [2]byte
+			if _, err := io.ReadFull(addrBuf, p[:]); err != nil {
+				return nil, err
+			}
+
+			onionService := tor.Base32Encoding.EncodeToString(h[:])
+			onionService += tor.OnionSuffix
+			port := int(binary.BigEndian.Uint16(p[:]))
+
+			address = &tor.OnionAddr{
+				OnionService: onionService,
+				Port:         port,
+			}
+			addrBytesRead += v2OnionAddrLen
+
+		case v3OnionAddr:
+			var h [tor.V3DecodedLen]byte
+			if _, err := io.ReadFull(addrBuf, h[:]); err != nil {
+				return nil, err
+			}
+
+			var p [2]byte
+			if _, err := io.ReadFull(addrBuf, p[:]); err != nil {
+				return nil, err
+			}
+
+			onionService := tor.Base32Encoding.EncodeToString(h[:])
+			onionService += tor.OnionSuffix
+			port := int(binary.BigEndian.Uint16(p[:]))
+
+			address = &tor.OnionAddr{
+				OnionService: onionService,
+				Port:         port,
+			}
+			addrBytesRead += v3OnionAddrLen
+
+		case dnsAddr:
+			var hostnameLen [1]byte
+			_, err := io.ReadFull(addrBuf, hostnameLen[:])
+			if err != nil {
+				return nil, err
+			}
+
+			hostname := make([]byte, hostnameLen[0])
+			_, err = io.ReadFull(addrBuf, hostname)
+			if err != nil {
+				return nil, err
+			}
+
+			var port [2]byte
+			_, err = io.ReadFull(addrBuf, port[:])
+			if err != nil {
+				return nil, err
+			}
+
+			address = &DNSAddress{
+				Hostname: string(hostname),
+				Port: binary.BigEndian.Uint16(
+					port[:],
+				),
+			}
+			addrBytesRead += dnsAddrOverhead +
+				uint16(len(hostname))
+
+		default:
+			// If we don't understand this address type,
+			// we just store it along with the remaining
+			// address bytes as type OpaqueAddrs. We need
+			// to hold onto the bytes so that we can still
+			// write them back to the wire when we
+			// propagate this message.
+			payloadLen := 1 + addrsLen - addrBytesRead
+			payload := make([]byte, payloadLen)
+
+			// First write a byte for the address type that
+			// we already read.
+			payload[0] = byte(aType)
+
+			// Now append the rest of the address bytes.
+			_, err := io.ReadFull(addrBuf, payload[1:])
+			if err != nil {
+				return nil, err
+			}
+
+			address = &OpaqueAddrs{
+				Payload: payload,
+			}
+			addrBytesRead = addrsLen
+		}
+
+		addresses = append(addresses, address)
+	}
+
+	return addresses, nil
 }

--- a/lnwire/lnwire.go
+++ b/lnwire/lnwire.go
@@ -28,6 +28,24 @@ const (
 	MaxMsgBody = 65533
 )
 
+const (
+	// tcp4AddrLen is the length of an IPv4 address
+	// (4 bytes IP + 2 bytes port).
+	tcp4AddrLen = 6
+
+	// tcp6AddrLen is the length of an IPv6 address
+	// (16 bytes IP + 2 bytes port).
+	tcp6AddrLen = 18
+
+	// v2OnionAddrLen is the length of a version 2 Tor onion service
+	// address.
+	v2OnionAddrLen = 12
+
+	// v3OnionAddrLen is the length of a version 3 Tor onion service address
+	// (35 bytes decoded onion + 2 bytes port).
+	v3OnionAddrLen = 37
+)
+
 // PkScript is simple type definition which represents a raw serialized public
 // key script.
 type PkScript []byte
@@ -53,25 +71,6 @@ const (
 	// v3OnionAddr denotes a version 3 Tor (prop224) onion service address.
 	v3OnionAddr addressType = 4
 )
-
-// AddrLen returns the number of bytes that it takes to encode the target
-// address.
-func (a addressType) AddrLen() uint16 {
-	switch a {
-	case noAddr:
-		return 0
-	case tcp4Addr:
-		return 6
-	case tcp6Addr:
-		return 18
-	case v2OnionAddr:
-		return 12
-	case v3OnionAddr:
-		return 37
-	default:
-		return 0
-	}
-}
 
 // WriteElement is a one-stop shop to write the big endian representation of
 // any element which is to be serialized for the wire protocol.
@@ -743,7 +742,6 @@ func ReadElement(r io.Reader, element interface{}) error {
 			var address net.Addr
 			switch aType := addressType(descriptor[0]); aType {
 			case noAddr:
-				addrBytesRead += aType.AddrLen()
 				continue
 
 			case tcp4Addr:
@@ -761,7 +759,7 @@ func ReadElement(r io.Reader, element interface{}) error {
 					IP:   net.IP(ip[:]),
 					Port: int(binary.BigEndian.Uint16(port[:])),
 				}
-				addrBytesRead += aType.AddrLen()
+				addrBytesRead += tcp4AddrLen
 
 			case tcp6Addr:
 				var ip [16]byte
@@ -778,7 +776,7 @@ func ReadElement(r io.Reader, element interface{}) error {
 					IP:   net.IP(ip[:]),
 					Port: int(binary.BigEndian.Uint16(port[:])),
 				}
-				addrBytesRead += aType.AddrLen()
+				addrBytesRead += tcp6AddrLen
 
 			case v2OnionAddr:
 				var h [tor.V2DecodedLen]byte
@@ -799,7 +797,7 @@ func ReadElement(r io.Reader, element interface{}) error {
 					OnionService: onionService,
 					Port:         port,
 				}
-				addrBytesRead += aType.AddrLen()
+				addrBytesRead += v2OnionAddrLen
 
 			case v3OnionAddr:
 				var h [tor.V3DecodedLen]byte
@@ -820,7 +818,7 @@ func ReadElement(r io.Reader, element interface{}) error {
 					OnionService: onionService,
 					Port:         port,
 				}
-				addrBytesRead += aType.AddrLen()
+				addrBytesRead += v3OnionAddrLen
 
 			default:
 				// If we don't understand this address type,

--- a/lnwire/message_test.go
+++ b/lnwire/message_test.go
@@ -1000,13 +1000,32 @@ func randV3OnionAddr(t testing.TB, r *rand.Rand) *tor.OnionAddr {
 	return &tor.OnionAddr{OnionService: onionService, Port: addrPort}
 }
 
+// randDNSAddr generates a random DNS address for testing purposes.
+func randDNSAddr(t testing.TB, r *rand.Rand) *lnwire.DNSAddress {
+	t.Helper()
+
+	var domain [1]byte
+	_, err := r.Read(domain[:])
+	require.NoError(t, err)
+
+	var port [2]byte
+	_, err = r.Read(port[:])
+	require.NoError(t, err, "unable to read port")
+
+	return &lnwire.DNSAddress{
+		Hostname: string(domain[:]),
+		Port:     uint16(port[0]),
+	}
+}
+
 func randAddrs(t testing.TB, r *rand.Rand) []net.Addr {
 	tcp4Addr := randTCP4Addr(t, r)
 	tcp6Addr := randTCP6Addr(t, r)
 	v2OnionAddr := randV2OnionAddr(t, r)
 	v3OnionAddr := randV3OnionAddr(t, r)
+	dnsAddr := randDNSAddr(t, r)
 
-	return []net.Addr{tcp4Addr, tcp6Addr, v2OnionAddr, v3OnionAddr}
+	return []net.Addr{tcp4Addr, tcp6Addr, v2OnionAddr, v3OnionAddr, dnsAddr}
 }
 
 func randAlias(r *rand.Rand) lnwire.NodeAlias {

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -226,6 +226,13 @@
 ; support devices behind multiple NATs.
 ; nat=false
 
+; Specify a DNS address for the node's external address. If no port is provided,
+; the default (9735) is used.
+; Default:
+;   external-dns-address=
+; Example:
+;   external-dns-address=my-node-domain.com
+
 ; Disable REST API.
 ; norest=false
 

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,299 @@
+package lnd
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/tor"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseAddress verifies the behavior of parseAddr for a variety of address
+// formats and input scenarios.
+func TestParseAddress(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		address   string
+		netCfg    tor.Net
+		expected  net.Addr
+		expectErr bool
+		errMsg    string
+	}{
+		{
+			name:    "OnionAddressWithExplicitPortReturnsAddr",
+			address: "3g2upl4pq6kufc4m.onion:9735",
+			netCfg:  new(MockTorNet),
+			expected: &tor.OnionAddr{
+				OnionService: "3g2upl4pq6kufc4m.onion",
+				Port:         9735,
+			},
+			expectErr: false,
+		},
+		{
+			name:    "OnionAddressWithoutPortReturnsAddrWithPort",
+			address: "3g2upl4pq6kufc4m.onion",
+			netCfg:  new(MockTorNet),
+			expected: &tor.OnionAddr{
+				OnionService: "3g2upl4pq6kufc4m.onion",
+				Port:         defaultPeerPort,
+			},
+			expectErr: false,
+		},
+		{
+			name:    "LoopbackAddressWithExplicitPortReturnsAddr",
+			address: "127.0.0.1:8080",
+			netCfg: func() tor.Net {
+				mockNet := new(MockTorNet)
+				mockExpectation := mockNet.On(
+					"ResolveTCPAddr", "tcp",
+					"127.0.0.1:8080",
+				)
+				mockExpectation.Return(
+					&net.TCPAddr{
+						IP:   net.ParseIP("127.0.0.1"),
+						Port: 8080,
+					},
+					nil,
+				)
+
+				return mockNet
+			}(),
+			expected: &net.TCPAddr{
+				IP:   net.ParseIP("127.0.0.1"),
+				Port: 8080,
+			},
+			expectErr: false,
+		},
+		{
+			name:    "LoopbackAddressWithoutPortReturnsAddr",
+			address: "127.0.0.1",
+			netCfg: func() tor.Net {
+				mockNet := new(MockTorNet)
+				mockExpectation := mockNet.On(
+					"ResolveTCPAddr", "tcp",
+					"127.0.0.1:9735",
+				)
+				mockExpectation.Return(
+					&net.TCPAddr{
+						IP:   net.ParseIP("127.0.0.1"),
+						Port: defaultPeerPort,
+					},
+					nil,
+				)
+
+				return mockNet
+			}(),
+			expected: &net.TCPAddr{
+				IP:   net.ParseIP("127.0.0.1"),
+				Port: defaultPeerPort,
+			},
+			expectErr: false,
+		},
+		{
+			name:    "IPv4AddressWithExplicitPortReturnsTCPAddr",
+			address: "10.1.1.1:9735",
+			netCfg: func() tor.Net {
+				mockNet := new(MockTorNet)
+				mockExpectation := mockNet.On(
+					"ResolveTCPAddr", "tcp",
+					"10.1.1.1:9735",
+				)
+				mockExpectation.Return(
+					&net.TCPAddr{
+						IP:   net.ParseIP("10.1.1.1"),
+						Port: 9735,
+					},
+					nil,
+				)
+
+				return mockNet
+			}(),
+			expected: &net.TCPAddr{
+				IP:   net.ParseIP("10.1.1.1"),
+				Port: 9735,
+			},
+			expectErr: false,
+		},
+		{
+			name:    "IPv4AddressWithoutPortReturnsAddrWithPort",
+			address: "10.1.1.1",
+			netCfg: func() tor.Net {
+				mockNet := new(MockTorNet)
+				mockExpectation := mockNet.On(
+					"ResolveTCPAddr", "tcp",
+					"10.1.1.1:9735",
+				)
+				mockExpectation.Return(
+					&net.TCPAddr{
+						IP:   net.ParseIP("10.1.1.1"),
+						Port: defaultPeerPort,
+					},
+					nil,
+				)
+
+				return mockNet
+			}(),
+			expected: &net.TCPAddr{
+				IP:   net.ParseIP("10.1.1.1"),
+				Port: defaultPeerPort,
+			},
+			expectErr: false,
+		},
+		{
+			name:    "IPv6AddressWithExplicitPortReturnsTCPAddr",
+			address: "[2001::]:9735",
+			netCfg: func() tor.Net {
+				mockNet := new(MockTorNet)
+				mockExpectation := mockNet.On(
+					"ResolveTCPAddr", "tcp",
+					"[2001::]:9735",
+				)
+				mockExpectation.Return(
+					&net.TCPAddr{
+						IP:   net.ParseIP("2001::"),
+						Port: 9735,
+					},
+					nil,
+				)
+
+				return mockNet
+			}(),
+			expected: &net.TCPAddr{
+				IP:   net.ParseIP("2001::"),
+				Port: 9735,
+			},
+			expectErr: false,
+		},
+		{
+			name:    "IPv6AddressWithoutPortReturnsAddrWithPort",
+			address: "2001::",
+			netCfg: func() tor.Net {
+				mockNet := new(MockTorNet)
+				mockExpectation := mockNet.On(
+					"ResolveTCPAddr", "tcp",
+					"[2001::]:9735",
+				)
+				mockExpectation.Return(
+					&net.TCPAddr{
+						IP:   net.ParseIP("2001::"),
+						Port: defaultPeerPort,
+					},
+					nil,
+				)
+
+				return mockNet
+			}(),
+			expected: &net.TCPAddr{
+				IP:   net.ParseIP("2001::"),
+				Port: defaultPeerPort,
+			},
+			expectErr: false,
+		},
+		{
+			name:    "IPAddressTCPResolutionFailureReturnsError",
+			address: "10.1.1.1:9735",
+			netCfg: func() tor.Net {
+				mockNet := new(MockTorNet)
+				mockExpectation := mockNet.On(
+					"ResolveTCPAddr", "tcp",
+					"10.1.1.1:9735",
+				)
+				mockExpectation.Return(
+					&net.TCPAddr{},
+					errors.New("resolve error"),
+				)
+
+				return mockNet
+			}(),
+			expectErr: true,
+			errMsg:    "resolve error",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			addr, err := parseAddr(test.address, test.netCfg)
+
+			if test.expectErr {
+				require.ErrorContains(t, err, test.errMsg)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.expected, addr)
+
+			// Verify that all expected mock method calls were made.
+			if mockNet, ok := test.netCfg.(*MockTorNet); ok {
+				mockNet.AssertExpectations(t)
+			}
+		})
+	}
+}
+
+// MockTorNet is a mock implementation of tor.Net.
+type MockTorNet struct {
+	mock.Mock
+}
+
+// Dial implements the tor.Net Dial method for testing.
+func (m *MockTorNet) Dial(network, address string,
+	timeout time.Duration) (net.Conn, error) {
+
+	args := m.Called(network, address, timeout)
+	arg0, ok := args.Get(0).(net.Conn)
+	if !ok {
+		return nil, errors.New("type assertion failed for arg0")
+	}
+
+	return arg0, args.Error(1)
+}
+
+// LookupHost implements the tor.Net LookupHost method for testing.
+func (m *MockTorNet) LookupHost(host string) ([]string, error) {
+	args := m.Called(host)
+	arg0, ok := args.Get(0).([]string)
+	if !ok {
+		return nil, errors.New("type assertion failed for arg0")
+	}
+
+	return arg0, args.Error(1)
+}
+
+// LookupSRV implements the tor.Net LookupSRV method for testing.
+func (m *MockTorNet) LookupSRV(service, proto, name string,
+	timeout time.Duration) (string, []*net.SRV, error) {
+
+	args := m.Called(service, proto, name, timeout)
+
+	arg0, ok := args.Get(0).(string)
+	if !ok {
+		return "", nil, errors.New("type assertion failed for arg0")
+	}
+
+	arg1, ok := args.Get(1).([]*net.SRV)
+	if !ok {
+		return "", nil, errors.New("type assertion failed for arg1")
+	}
+
+	return arg0, arg1, args.Error(2)
+}
+
+// ResolveTCPAddr implements the tor.Net ResolveTCPAddr method for testing.
+func (m *MockTorNet) ResolveTCPAddr(network,
+	address string) (*net.TCPAddr, error) {
+
+	args := m.Called(network, address)
+	arg0, ok := args.Get(0).(*net.TCPAddr)
+	if !ok {
+		return nil, errors.New("type assertion failed for arg0")
+	}
+
+	return arg0, args.Error(1)
+}


### PR DESCRIPTION
## Change Description

With this PR, we expose the support for DNS in Node Announcement message through `external-dns-address` config field.

Depends on #9455.
Closes #6337.
Closes #9126.

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
