### PR TITLE
multi: disable postgres db timeout setting

### DIFF
--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -29,8 +29,9 @@ LND is configured for Postgres through the following configuration options:
 * `db.backend=postgres` to select the Postgres backend.
 * `db.postgres.dsn=...` to set the database connection string that includes
   database, user and password.
-* `db.postgres.timeout=...` to set the connection timeout. If not set, no
-  timeout applies.
+* `db.postgres.timeout` is always set to 0 (disabled). This setting is not
+  user-configurable as LND does not properly retry on timeout errors. Any
+  non-zero value will be ignored with a warning logged.
 
 Example as follows:
 ```
@@ -39,8 +40,8 @@ db.backend=postgres
 db.postgres.dsn=postgresql://dbuser:dbpass@127.0.0.1:5432/dbname
 db.postgres.timeout=0
 ```
-Connection timeout is disabled, to account for situations where the database
-might be slow for unexpected reasons.
+Connection timeout is always disabled to prevent issues where LND would fail to
+properly retry after a timeout error occurs.
 
 Moreover for particular kv tables we also add the option to access the
 tables via a global lock (single wirter). This is a temorpary measure until 

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1610,8 +1610,8 @@
 ; Example:
 ;   db.postgres.dsn=postgres://lnd:lnd@localhost:45432/lnd?sslmode=disable
 
-; Postgres connection timeout. Valid time units are {s, m, h}. Set to zero to
-; disable.
+; Postgres connection timeout. This setting is currently not supported and is
+; always set to 0 (disabled) as LND does not properly retry on timeout errors.
 ; db.postgres.timeout=
 
 ; Postgres maximum number of connections. Set to zero for unlimited. It is

--- a/sqldb/config.go
+++ b/sqldb/config.go
@@ -65,6 +65,15 @@ func (p *PostgresConfig) Validate() error {
 		return fmt.Errorf("invalid DSN: %w", err)
 	}
 
+	// Force timeout to 0 since LND doesn't properly retry on timeout
+	// errors. Log a warning if the user tried to set a non-zero value.
+	if p.Timeout != 0 {
+		log.Warnf("db.postgres.timeout is not supported and will be "+
+			"ignored. LND does not properly retry on timeout "+
+			"errors, so timeout is always set to 0 (disabled).")
+		p.Timeout = 0
+	}
+
 	if err := p.QueryConfig.Validate(false); err != nil {
 		return fmt.Errorf("invalid query config: %w", err)
 	}


### PR DESCRIPTION
Force db.postgres.timeout to always be 0 (disabled) as LND currently
does not properly retry when timeout errors occur. Any user-provided
non-zero timeout value will be overridden to 0 with a warning logged.

This is a temporary measure until proper retry logic is implemented for
postgres timeout errors. Once the retry mechanism is fixed, this
restriction can be removed to allow users to configure timeouts again.
