### PR TITLE
multi: make updatechanpolicy fields optional with *_specified flags

### DIFF
--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -95,6 +95,13 @@
 
 ## RPC Updates
 
+* [Added `*_specified` boolean fields to `PolicyUpdateRequest`](https://github.com/lightningnetwork/lnd/pull/10500)
+  for `base_fee_msat`, `fee_rate`, and `time_lock_delta`. This enables truly
+  optional updates to channel policies - when a `*_specified` field is false,
+  the corresponding parameter is not modified, allowing users to update only
+  specific policy fields while preserving others. Previously, omitting a field
+  would reset it to zero (which was invalid for `time_lock_delta`).
+
 ## lncli Updates
 
 ## Breaking Changes

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -15712,14 +15712,27 @@ type PolicyUpdateRequest struct {
 	//	*PolicyUpdateRequest_ChanPoint
 	Scope isPolicyUpdateRequest_Scope `protobuf_oneof:"scope"`
 	// The base fee charged regardless of the number of milli-satoshis sent.
+	// Only applied if base_fee_msat_specified is true.
 	BaseFeeMsat int64 `protobuf:"varint,3,opt,name=base_fee_msat,json=baseFeeMsat,proto3" json:"base_fee_msat,omitempty"`
+	// If true, base_fee_msat is applied. If false, the existing base fee is
+	// retained.
+	BaseFeeMsatSpecified bool `protobuf:"varint,12,opt,name=base_fee_msat_specified,json=baseFeeMsatSpecified,proto3" json:"base_fee_msat_specified,omitempty"`
 	// The effective fee rate in milli-satoshis. The precision of this value
-	// goes up to 6 decimal places, so 1e-6.
+	// goes up to 6 decimal places, so 1e-6. Only applied if fee_rate_specified
+	// is true.
 	FeeRate float64 `protobuf:"fixed64,4,opt,name=fee_rate,json=feeRate,proto3" json:"fee_rate,omitempty"`
-	// The effective fee rate in micro-satoshis (parts per million).
+	// The effective fee rate in micro-satoshis (parts per million). Only
+	// applied if fee_rate_specified is true.
 	FeeRatePpm uint32 `protobuf:"varint,9,opt,name=fee_rate_ppm,json=feeRatePpm,proto3" json:"fee_rate_ppm,omitempty"`
-	// The required timelock delta for HTLCs forwarded over the channel.
+	// If true, fee_rate or fee_rate_ppm is applied. If false, the existing fee
+	// rate is retained.
+	FeeRateSpecified bool `protobuf:"varint,13,opt,name=fee_rate_specified,json=feeRateSpecified,proto3" json:"fee_rate_specified,omitempty"`
+	// The required timelock delta for HTLCs forwarded over the channel. Only
+	// applied if time_lock_delta_specified is true.
 	TimeLockDelta uint32 `protobuf:"varint,5,opt,name=time_lock_delta,json=timeLockDelta,proto3" json:"time_lock_delta,omitempty"`
+	// If true, time_lock_delta is applied. If false, the existing time lock
+	// delta is retained.
+	TimeLockDeltaSpecified bool `protobuf:"varint,14,opt,name=time_lock_delta_specified,json=timeLockDeltaSpecified,proto3" json:"time_lock_delta_specified,omitempty"`
 	// If set, the maximum HTLC size in milli-satoshis. If unset, the maximum
 	// HTLC will be unchanged.
 	MaxHtlcMsat uint64 `protobuf:"varint,6,opt,name=max_htlc_msat,json=maxHtlcMsat,proto3" json:"max_htlc_msat,omitempty"`
@@ -15820,6 +15833,27 @@ func (x *PolicyUpdateRequest) GetTimeLockDelta() uint32 {
 		return x.TimeLockDelta
 	}
 	return 0
+}
+
+func (x *PolicyUpdateRequest) GetBaseFeeMsatSpecified() bool {
+	if x != nil {
+		return x.BaseFeeMsatSpecified
+	}
+	return false
+}
+
+func (x *PolicyUpdateRequest) GetFeeRateSpecified() bool {
+	if x != nil {
+		return x.FeeRateSpecified
+	}
+	return false
+}
+
+func (x *PolicyUpdateRequest) GetTimeLockDeltaSpecified() bool {
+	if x != nil {
+		return x.TimeLockDeltaSpecified
+	}
+	return false
 }
 
 func (x *PolicyUpdateRequest) GetMaxHtlcMsat() uint64 {

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -4737,17 +4737,33 @@ message PolicyUpdateRequest {
     }
 
     // The base fee charged regardless of the number of milli-satoshis sent.
+    // Only applied if base_fee_msat_specified is true.
     int64 base_fee_msat = 3;
 
+    // If true, base_fee_msat is applied. If false, the existing base fee is
+    // retained.
+    bool base_fee_msat_specified = 12;
+
     // The effective fee rate in milli-satoshis. The precision of this value
-    // goes up to 6 decimal places, so 1e-6.
+    // goes up to 6 decimal places, so 1e-6. Only applied if fee_rate_specified
+    // is true.
     double fee_rate = 4;
 
-    // The effective fee rate in micro-satoshis (parts per million).
+    // The effective fee rate in micro-satoshis (parts per million). Only
+    // applied if fee_rate_specified is true.
     uint32 fee_rate_ppm = 9;
 
-    // The required timelock delta for HTLCs forwarded over the channel.
+    // If true, fee_rate or fee_rate_ppm is applied. If false, the existing fee
+    // rate is retained.
+    bool fee_rate_specified = 13;
+
+    // The required timelock delta for HTLCs forwarded over the channel. Only
+    // applied if time_lock_delta_specified is true.
     uint32 time_lock_delta = 5;
+
+    // If true, time_lock_delta is applied. If false, the existing time lock
+    // delta is retained.
+    bool time_lock_delta_specified = 14;
 
     // If set, the maximum HTLC size in milli-satoshis. If unset, the maximum
     // HTLC will be unchanged.

--- a/routing/localchans/manager.go
+++ b/routing/localchans/manager.go
@@ -372,11 +372,15 @@ func (r *Manager) updateEdge(chanPoint wire.OutPoint,
 		return err
 	}
 
-	// Update forwarding fee scheme and required time lock delta.
-	edge.FeeBaseMSat = newSchema.BaseFee
-	edge.FeeProportionalMillionths = lnwire.MilliSatoshi(
-		newSchema.FeeRate,
-	)
+	// Update forwarding fee scheme if specified.
+	if newSchema.BaseFee != nil {
+		edge.FeeBaseMSat = *newSchema.BaseFee
+	}
+	if newSchema.FeeRate != nil {
+		edge.FeeProportionalMillionths = lnwire.MilliSatoshi(
+			*newSchema.FeeRate,
+		)
+	}
 
 	// If inbound fees are set, we update the edge with them.
 	err = fn.MapOptionZ(newSchema.InboundFee,
@@ -392,7 +396,10 @@ func (r *Manager) updateEdge(chanPoint wire.OutPoint,
 		return err
 	}
 
-	edge.TimeLockDelta = uint16(newSchema.TimeLockDelta)
+	// Update time lock delta if specified.
+	if newSchema.TimeLockDelta != nil {
+		edge.TimeLockDelta = uint16(*newSchema.TimeLockDelta)
+	}
 
 	// Retrieve negotiated channel htlc amt limits.
 	amtMin, amtMax, err := r.getHtlcAmtLimits(channel)

--- a/routing/localchans/manager_test.go
+++ b/routing/localchans/manager_test.go
@@ -54,12 +54,15 @@ func TestManager(t *testing.T) {
 	localMultisigKey := localMultisigPrivKey.PubKey()
 	remoteMultisigPrivKey, _ := btcec.NewPrivateKey()
 	remoteMultisigKey := remoteMultisigPrivKey.PubKey()
+	baseFee := lnwire.MilliSatoshi(100)
+	feeRate := uint32(200)
+	timeLockDelta := uint32(80)
 	newPolicy := routing.ChannelPolicy{
 		FeeSchema: routing.FeeSchema{
-			BaseFee: 100,
-			FeeRate: 200,
+			BaseFee: &baseFee,
+			FeeRate: &feeRate,
 		},
-		TimeLockDelta: 80,
+		TimeLockDelta: &timeLockDelta,
 		MaxHTLC:       5000,
 	}
 
@@ -80,13 +83,13 @@ func TestManager(t *testing.T) {
 		}
 
 		policy := chanPolicies[chanPointValid]
-		if policy.TimeLockDelta != newPolicy.TimeLockDelta {
+		if policy.TimeLockDelta != *newPolicy.TimeLockDelta {
 			t.Fatal("unexpected time lock delta")
 		}
-		if policy.BaseFee != newPolicy.BaseFee {
+		if policy.BaseFee != *newPolicy.BaseFee {
 			t.Fatal("unexpected base fee")
 		}
-		if uint32(policy.FeeRate) != newPolicy.FeeRate {
+		if uint32(policy.FeeRate) != *newPolicy.FeeRate {
 			t.Fatal("unexpected base fee")
 		}
 		if policy.MaxHTLC != newPolicy.MaxHTLC {
@@ -108,13 +111,13 @@ func TestManager(t *testing.T) {
 			if !policy.MessageFlags.HasMaxHtlc() {
 				t.Fatal("expected max htlc flag")
 			}
-			if policy.TimeLockDelta != uint16(newPolicy.TimeLockDelta) {
+			if policy.TimeLockDelta != uint16(*newPolicy.TimeLockDelta) {
 				t.Fatal("unexpected time lock delta")
 			}
-			if policy.FeeBaseMSat != newPolicy.BaseFee {
+			if policy.FeeBaseMSat != *newPolicy.BaseFee {
 				t.Fatal("unexpected base fee")
 			}
-			if uint32(policy.FeeProportionalMillionths) != newPolicy.FeeRate {
+			if uint32(policy.FeeProportionalMillionths) != *newPolicy.FeeRate {
 				t.Fatal("unexpected base fee")
 			}
 			if policy.MaxHTLC != newPolicy.MaxHTLC {

--- a/routing/router.go
+++ b/routing/router.go
@@ -189,16 +189,16 @@ type MissionControlQuerier interface {
 // Using the coefficients described within the schema, the required fee to
 // forward outgoing payments can be derived.
 type FeeSchema struct {
-	// BaseFee is the base amount of milli-satoshis that will be chained
-	// for ANY payment forwarded.
-	BaseFee lnwire.MilliSatoshi
+	// BaseFee is the base amount of milli-satoshis that will be charged
+	// for ANY payment forwarded. If nil, the existing base fee is retained.
+	BaseFee *lnwire.MilliSatoshi
 
 	// FeeRate is the rate that will be charged for forwarding payments.
 	// This value should be interpreted as the numerator for a fraction
 	// (fixed point arithmetic) whose denominator is 1 million. As a result
 	// the effective fee rate charged per mSAT will be: (amount *
-	// FeeRate/1,000,000).
-	FeeRate uint32
+	// FeeRate/1,000,000). If nil, the existing fee rate is retained.
+	FeeRate *uint32
 
 	// InboundFee is the inbound fee schedule that applies to forwards
 	// coming in through a channel to which this FeeSchema pertains.
@@ -213,8 +213,9 @@ type ChannelPolicy struct {
 	FeeSchema
 
 	// TimeLockDelta is the required HTLC timelock delta to be used
-	// when forwarding payments.
-	TimeLockDelta uint32
+	// when forwarding payments. If nil, the existing time lock delta is
+	// retained.
+	TimeLockDelta *uint32
 
 	// MaxHTLC is the maximum HTLC size including fees we are allowed to
 	// forward over this channel.

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -8078,54 +8078,70 @@ func (r *rpcServer) UpdateChannelPolicy(ctx context.Context,
 		return nil, fmt.Errorf("unknown scope: %v", scope)
 	}
 
-	var feeRateFixed uint32
+	var feeRateFixed *uint32
 
-	switch {
-	// The request should use either the fee rate in percent, or the new
-	// ppm rate, but not both.
-	case req.FeeRate != 0 && req.FeeRatePpm != 0:
-		errMsg := "cannot set both FeeRate and FeeRatePpm at the " +
-			"same time"
+	// Only process fee rate if explicitly specified.
+	if req.FeeRateSpecified {
+		switch {
+		// The request should use either the fee rate in percent, or
+		// the new ppm rate, but not both.
+		case req.FeeRate != 0 && req.FeeRatePpm != 0:
+			errMsg := "cannot set both FeeRate and FeeRatePpm " +
+				"at the same time"
 
-		return nil, status.Errorf(codes.InvalidArgument, "%v", errMsg)
+			return nil, status.Errorf(
+				codes.InvalidArgument, "%v", errMsg,
+			)
 
-	// If the request is using fee_rate.
-	case req.FeeRate != 0:
-		// As a sanity check, if the fee isn't zero, we'll ensure that
-		// the passed fee rate is below 1e-6, or the lowest allowed
-		// non-zero fee rate expressible within the protocol.
-		if req.FeeRate != 0 && req.FeeRate < minFeeRate {
-			return nil, fmt.Errorf("fee rate of %v is too "+
-				"small, min fee rate is %v", req.FeeRate,
-				minFeeRate)
+		// If the request is using fee_rate.
+		case req.FeeRate != 0:
+			// As a sanity check, if the fee isn't zero, we'll
+			// ensure that the passed fee rate is below 1e-6, or
+			// the lowest allowed non-zero fee rate expressible
+			// within the protocol.
+			if req.FeeRate < minFeeRate {
+				return nil, fmt.Errorf("fee rate of %v is "+
+					"too small, min fee rate is %v",
+					req.FeeRate, minFeeRate)
+			}
+
+			// We'll also need to convert the floating point fee
+			// rate we accept over RPC to the fixed point rate
+			// that we use within the protocol. We do this by
+			// multiplying the passed fee rate by the fee base.
+			// This gives us the fixed point, scaled by 1 million
+			// that's used within the protocol.
+			//
+			// Because of the inaccurate precision of the IEEE 754
+			// standard, we need to round the product of feerate
+			// and feebase.
+			rate := uint32(math.Round(req.FeeRate * feeBase))
+			feeRateFixed = &rate
+
+		// Otherwise, we use the fee_rate_ppm parameter.
+		case req.FeeRatePpm != 0:
+			feeRateFixed = &req.FeeRatePpm
+
+		// If fee_rate_specified is true but both rates are 0, set to 0.
+		default:
+			zero := uint32(0)
+			feeRateFixed = &zero
 		}
-
-		// We'll also need to convert the floating point fee rate we
-		// accept over RPC to the fixed point rate that we use within
-		// the protocol. We do this by multiplying the passed fee rate
-		// by the fee base. This gives us the fixed point, scaled by 1
-		// million that's used within the protocol.
-		//
-		// Because of the inaccurate precision of the IEEE 754
-		// standard, we need to round the product of feerate and
-		// feebase.
-		feeRateFixed = uint32(math.Round(req.FeeRate * feeBase))
-
-	// Otherwise, we use the fee_rate_ppm parameter.
-	case req.FeeRatePpm != 0:
-		feeRateFixed = req.FeeRatePpm
 	}
 
-	// We'll also ensure that the user isn't setting a CLTV delta that
-	// won't give outgoing HTLCs enough time to fully resolve if needed.
-	if req.TimeLockDelta < minTimeLockDelta {
-		return nil, fmt.Errorf("time lock delta of %v is too small, "+
-			"minimum supported is %v", req.TimeLockDelta,
-			minTimeLockDelta)
-	} else if req.TimeLockDelta > uint32(MaxTimeLockDelta) {
-		return nil, fmt.Errorf("time lock delta of %v is too big, "+
-			"maximum supported is %v", req.TimeLockDelta,
-			MaxTimeLockDelta)
+	// Only validate time lock delta if explicitly specified.
+	var timeLockDelta *uint32
+	if req.TimeLockDeltaSpecified {
+		if req.TimeLockDelta < minTimeLockDelta {
+			return nil, fmt.Errorf("time lock delta of %v is too "+
+				"small, minimum supported is %v",
+				req.TimeLockDelta, minTimeLockDelta)
+		} else if req.TimeLockDelta > uint32(MaxTimeLockDelta) {
+			return nil, fmt.Errorf("time lock delta of %v is too "+
+				"big, maximum supported is %v",
+				req.TimeLockDelta, MaxTimeLockDelta)
+		}
+		timeLockDelta = &req.TimeLockDelta
 	}
 
 	// By default, positive inbound fees are rejected.
@@ -8153,9 +8169,15 @@ func (r *rpcServer) UpdateChannelPolicy(ctx context.Context,
 		})
 	}
 
-	baseFeeMsat := lnwire.MilliSatoshi(req.BaseFeeMsat)
+	// Only set base fee if explicitly specified.
+	var baseFee *lnwire.MilliSatoshi
+	if req.BaseFeeMsatSpecified {
+		baseFeeMsat := lnwire.MilliSatoshi(req.BaseFeeMsat)
+		baseFee = &baseFeeMsat
+	}
+
 	feeSchema := routing.FeeSchema{
-		BaseFee:    baseFeeMsat,
+		BaseFee:    baseFee,
 		FeeRate:    feeRateFixed,
 		InboundFee: inboundFee,
 	}
@@ -8169,7 +8191,7 @@ func (r *rpcServer) UpdateChannelPolicy(ctx context.Context,
 
 	chanPolicy := routing.ChannelPolicy{
 		FeeSchema:     feeSchema,
-		TimeLockDelta: req.TimeLockDelta,
+		TimeLockDelta: timeLockDelta,
 		MaxHTLC:       maxHtlc,
 		MinHTLC:       minHtlc,
 	}


### PR DESCRIPTION
## Summary

This PR makes the `base_fee_msat`, `fee_rate`/`fee_rate_ppm`, and `time_lock_delta` fields truly optional in the `UpdateChannelPolicy` RPC.

- Adds `base_fee_msat_specified`, `fee_rate_specified`, `time_lock_delta_specified` proto fields
- Changes internal structs to use pointers for optional semantics
- Makes fields truly optional - users can now update individual fields independently
- Backwards compatible - existing clients continue to work
- Marked as draft because proto regeneration (`make rpc`) is needed

## Related PR

- **Phase 1**: #10499 - Fixes help text only (simpler, can merge immediately)
- This PR (Phase 2) is more invasive but provides the full solution users have been asking for
- If this PR is merged, Phase 1 becomes unnecessary (but Phase 1 provides value on its own if this PR takes longer to review/merge)

## Problem

Previously, users had to specify ALL fields on every invocation, even when they only wanted to update a single field. This was a major pain point reported in #1523.

## Solution

Add `*_specified` boolean flags (following the existing `MinHtlcMsatSpecified` pattern) that allow the server to distinguish between "user wants to set this to X" and "user didn't specify this, keep the existing value".

## Changes

### Protocol changes (`lnrpc/lightning.proto`)
- Add `base_fee_msat_specified` (field 12)
- Add `fee_rate_specified` (field 13) 
- Add `time_lock_delta_specified` (field 14)

### Internal API changes (`routing/router.go`)
- `FeeSchema.BaseFee`: changed from value to pointer (`*lnwire.MilliSatoshi`)
- `FeeSchema.FeeRate`: changed from value to pointer (`*uint32`)
- `ChannelPolicy.TimeLockDelta`: changed from value to pointer (`*uint32`)

### RPC server changes (`rpcserver.go`)
- Only validate and apply fields when their `*_specified` flag is true
- When a field is not specified, the existing channel value is retained

### CLI changes (`cmd/commands/commands.go`)
- Fields are now truly optional (no "argument missing" errors)
- `ctx.IsSet()` determines whether to set `*_specified` flags
- Default values shown in help text from `chainreg` constants
- Help text updated to say "If unset, existing value is retained"

### Local channel manager changes (`routing/localchans/manager.go`)
- `updateEdge()` only updates fields when pointers are non-nil
- Follows the same pattern already used for `MinHTLC`

## Usage Example

Users can now update individual policy fields independently:

```bash
# Update only base fee
lncli updatechanpolicy --base_fee_msat 1000 --chan_point abc:0

# Update only fee rate
lncli updatechanpolicy --fee_rate_ppm 100 --chan_point abc:0

# Update only time lock delta
lncli updatechanpolicy --time_lock_delta 80 --chan_point abc:0
```

## API Compatibility

This is a **backwards compatible** change:
- Existing clients that set all fields will continue to work
- New clients can omit fields they don't want to change
- The `*_specified` flags default to `false`, preserving existing behavior

## Test Plan

- [x] `go build ./...` - compiles successfully
- [x] `go test ./routing/localchans/...` - all tests pass
- [ ] Proto regeneration required (`make rpc`) - manual step needed
- [ ] Integration tests for partial updates

## Note

⚠️ **Proto regeneration required**: The `lightning.pb.go` file was manually updated to match the proto changes. A proper `make rpc` regeneration is needed before merge.

Fixes #1523