### PR TITLE
multi: attempt to more uniformly use SpewLogClosure across project

### DIFF
--- a/autopilot/agent.go
+++ b/autopilot/agent.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/lnutils"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
 
@@ -443,7 +443,7 @@ func (a *Agent) controller(ctx context.Context) {
 			case *chanOpenUpdate:
 				log.Debugf("New channel successfully opened, "+
 					"updating state with: %v",
-					spew.Sdump(update.newChan))
+					lnutils.SpewLogClosure(update.newChan))
 
 				newChan := update.newChan
 				a.chanStateMtx.Lock()
@@ -460,7 +460,9 @@ func (a *Agent) controller(ctx context.Context) {
 			case *chanCloseUpdate:
 				log.Debugf("Applying closed channel "+
 					"updates: %v",
-					spew.Sdump(update.closedChans))
+					lnutils.SpewLogClosure(
+						update.closedChans),
+				)
 
 				a.chanStateMtx.Lock()
 				for _, closedChan := range update.closedChans {
@@ -515,7 +517,8 @@ func (a *Agent) controller(ctx context.Context) {
 		}
 
 		a.pendingMtx.Lock()
-		log.Debugf("Pending channels: %v", spew.Sdump(a.pendingOpens))
+		log.Debugf("Pending channels: %v",
+			lnutils.SpewLogClosure(a.pendingOpens))
 		a.pendingMtx.Unlock()
 
 		// With all the updates applied, we'll obtain a set of the
@@ -699,7 +702,7 @@ func (a *Agent) openChans(ctx context.Context, availableFunds btcutil.Amount,
 	}
 
 	log.Infof("Attempting to execute channel attachment "+
-		"directives: %v", spew.Sdump(chanCandidates))
+		"directives: %v", lnutils.SpewLogClosure(chanCandidates))
 
 	// Before proceeding, check to see if we have any slots
 	// available to open channels. If there are any, we will attempt

--- a/contractcourt/chain_watcher.go
+++ b/contractcourt/chain_watcher.go
@@ -588,10 +588,10 @@ func newChainSet(chanState *channeldb.OpenChannel) (*chainSet, error) {
 
 	log.Tracef("ChannelPoint(%v): local_commit_type=%v, local_commit=%v",
 		chanState.FundingOutpoint, chanState.ChanType,
-		spew.Sdump(localCommit))
+		lnutils.SpewLogClosure(localCommit))
 	log.Tracef("ChannelPoint(%v): remote_commit_type=%v, remote_commit=%v",
 		chanState.FundingOutpoint, chanState.ChanType,
-		spew.Sdump(remoteCommit))
+		lnutils.SpewLogClosure(remoteCommit))
 
 	// Fetch the current known commit height for the remote party, and
 	// their pending commitment chain tip if it exists.
@@ -619,7 +619,7 @@ func newChainSet(chanState *channeldb.OpenChannel) (*chainSet, error) {
 		log.Tracef("ChannelPoint(%v): remote_pending_commit_type=%v, "+
 			"remote_pending_commit=%v", chanState.FundingOutpoint,
 			chanState.ChanType,
-			spew.Sdump(remoteChainTip.Commitment))
+			lnutils.SpewLogClosure(remoteChainTip.Commitment))
 
 		htlcs := remoteChainTip.Commitment.Htlcs
 		commitSet.HtlcSets[RemotePendingHtlcSet] = htlcs
@@ -995,7 +995,8 @@ func (c *chainWatcher) dispatchCooperativeClose(commitSpend *chainntnfs.SpendDet
 	broadcastTx := commitSpend.SpendingTx
 
 	log.Infof("Cooperative closure for ChannelPoint(%v): %v",
-		c.cfg.chanState.FundingOutpoint, spew.Sdump(broadcastTx))
+		c.cfg.chanState.FundingOutpoint,
+		lnutils.SpewLogClosure(broadcastTx))
 
 	// If the input *is* final, then we'll check to see which output is
 	// ours.

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -10,7 +10,6 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/fn/v2"
@@ -167,7 +166,7 @@ func (h *htlcTimeoutResolver) claimCleanUp(
 
 	log.Infof("%T(%v): extracting preimage! remote party spent "+
 		"HTLC with tx=%v", h, h.htlcResolution.ClaimOutpoint,
-		spew.Sdump(commitSpend.SpendingTx))
+		lnutils.SpewLogClosure(commitSpend.SpendingTx))
 
 	// If this is the remote party's commitment, then we'll be looking for
 	// them to spend using the second-level success transaction.

--- a/contractcourt/utxonursery.go
+++ b/contractcourt/utxonursery.go
@@ -12,7 +12,6 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/fn/v2"
@@ -964,7 +963,7 @@ func (u *UtxoNursery) sweepCribOutput(classHeight uint32, baby *babyOutput) erro
 		!errors.Is(err, lnwallet.ErrMempoolFee) {
 
 		utxnLog.Errorf("Unable to broadcast baby tx: "+
-			"%v, %v", err, spew.Sdump(baby.timeoutTx))
+			"%v, %v", err, lnutils.SpewLogClosure(baby.timeoutTx))
 		return err
 	}
 

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -15,7 +15,6 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lightninglabs/neutrino/cache"
 	"github.com/lightninglabs/neutrino/cache/lru"
 	"github.com/lightningnetwork/lnd/batch"
@@ -1650,7 +1649,7 @@ func (d *AuthenticatedGossiper) handleNetworkMessages(ctx context.Context,
 	if err != nil {
 		// Something is wrong if SignalDependents returns an error.
 		log.Errorf("SignalDependents returned error for msg=%v with "+
-			"JobID=%v", spew.Sdump(nMsg.msg), jobID)
+			"JobID=%v", lnutils.SpewLogClosure(nMsg.msg), jobID)
 
 		nMsg.err <- err
 
@@ -3196,7 +3195,7 @@ func (d *AuthenticatedGossiper) handleChanUpdate(ctx context.Context,
 	if err != nil {
 		rErr := fmt.Errorf("unable to validate channel update "+
 			"announcement for short_chan_id=%v: %v",
-			spew.Sdump(upd.ShortChannelID), err)
+			lnutils.SpewLogClosure(upd.ShortChannelID), err)
 
 		log.Error(rErr)
 		nMsg.err <- rErr

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -18,7 +18,6 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/chanacceptor"
 	"github.com/lightningnetwork/lnd/channeldb"
@@ -992,7 +991,9 @@ func (f *Manager) failFundingFlow(peer lnpeer.Peer, cid *chanIdentifier,
 	}
 
 	log.Debugf("Sending funding error to peer (%x): %v",
-		peer.IdentityKey().SerializeCompressed(), spew.Sdump(errMsg))
+		peer.IdentityKey().SerializeCompressed(),
+		lnutils.SpewLogClosure(errMsg))
+
 	if err := peer.SendMessage(false, errMsg); err != nil {
 		log.Errorf("unable to send error message to peer %v", err)
 	}
@@ -1012,7 +1013,7 @@ func (f *Manager) sendWarning(peer lnpeer.Peer, cid *chanIdentifier,
 
 	log.Debugf("Sending funding warning to peer (%x): %v",
 		peer.IdentityKey().SerializeCompressed(),
-		spew.Sdump(errMsg),
+		lnutils.SpewLogClosure(errMsg),
 	)
 
 	if err := peer.SendMessage(false, errMsg); err != nil {

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -13,7 +13,6 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/clock"
@@ -1625,7 +1624,7 @@ out:
 			}
 
 			log.Debugf("Received outside contract resolution, "+
-				"mapping to: %v", spew.Sdump(pkt))
+				"mapping to: %v", lnutils.SpewLogClosure(pkt))
 
 			// We don't check the error, as the only failure we can
 			// encounter is due to the circuit already being

--- a/invoices/sql_store.go
+++ b/invoices/sql_store.go
@@ -10,10 +10,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/graph/db/models"
 	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnutils"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
 	"github.com/lightningnetwork/lnd/sqldb"
@@ -409,7 +409,7 @@ func getInvoiceByRef(ctx context.Context,
 		// In case the reference is ambiguous, meaning it matches more
 		// than	one invoice, we'll return an error.
 		return sqlc.Invoice{}, fmt.Errorf("ambiguous invoice ref: "+
-			"%s: %s", ref.String(), spew.Sdump(rows))
+			"%s: %s", ref.String(), lnutils.SpewLogClosure(rows))
 
 	case err != nil:
 		return sqlc.Invoice{}, fmt.Errorf("unable to fetch invoice: %w",

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -24,12 +24,12 @@ import (
 	"github.com/btcsuite/btcwallet/wallet/txrules"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/blockcache"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/lnutils"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 )
@@ -1184,7 +1184,8 @@ func (b *BtcWallet) PublishTransaction(tx *wire.MsgTx, label string) error {
 	}
 
 	result := results[0]
-	log.Debugf("TestMempoolAccept result: %s", spew.Sdump(result))
+	log.Debugf("TestMempoolAccept result: %s",
+		lnutils.SpewLogClosure(result))
 
 	// Once mempool check passed, we can publish the transaction.
 	if result.Allowed {
@@ -1833,7 +1834,8 @@ func (b *BtcWallet) CheckMempoolAcceptance(tx *wire.MsgTx) error {
 	}
 
 	result := results[0]
-	log.Debugf("TestMempoolAccept result: %s", spew.Sdump(result))
+	log.Debugf("TestMempoolAccept result: %s",
+		lnutils.SpewLogClosure(result))
 
 	// Mempool check failed, we now map the reject reason to a proper RPC
 	// error and return it.

--- a/lnwallet/chancloser/chancloser.go
+++ b/lnwallet/chancloser/chancloser.go
@@ -10,7 +10,6 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/htlcswitch"
@@ -414,7 +413,7 @@ func (c *ChanCloser) initChanShutdown() (*lnwire.Shutdown, error) {
 		)
 
 		chancloserLog.Infof("Initiating shutdown w/ nonce: %v",
-			spew.Sdump(firstClosingNonce.PubNonce))
+			lnutils.SpewLogClosure(firstClosingNonce.PubNonce))
 	}
 
 	// Before closing, we'll attempt to send a disable update for the

--- a/lnwallet/chancloser/rbf_coop_transitions.go
+++ b/lnwallet/chancloser/rbf_coop_transitions.go
@@ -9,7 +9,6 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/mempool"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/labels"
@@ -799,7 +798,7 @@ func (l *LocalCloseStart) ProcessEvent(event ProtocolEvent,
 			l.RemoteDeliveryScript[:], absoluteFee)
 
 		chancloserLog.Infof("proposing closing_tx=%v",
-			spew.Sdump(closeTx))
+			lnutils.SpewLogClosure(closeTx))
 
 		// Now that we have our signature, we'll set the proper
 		// closingSigs field based on if the remote party's output is

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -21,7 +21,6 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/fn/v2"
@@ -2850,7 +2849,7 @@ func (lc *LightningChannel) fetchCommitmentView(
 		return nil, fmt.Errorf("height=%v, for ChannelPoint(%v) "+
 			"attempts to create commitment with feerate %v: %v",
 			nextHeight, lc.channelState.FundingOutpoint,
-			effFeeRate, spew.Sdump(commitTx))
+			effFeeRate, lnutils.SpewLogClosure(commitTx))
 	}
 
 	// Given the custom blob of the past state, and this new HTLC view,

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -21,12 +21,12 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/wallet"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnutils"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwallet/chanfunding"
 	"github.com/lightningnetwork/lnd/lnwallet/chanvalidate"
@@ -1733,7 +1733,8 @@ func (l *LightningWallet) handleContributionMsg(req *addContributionMsg) {
 		}
 
 		walletLog.Tracef("Funding tx for ChannelPoint(%v) "+
-			"generated: %v", chanPoint, spew.Sdump(fundingTx))
+			"generated: %v", chanPoint,
+			lnutils.SpewLogClosure(fundingTx))
 	}
 
 	// If we landed here and didn't exit early, it means we already have
@@ -2001,9 +2002,9 @@ func (l *LightningWallet) handleChanPointReady(req *continueContributionMsg) {
 	txsort.InPlaceSort(theirCommitTx)
 
 	walletLog.Tracef("Local commit tx for ChannelPoint(%v): %v",
-		chanPoint, spew.Sdump(ourCommitTx))
+		chanPoint, lnutils.SpewLogClosure(ourCommitTx))
 	walletLog.Tracef("Remote commit tx for ChannelPoint(%v): %v",
-		chanPoint, spew.Sdump(theirCommitTx))
+		chanPoint, lnutils.SpewLogClosure(theirCommitTx))
 
 	// Record newly available information within the open channel state.
 	chanState.FundingOutpoint = chanPoint
@@ -2449,9 +2450,9 @@ func (l *LightningWallet) handleSingleFunderSigs(req *addSingleFunderSigsMsg) {
 	chanState.RemoteCommitment.CommitTx = theirCommitTx
 
 	walletLog.Debugf("Local commit tx for ChannelPoint(%v): %v",
-		req.fundingOutpoint, spew.Sdump(ourCommitTx))
+		req.fundingOutpoint, lnutils.SpewLogClosure(ourCommitTx))
 	walletLog.Debugf("Remote commit tx for ChannelPoint(%v): %v",
-		req.fundingOutpoint, spew.Sdump(theirCommitTx))
+		req.fundingOutpoint, lnutils.SpewLogClosure(theirCommitTx))
 
 	// With both commitment transactions created, we'll now verify their
 	// signature on our commitment.

--- a/netann/channel_update.go
+++ b/netann/channel_update.go
@@ -8,9 +8,9 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/graph/db/models"
 	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnutils"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/tlv"
@@ -226,7 +226,7 @@ func verifyChannelUpdate1Signature(msg *lnwire.ChannelUpdate1,
 
 	if !nodeSig.Verify(dataHash, pubKey) {
 		return fmt.Errorf("invalid signature for channel update %v",
-			spew.Sdump(msg))
+			lnutils.SpewLogClosure(msg))
 	}
 
 	return nil
@@ -249,7 +249,7 @@ func verifyChannelUpdate2Signature(c *lnwire.ChannelUpdate2,
 
 	if !nodeSig.Verify(digest, pubKey) {
 		return fmt.Errorf("invalid signature for channel update %v",
-			spew.Sdump(c))
+			lnutils.SpewLogClosure(c))
 	}
 
 	return nil
@@ -279,13 +279,13 @@ func validateChannelUpdate1Fields(capacity btcutil.Amount,
 	// The maxHTLC flag is mandatory.
 	if !msg.MessageFlags.HasMaxHtlc() {
 		return fmt.Errorf("max htlc flag not set for channel "+
-			"update %v", spew.Sdump(msg))
+			"update %v", lnutils.SpewLogClosure(msg))
 	}
 
 	maxHtlc := msg.HtlcMaximumMsat
 	if maxHtlc == 0 || maxHtlc < msg.HtlcMinimumMsat {
 		return fmt.Errorf("invalid max htlc for channel "+
-			"update %v", spew.Sdump(msg))
+			"update %v", lnutils.SpewLogClosure(msg))
 	}
 
 	// For light clients, the capacity will not be set so we'll skip
@@ -308,7 +308,7 @@ func validateChannelUpdate2Fields(capacity btcutil.Amount,
 	maxHtlc := c.HTLCMaximumMsat.Val
 	if maxHtlc == 0 || maxHtlc < c.HTLCMinimumMsat.Val {
 		return fmt.Errorf("invalid max htlc for channel update %v",
-			spew.Sdump(c))
+			lnutils.SpewLogClosure(c))
 	}
 
 	// Checking whether the MaxHTLC value respects the channel's capacity.

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -19,7 +19,6 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/buffer"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
@@ -1230,7 +1229,7 @@ func (p *Brontide) loadActiveChannels(chans []*channeldb.OpenChannel) (
 		}
 
 		p.log.Tracef("Using link policy of: %v",
-			spew.Sdump(forwardingPolicy))
+			lnutils.SpewLogClosure(forwardingPolicy))
 
 		// If the channel is pending, set the value to nil in the
 		// activeChannels map. This is done to signify that the channel
@@ -2839,7 +2838,7 @@ func (p *Brontide) queue(priority bool, msg lnwire.Message,
 	case p.outgoingQueue <- outgoingMsg{priority, msg, errChan}:
 	case <-p.cg.Done():
 		p.log.Tracef("Peer shutting down, could not enqueue msg: %v.",
-			spew.Sdump(msg))
+			lnutils.SpewLogClosure(msg))
 		if errChan != nil {
 			errChan <- lnpeer.ErrPeerExiting
 		}

--- a/routing/payment_lifecycle.go
+++ b/routing/payment_lifecycle.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/davecgh/go-spew/spew"
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/graph/db/models"
@@ -301,7 +300,7 @@ lifecycle:
 			continue lifecycle
 		}
 
-		log.Tracef("Found route: %s", spew.Sdump(rt.Hops))
+		log.Tracef("Found route: %s", lnutils.SpewLogClosure(rt.Hops))
 
 		// We found a route to try, create a new HTLC attempt to try.
 		attempt, err := p.registerAttempt(rt, ps.RemainingAmt)
@@ -767,7 +766,7 @@ func (p *paymentLifecycle) amendFirstHopData(rt *route.Route) error {
 
 			log.Debugf("Aux traffic shaper returned custom "+
 				"records %v and amount %d msat for HTLC",
-				spew.Sdump(newRecords), newAmt)
+				lnutils.SpewLogClosure(newRecords), newAmt)
 
 			return fn.Ok(extraDataRequest{
 				customRecords: fn.Some(newRecords),

--- a/routing/router.go
+++ b/routing/router.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/amp"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/fn/v2"
@@ -958,7 +957,8 @@ func spewPayment(payment *LightningPayment) lnutils.LogClosure {
 		}
 		p := *payment
 		p.RouteHints = routeHints
-		return spew.Sdump(p)
+
+		return lnutils.SpewLogClosure(p)()
 	})
 }
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -33,7 +33,6 @@ import (
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/btcsuite/btcwallet/wallet/txauthor"
-	"github.com/davecgh/go-spew/spew"
 	proxy "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/lightningnetwork/lnd/autopilot"
 	"github.com/lightningnetwork/lnd/build"
@@ -1526,7 +1525,8 @@ func (r *rpcServer) SendCoins(ctx context.Context,
 		}
 
 		rpcsLog.Debugf("Sweeping coins from wallet to addr=%v, "+
-			"with tx=%v", in.Addr, spew.Sdump(sweepTxPkg.SweepTx))
+			"with tx=%v", in.Addr,
+			lnutils.SpewLogClosure(sweepTxPkg.SweepTx))
 
 		// As our sweep transaction was created, successfully, we'll
 		// now attempt to publish it, cancelling the sweep pkg to
@@ -1612,7 +1612,7 @@ func (r *rpcServer) SendMany(ctx context.Context,
 	}
 
 	rpcsLog.Infof("[sendmany] outputs=%v, sat/kw=%v",
-		spew.Sdump(in.AddrToAmount), int64(feePerKw))
+		lnutils.SpewLogClosure(in.AddrToAmount), int64(feePerKw))
 
 	var txid *chainhash.Hash
 

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -9,7 +9,6 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/chainio"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/fn/v2"
@@ -626,7 +625,7 @@ func (s *UtxoSweeper) removeConflictSweepDescendants(
 		// all the transactions that are descendants of outputs created
 		// by the sweepTx and the sweepTx itself.
 		log.Debugf("Removing sweep txid=%v from wallet: %v",
-			sweepTx.TxHash(), spew.Sdump(sweepTx))
+			sweepTx.TxHash(), lnutils.SpewLogClosure(sweepTx))
 
 		err = s.cfg.Wallet.RemoveDescendants(sweepTx)
 		if err != nil {
@@ -1435,7 +1434,7 @@ func (s *UtxoSweeper) handleInputSpent(spend *chainntnfs.SpendDetail) {
 
 		log.Debugf("Attempting to remove descendant txns invalidated "+
 			"by (txid=%v): %v", spendingTx.TxHash(),
-			spew.Sdump(spendingTx))
+			lnutils.SpewLogClosure(spendingTx))
 
 		err := s.removeConflictSweepDescendants(inputsSpent)
 		if err != nil {

--- a/watchtower/lookout/justice_descriptor.go
+++ b/watchtower/lookout/justice_descriptor.go
@@ -9,7 +9,6 @@ import (
 	"github.com/btcsuite/btcd/btcutil/txsort"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnutils"
@@ -197,7 +196,7 @@ func (p *JusticeDescriptor) assembleJusticeTxn(txWeight lntypes.WeightUnit,
 		}
 		if err := vm.Execute(); err != nil {
 			log.Debugf("Failed to validate justice transaction: %s",
-				spew.Sdump(justiceTxn))
+				lnutils.SpewLogClosure(justiceTxn))
 			return nil, fmt.Errorf("error validating TX: %w", err)
 		}
 	}


### PR DESCRIPTION
We added this helper function to address the common case of wanting to make a log closure to spew a struct. In this PR, we attempt to make this more uniform. Occurrences were found with the help of a simple grep script. 