### PR TITLE
[docs] Document use-native-sql=true for SQL migration step 2

### DIFF
--- a/docs/db_migration_guide.md
+++ b/docs/db_migration_guide.md
@@ -127,6 +127,9 @@ This will mitigate the poor Postgres performance on kvdb.
 
 This stage unlocks true SQL performance by restructuring data into relational tables. Migration is **per-subsystem** and **incremental**.
 
+The migration steps are automatically applied when LND is restarted after step 1 was successfully completed and the config value db.use-native-sql=true is set.
+You will see log lines from the `SQLD` subsystem about the migration, such as `Starting migration of invoices from KV to SQL`.
+
 ### Subsystem Readiness
 
 | Subsystem           | Relational Backend | Migration Script | Status |


### PR DESCRIPTION
In migrating, use-native-sql must be set. Add to docs.

cc @ziggie1984 @saubyk