### PR TITLE
docs: add French installation guide for LND on Debian/Ubuntu

### DIFF
--- a/docs/fr/installation-debian.md
+++ b/docs/fr/installation-debian.md
@@ -1,0 +1,25 @@
+# Installation de LND sous Debian/Ubuntu (FR)
+
+Ce guide explique comment installer et lancer **LND** (Lightning Network Daemon) sur Debian/Ubuntu.
+
+---
+
+## 1. Prérequis
+- Linux Debian/Ubuntu
+- Go 1.20+
+- Git
+- Accès à un nœud Bitcoin (bitcoind ou btcd)
+
+---
+
+## 2. Installation
+```bash
+# Installer Go si nécessaire
+sudo apt update && sudo apt install golang-go git -y
+
+# Cloner LND
+git clone https://github.com/lightningnetwork/lnd.git
+cd lnd
+
+# Compiler
+make && make install


### PR DESCRIPTION
Summary

Added a French installation guide for LND on Debian/Ubuntu.

Changes

Created docs/fr/installation-debian.md

Covered prerequisites (Go, Git, Bitcoin node)

Installation steps on Debian/Ubuntu

Basic run command and version check

Notes

Documentation only, no code changes

Goal: help French-speaking developers install and use LND more easily