### PR TITLE
htlcswitch: fix error misclassification for on-chain resolutions

### DIFF
--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -1161,7 +1161,7 @@ func (s *Switch) parseFailedPayment(deobfuscator ErrorDecrypter,
 	// the first hop. In this case, we'll report a permanent
 	// channel failure as this means us, or the remote party had to
 	// go on chain.
-	case isResolution && htlc.Reason == nil:
+	case isResolution && len(htlc.Reason) == 0:
 		linkError := NewDetailedLinkError(
 			&lnwire.FailPermanentChannelFailure{},
 			OutgoingFailureOnChainTimeout,

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -5934,6 +5934,13 @@ func TestOnChainResolutionFailure(t *testing.T) {
 	// ID).
 	rhash := lntypes.Hash{1}
 
+	// onChainTimeout is the error the resolution branch produces for an
+	// on-chain HTLC timeout.
+	onChainTimeout := NewDetailedLinkError(
+		&lnwire.FailPermanentChannelFailure{},
+		OutgoingFailureOnChainTimeout,
+	)
+
 	tests := []struct {
 		name         string
 		isResolution bool
@@ -5946,7 +5953,7 @@ func TestOnChainResolutionFailure(t *testing.T) {
 			name:         "on-chain resolution, empty reason",
 			isResolution: true,
 			reason:       nil,
-			wantErr:      ErrUnreadableFailureMessage,
+			wantErr:      onChainTimeout,
 		},
 
 		// A resolution carrying a real reason must still decrypt, so

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -5910,3 +5910,100 @@ func TestExtractResult(t *testing.T) {
 		})
 	}
 }
+
+// TestOnChainResolutionFailure verifies that an on-chain resolution failure
+// read back from the result store is classified as a permanent on-chain
+// channel failure, rather than being misclassified as an unreadable failure.
+//
+// The result must travel through the store: the lnwire codec turns a nil
+// reason into a non-nil empty slice, and only the persisted (disk-fetch) path
+// exercises that transformation. The in-memory path is covered by
+// TestExtractResult.
+func TestOnChainResolutionFailure(t *testing.T) {
+	t.Parallel()
+
+	s, err := initSwitchWithTempDB(t, testStartingHeight)
+	require.NoError(t, err, "unable to init switch")
+	require.NoError(t, s.Start(), "unable to start switch")
+	defer func() {
+		require.NoError(t, s.Stop(), "unable to stop switch")
+	}()
+
+	// rhash is only cosmetic here: parseFailedPayment uses the payment hash
+	// solely for log lines, not for result lookup (that is keyed by attempt
+	// ID).
+	rhash := lntypes.Hash{1}
+
+	tests := []struct {
+		name         string
+		isResolution bool
+		reason       lnwire.OpaqueReason
+		wantErr      error
+	}{
+		// An on-chain resolution with a nil reason round-trips to a
+		// non-nil empty slice. This is the case the fix addresses.
+		{
+			name:         "on-chain resolution, empty reason",
+			isResolution: true,
+			reason:       nil,
+			wantErr:      ErrUnreadableFailureMessage,
+		},
+
+		// A resolution carrying a real reason must still decrypt, so
+		// the widened predicate cannot swallow populated reasons.
+		{
+			name:         "on-chain resolution, non-empty reason",
+			isResolution: true,
+			reason:       lnwire.OpaqueReason{1, 2, 3},
+			wantErr:      ErrUnreadableFailureMessage,
+		},
+	}
+
+	for i, tt := range tests {
+		tt := tt
+		attemptID := uint64(i + 1)
+
+		t.Run(tt.name, func(t *testing.T) {
+			// A deobfuscator that fails to decrypt, standing in for
+			// an empty/invalid reason. If the resolution branch is
+			// wrongly skipped, this surfaces as
+			// ErrUnreadableFailureMessage.
+			deobfuscator := &mockErrorDecryptor{
+				err: ErrUnreadableFailureMessage,
+			}
+
+			// Store the result, which serializes the reason and
+			// transforms a nil reason into a non-nil empty slice on
+			// read-back.
+			storedResult := &networkResult{
+				msg: &lnwire.UpdateFailHTLC{
+					Reason: tt.reason,
+				},
+				isResolution: tt.isResolution,
+			}
+			err := s.attemptStore.StoreResult(
+				attemptID, storedResult,
+			)
+			require.NoError(t, err, "unable to store result")
+
+			// Fetch the result through the normal path and confirm
+			// it is classified as expected.
+			resultChan, err := s.GetAttemptResult(
+				attemptID, rhash, deobfuscator,
+			)
+			require.NoError(t, err, "unable to get result")
+
+			// We expect a result immediately since it is already in
+			// the store.
+			select {
+			case res := <-resultChan:
+				require.NotNil(t, res.Error,
+					"expected error for failed result")
+				require.Equal(t, tt.wantErr, res.Error)
+
+			case <-time.After(1 * time.Second):
+				t.Fatalf("result not received")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Change Description
This PR demonstrates a subtle bug in the `htlcswitch` that causes an incorrect error to be returned for on-chain HTLC resolutions. On the introduction of the `switchrpc` service in #9489, this bug can be escalated, leading to an ambiguous scenario where the Switch reports a payment result which has no forwarding error, pre-image, or encrypted error for the RPC client.

### Problem

When the `contractcourt` resolves a [dust HTLC](https://github.com/lightningnetwork/lnd/blob/v0.20.0-beta/contractcourt/channel_arbitrator.go#L1007) on-chain, it [sends a `ResolutionMsg`](https://github.com/lightningnetwork/lnd/blob/v0.20.0-beta/contractcourt/channel_arbitrator.go#L3381) to the switch that results in an `UpdateFailHTLC` with a `nil` error `Reason`. 

The core issue stems from a a subtle artifact in the `networkResult` store's persistence logic:
1.  A `nil` `htlc.Reason` slice is serialized to disk as a zero-length byte array.
2.  Upon deserialization, this is read back as a **_non-nil, empty_** byte slice (`[]byte{}`).

This `nil` -> `[]byte{}` transformation causes the [check](https://github.com/lightningnetwork/lnd/blob/v0.20.0-beta/htlcswitch/switch.go#L1093) for on-chain resolutions to fail. As a result, this code path, which is intended to return `FailPermanentChannelFailure` to signal the channel is being resolved on-chain, is never executed for results read from disk.

Instead, the code falls through to the `default` case. The Switch attempts to decrypt the empty slice, which fails, causing `parseFailedPayment` to [return `ErrUnreadableFailureMessage`](https://github.com/lightningnetwork/lnd/blob/v0.20.0-beta/htlcswitch/switch.go#L1116).

The impact on `master` is a **misclassification of the error**. The `ChannelRouter` receives a generic, imprecise error instead of the correct `FailPermanentChannelFailure`, hindering its ability to accurately understand the payment's terminal state.

### Solution

The fix is to make the check in `parseFailedPayment` robust to the serialization artifact by checking the length of the reason instead of whether it's `nil`.

```diff
--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
-       case isResolution && htlc.Reason == nil:
+       case isResolution && len(htlc.Reason) == 0:
```

This change ensures that on-chain resolutions are correctly identified and processed, whether the `Reason` is `nil` (in-memory) or an empty slice (post-deserialization). This makes the intended code path reachable and allows the switch to return the precise error to the `ChannelRouter`.

## Steps to Test
- Run this to demo the `nil` -> `[]byte{}` transformation during a disk round-trip: 
  - `go test -v -timeout 30s --tags dev -run ^TestNetworkResultSerialization$ github.com/lightningnetwork/lnd/htlcswitch`
- Then run this more realistic `TestExtractResult`, which simulates the disk I/O, both with and _without_ the final commit which provides the fix: 
  - `go test -v -timeout 30s -run ^TestExtractResult$ github.com/lightningnetwork/lnd/htlcswitch`

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.