### PR TITLE
Routing: reduce impact of second chance

### DIFF
--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -153,6 +153,12 @@
   for the adversary model, the layers, the defaults, and operator
   recipes.
 
+- The second chance mechanism of the pathfinder was adjusted to apply a
+significant penalty to the route instead of immediately retrying it. This means
+that if a failure carries a fee policy update we'll still take it into account
+but will retry that route with a lower priority. See more in the
+[PR](https://github.com/lightningnetwork/lnd/pull/10278).
+
 ## RPC Additions
 
 * [Added `DeleteForwardingHistory`

--- a/routing/missioncontrol.go
+++ b/routing/missioncontrol.go
@@ -240,6 +240,12 @@ type TimedPairResult struct {
 	// success amount. Because of this, SuccessAmt may not match
 	// SuccessTime.
 	SuccessAmt lnwire.MilliSatoshi
+
+	// HalfPenalty indicates whether the recorded failure should be
+	// weighted with half the usual weight in probability calculations.
+	// It is set when a failure is recorded as part of a granted
+	// "second chance" for a policy-update failure.
+	HalfPenalty bool
 }
 
 // MissionControlSnapshot contains a snapshot of the current state of mission
@@ -672,13 +678,29 @@ func (m *MissionControl) applyPaymentResult(
 	// Interpret result.
 	i := interpretResult(&result.route.Val, result.failure.ValOpt())
 
-	if i.policyFailure != nil {
-		if m.state.requestSecondChance(
-			time.Unix(0, int64(result.timeReply.Val)),
-			i.policyFailure.From, i.policyFailure.To,
-		) {
-			return nil
-		}
+	ts := time.Unix(0, int64(result.timeReply.Val))
+
+	// If the failure carries a policy update for a specific hop and we
+	// haven't recently granted a second chance for that pair, record a
+	// half-weight penalty against the offending pair only and return.
+	// Unlike a full failure, we don't penalize sibling channels of the
+	// reporting node and don't fail the pair in reverse, since the
+	// updated policy applies only to the direction we just tried.
+	if i.policyFailure != nil && m.state.requestSecondChance(
+		ts, i.policyFailure.From, i.policyFailure.To,
+	) {
+
+		m.log.Debugf("Reporting half-penalty failure to Mission "+
+			"Control: pair=%v", *i.policyFailure)
+
+		halfResult := failPairResult(0)
+		halfResult.halfPenalty = true
+		m.state.setLastPairResult(
+			i.policyFailure.From, i.policyFailure.To, ts,
+			&halfResult, false,
+		)
+
+		return i.finalFailureReason
 	}
 
 	// If there is a node-level failure, record a failure for every tried
@@ -702,10 +724,7 @@ func (m *MissionControl) applyPaymentResult(
 		m.log.Debugf("Reporting node failure to Mission Control: "+
 			"node=%v", *i.nodeFailure)
 
-		m.state.setAllFail(
-			*i.nodeFailure,
-			time.Unix(0, int64(result.timeReply.Val)),
-		)
+		m.state.setAllFail(*i.nodeFailure, ts)
 	}
 
 	for pair, pairResult := range i.pairResults {
@@ -722,9 +741,7 @@ func (m *MissionControl) applyPaymentResult(
 		}
 
 		m.state.setLastPairResult(
-			pair.From, pair.To,
-			time.Unix(0, int64(result.timeReply.Val)), &pairResult,
-			false,
+			pair.From, pair.To, ts, &pairResult, false,
 		)
 	}
 

--- a/routing/missioncontrol_state.go
+++ b/routing/missioncontrol_state.go
@@ -114,8 +114,23 @@ func (m *missionControlState) setLastPairResult(fromNode, toNode route.Vertex,
 			return
 		}
 
+		// Don't let a half-penalty failure overwrite an existing
+		// full-penalty failure. Without this guard, a peer could
+		// follow a real failure with a policy-update failure to
+		// soften its own recorded penalty.
+		if !force && result.halfPenalty && !current.HalfPenalty &&
+			!current.FailTime.IsZero() {
+
+			log.Debugf("Ignoring half-penalty failure: pair has "+
+				"an existing full-penalty failure recorded "+
+				"at %v", current.FailTime)
+
+			return
+		}
+
 		current.FailTime = timestamp
 		current.FailAmt = failAmt
+		current.HalfPenalty = result.halfPenalty
 
 		switch {
 		// The failure amount is set to zero when the failure is
@@ -233,6 +248,7 @@ func (m *missionControlState) importSnapshot(snapshot *MissionControlSnapshot,
 		lastResult := results[toNode]
 
 		failResult := failPairResult(pair.FailAmt)
+		failResult.halfPenalty = pair.HalfPenalty
 		imported += m.importResult(
 			lastResult.FailTime, pair.FailTime, failResult,
 			fromNode, toNode, force,

--- a/routing/missioncontrol_test.go
+++ b/routing/missioncontrol_test.go
@@ -228,19 +228,28 @@ func TestMissionControl(t *testing.T) {
 }
 
 // TestMissionControlChannelUpdate tests that the first channel update is not
-// penalizing the channel yet.
+// fully penalizing the channel. Instead we should see a half penalty being
+// applied to the probability, scoped only to the offending pair.
 func TestMissionControlChannelUpdate(t *testing.T) {
 	ctx := createMcTestContext(t)
 
-	// Report a policy related failure. Because it is the first, we don't
-	// expect a penalty.
+	// Report a policy related failure. As this is the first time we see a
+	// channel update for this pair, mission control grants a second chance
+	// and records a half-penalty failure on the offending pair only.
 	ctx.reportFailure(
 		0, lnwire.NewFeeInsufficient(0, lnwire.ChannelUpdate1{}),
 	)
-	ctx.expectP(100, testAprioriHopProbability)
 
-	// Report another failure for the same channel. We expect it to be
-	// pruned.
+	// Because the half penalty is scoped to this pair, the node-level
+	// probability for node1 is unaffected (no other entries exist), so
+	// it equals the a priori hop probability. The pair-specific weight is
+	// halved (fresh half-penalty), which yields a probability of
+	// nodeProbability * (1 - 0.5) = testAprioriHopProbability * 0.5.
+	ctx.expectP(100, testAprioriHopProbability*0.5)
+
+	// Report another failure for the same channel. The second chance is
+	// not granted again within the second-chance interval, so this falls
+	// back to the normal full-penalty path and the channel is pruned.
 	ctx.reportFailure(
 		0, lnwire.NewFeeInsufficient(0, lnwire.ChannelUpdate1{}),
 	)

--- a/routing/probability_apriori.go
+++ b/routing/probability_apriori.go
@@ -236,6 +236,13 @@ func (p *AprioriEstimator) getNodeProbability(now time.Time,
 			totalWeight++
 			probabilitiesTotal += p.prevSuccessProbability
 
+		// A half-penalty failure expresses a soft, pair-specific
+		// "second chance" penalty. It isn't meant to penalize sibling
+		// channels of the same node, so we leave the node-level
+		// weighting untouched and only apply the penalty in the
+		// pair-specific calculation below.
+		case result.HalfPenalty:
+
 		// Weigh failures in accordance with their age. The base
 		// probability of a failure is considered zero, so nothing needs
 		// to be added to probabilitiesTotal.
@@ -371,6 +378,15 @@ func (p *AprioriEstimator) calculateProbability(
 	// probability 0. Over time the probability recovers to the node
 	// probability. It would be as if this channel was never tried before.
 	weight := p.getWeight(timeSinceLastFailure)
+
+	// A half-penalty failure represents a softer "second chance" penalty,
+	// so we halve its weight contribution. A fresh half-penalty therefore
+	// halves the node probability instead of zeroing it out, and the
+	// recovery follows the same exponential decay.
+	if lastPairResult.HalfPenalty {
+		weight *= 0.5
+	}
+
 	probability := nodeProbability * (1 - weight)
 
 	return probability

--- a/routing/probability_bimodal.go
+++ b/routing/probability_bimodal.go
@@ -185,7 +185,15 @@ func (p *BimodalEstimator) LocalPairProbability(now time.Time,
 			timeAgo = 0
 		}
 		exponent := -float64(timeAgo) / float64(p.BimodalDecayTime)
-		directProbability -= math.Exp(exponent)
+		penalty := math.Exp(exponent)
+
+		// A half-penalty failure expresses a softer "second chance"
+		// style penalty, so we apply half the usual reduction.
+		if result.HalfPenalty {
+			penalty *= 0.5
+		}
+
+		directProbability -= penalty
 	}
 
 	return directProbability
@@ -212,7 +220,7 @@ func (p *BimodalEstimator) directProbability(now time.Time,
 		if !result.FailTime.IsZero() {
 			failAmount = cannotSend(
 				result.FailAmt, capacity, now, result.FailTime,
-				p.BimodalDecayTime,
+				p.BimodalDecayTime, result.HalfPenalty,
 			)
 		}
 
@@ -362,7 +370,10 @@ func (p *BimodalEstimator) calculateProbability(directProbability float64,
 			totalProbabilities += w * weight
 			totalWeights += w * weight
 		}
-		if result.FailAmt > 0 {
+
+		// A half-penalty failure is a soft, pair-specific second-chance
+		// penalty and isn't applied to sibling channels of the node.
+		if result.FailAmt > 0 && !result.HalfPenalty {
 			exponent := -float64(now.Sub(result.FailTime)) / dt
 			weight = math.Exp(exponent)
 
@@ -393,9 +404,11 @@ func canSend(successAmount lnwire.MilliSatoshi, now, successTime time.Time,
 
 // cannotSend returns the not sendable amount over the channel, respecting time
 // decay. cannotSend approaches the capacity, if we wait for a much longer time
-// than the decay time.
+// than the decay time. When halfPenalty is true, the failure is treated as a
+// softer second-chance penalty and its effect is halved.
 func cannotSend(failAmount, capacity lnwire.MilliSatoshi, now,
-	failTime time.Time, decayConstant time.Duration) lnwire.MilliSatoshi {
+	failTime time.Time, decayConstant time.Duration,
+	halfPenalty bool) lnwire.MilliSatoshi {
 
 	if failAmount > capacity {
 		failAmount = capacity
@@ -406,6 +419,10 @@ func cannotSend(failAmount, capacity lnwire.MilliSatoshi, now,
 	factor := math.Exp(
 		-float64(now.Sub(failTime)) / float64(decayConstant),
 	)
+
+	if halfPenalty {
+		factor *= 0.5
+	}
 
 	cannotSend := capacity - lnwire.MilliSatoshi(
 		factor*float64(capacity-failAmount),

--- a/routing/probability_bimodal_test.go
+++ b/routing/probability_bimodal_test.go
@@ -428,7 +428,7 @@ func TestCannotSend(t *testing.T) {
 
 	// Test immediate retry.
 	require.EqualValues(t, failAmount, cannotSend(
-		failAmount, capacity, failTime, failTime, decayTime,
+		failAmount, capacity, failTime, failTime, decayTime, false,
 	))
 
 	// After the decay time we want to be between the fail amount and
@@ -436,12 +436,12 @@ func TestCannotSend(t *testing.T) {
 	summand := lnwire.MilliSatoshi(float64(capacity-failAmount) / math.E)
 	expected := capacity - summand
 	require.Equal(t, expected, cannotSend(
-		failAmount, capacity, now, failTime, decayTime,
+		failAmount, capacity, now, failTime, decayTime, false,
 	))
 
 	// After a long time, we want the amount to approach the capacity.
 	require.Equal(t, capacity, cannotSend(
-		failAmount, capacity, infinity, failTime, decayTime,
+		failAmount, capacity, infinity, failTime, decayTime, false,
 	))
 }
 

--- a/routing/result_interpretation.go
+++ b/routing/result_interpretation.go
@@ -28,6 +28,12 @@ type pairResult struct {
 	// success indicates whether the payment attempt was successful through
 	// this pair.
 	success bool
+
+	// halfPenalty indicates that the recorded failure should be applied
+	// with half the normal weight. It is used to express a softer
+	// "second-chance" style penalty: we want to discourage immediate
+	// retries over the same pair, but not as severely as a hard failure.
+	halfPenalty bool
 }
 
 // failPairResult creates a new result struct for a failure.

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -792,6 +792,133 @@ func TestSendPaymentErrorFeeInsufficientPrivateEdge(t *testing.T) {
 	)
 }
 
+// TestSendPaymentErrorFeeInsufficientSecondChance tests that the half-penalty
+// behavior of the second chance logic is properly applied when receiving
+// errors that contain channel updates. We expose the path where the second
+// chance penalty along with the fee update are sufficient for a different route
+// to be picked.
+func TestSendPaymentErrorFeeInsufficientSecondChance(t *testing.T) {
+	t.Parallel()
+
+	const startingBlockHeight = 101
+	ctx := createTestCtxFromFile(t, startingBlockHeight, basicGraphFilePath)
+
+	// Get the channel ID for the first hop of the route that will retrieve
+	// the second chance.
+	roasbeefSongoku := lnwire.NewShortChanIDFromInt(
+		ctx.getChannelIDFromAlias(t, "roasbeef", "songoku"),
+	)
+
+	var (
+		preImage    [32]byte
+		amt         = lnwire.NewMSatFromSatoshis(1000)
+		expiryDelta = uint16(32)
+	)
+
+	// Craft a LightningPayment struct that'll send a payment from roasbeef
+	// to elst. Initially a path via songoku will be picked as it's the one
+	// with significantly lower fees.
+	payment := createDummyLightningPayment(
+		t, ctx.aliases["elst"], amt,
+	)
+
+	// Grab the chan ID that we'll apply the channel update on.
+	chanID := ctx.getChannelIDFromAlias(t, "songoku", "sophon")
+
+	// Grab the chan ID of the expensive channel. We'll use this channel's
+	// policy as a reference to what will be provided in the other channel's
+	// update.
+	expChanID := ctx.getChannelIDFromAlias(t, "roasbeef", "phamnuwen")
+	_, expPolicy, _, err := ctx.graph.FetchChannelEdgesByID(
+		t.Context(), expChanID,
+	)
+	require.NoError(t, err)
+
+	// Prepare an error update for the channel where the fees are updated
+	// to be close to the alternative (more expensive) route. We subtract
+	// a small fee delta so the updated route is, on fee alone, still
+	// marginally cheaper. The second-chance half-penalty on the offending
+	// pair is what flips the choice to the alternative route.
+	feeDelta := uint32(50)
+	newFeeBase := uint32(expPolicy.FeeBaseMSat) - feeDelta
+	newFeePpm := uint32(expPolicy.FeeProportionalMillionths) - feeDelta
+
+	errChanUpdate := lnwire.ChannelUpdate1{
+		ShortChannelID: lnwire.NewShortChanIDFromInt(chanID),
+		Timestamp:      uint32(testTime.Add(time.Minute).Unix()),
+		BaseFee:        newFeeBase,
+		FeeRate:        newFeePpm,
+		TimeLockDelta:  expiryDelta,
+	}
+	signErrChanUpdate(t, ctx.privKeys["songoku"], &errChanUpdate)
+
+	// We'll now modify the SendHTLC method to return an error for the
+	// songoku->sophon channel.
+	errorReturned := false
+	copy(preImage[:], bytes.Repeat([]byte{9}, 32))
+
+	dispatch, ok := ctx.router.cfg.Payer.(*mockPaymentAttemptDispatcherOld)
+	require.True(t, ok)
+
+	dispatch.setPaymentResult(
+		func(firstHop lnwire.ShortChannelID) ([32]byte, error) {
+			if firstHop != roasbeefSongoku || errorReturned {
+				return preImage, nil
+			}
+
+			errorReturned = true
+
+			return [32]byte{}, htlcswitch.NewForwardingError(
+				// Within our error, we'll add a
+				// channel update which is meant to
+				// reflect the new fee schedule for the
+				// node/channel.
+				&lnwire.FailFeeInsufficient{
+					Update: errChanUpdate,
+				}, 1,
+			)
+		},
+	)
+
+	// Send off the payment request to the router, what's expected to happen
+	// here is:
+	// * attempt 1: roasbeef -> songoku -> sophon -> elst, with an error
+	//	that contains a channel update for songoku->sophon.
+	// * attempt 2: roasbeef -> phamnuwen -> sophon -> elst, with success.
+	paymentPreImage, route, err := ctx.router.SendPayment(
+		t.Context(), payment,
+	)
+	require.NoErrorf(t, err, "unable to send payment: %v",
+		payment.paymentHash)
+
+	require.True(t, errorReturned,
+		"failed to simulate error in the first payment attempt",
+	)
+
+	// The route selected should have three hops. Make sure that,
+	//   path: roasbeef -> pham nuwen -> sophon -> elst
+	// is selected.
+	require.Equal(t, 3, len(route.Hops), "incorrect route length")
+
+	// The preimage should match up with the one created above.
+	require.Equal(t,
+		paymentPreImage[:], preImage[:], "incorrect preimage used",
+	)
+
+	// The route should have pham nuwen as the first hop.
+	require.Equal(t, route.Hops[0].PubKeyBytes, ctx.aliases["phamnuwen"],
+		"route should go through pham nuwen as first hop",
+	)
+
+	expectedFinalHop := ctx.getChannelIDFromAlias(t, "sophon", "elst")
+
+	// The route should pass via the expected final hop.
+	require.Equal(t,
+		expectedFinalHop, route.FinalHop().ChannelID,
+		"route did not pass through expected final hop",
+	)
+}
+
 // TestSendPaymentPrivateEdgeUpdateFeeExceedsLimit tests that upon receiving a
 // ChannelUpdate in a fee related error from the private channel, we won't
 // choose the route in our second attempt if the updated fee exceeds our fee


### PR DESCRIPTION
## Description

This PR changes the impact of granting second chances to payment failures that return a fee policy update. Previously we'd immediately (within a min interval) retry a route if that was the case, but that might not be ideal (see https://github.com/lightningnetwork/lnd/issues/6883 for more info).

Instead we apply a half penalty, which discourages immediate future attempts over the same route. Other routes with greater success probability will be attempted as the penalty is not absolute but still severe. If alternative routes prove ineffective then the same route may be attempted again. It's important to be able to eventually retry the penalized route as it may be the only route available to reach the destination.

Apart from the reasons included in the issue linked above, avoiding immediate route retries is good for privacy, as it is a mitigation against an on-path adversary trying analyze time deltas of HTLCs for the purpose of locating the sender / receiver in the graph.

### Testing

The weight of the penalty is not too harsh in order to allow for previously captured test cases to still pass. A new test was also added which demonstrates how alternative routes can be picked.


#### Refs

Closes https://github.com/lightningnetwork/lnd/issues/6883 (since it addresses all the concerns outlined in that issue)

Replaces https://github.com/lightningnetwork/lnd/pull/6891