### PR TITLE
htlcswitch: make SendHTLC idempotent for safe retries

### DIFF
--- a/htlcswitch/circuit_map.go
+++ b/htlcswitch/circuit_map.go
@@ -118,6 +118,10 @@ type CircuitMap interface {
 	// settles/fails from being accepted for the same circuit.
 	FailCircuit(inKey CircuitKey) (*PaymentCircuit, error)
 
+	// HasCircuit returns true if a circuit with the given incoming circuit
+	// key exists in the circuit map.
+	HasCircuit(inKey CircuitKey) bool
+
 	// LookupByPaymentHash queries the circuit map and returns all open
 	// circuits that use the given payment hash.
 	LookupByPaymentHash(hash [32]byte) []*PaymentCircuit
@@ -1066,6 +1070,16 @@ func (cm *circuitMap) CloseCircuit(outKey CircuitKey) (*PaymentCircuit, error) {
 	cm.closed[circuit.Incoming] = struct{}{}
 
 	return circuit, nil
+}
+
+// HasCircuit returns true if a circuit with the given incoming circuit key
+// exists in the circuit map (in pending state).
+func (cm *circuitMap) HasCircuit(inKey CircuitKey) bool {
+	cm.mtx.RLock()
+	defer cm.mtx.RUnlock()
+
+	_, exists := cm.pending[inKey]
+	return exists
 }
 
 // DeleteCircuits destroys the target circuits by removing them from the circuit

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -1113,6 +1113,10 @@ func (m *mockCircuitMap) FailCircuit(inKey CircuitKey) (*PaymentCircuit,
 	return nil, nil
 }
 
+func (m *mockCircuitMap) HasCircuit(inKey CircuitKey) bool {
+	return false
+}
+
 func (m *mockCircuitMap) LookupCircuit(inKey CircuitKey) *PaymentCircuit {
 	return <-m.lookup
 }


### PR DESCRIPTION
Adds per-attemptID locking to prevent race conditions between result
storage and circuit deletion, making SendHTLC safe to retry from
external subsystems.

Changes:
- SendHTLC: Hold attemptIDMtx while checking result store and
  committing circuit to prevent duplicate payments on retry
- handleLocalResponse: Hold attemptIDMtx while storing result and
  deleting circuit to ensure atomic state transition
- Add GetPaymentResult method for external callers to query payment
  results after crash/restart

The lock is sharded per attemptID (multimutex), so different attempts
don't contend with each other. This enables external callers to safely
retry SendHTLC after connection loss without risking duplicate payments.



Alternative to https://github.com/lightningnetwork/lnd/pull/10049