### PR TITLE
enhance Docker Image Tag release process

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,17 @@ jobs:
         if: github.event.schedule == '0 0 * * *'
         run: |
           echo "RELEASE_VERSION=master" >> $GITHUB_ENV
-          echo "IMAGE_TAG=daily-testing-$(date -u +%Y%m%d),${DOCKER_REPO}/${DOCKER_IMAGE}:daily-testing-only" >> $GITHUB_ENV
+          echo "IMAGE_TAG=daily-testing-$(date -u +%Y%m%d)" >> $GITHUB_ENV
+
+      - name: Check if version is stable (strict semantic version)
+        id: version_check
+        run: |
+          # Regex to match strict semantic version: vX.Y.Z (no suffixes like .rc, .beta, .alpha, etc.)
+          if [[ "${{ env.IMAGE_TAG }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "is_stable=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_stable=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Build and push
         id: docker_build
@@ -69,7 +79,9 @@ jobs:
         with:
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: "${{ env.DOCKER_REPO }}/${{ env.DOCKER_IMAGE }}:${{ env.IMAGE_TAG }}"
+          tags: |
+            ${{ env.DOCKER_REPO }}/${{ env.DOCKER_IMAGE }}:${{ env.IMAGE_TAG }}
+            ${{ steps.version_check.outputs.is_stable == 'true' && format('{0}/{1}:latest', env.DOCKER_REPO, env.DOCKER_IMAGE) || '' }}
           build-args: checkout=${{ env.RELEASE_VERSION }}
 
       - name: Image digest


### PR DESCRIPTION
## Change Description

- When a tag is pushed that follows the v* format (e.g., v1.0.0, v2.1.0), it will push a Docker image tagged with both the specific release version and latest
- Use strict semantic versioning regex (vX.Y.Z) to determine if version
should be tagged as 'latest'. This future-proofs the pipeline against
any non-official release suffixes like .rc, .beta, .alpha, etc.

fixes: #9397
## Steps to Test
```bash
[[ "v1.0.0" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && echo "✓ Stable version gets 'latest'" || echo "✗ Failed"
[[ "v1.0.0.rc" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && echo "✗ RC should NOT get 'latest'" || echo "✓ RC correctly rejected"
[[ "v1.0.0-beta" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && echo "✗ Beta should NOT get 'latest'" || echo "✓ Beta correctly rejected"
python3 -m yaml < .github/workflows/docker.yml && echo "✓ YAML syntax valid"
```

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
