### PR TITLE
multi: Rename LightningNode to Node

### DIFF
--- a/autopilot/graph.go
+++ b/autopilot/graph.go
@@ -48,7 +48,7 @@ func ChannelGraphFromDatabase(db GraphSource) ChannelGraph {
 }
 
 // type dbNode is a wrapper struct around a database transaction an
-// channeldb.LightningNode. The wrapper method implement the autopilot.Node
+// channeldb.Node. The wrapper method implement the autopilot.Node
 // interface.
 type dbNode struct {
 	pub   [33]byte
@@ -84,7 +84,7 @@ func (d *dbNode) Addrs() []net.Addr {
 func (d *databaseChannelGraph) ForEachNode(ctx context.Context,
 	cb func(context.Context, Node) error, reset func()) error {
 
-	return d.db.ForEachNode(ctx, func(n *models.LightningNode) error {
+	return d.db.ForEachNode(ctx, func(n *models.Node) error {
 		// We'll skip over any node that doesn't have any advertised
 		// addresses. As we won't be able to reach them to actually
 		// open any channels.
@@ -161,7 +161,7 @@ func ChannelGraphFromCachedDatabase(db GraphSource) ChannelGraph {
 }
 
 // dbNodeCached is a wrapper struct around a database transaction for a
-// channeldb.LightningNode. The wrapper methods implement the autopilot.Node
+// channeldb.Node. The wrapper methods implement the autopilot.Node
 // interface.
 type dbNodeCached struct {
 	node     route.Vertex

--- a/autopilot/interface.go
+++ b/autopilot/interface.go
@@ -230,7 +230,7 @@ type GraphSource interface {
 	// graph, executing the passed callback with each node encountered. If
 	// the callback returns an error, then the transaction is aborted and
 	// the iteration stops early.
-	ForEachNode(context.Context, func(*models.LightningNode) error,
+	ForEachNode(context.Context, func(*models.Node) error,
 		func()) error
 
 	// ForEachNodeCached is similar to ForEachNode, but it utilizes the

--- a/autopilot/prefattach_test.go
+++ b/autopilot/prefattach_test.go
@@ -412,7 +412,7 @@ func (d *testDBGraph) addRandChannel(node1, node2 *btcec.PublicKey,
 				return nil, err
 			}
 
-			dbNode, err := d.db.FetchLightningNode(ctx, vertex)
+			dbNode, err := d.db.FetchNode(ctx, vertex)
 			switch {
 			case errors.Is(err, graphdb.ErrGraphNodeNotFound):
 				fallthrough

--- a/autopilot/prefattach_test.go
+++ b/autopilot/prefattach_test.go
@@ -403,7 +403,7 @@ func (d *testDBGraph) addRandChannel(node1, node2 *btcec.PublicKey,
 
 	ctx := context.Background()
 
-	fetchNode := func(pub *btcec.PublicKey) (*models.LightningNode, error) {
+	fetchNode := func(pub *btcec.PublicKey) (*models.Node, error) {
 		if pub != nil {
 			vertex, err := route.NewVertexFromBytes(
 				pub.SerializeCompressed(),
@@ -417,7 +417,7 @@ func (d *testDBGraph) addRandChannel(node1, node2 *btcec.PublicKey,
 			case errors.Is(err, graphdb.ErrGraphNodeNotFound):
 				fallthrough
 			case errors.Is(err, graphdb.ErrGraphNotFound):
-				graphNode := &models.LightningNode{
+				graphNode := &models.Node{
 					HaveNodeAnnouncement: true,
 					Addresses: []net.Addr{&net.TCPAddr{
 						IP: bytes.Repeat(
@@ -447,7 +447,7 @@ func (d *testDBGraph) addRandChannel(node1, node2 *btcec.PublicKey,
 		if err != nil {
 			return nil, err
 		}
-		dbNode := &models.LightningNode{
+		dbNode := &models.Node{
 			HaveNodeAnnouncement: true,
 			Addresses: []net.Addr{
 				&net.TCPAddr{
@@ -548,7 +548,7 @@ func (d *testDBGraph) addRandNode() (*btcec.PublicKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	dbNode := &models.LightningNode{
+	dbNode := &models.Node{
 		HaveNodeAnnouncement: true,
 		Addresses: []net.Addr{
 			&net.TCPAddr{

--- a/autopilot/prefattach_test.go
+++ b/autopilot/prefattach_test.go
@@ -430,7 +430,7 @@ func (d *testDBGraph) addRandChannel(node1, node2 *btcec.PublicKey,
 					AuthSigBytes: testSig.Serialize(),
 				}
 				graphNode.AddPubKey(pub)
-				err := d.db.AddLightningNode(
+				err := d.db.AddNode(
 					context.Background(), graphNode,
 				)
 				if err != nil {
@@ -460,7 +460,7 @@ func (d *testDBGraph) addRandChannel(node1, node2 *btcec.PublicKey,
 			AuthSigBytes: testSig.Serialize(),
 		}
 		dbNode.AddPubKey(nodeKey)
-		if err := d.db.AddLightningNode(
+		if err := d.db.AddNode(
 			context.Background(), dbNode,
 		); err != nil {
 			return nil, err
@@ -561,7 +561,7 @@ func (d *testDBGraph) addRandNode() (*btcec.PublicKey, error) {
 		AuthSigBytes: testSig.Serialize(),
 	}
 	dbNode.AddPubKey(nodeKey)
-	err = d.db.AddLightningNode(context.Background(), dbNode)
+	err = d.db.AddNode(context.Background(), dbNode)
 	if err != nil {
 		return nil, err
 	}

--- a/channeldb/db_test.go
+++ b/channeldb/db_test.go
@@ -807,11 +807,11 @@ func TestFetchPermTempPeer(t *testing.T) {
 	)
 }
 
-func createLightningNode(priv *btcec.PrivateKey) *models.LightningNode {
+func createLightningNode(priv *btcec.PrivateKey) *models.Node {
 	updateTime := rand.Int63()
 
 	pub := priv.PubKey().SerializeCompressed()
-	n := &models.LightningNode{
+	n := &models.Node{
 		HaveNodeAnnouncement: true,
 		AuthSigBytes:         testSig.Serialize(),
 		LastUpdate:           time.Unix(updateTime, 0),
@@ -825,7 +825,7 @@ func createLightningNode(priv *btcec.PrivateKey) *models.LightningNode {
 	return n
 }
 
-func createTestVertex(t *testing.T) *models.LightningNode {
+func createTestVertex(t *testing.T) *models.Node {
 	priv, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 

--- a/channeldb/db_test.go
+++ b/channeldb/db_test.go
@@ -807,7 +807,7 @@ func TestFetchPermTempPeer(t *testing.T) {
 	)
 }
 
-func createLightningNode(priv *btcec.PrivateKey) *models.Node {
+func createNode(priv *btcec.PrivateKey) *models.Node {
 	updateTime := rand.Int63()
 
 	pub := priv.PubKey().SerializeCompressed()
@@ -829,5 +829,5 @@ func createTestVertex(t *testing.T) *models.Node {
 	priv, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
-	return createLightningNode(priv)
+	return createNode(priv)
 }

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -2235,7 +2235,7 @@ func (d *AuthenticatedGossiper) processZombieUpdate(_ context.Context,
 func (d *AuthenticatedGossiper) fetchNodeAnn(ctx context.Context,
 	pubKey [33]byte) (*lnwire.NodeAnnouncement, error) {
 
-	node, err := d.cfg.Graph.FetchLightningNode(ctx, pubKey)
+	node, err := d.cfg.Graph.FetchNode(ctx, pubKey)
 	if err != nil {
 		return nil, err
 	}

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -295,7 +295,7 @@ func (r *mockGraphSource) GetChannelByID(chanID lnwire.ShortChannelID) (
 	return &chanInfo, edge1, edge2, nil
 }
 
-func (r *mockGraphSource) FetchLightningNode(_ context.Context,
+func (r *mockGraphSource) FetchNode(_ context.Context,
 	nodePub route.Vertex) (*models.Node, error) {
 
 	for _, node := range r.nodes {

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -83,7 +83,7 @@ type mockGraphSource struct {
 	bestHeight uint32
 
 	mu            sync.Mutex
-	nodes         []models.LightningNode
+	nodes         []models.Node
 	infos         map[uint64]models.ChannelEdgeInfo
 	edges         map[uint64][]models.ChannelEdgePolicy
 	zombies       map[uint64][][33]byte
@@ -109,7 +109,7 @@ func newMockRouter(t *testing.T, height uint32) *mockGraphSource {
 
 var _ graph.ChannelGraphSource = (*mockGraphSource)(nil)
 
-func (r *mockGraphSource) AddNode(_ context.Context, node *models.LightningNode,
+func (r *mockGraphSource) AddNode(_ context.Context, node *models.Node,
 	_ ...batch.SchedulerOption) error {
 
 	r.mu.Lock()
@@ -206,7 +206,7 @@ func (r *mockGraphSource) AddProof(chanID lnwire.ShortChannelID,
 }
 
 func (r *mockGraphSource) ForEachNode(
-	func(node *models.LightningNode) error) error {
+	func(node *models.Node) error) error {
 
 	return nil
 }
@@ -296,7 +296,7 @@ func (r *mockGraphSource) GetChannelByID(chanID lnwire.ShortChannelID) (
 }
 
 func (r *mockGraphSource) FetchLightningNode(_ context.Context,
-	nodePub route.Vertex) (*models.LightningNode, error) {
+	nodePub route.Vertex) (*models.Node, error) {
 
 	for _, node := range r.nodes {
 		if bytes.Equal(nodePub[:], node.PubKeyBytes[:]) {

--- a/graph/builder.go
+++ b/graph/builder.go
@@ -1003,7 +1003,7 @@ func (b *Builder) addNode(ctx context.Context, node *models.Node,
 		return err
 	}
 
-	if err := b.cfg.Graph.AddLightningNode(ctx, node, op...); err != nil {
+	if err := b.cfg.Graph.AddNode(ctx, node, op...); err != nil {
 		return fmt.Errorf("unable to add node %x to the "+
 			"graph: %w", node.PubKeyBytes, err)
 	}

--- a/graph/builder.go
+++ b/graph/builder.go
@@ -1257,15 +1257,15 @@ func (b *Builder) GetChannelByID(chanID lnwire.ShortChannelID) (
 	return b.cfg.Graph.FetchChannelEdgesByID(chanID.ToUint64())
 }
 
-// FetchLightningNode attempts to look up a target node by its identity public
+// FetchNode attempts to look up a target node by its identity public
 // key. graphdb.ErrGraphNodeNotFound is returned if the node doesn't exist
 // within the graph.
 //
 // NOTE: This method is part of the ChannelGraphSource interface.
-func (b *Builder) FetchLightningNode(ctx context.Context,
+func (b *Builder) FetchNode(ctx context.Context,
 	node route.Vertex) (*models.Node, error) {
 
-	return b.cfg.Graph.FetchLightningNode(ctx, node)
+	return b.cfg.Graph.FetchNode(ctx, node)
 }
 
 // ForAllOutgoingChannels is used to iterate over all outgoing channels owned by

--- a/graph/builder.go
+++ b/graph/builder.go
@@ -975,7 +975,7 @@ func (b *Builder) ApplyChannelUpdate(msg *lnwire.ChannelUpdate1) bool {
 // be ignored.
 //
 // NOTE: This method is part of the ChannelGraphSource interface.
-func (b *Builder) AddNode(ctx context.Context, node *models.LightningNode,
+func (b *Builder) AddNode(ctx context.Context, node *models.Node,
 	op ...batch.SchedulerOption) error {
 
 	err := b.addNode(ctx, node, op...)
@@ -988,11 +988,11 @@ func (b *Builder) AddNode(ctx context.Context, node *models.LightningNode,
 	return nil
 }
 
-// addNode does some basic checks on the given LightningNode against what we
+// addNode does some basic checks on the given Node against what we
 // currently have persisted in the graph, and then adds it to the graph. If we
 // already know about the node, then we only update our DB if the new update
 // has a newer timestamp than the last one we received.
-func (b *Builder) addNode(ctx context.Context, node *models.LightningNode,
+func (b *Builder) addNode(ctx context.Context, node *models.Node,
 	op ...batch.SchedulerOption) error {
 
 	// Before we add the node to the database, we'll check to see if the
@@ -1263,7 +1263,7 @@ func (b *Builder) GetChannelByID(chanID lnwire.ShortChannelID) (
 //
 // NOTE: This method is part of the ChannelGraphSource interface.
 func (b *Builder) FetchLightningNode(ctx context.Context,
-	node route.Vertex) (*models.LightningNode, error) {
+	node route.Vertex) (*models.Node, error) {
 
 	return b.cfg.Graph.FetchLightningNode(ctx, node)
 }

--- a/graph/builder.go
+++ b/graph/builder.go
@@ -873,7 +873,7 @@ func (b *Builder) assertNodeAnnFreshness(ctx context.Context, node route.Vertex,
 	// node announcements, we will ignore such nodes. If we do know about
 	// this node, check that this update brings info newer than what we
 	// already have.
-	lastUpdate, exists, err := b.cfg.Graph.HasLightningNode(ctx, node)
+	lastUpdate, exists, err := b.cfg.Graph.HasNode(ctx, node)
 	if err != nil {
 		return fmt.Errorf("unable to query for the "+
 			"existence of node: %w", err)

--- a/graph/builder_test.go
+++ b/graph/builder_test.go
@@ -1475,7 +1475,7 @@ func parseTestGraph(t *testing.T, useCache bool, path string) (
 
 		// With the node fully parsed, add it as a vertex within the
 		// graph.
-		if err := graph.AddLightningNode(ctx, dbNode); err != nil {
+		if err := graph.AddNode(ctx, dbNode); err != nil {
 			return nil, err
 		}
 	}
@@ -1806,7 +1806,7 @@ func createTestGraphFromChannels(t *testing.T, useCache bool,
 			err = graph.SetSourceNode(ctx, dbNode)
 			require.NoError(t, err)
 		} else {
-			err := graph.AddLightningNode(ctx, dbNode)
+			err := graph.AddNode(ctx, dbNode)
 			require.NoError(t, err)
 		}
 

--- a/graph/builder_test.go
+++ b/graph/builder_test.go
@@ -97,7 +97,7 @@ func TestIgnoreNodeAnnouncement(t *testing.T) {
 	ctx := createTestCtxFromFile(t, startingBlockHeight, basicGraphFilePath)
 
 	pub := priv1.PubKey()
-	node := &models.LightningNode{
+	node := &models.Node{
 		HaveNodeAnnouncement: true,
 		LastUpdate:           time.Unix(123, 0),
 		Addresses:            testAddrs,
@@ -1084,7 +1084,7 @@ func TestIsStaleNode(t *testing.T) {
 
 	// With the node stub in the database, we'll add the fully node
 	// announcement to the database.
-	n1 := &models.LightningNode{
+	n1 := &models.Node{
 		HaveNodeAnnouncement: true,
 		LastUpdate:           updateTimeStamp,
 		Addresses:            testAddrs,
@@ -1392,7 +1392,7 @@ func parseTestGraph(t *testing.T, useCache bool, path string) (
 	privKeyMap := make(map[string]*btcec.PrivateKey)
 	channelIDs := make(map[route.Vertex]map[route.Vertex]uint64)
 	links := make(map[lnwire.ShortChannelID]htlcswitch.ChannelLink)
-	var source *models.LightningNode
+	var source *models.Node
 
 	// First we insert all the nodes within the graph as vertexes.
 	for _, node := range g.Nodes {
@@ -1401,7 +1401,7 @@ func parseTestGraph(t *testing.T, useCache bool, path string) (
 			return nil, err
 		}
 
-		dbNode := &models.LightningNode{
+		dbNode := &models.Node{
 			HaveNodeAnnouncement: true,
 			AuthSigBytes:         testSig.Serialize(),
 			LastUpdate:           testTime,
@@ -1787,7 +1787,7 @@ func createTestGraphFromChannels(t *testing.T, useCache bool,
 			features = lnwire.EmptyFeatureVector()
 		}
 
-		dbNode := &models.LightningNode{
+		dbNode := &models.Node{
 			HaveNodeAnnouncement: true,
 			AuthSigBytes:         testSig.Serialize(),
 			LastUpdate:           testTime,

--- a/graph/db/benchmark_test.go
+++ b/graph/db/benchmark_test.go
@@ -585,7 +585,7 @@ func syncGraph(t *testing.T, src, dest *ChannelGraph) {
 		go func() {
 			defer wgNodes.Done()
 
-			err := dest.AddLightningNode(ctx, node, batch.LazyAdd())
+			err := dest.AddNode(ctx, node, batch.LazyAdd())
 			require.NoError(t, err)
 
 			mu.Lock()

--- a/graph/db/benchmark_test.go
+++ b/graph/db/benchmark_test.go
@@ -350,7 +350,7 @@ func TestPopulateDBs(t *testing.T) {
 	countNodes := func(graph *ChannelGraph) int {
 		numNodes := 0
 		err := graph.ForEachNode(
-			ctx, func(node *models.LightningNode) error {
+			ctx, func(node *models.Node) error {
 				numNodes++
 
 				return nil
@@ -580,7 +580,7 @@ func syncGraph(t *testing.T, src, dest *ChannelGraph) {
 	}
 
 	var wgNodes sync.WaitGroup
-	err := src.ForEachNode(ctx, func(node *models.LightningNode) error {
+	err := src.ForEachNode(ctx, func(node *models.Node) error {
 		wgNodes.Add(1)
 		go func() {
 			defer wgNodes.Done()
@@ -746,7 +746,7 @@ func BenchmarkGraphReadMethods(b *testing.B) {
 			fn: func(b testing.TB, store V1Store) {
 				err := store.ForEachNode(
 					ctx,
-					func(_ *models.LightningNode) error {
+					func(_ *models.Node) error {
 						// Increment the counter to
 						// ensure the callback is doing
 						// something.
@@ -932,10 +932,9 @@ func BenchmarkFindOptimalSQLQueryConfig(b *testing.B) {
 						numChannels = 0
 					)
 
-					//nolint:ll
 					err := store.ForEachNode(
 						ctx,
-						func(_ *models.LightningNode) error {
+						func(_ *models.Node) error {
 							numNodes++
 
 							return nil

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -266,16 +266,16 @@ func (c *ChannelGraph) ForEachNodeCached(ctx context.Context, withAddrs bool,
 	return c.V1Store.ForEachNodeCached(ctx, withAddrs, cb, reset)
 }
 
-// AddLightningNode adds a vertex/node to the graph database. If the node is not
+// AddNode adds a vertex/node to the graph database. If the node is not
 // in the database from before, this will add a new, unconnected one to the
 // graph. If it is present from before, this will update that node's
 // information. Note that this method is expected to only be called to update an
 // already present node from a node announcement, or to insert a node found in a
 // channel update.
-func (c *ChannelGraph) AddLightningNode(ctx context.Context,
+func (c *ChannelGraph) AddNode(ctx context.Context,
 	node *models.Node, op ...batch.SchedulerOption) error {
 
-	err := c.V1Store.AddLightningNode(ctx, node, op...)
+	err := c.V1Store.AddNode(ctx, node, op...)
 	if err != nil {
 		return err
 	}

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -295,12 +295,12 @@ func (c *ChannelGraph) AddNode(ctx context.Context,
 	return nil
 }
 
-// DeleteLightningNode starts a new database transaction to remove a vertex/node
+// DeleteNode starts a new database transaction to remove a vertex/node
 // from the database according to the node's public key.
-func (c *ChannelGraph) DeleteLightningNode(ctx context.Context,
+func (c *ChannelGraph) DeleteNode(ctx context.Context,
 	nodePub route.Vertex) error {
 
-	err := c.V1Store.DeleteLightningNode(ctx, nodePub)
+	err := c.V1Store.DeleteNode(ctx, nodePub)
 	if err != nil {
 		return err
 	}

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -273,7 +273,7 @@ func (c *ChannelGraph) ForEachNodeCached(ctx context.Context, withAddrs bool,
 // already present node from a node announcement, or to insert a node found in a
 // channel update.
 func (c *ChannelGraph) AddLightningNode(ctx context.Context,
-	node *models.LightningNode, op ...batch.SchedulerOption) error {
+	node *models.Node, op ...batch.SchedulerOption) error {
 
 	err := c.V1Store.AddLightningNode(ctx, node, op...)
 	if err != nil {

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -151,13 +151,13 @@ func TestNodeInsertionAndDeletion(t *testing.T) {
 
 	// Next, delete the node from the graph, this should purge all data
 	// related to the node.
-	require.NoError(t, graph.DeleteLightningNode(ctx, testPub))
+	require.NoError(t, graph.DeleteNode(ctx, testPub))
 	assertNodeNotInCache(t, graph, testPub)
 
 	// Attempting to delete the node again should return an error since
 	// the node is no longer known.
 	require.ErrorIs(
-		t, graph.DeleteLightningNode(ctx, testPub),
+		t, graph.DeleteNode(ctx, testPub),
 		ErrGraphNodeNotFound,
 	)
 
@@ -331,7 +331,7 @@ func TestPartialNode(t *testing.T) {
 
 	// Next, delete the node from the graph, this should purge all data
 	// related to the node.
-	require.NoError(t, graph.DeleteLightningNode(ctx, pubKey1))
+	require.NoError(t, graph.DeleteNode(ctx, pubKey1))
 	assertNodeNotInCache(t, graph, testPub)
 
 	// Finally, attempt to fetch the node again. This should fail as the
@@ -3520,7 +3520,7 @@ func TestNodePruningUpdateIndexDeletion(t *testing.T) {
 
 	// We'll now delete the node from the graph, this should result in it
 	// being removed from the update index as well.
-	err = graph.DeleteLightningNode(ctx, node1.PubKeyBytes)
+	err = graph.DeleteNode(ctx, node1.PubKeyBytes)
 	require.NoError(t, err)
 
 	// Now that the node has been deleted, we'll again query the nodes in

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -127,7 +127,7 @@ func TestNodeInsertionAndDeletion(t *testing.T) {
 
 	// Next, fetch the node from the database to ensure everything was
 	// serialized properly.
-	dbNode, err := graph.FetchLightningNode(ctx, testPub)
+	dbNode, err := graph.FetchNode(ctx, testPub)
 	require.NoError(t, err, "unable to locate node")
 
 	_, exists, err := graph.HasLightningNode(ctx, dbNode.PubKeyBytes)
@@ -163,7 +163,7 @@ func TestNodeInsertionAndDeletion(t *testing.T) {
 
 	// Finally, attempt to fetch the node again. This should fail as the
 	// node should have been deleted from the database.
-	_, err = graph.FetchLightningNode(ctx, testPub)
+	_, err = graph.FetchNode(ctx, testPub)
 	require.ErrorIs(t, err, ErrGraphNodeNotFound)
 
 	// Now, we'll specifically test the updating of addresses of a node
@@ -185,7 +185,7 @@ func TestNodeInsertionAndDeletion(t *testing.T) {
 	require.NoError(t, graph.AddNode(ctx, node))
 
 	// Fetch the node and assert the empty addresses.
-	dbNode, err = graph.FetchLightningNode(ctx, testPub)
+	dbNode, err = graph.FetchNode(ctx, testPub)
 	require.NoError(t, err)
 	compareNodes(t, node, dbNode)
 
@@ -214,7 +214,7 @@ func TestNodeInsertionAndDeletion(t *testing.T) {
 	require.NoError(t, graph.AddNode(ctx, node))
 
 	// Fetch the node and assert the updated addresses.
-	dbNode, err = graph.FetchLightningNode(ctx, testPub)
+	dbNode, err = graph.FetchNode(ctx, testPub)
 	require.NoError(t, err)
 	require.Equal(t, expAddrs, dbNode.Addresses)
 
@@ -235,7 +235,7 @@ func TestNodeInsertionAndDeletion(t *testing.T) {
 	require.NoError(t, graph.AddNode(ctx, node))
 
 	// Fetch the node and assert the updated addresses.
-	dbNode, err = graph.FetchLightningNode(ctx, testPub)
+	dbNode, err = graph.FetchNode(ctx, testPub)
 	require.NoError(t, err)
 	require.Equal(t, expAddrs, dbNode.Addresses)
 
@@ -248,7 +248,7 @@ func TestNodeInsertionAndDeletion(t *testing.T) {
 	require.NoError(t, graph.AddNode(ctx, node))
 
 	// Fetch the node and assert the updated addresses.
-	dbNode, err = graph.FetchLightningNode(ctx, testPub)
+	dbNode, err = graph.FetchNode(ctx, testPub)
 	require.NoError(t, err)
 	require.Equal(t, expAddrs, dbNode.Addresses)
 
@@ -296,9 +296,9 @@ func TestPartialNode(t *testing.T) {
 
 	// Next, fetch the node2 from the database to ensure everything was
 	// serialized properly.
-	dbNode1, err := graph.FetchLightningNode(ctx, pubKey1)
+	dbNode1, err := graph.FetchNode(ctx, pubKey1)
 	require.NoError(t, err)
-	dbNode2, err := graph.FetchLightningNode(ctx, pubKey2)
+	dbNode2, err := graph.FetchNode(ctx, pubKey2)
 	require.NoError(t, err)
 
 	_, exists, err := graph.HasLightningNode(ctx, dbNode1.PubKeyBytes)
@@ -336,7 +336,7 @@ func TestPartialNode(t *testing.T) {
 
 	// Finally, attempt to fetch the node again. This should fail as the
 	// node should have been deleted from the database.
-	_, err = graph.FetchLightningNode(ctx, testPub)
+	_, err = graph.FetchNode(ctx, testPub)
 	require.ErrorIs(t, err, ErrGraphNodeNotFound)
 }
 
@@ -3443,7 +3443,7 @@ func TestPruneGraphNodes(t *testing.T) {
 
 	// Finally, we'll ensure that node3, the only fully unconnected node as
 	// properly deleted from the graph and not another node in its place.
-	_, err := graph.FetchLightningNode(ctx, node3.PubKeyBytes)
+	_, err := graph.FetchNode(ctx, node3.PubKeyBytes)
 	require.NotNil(t, err)
 }
 
@@ -3469,11 +3469,11 @@ func TestAddChannelEdgeShellNodes(t *testing.T) {
 
 	// Ensure that node1 was inserted as a full node, while node2 only has
 	// a shell node present.
-	node1, err := graph.FetchLightningNode(ctx, node1.PubKeyBytes)
+	node1, err := graph.FetchNode(ctx, node1.PubKeyBytes)
 	require.NoError(t, err, "unable to fetch node1")
 	require.True(t, node1.HaveNodeAnnouncement)
 
-	node2, err = graph.FetchLightningNode(ctx, node2.PubKeyBytes)
+	node2, err = graph.FetchNode(ctx, node2.PubKeyBytes)
 	require.NoError(t, err, "unable to fetch node2")
 	require.False(t, node2.HaveNodeAnnouncement)
 
@@ -4470,7 +4470,7 @@ func TestLightningNodePersistence(t *testing.T) {
 	require.NoError(t, err)
 
 	// Read the node from disk.
-	diskNode, err := graph.FetchLightningNode(ctx, node.PubKeyBytes)
+	diskNode, err := graph.FetchNode(ctx, node.PubKeyBytes)
 	require.NoError(t, err)
 
 	// Convert it back to a wire message.

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -122,7 +122,7 @@ func TestNodeInsertionAndDeletion(t *testing.T) {
 	// First, insert the node into the graph DB. This should succeed
 	// without any errors.
 	node := nodeWithAddrs(testAddrs)
-	require.NoError(t, graph.AddLightningNode(ctx, node))
+	require.NoError(t, graph.AddNode(ctx, node))
 	assertNodeInCache(t, graph, node, testFeatures)
 
 	// Next, fetch the node from the database to ensure everything was
@@ -182,7 +182,7 @@ func TestNodeInsertionAndDeletion(t *testing.T) {
 
 	// Add the node without any addresses.
 	node = nodeWithAddrs(nil)
-	require.NoError(t, graph.AddLightningNode(ctx, node))
+	require.NoError(t, graph.AddNode(ctx, node))
 
 	// Fetch the node and assert the empty addresses.
 	dbNode, err = graph.FetchLightningNode(ctx, testPub)
@@ -211,7 +211,7 @@ func TestNodeInsertionAndDeletion(t *testing.T) {
 		testOpaqueAddr,
 	}
 	node = nodeWithAddrs(expAddrs)
-	require.NoError(t, graph.AddLightningNode(ctx, node))
+	require.NoError(t, graph.AddNode(ctx, node))
 
 	// Fetch the node and assert the updated addresses.
 	dbNode, err = graph.FetchLightningNode(ctx, testPub)
@@ -232,7 +232,7 @@ func TestNodeInsertionAndDeletion(t *testing.T) {
 		testIPV6Addr,
 	}
 	node = nodeWithAddrs(expAddrs)
-	require.NoError(t, graph.AddLightningNode(ctx, node))
+	require.NoError(t, graph.AddNode(ctx, node))
 
 	// Fetch the node and assert the updated addresses.
 	dbNode, err = graph.FetchLightningNode(ctx, testPub)
@@ -245,7 +245,7 @@ func TestNodeInsertionAndDeletion(t *testing.T) {
 		testOnionV3Addr,
 	}
 	node = nodeWithAddrs(expAddrs)
-	require.NoError(t, graph.AddLightningNode(ctx, node))
+	require.NoError(t, graph.AddNode(ctx, node))
 
 	// Fetch the node and assert the updated addresses.
 	dbNode, err = graph.FetchLightningNode(ctx, testPub)
@@ -353,7 +353,7 @@ func TestAliasLookup(t *testing.T) {
 
 	// Add the node to the graph's database, this should also insert an
 	// entry into the alias index for this node.
-	require.NoError(t, graph.AddLightningNode(ctx, testNode))
+	require.NoError(t, graph.AddNode(ctx, testNode))
 
 	// Next, attempt to lookup the alias. The alias should exactly match
 	// the one which the test node was assigned.
@@ -824,12 +824,12 @@ func TestEdgeInfoUpdates(t *testing.T) {
 	// We'd like to test the update of edges inserted into the database, so
 	// we create two vertexes to connect.
 	node1 := createTestVertex(t)
-	if err := graph.AddLightningNode(ctx, node1); err != nil {
+	if err := graph.AddNode(ctx, node1); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
 	assertNodeInCache(t, graph, node1, testFeatures)
 	node2 := createTestVertex(t)
-	if err := graph.AddLightningNode(ctx, node2); err != nil {
+	if err := graph.AddNode(ctx, node2); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
 	assertNodeInCache(t, graph, node2, testFeatures)
@@ -1595,7 +1595,7 @@ func fillTestGraph(t testing.TB, graph *ChannelGraph, numNodes,
 	// Add each of the nodes into the graph, they should be inserted
 	// without error.
 	for _, node := range nodes {
-		require.NoError(t, graph.AddLightningNode(ctx, node))
+		require.NoError(t, graph.AddNode(ctx, node))
 	}
 
 	// Iterate over each node as returned by the graph, if all nodes are
@@ -1788,7 +1788,7 @@ func TestGraphPruning(t *testing.T) {
 	for i := 0; i < numNodes; i++ {
 		node := createTestVertex(t)
 
-		if err := graph.AddLightningNode(ctx, node); err != nil {
+		if err := graph.AddNode(ctx, node); err != nil {
 			t.Fatalf("unable to add node: %v", err)
 		}
 
@@ -2039,11 +2039,11 @@ func TestChanUpdatesInHorizon(t *testing.T) {
 
 	// We'll start by creating two nodes which will seed our test graph.
 	node1 := createTestVertex(t)
-	if err := graph.AddLightningNode(ctx, node1); err != nil {
+	if err := graph.AddNode(ctx, node1); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
 	node2 := createTestVertex(t)
-	if err := graph.AddLightningNode(ctx, node2); err != nil {
+	if err := graph.AddNode(ctx, node2); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
 
@@ -2212,7 +2212,7 @@ func TestNodeUpdatesInHorizon(t *testing.T) {
 
 		nodeAnns = append(nodeAnns, *nodeAnn)
 
-		require.NoError(t, graph.AddLightningNode(ctx, nodeAnn))
+		require.NoError(t, graph.AddNode(ctx, nodeAnn))
 	}
 
 	queryCases := []struct {
@@ -2384,11 +2384,11 @@ func TestFilterKnownChanIDs(t *testing.T) {
 
 	// We'll start by creating two nodes which will seed our test graph.
 	node1 := createTestVertex(t)
-	if err := graph.AddLightningNode(ctx, node1); err != nil {
+	if err := graph.AddNode(ctx, node1); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
 	node2 := createTestVertex(t)
-	if err := graph.AddLightningNode(ctx, node2); err != nil {
+	if err := graph.AddNode(ctx, node2); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
 
@@ -2539,10 +2539,10 @@ func TestStressTestChannelGraphAPI(t *testing.T) {
 	graph := MakeTestGraph(t)
 
 	node1 := createTestVertex(t)
-	require.NoError(t, graph.AddLightningNode(ctx, node1))
+	require.NoError(t, graph.AddNode(ctx, node1))
 
 	node2 := createTestVertex(t)
-	require.NoError(t, graph.AddLightningNode(ctx, node2))
+	require.NoError(t, graph.AddNode(ctx, node2))
 
 	// We need to update the node's timestamp since this call to
 	// SetSourceNode will trigger an upsert which will only be allowed if
@@ -2830,10 +2830,10 @@ func TestFilterChannelRange(t *testing.T) {
 	// We'll first populate our graph with two nodes. All channels created
 	// below will be made between these two nodes.
 	node1 := createTestVertex(t)
-	require.NoError(t, graph.AddLightningNode(ctx, node1))
+	require.NoError(t, graph.AddNode(ctx, node1))
 
 	node2 := createTestVertex(t)
-	require.NoError(t, graph.AddLightningNode(ctx, node2))
+	require.NoError(t, graph.AddNode(ctx, node2))
 
 	// If we try to filter a channel range before we have any channels
 	// inserted, we should get an empty slice of results.
@@ -3049,11 +3049,11 @@ func TestFetchChanInfos(t *testing.T) {
 	// We'll first populate our graph with two nodes. All channels created
 	// below will be made between these two nodes.
 	node1 := createTestVertex(t)
-	if err := graph.AddLightningNode(ctx, node1); err != nil {
+	if err := graph.AddNode(ctx, node1); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
 	node2 := createTestVertex(t)
-	if err := graph.AddLightningNode(ctx, node2); err != nil {
+	if err := graph.AddNode(ctx, node2); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
 
@@ -3151,11 +3151,11 @@ func TestIncompleteChannelPolicies(t *testing.T) {
 
 	// Create two nodes.
 	node1 := createTestVertex(t)
-	if err := graph.AddLightningNode(ctx, node1); err != nil {
+	if err := graph.AddNode(ctx, node1); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
 	node2 := createTestVertex(t)
-	if err := graph.AddLightningNode(ctx, node2); err != nil {
+	if err := graph.AddNode(ctx, node2); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
 
@@ -3256,11 +3256,11 @@ func TestChannelEdgePruningUpdateIndexDeletion(t *testing.T) {
 	// We'll first populate our graph with two nodes. All channels created
 	// below will be made between these two nodes.
 	node1 := createTestVertex(t)
-	if err := graph.AddLightningNode(ctx, node1); err != nil {
+	if err := graph.AddNode(ctx, node1); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
 	node2 := createTestVertex(t)
-	if err := graph.AddLightningNode(ctx, node2); err != nil {
+	if err := graph.AddNode(ctx, node2); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
 
@@ -3401,15 +3401,15 @@ func TestPruneGraphNodes(t *testing.T) {
 	// channel graph, at the end of the scenario, only two of these nodes
 	// should still be in the graph.
 	node1 := createTestVertex(t)
-	if err := graph.AddLightningNode(ctx, node1); err != nil {
+	if err := graph.AddNode(ctx, node1); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
 	node2 := createTestVertex(t)
-	if err := graph.AddLightningNode(ctx, node2); err != nil {
+	if err := graph.AddNode(ctx, node2); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
 	node3 := createTestVertex(t)
-	if err := graph.AddLightningNode(ctx, node3); err != nil {
+	if err := graph.AddNode(ctx, node3); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
 
@@ -3483,7 +3483,7 @@ func TestAddChannelEdgeShellNodes(t *testing.T) {
 	require.ErrorIs(t, err, ErrEdgeAlreadyExist)
 
 	// Show that updating the shell node to a full node record works.
-	require.NoError(t, graph.AddLightningNode(ctx, node2))
+	require.NoError(t, graph.AddNode(ctx, node2))
 }
 
 // TestNodePruningUpdateIndexDeletion tests that once a node has been removed
@@ -3498,7 +3498,7 @@ func TestNodePruningUpdateIndexDeletion(t *testing.T) {
 	// We'll first populate our graph with a single node that will be
 	// removed shortly.
 	node1 := createTestVertex(t)
-	if err := graph.AddLightningNode(ctx, node1); err != nil {
+	if err := graph.AddNode(ctx, node1); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
 
@@ -3591,7 +3591,7 @@ func TestNodeIsPublic(t *testing.T) {
 	for _, graph := range graphs {
 		for _, node := range nodes {
 			node.LastUpdate = nextUpdateTime()
-			err := graph.AddLightningNode(ctx, node)
+			err := graph.AddNode(ctx, node)
 			require.NoError(t, err)
 		}
 		for _, edge := range edges {
@@ -3693,20 +3693,20 @@ func TestDisabledChannelIDs(t *testing.T) {
 
 	// Create first node and add it to the graph.
 	node1 := createTestVertex(t)
-	if err := graph.AddLightningNode(ctx, node1); err != nil {
+	if err := graph.AddNode(ctx, node1); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
 
 	// Create second node and add it to the graph.
 	node2 := createTestVertex(t)
-	if err := graph.AddLightningNode(ctx, node2); err != nil {
+	if err := graph.AddNode(ctx, node2); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
 
 	// Adding a new channel edge to the graph.
 	edgeInfo, edge1, edge2 := createChannelEdge(node1, node2)
 	node2.LastUpdate = nextUpdateTime()
-	if err := graph.AddLightningNode(ctx, node2); err != nil {
+	if err := graph.AddNode(ctx, node2); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
 
@@ -3785,13 +3785,13 @@ func TestEdgePolicyMissingMaxHTLC(t *testing.T) {
 	// We'd like to test the update of edges inserted into the database, so
 	// we create two vertexes to connect.
 	node1 := createTestVertex(t)
-	if err := graph.AddLightningNode(ctx, node1); err != nil {
+	if err := graph.AddNode(ctx, node1); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
 	node2 := createTestVertex(t)
 
 	edgeInfo, edge1, edge2 := createChannelEdge(node1, node2)
-	if err := graph.AddLightningNode(ctx, node2); err != nil {
+	if err := graph.AddNode(ctx, node2); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
 	if err := graph.AddChannelEdge(ctx, edgeInfo); err != nil {
@@ -4186,9 +4186,9 @@ func TestBatchedUpdateEdgePolicy(t *testing.T) {
 	// We'd like to test the update of edges inserted into the database, so
 	// we create two vertexes to connect.
 	node1 := createTestVertex(t)
-	require.NoError(t, graph.AddLightningNode(ctx, node1))
+	require.NoError(t, graph.AddNode(ctx, node1))
 	node2 := createTestVertex(t)
-	require.NoError(t, graph.AddLightningNode(ctx, node2))
+	require.NoError(t, graph.AddNode(ctx, node2))
 
 	// Create an edge and add it to the db.
 	edgeInfo, edge1, edge2 := createChannelEdge(node1, node2)
@@ -4294,9 +4294,9 @@ func TestGraphCacheForEachNodeChannel(t *testing.T) {
 	graph.graphCache = nil
 
 	node1 := createTestVertex(t)
-	require.NoError(t, graph.AddLightningNode(ctx, node1))
+	require.NoError(t, graph.AddNode(ctx, node1))
 	node2 := createTestVertex(t)
-	require.NoError(t, graph.AddLightningNode(ctx, node2))
+	require.NoError(t, graph.AddNode(ctx, node2))
 
 	// Create an edge and add it to the db.
 	edgeInfo, e1, e2 := createChannelEdge(node1, node2)
@@ -4466,7 +4466,7 @@ func TestLightningNodePersistence(t *testing.T) {
 	node := models.NodeFromWireAnnouncement(na)
 
 	// Persist the node to disk.
-	err = graph.AddLightningNode(ctx, node)
+	err = graph.AddNode(ctx, node)
 	require.NoError(t, err)
 
 	// Read the node from disk.

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -130,7 +130,7 @@ func TestNodeInsertionAndDeletion(t *testing.T) {
 	dbNode, err := graph.FetchNode(ctx, testPub)
 	require.NoError(t, err, "unable to locate node")
 
-	_, exists, err := graph.HasLightningNode(ctx, dbNode.PubKeyBytes)
+	_, exists, err := graph.HasNode(ctx, dbNode.PubKeyBytes)
 	require.NoError(t, err)
 	require.True(t, exists)
 
@@ -301,7 +301,7 @@ func TestPartialNode(t *testing.T) {
 	dbNode2, err := graph.FetchNode(ctx, pubKey2)
 	require.NoError(t, err)
 
-	_, exists, err := graph.HasLightningNode(ctx, dbNode1.PubKeyBytes)
+	_, exists, err := graph.HasNode(ctx, dbNode1.PubKeyBytes)
 	require.NoError(t, err)
 	require.True(t, exists)
 
@@ -315,7 +315,7 @@ func TestPartialNode(t *testing.T) {
 	}
 	compareNodes(t, expectedNode1, dbNode1)
 
-	_, exists, err = graph.HasLightningNode(ctx, dbNode2.PubKeyBytes)
+	_, exists, err = graph.HasNode(ctx, dbNode2.PubKeyBytes)
 	require.NoError(t, err)
 	require.True(t, exists)
 

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -69,7 +69,7 @@ var (
 	}
 )
 
-func createLightningNode(priv *btcec.PrivateKey) *models.Node {
+func createNode(priv *btcec.PrivateKey) *models.Node {
 	pub := priv.PubKey().SerializeCompressed()
 	n := &models.Node{
 		HaveNodeAnnouncement: true,
@@ -91,7 +91,7 @@ func createTestVertex(t testing.TB) *models.Node {
 	priv, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
-	return createLightningNode(priv)
+	return createNode(priv)
 }
 
 // TestNodeInsertionAndDeletion tests the CRUD operations for a Node.
@@ -4069,7 +4069,7 @@ func TestLightningNodeSigVerification(t *testing.T) {
 	}
 
 	// Create a Node from the same private key.
-	node := createLightningNode(priv)
+	node := createNode(priv)
 
 	// And finally check that we can verify the same signature from the
 	// pubkey returned from the lightning node.

--- a/graph/db/interfaces.go
+++ b/graph/db/interfaces.go
@@ -101,9 +101,9 @@ type V1Store interface { //nolint:interfacebloat
 	// node.
 	LookupAlias(ctx context.Context, pub *btcec.PublicKey) (string, error)
 
-	// DeleteLightningNode starts a new database transaction to remove a
+	// DeleteNode starts a new database transaction to remove a
 	// vertex/node from the database according to the node's public key.
-	DeleteLightningNode(ctx context.Context, nodePub route.Vertex) error
+	DeleteNode(ctx context.Context, nodePub route.Vertex) error
 
 	// NodeUpdatesInHorizon returns all the known lightning node which have
 	// an update timestamp within the passed range. This method can be used

--- a/graph/db/interfaces.go
+++ b/graph/db/interfaces.go
@@ -112,11 +112,11 @@ type V1Store interface { //nolint:interfacebloat
 	NodeUpdatesInHorizon(startTime,
 		endTime time.Time) ([]models.Node, error)
 
-	// FetchLightningNode attempts to look up a target node by its identity
+	// FetchNode attempts to look up a target node by its identity
 	// public key. If the node isn't found in the database, then
 	// ErrGraphNodeNotFound is returned.
-	FetchLightningNode(ctx context.Context,
-		nodePub route.Vertex) (*models.Node, error)
+	FetchNode(ctx context.Context, nodePub route.Vertex) (*models.Node,
+		error)
 
 	// HasLightningNode determines if the graph has a vertex identified by
 	// the target node identity public key. If the node exists in the

--- a/graph/db/interfaces.go
+++ b/graph/db/interfaces.go
@@ -32,13 +32,13 @@ type NodeTraverser interface {
 type V1Store interface { //nolint:interfacebloat
 	NodeTraverser
 
-	// AddLightningNode adds a vertex/node to the graph database. If the
+	// AddNode adds a vertex/node to the graph database. If the
 	// node is not in the database from before, this will add a new,
 	// unconnected one to the graph. If it is present from before, this will
 	// update that node's information. Note that this method is expected to
 	// only be called to update an already present node from a node
 	// announcement, or to insert a node found in a channel update.
-	AddLightningNode(ctx context.Context, node *models.Node,
+	AddNode(ctx context.Context, node *models.Node,
 		op ...batch.SchedulerOption) error
 
 	// AddrsForNode returns all known addresses for the target node public

--- a/graph/db/interfaces.go
+++ b/graph/db/interfaces.go
@@ -118,13 +118,12 @@ type V1Store interface { //nolint:interfacebloat
 	FetchNode(ctx context.Context, nodePub route.Vertex) (*models.Node,
 		error)
 
-	// HasLightningNode determines if the graph has a vertex identified by
+	// HasNode determines if the graph has a vertex identified by
 	// the target node identity public key. If the node exists in the
 	// database, a timestamp of when the data for the node was lasted
 	// updated is returned along with a true boolean. Otherwise, an empty
 	// time.Time is returned with a false boolean.
-	HasLightningNode(ctx context.Context, nodePub [33]byte) (time.Time,
-		bool, error)
+	HasNode(ctx context.Context, nodePub [33]byte) (time.Time, bool, error)
 
 	// IsPublicNode is a helper method that determines whether the node with
 	// the given public key is seen as a public node in the graph from the

--- a/graph/db/interfaces.go
+++ b/graph/db/interfaces.go
@@ -38,7 +38,7 @@ type V1Store interface { //nolint:interfacebloat
 	// update that node's information. Note that this method is expected to
 	// only be called to update an already present node from a node
 	// announcement, or to insert a node found in a channel update.
-	AddLightningNode(ctx context.Context, node *models.LightningNode,
+	AddLightningNode(ctx context.Context, node *models.Node,
 		op ...batch.SchedulerOption) error
 
 	// AddrsForNode returns all known addresses for the target node public
@@ -53,7 +53,7 @@ type V1Store interface { //nolint:interfacebloat
 	// the channel and the channel peer's node information.
 	ForEachSourceNodeChannel(ctx context.Context,
 		cb func(chanPoint wire.OutPoint, havePolicy bool,
-			otherNode *models.LightningNode) error,
+			otherNode *models.Node) error,
 		reset func()) error
 
 	// ForEachNodeChannel iterates through all channels of the given node,
@@ -87,7 +87,7 @@ type V1Store interface { //nolint:interfacebloat
 	// graph, executing the passed callback with each node encountered. If
 	// the callback returns an error, then the transaction is aborted and
 	// the iteration stops early.
-	ForEachNode(ctx context.Context, cb func(*models.LightningNode) error,
+	ForEachNode(ctx context.Context, cb func(*models.Node) error,
 		reset func()) error
 
 	// ForEachNodeCacheable iterates through all the stored vertices/nodes
@@ -110,13 +110,13 @@ type V1Store interface { //nolint:interfacebloat
 	// by two nodes to quickly determine if they have the same set of up to
 	// date node announcements.
 	NodeUpdatesInHorizon(startTime,
-		endTime time.Time) ([]models.LightningNode, error)
+		endTime time.Time) ([]models.Node, error)
 
 	// FetchLightningNode attempts to look up a target node by its identity
 	// public key. If the node isn't found in the database, then
 	// ErrGraphNodeNotFound is returned.
 	FetchLightningNode(ctx context.Context,
-		nodePub route.Vertex) (*models.LightningNode, error)
+		nodePub route.Vertex) (*models.Node, error)
 
 	// HasLightningNode determines if the graph has a vertex identified by
 	// the target node identity public key. If the node exists in the
@@ -327,13 +327,13 @@ type V1Store interface { //nolint:interfacebloat
 	// treated as the center node within a star-graph. This method may be
 	// used to kick off a path finding algorithm in order to explore the
 	// reachability of another node based off the source node.
-	SourceNode(ctx context.Context) (*models.LightningNode, error)
+	SourceNode(ctx context.Context) (*models.Node, error)
 
 	// SetSourceNode sets the source node within the graph database. The
 	// source node is to be used as the center of a star-graph within path
 	// finding algorithms.
 	SetSourceNode(ctx context.Context,
-		node *models.LightningNode) error
+		node *models.Node) error
 
 	// PruneTip returns the block height and hash of the latest block that
 	// has been used to prune channels in the graph. Knowing the "prune tip"

--- a/graph/db/kv_store.go
+++ b/graph/db/kv_store.go
@@ -1061,9 +1061,9 @@ func (c *KVStore) LookupAlias(_ context.Context,
 	return alias, nil
 }
 
-// DeleteLightningNode starts a new database transaction to remove a vertex/node
+// DeleteNode starts a new database transaction to remove a vertex/node
 // from the database according to the node's public key.
-func (c *KVStore) DeleteLightningNode(_ context.Context,
+func (c *KVStore) DeleteNode(_ context.Context,
 	nodePub route.Vertex) error {
 
 	// TODO(roasbeef): ensure dangling edges are removed...

--- a/graph/db/kv_store.go
+++ b/graph/db/kv_store.go
@@ -3124,7 +3124,7 @@ func (c *KVStore) fetchLightningNode(tx kvdb.RTx,
 // timestamp of when the data for the node was lasted updated is returned along
 // with a true boolean. Otherwise, an empty time.Time is returned with a false
 // boolean.
-func (c *KVStore) HasLightningNode(_ context.Context,
+func (c *KVStore) HasNode(_ context.Context,
 	nodePub [33]byte) (time.Time, bool, error) {
 
 	var (

--- a/graph/db/kv_store.go
+++ b/graph/db/kv_store.go
@@ -980,7 +980,7 @@ func (c *KVStore) SetSourceNode(_ context.Context,
 	}, func() {})
 }
 
-// AddLightningNode adds a vertex/node to the graph database. If the node is not
+// AddNode adds a vertex/node to the graph database. If the node is not
 // in the database from before, this will add a new, unconnected one to the
 // graph. If it is present from before, this will update that node's
 // information. Note that this method is expected to only be called to update an
@@ -988,7 +988,7 @@ func (c *KVStore) SetSourceNode(_ context.Context,
 // channel update.
 //
 // TODO(roasbeef): also need sig of announcement.
-func (c *KVStore) AddLightningNode(ctx context.Context,
+func (c *KVStore) AddNode(ctx context.Context,
 	node *models.Node, opts ...batch.SchedulerOption) error {
 
 	r := &batch.Request[kvdb.RwTx]{

--- a/graph/db/kv_store.go
+++ b/graph/db/kv_store.go
@@ -382,7 +382,7 @@ func (c *KVStore) AddrsForNode(ctx context.Context,
 		return false, nil, err
 	}
 
-	node, err := c.FetchLightningNode(ctx, pubKey)
+	node, err := c.FetchNode(ctx, pubKey)
 	// We don't consider it an error if the graph is unaware of the node.
 	switch {
 	case err != nil && !errors.Is(err, ErrGraphNodeNotFound):
@@ -629,7 +629,7 @@ func (c *KVStore) fetchNodeFeatures(tx kvdb.RTx,
 	node route.Vertex) (*lnwire.FeatureVector, error) {
 
 	// Fallback that uses the database.
-	targetNode, err := c.FetchLightningNodeTx(tx, node)
+	targetNode, err := c.fetchNodeTx(tx, node)
 	switch {
 	// If the node exists and has features, return them directly.
 	case err == nil:
@@ -3043,20 +3043,20 @@ func (c *KVStore) isPublic(tx kvdb.RTx, nodePub route.Vertex,
 	return nodeIsPublic, nil
 }
 
-// FetchLightningNodeTx attempts to look up a target node by its identity
+// fetchNodeTx attempts to look up a target node by its identity
 // public key. If the node isn't found in the database, then
 // ErrGraphNodeNotFound is returned. An optional transaction may be provided.
 // If none is provided, then a new one will be created.
-func (c *KVStore) FetchLightningNodeTx(tx kvdb.RTx, nodePub route.Vertex) (
-	*models.Node, error) {
+func (c *KVStore) fetchNodeTx(tx kvdb.RTx, nodePub route.Vertex) (*models.Node,
+	error) {
 
 	return c.fetchLightningNode(tx, nodePub)
 }
 
-// FetchLightningNode attempts to look up a target node by its identity public
+// FetchNode attempts to look up a target node by its identity public
 // key. If the node isn't found in the database, then ErrGraphNodeNotFound is
 // returned.
-func (c *KVStore) FetchLightningNode(_ context.Context,
+func (c *KVStore) FetchNode(_ context.Context,
 	nodePub route.Vertex) (*models.Node, error) {
 
 	return c.fetchLightningNode(nil, nodePub)

--- a/graph/db/models/node.go
+++ b/graph/db/models/node.go
@@ -11,11 +11,11 @@ import (
 	"github.com/lightningnetwork/lnd/lnwire"
 )
 
-// LightningNode represents an individual vertex/node within the channel graph.
+// Node represents an individual vertex/node within the channel graph.
 // A node is connected to other nodes by one or more channel edges emanating
 // from it. As the graph is directed, a node will also have an incoming edge
 // attached to it for each outgoing edge.
-type LightningNode struct {
+type Node struct {
 	// PubKeyBytes is the raw bytes of the public key of the target node.
 	PubKeyBytes [33]byte
 	pubKey      *btcec.PublicKey
@@ -65,7 +65,7 @@ type LightningNode struct {
 //
 // NOTE: By having this method to access an attribute, we ensure we only need
 // to fully deserialize the pubkey if absolutely necessary.
-func (l *LightningNode) PubKey() (*btcec.PublicKey, error) {
+func (l *Node) PubKey() (*btcec.PublicKey, error) {
 	if l.pubKey != nil {
 		return l.pubKey, nil
 	}
@@ -84,19 +84,19 @@ func (l *LightningNode) PubKey() (*btcec.PublicKey, error) {
 //
 // NOTE: By having this method to access an attribute, we ensure we only need
 // to fully deserialize the signature if absolutely necessary.
-func (l *LightningNode) AuthSig() (*ecdsa.Signature, error) {
+func (l *Node) AuthSig() (*ecdsa.Signature, error) {
 	return ecdsa.ParseSignature(l.AuthSigBytes)
 }
 
 // AddPubKey is a setter-link method that can be used to swap out the public
 // key for a node.
-func (l *LightningNode) AddPubKey(key *btcec.PublicKey) {
+func (l *Node) AddPubKey(key *btcec.PublicKey) {
 	l.pubKey = key
 	copy(l.PubKeyBytes[:], key.SerializeCompressed())
 }
 
 // NodeAnnouncement retrieves the latest node announcement of the node.
-func (l *LightningNode) NodeAnnouncement(signed bool) (*lnwire.NodeAnnouncement,
+func (l *Node) NodeAnnouncement(signed bool) (*lnwire.NodeAnnouncement,
 	error) {
 
 	if !l.HaveNodeAnnouncement {
@@ -132,13 +132,13 @@ func (l *LightningNode) NodeAnnouncement(signed bool) (*lnwire.NodeAnnouncement,
 	return nodeAnn, nil
 }
 
-// NodeFromWireAnnouncement creates a LightningNode instance from an
+// NodeFromWireAnnouncement creates a Node instance from an
 // lnwire.NodeAnnouncement message.
-func NodeFromWireAnnouncement(msg *lnwire.NodeAnnouncement) *LightningNode {
+func NodeFromWireAnnouncement(msg *lnwire.NodeAnnouncement) *Node {
 	timestamp := time.Unix(int64(msg.Timestamp), 0)
 	features := lnwire.NewFeatureVector(msg.Features, lnwire.Features)
 
-	return &LightningNode{
+	return &Node{
 		HaveNodeAnnouncement: true,
 		LastUpdate:           timestamp,
 		Addresses:            msg.Addresses,

--- a/graph/db/notifications.go
+++ b/graph/db/notifications.go
@@ -382,7 +382,7 @@ func (c *ChannelGraph) addToTopologyChange(update *TopologyChange,
 
 	// Any node announcement maps directly to a NetworkNodeUpdate struct.
 	// No further data munging or db queries are required.
-	case *models.LightningNode:
+	case *models.Node:
 		pubKey, err := m.PubKey()
 		if err != nil {
 			return err

--- a/graph/db/sql_migration.go
+++ b/graph/db/sql_migration.go
@@ -137,7 +137,7 @@ func migrateNodes(ctx context.Context, cfg *sqldb.QueryConfig,
 	// fetch the corresponding node object in the SQL store, and it will
 	// then be compared against the original KVDB node object.
 	batch := make(
-		map[int64]*models.LightningNode, cfg.MaxBatchSize,
+		map[int64]*models.Node, cfg.MaxBatchSize,
 	)
 
 	// validateBatch validates that the batch of nodes in the 'batch' map
@@ -226,7 +226,7 @@ func migrateNodes(ctx context.Context, cfg *sqldb.QueryConfig,
 
 		// Clear the batch map for the next iteration.
 		batch = make(
-			map[int64]*models.LightningNode, cfg.MaxBatchSize,
+			map[int64]*models.Node, cfg.MaxBatchSize,
 		)
 
 		return nil
@@ -235,7 +235,7 @@ func migrateNodes(ctx context.Context, cfg *sqldb.QueryConfig,
 	// Loop through each node in the KV store and insert it into the SQL
 	// database.
 	err := forEachNode(kvBackend, func(_ kvdb.RTx,
-		node *models.LightningNode) error {
+		node *models.Node) error {
 
 		pub := node.PubKeyBytes
 
@@ -307,7 +307,7 @@ func migrateNodes(ctx context.Context, cfg *sqldb.QueryConfig,
 		chunk = 0
 		skipped = 0
 		t0 = time.Now()
-		batch = make(map[int64]*models.LightningNode, cfg.MaxBatchSize)
+		batch = make(map[int64]*models.Node, cfg.MaxBatchSize)
 	})
 	if err != nil {
 		return fmt.Errorf("could not migrate nodes: %w", err)
@@ -1371,7 +1371,7 @@ func forEachClosedSCID(db kvdb.Backend,
 // the migration to be idempotent and dont want to error out if we re-insert the
 // exact same node.
 func insertNodeSQLMig(ctx context.Context, db SQLQueries,
-	node *models.LightningNode) (int64, error) {
+	node *models.Node) (int64, error) {
 
 	params := sqlc.InsertNodeMigParams{
 		Version: int16(ProtocolV1),

--- a/graph/db/sql_migration_test.go
+++ b/graph/db/sql_migration_test.go
@@ -73,7 +73,7 @@ func TestMigrateGraphToSQL(t *testing.T) {
 
 		var err error
 		switch obj := object.(type) {
-		case *models.LightningNode:
+		case *models.Node:
 			err = db.AddLightningNode(ctx, obj)
 		case *models.ChannelEdgeInfo:
 			err = db.AddChannelEdge(ctx, obj)
@@ -118,11 +118,11 @@ func TestMigrateGraphToSQL(t *testing.T) {
 				// A node with no node announcement.
 				makeTestShellNode(t),
 				// A node with an announcement but no addresses.
-				makeTestNode(t, func(n *models.LightningNode) {
+				makeTestNode(t, func(n *models.Node) {
 					n.Addresses = nil
 				}),
 				// A node with all types of addresses.
-				makeTestNode(t, func(n *models.LightningNode) {
+				makeTestNode(t, func(n *models.Node) {
 					n.Addresses = []net.Addr{
 						testAddr,
 						testIPV4Addr,
@@ -134,11 +134,11 @@ func TestMigrateGraphToSQL(t *testing.T) {
 					}
 				}),
 				// No extra opaque data.
-				makeTestNode(t, func(n *models.LightningNode) {
+				makeTestNode(t, func(n *models.Node) {
 					n.ExtraOpaqueData = nil
 				}),
 				// A node with no features.
-				makeTestNode(t, func(n *models.LightningNode) {
+				makeTestNode(t, func(n *models.Node) {
 					n.Features = lnwire.EmptyFeatureVector()
 				}),
 			},
@@ -149,7 +149,7 @@ func TestMigrateGraphToSQL(t *testing.T) {
 		{
 			name: "source node",
 			write: func(t *testing.T, db *KVStore, object any) {
-				node, ok := object.(*models.LightningNode)
+				node, ok := object.(*models.Node)
 				require.True(t, ok)
 
 				err := db.SetSourceNode(ctx, node)
@@ -175,11 +175,11 @@ func TestMigrateGraphToSQL(t *testing.T) {
 
 				// Insert some nodes.
 				// 	- node count += 1
-				makeTestNode(t, func(n *models.LightningNode) {
+				makeTestNode(t, func(n *models.Node) {
 					n.PubKeyBytes = node1
 				}),
 				// 	- node count += 1
-				makeTestNode(t, func(n *models.LightningNode) {
+				makeTestNode(t, func(n *models.Node) {
 					n.PubKeyBytes = node2
 				}),
 
@@ -228,11 +228,11 @@ func TestMigrateGraphToSQL(t *testing.T) {
 
 				// Insert some nodes.
 				// 	- node count += 1
-				makeTestNode(t, func(n *models.LightningNode) {
+				makeTestNode(t, func(n *models.Node) {
 					n.PubKeyBytes = node1
 				}),
 				// 	- node count += 1
-				makeTestNode(t, func(n *models.LightningNode) {
+				makeTestNode(t, func(n *models.Node) {
 					n.PubKeyBytes = node2
 				}),
 
@@ -296,7 +296,7 @@ func TestMigrateGraphToSQL(t *testing.T) {
 				require.NoError(t, err)
 
 				switch obj := object.(type) {
-				case *models.LightningNode:
+				case *models.Node:
 					err = db.SetSourceNode(ctx, obj)
 				default:
 					height, ok := obj.(uint32)
@@ -312,7 +312,7 @@ func TestMigrateGraphToSQL(t *testing.T) {
 				// The PruneGraph call requires that the source
 				// node be set. So that is the first object
 				// we will write.
-				&models.LightningNode{
+				&models.Node{
 					HaveNodeAnnouncement: false,
 					PubKeyBytes:          testPub,
 				},
@@ -455,14 +455,13 @@ func assertInSync(t *testing.T, kvDB *KVStore, sqlDB *SQLStore,
 
 // fetchAllNodes retrieves all nodes from the given store and returns them
 // sorted by their public key.
-func fetchAllNodes(t *testing.T, store V1Store) []*models.LightningNode {
-	nodes := make([]*models.LightningNode, 0)
+func fetchAllNodes(t *testing.T, store V1Store) []*models.Node {
+	nodes := make([]*models.Node, 0)
 
 	err := store.ForEachNode(t.Context(),
-		func(node *models.LightningNode) error {
-
-			// Call PubKey to ensure the objects cached pubkey is set so that
-			// the objects can be compared as a whole.
+		func(node *models.Node) error {
+			// Call PubKey to ensure the objects cached pubkey is
+			// set so that the objects can be compared as a whole.
 			_, err := node.PubKey()
 			require.NoError(t, err)
 
@@ -479,7 +478,7 @@ func fetchAllNodes(t *testing.T, store V1Store) []*models.LightningNode {
 	require.NoError(t, err)
 
 	// Sort the nodes by their public key to ensure a consistent order.
-	slices.SortFunc(nodes, func(i, j *models.LightningNode) int {
+	slices.SortFunc(nodes, func(i, j *models.Node) int {
 		return bytes.Compare(i.PubKeyBytes[:], j.PubKeyBytes[:])
 	})
 
@@ -487,7 +486,7 @@ func fetchAllNodes(t *testing.T, store V1Store) []*models.LightningNode {
 }
 
 // fetchSourceNode retrieves the source node from the given store.
-func fetchSourceNode(t *testing.T, store V1Store) *models.LightningNode {
+func fetchSourceNode(t *testing.T, store V1Store) *models.Node {
 	node, err := store.SourceNode(t.Context())
 	if errors.Is(err, ErrSourceNodeNotSet) {
 		return nil
@@ -670,13 +669,13 @@ func genPubKey(t require.TestingT) route.Vertex {
 }
 
 // testNodeOpt defines a functional option type that can be used to
-// modify the attributes of a models.LightningNode crated by makeTestNode.
-type testNodeOpt func(*models.LightningNode)
+// modify the attributes of a models.Node crated by makeTestNode.
+type testNodeOpt func(*models.Node)
 
-// makeTestNode can be used to create a test models.LightningNode. The
+// makeTestNode can be used to create a test models.Node. The
 // functional options can be used to modify the node's attributes.
-func makeTestNode(t *testing.T, opts ...testNodeOpt) *models.LightningNode {
-	n := &models.LightningNode{
+func makeTestNode(t *testing.T, opts ...testNodeOpt) *models.Node {
+	n := &models.Node{
 		HaveNodeAnnouncement: true,
 		AuthSigBytes:         testSigBytes,
 		LastUpdate:           testTime,
@@ -700,12 +699,12 @@ func makeTestNode(t *testing.T, opts ...testNodeOpt) *models.LightningNode {
 	return n
 }
 
-// makeTestShellNode creates a minimal models.LightningNode
+// makeTestShellNode creates a minimal models.Node
 // that only contains the public key and no other attributes.
 func makeTestShellNode(t *testing.T,
-	opts ...testNodeOpt) *models.LightningNode {
+	opts ...testNodeOpt) *models.Node {
 
-	n := &models.LightningNode{
+	n := &models.Node{
 		HaveNodeAnnouncement: false,
 		PubKeyBytes:          genPubKey(t),
 		Features:             testEmptyFeatures,
@@ -934,7 +933,7 @@ func TestSQLMigrationEdgeCases(t *testing.T) {
 
 		// Make one valid node and one node with invalid TLV data.
 		n1 := makeTestNode(t)
-		n2 := makeTestNode(t, func(n *models.LightningNode) {
+		n2 := makeTestNode(t, func(n *models.Node) {
 			n.ExtraOpaqueData = invalidTLVData
 		})
 
@@ -947,7 +946,7 @@ func TestSQLMigrationEdgeCases(t *testing.T) {
 		runTestMigration(t, populateKV, dbState{
 			// We expect only the valid node to be present in the
 			// SQL db.
-			nodes: []*models.LightningNode{n1},
+			nodes: []*models.Node{n1},
 		})
 	})
 
@@ -995,7 +994,7 @@ func TestSQLMigrationEdgeCases(t *testing.T) {
 
 		runTestMigration(t, populateKV, dbState{
 			// Both nodes will be present.
-			nodes: []*models.LightningNode{n1, n2},
+			nodes: []*models.Node{n1, n2},
 			// We only expect the first channel and its policy to
 			// be present in the SQL db.
 			chans: chanSet{{
@@ -1056,7 +1055,7 @@ func TestSQLMigrationEdgeCases(t *testing.T) {
 
 		runTestMigration(t, populateKV, dbState{
 			// Both nodes will be present.
-			nodes: []*models.LightningNode{n1, n2},
+			nodes: []*models.Node{n1, n2},
 			// The channel will be present, but only the
 			// valid policy will be included in the SQL db.
 			chans: chanSet{{
@@ -1132,7 +1131,7 @@ func TestSQLMigrationEdgeCases(t *testing.T) {
 
 		runTestMigration(t, populateKV, dbState{
 			// Both nodes will be present.
-			nodes: []*models.LightningNode{n1, n2},
+			nodes: []*models.Node{n1, n2},
 			// The channel will be present, but only the
 			// valid policy will be included in the SQL db.
 			chans: chanSet{{
@@ -1205,7 +1204,7 @@ func runTestMigration(t *testing.T, populateKV func(t *testing.T, db *KVStore),
 
 // dbState describes the expected state of the SQLStore after a migration.
 type dbState struct {
-	nodes   []*models.LightningNode
+	nodes   []*models.Node
 	chans   chanSet
 	closed  []uint64
 	zombies []uint64
@@ -1294,7 +1293,7 @@ func testMigrateGraphToSQLRapidOnce(t *testing.T, rt *rapid.T,
 	// Keep track of all nodes that should be in the database. We may expect
 	// more than just the ones we generated above if we have channels that
 	// point to shell nodes.
-	allNodes := make(map[route.Vertex]*models.LightningNode)
+	allNodes := make(map[route.Vertex]*models.Node)
 	var nodePubs []route.Vertex
 	for _, node := range nodes {
 		allNodes[node.PubKeyBytes] = node
@@ -1333,7 +1332,7 @@ func testMigrateGraphToSQLRapidOnce(t *testing.T, rt *rapid.T,
 			}
 
 			shellNode := makeTestShellNode(
-				t, func(node *models.LightningNode) {
+				t, func(node *models.Node) {
 					node.PubKeyBytes = n
 				},
 			)
@@ -1389,7 +1388,7 @@ func testMigrateGraphToSQLRapidOnce(t *testing.T, rt *rapid.T,
 	require.NoError(t, err)
 
 	// Create a slice of all nodes.
-	var nodesSlice []*models.LightningNode
+	var nodesSlice []*models.Node
 	for _, node := range allNodes {
 		nodesSlice = append(nodesSlice, node)
 	}
@@ -1603,7 +1602,7 @@ func sortAddrs(addrs []net.Addr) {
 }
 
 // genRandomNode is a rapid generator for creating random lightning nodes.
-func genRandomNode(t *rapid.T) *models.LightningNode {
+func genRandomNode(t *rapid.T) *models.Node {
 	// Generate a random alias that is valid.
 	alias := lnwire.RandNodeAlias(t)
 
@@ -1647,7 +1646,7 @@ func genRandomNode(t *rapid.T) *models.LightningNode {
 		extraOpaqueData = nil
 	}
 
-	node := &models.LightningNode{
+	node := &models.Node{
 		HaveNodeAnnouncement: true,
 		AuthSigBytes:         sigBytes,
 		LastUpdate:           randTime,

--- a/graph/db/sql_migration_test.go
+++ b/graph/db/sql_migration_test.go
@@ -74,7 +74,7 @@ func TestMigrateGraphToSQL(t *testing.T) {
 		var err error
 		switch obj := object.(type) {
 		case *models.Node:
-			err = db.AddLightningNode(ctx, obj)
+			err = db.AddNode(ctx, obj)
 		case *models.ChannelEdgeInfo:
 			err = db.AddChannelEdge(ctx, obj)
 		case *models.ChannelEdgePolicy:
@@ -939,8 +939,8 @@ func TestSQLMigrationEdgeCases(t *testing.T) {
 
 		populateKV := func(t *testing.T, db *KVStore) {
 			// Insert both nodes into the KV store.
-			require.NoError(t, db.AddLightningNode(ctx, n1))
-			require.NoError(t, db.AddLightningNode(ctx, n2))
+			require.NoError(t, db.AddNode(ctx, n1))
+			require.NoError(t, db.AddNode(ctx, n2))
 		}
 
 		runTestMigration(t, populateKV, dbState{
@@ -978,8 +978,8 @@ func TestSQLMigrationEdgeCases(t *testing.T) {
 
 		populateKV := func(t *testing.T, db *KVStore) {
 			// Insert both nodes into the KV store.
-			require.NoError(t, db.AddLightningNode(ctx, n1))
-			require.NoError(t, db.AddLightningNode(ctx, n2))
+			require.NoError(t, db.AddNode(ctx, n1))
+			require.NoError(t, db.AddNode(ctx, n2))
 
 			// Insert both channels into the KV store.
 			require.NoError(t, db.AddChannelEdge(ctx, c1))
@@ -1032,8 +1032,8 @@ func TestSQLMigrationEdgeCases(t *testing.T) {
 
 		populateKV := func(t *testing.T, db *KVStore) {
 			// Insert both nodes into the KV store.
-			require.NoError(t, db.AddLightningNode(ctx, n1))
-			require.NoError(t, db.AddLightningNode(ctx, n2))
+			require.NoError(t, db.AddNode(ctx, n1))
+			require.NoError(t, db.AddNode(ctx, n2))
 
 			// Insert the channel into the KV store.
 			require.NoError(t, db.AddChannelEdge(ctx, c))
@@ -1113,8 +1113,8 @@ func TestSQLMigrationEdgeCases(t *testing.T) {
 
 		populateKV := func(t *testing.T, db *KVStore) {
 			// Insert both nodes into the KV store.
-			require.NoError(t, db.AddLightningNode(ctx, n1))
-			require.NoError(t, db.AddLightningNode(ctx, n2))
+			require.NoError(t, db.AddNode(ctx, n1))
+			require.NoError(t, db.AddNode(ctx, n2))
 
 			// Insert the channel into the KV store.
 			require.NoError(t, db.AddChannelEdge(ctx, c))
@@ -1371,7 +1371,7 @@ func testMigrateGraphToSQLRapidOnce(t *testing.T, rt *rapid.T,
 
 	// Write the test objects to the kvdb store.
 	for _, node := range allNodes {
-		err := kvDB.AddLightningNode(ctx, node)
+		err := kvDB.AddNode(ctx, node)
 		require.NoError(t, err)
 	}
 	for _, channel := range channels {

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -261,12 +261,12 @@ func (s *SQLStore) AddNode(ctx context.Context,
 	return s.nodeScheduler.Execute(ctx, r)
 }
 
-// FetchLightningNode attempts to look up a target node by its identity public
+// FetchNode attempts to look up a target node by its identity public
 // key. If the node isn't found in the database, then ErrGraphNodeNotFound is
 // returned.
 //
 // NOTE: part of the V1Store interface.
-func (s *SQLStore) FetchLightningNode(ctx context.Context,
+func (s *SQLStore) FetchNode(ctx context.Context,
 	pubKey route.Vertex) (*models.Node, error) {
 
 	var node *models.Node

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -283,14 +283,14 @@ func (s *SQLStore) FetchNode(ctx context.Context,
 	return node, nil
 }
 
-// HasLightningNode determines if the graph has a vertex identified by the
+// HasNode determines if the graph has a vertex identified by the
 // target node identity public key. If the node exists in the database, a
 // timestamp of when the data for the node was lasted updated is returned along
 // with a true boolean. Otherwise, an empty time.Time is returned with a false
 // boolean.
 //
 // NOTE: part of the V1Store interface.
-func (s *SQLStore) HasLightningNode(ctx context.Context,
+func (s *SQLStore) HasNode(ctx context.Context,
 	pubKey [33]byte) (time.Time, bool, error) {
 
 	var (

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -241,13 +241,13 @@ func NewSQLStore(cfg *SQLStoreConfig, db BatchedSQLQueries,
 	return s, nil
 }
 
-// AddLightningNode adds a vertex/node to the graph database. If the node is not
+// AddNode adds a vertex/node to the graph database. If the node is not
 // in the database from before, this will add a new, unconnected one to the
 // graph. If it is present from before, this will update that node's
 // information.
 //
 // NOTE: part of the V1Store interface.
-func (s *SQLStore) AddLightningNode(ctx context.Context,
+func (s *SQLStore) AddNode(ctx context.Context,
 	node *models.Node, opts ...batch.SchedulerOption) error {
 
 	r := &batch.Request[SQLQueries]{

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -248,7 +248,7 @@ func NewSQLStore(cfg *SQLStoreConfig, db BatchedSQLQueries,
 //
 // NOTE: part of the V1Store interface.
 func (s *SQLStore) AddLightningNode(ctx context.Context,
-	node *models.LightningNode, opts ...batch.SchedulerOption) error {
+	node *models.Node, opts ...batch.SchedulerOption) error {
 
 	r := &batch.Request[SQLQueries]{
 		Opts: batch.NewSchedulerOptions(opts...),
@@ -267,9 +267,9 @@ func (s *SQLStore) AddLightningNode(ctx context.Context,
 //
 // NOTE: part of the V1Store interface.
 func (s *SQLStore) FetchLightningNode(ctx context.Context,
-	pubKey route.Vertex) (*models.LightningNode, error) {
+	pubKey route.Vertex) (*models.Node, error) {
 
-	var node *models.LightningNode
+	var node *models.Node
 	err := s.db.ExecTx(ctx, sqldb.ReadTxOpt(), func(db SQLQueries) error {
 		var err error
 		_, node, err = getNodeByPubKey(ctx, s.cfg.QueryCfg, db, pubKey)
@@ -489,10 +489,10 @@ func (s *SQLStore) LookupAlias(ctx context.Context,
 // node based off the source node.
 //
 // NOTE: part of the V1Store interface.
-func (s *SQLStore) SourceNode(ctx context.Context) (*models.LightningNode,
+func (s *SQLStore) SourceNode(ctx context.Context) (*models.Node,
 	error) {
 
-	var node *models.LightningNode
+	var node *models.Node
 	err := s.db.ExecTx(ctx, sqldb.ReadTxOpt(), func(db SQLQueries) error {
 		_, nodePub, err := s.getSourceNode(ctx, db, ProtocolV1)
 		if err != nil {
@@ -517,7 +517,7 @@ func (s *SQLStore) SourceNode(ctx context.Context) (*models.LightningNode,
 //
 // NOTE: part of the V1Store interface.
 func (s *SQLStore) SetSourceNode(ctx context.Context,
-	node *models.LightningNode) error {
+	node *models.Node) error {
 
 	return s.db.ExecTx(ctx, sqldb.WriteTxOpt(), func(db SQLQueries) error {
 		id, err := upsertNode(ctx, db, node)
@@ -553,11 +553,11 @@ func (s *SQLStore) SetSourceNode(ctx context.Context,
 //
 // NOTE: This is part of the V1Store interface.
 func (s *SQLStore) NodeUpdatesInHorizon(startTime,
-	endTime time.Time) ([]models.LightningNode, error) {
+	endTime time.Time) ([]models.Node, error) {
 
 	ctx := context.TODO()
 
-	var nodes []models.LightningNode
+	var nodes []models.Node
 	err := s.db.ExecTx(ctx, sqldb.ReadTxOpt(), func(db SQLQueries) error {
 		dbNodes, err := db.GetNodesByLastUpdateRange(
 			ctx, sqlc.GetNodesByLastUpdateRangeParams{
@@ -571,7 +571,7 @@ func (s *SQLStore) NodeUpdatesInHorizon(startTime,
 
 		err = forEachNodeInBatch(
 			ctx, s.cfg.QueryCfg, db, dbNodes,
-			func(_ int64, node *models.LightningNode) error {
+			func(_ int64, node *models.Node) error {
 				nodes = append(nodes, *node)
 
 				return nil
@@ -776,7 +776,7 @@ func (s *SQLStore) updateEdgeCache(e *models.ChannelEdgePolicy,
 // NOTE: part of the V1Store interface.
 func (s *SQLStore) ForEachSourceNodeChannel(ctx context.Context,
 	cb func(chanPoint wire.OutPoint, havePolicy bool,
-		otherNode *models.LightningNode) error, reset func()) error {
+		otherNode *models.Node) error, reset func()) error {
 
 	return s.db.ExecTx(ctx, sqldb.ReadTxOpt(), func(db SQLQueries) error {
 		nodeID, nodePub, err := s.getSourceNode(ctx, db, ProtocolV1)
@@ -832,13 +832,13 @@ func (s *SQLStore) ForEachSourceNodeChannel(ctx context.Context,
 //
 // NOTE: part of the V1Store interface.
 func (s *SQLStore) ForEachNode(ctx context.Context,
-	cb func(node *models.LightningNode) error, reset func()) error {
+	cb func(node *models.Node) error, reset func()) error {
 
 	return s.db.ExecTx(ctx, sqldb.ReadTxOpt(), func(db SQLQueries) error {
 		return forEachNodePaginated(
 			ctx, s.cfg.QueryCfg, db,
 			ProtocolV1, func(_ context.Context, _ int64,
-				node *models.LightningNode) error {
+				node *models.Node) error {
 
 				return cb(node)
 			},
@@ -3201,7 +3201,7 @@ func updateChanEdgePolicy(ctx context.Context, tx SQLQueries,
 
 // getNodeByPubKey attempts to look up a target node by its public key.
 func getNodeByPubKey(ctx context.Context, cfg *sqldb.QueryConfig, db SQLQueries,
-	pubKey route.Vertex) (int64, *models.LightningNode, error) {
+	pubKey route.Vertex) (int64, *models.Node, error) {
 
 	dbNode, err := db.GetNodeByPubKey(
 		ctx, sqlc.GetNodeByPubKeyParams{
@@ -3236,11 +3236,11 @@ func buildCacheableChannelInfo(scid []byte, capacity int64, node1Pub,
 	}
 }
 
-// buildNode constructs a LightningNode instance from the given database node
+// buildNode constructs a Node instance from the given database node
 // record. The node's features, addresses and extra signed fields are also
 // fetched from the database and set on the node.
 func buildNode(ctx context.Context, cfg *sqldb.QueryConfig, db SQLQueries,
-	dbNode sqlc.GraphNode) (*models.LightningNode, error) {
+	dbNode sqlc.GraphNode) (*models.Node, error) {
 
 	data, err := batchLoadNodeData(ctx, cfg, db, []int64{dbNode.ID})
 	if err != nil {
@@ -3251,12 +3251,12 @@ func buildNode(ctx context.Context, cfg *sqldb.QueryConfig, db SQLQueries,
 	return buildNodeWithBatchData(dbNode, data)
 }
 
-// buildNodeWithBatchData builds a models.LightningNode instance
+// buildNodeWithBatchData builds a models.Node instance
 // from the provided sqlc.GraphNode and batchNodeData. If the node does have
 // features/addresses/extra fields, then the corresponding fields are expected
 // to be present in the batchNodeData.
 func buildNodeWithBatchData(dbNode sqlc.GraphNode,
-	batchData *batchNodeData) (*models.LightningNode, error) {
+	batchData *batchNodeData) (*models.Node, error) {
 
 	if dbNode.Version != int16(ProtocolV1) {
 		return nil, fmt.Errorf("unsupported node version: %d",
@@ -3266,7 +3266,7 @@ func buildNodeWithBatchData(dbNode sqlc.GraphNode,
 	var pub [33]byte
 	copy(pub[:], dbNode.PubKey)
 
-	node := &models.LightningNode{
+	node := &models.Node{
 		PubKeyBytes: pub,
 		Features:    lnwire.EmptyFeatureVector(),
 		LastUpdate:  time.Unix(0, 0),
@@ -3328,7 +3328,7 @@ func buildNodeWithBatchData(dbNode sqlc.GraphNode,
 // with the preloaded data, and executes the provided callback for each node.
 func forEachNodeInBatch(ctx context.Context, cfg *sqldb.QueryConfig,
 	db SQLQueries, nodes []sqlc.GraphNode,
-	cb func(dbID int64, node *models.LightningNode) error) error {
+	cb func(dbID int64, node *models.Node) error) error {
 
 	// Extract node IDs for batch loading.
 	nodeIDs := make([]int64, len(nodes))
@@ -3382,7 +3382,7 @@ func getNodeFeatures(ctx context.Context, db SQLQueries,
 // then a new node is created. The node's features, addresses and extra TLV
 // types are also updated. The node's DB ID is returned.
 func upsertNode(ctx context.Context, db SQLQueries,
-	node *models.LightningNode) (int64, error) {
+	node *models.Node) (int64, error) {
 
 	params := sqlc.UpsertNodeParams{
 		Version: int16(ProtocolV1),
@@ -5064,7 +5064,7 @@ func batchLoadChannelPolicyExtrasHelper(ctx context.Context,
 func forEachNodePaginated(ctx context.Context, cfg *sqldb.QueryConfig,
 	db SQLQueries, protocol ProtocolVersion,
 	processNode func(context.Context, int64,
-		*models.LightningNode) error) error {
+		*models.Node) error) error {
 
 	pageQueryFunc := func(ctx context.Context, lastID int64,
 		limit int32) ([]sqlc.GraphNode, error) {

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -369,11 +369,11 @@ func (s *SQLStore) AddrsForNode(ctx context.Context,
 	return known, addresses, nil
 }
 
-// DeleteLightningNode starts a new database transaction to remove a vertex/node
+// DeleteNode starts a new database transaction to remove a vertex/node
 // from the database according to the node's public key.
 //
 // NOTE: part of the V1Store interface.
-func (s *SQLStore) DeleteLightningNode(ctx context.Context,
+func (s *SQLStore) DeleteNode(ctx context.Context,
 	pubKey route.Vertex) error {
 
 	err := s.db.ExecTx(ctx, sqldb.WriteTxOpt(), func(db SQLQueries) error {

--- a/graph/interfaces.go
+++ b/graph/interfaces.go
@@ -83,11 +83,10 @@ type ChannelGraphSource interface {
 		*models.ChannelEdgeInfo, *models.ChannelEdgePolicy,
 		*models.ChannelEdgePolicy, error)
 
-	// FetchLightningNode attempts to look up a target node by its identity
+	// FetchNode attempts to look up a target node by its identity
 	// public key. channeldb.ErrGraphNodeNotFound is returned if the node
 	// doesn't exist within the graph.
-	FetchLightningNode(context.Context,
-		route.Vertex) (*models.Node, error)
+	FetchNode(context.Context, route.Vertex) (*models.Node, error)
 
 	// MarkZombieEdge marks the channel with the given ID as a zombie edge.
 	MarkZombieEdge(chanID uint64) error
@@ -243,11 +242,11 @@ type DB interface {
 	HasLightningNode(ctx context.Context, nodePub [33]byte) (time.Time,
 		bool, error)
 
-	// FetchLightningNode attempts to look up a target node by its identity
+	// FetchNode attempts to look up a target node by its identity
 	// public key. If the node isn't found in the database, then
 	// ErrGraphNodeNotFound is returned.
-	FetchLightningNode(ctx context.Context,
-		nodePub route.Vertex) (*models.Node, error)
+	FetchNode(ctx context.Context, nodePub route.Vertex) (*models.Node,
+		error)
 
 	// ForEachNodeChannel iterates through all channels of the given node,
 	// executing the passed callback with an edge info structure and the

--- a/graph/interfaces.go
+++ b/graph/interfaces.go
@@ -23,7 +23,7 @@ type ChannelGraphSource interface {
 	// AddNode is used to add information about a node to the router
 	// database. If the node with this pubkey is not present in an existing
 	// channel, it will be ignored.
-	AddNode(ctx context.Context, node *models.LightningNode,
+	AddNode(ctx context.Context, node *models.Node,
 		op ...batch.SchedulerOption) error
 
 	// AddEdge is used to add edge/channel to the topology of the router,
@@ -87,7 +87,7 @@ type ChannelGraphSource interface {
 	// public key. channeldb.ErrGraphNodeNotFound is returned if the node
 	// doesn't exist within the graph.
 	FetchLightningNode(context.Context,
-		route.Vertex) (*models.LightningNode, error)
+		route.Vertex) (*models.Node, error)
 
 	// MarkZombieEdge marks the channel with the given ID as a zombie edge.
 	MarkZombieEdge(chanID uint64) error
@@ -135,7 +135,7 @@ type DB interface {
 	// treated as the center node within a star-graph. This method may be
 	// used to kick off a path finding algorithm in order to explore the
 	// reachability of another node based off the source node.
-	SourceNode(ctx context.Context) (*models.LightningNode, error)
+	SourceNode(ctx context.Context) (*models.Node, error)
 
 	// DisabledChannelIDs returns the channel ids of disabled channels.
 	// A channel is disabled when two of the associated ChanelEdgePolicies
@@ -206,7 +206,7 @@ type DB interface {
 	// update that node's information. Note that this method is expected to
 	// only be called to update an already present node from a node
 	// announcement, or to insert a node found in a channel update.
-	AddLightningNode(ctx context.Context, node *models.LightningNode,
+	AddLightningNode(ctx context.Context, node *models.Node,
 		op ...batch.SchedulerOption) error
 
 	// AddChannelEdge adds a new (undirected, blank) edge to the graph
@@ -247,7 +247,7 @@ type DB interface {
 	// public key. If the node isn't found in the database, then
 	// ErrGraphNodeNotFound is returned.
 	FetchLightningNode(ctx context.Context,
-		nodePub route.Vertex) (*models.LightningNode, error)
+		nodePub route.Vertex) (*models.Node, error)
 
 	// ForEachNodeChannel iterates through all channels of the given node,
 	// executing the passed callback with an edge info structure and the

--- a/graph/interfaces.go
+++ b/graph/interfaces.go
@@ -200,13 +200,13 @@ type DB interface {
 	FetchChannelEdgesByID(chanID uint64) (*models.ChannelEdgeInfo,
 		*models.ChannelEdgePolicy, *models.ChannelEdgePolicy, error)
 
-	// AddLightningNode adds a vertex/node to the graph database. If the
+	// AddNode adds a vertex/node to the graph database. If the
 	// node is not in the database from before, this will add a new,
 	// unconnected one to the graph. If it is present from before, this will
 	// update that node's information. Note that this method is expected to
 	// only be called to update an already present node from a node
 	// announcement, or to insert a node found in a channel update.
-	AddLightningNode(ctx context.Context, node *models.Node,
+	AddNode(ctx context.Context, node *models.Node,
 		op ...batch.SchedulerOption) error
 
 	// AddChannelEdge adds a new (undirected, blank) edge to the graph

--- a/graph/interfaces.go
+++ b/graph/interfaces.go
@@ -234,13 +234,12 @@ type DB interface {
 	UpdateEdgePolicy(ctx context.Context, edge *models.ChannelEdgePolicy,
 		op ...batch.SchedulerOption) error
 
-	// HasLightningNode determines if the graph has a vertex identified by
+	// HasNode determines if the graph has a vertex identified by
 	// the target node identity public key. If the node exists in the
 	// database, a timestamp of when the data for the node was lasted
 	// updated is returned along with a true boolean. Otherwise, an empty
 	// time.Time is returned with a false boolean.
-	HasLightningNode(ctx context.Context, nodePub [33]byte) (time.Time,
-		bool, error)
+	HasNode(ctx context.Context, nodePub [33]byte) (time.Time, bool, error)
 
 	// FetchNode attempts to look up a target node by its identity
 	// public key. If the node isn't found in the database, then

--- a/graph/notifications_test.go
+++ b/graph/notifications_test.go
@@ -76,14 +76,14 @@ var (
 	}
 )
 
-func createTestNode(t *testing.T) *models.LightningNode {
+func createTestNode(t *testing.T) *models.Node {
 	updateTime := prand.Int63()
 
 	priv, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
 	pub := priv.PubKey().SerializeCompressed()
-	n := &models.LightningNode{
+	n := &models.Node{
 		HaveNodeAnnouncement: true,
 		LastUpdate:           time.Unix(updateTime, 0),
 		Addresses:            testAddrs,
@@ -98,7 +98,7 @@ func createTestNode(t *testing.T) *models.LightningNode {
 }
 
 func randEdgePolicy(chanID *lnwire.ShortChannelID,
-	node *models.LightningNode) (*models.ChannelEdgePolicy, error) {
+	node *models.Node) (*models.ChannelEdgePolicy, error) {
 
 	InboundFee := models.InboundFee{
 		Base: prand.Int31() * -1,
@@ -676,7 +676,7 @@ func TestNodeUpdateNotification(t *testing.T) {
 		t.Fatalf("unable to add node: %v", err)
 	}
 
-	assertNodeNtfnCorrect := func(t *testing.T, ann *models.LightningNode,
+	assertNodeNtfnCorrect := func(t *testing.T, ann *models.Node,
 		nodeUpdate *graphdb.NetworkNodeUpdate) {
 
 		nodeKey, _ := ann.PubKey()

--- a/lnrpc/devrpc/dev_server.go
+++ b/lnrpc/devrpc/dev_server.go
@@ -260,7 +260,7 @@ func (s *Server) ImportGraph(ctx context.Context,
 			return nil, err
 		}
 
-		if err := graphDB.AddLightningNode(ctx, node); err != nil {
+		if err := graphDB.AddNode(ctx, node); err != nil {
 			return nil, fmt.Errorf("unable to add node %v: %w",
 				rpcNode.PubKey, err)
 		}

--- a/lnrpc/devrpc/dev_server.go
+++ b/lnrpc/devrpc/dev_server.go
@@ -226,7 +226,7 @@ func (s *Server) ImportGraph(ctx context.Context,
 
 	var err error
 	for _, rpcNode := range graph.Nodes {
-		node := &models.LightningNode{
+		node := &models.Node{
 			HaveNodeAnnouncement: true,
 			LastUpdate: time.Unix(
 				int64(rpcNode.LastUpdate), 0,

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -219,7 +219,7 @@ func parseTestGraph(t *testing.T, useCache bool, path string) (
 	privKeyMap := make(map[string]*btcec.PrivateKey)
 	channelIDs := make(map[route.Vertex]map[route.Vertex]uint64)
 	links := make(map[lnwire.ShortChannelID]htlcswitch.ChannelLink)
-	var source *models.LightningNode
+	var source *models.Node
 
 	// First we insert all the nodes within the graph as vertexes.
 	for _, node := range g.Nodes {
@@ -228,7 +228,7 @@ func parseTestGraph(t *testing.T, useCache bool, path string) (
 			return nil, err
 		}
 
-		dbNode := &models.LightningNode{
+		dbNode := &models.Node{
 			HaveNodeAnnouncement: true,
 			AuthSigBytes:         testSig.Serialize(),
 			LastUpdate:           testTime,
@@ -565,7 +565,7 @@ func createTestGraphFromChannels(t *testing.T, useCache bool,
 			features = lnwire.EmptyFeatureVector()
 		}
 
-		dbNode := &models.LightningNode{
+		dbNode := &models.Node{
 			HaveNodeAnnouncement: true,
 			AuthSigBytes:         testSig.Serialize(),
 			LastUpdate:           testTime,
@@ -1253,7 +1253,7 @@ func runPathFindingWithAdditionalEdges(t *testing.T, useCache bool) {
 	dogePubKey, err := btcec.ParsePubKey(dogePubKeyBytes)
 	require.NoError(t, err, "unable to parse public key from bytes")
 
-	doge := &models.LightningNode{}
+	doge := &models.Node{}
 	doge.AddPubKey(dogePubKey)
 	doge.Alias = "doge"
 	copy(doge.PubKeyBytes[:], dogePubKeyBytes)

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -293,14 +293,14 @@ func parseTestGraph(t *testing.T, useCache bool, path string) (
 			source = dbNode
 
 			// If this is the source node, we don't have to call
-			// AddLightningNode below since we will call
+			// AddNode below since we will call
 			// SetSourceNode later.
 			continue
 		}
 
 		// With the node fully parsed, add it as a vertex within the
 		// graph.
-		if err := graph.AddLightningNode(ctx, dbNode); err != nil {
+		if err := graph.AddNode(ctx, dbNode); err != nil {
 			return nil, err
 		}
 	}
@@ -584,7 +584,7 @@ func createTestGraphFromChannels(t *testing.T, useCache bool,
 			err = graph.SetSourceNode(ctx, dbNode)
 			require.NoError(t, err)
 		} else {
-			err := graph.AddLightningNode(ctx, dbNode)
+			err := graph.AddNode(ctx, dbNode)
 			require.NoError(t, err)
 		}
 

--- a/routing/payment_session_source.go
+++ b/routing/payment_session_source.go
@@ -24,7 +24,7 @@ type SessionSource struct {
 	GraphSessionFactory GraphSessionFactory
 
 	// SourceNode is the graph's source node.
-	SourceNode *models.LightningNode
+	SourceNode *models.Node
 
 	// GetLink is a method that allows querying the lower link layer
 	// to determine the up to date available bandwidth at a prospective link
@@ -102,7 +102,7 @@ func RouteHintsToEdges(routeHints [][]zpay32.HopHint, target route.Vertex) (
 			// we'll need to look at the next hint's start node. If
 			// we've reached the end of the hints list, we can
 			// assume we've reached the destination.
-			endNode := &models.LightningNode{}
+			endNode := &models.Node{}
 			if i != len(routeHint)-1 {
 				endNode.AddPubKey(routeHint[i+1].NodeID)
 			} else {

--- a/routing/payment_session_test.go
+++ b/routing/payment_session_test.go
@@ -89,7 +89,7 @@ func TestUpdateAdditionalEdge(t *testing.T) {
 
 	// Create a minimal test node using the private key priv1.
 	pub := priv1.PubKey().SerializeCompressed()
-	testNode := &models.LightningNode{}
+	testNode := &models.Node{}
 	copy(testNode.PubKeyBytes[:], pub)
 
 	nodeID, err := testNode.PubKey()

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -2718,11 +2718,11 @@ func TestAddEdgeUnknownVertexes(t *testing.T) {
 	copy(pub2[:], priv2.PubKey().SerializeCompressed())
 
 	// The two nodes we are about to add should not exist yet.
-	_, exists1, err := ctx.graph.HasLightningNode(ctxb, pub1)
+	_, exists1, err := ctx.graph.HasNode(ctxb, pub1)
 	require.NoError(t, err, "unable to query graph")
 	require.False(t, exists1)
 
-	_, exists2, err := ctx.graph.HasLightningNode(ctxb, pub2)
+	_, exists2, err := ctx.graph.HasNode(ctxb, pub2)
 	require.NoError(t, err, "unable to query graph")
 	require.False(t, exists2)
 
@@ -2779,11 +2779,11 @@ func TestAddEdgeUnknownVertexes(t *testing.T) {
 
 	// After adding the edge between the two previously unknown nodes, they
 	// should have been added to the graph.
-	_, exists1, err = ctx.graph.HasLightningNode(ctxb, pub1)
+	_, exists1, err = ctx.graph.HasNode(ctxb, pub1)
 	require.NoError(t, err, "unable to query graph")
 	require.True(t, exists1)
 
-	_, exists2, err = ctx.graph.HasLightningNode(ctxb, pub2)
+	_, exists2, err = ctx.graph.HasNode(ctxb, pub2)
 	require.NoError(t, err, "unable to query graph")
 	require.True(t, exists2)
 

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -2882,7 +2882,7 @@ func TestAddEdgeUnknownVertexes(t *testing.T) {
 	}
 	copy(n1.PubKeyBytes[:], priv1.PubKey().SerializeCompressed())
 
-	require.NoError(t, ctx.graph.AddLightningNode(ctxb, n1))
+	require.NoError(t, ctx.graph.AddNode(ctxb, n1))
 
 	n2 := &models.Node{
 		HaveNodeAnnouncement: true,
@@ -2895,7 +2895,7 @@ func TestAddEdgeUnknownVertexes(t *testing.T) {
 	}
 	copy(n2.PubKeyBytes[:], priv2.PubKey().SerializeCompressed())
 
-	require.NoError(t, ctx.graph.AddLightningNode(ctxb, n2))
+	require.NoError(t, ctx.graph.AddNode(ctxb, n2))
 
 	// Should still be able to find the route, and the info should be
 	// updated.

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -183,7 +183,7 @@ func createTestCtxFromGraphInstanceAssumeValid(t *testing.T,
 	return ctx
 }
 
-func createTestNode() (*models.LightningNode, error) {
+func createTestNode() (*models.Node, error) {
 	updateTime := rand.Int63()
 
 	priv, err := btcec.NewPrivateKey()
@@ -192,7 +192,7 @@ func createTestNode() (*models.LightningNode, error) {
 	}
 
 	pub := priv.PubKey().SerializeCompressed()
-	n := &models.LightningNode{
+	n := &models.Node{
 		HaveNodeAnnouncement: true,
 		LastUpdate:           time.Unix(updateTime, 0),
 		Addresses:            testAddrs,
@@ -2871,7 +2871,7 @@ func TestAddEdgeUnknownVertexes(t *testing.T) {
 
 	// Now check that we can update the node info for the partial node
 	// without messing up the channel graph.
-	n1 := &models.LightningNode{
+	n1 := &models.Node{
 		HaveNodeAnnouncement: true,
 		LastUpdate:           time.Unix(123, 0),
 		Addresses:            testAddrs,
@@ -2884,7 +2884,7 @@ func TestAddEdgeUnknownVertexes(t *testing.T) {
 
 	require.NoError(t, ctx.graph.AddLightningNode(ctxb, n1))
 
-	n2 := &models.LightningNode{
+	n2 := &models.Node{
 		HaveNodeAnnouncement: true,
 		LastUpdate:           time.Unix(123, 0),
 		Addresses:            testAddrs,

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -2908,12 +2908,12 @@ func TestAddEdgeUnknownVertexes(t *testing.T) {
 	_, _, err = ctx.router.FindRoute(req)
 	require.NoError(t, err, "unable to find any routes")
 
-	copy1, err := ctx.graph.FetchLightningNode(ctxb, pub1)
+	copy1, err := ctx.graph.FetchNode(ctxb, pub1)
 	require.NoError(t, err, "unable to fetch node")
 
 	require.Equal(t, n1.Alias, copy1.Alias)
 
-	copy2, err := ctx.graph.FetchLightningNode(ctxb, pub2)
+	copy2, err := ctx.graph.FetchNode(ctxb, pub2)
 	require.NoError(t, err, "unable to fetch node")
 
 	require.Equal(t, n2.Alias, copy2.Alias)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1783,7 +1783,7 @@ func (r *rpcServer) VerifyMessage(ctx context.Context,
 	//
 	// TODO(phlip9): Require valid nodes to have capital in active channels.
 	graph := r.server.graphDB
-	_, active, err := graph.HasLightningNode(ctx, pub)
+	_, active, err := graph.HasNode(ctx, pub)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query graph: %w", err)
 	}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -6758,7 +6758,7 @@ func (r *rpcServer) DescribeGraph(ctx context.Context,
 	// First iterate through all the known nodes (connected or unconnected
 	// within the graph), collating their current state into the RPC
 	// response.
-	err := graph.ForEachNode(ctx, func(node *models.LightningNode) error {
+	err := graph.ForEachNode(ctx, func(node *models.Node) error {
 		lnNode := marshalNode(node)
 
 		resp.Nodes = append(resp.Nodes, lnNode)
@@ -7114,7 +7114,7 @@ func (r *rpcServer) GetNodeInfo(ctx context.Context,
 	}, nil
 }
 
-func marshalNode(node *models.LightningNode) *lnrpc.LightningNode {
+func marshalNode(node *models.Node) *lnrpc.LightningNode {
 	nodeAddrs := make([]*lnrpc.NodeAddress, len(node.Addresses))
 	for i, addr := range node.Addresses {
 		nodeAddr := &lnrpc.NodeAddress{

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -7053,7 +7053,7 @@ func (r *rpcServer) GetNodeInfo(ctx context.Context,
 	// With the public key decoded, attempt to fetch the node corresponding
 	// to this public key. If the node cannot be found, then an error will
 	// be returned.
-	node, err := graph.FetchLightningNode(ctx, pubKey)
+	node, err := graph.FetchNode(ctx, pubKey)
 	switch {
 	case errors.Is(err, graphdb.ErrGraphNodeNotFound):
 		return nil, status.Error(codes.NotFound, err.Error())
@@ -8189,7 +8189,7 @@ func (r *rpcServer) ForwardingHistory(ctx context.Context,
 			return "", err
 		}
 
-		peer, err := r.server.graphDB.FetchLightningNode(ctx, vertex)
+		peer, err := r.server.graphDB.FetchNode(ctx, vertex)
 		if err != nil {
 			return "", err
 		}

--- a/server.go
+++ b/server.go
@@ -3316,7 +3316,7 @@ func (s *server) createNewHiddenService(ctx context.Context) error {
 
 	// Finally, we'll update the on-disk version of our announcement so it
 	// will eventually propagate to nodes in the network.
-	selfNode := &models.LightningNode{
+	selfNode := &models.Node{
 		HaveNodeAnnouncement: true,
 		LastUpdate:           time.Unix(int64(newNodeAnn.Timestamp), 0),
 		Addresses:            newNodeAnn.Addresses,
@@ -3505,7 +3505,7 @@ func (s *server) establishPersistentConnections(ctx context.Context) error {
 	// each of the nodes.
 	graphAddrs := make(map[string]*nodeAddresses)
 	forEachSrcNodeChan := func(chanPoint wire.OutPoint,
-		havePolicy bool, channelPeer *models.LightningNode) error {
+		havePolicy bool, channelPeer *models.Node) error {
 
 		// If the remote party has announced the channel to us, but we
 		// haven't yet, then we won't have a policy. However, we don't
@@ -5634,7 +5634,7 @@ func (s *server) setSelfNode(ctx context.Context, nodePub route.Vertex,
 
 	// TODO(abdulkbk): potentially find a way to use the source node's
 	// features in the self node.
-	selfNode := &models.LightningNode{
+	selfNode := &models.Node{
 		HaveNodeAnnouncement: true,
 		LastUpdate:           nodeLastUpdate,
 		Addresses:            addrs,

--- a/server.go
+++ b/server.go
@@ -5208,7 +5208,7 @@ func (s *server) fetchNodeAdvertisedAddrs(ctx context.Context,
 		return nil, err
 	}
 
-	node, err := s.graphDB.FetchLightningNode(ctx, vertex)
+	node, err := s.graphDB.FetchNode(ctx, vertex)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Rename the `models.LightningNode` struct to `models.Node`. 
Also rename any DB methods ending with `*LightningNode(...)` to `*Node(...)`. 

To keep the diff as small as possible, multi-line comments have not been reformatted (everything will still fit since the new naming is strictly shorter)