### PR TITLE
sqldb: fix SQLStr helper

### DIFF
--- a/graph/db/sql_migration.go
+++ b/graph/db/sql_migration.go
@@ -1380,8 +1380,8 @@ func insertNodeSQLMig(ctx context.Context, db SQLQueries,
 
 	if node.HaveNodeAnnouncement {
 		params.LastUpdate = sqldb.SQLInt64(node.LastUpdate.Unix())
-		params.Color = sqldb.SQLStr(EncodeHexColor(node.Color))
-		params.Alias = sqldb.SQLStr(node.Alias)
+		params.Color = sqldb.SQLStrValid(EncodeHexColor(node.Color))
+		params.Alias = sqldb.SQLStrValid(node.Alias)
 		params.Signature = node.AuthSigBytes
 	}
 

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -3391,8 +3391,8 @@ func upsertNode(ctx context.Context, db SQLQueries,
 
 	if node.HaveNodeAnnouncement {
 		params.LastUpdate = sqldb.SQLInt64(node.LastUpdate.Unix())
-		params.Color = sqldb.SQLStr(EncodeHexColor(node.Color))
-		params.Alias = sqldb.SQLStr(node.Alias)
+		params.Color = sqldb.SQLStrValid(EncodeHexColor(node.Color))
+		params.Alias = sqldb.SQLStrValid(node.Alias)
 		params.Signature = node.AuthSigBytes
 	}
 

--- a/sqldb/sqlutils.go
+++ b/sqldb/sqlutils.go
@@ -49,11 +49,26 @@ func SQLInt64[T constraints.Integer](num T) sql.NullInt64 {
 
 // SQLStr turns a string into the NullString that sql/sqlc uses when a string
 // can be permitted to be NULL.
+//
+// NOTE: If the input string is empty, it returns a NullString with Valid set to
+// false. If this is not the desired behavior, consider using SQLStrValid
+// instead.
 func SQLStr(s string) sql.NullString {
 	if s == "" {
 		return sql.NullString{}
 	}
 
+	return sql.NullString{
+		String: s,
+		Valid:  true,
+	}
+}
+
+// SQLStrValid turns a string into the NullString that sql/sqlc uses when a
+// string can be permitted to be NULL.
+//
+// NOTE: Valid is always set to true, even if the input string is empty.
+func SQLStrValid(s string) sql.NullString {
 	return sql.NullString{
 		String: s,
 		Valid:  true,


### PR DESCRIPTION
The SQL* helpers are meant to always set the `Valid` field of the sql.Null* type to true. Otherwise they cannot be used to set a valid, empty field. In this commit, the SQLStr helper is fixed so that we can represent a valid/set empty string field.

This is important for something like storing node announcement data where fields like `Alias` might be present but might be a zero length string. The difference is important so that when we construct a pure TLV message, we know wether to include the field or not. 

We need this for https://github.com/lightningnetwork/lnd/issues/9795