### PR TITLE
lnwire: enforce non-zero timestamp in gossip messages

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -2502,6 +2502,22 @@ func (d *AuthenticatedGossiper) handleNodeAnnouncement(ctx context.Context,
 		"node=%x, source=%x", nMsg.peer, timestamp, nodeAnn.NodeID,
 		nMsg.source.SerializeCompressed())
 
+	// Although not explicitly required by BOLT 7 for node announcements
+	// (unlike channel updates), we still enforce non-zero timestamps as a
+	// sanity check. A timestamp of zero is likely indicative of a bug or
+	// uninitialized message.
+	if nodeAnn.Timestamp == 0 {
+		err := fmt.Errorf("rejecting node announcement with zero "+
+			"timestamp for node %x", nodeAnn.NodeID)
+
+		log.Warnf("Rejecting node announcement from peer=%v: %v",
+			nMsg.peer, err)
+
+		nMsg.err <- err
+
+		return nil, false
+	}
+
 	// We'll quickly ask the router if it already has a newer update for
 	// this node so we can skip validating signatures if not required.
 	if d.cfg.Graph.IsStaleNode(ctx, nodeAnn.NodeID, timestamp) {
@@ -3055,6 +3071,27 @@ func (d *AuthenticatedGossiper) handleChanUpdate(ctx context.Context,
 	// whether this update is stale or is for a zombie channel in order to
 	// quickly reject it.
 	timestamp := time.Unix(int64(upd.Timestamp), 0)
+
+	// Per BOLT 7, the timestamp MUST be greater than 0.
+	if upd.Timestamp == 0 {
+		err := fmt.Errorf("rejecting channel update with zero "+
+			"timestamp for short_chan_id(%v)", shortChanID)
+
+		// Only increase ban score for remote peers.
+		if nMsg.isRemote {
+			log.Warnf("Increasing ban score for peer=%v: %v",
+				nMsg.peer, err)
+
+			dcErr := d.handleBadPeer(nMsg.peer)
+			if dcErr != nil {
+				err = dcErr
+			}
+		}
+
+		nMsg.err <- err
+
+		return nil, false
+	}
 
 	// Fetch the SCID we should be using to lock the channelMtx and make
 	// graph queries with.

--- a/docs/release-notes/release-notes-0.20.1.md
+++ b/docs/release-notes/release-notes-0.20.1.md
@@ -103,6 +103,12 @@
 # Technical and Architectural Updates
 ## BOLT Spec Updates
 
+* [Enforce non-zero timestamps](https://github.com/lightningnetwork/lnd/pull/10469)
+  for `channel_update` (as required by BOLT 7) and `node_announcement` messages.
+  Gossip messages with zero timestamps are now rejected. For `channel_update`
+  messages, remote peers sending such invalid messages will have their ban score
+  incremented.
+
 ## Testing
 
 ## Database


### PR DESCRIPTION
In this commit, we adds extra validation of the `channel_update` and `node_announcement` during the decoding process to ensure that the timestamp is not zero. Per BOLT 7:
```
For channel_update:
  "MUST set timestamp to greater than 0, AND to greater than any
  previously-sent channel_update for this short_channel_id."
```
