### PR TITLE
Gossiper - Bugfix context check

### DIFF
--- a/discovery/syncer.go
+++ b/discovery/syncer.go
@@ -1523,6 +1523,20 @@ func (g *GossipSyncer) ApplyGossipFilter(ctx context.Context,
 		// Continue with the rest of the messages using the same pull
 		// iterator.
 		for {
+			select {
+			case <-ctx.Done():
+				log.Debugf("GossipSyncer(%x): context "+
+					"canceled, exiting", g.cfg.peerPub[:])
+
+				return
+			case <-g.cg.Done():
+				log.Debugf("GossipSyncer(%x): shutting down, "+
+					"exiting", g.cfg.peerPub[:])
+
+				return
+			default:
+			}
+
 			msg, err, ok := next()
 			if !ok {
 				return


### PR DESCRIPTION
We need to be careful when it comes to goroutines which run in a loop, the `channelGraphSyncer` ended up in an endless loop for me a lot of these log lines:

```
2025-10-29 17:07:27.349 [ERR] DISC: Unable to gen chan range query: unable to fetch highest chan ID: context canceled
2025-10-29 17:07:27.349 [DBG] DISC: GossipSyncer(037f66e84e38fc2787d578599dfe1fcb7b71f9de4fb1e453c5ab85c05f5ce8c2e3): state=syncingChans, type=PinnedSync
2025-10-29 17:07:27.349 [ERR] DISC: Unable to gen chan range query: unable to fetch highest chan ID: context canceled
2025-10-29 17:07:27.349 [DBG] DISC: GossipSyncer(037f66e84e38fc2787d578599dfe1fcb7b71f9de4fb1e453c5ab85c05f5ce8c2e3): state=syncingChans, type=PinnedSync
2025-10-29 17:07:27.349 [ERR] DISC: Unable to gen chan range query: unable to fetch highest chan ID: context canceled
2025-10-29 17:07:27.349 [DBG] DISC: GossipSyncer(037f66e84e38fc2787d578599dfe1fcb7b71f9de4fb1e453c5ab85c05f5ce8c2e3): state=syncingChans, type=PinnedSync
2025-10-29 17:07:27.349 [ERR] DISC: Unable to gen chan range query: unable to fetch highest chan ID: context canceled
2025-10-29 17:07:27.349 [DBG] DISC: GossipSyncer(037f66e84e38fc2787d578599dfe1fcb7b71f9de4fb1e453c5ab85c05f5ce8c2e3): state=syncingChans, type=PinnedSync
2025-10-29 17:07:27.349 [ERR] DISC: Unable to gen chan range query: unable to fetch highest chan ID: context canceled
2025-10-29 17:07:27.349 [DBG] DISC: GossipSyncer(037f66e84e38fc2787d578599dfe1fcb7b71f9de4fb1e453c5ab85c05f5ce8c2e3): state=syncingChans, type=PinnedSync
2025-10-29 17:07:27.349 [ERR] DISC: Unable to gen chan range query: unable to fetch highest chan ID: context canceled
2025-10-29 17:07:27.349 [DBG] DISC: GossipSyncer(037f66e84e38fc2787d578599dfe1fcb7b71f9de4fb1e453c5ab85c05f5ce8c2e3): state=syncingChans, type=PinnedSync
2025-10-29 17:07:27.349 [ERR] DISC: Unable to gen chan range query: unable to fetch highest chan ID: context canceled
2025-10-29 17:07:27.349 [DBG] DISC: GossipSyncer(037f66e84e38fc2787d578599dfe1fcb7b71f9de4fb1e453c5ab85c05f5ce8c2e3): state=syncingChans, type=PinnedSync
2025-10-29 17:07:27.349 [ERR] DISC: Unable to gen chan range query: unable to fetch highest chan ID: context canceled
2025-10-29 17:07:27.349 [DBG] DISC: GossipSyncer(037f66e84e38fc2787d578599dfe1fcb7b71f9de4fb1e453c5ab85c05f5ce8c2e3): state=syncingChans, type=PinnedSync
```