### PR TITLE
rpcperms: enable rich gRPC status errors in middleware API

### DIFF
--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -71,6 +71,11 @@
 
 ## RPC Updates
 
+* [Enabled rich gRPC status error support in the middleware
+  API](https://github.com/lightningnetwork/lnd/pull/10458), allowing middleware
+  to inspect and modify full gRPC error details including error codes, not just
+  plain error strings.
+
 ## lncli Updates
 
 ## Breaking Changes

--- a/rpcperms/middleware_handler_test.go
+++ b/rpcperms/middleware_handler_test.go
@@ -1,11 +1,16 @@
 package rpcperms
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 // TestReplaceProtoMsg makes sure the proto message replacement works as
@@ -87,4 +92,134 @@ func jsonEqual(t *testing.T, expected, actual interface{}) {
 	require.NoError(t, err)
 
 	require.JSONEq(t, string(expectedJSON), string(actualJSON))
+}
+
+// TestParseErrorReplacement tests that parseErrorReplacement correctly parses
+// both plain error strings and rich gRPC status errors.
+func TestParseErrorReplacement(t *testing.T) {
+	testCases := []struct {
+		name           string
+		typeName       string
+		serialized     []byte
+		expectedErrMsg string
+		expectParseErr bool
+	}{{
+		name:           "plain error string",
+		typeName:       StatusTypeNameError,
+		serialized:     []byte("this is a plain error"),
+		expectedErrMsg: "this is a plain error",
+	}, {
+		name:           "empty error string",
+		typeName:       StatusTypeNameError,
+		serialized:     []byte(""),
+		expectedErrMsg: "",
+	}, {
+		name:           "invalid status proto",
+		typeName:       StatusTypeNameStatus,
+		serialized:     []byte("not a valid proto"),
+		expectParseErr: true,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(tt *testing.T) {
+			resultErr, parseErr := parseErrorReplacement(
+				tc.typeName, tc.serialized,
+			)
+
+			if tc.expectParseErr {
+				require.Error(tt, parseErr)
+				return
+			}
+
+			require.NoError(tt, parseErr)
+			require.Equal(tt, tc.expectedErrMsg, resultErr.Error())
+		})
+	}
+}
+
+// TestParseErrorReplacementWithStatus tests that parseErrorReplacement
+// correctly handles gRPC status errors with proper error codes.
+func TestParseErrorReplacementWithStatus(t *testing.T) {
+	// Create a gRPC status error with a specific code and message.
+	st := status.New(codes.NotFound, "resource not found")
+	statusProto := st.Proto()
+
+	// Serialize the status proto.
+	serialized, err := proto.Marshal(statusProto)
+	require.NoError(t, err)
+
+	// Parse it back.
+	resultErr, parseErr := parseErrorReplacement(
+		StatusTypeNameStatus, serialized,
+	)
+	require.NoError(t, parseErr)
+	require.Error(t, resultErr)
+
+	// Verify we can extract the status back.
+	resultStatus, ok := status.FromError(resultErr)
+	require.True(t, ok)
+	require.Equal(t, codes.NotFound, resultStatus.Code())
+	require.Equal(t, "resource not found", resultStatus.Message())
+}
+
+// TestNewMessageInterceptionRequestWithStatusError tests that
+// NewMessageInterceptionRequest correctly serializes gRPC status errors
+// as google.rpc.Status protos instead of plain error strings.
+func TestNewMessageInterceptionRequestWithStatusError(t *testing.T) {
+	testCases := []struct {
+		name             string
+		err              error
+		expectedTypeName string
+		isStatusError    bool
+	}{{
+		name:             "plain error",
+		err:              errors.New("this is a plain error"),
+		expectedTypeName: StatusTypeNameError,
+		isStatusError:    false,
+	}, {
+		name:             "gRPC status error",
+		err:              status.Error(codes.NotFound, "resource not found"),
+		expectedTypeName: StatusTypeNameStatus,
+		isStatusError:    true,
+	}, {
+		name:             "gRPC status error with different code",
+		err:              status.Error(codes.PermissionDenied, "access denied"),
+		expectedTypeName: StatusTypeNameStatus,
+		isStatusError:    true,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(tt *testing.T) {
+			ctx := context.Background()
+			req, err := NewMessageInterceptionRequest(
+				ctx, TypeResponse, false, "/test/Method",
+				tc.err,
+			)
+			require.NoError(tt, err)
+			require.True(tt, req.IsError)
+			require.Equal(tt, tc.expectedTypeName, req.ProtoTypeName)
+
+			if tc.isStatusError {
+				// Verify we can parse the status back.
+				resultErr, parseErr := parseErrorReplacement(
+					req.ProtoTypeName, req.ProtoSerialized,
+				)
+				require.NoError(tt, parseErr)
+
+				// Verify the error code is preserved.
+				resultStatus, ok := status.FromError(resultErr)
+				require.True(tt, ok)
+
+				originalStatus, _ := status.FromError(tc.err)
+				require.Equal(
+					tt, originalStatus.Code(),
+					resultStatus.Code(),
+				)
+				require.Equal(
+					tt, originalStatus.Message(),
+					resultStatus.Message(),
+				)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Change Description
Enable the RPC middleware API to return "rich" gRPC errors with full error details including gRPC error codes (fixes #6729).

Previously, errors intercepted by the RPC middleware were always serialized as plain error strings. This meant middleware could only see 

## Steps to Test
1. Run the rpcperms package tests:
```bash
go test -v ./rpcperms/...
```

2. Build the project to verify no regressions:
```bash
go build ./...
```
## Pull Request Checklist

### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only).
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [x] No new logging statements (change only affects internal error handling).
- [x] No new lncli commands (RPC middleware API enhancement only).
- [x] This is a small enhancement; marked with `[skip ci]` not needed as tests are included.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
