### PR TITLE
brontide: implement tiered buffer pool for message encryption

### DIFF
--- a/brontide/bench_test.go
+++ b/brontide/bench_test.go
@@ -119,15 +119,15 @@ func BenchmarkWriteMessageSizes(b *testing.B) {
 		name string
 		size int
 	}{
-		{"100B", 100},   // Tiny message (256B tier)
-		{"256B", 256},   // At 256B tier boundary
-		{"500B", 500},   // Small message (1KB tier)
-		{"1KB", 1024},   // At 1KB tier boundary
-		{"2KB", 2048},   // Medium message (4KB tier)
-		{"4KB", 4096},   // At 4KB tier boundary
-		{"8KB", 8192},   // Large message (64KB tier)
-		{"32KB", 32768}, // Large message
-		{"64KB", 65535}, // Max message size
+		{"100B", 100},            // Tiny message (256B tier)
+		{"256B", 256},            // At 256B tier boundary
+		{"500B", 500},            // Small message (1KB tier)
+		{"1KB", 1024},            // At 1KB tier boundary
+		{"2KB", 2048},            // Medium message (4KB tier)
+		{"4KB", 4096},            // At 4KB tier boundary
+		{"8KB", 8192},            // Large message (64KB tier)
+		{"32KB", 32768},          // Large message
+		{"64KB", math.MaxUint16}, // Max message size
 	}
 
 	for _, sz := range sizes {

--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -77,6 +77,12 @@
 
 ## Performance Improvements
 
+* [Implemented a tiered buffer pool for message
+  encryption](https://github.com/lightningnetwork/lnd/pull/10457) in the
+  brontide package, reducing memory overhead by allocating appropriately-sized
+  buffers (256B, 1KB, 4KB, 64KB) based on actual message size instead of always
+  using 64KB buffers.
+
 ## Deprecations
 
 ### ⚠️ **Warning:** The deprecated fee rate option `--sat_per_byte` will be removed in release version **0.22**


### PR DESCRIPTION
## Change Description

Implements a tiered buffer pool for the brontide package's encrypted message body buffers. Instead of always allocating 65KB buffers (the maximum message size), the pool now provides appropriately sized buffers based on actual message size.

Most Lightning Network messages are much smaller than the 65KB maximum. This change reduces per-message memory overhead while maintaining the allocation reduction benefits of buffer pooling.

The pool uses four tiers:
- 256B (+MAC): very small messages
- 1KB (+MAC): small messages  
- 4KB (+MAC): medium messages
- 64KB (+MAC): large messages

Fixes #10246

## Steps to Test

1. Run all brontide tests:
   ```bash
   go test -v ./brontide/... -count=1
   ```

2. Run benchmarks to verify performance across message sizes:
   ```bash
   go test -bench="BenchmarkWriteMessageSizes" -benchmem ./brontide/...
   ```

3. Verify zero allocations in benchmarks - all should show `0 allocs/op`

## Pull Request Checklist

### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Unit tests for tier selection, buffer reuse, nil handling, and concurrency added.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
