### PR TITLE
funding: skip rescan for already-confirmed zero-conf channels 

### DIFF
--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -77,6 +77,11 @@
 
 ## Performance Improvements
 
+* [Zero-conf channels that are already confirmed no longer trigger historical
+  chain rescans](https://github.com/lightningnetwork/lnd/pull/10459) from the
+  broadcast height on restart. This significantly reduces bandwidth usage for
+  mobile and neutrino clients.
+
 ## Deprecations
 
 ### ⚠️ **Warning:** The deprecated fee rate option `--sat_per_byte` will be removed in release version **0.22**


### PR DESCRIPTION

## Change Description
Fixes #9299. On restart, zero-conf channels that are already confirmed no longer trigger historical chain rescans from the broadcast height, reducing bandwidth usage on mobile/neutrino.

## Steps to Test
1. Open a zero-conf channel and wait for it to confirm
2. Restart lnd
3. Check logs - no rescan from broadcast height should occur

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.