### PR TITLE
lnwallet: improve ErrBelowChanReserve error message for better UX

### DIFF
--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -64,8 +64,9 @@ var (
 
 	// ErrBelowChanReserve is returned when a proposed HTLC would cause
 	// one of the peer's funds to dip below the channel reserve limit.
-	ErrBelowChanReserve = fmt.Errorf("cannot complete request: insufficient funds available to maintain " +
-		"required channel reserve (this reserve ensures both parties have skin in the game to discourage cheating)")
+	ErrBelowChanReserve = fmt.Errorf("insufficient funds to maintain " +
+		"channel reserve (this reserve ensures both parties have " +
+		"skin in the game to discourage cheating)")
 
 	// ErrBelowMinHTLC is returned when a proposed HTLC has a value that
 	// is below the minimum HTLC value constraint for either us or our


### PR DESCRIPTION
Fixes #8957

## Changes
- Changed the `ErrBelowChanReserve` error message from the terse "commitment transaction dips peer below chan reserve" to a more user-friendly message that explains what went wrong and why channel reserves exist
- The new message helps developers and users understand the constraint and educates them about Lightning channel mechanics