### PR TITLE
Improve lncli closechannel error messages for mempool fee and channel state (#9155)

### DIFF
--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -1136,7 +1136,7 @@ func mapRpcclientError(err error) error {
 	case errors.Is(err, chain.ErrMempoolMinFeeNotMet),
 		errors.Is(err, chain.ErrMinRelayFeeNotMet):
 
-		return fmt.Errorf("%w: %v", lnwallet.ErrMempoolFee, err.Error())
+		return fmt.Errorf("%w: %v. The cooperative close transaction was created but not accepted into the mempool due to low fees. You may need to use 'lncli wallet bumpfee' to increase the fee and get the transaction confirmed", lnwallet.ErrMempoolFee, err.Error())
 	}
 
 	return err

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -1136,7 +1136,11 @@ func mapRpcclientError(err error) error {
 	case errors.Is(err, chain.ErrMempoolMinFeeNotMet),
 		errors.Is(err, chain.ErrMinRelayFeeNotMet):
 
-		return fmt.Errorf("%w: %v. The cooperative close transaction was created but not accepted into the mempool due to low fees. You may need to use 'lncli wallet bumpfee' to increase the fee and get the transaction confirmed", lnwallet.ErrMempoolFee, err.Error())
+		return fmt.Errorf("%w: %v. The cooperative close transaction " +
+		"was created but not accepted into the mempool due to low " + 
+		"fees. You may need to use 'lncli wallet bumpfee' to increase "+ 
+		"the fee and get the transaction confirmed", 
+		lnwallet.ErrMempoolFee, err.Error())
 	}
 
 	return err

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2849,16 +2849,24 @@ func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 			// RBF variant, then we can actually bypass the switch.
 			// Otherwise, we'll return an error.
 			if !chanHasRbfCloser {
-			rpcsLog.Debugf("Trying to non-force close "+
-				"offline channel with chan_point=%v",
-				chanPoint)
+				rpcsLog.Debugf("Trying to non-force close "+
+					"offline channel with chan_point=%v",
+					chanPoint)
 
-			// Check if the channel is already closed or has a pending close tx.
-				if channel.HasChanStatus(channeldb.ChanStatusCoopBroadcasted) {
-					return fmt.Errorf("channel is already in the process of closing. Check 'lncli pendingchannels' for status. If the close transaction is not confirmed, you may need to use 'lncli wallet bumpfee'")
+				// Check if the channel is already closed or has a pending close tx.
+				if channel.HasChanStatus(
+					channeldb.ChanStatusCoopBroadcasted) {
+					return fmt.Errorf("channel is already " + 
+					"in the process of closing. Check " + 
+					"'lncli pendingchannels' for status. " +
+					"If the close transaction is not " +  
+					"confirmed, you may need to use "  + 
+					"'lncli wallet bumpfee'")
 				}
 
-			return fmt.Errorf("unable to gracefully close channel while peer is offline (try force closing it instead): %v", err)
+				return fmt.Errorf("unable to gracefully close "+
+				"channel while peer is offline " + 
+				"(try force closing it instead): %v", err)
 			}
 		}
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2849,13 +2849,16 @@ func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 			// RBF variant, then we can actually bypass the switch.
 			// Otherwise, we'll return an error.
 			if !chanHasRbfCloser {
-				rpcsLog.Debugf("Trying to non-force close "+
-					"offline channel with chan_point=%v",
-					chanPoint)
+			rpcsLog.Debugf("Trying to non-force close "+
+				"offline channel with chan_point=%v",
+				chanPoint)
 
-				return fmt.Errorf("unable to gracefully close "+
-					"channel while peer is offline (try "+
-					"force closing it instead): %v", err)
+			// Check if the channel is already closed or has a pending close tx.
+				if channel.HasChanStatus(channeldb.ChanStatusCoopBroadcasted) {
+					return fmt.Errorf("channel is already in the process of closing. Check 'lncli pendingchannels' for status. If the close transaction is not confirmed, you may need to use 'lncli wallet bumpfee'")
+				}
+
+			return fmt.Errorf("unable to gracefully close channel while peer is offline (try force closing it instead): %v", err)
 			}
 		}
 


### PR DESCRIPTION
## Change Description
This PR addresses issue #9155 by making error messages for lncli closechannel more actionable and less confusing:

- When the mempool minimum fee is not met, the error now explains that a cooperative close transaction was created but not accepted, and suggests using lncli wallet bumpfee.
- If a channel is already in the process of closing, the error now clearly states this and guides users to check lncli pendingchannels and use bumpfee if needed.
All error strings follow Go style guidelines.


## Steps to Test
- Attempt to close a channel with a low fee and verify the new error message suggests bumpfee.
- Try to close a channel that is already closing and confirm the error directs you to pendingchannels and bumpfee.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
