### PR TITLE
lnd: fix externalip retention issue

### DIFF
--- a/config.go
+++ b/config.go
@@ -339,7 +339,7 @@ type Config struct {
 	RawRPCListeners   []string `long:"rpclisten" description:"Add an interface/port/socket to listen for RPC connections"`
 	RawRESTListeners  []string `long:"restlisten" description:"Add an interface/port/socket to listen for REST connections"`
 	RawListeners      []string `long:"listen" description:"Add an interface/port to listen for peer connections"`
-	RawExternalIPs    []string `long:"externalip" description:"Add an ip:port to the list of local addresses we claim to listen on to peers. If a port is not specified, the default (9735) will be used regardless of other parameters"`
+	RawExternalIPs    []string `long:"externalip" description:"Add an ip:port (local addresses we listen on) to advertise to the network (default port 9735 is used if port is not specified). Note: Removing this option does not clear previously advertised addresses; remove them with 'lncli peers updatenodeannouncement --address_remove=host:port'."`
 	ExternalHosts     []string `long:"externalhosts" description:"Add a hostname:port that should be periodically resolved to announce IPs for. If a port is not specified, the default (9735) will be used."`
 	RPCListeners      []net.Addr
 	RESTListeners     []net.Addr

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -212,6 +212,14 @@
 ; advertise your node, this value doesn't need to be set. Unless specified
 ; (with host:port notation), the default port (9735) will be added to the
 ; address.
+;
+; NOTE: If you previously set one or more `externalip` entries and later
+; remove `externalip` entirely from the config, lnd will continue to advertise
+; the last known addresses from the previous run (they are stored with your node
+; information). To stop advertising them, remove those addresses explicitly
+; using the peers RPC/CLI, for example:
+;   `lncli peers updatenodeannouncement --address_remove=1.2.3.4:9735`
+; A restart is not required, a new node announcement will be broadcasted.
 ; externalip=
 ;
 ; Instead of explicitly stating your external IP address, you can also enable
@@ -553,13 +561,19 @@
 
 ; The alias your node will use, which can be up to 32 UTF-8 characters in
 ; length.
-; Default:
+; Default is the first 10-bytes of the node's pubkey. 
+; 
+; NOTE: If this is not set lnd will use the last known alias from the previous
+; run.
 ;   alias=
 ; Example:
 ;   alias=My Lightning ☇
 
 ; The color of the node in hex format, used to customize node appearance in
 ; intelligence services.
+;
+; NOTE: If this is not set or is set to the default (#3399FF) lnd will use the 
+; last known color from the previous run.
 ; color=#3399FF
 
 ; The maximum duration that the server will wait before timing out reading

--- a/server.go
+++ b/server.go
@@ -5559,15 +5559,6 @@ func (s *server) setSelfNode(ctx context.Context, nodePub route.Vertex,
 		return fmt.Errorf("unable to normalize addresses: %w", err)
 	}
 
-	// To avoid having duplicate addresses, we'll only add addresses from
-	// the source node that are not already in our address list yet. We
-	// create this map for quick lookup.
-	addressMap := make(map[string]struct{}, len(addrs))
-	// Populate the map with the existing addresses.
-	for _, existingAddr := range addrs {
-		addressMap[existingAddr.String()] = struct{}{}
-	}
-
 	// Parse the color from config. We will update this later if the config
 	// color is not changed from default (#3399FF) and we have a value in
 	// the source node.
@@ -5602,15 +5593,6 @@ func (s *server) setSelfNode(ctx context.Context, nodePub route.Vertex,
 		// source node's alias.
 		if alias == "" {
 			alias = srcNode.Alias
-		}
-
-		// Append unique addresses from the source node to the address
-		// list.
-		for _, addr := range srcNode.Addresses {
-			if _, found := addressMap[addr.String()]; !found {
-				addrs = append(addrs, addr)
-				addressMap[addr.String()] = struct{}{}
-			}
 		}
 
 	case errors.Is(err, graphdb.ErrSourceNodeNotSet):

--- a/server.go
+++ b/server.go
@@ -5595,6 +5595,12 @@ func (s *server) setSelfNode(ctx context.Context, nodePub route.Vertex,
 			alias = srcNode.Alias
 		}
 
+		// If the `externalip` is not specified in the config, it means
+		// `addrs` will be empty, we'll use the source node's addresses.
+		if len(s.cfg.ExternalIPs) == 0 {
+			addrs = srcNode.Addresses
+		}
+
 	case errors.Is(err, graphdb.ErrSourceNodeNotSet):
 		// If an alias is not specified in the config, we'll use the
 		// default, which is the first 10 bytes of the serialized


### PR DESCRIPTION
Fixes #10233

Currently, when a node restarts, persisted addresses are combined with addresses (externalip) set in config, resulting in the retention of addresses that may no longer be valid, in the node announcement. In this PR, we make addresses derived from `--externalip` config take precedence over persisted addresses. However, if `--externalip` is not set and a node restarts, we assume that the persisted addresses are still valid, and therefore we use them for the node announcement.

## Steps to Test
```bash
make build-itest

make itest-only icase="self node announcement persistence"
```


