### PR TITLE
Aux feature bits

### DIFF
--- a/config_builder.go
+++ b/config_builder.go
@@ -213,6 +213,11 @@ type AuxComponents struct {
 	// AuxContractResolver is an optional interface that can be used to
 	// modify the way contracts are resolved.
 	AuxContractResolver fn.Option[lnwallet.AuxContractResolver]
+
+	// AuxChannelNegotiator is an optional interface that allows aux channel
+	// implementations to inject and process custom records over channel
+	// related wire messages.
+	AuxChannelNegotiator fn.Option[lnwallet.AuxChannelNegotiator]
 }
 
 // DefaultWalletImpl is the default implementation of our normal, btcwallet

--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -76,6 +76,11 @@ a certain amount of msats.
    [allow](https://github.com/lightningnetwork/lnd/pull/10087)
   `conf_target=1`. Previously they required `conf_target >= 2`.
 
+* A new AuxComponent was added named AuxChannelNegotiator. This component aids
+  with custom data communication for aux channels, by injecting and handling
+  data in channel related wire messages. See
+  [PR](https://github.com/lightningnetwork/lnd/pull/10182) for more info.
+
 ## RPC Additions
 * When querying [`ForwardingEvents`](https://github.com/lightningnetwork/lnd/pull/9813)
 logs, the response now include the incoming and outgoing htlc indices of the payment 

--- a/lnwallet/aux_leaf_store.go
+++ b/lnwallet/aux_leaf_store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
@@ -97,6 +98,10 @@ type AuxChanState struct {
 	// funding output.
 	TapscriptRoot fn.Option[chainhash.Hash]
 
+	// PeerPubKey is the peer pub key of the peer we've established this
+	// channel with.
+	PeerPubKey route.Vertex
+
 	// CustomBlob is an optional blob that can be used to store information
 	// specific to a custom channel type. This information is only created
 	// at channel funding time, and after wards is to be considered
@@ -106,6 +111,8 @@ type AuxChanState struct {
 
 // NewAuxChanState creates a new AuxChanState from the given channel state.
 func NewAuxChanState(chanState *channeldb.OpenChannel) AuxChanState {
+	peerPub := chanState.IdentityPub.SerializeCompressed()
+
 	return AuxChanState{
 		ChanType:        chanState.ChanType,
 		FundingOutpoint: chanState.FundingOutpoint,
@@ -116,6 +123,7 @@ func NewAuxChanState(chanState *channeldb.OpenChannel) AuxChanState {
 		RemoteChanCfg:   chanState.RemoteChanCfg,
 		ThawHeight:      chanState.ThawHeight,
 		TapscriptRoot:   chanState.TapscriptRoot,
+		PeerPubKey:      route.Vertex(peerPub),
 		CustomBlob:      chanState.CustomBlob,
 	}
 }

--- a/lnwallet/aux_negotiator.go
+++ b/lnwallet/aux_negotiator.go
@@ -1,0 +1,34 @@
+package lnwallet
+
+import (
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/route"
+)
+
+// AuxChannelNegotiator is an interface that allows aux channel implementations
+// to inject or handle custom records in the init message that is used when
+// establishing a connection with a peer. It may also notify the aux channel
+// implementation for the channel ready or channel reestablish events, which
+// mark the channel as ready to use.
+type AuxChannelNegotiator interface {
+	// GetInitRecords is called when sending an init message to a peer.
+	// It returns custom records to include in the init message TLVs. The
+	// implementation can decide which records to include based on the peer
+	// identity.
+	GetInitRecords(peer route.Vertex) (lnwire.CustomRecords, error)
+
+	// ProcessInitRecords handles received init records from a peer. The
+	// implementation can store state internally to affect future
+	// channel operations with this peer.
+	ProcessInitRecords(peer route.Vertex,
+		customRecords lnwire.CustomRecords) error
+
+	// ProcessChannelReady handles the event of marking a channel identified
+	// by its channel ID as ready to use. We also provide the peer the
+	// channel was established with.
+	ProcessChannelReady(cid lnwire.ChannelID, peer route.Vertex)
+
+	// ProcessReestablish handles the received channel_reestablish message
+	// which marks a channel identified by its cid as ready to use again.
+	ProcessReestablish(cid lnwire.ChannelID, peer route.Vertex)
+}

--- a/lnwire/init_message_test.go
+++ b/lnwire/init_message_test.go
@@ -1,0 +1,61 @@
+package lnwire
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestInitEncodeDecode checks that we can encode and decode an Init message
+// to and from a byte stream.
+func TestInitEncodeDecode(t *testing.T) {
+	t.Parallel()
+
+	// These are the raw bytes that we expect to be generated from the
+	// sample Init message.
+	rawBytes := []byte{
+		// GlobalFeatures
+		0x00, 0x01, 0xc0,
+
+		// Features
+		0x00, 0x01, 0xc0,
+
+		// ExtraData - unknown odd-type TLV record.
+		0x6f,       // type (111)
+		0x02,       // length
+		0x79, 0x79, // value
+
+		// ExtraData - custom TLV record.
+		// TLV record for type 67676
+		0xfe, 0x00, 0x01, 0x08, 0x6c, // type (67676)
+		0x05,                         // length
+		0x01, 0x02, 0x03, 0x04, 0x05, // value
+
+		// ExtraData - custom TLV record.
+		// TLV record for type 67777
+		0xfe, 0x00, 0x01, 0x08, 0xc1, // type (67777)
+		0x03,             // length
+		0x01, 0x02, 0x03, // value
+	}
+
+	// Create a new empty message and decode the raw bytes into it.
+	msg := &Init{}
+	r := bytes.NewReader(rawBytes)
+	err := msg.Decode(r, 0)
+	require.NoError(t, err)
+
+	require.NotNil(t, msg.GlobalFeatures)
+	require.NotNil(t, msg.Features)
+	require.NotNil(t, msg.CustomRecords)
+	require.NotNil(t, msg.ExtraData)
+
+	// Next, encode the message back into a new byte buffer.
+	var b bytes.Buffer
+	err = msg.Encode(&b, 0)
+	require.NoError(t, err)
+
+	// The re-encoded bytes should be exactly the same as the original raw
+	// bytes.
+	require.Equal(t, rawBytes, b.Bytes())
+}

--- a/lnwire/test_message.go
+++ b/lnwire/test_message.go
@@ -1188,6 +1188,10 @@ func (msg *Init) RandTestMessage(t *rapid.T) Message {
 		local.Set(bit)
 	}
 
+	ignoreRecords := fn.NewSet[uint64]()
+
+	msg.ExtraData = RandExtraOpaqueData(t, ignoreRecords)
+
 	return NewInitMessage(global, local)
 }
 

--- a/server.go
+++ b/server.go
@@ -1628,6 +1628,7 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 		AuxFundingController: implCfg.AuxFundingController,
 		AuxSigner:            implCfg.AuxSigner,
 		AuxResolver:          implCfg.AuxContractResolver,
+		AuxChannelNegotiator: implCfg.AuxChannelNegotiator,
 	})
 	if err != nil {
 		return nil, err

--- a/server.go
+++ b/server.go
@@ -4431,6 +4431,7 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 		AuxChanCloser:          s.implCfg.AuxChanCloser,
 		AuxResolver:            s.implCfg.AuxContractResolver,
 		AuxTrafficShaper:       s.implCfg.TrafficShaper,
+		AuxChannelNegotiator:   s.implCfg.AuxChannelNegotiator,
 		ShouldFwdExpEndorsement: func() bool {
 			if s.cfg.ProtocolOptions.NoExperimentalEndorsement() {
 				return false


### PR DESCRIPTION
## Description

Adds a new aux component named `AuxChannelNegotiator`. The responsibility of this component is to inject custom feature bits on the peer init & reestablish messages. The interface allows for both reading and setting any custom feature bits.

The aux feature bits are treated as a `tlv.Blob` by LND, and reside within their own TLV type. So any node that does not support/understand aux feature bits will simply drop the TLV and not read it.