### PR TITLE
lncli: remove dead code

### DIFF
--- a/cmd/commands/commands.go
+++ b/cmd/commands/commands.go
@@ -2972,19 +2972,6 @@ func exportChanBackup(ctx *cli.Context) error {
 
 	// TODO(roasbeef): support for export | restore ?
 
-	var chanPoints []string
-	for _, chanPoint := range chanBackup.MultiChanBackup.ChanPoints {
-		txid, err := chainhash.NewHash(chanPoint.GetFundingTxidBytes())
-		if err != nil {
-			return err
-		}
-
-		chanPoints = append(chanPoints, wire.OutPoint{
-			Hash:  *txid,
-			Index: chanPoint.OutputIndex,
-		}.String())
-	}
-
 	printRespJSON(chanBackup)
 
 	return nil


### PR DESCRIPTION
## Change Description

Variable `chanPoints` was accumulated but never used. Found with staticcheck tool.

The code is dead since 8f5d78c875b8eca436f7ee2e86e743afee262386

## Steps to Test

Make sure it compiles (already)

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
