### PR TITLE
Add NodeAnnouncment Cache to the Gossiper

### DIFF
--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -295,6 +295,25 @@ func (c *ChannelGraph) AddNode(ctx context.Context,
 	return nil
 }
 
+// SetSourceNode sets the source node in the graph database and also adds it
+// to the graph cache.
+func (c *ChannelGraph) SetSourceNode(ctx context.Context,
+	node *models.Node) error {
+
+	err := c.V1Store.SetSourceNode(ctx, node)
+	if err != nil {
+		return err
+	}
+
+	if c.graphCache != nil {
+		c.graphCache.AddNodeFeatures(
+			node.PubKeyBytes, node.Features,
+		)
+	}
+
+	return nil
+}
+
 // DeleteNode starts a new database transaction to remove a vertex/node
 // from the database according to the node's public key.
 func (c *ChannelGraph) DeleteNode(ctx context.Context,

--- a/lncfg/protocol_legacy_on.go
+++ b/lncfg/protocol_legacy_on.go
@@ -12,6 +12,10 @@ type LegacyProtocol struct {
 	// LegacyOnionFormat if set to true, then we won't signal
 	// TLVOnionPayloadOptional. As a result, nodes that include us in the
 	// route won't use the new modern onion framing.
+	//
+	// NOTE: LND will still be able to decode tlv onion payloads if they
+	// reach us because the decoder supports both formats althoug we
+	// explicitly gossip that we don't support it via this config.
 	LegacyOnionFormat bool `long:"onion" description:"force node to not advertise the new modern TLV onion format"`
 
 	// CommitmentTweak guards if we should use the old legacy commitment


### PR DESCRIPTION
While this PR started to enforce the tlv onion, we decided against the enforcement of assumed feature bits. During the implementation however I encountered some flaky tests where we would not add the node currently in our graph because we would receive the node announcement before the channel announcement which would lead us to drop the node announcement message. Now we precache them similar to channel update messages and replay them as soon as a new channel announcement is received. The cache is a LRU storage which makes sure we limit its capacity to prevent OOM attacks.