### PR TITLE
netann: fix race condition in TestChanStatusManagerStateMachine

### DIFF
--- a/netann/chan_status_manager_test.go
+++ b/netann/chan_status_manager_test.go
@@ -752,14 +752,16 @@ var stateMachineTests = []stateMachineTest{
 
 			// Now, insert edge policies for the channel into the
 			// graph, starting with the channel enabled, and mark
-			// the link active.
+			// the link active. Mark the channels active first to
+			// avoid a race where the manager's ticker fires after
+			// adding edge policies but before marking active.
+			h.markActive(newChans)
 			for _, c := range newChans {
 				info, pol1, pol2 := createEdgePolicies(
 					h.t, c, h.ourPubKey, true,
 				)
 				h.graph.addEdgePolicy(c, info, pol1, pol2)
 			}
-			h.markActive(newChans)
 
 			// We expect no updates to be sent since the channel is
 			// enabled and active.


### PR DESCRIPTION
Fix a race condition in the "add new channels" subtest where the manager's status sampling ticker could fire between adding channel edge policies and marking channels as active in the switch.

This race caused the manager to:
1. Discover new channels with enabled edge policies
2. Check if they're active (they weren't yet)
3. Schedule and send a disable update

The fix reorders the operations to mark channels active before adding edge policies, ensuring the manager always sees them as active.

FIxes a flake found in [this build](https://github.com/lightningnetwork/lnd/actions/runs/20088220763/job/57630234879?pr=10436)