### PR TITLE
peer: fix log output when not applicable

### DIFF
--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -1641,13 +1641,23 @@ func (p *Brontide) Disconnect(reason error) {
 	// started, otherwise we will skip reading it as this chan won't be
 	// closed, hence blocks forever.
 	if atomic.LoadInt32(&p.started) == 1 {
-		p.log.Debugf("Peer hasn't finished starting up yet, waiting " +
-			"on startReady signal before closing connection")
-
+		// First check if startup has already completed (non-blocking).
 		select {
 		case <-p.startReady:
-		case <-p.cg.Done():
-			return
+			// Startup already completed, no need to wait.
+
+		default:
+			// Still starting up, need to wait.
+			p.log.Debugf("Peer hasn't finished starting up yet, " +
+				"waiting on startReady signal before " +
+				"closing connection")
+
+			select {
+			case <-p.startReady:
+
+			case <-p.cg.Done():
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
Before we would always log that the peer was not ready starting
up although it was not the case. We now make sure we still log
this case but only when applicable.
