### PR TITLE
Don't fail on invalid extra tlv data when decoding a payment

### DIFF
--- a/lnwire/channel_update.go
+++ b/lnwire/channel_update.go
@@ -169,7 +169,7 @@ func (a *ChannelUpdate1) Decode(r io.Reader, _ uint32) error {
 	var inboundFee = a.InboundFee.Zero()
 	typeMap, err := tlvRecords.ExtractRecords(&inboundFee)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %w", ErrParsingExtraTLVBytes, err)
 	}
 
 	val, ok := typeMap[a.InboundFee.TlvType()]

--- a/lnwire/error.go
+++ b/lnwire/error.go
@@ -6,6 +6,13 @@ import (
 	"io"
 )
 
+var (
+	// ErrParsingExtraTLVBytes is returned when we attempt to parse
+	// extra opaque bytes as a TLV stream, but the parsing fails due to
+	// and invalid TLV stream.
+	ErrParsingExtraTLVBytes = fmt.Errorf("error parsing extra TLV bytes")
+)
+
 // FundingError represents a set of errors that can be encountered and sent
 // during the funding workflow.
 type FundingError uint8

--- a/lnwire/onion_error.go
+++ b/lnwire/onion_error.go
@@ -1361,7 +1361,7 @@ func DecodeFailureMessage(r io.Reader, pver uint32) (FailureMessage, error) {
 	case Serializable:
 		if err := f.Decode(r, pver); err != nil {
 			return nil, fmt.Errorf("unable to decode error "+
-				"update (type=%T): %v", failure, err)
+				"update (type=%T): %w", failure, err)
 		}
 	}
 

--- a/payments/db/kv_store.go
+++ b/payments/db/kv_store.go
@@ -2099,8 +2099,18 @@ func deserializeHTLCFailInfo(r io.Reader) (*HTLCFailInfo, error) {
 		f.Message, err = lnwire.DecodeFailureMessage(
 			bytes.NewReader(failureBytes), 0,
 		)
-		if err != nil {
+		if err != nil &&
+			!errors.Is(err, lnwire.ErrParsingExtraTLVBytes) {
+
 			return nil, err
+		}
+
+		// In case we have an invalid TLV stream regarding the extra
+		// tlv data we still continue with the decoding of the
+		// HTLCFailInfo.
+		if errors.Is(err, lnwire.ErrParsingExtraTLVBytes) {
+			log.Warnf("Failed to decode extra TLV bytes for "+
+				"failure message: %v", err)
 		}
 	}
 


### PR DESCRIPTION
Older payments might have a invalid tlv stream, we now catch this
case.
