### PR TITLE
move pgp check to daily builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,26 @@ env:
   DOCKER_IMAGE: lnd
 
 jobs:
+  ########################
+  # Check release signing keys
+  ########################
+  pgp-key-check:
+    name: Check PGP key expirations
+    runs-on: ubuntu-latest
+    # We don't want to fail the build because of PGP key expirations because
+    # they are only used for release builds and this job failing should catch
+    # the attention of the maintainers.
+    continue-on-error: true
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+
+      - name: Check PGP key expirations
+        run: scripts/check-pgp-expiry.sh
+
+  ########################
+  # Build and push the daily docker image
+  ########################
   main:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,19 +16,6 @@ env:
 
 jobs:
   ########################
-  # Check release signing keys
-  ########################
-  pgp-key-expiration-check:
-    name: Check release signing key expirations
-    runs-on: ubuntu-latest
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v4
-
-      - name: Check PGP key expirations
-        run: scripts/check-pgp-expiry.sh
-
-  ########################
   # Create release
   ########################
   main:


### PR DESCRIPTION
based on https://github.com/lightningnetwork/lnd/pull/10112#issuecomment-3190755653, I don't think we need to fail in general because of expired keys, there will always be enough valid keys to sign the release IMO, wdyt ?