### PR TITLE
build: make special label checks auto-pass instead of skip

### DIFF
--- a/.github/actions/check-label/action.yml
+++ b/.github/actions/check-label/action.yml
@@ -1,0 +1,30 @@
+name: "Check PR labels"
+description: "Checks if specific labels are present on a PR and sets outputs accordingly."
+
+inputs:
+  label:
+    description: "The label to check for"
+    required: true
+  skip-message:
+    description: "The message to display when skipping due to label"
+    required: true
+
+outputs:
+  skip:
+    description: "Whether to skip the tests (true/false)"
+    value: ${{ steps.check.outputs.skip }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check for label
+      id: check
+      shell: bash
+      run: |
+        if [[ "${{ contains(github.event.pull_request.labels.*.name, inputs.label) }}" == "true" ]]; then
+          echo "::notice::${{ inputs.skip-message }}"
+          echo "${{ inputs.skip-message }}" >> $GITHUB_STEP_SUMMARY
+          echo "skip=true" >> $GITHUB_OUTPUT
+        else
+          echo "skip=false" >> $GITHUB_OUTPUT
+        fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -269,7 +269,6 @@ jobs:
   basic-integration-test:
     name: Run basic itests
     runs-on: ubuntu-latest
-    if: '!contains(github.event.pull_request.labels.*.name, ''no-itest'')'
     strategy:
       # Allow other tests in the matrix to continue if one fails.
       fail-fast: false
@@ -289,31 +288,42 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check for no-itest label
+        id: check-label
+        uses: ./.github/actions/check-label
+        with:
+          label: 'no-itest'
+          skip-message: "Tests auto-passed due to 'no-itest' label"
+
       - name: Clean up runner space
+        if: steps.check-label.outputs.skip != 'true'
         uses: ./.github/actions/cleanup-space
 
       - name: Fetch and rebase on ${{ github.base_ref }}
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.check-label.outputs.skip != 'true'
         uses: ./.github/actions/rebase
 
       - name: Setup go ${{ env.GO_VERSION }}
+        if: steps.check-label.outputs.skip != 'true'
         uses: ./.github/actions/setup-go
         with:
           go-version: '${{ env.GO_VERSION }}'
           key-prefix: integration-test
 
       - name: Install bitcoind
+        if: steps.check-label.outputs.skip != 'true'
         run: ./scripts/install_bitcoind.sh $BITCOIN_VERSION
 
       - name: Run ${{ matrix.name }}
+        if: steps.check-label.outputs.skip != 'true'
         run: make itest-parallel tranches=${{ env.TRANCHES }} ${{ matrix.args }} shuffleseed=${{ github.run_id }}${{ strategy.job-index }}
 
       - name: Clean coverage
         run: grep -Ev '(\.pb\.go|\.pb\.json\.go|\.pb\.gw\.go)' coverage.txt > coverage-norpc.txt
-        if: ${{ contains(matrix.args, 'cover=1') }}
+        if: ${{ contains(matrix.args, 'cover=1') && steps.check-label.outputs.skip != 'true' }}
 
       - name: Send coverage
-        if: ${{ contains(matrix.args, 'cover=1') }}
+        if: ${{ contains(matrix.args, 'cover=1') && steps.check-label.outputs.skip != 'true' }}
         continue-on-error: true
         uses: coverallsapp/github-action@v2
         with:
@@ -323,13 +333,13 @@ jobs:
           parallel: true
 
       - name: Zip log files on failure
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.check-label.outputs.skip != 'true' }}
         timeout-minutes: 5 # timeout after 5 minute
         run: 7z a logs-itest-${{ matrix.name }}.zip itest/**/*.log itest/postgres.log
 
       - name: Upload log files on failure
         uses: actions/upload-artifact@v4
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.check-label.outputs.skip != 'true' }}
         with:
           name: logs-itest-${{ matrix.name }}
           path: logs-itest-${{ matrix.name }}.zip
@@ -341,7 +351,6 @@ jobs:
   integration-test:
     name: Run itests
     runs-on: ubuntu-latest
-    if: '!contains(github.event.pull_request.labels.*.name, ''no-itest'')'
     strategy:
       # Allow other tests in the matrix to continue if one fails.
       fail-fast: false
@@ -369,31 +378,42 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check for no-itest label
+        id: check-label
+        uses: ./.github/actions/check-label
+        with:
+          label: 'no-itest'
+          skip-message: "Tests auto-passed due to 'no-itest' label"
+
       - name: Clean up runner space
+        if: steps.check-label.outputs.skip != 'true'
         uses: ./.github/actions/cleanup-space
 
       - name: Fetch and rebase on ${{ github.base_ref }}
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.check-label.outputs.skip != 'true'
         uses: ./.github/actions/rebase
 
       - name: Setup go ${{ env.GO_VERSION }}
+        if: steps.check-label.outputs.skip != 'true'
         uses: ./.github/actions/setup-go
         with:
           go-version: '${{ env.GO_VERSION }}'
           key-prefix: integration-test
 
       - name: Install bitcoind
+        if: steps.check-label.outputs.skip != 'true'
         run: ./scripts/install_bitcoind.sh $BITCOIN_VERSION
 
       - name: Run ${{ matrix.name }}
+        if: steps.check-label.outputs.skip != 'true'
         run: make itest-parallel tranches=${{ env.SMALL_TRANCHES }} ${{ matrix.args }} shuffleseed=${{ github.run_id }}${{ strategy.job-index }}
 
       - name: Clean coverage
         run: grep -Ev '(\.pb\.go|\.pb\.json\.go|\.pb\.gw\.go)' coverage.txt > coverage-norpc.txt
-        if: ${{ contains(matrix.args, 'cover=1') }}
+        if: ${{ contains(matrix.args, 'cover=1') && steps.check-label.outputs.skip != 'true' }}
 
       - name: Send coverage
-        if: ${{ contains(matrix.args, 'cover=1') }}
+        if: ${{ contains(matrix.args, 'cover=1') && steps.check-label.outputs.skip != 'true' }}
         continue-on-error: true
         uses: coverallsapp/github-action@v2
         with:
@@ -403,13 +423,13 @@ jobs:
           parallel: true
 
       - name: Zip log files on failure
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.check-label.outputs.skip != 'true' }}
         timeout-minutes: 5 # timeout after 5 minute
         run: 7z a logs-itest-${{ matrix.name }}.zip itest/**/*.log
 
       - name: Upload log files on failure
         uses: actions/upload-artifact@v4
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.check-label.outputs.skip != 'true' }}
         with:
           name: logs-itest-${{ matrix.name }}
           path: logs-itest-${{ matrix.name }}.zip
@@ -422,39 +442,47 @@ jobs:
   windows-integration-test:
     name: Run windows itest
     runs-on: windows-latest
-    if: '!contains(github.event.pull_request.labels.*.name, ''no-itest'')'
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      - name: Check for no-itest label
+        id: check-label
+        uses: ./.github/actions/check-label
+        with:
+          label: 'no-itest'
+          skip-message: "Tests auto-passed due to 'no-itest' label"
+
       - name: Fetch and rebase on ${{ github.base_ref }}
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.check-label.outputs.skip != 'true'
         uses: ./.github/actions/rebase
 
       - name: Setup go ${{ env.GO_VERSION }}
+        if: steps.check-label.outputs.skip != 'true'
         uses: ./.github/actions/setup-go
         with:
           go-version: '${{ env.GO_VERSION }}'
           key-prefix: integration-test
 
       - name: Run itest
+        if: steps.check-label.outputs.skip != 'true'
         run: make itest-parallel tranches=${{ env.SMALL_TRANCHES }} windows=1 shuffleseed=${{ github.run_id }}
         
       - name: Kill any remaining lnd processes
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.check-label.outputs.skip != 'true' }}
         shell: powershell
         run: taskkill /IM lnd-itest.exe /T /F
 
       - name: Zip log files on failure
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.check-label.outputs.skip != 'true' }}
         timeout-minutes: 5 # timeout after 5 minute
         run: 7z a logs-itest-windows.zip itest/**/*.log
 
       - name: Upload log files on failure
         uses: actions/upload-artifact@v4
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.check-label.outputs.skip != 'true' }}
         with:
           name: logs-itest-windows
           path: logs-itest-windows.zip
@@ -466,34 +494,42 @@ jobs:
   macos-integration-test:
     name: Run macOS itest
     runs-on: macos-14
-    if: '!contains(github.event.pull_request.labels.*.name, ''no-itest'')'
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      - name: Check for no-itest label
+        id: check-label
+        uses: ./.github/actions/check-label
+        with:
+          label: 'no-itest'
+          skip-message: "Tests auto-passed due to 'no-itest' label"
+
       - name: Fetch and rebase on ${{ github.base_ref }}
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.check-label.outputs.skip != 'true'
         uses: ./.github/actions/rebase
 
       - name: Setup go ${{ env.GO_VERSION }}
+        if: steps.check-label.outputs.skip != 'true'
         uses: ./.github/actions/setup-go
         with:
           go-version: '${{ env.GO_VERSION }}'
           key-prefix: integration-test
 
       - name: Run itest
+        if: steps.check-label.outputs.skip != 'true'
         run: make itest-parallel tranches=${{ env.SMALL_TRANCHES }} shuffleseed=${{ github.run_id }}
 
       - name: Zip log files on failure
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.check-label.outputs.skip != 'true' }}
         timeout-minutes: 5 # timeout after 5 minute
         run: 7z a logs-itest-macos.zip itest/**/*.log
 
       - name: Upload log files on failure
         uses: actions/upload-artifact@v4
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.check-label.outputs.skip != 'true' }}
         with:
           name: logs-itest-macos
           path: logs-itest-macos.zip
@@ -529,15 +565,23 @@ jobs:
   milestone-check:
     name: Check release notes updated
     runs-on: ubuntu-latest
-    if: '!contains(github.event.pull_request.labels.*.name, ''no-changelog'')'
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
 
+      - name: Check for no-changelog label
+        id: check-label
+        uses: ./.github/actions/check-label
+        with:
+          label: 'no-changelog'
+          skip-message: "Changelog check auto-passed due to 'no-changelog' label"
+
       - name: Clean up runner space
+        if: steps.check-label.outputs.skip != 'true'
         uses: ./.github/actions/cleanup-space
 
       - name: Release notes check
+        if: steps.check-label.outputs.skip != 'true'
         run: scripts/check-release-notes.sh
 
   ########################


### PR DESCRIPTION
In this commit, we revamp the way our skip-labels worked to instead mark certain stages as green, instead of skipping them. Skipped changes didn't count towards the set of required checks, which slowed down PR velocity.

Previously, when PRs were labeled with 'no-itest' or 'no-changelog', the corresponding CI jobs would be completely skipped. This caused the GitHub checks to show as skipped rather than successful, which could be confusing and prevented certain merge rules from working properly.

This commit changes the behavior so that these jobs still run but immediately report success when the special labels are detected. Each affected job now starts with a label check step that sets a skip flag, and all subsequent steps are conditionally executed based on this flag. When skipped, the jobs add a notice to the GitHub step summary explaining that tests were auto-passed due to the label.

Making this initial PR to test if it works properly....