### PR TITLE
release.sh: make sure GNU gzip is used

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -22,6 +22,7 @@ BUILD_DATE_STAMP="202001010000.00"
 function reproducible_tar_gzip() {
   local dir=$1
   local tar_cmd=tar
+  local gzip_cmd=gzip
 
   # MacOS has a version of BSD tar which doesn't support setting the --mtime
   # flag. We need gnu-tar, or gtar for short to be installed for this script to
@@ -36,6 +37,20 @@ function reproducible_tar_gzip() {
 
     # We have gtar installed, use that instead.
     tar_cmd=gtar
+  fi
+
+  # On MacOS, the default BSD gzip produces a different output than the GNU
+  # gzip on Linux. To ensure reproducible builds, we need to use GNU gzip.
+  gzip_version=$(gzip --version 2>&1 || true)
+  if [[ ! "$gzip_version" =~ "GNU" ]]; then
+    if ! command -v "ggzip" >/dev/null 2>&1; then
+      echo "GNU gzip is required but cannot be found!"
+      echo "On MacOS please run 'brew install gzip' to install ggzip."
+      exit 1
+    fi
+
+    # We have ggzip installed, use that instead.
+    gzip_cmd=ggzip
   fi
 
   # Pin down the timestamp time zone.


### PR DESCRIPTION
## Change Description

On macOS, the default BSD `gzip` produces different output than the GNU `gzip` used on Linux. To ensure reproducible builds, we need to enforce the use of GNU `gzip`.

This is similar to what we already do for GNU `tar`.

While working on [reproducible builds for Loop](https://github.com/lightninglabs/loop/pull/1007), I encountered this `gzip` issue and fixed it there. This PR applies the same fix to LND.

## Steps to Test

Clone my branch into a fresh Git repository to ensure the state is clean and tagged with `v0.0.0-test`. Build it and compare the resulting hashes against the ones listed below:

```
$ git clone https://github.com/starius/lnd -b release-gnu-gzip
$ cd lnd
$ SKIP_VERSION_CHECK=1 make release sys="linux-arm64" tag=v0.0.0-test
68896c0eb8fd034332d0a25eca66abfe0176457f38a5f22f0a19100e85d2ae1a  lnd-linux-arm64-v0.0.0-test.tar.gz
ea79c6f620b15abfa65a2f6daf95a74cc1d29cd8197e34b454fadcf08905ab21  lnd-linux-arm64-v0.0.0-test/lncli
7174fe5ba06fdc97d23405c2e5872f3ceb0652d83a345c106bafe31f76cc7cda  lnd-linux-arm64-v0.0.0-test/lnd
23bd143ac945b4db6c292e11781dbada0796cd12c13479a3fe9bf005557f9764  lnd-source-v0.0.0-test.tar.gz
3a914dc298f1441a3432118b8674908def8e52f87092863d14a227e0f5f9d80d  vendor.tar.gz
```

If you are on macOS, this verification is especially valuable, since this PR fixes reproducibility issues caused by BSD `gzip` compression on macOS.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
