### PR TITLE
lnwallet/test: increase wait for wallet to sync to `30s` to match with the returned error in case of timeout

### DIFF
--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net"
 	"path/filepath"
@@ -2977,7 +2978,7 @@ func waitForMempoolTx(r *rpctest.Harness, txid *chainhash.Hash) error {
 		// Do a short wait
 		select {
 		case <-timeout:
-			return fmt.Errorf("timeout after 10s")
+			return errors.New("timeout after 30s")
 		default:
 		}
 		time.Sleep(100 * time.Millisecond)
@@ -3008,12 +3009,12 @@ func waitForWalletSync(r *rpctest.Harness, w *lnwallet.LightningWallet) error {
 		bestHash, knownHash     *chainhash.Hash
 		bestHeight, knownHeight int32
 	)
-	timeout := time.After(10 * time.Second)
+	timeout := time.After(30 * time.Second)
 	for !synced {
 		// Do a short wait
 		select {
 		case <-timeout:
-			return fmt.Errorf("timeout after 30s")
+			return errors.New("timeout after 30s")
 		case <-time.Tick(100 * time.Millisecond):
 		}
 


### PR DESCRIPTION
## Motivation and Context

That test `TestLightningWallet/btcwallet/neutrino:reorg_wallet_balance ` failed recently. It is not clear why it flaky failed. Currently the timeout was set to 10seconds but the error message said it is timeout after 30seconds. Increasing the timeout may give the wallet some time to sync as well as to match the error message:
https://github.com/lightningnetwork/lnd/actions/runs/16982438758/job/48145091023?pr=9455

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
