### PR TITLE
build: update CI+release version to Go 1.25.2

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -50,10 +50,10 @@ runs:
           ~\AppData\Local\go-build
 
         # The key is used to create and later look up the cache. It's made of
-        # four parts:  
+        # four parts:
         # - The base part is made from the OS name, Go version and a
-        #   job-specified key prefix. Example: `linux-go-1.24.6-unit-test-`.
-        #   It ensures that a job running on Linux with Go 1.24 only looks for
+        #   job-specified key prefix. Example: `linux-go-1.25.2-unit-test-`.
+        #   It ensures that a job running on Linux with Go 1.25 only looks for
         #   caches from the same environment.
         # - The unique part is the `hashFiles('**/go.sum')`, which calculates a
         #   hash (a fingerprint) of the go.sum file. 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ env:
 
   # If you change this please also update GO_VERSION in Makefile (then run
   # `make lint` to see where else it needs to be updated as well).
-  GO_VERSION: 1.24.6
+  GO_VERSION: 1.25.2
 
 jobs:
   static-checks:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ defaults:
 env:
   # If you change this please also update GO_VERSION in Makefile (then run
   # `make lint` to see where else it needs to be updated as well).
-  GO_VERSION: 1.24.6
+  GO_VERSION: 1.25.2
 
 jobs:
   ########################

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 run:
   # If you change this please also update GO_VERSION in Makefile (then run
   # `make lint` to see where else it needs to be updated as well).
-  go: "1.24.6"
+  go: "1.25.2"
 
   # Abort after 10 minutes.
   timeout: 10m

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # If you change this please also update GO_VERSION in Makefile (then run
 # `make lint` to see where else it needs to be updated as well).
-FROM golang:1.24.6-alpine as builder
+FROM golang:1.25.2-alpine as builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ACTIVE_GO_VERSION_MINOR := $(shell echo $(ACTIVE_GO_VERSION) | cut -d. -f2)
 # GO_VERSION is the Go version used for the release build, docker files, and
 # GitHub Actions. This is the reference version for the project. All other Go
 # versions are checked against this version.
-GO_VERSION = 1.24.6
+GO_VERSION = 1.25.2
 
 GOBUILD := $(GOCC) build -v
 GOINSTALL := $(GOCC) install -v

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,6 +1,6 @@
 # If you change this please also update GO_VERSION in Makefile (then run
 # `make lint` to see where else it needs to be updated as well).
-FROM golang:1.24.6-alpine AS builder
+FROM golang:1.25.2-alpine AS builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 

--- a/docker/btcd/Dockerfile
+++ b/docker/btcd/Dockerfile
@@ -1,6 +1,6 @@
 # If you change this please also update GO_VERSION in Makefile (then run
 # `make lint` to see where else it needs to be updated as well).
-FROM golang:1.24.6-alpine as builder
+FROM golang:1.25.2-alpine as builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -93,7 +93,7 @@ following build dependencies are required:
 
 ### Installing Go
 
-`lnd` is written in Go, with a minimum version of `1.24.6` (or, in case this
+`lnd` is written in Go, with a minimum version of `1.24.8` (or, in case this
 document gets out of date, whatever the Go version in the main `go.mod` file
 requires). To install, run one of the following commands for your OS:
 
@@ -101,16 +101,15 @@ requires). To install, run one of the following commands for your OS:
   <summary>Linux (x86-64)</summary>
 
   ```
-  wget https://dl.google.com/go/go1.24.6.linux-amd64.tar.gz
-  sha256sum go1.24.6.linux-amd64.tar.gz | awk -F " " '{ print $1 }'
+  wget https://dl.google.com/go/go1.24.8.linux-amd64.tar.gz
+  echo "6842c516ca66c89d648a7f1dbe28e28c47b61b59f8f06633eb2ceb1188e9251d  go1.24.8.linux-amd64.tar.gz" | sha256sum --check
   ```
 
-  The final output of the command above should be
-  `bbca37cc395c974ffa4893ee35819ad23ebb27426df87af92e93a9ec66ef8712`. If it
-  isn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
+  The command above should output `go1.24.8.linux-amd64.tar.gz: OK`. If it
+  doesn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
   this version of Go. If it matches, then proceed to install Go:
   ```
-  sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.24.6.linux-amd64.tar.gz
+  sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.24.8.linux-amd64.tar.gz
   export PATH=$PATH:/usr/local/go/bin
   ```
 </details>
@@ -119,16 +118,15 @@ requires). To install, run one of the following commands for your OS:
   <summary>Linux (ARMv6)</summary>
 
   ```
-  wget https://dl.google.com/go/go1.24.6.linux-armv6l.tar.gz
-  sha256sum go1.24.6.linux-armv6l.tar.gz | awk -F " " '{ print $1 }'
+  wget https://dl.google.com/go/go1.24.8.linux-armv6l.tar.gz
+  echo "3ed8537300ab22449885a43d2931336a571df72c5433d2db4377fe7e2d5e83db  go1.24.8.linux-armv6l.tar.gz" | sha256sum --check
   ```
 
-  The final output of the command above should be
-  `7feb4d25f5e72f94fda81c99d4adb6630dfa2c35211e0819417d53af6e71809e`. If it
+  The command above should output `go1.24.8.linux-armv6l.tar.gz: OK`. If it
   isn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
   this version of Go. If it matches, then proceed to install Go:
   ```
-  sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.24.6.linux-armv6l.tar.gz
+  sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.24.8.linux-armv6l.tar.gz
   export PATH=$PATH:/usr/local/go/bin
   ```
 

--- a/go.mod
+++ b/go.mod
@@ -216,6 +216,6 @@ replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-d
 // If you change this please also update docs/INSTALL.md and GO_VERSION in
 // Makefile (then run `make lint` to see where else it needs to be updated as
 // well).
-go 1.24.6
+go 1.24.8
 
 retract v0.0.2

--- a/healthcheck/go.mod
+++ b/healthcheck/go.mod
@@ -24,4 +24,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.24.6
+go 1.24.8

--- a/kvdb/go.mod
+++ b/kvdb/go.mod
@@ -147,4 +147,4 @@ replace github.com/ulikunitz/xz => github.com/ulikunitz/xz v0.5.11
 // https://deps.dev/advisory/OSV/GO-2021-0053?from=%2Fgo%2Fgithub.com%252Fgogo%252Fprotobuf%2Fv1.3.1
 replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 
-go 1.24.6
+go 1.24.8

--- a/lnrpc/Dockerfile
+++ b/lnrpc/Dockerfile
@@ -1,6 +1,6 @@
 # If you change this please also update GO_VERSION in Makefile (then run
 # `make lint` to see where else it needs to be updated as well).
-FROM golang:1.24.6-bookworm
+FROM golang:1.25.2-bookworm
 
 RUN apt-get update && apt-get install -y \
   git \

--- a/lnrpc/gen_protos_docker.sh
+++ b/lnrpc/gen_protos_docker.sh
@@ -6,7 +6,7 @@ set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # golang docker image version used in this script.
-GO_IMAGE=docker.io/library/golang:1.24.6-alpine
+GO_IMAGE=docker.io/library/golang:1.25.2-alpine
 
 PROTOBUF_VERSION=$(docker run --rm -v $DIR/../:/lnd -w /lnd $GO_IMAGE \
 	go list -f '{{.Version}}' -m google.golang.org/protobuf)

--- a/make/builder.Dockerfile
+++ b/make/builder.Dockerfile
@@ -1,6 +1,6 @@
 # If you change this please also update GO_VERSION in Makefile (then run
 # `make lint` to see where else it needs to be updated as well).
-FROM golang:1.24.6-bookworm
+FROM golang:1.25.2-bookworm
 
 MAINTAINER Olaoluwa Osuntokun <laolu@lightning.engineering>
 

--- a/sqldb/go.mod
+++ b/sqldb/go.mod
@@ -75,4 +75,4 @@ require (
 	modernc.org/token v1.1.0 // indirect
 )
 
-go 1.24.6
+go 1.24.8

--- a/tlv/go.mod
+++ b/tlv/go.mod
@@ -22,4 +22,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.24.6
+go 1.24.8

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.6
+FROM golang:1.25.2
 
 RUN apt-get update && apt-get install -y git
 ENV GOCACHE=/tmp/build/.cache

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/tools
 
-go 1.24.6
+go 1.24.8
 
 require (
 	github.com/btcsuite/btcd v0.24.2

--- a/tools/linters/go.mod
+++ b/tools/linters/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/tools/linters
 
-go 1.24.6
+go 1.24.8
 
 require (
 	github.com/golangci/plugin-module-register v0.1.1

--- a/tor/go.mod
+++ b/tor/go.mod
@@ -23,4 +23,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.24.6
+go 1.24.8


### PR DESCRIPTION
We also update the go.mod files to pin to Go 1.24.8.

