### PR TITLE
docs: fix build instructions doc url

### DIFF
--- a/docs/signing_release_candidate.md
+++ b/docs/signing_release_candidate.md
@@ -38,7 +38,7 @@ through the aforementioned PR example, they are now able to provide their
 signature for the new release's "Manifest" file. To do so, the developer must
 follow these steps:
 
-* Follow the build instructions at https://github.com/lightningnetwork/lnd/blob/masterdocs/release.md#building-a-new-release.
+* Follow the [build instructions](/docs/release.md#building-a-new-release).
 
 * After a successful build, all binaries and Manifest files, will be placed
 in a directory, named after the tag, created within the directory in which the build occurred. For 


### PR DESCRIPTION
## Change Description
Chore: Fixed a broken link on the release signing doc pointing to the build instructions.