### PR TITLE
[docs] Typo recovery.md

### DIFF
--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -313,7 +313,7 @@ schemes, compared to the file system notification based approach.
 If a node is being created from scratch, then it's possible to pass in an
 existing SCB using the `lncli create` or `lncli unlock` commands:
 ```shell
-$  lncli create -multi_file=channel.backup
+$  lncli create --multi_file=channel.backup
 ```
 
 Alternatively, the `restorechanbackup` command can be used if `lnd` has already


### PR DESCRIPTION
`-multi_file` should be `--multi_file`