### PR TITLE
Makefile+tools: reduce LND linter docker image size by 85% from `2330 MB` to `355 MB`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,7 @@ endif
 
 DOCKER_TOOLS = docker run \
   --rm \
-  -v $(shell bash -c "$(GOCC) env GOCACHE || (mkdir -p /tmp/go-cache; echo /tmp/go-cache)"):/tmp/build/.cache \
-  -v $(shell bash -c "$(GOCC) env GOMODCACHE || (mkdir -p /tmp/go-modcache; echo /tmp/go-modcache)"):/tmp/build/.modcache \
+  -v $(shell bash -c "mkdir -p /tmp/go-build-cache; echo /tmp/go-build-cache"):/root/.cache/go-build \
   -v $(shell bash -c "mkdir -p /tmp/go-lint-cache; echo /tmp/go-lint-cache"):/root/.cache/golangci-lint \
   -v $$(pwd):/build lnd-tools
 

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,19 +1,20 @@
-FROM golang:1.24.6
+FROM golang:1.24.6-alpine
 
-RUN apt-get update && apt-get install -y git
-ENV GOCACHE=/tmp/build/.cache
-ENV GOMODCACHE=/tmp/build/.modcache
+ENV GOFLAGS="-buildvcs=false"
 
-COPY . /tmp/tools
+RUN apk update && apk add --no-cache git
 
-RUN cd /tmp \
-  && mkdir -p /tmp/build/.cache \
-  && mkdir -p /tmp/build/.modcache \
-  && cd /tmp/tools \
-  && CGO_ENABLED=0 go install -trimpath github.com/golangci/golangci-lint/cmd/golangci-lint \
+WORKDIR /tmp/tools
+
+COPY . ./
+
+RUN CGO_ENABLED=0 go install -trimpath github.com/golangci/golangci-lint/cmd/golangci-lint \
   && CGO_ENABLED=0 golangci-lint custom \
   && mv ./custom-gcl /usr/local/bin/custom-gcl \
-  && chmod -R 777 /tmp/build/ \
-  && git config --global --add safe.directory /build
+  && git config --global --add safe.directory /build \
+  && rm -rf /go/pkg/mod \
+  && rm -rf /root/.cache/go-build \
+  && rm -rf /var/cache/apk/* \
+  && rm -rf /tmp/*
 
 WORKDIR /build


### PR DESCRIPTION
## Change Description
Description of change / link to associated issue.

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
