### PR TITLE
ci: fix some minor issues in the backport ci job

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -112,7 +112,10 @@ jobs:
 
           # Automatically add labels to backport PRs.
           # The 'no-changelog' label skips the release notes check in CI.
-          labels: no-changelog
+          add_labels: no-changelog
+
+          # Copy milestone from original PR to backport PR.
+          copy_milestone: true
 
           # Merge strategy - skip merge commits, use cherry-pick only.
           merge_commits: skip

--- a/docs/backport-workflow.md
+++ b/docs/backport-workflow.md
@@ -482,7 +482,7 @@ Error: Please ensure the branch exists before adding the backport label
 2. **Check workflow configuration:**
    - Verify `.github/workflows/backport.yml` has:
      ```yaml
-     labels: no-changelog
+     add_labels: no-changelog
      ```
 
 3. **Re-run the workflow:**


### PR DESCRIPTION
-Due to a newer version we need to use add_labels instead of just
 labels

-The backport PR will now also copy the milestones in case the
 milstones were set
