### PR TITLE
docs: move release notes from 0.20.0 to 0.21.0

### DIFF
--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -59,11 +59,6 @@
 - [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/10330) to ensure that goroutine resources are properly freed in the case
   of a disconnection or other failure event.
 
-- Chain notifier RPCs now [return the gRPC `Unavailable`
-  status](https://github.com/lightningnetwork/lnd/pull/10352) while the
-  sub-server is still starting. This allows clients to reliably detect the
-  transient condition and retry without brittle string matching.
-
 # New Features
  
 * Use persisted [nodeannouncement](https://github.com/lightningnetwork/lnd/pull/8825) 

--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -21,6 +21,11 @@
 
 # Bug Fixes
 
+- Chain notifier RPCs now [return the gRPC `Unavailable`
+  status](https://github.com/lightningnetwork/lnd/pull/10352) while the
+  sub-server is still starting. This allows clients to reliably detect the
+  transient condition and retry without brittle string matching.
+
 # New Features
 
 - Basic Support for [onion messaging forwarding](https://github.com/lightningnetwork/lnd/pull/9868) 
@@ -64,4 +69,5 @@
 
 # Contributors (Alphabetical Order)
 
+* Boris Nagaev
 * Elle Mouton


### PR DESCRIPTION
## Change Description

In https://github.com/lightningnetwork/lnd/pull/10352 release notes were added to 0.20 by mistake.

Remove the chain notifier RPC note from the 0.20 release notes and add it to 0.21.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
