### PR TITLE
build: bump master version to v0.20.99

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -47,7 +47,7 @@ const (
 	AppMinor uint = 20
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 00
+	AppPatch uint = 99
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.


### PR DESCRIPTION
This reflects the fact that master is beyond the last major release and will be a super set of anything in the v0.20.x series.

