### PR TITLE
Make verifyAttempt more robust

### DIFF
--- a/payments/db/errors.go
+++ b/payments/db/errors.go
@@ -78,6 +78,12 @@ var (
 	ErrBlindedPaymentTotalAmountMismatch = errors.New("blinded path " +
 		"total amount mismatch")
 
+	// ErrMixedBlindedAndNonBlindedPayments is returned if we try to
+	// register a non-blinded attempt to a payment which uses a blinded
+	// paths or vice versa.
+	ErrMixedBlindedAndNonBlindedPayments = errors.New("mixed blinded and " +
+		"non-blinded payments")
+
 	// ErrMPPPaymentAddrMismatch is returned if we try to register an MPP
 	// shard where the payment address doesn't match existing shards.
 	ErrMPPPaymentAddrMismatch = errors.New("payment address mismatch")

--- a/payments/db/payment.go
+++ b/payments/db/payment.go
@@ -754,11 +754,19 @@ func verifyAttempt(payment *MPPayment, attempt *HTLCAttemptInfo) error {
 
 	for _, h := range payment.InFlightHTLCs() {
 		hMpp := h.Route.FinalHop().MPP
+		hBlinded := len(h.Route.FinalHop().EncryptedData) != 0
 
 		// If this is a blinded payment, then no existing HTLCs
 		// should have MPP records.
 		if isBlinded && hMpp != nil {
 			return ErrMPPRecordInBlindedPayment
+		}
+
+		// If the payment is blinded (previous attempts used blinded
+		// paths) and the attempt is not, or vice versa, return an
+		// error.
+		if isBlinded != hBlinded {
+			return ErrMixedBlindedAndNonBlindedPayments
 		}
 
 		// If this is a blinded payment, then we just need to


### PR DESCRIPTION
We now return an error when blinded and non blinded attempts are
combined. This was theoretically possible to register a legacy
attempt in combination with a blinded payment. This would have
been prevented by other checks in the code because legacy payments
are not split into shards.

resulted from https://github.com/lightningnetwork/lnd/pull/9147#discussion_r2306608118
