### PR TITLE
docs: release-notes-0.21

### DIFF
--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -63,6 +63,30 @@
 
 ## Deprecations
 
+### ⚠️ **Warning:** The deprecated fee rate option `--sat_per_byte` will be removed in release version **0.22**
+
+  The deprecated `--sat_per_byte` option will be fully removed. This flag was
+  originally deprecated and hidden from the lncli commands in v0.13.0
+  ([PR#4704](https://github.com/lightningnetwork/lnd/pull/4704)). Users should
+  migrate to the `--sat_per_vbyte` option, which correctly represents fee rates
+  in terms of virtual bytes (vbytes).
+  
+  Internally `--sat_per_byte` was treated as sat/vbyte, this meant the option
+  name was misleading and could result in unintended fee calculations. To avoid 
+  further confusion and to align with ecosystem terminology, the option will be
+  removed.
+
+  The following RPCs will be impacted:
+
+  | RPC Method | Messages | Removed Option | 
+  |----------------------|----------------|-------------|
+| [`lnrpc.CloseChannel`](https://lightning.engineering/api-docs/api/lnd/lightning/close-channel/) | [`lnrpc.CloseChannelRequest`](https://lightning.engineering/api-docs/api/lnd/lightning/close-channel/#lnrpcclosechannelrequest) | sat_per_byte
+| [`lnrpc.OpenChannelSync`](https://lightning.engineering/api-docs/api/lnd/lightning/open-channel-sync/) | [`lnrpc.OpenChannelRequest`](https://lightning.engineering/api-docs/api/lnd/lightning/open-channel-sync/#lnrpcopenchannelrequest) | sat_per_byte 
+| [`lnrpc.OpenChannel`](https://lightning.engineering/api-docs/api/lnd/lightning/open-channel/) | [`lnrpc.OpenChannelRequest`](https://lightning.engineering/api-docs/api/lnd/lightning/open-channel/#lnrpcopenchannelrequest) | sat_per_byte
+| [`lnrpc.SendCoins`](https://lightning.engineering/api-docs/api/lnd/lightning/send-coins/) | [`lnrpc.SendCoinsRequest`](https://lightning.engineering/api-docs/api/lnd/lightning/send-coins/#lnrpcsendcoinsrequest) | sat_per_byte
+| [`lnrpc.SendMany`](https://lightning.engineering/api-docs/api/lnd/lightning/send-many/) | [`lnrpc.SendManyRequest`](https://lightning.engineering/api-docs/api/lnd/lightning/send-many/#lnrpcsendmanyrequest) | sat_per_byte
+| [`walletrpc.BumpFee`](https://lightning.engineering/api-docs/api/lnd/wallet-kit/bump-fee/) | [`walletrpc.BumpFeeRequest`](walletrpc.BumpFeeRequest) | sat_per_byte
+
 # Technical and Architectural Updates
 ## BOLT Spec Updates
 
@@ -84,3 +108,4 @@
 * Elle Mouton
 * Mohamed Awnallah
 * Nishant Bansal
+* Pins


### PR DESCRIPTION
Release notes warning the users that the deprecated fee rate option --sat_per_byte will be removed in release version 0.22