### PR TITLE
bugfix error matching sweeper

### DIFF
--- a/chainntnfs/txnotifier.go
+++ b/chainntnfs/txnotifier.go
@@ -356,11 +356,22 @@ func NewSpendRequest(op *wire.OutPoint, pkScript []byte) (SpendRequest, error) {
 
 // String returns the string representation of the SpendRequest.
 func (r SpendRequest) String() string {
-	if r.OutPoint != ZeroOutPoint {
-		return fmt.Sprintf("outpoint=%v, script=%v", r.OutPoint,
-			r.PkScript)
+	var (
+		outpointStr = fmt.Sprintf("%v", r.OutPoint)
+		scriptStr   = fmt.Sprintf("%v", r.PkScript)
+	)
+
+	if r.OutPoint == ZeroOutPoint {
+		outpointStr = "<zero>"
 	}
-	return fmt.Sprintf("outpoint=<zero>, script=%v", r.PkScript)
+
+	// If the pk script is all zeros, we blank the pk script.
+	// Currently we do not support taproot pk scripts for notifications.
+	if r.PkScript == ZeroTaprootPkScript {
+		scriptStr = "<zero> (taproot pk script not supported)"
+	}
+
+	return fmt.Sprintf("outpoint=%s, script=%s", outpointStr, scriptStr)
 }
 
 // MatchesTx determines whether the given transaction satisfies the spend

--- a/config_builder.go
+++ b/config_builder.go
@@ -1807,8 +1807,11 @@ func broadcastErrorMapper(err error) error {
 	// in the first place are rebroadcasted despite of their backend error.
 	// Mempool conditions change over time so it makes sense to retry
 	// publishing the transaction. Moreover we log the detailed error so the
-	// user can intervene and increase the size of his mempool.
-	case errors.Is(err, chain.ErrMempoolMinFeeNotMet):
+	// user can intervene and increase the size of his mempool or increase
+	// his min relay fee configuration.
+	case errors.Is(err, chain.ErrMempoolMinFeeNotMet),
+		errors.Is(err, chain.ErrMinRelayFeeNotMet):
+
 		ltndLog.Warnf("Error while broadcasting transaction: %v", err)
 
 		returnErr = &pushtx.BroadcastError{

--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -42,6 +42,10 @@
   send unnecessary `channel_announcement` and `node_announcement` messages when
   replying to a `gossip_timestamp_filter` query.
 
+- [Fixed](https://github.com/lightningnetwork/lnd/pull/10189) a case in the
+  sweeper where some outputs would not be resolved due to an error string
+  mismatch.
+
 # New Features
  
 * Use persisted [nodeannouncement](https://github.com/lightningnetwork/lnd/pull/8825) 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/btcsuite/btclog v0.0.0-20241003133417-09c4e92e319c
 	github.com/btcsuite/btclog/v2 v2.0.1-0.20250728225537-6090e87c6c5b
-	github.com/btcsuite/btcwallet v0.16.15-0.20250811092146-05b3a40651e6
+	github.com/btcsuite/btcwallet v0.16.17
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.3.5
 	github.com/btcsuite/btcwallet/wallet/txrules v1.2.2
 	github.com/btcsuite/btcwallet/walletdb v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/btcsuite/btclog v0.0.0-20241003133417-09c4e92e319c/go.mod h1:w7xnGOhw
 github.com/btcsuite/btclog/v2 v2.0.1-0.20250728225537-6090e87c6c5b h1:MQ+Q6sDy37V1wP1Yu79A5KqJutolqUGwA99UZWQDWZM=
 github.com/btcsuite/btclog/v2 v2.0.1-0.20250728225537-6090e87c6c5b/go.mod h1:XItGUfVOxotJL8kkuk2Hj3EVow5KCugXl3wWfQ6K0AE=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
-github.com/btcsuite/btcwallet v0.16.15-0.20250811092146-05b3a40651e6 h1:s6NCipDdvDK5rBrC4dIlni1iHsuDOKdfwpL32I3b6Tw=
-github.com/btcsuite/btcwallet v0.16.15-0.20250811092146-05b3a40651e6/go.mod h1:H6dfoZcWPonM2wbVsR2ZBY0PKNZKdQyLAmnX8vL9JFA=
+github.com/btcsuite/btcwallet v0.16.17 h1:1N6lHznRdcjDopBvcofxaIHknArkJ/EcVKgLKfGL4Dg=
+github.com/btcsuite/btcwallet v0.16.17/go.mod h1:YO+W745BAH8n/Rpgj68QsLR6eLlgM4W2do4RejT0buo=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.5 h1:Rr0njWI3r341nhSPesKQ2JF+ugDSzdPoeckS75SeDZk=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.5/go.mod h1:+tXJ3Ym0nlQc/iHSwW1qzjmPs3ev+UVWMbGgfV1OZqU=
 github.com/btcsuite/btcwallet/wallet/txrules v1.2.2 h1:YEO+Lx1ZJJAtdRrjuhXjWrYsmAk26wLTlNzxt2q0lhk=

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -1133,7 +1133,9 @@ func mapRpcclientError(err error) error {
 	// If the wallet reports that fee requirements for accepting the tx
 	// into mempool are not met, convert it to our internal ErrMempoolFee
 	// and return.
-	case errors.Is(err, chain.ErrMempoolMinFeeNotMet):
+	case errors.Is(err, chain.ErrMempoolMinFeeNotMet),
+		errors.Is(err, chain.ErrMinRelayFeeNotMet):
+
 		return fmt.Errorf("%w: %v", lnwallet.ErrMempoolFee, err.Error())
 	}
 

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -565,7 +565,10 @@ func (t *TxPublisher) createRBFCompliantTx(
 
 		// If the error indicates the fees paid is not enough, we will
 		// ask the fee function to increase the fee rate and retry.
-		case errors.Is(err, lnwallet.ErrMempoolFee):
+		case errors.Is(err, lnwallet.ErrMempoolFee),
+			errors.Is(err, chain.ErrMinRelayFeeNotMet),
+			errors.Is(err, chain.ErrMempoolMinFeeNotMet):
+
 			// We should at least start with a feerate above the
 			// mempool min feerate, so if we get this error, it
 			// means something is wrong earlier in the pipeline.
@@ -574,7 +577,8 @@ func (t *TxPublisher) createRBFCompliantTx(
 
 			fallthrough
 
-		// We are not paying enough fees so we increase it.
+		// We are not paying enough fees to RBF a previous tx, so we
+		// increase it.
 		case errors.Is(err, chain.ErrInsufficientFee):
 			increased := false
 

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -1668,6 +1668,16 @@ func prepareSweepTx(inputs []input.Input, changePkScript lnwallet.AddrWithKey,
 		return 0, noChange, noLocktime, err
 	}
 
+	// We also add the extra change output to the change pk scripts.
+	//
+	// NOTE: The weight estimation will not be quite accurate because the
+	// witness data is greater when overlay channels are used. But that
+	// shouldn't be a problem since we will increase the fee rate
+	// incrementally via the fee function.
+	extraChangeOut.WhenSome(func(o SweepOutput) {
+		changePkScripts = append(changePkScripts, o.TxOut.PkScript)
+	})
+
 	// Creating a weight estimator with nil outputs and zero max fee rate.
 	// We don't allow adding customized outputs in the sweeping tx, and the
 	// fee rate is already being managed before we get here.

--- a/sweep/mock_test.go
+++ b/sweep/mock_test.go
@@ -338,7 +338,7 @@ func (m *MockAuxSweeper) DeriveSweepAddr(_ []input.Input,
 			Value:    123,
 			PkScript: changePkScript.DeliveryAddress,
 		},
-		IsExtra:     false,
+		IsExtra:     true,
 		InternalKey: fn.None[keychain.KeyDescriptor](),
 	})
 }


### PR DESCRIPTION
Depends on:

https://github.com/btcsuite/btcwallet/pull/1053

Fixes:

https://github.com/lightninglabs/taproot-assets/issues/1770

and 

https://github.com/lightninglabs/lightning-terminal/issues/1139 (which needs to bump the corresponding LND version if this is merged.)


!!!ATTENTION!!! First 9 commits belong to https://github.com/lightningnetwork/lnd/pull/10209 !!!ATTENTION!!! 
