### PR TITLE
commands: improve UX for estimate fee command

### DIFF
--- a/cmd/commands/commands.go
+++ b/cmd/commands/commands.go
@@ -396,7 +396,7 @@ var estimateFeeCommand = cli.Command{
 	    '{"ExampleAddr": NumCoinsInSatoshis, "SecondAddr": NumCoins}'
 	`,
 	Flags: []cli.Flag{
-		cli.Uint64Flag{
+		cli.Int64Flag{
 			Name: "conf_target",
 			Usage: "the number of blocks that the transaction " +
 				"should be confirmed on-chain within",


### PR DESCRIPTION
The RPC call expects a value different from `0` for `conf_target`.

Since the command description says the parameter is optional, it makes sense to provide a default.

The default and the description were taken from the command `wallet psbt fund`.

## Change Description
A default value was added for the  `conf_target` parameter, for the command `estimatefee`.

## Steps to Test
Call the `estimatefee` command without providing a value for `conf_target`:
```bash
lncli estimatefee '{"address": 10000}'
```

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
