### PR TITLE
lncfg: add deprecated no-experimental-endorsement config option

### DIFF
--- a/lncfg/protocol.go
+++ b/lncfg/protocol.go
@@ -74,6 +74,11 @@ type ProtocolOptions struct {
 	// NoExperimentalAccountabilityOption disables experimental accountability.
 	NoExperimentalAccountabilityOption bool `long:"no-experimental-accountability" description:"do not forward experimental accountability signals"`
 
+	// NoExperimentalEndorsementOption is the deprecated name for
+	// NoExperimentalAccountabilityOption. It is hidden and will be removed
+	// in a future release.
+	NoExperimentalEndorsementOption bool `long:"no-experimental-endorsement" hidden:"true" description:"deprecated: use no-experimental-accountability instead"`
+
 	// CustomMessage allows the custom message APIs to handle messages with
 	// the provided protocol numbers, which fall outside the custom message
 	// number range.
@@ -140,9 +145,11 @@ func (l *ProtocolOptions) NoRouteBlinding() bool {
 }
 
 // NoExpAccountability returns true if experimental accountability should be
-// disabled.
+// disabled. It also checks the deprecated NoExperimentalEndorsementOption for
+// backwards compatibility.
 func (l *ProtocolOptions) NoExpAccountability() bool {
-	return l.NoExperimentalAccountabilityOption
+	return l.NoExperimentalAccountabilityOption ||
+		l.NoExperimentalEndorsementOption
 }
 
 // NoQuiescence returns true if quiescence is disabled.

--- a/lncfg/protocol_integration.go
+++ b/lncfg/protocol_integration.go
@@ -77,6 +77,11 @@ type ProtocolOptions struct {
 	// NoExperimentalAccountabilityOption disables experimental accountability.
 	NoExperimentalAccountabilityOption bool `long:"no-experimental-accountability" description:"do not forward experimental accountability signals"`
 
+	// NoExperimentalEndorsementOption is the deprecated name for
+	// NoExperimentalAccountabilityOption. It is hidden and will be removed
+	// in a future release.
+	NoExperimentalEndorsementOption bool `long:"no-experimental-endorsement" hidden:"true" description:"deprecated: use no-experimental-accountability instead"`
+
 	// NoQuiescenceOption disables quiescence for all channels.
 	NoQuiescenceOption bool `long:"no-quiescence" description:"do not allow or advertise quiescence for any channel"`
 
@@ -138,9 +143,11 @@ func (l *ProtocolOptions) NoRouteBlinding() bool {
 }
 
 // NoExpAccountability returns true if experimental accountability should be
-// disabled.
+// disabled. It also checks the deprecated NoExperimentalEndorsementOption for
+// backwards compatibility.
 func (l *ProtocolOptions) NoExpAccountability() bool {
-	return l.NoExperimentalAccountabilityOption
+	return l.NoExperimentalAccountabilityOption ||
+		l.NoExperimentalEndorsementOption
 }
 
 // NoQuiescence returns true if quiescence is disabled.

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1443,6 +1443,10 @@
 ; Set to disable experimental accountability signaling.
 ; protocol.no-experimental-accountability=false
 
+; DEPRECATED: Use protocol.no-experimental-accountability instead.
+; Set to disable experimental endorsement signaling.
+; protocol.no-experimental-endorsement=false
+
 ; Set to enable support for RBF based coop close.
 ; protocol.rbf-coop-close=false
 


### PR DESCRIPTION
Re-adds the old no-experimental-endorsement config option as a hidden,
deprecated alias for no-experimental-accountability. This ensures
backward compatibility for users who have the old option in their
config files after the rename it.


it was renamed here: https://github.com/lightningnetwork/lnd/pull/10367
