### PR TITLE
lnwire: make htlc_maximum_msat mandatory in channel_update

### DIFF
--- a/lnwire/channel_update.go
+++ b/lnwire/channel_update.go
@@ -149,16 +149,10 @@ func (a *ChannelUpdate1) Decode(r io.Reader, _ uint32) error {
 		&a.HtlcMinimumMsat,
 		&a.BaseFee,
 		&a.FeeRate,
+		&a.HtlcMaximumMsat,
 	)
 	if err != nil {
 		return err
-	}
-
-	// Now check whether the max HTLC field is present and read it if so.
-	if a.MessageFlags.HasMaxHtlc() {
-		if err := ReadElements(r, &a.HtlcMaximumMsat); err != nil {
-			return err
-		}
 	}
 
 	var tlvRecords ExtraOpaqueData


### PR DESCRIPTION
Updates `ChannelUpdate1` parsing to make `htlc_maximum_msat` mandatory, aligning with the updated BOLT specification and fixing a compatibility issue with other Lightning implementations.

The BOLT specification was updated to make the `htlc_maximum_msat` field mandatory in `channel_update` messages. The `must_be_one` bit in `message_flags` that previously indicated this field's presence is now a constant value that should be ignored by receivers.

During differential fuzzing between LND and C-Lightning, a compatibility issue was discovered:

- LND: Accepts 130-byte `channel_update` messages (missing `htlc_maximum_msat`)
- C-Lightning: Rejects these messages as malformed (expecting 138 bytes with mandatory `htlc_maximum_msat`)

context: https://github.com/lightning/bolts/pull/999