### PR TITLE
autopilot: fix nil map assignment

### DIFF
--- a/autopilot/agent.go
+++ b/autopilot/agent.go
@@ -644,8 +644,8 @@ func (a *Agent) openChans(ctx context.Context, availableFunds btcutil.Amount,
 		nodes[nID] = struct{}{}
 		return nil
 	}, func() {
-		nodes = nil
-		addresses = nil
+		clear(nodes)
+		clear(addresses)
 	}); err != nil {
 		return fmt.Errorf("unable to get graph nodes: %w", err)
 	}

--- a/discovery/bootstrapper.go
+++ b/discovery/bootstrapper.go
@@ -249,7 +249,7 @@ func (c *ChannelGraphBootstrapper) SampleNodeAddrs(_ context.Context,
 
 			return errFound
 		}, func() {
-			a = nil
+			clear(a)
 		})
 		if err != nil && !errors.Is(err, errFound) {
 			return nil, err

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -7284,7 +7284,7 @@ func (r *rpcServer) GetNetworkInfo(ctx context.Context,
 		totalNetworkCapacity = 0
 		minChannelSize = math.MaxInt64
 		maxChannelSize = 0
-		allChans = nil
+		clear(allChans)
 		clear(seenChans)
 	})
 	if err != nil {


### PR DESCRIPTION
Use the `clear` call to reset a map on `reset` instead of assigning nil to the entry.

Fixes #10226 