### PR TITLE
channeldb: fix race condition in link node pruning

### DIFF
--- a/channeldb/nodes_test.go
+++ b/channeldb/nodes_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/stretchr/testify/require"
 )
 
@@ -128,4 +129,246 @@ func TestDeleteLinkNode(t *testing.T) {
 	if _, err := cdb.linkNodeDB.FetchLinkNode(pubKey); err == nil {
 		t.Fatal("should not have found link node in db, but did")
 	}
+}
+
+// TestRepairLinkNodes tests that the RepairLinkNodes function correctly
+// identifies and repairs missing link nodes for channels that exist in the
+// database.
+func TestRepairLinkNodes(t *testing.T) {
+	t.Parallel()
+
+	fullDB, err := MakeTestDB(t)
+	require.NoError(t, err, "unable to make test database")
+
+	cdb := fullDB.ChannelStateDB()
+
+	// Create a test channel and save it to the database.
+	channel1 := createTestChannel(t, cdb)
+
+	// Manually create a link node for the channel.
+	linkNode1 := NewLinkNode(
+		cdb.linkNodeDB, wire.MainNet, channel1.IdentityPub,
+	)
+	err = linkNode1.Sync()
+	require.NoError(t, err, "unable to sync link node")
+
+	// Verify that link node was created.
+	fetchedLinkNode, err := cdb.linkNodeDB.FetchLinkNode(
+		channel1.IdentityPub,
+	)
+	require.NoError(t, err, "link node should exist")
+	require.NotNil(t, fetchedLinkNode, "link node should not be nil")
+
+	// Now, manually delete one of the link nodes to simulate the race
+	// condition scenario where a link node was incorrectly pruned.
+	err = cdb.linkNodeDB.DeleteLinkNode(channel1.IdentityPub)
+	require.NoError(t, err, "unable to delete link node")
+
+	// Verify the link node is gone.
+	_, err = cdb.linkNodeDB.FetchLinkNode(channel1.IdentityPub)
+	require.ErrorIs(
+		t, err, ErrNodeNotFound,
+		"link node should be deleted",
+	)
+
+	// Now run the repair function with the correct network.
+	err = cdb.RepairLinkNodes(wire.MainNet)
+	require.NoError(t, err, "repair should succeed")
+
+	// Verify that the link node has been restored.
+	repairedLinkNode, err := cdb.linkNodeDB.FetchLinkNode(
+		channel1.IdentityPub,
+	)
+	require.NoError(t, err, "repaired link node should exist")
+	require.NotNil(
+		t, repairedLinkNode, "repaired link node should not be nil",
+	)
+	require.Equal(
+		t, wire.MainNet, repairedLinkNode.Network,
+		"repaired link node should have correct network",
+	)
+
+	// Run repair again - it should be idempotent and not fail.
+	err = cdb.RepairLinkNodes(wire.MainNet)
+	require.NoError(t, err, "second repair should succeed")
+
+	// Test with different network to ensure network parameter is used.
+	err = cdb.linkNodeDB.DeleteLinkNode(channel1.IdentityPub)
+	require.NoError(t, err, "unable to delete link node")
+
+	err = cdb.RepairLinkNodes(wire.TestNet3)
+	require.NoError(t, err, "repair with testnet should succeed")
+
+	repairedLinkNode, err = cdb.linkNodeDB.FetchLinkNode(
+		channel1.IdentityPub,
+	)
+	require.NoError(t, err, "repaired link node should exist")
+	require.Equal(
+		t, wire.TestNet3, repairedLinkNode.Network,
+		"repaired link node should use provided network",
+	)
+}
+
+// TestFindMissingLinkNodes tests the FindMissingLinkNodes method with various
+// scenarios.
+func TestFindMissingLinkNodes(t *testing.T) {
+	t.Parallel()
+
+	fullDB, err := MakeTestDB(t)
+	require.NoError(t, err, "unable to make test database")
+
+	cdb := fullDB.ChannelStateDB()
+
+	// Create three test public keys.
+	_, pub1 := btcec.PrivKeyFromBytes(key[:])
+	_, pub2 := btcec.PrivKeyFromBytes(rev[:])
+	testKey := [32]byte{0x03}
+	_, pub3 := btcec.PrivKeyFromBytes(testKey[:])
+
+	// Test 1: All nodes missing (empty database).
+	allPubs := []*btcec.PublicKey{pub1, pub2, pub3}
+	missing, err := cdb.linkNodeDB.FindMissingLinkNodes(nil, allPubs)
+	require.NoError(t, err, "FindMissingLinkNodes should succeed")
+	require.Len(t, missing, 3, "all nodes should be missing")
+
+	// Test 2: Create one link node, verify only 2 are missing.
+	node1 := NewLinkNode(cdb.linkNodeDB, wire.MainNet, pub1)
+	err = node1.Sync()
+	require.NoError(t, err, "unable to sync link node")
+
+	missing, err = cdb.linkNodeDB.FindMissingLinkNodes(nil, allPubs)
+	require.NoError(t, err, "FindMissingLinkNodes should succeed")
+	require.Len(t, missing, 2, "two nodes should be missing")
+	require.Contains(t, missing, pub2, "pub2 should be missing")
+	require.Contains(t, missing, pub3, "pub3 should be missing")
+	require.NotContains(t, missing, pub1, "pub1 should exist")
+
+	// Test 3: Create remaining nodes, verify none are missing.
+	node2 := NewLinkNode(cdb.linkNodeDB, wire.MainNet, pub2)
+	err = node2.Sync()
+	require.NoError(t, err, "unable to sync link node")
+
+	node3 := NewLinkNode(cdb.linkNodeDB, wire.MainNet, pub3)
+	err = node3.Sync()
+	require.NoError(t, err, "unable to sync link node")
+
+	missing, err = cdb.linkNodeDB.FindMissingLinkNodes(nil, allPubs)
+	require.NoError(t, err, "FindMissingLinkNodes should succeed")
+	require.Len(t, missing, 0, "no nodes should be missing")
+
+	// Test 4: Use with a provided transaction.
+	err = cdb.linkNodeDB.DeleteLinkNode(pub2)
+	require.NoError(t, err, "unable to delete link node")
+
+	backend := fullDB.ChannelStateDB().backend
+	err = kvdb.View(backend, func(tx kvdb.RTx) error {
+		missing, err := cdb.linkNodeDB.FindMissingLinkNodes(
+			tx, allPubs,
+		)
+		require.NoError(t, err, "FindMissingLinkNodes should succeed")
+		require.Len(t, missing, 1, "one node should be missing")
+		require.Contains(t, missing, pub2, "pub2 should be missing")
+
+		return nil
+	}, func() {})
+	require.NoError(t, err, "transaction should succeed")
+
+	// Test 5: Empty input list.
+	missing, err = cdb.linkNodeDB.FindMissingLinkNodes(nil, nil)
+	require.NoError(t, err, "FindMissingLinkNodes should succeed")
+	require.Len(t, missing, 0, "no nodes should be missing for empty input")
+}
+
+// TestCreateLinkNodes tests the CreateLinkNodes method with various scenarios.
+func TestCreateLinkNodes(t *testing.T) {
+	t.Parallel()
+
+	fullDB, err := MakeTestDB(t)
+	require.NoError(t, err, "unable to make test database")
+
+	cdb := fullDB.ChannelStateDB()
+
+	// Create three test public keys and link nodes.
+	_, pub1 := btcec.PrivKeyFromBytes(key[:])
+	_, pub2 := btcec.PrivKeyFromBytes(rev[:])
+	testKey := [32]byte{0x03}
+	_, pub3 := btcec.PrivKeyFromBytes(testKey[:])
+
+	node1 := NewLinkNode(cdb.linkNodeDB, wire.MainNet, pub1)
+	node2 := NewLinkNode(cdb.linkNodeDB, wire.TestNet3, pub2)
+	node3 := NewLinkNode(cdb.linkNodeDB, wire.SimNet, pub3)
+
+	// Test 1: Create multiple link nodes at once with nil transaction.
+	nodesToCreate := []*LinkNode{node1, node2, node3}
+	err = cdb.linkNodeDB.CreateLinkNodes(nil, nodesToCreate)
+	require.NoError(t, err, "CreateLinkNodes should succeed")
+
+	// Verify all nodes were created correctly.
+	fetchedNode1, err := cdb.linkNodeDB.FetchLinkNode(pub1)
+	require.NoError(t, err, "node1 should exist")
+	require.Equal(t, wire.MainNet, fetchedNode1.Network,
+		"node1 should have correct network")
+
+	fetchedNode2, err := cdb.linkNodeDB.FetchLinkNode(pub2)
+	require.NoError(t, err, "node2 should exist")
+	require.Equal(t, wire.TestNet3, fetchedNode2.Network,
+		"node2 should have correct network")
+
+	fetchedNode3, err := cdb.linkNodeDB.FetchLinkNode(pub3)
+	require.NoError(t, err, "node3 should exist")
+	require.Equal(t, wire.SimNet, fetchedNode3.Network,
+		"node3 should have correct network")
+
+	// Test 2: Create nodes within a provided transaction.
+	err = cdb.linkNodeDB.DeleteLinkNode(pub2)
+	require.NoError(t, err, "unable to delete link node")
+
+	// Verify node2 is deleted.
+	_, err = cdb.linkNodeDB.FetchLinkNode(pub2)
+	require.ErrorIs(t, err, ErrNodeNotFound, "node2 should be deleted")
+
+	// Recreate node2 using a provided transaction.
+	backend := fullDB.ChannelStateDB().backend
+	err = kvdb.Update(backend, func(tx kvdb.RwTx) error {
+		return cdb.linkNodeDB.CreateLinkNodes(tx, []*LinkNode{node2})
+	}, func() {})
+	require.NoError(t, err, "transaction should succeed")
+
+	// Verify node2 was recreated.
+	fetchedNode2, err = cdb.linkNodeDB.FetchLinkNode(pub2)
+	require.NoError(t, err, "node2 should exist after recreation")
+	require.Equal(t, wire.TestNet3, fetchedNode2.Network,
+		"node2 should have correct network")
+
+	// Test 3: Creating nodes that already exist should succeed
+	// (idempotent behavior).
+	err = cdb.linkNodeDB.CreateLinkNodes(nil, nodesToCreate)
+	require.NoError(t, err, "recreating existing nodes should succeed")
+
+	// Verify nodes still exist with correct data.
+	fetchedNode1, err = cdb.linkNodeDB.FetchLinkNode(pub1)
+	require.NoError(t, err, "node1 should still exist")
+	require.Equal(t, wire.MainNet, fetchedNode1.Network,
+		"node1 should still have correct network")
+
+	// Test 4: Empty input list.
+	err = cdb.linkNodeDB.CreateLinkNodes(nil, nil)
+	require.NoError(
+		t, err, "CreateLinkNodes with empty list should succeed",
+	)
+
+	// Test 5: Create single node.
+	testKey4 := [32]byte{0x04}
+	_, pub4 := btcec.PrivKeyFromBytes(testKey4[:])
+	node4 := NewLinkNode(cdb.linkNodeDB, wire.MainNet, pub4)
+
+	err = cdb.linkNodeDB.CreateLinkNodes(nil, []*LinkNode{node4})
+	require.NoError(
+		t, err, "CreateLinkNodes with single node should succeed",
+	)
+
+	fetchedNode4, err := cdb.linkNodeDB.FetchLinkNode(pub4)
+	require.NoError(t, err, "node4 should exist")
+	require.Equal(t, wire.MainNet, fetchedNode4.Network,
+		"node4 should have correct network")
 }

--- a/server.go
+++ b/server.go
@@ -2144,6 +2144,21 @@ func (s *server) Start(ctx context.Context) error {
 	cleanup := cleaner{}
 
 	s.start.Do(func() {
+		// Before starting any subsystems, repair any link nodes that
+		// may have been incorrectly pruned due to the race condition
+		// that was fixed in the link node pruning logic. This must
+		// happen before the chain arbitrator and other subsystems load
+		// channels, to ensure the invariant "link node exists iff
+		// channels exist" is maintained.
+		err := s.chanStateDB.RepairLinkNodes(s.cfg.ActiveNetParams.Net)
+		if err != nil {
+			srvrLog.Errorf("Failed to repair link nodes: %v", err)
+
+			startErr = err
+
+			return
+		}
+
 		cleanup = cleanup.add(s.customMessageServer.Stop)
 		if err := s.customMessageServer.Start(); err != nil {
 			startErr = err
@@ -2473,9 +2488,8 @@ func (s *server) Start(ctx context.Context) error {
 		// With all the relevant sub-systems started, we'll now attempt
 		// to establish persistent connections to our direct channel
 		// collaborators within the network. Before doing so however,
-		// we'll prune our set of link nodes found within the database
-		// to ensure we don't reconnect to any nodes we no longer have
-		// open channels with.
+		// we'll prune our set of link nodes to ensure we don't
+		// reconnect to any nodes we no longer have open channels with.
 		if err := s.chanStateDB.PruneLinkNodes(); err != nil {
 			srvrLog.Errorf("Failed to prune link nodes: %v", err)
 


### PR DESCRIPTION
This commit fixes a critical race condition in MarkChanFullyClosed and
pruneLinkNode where link nodes could be incorrectly deleted despite
having pending channel.

The race occurred because the check for open channels and the link node
deletion happened in separate database transactions:

  Thread A: TX1 checks open channels → [] (empty)
  Thread A: TX1 commits
  Thread B: Opens new channel with same peer
  Thread A: TX2 deletes link node (using stale data)
  Result: Link node deleted despite pending channel existing

This creates a TOCTOU (time-of-check to time-of-use) vulnerability where
database state changes between reading the channel count and deleting
the node.

Fix for MarkChanFullyClosed:
- Move link node deletion into the same transaction as the channel
  closing check, making the check-and-delete operation atomic

Fix for pruneLinkNode:
- Add double-check within the write transaction to verify no channels
  were opened since the caller's initial check
- Maintains performance by keeping early return for common case
- Prevents deletion if channels exist at delete time

This ensures the invariant: "link node exists iff channels exist"
is never violated, preventing database corruption and potential
connection issues.
