### PR TITLE
lncli: fix misleading default values in updatechanpolicy help

### DIFF
--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -97,6 +97,11 @@
 
 ## lncli Updates
 
+* [Fixed misleading "(default: 0)" help text](https://github.com/lightningnetwork/lnd/pull/10499)
+  for `base_fee_msat`, `fee_rate`/`fee_rate_ppm`, and `time_lock_delta` flags in
+  `lncli updatechanpolicy`. These fields are now marked as `[required]` since
+  omitting them with the current implementation would set them to invalid values.
+
 ## Breaking Changes
 
 ## Performance Improvements


### PR DESCRIPTION
## Summary

This PR fixes issue #1523 where the `updatechanpolicy` command displayed misleading "(default: 0)" text for required numeric flags.

- Converts `base_fee_msat`, `fee_rate_ppm`, `time_lock_delta` to `StringFlag`
- Adds `[required]` prefix and example values to help text
- Removes misleading "(default: 0)" text
- No behavior changes, just improved UX

## Related PR

- **Phase 2**: #10500 - Makes fields truly optional with `*_specified` proto flags (more invasive but complete solution)
- This PR (Phase 1) is a standalone fix that can be merged immediately
- If Phase 2 is merged, Phase 1 becomes unnecessary (but Phase 1 provides value on its own if Phase 2 takes longer to review/merge)

## Problem

`cli.Int64Flag` and `cli.Uint64Flag` automatically append "(default: 0)" to help text, which confused users because:
1. These fields are actually required, not optional
2. For `time_lock_delta`, 0 is not even a valid value (minimum is 18)

## Solution

Convert numeric flags to `StringFlag` (following the existing pattern used by `fee_rate` which was already a StringFlag), and add clear `[required]` labels.

## Changes

- Convert `base_fee_msat` from `Int64Flag` to `StringFlag`
- Convert `fee_rate_ppm` from `Uint64Flag` to `StringFlag`  
- Convert `time_lock_delta` from `Uint64Flag` to `StringFlag`
- Add `[required]` prefix to usage text for required fields
- Add example values and valid ranges to help users
- Update parsing logic to use explicit `strconv` functions

## Before vs After

**Before:**
```
--base_fee_msat value    the base fee in milli-satoshis... (default: 0)
--time_lock_delta value  the CLTV delta... (default: 0)
```

**After:**
```
--base_fee_msat value    [required] the base fee in milli-satoshis... (e.g., 1000)
--time_lock_delta value  [required] the CLTV delta... Must be between 18 and 65535 (e.g., 80)
```

## Why StringFlag?

1. **Existing precedent:** `fee_rate` was already a `StringFlag` in this same command
2. **Option 2 (Value + ctx.IsSet) cannot work without protocol changes:** The RPC server validates `time_lock_delta >= 18`, so sending 0 to mean "don't change" would fail
3. **Directly addresses user feedback:** As suggested in #1523, "it should just say this is a required argument"
4. **No breaking changes:** Behavior remains identical, only help text improves

See detailed analysis of previous attempts in PR #6762 and #8673.

## Test Plan

- [x] `go build ./cmd/lncli` - compiles successfully
- [x] `go test ./cmd/commands/...` - all tests pass
- [x] `go vet ./cmd/commands/...` - no issues
- [x] Verified help output shows correct text without "(default: 0)"

Fixes #1523