### PR TITLE
commands: add extra warning on wallet creation

### DIFF
--- a/cmd/commands/cmd_walletunlocker.go
+++ b/cmd/commands/cmd_walletunlocker.go
@@ -935,4 +935,6 @@ func printCipherSeedWords(mnemonicWords []string) {
 
 	fmt.Println("\n!!!YOU MUST WRITE DOWN THIS SEED TO BE ABLE TO " +
 		"RESTORE THE WALLET!!!")
+	fmt.Println("\n!!! DO NOT UNDER ANY CIRCUMSTANCES SHARE THIS SEED " +
+		"WITH ANYONE AS IT MAY RESULT IN LOSS OF YOUR FUNDS !!!")
 }


### PR DESCRIPTION
## Change Description
Sometimes user can get scammed as they're unaware that sharing the seed can lead to loss of funds. With this message we emphasize the dangers of sharing.