### PR TITLE
Enforces low-S canonical signatures when the `n`  field is present in a BOLT11 invoice

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -102,6 +102,9 @@
 
 ## BOLT Spec Updates
 
+* LND now [enforces](https://github.com/lightning/bolts/pull/1284) low-S
+  canonical signatures when the `n` field is present in a BOLT11 invoice.
+
 * The fundee now [enforces the BOLT-02 bound on
   `push_msat`](https://github.com/lightningnetwork/lnd/pull/10765),
   rejecting incoming `open_channel` messages where `push_msat` exceeds
@@ -148,3 +151,4 @@
 * Boris Nagaev
 * Erick Cestari
 * Jared Tobin
+* Pins

--- a/zpay32/decode.go
+++ b/zpay32/decode.go
@@ -186,6 +186,11 @@ func Decode(invoice string, net *chaincfg.Params, opts ...DecodeOption) (
 			return nil, fmt.Errorf("unable to deserialize "+
 				"signature: %v", err)
 		}
+		// Ensure the signature is in canonical low-S form.
+		if err = ecdsa.VerifyLowS(sig.ToSignatureBytes()); err != nil {
+			return nil, fmt.Errorf("invalid invoice "+
+				"signature: %w", err)
+		}
 		if !signature.Verify(hash, decodedInvoice.Destination) {
 			return nil, fmt.Errorf("invalid invoice signature")
 		}

--- a/zpay32/invoice_test.go
+++ b/zpay32/invoice_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+//nolint:ll
 var (
 	testMillisat24BTC    = lnwire.MilliSatoshi(2400000000000)
 	testMillisat2500uBTC = lnwire.MilliSatoshi(250000000)
@@ -60,6 +61,9 @@ var (
 
 	testPrivKeyBytes, _     = hex.DecodeString("e126f68f7eafcc8b74f54d269fe206be715000f94dac067d1c04a8ca3b2db734")
 	testPrivKey, testPubKey = btcec.PrivKeyFromBytes(testPrivKeyBytes)
+
+	testHighSPubKeyBytes, _ = hex.DecodeString("02d0139ce7427d6dfffd26a326c18be754ef1e64672b42694ba5b23ef6e6e7803d")
+	testHighSPubKey, _      = btcec.ParsePubKey(testHighSPubKeyBytes)
 
 	testDescriptionHashSlice = chainhash.HashB([]byte("One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon"))
 
@@ -211,6 +215,7 @@ func TestDecodeEncode(t *testing.T) {
 		decodeOpts     []DecodeOption
 		skipEncoding   bool
 		beforeEncoding func(*Invoice)
+		errContains    string
 	}{
 		{
 			encodedInvoice: "asdsaddnasdnas", // no hrp
@@ -914,6 +919,36 @@ func TestDecodeEncode(t *testing.T) {
 				WithErrorOnUnknownFeatureBit(),
 			},
 		},
+		{
+			// Invoice with high-S signature and Public-key
+			// recovery.
+			encodedInvoice: "lnbc1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq9qrsgq357wnc5r2ueh7ck6q93dj32dlqnls087fxdwk8qakdyafkq3yap2r09nt4ndd0unm3z9u5t48y6ucv4r5sg7lk98c77ctvjczkspk5qprc90gx",
+			valid:          true,
+			skipEncoding:   true,
+			decodedInvoice: func() *Invoice {
+				return &Invoice{
+					Net:         &chaincfg.MainNetParams,
+					Timestamp:   time.Unix(1496314658, 0),
+					PaymentHash: &testPaymentHash,
+					PaymentAddr: fn.Some(specPaymentAddr),
+					Description: &testPleaseConsider,
+					Destination: testHighSPubKey,
+					Features: lnwire.NewFeatureVector(
+						lnwire.NewRawFeatureVector(
+							8, 14,
+						),
+						lnwire.Features,
+					),
+				}
+			},
+		},
+		{
+			// Invoice with high-S signature and 'n' tagged field
+			// for destination pubkey.
+			encodedInvoice: "lnbc25m1p70xwfzpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaqnp4q0n326hr8v9zprg8gsvezcch06gfaqqhde2aj730yg0durunfhv66sp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9qrsgqsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygsp5cfzp9ugllvk03rltd6hvndxj26ux6gcxc5azyxk060rj9tzghct5zvjlps76gx8wpq5yuu79688k8gnm2c0al6v608s96l0xzrrlqqwnzxmu",
+			valid:          false,
+			errContains:    "low-S",
+		},
 	}
 
 	for i, test := range tests {
@@ -933,6 +968,11 @@ func TestDecodeEncode(t *testing.T) {
 			)
 			if !test.valid {
 				require.Error(t, err)
+				if test.errContains != "" {
+					require.ErrorContains(
+						t, err, test.errContains,
+					)
+				}
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, decodedInvoice, invoice)


### PR DESCRIPTION
Fixes #10222 

This change enforces low-S canonical signatures in BOLT11 invoices when `n` is present and adds the corresponding Bolts test vectors ([PR#1284](https://github.com/lightning/bolts/pull/1284) and [PR#1298](https://github.com/lightning/bolts/pull/1298)).

This PR depends on btcd PR https://github.com/btcsuite/btcd/pull/2524

This cannot be merged until that PR is merged and LND updates btcdc/v2.