### PR TITLE
fix channel disable/enable race condition

### DIFF
--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -46,6 +46,13 @@
   sweeper where some outputs would not be resolved due to an error string
   mismatch.
 
+- [Fixed](https://github.com/lightningnetwork/lnd/pull/10277) a case in the
+  status manager where we would have disabled a channel although it was already
+  active in the switch. When a channel reconnects it starts a timer which might
+  only trigger after the disable timer has already been triggered, so we had a
+  race condition where we would unnecessarily mark a channel as disabled
+  although it was active in the first place.
+
 # New Features
  
 * Use persisted [nodeannouncement](https://github.com/lightningnetwork/lnd/pull/8825) 


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/10259


The problem:

Timeline: Channel Disconnection and Reconnection Race Condition
```
Timeline: 0ms ────── 100ms ────── 800ms ────── 1100ms ────── 1300ms
          │          │           │            │             │
Channel:  [INACTIVE] → [PENDING] → [ACTIVE]   → [DISABLED]  → [ENABLED]
          │          │           │            │             │
Events:   Disconnect  Mark       Reconnect    Disable       Enable
          │          Pending     │            │             │
          │          │           │            │             │
          └──────────┼───────────┼────────────┼─────────────┘
                     │           │            │
Disable Timer:       └───────────┼────────────┘
                     (1000ms)    │
                                 │
Enable Timer:                    └────────────┼─────────────┘
                                 (500ms)     │
                                              │
                                              ❌ PROBLEM!


```

```
T=0ms:    Channel disconnects
T=100ms:  Marked as pending disabled → Disable timer starts (1000ms)
T=800ms:  Channel reconnects → Enable timer starts (500ms)
T=1100ms: Disable timer fires → Channel gets DISABLED ❌ although it is active
T=1300ms: Enable timer fires → Channel gets ENABLED
```

The timing here are examples and configurable in LND, the defaults are

20min for disableTimer
19 for enableTimer
