### PR TITLE
routerrpc: add outgoing_chan_ids to EstimateRouteFee

### DIFF
--- a/cmd/commands/cmd_payments.go
+++ b/cmd/commands/cmd_payments.go
@@ -2094,6 +2094,15 @@ var estimateRouteFeeCommand = cli.Command{
 				"applicable if pay_req is specified.",
 			Value: paymentTimeout,
 		},
+		cli.StringSliceFlag{
+			Name: "outgoing_chan_id",
+			Usage: "short channel id of the outgoing channel " +
+				"to use for the first hop of the fee " +
+				"estimation; if specified multiple " +
+				"times, only the listed channels are " +
+				"considered for the first hop",
+			Value: &cli.StringSlice{},
+		},
 	},
 }
 
@@ -2138,6 +2147,15 @@ func estimateRouteFee(ctx *cli.Context) error {
 
 	default:
 		return fmt.Errorf("fee estimation arguments missing")
+	}
+
+	var (
+		err        error
+		outChanIDs = ctx.StringSlice("outgoing_chan_id")
+	)
+	req.OutgoingChanIds, err = parseChanIDs(outChanIDs)
+	if err != nil {
+		return fmt.Errorf("unable to decode outgoing_chan_id: %w", err)
 	}
 
 	resp, err := client.EstimateRouteFee(ctxc, req)

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -27,7 +27,17 @@
 
 ## RPC Additions
 
+* The `routerrpc.EstimateRouteFee` RPC now supports [restricting fee estimates
+  to specific first-hop outgoing
+  channels](https://github.com/lightningnetwork/lnd/pull/10501) via the new
+  `outgoing_chan_ids` field in `RouteFeeRequest`.
+
 ## lncli Additions
+
+* The `estimateroutefee` command now supports [restricting fee estimates to
+  specific first-hop outgoing
+  channels](https://github.com/lightningnetwork/lnd/pull/10501) via the new
+  `--outgoing_chan_id` flag.
 
 # Improvements
 

--- a/itest/lnd_estimate_route_fee_test.go
+++ b/itest/lnd_estimate_route_fee_test.go
@@ -19,12 +19,14 @@ var (
 	probeAmount    = btcutil.Amount(100_000)
 	probeAmt       = int64(probeAmount) * 1_000
 
-	failureReasonNone    = lnrpc.PaymentFailureReason_FAILURE_REASON_NONE
-	failureReasonNoRoute = lnrpc.PaymentFailureReason_FAILURE_REASON_NO_ROUTE //nolint:ll
+	failureReasonNone          = lnrpc.PaymentFailureReason_FAILURE_REASON_NONE                 //nolint:ll
+	failureReasonNoRoute       = lnrpc.PaymentFailureReason_FAILURE_REASON_NO_ROUTE             //nolint:ll
+	failureInsufficientBalance = lnrpc.PaymentFailureReason_FAILURE_REASON_INSUFFICIENT_BALANCE //nolint:ll
 )
 
 const (
-	ErrNoRouteInGraph = "unable to find a path to destination"
+	ErrNoRouteInGraph      = "unable to find a path to destination"
+	ErrInsufficientBalance = "insufficient local balance"
 )
 
 type estimateRouteFeeTestCase struct {
@@ -40,6 +42,10 @@ type estimateRouteFeeTestCase struct {
 
 	// routeHints are the route hints that will be used for the probe.
 	routeHints []*lnrpc.RouteHint
+
+	// outgoingChanIds is the list of channel IDs allowed for the first
+	// hop. If empty, any channel may be used.
+	outgoingChanIds []uint64
 
 	// expectedRoutingFeesMsat are the expected routing fees that will be
 	// returned by the probe.
@@ -153,6 +159,11 @@ func testEstimateRouteFee(ht *lntest.HarnessTest) {
 	)
 	require.Len(ht, davesPrivChannels.Channels, 1)
 	daveFrankChanID := davesPrivChannels.Channels[0].ChanId
+
+	channelAliceCarol := ht.QueryChannelByChanPoint(
+		mts.alice, mts.channelPoints[0],
+	)
+	aliceCarolChanID := channelAliceCarol.ChanId
 
 	// Let's disable the paths from Alice to Bob through Dave and Eve with
 	// high fees. This ensures that the path estimates are based on Carol's
@@ -441,6 +452,58 @@ func testEstimateRouteFee(ht *lntest.HarnessTest) {
 				highestFeeRouteDelta,
 			expectedFailureReason: failureReasonNone,
 		},
+		// Test probe-based estimation with a specific outgoing channel.
+		// We specify the Alice-Carol channel, so the route should go
+		// through Carol to Bob.
+		{
+			name: "probe based estimate with " +
+				"outgoing channel",
+			probing:                 true,
+			destination:             mts.bob,
+			routeHints:              []*lnrpc.RouteHint{},
+			outgoingChanIds:         []uint64{aliceCarolChanID},
+			expectedRoutingFeesMsat: feeStandardSingleHop,
+			expectedCltvDelta:       locktime + deltaCB,
+			expectedFailureReason:   failureReasonNone,
+		},
+		// Test probe-based estimation with a non-existent outgoing
+		// channel. This should fail because the specified channel
+		// doesn't exist and has no balance.
+		{
+			name: "probe based estimate with " +
+				"invalid outgoing channel",
+			probing:                 true,
+			destination:             mts.bob,
+			routeHints:              []*lnrpc.RouteHint{},
+			outgoingChanIds:         []uint64{999999999},
+			expectedRoutingFeesMsat: 0,
+			expectedCltvDelta:       0,
+			expectedFailureReason:   failureInsufficientBalance,
+		},
+		// Test graph-based estimation with a specific outgoing channel.
+		// We specify the Alice-Carol channel, so the route should go
+		// through Carol to Bob.
+		{
+			name: "graph based estimate with " +
+				"outgoing channel",
+			probing:                 false,
+			destination:             mts.bob,
+			outgoingChanIds:         []uint64{aliceCarolChanID},
+			expectedRoutingFeesMsat: feeStandardSingleHop,
+			expectedCltvDelta:       locktime + deltaCB,
+			expectedFailureReason:   failureReasonNone,
+		},
+		// Test graph-based estimation with a non-existent outgoing
+		// channel. This should fail because the specified channel
+		// doesn't exist and has no balance.
+		{
+			name: "graph based estimate with " +
+				"invalid outgoing channel",
+			probing:         false,
+			destination:     mts.bob,
+			outgoingChanIds: []uint64{999999999},
+			expectedError:   ErrInsufficientBalance,
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -467,13 +530,15 @@ func runFeeEstimationTestCase(ht *lntest.HarnessTest,
 			tc.destination, probeAmount, 1, tc.routeHints...,
 		)
 		feeReq = &routerrpc.RouteFeeRequest{
-			PaymentRequest: payReqs[0],
-			Timeout:        uint32(wait.PaymentTimeout.Seconds()),
+			PaymentRequest:  payReqs[0],
+			Timeout:         uint32(wait.PaymentTimeout.Seconds()),
+			OutgoingChanIds: tc.outgoingChanIds,
 		}
 	} else {
 		feeReq = &routerrpc.RouteFeeRequest{
-			Dest:   tc.destination.PubKey[:],
-			AmtSat: int64(probeAmount),
+			Dest:            tc.destination.PubKey[:],
+			AmtSat:          int64(probeAmount),
+			OutgoingChanIds: tc.outgoingChanIds,
 		}
 	}
 

--- a/lnrpc/routerrpc/router.pb.go
+++ b/lnrpc/routerrpc/router.pb.go
@@ -862,9 +862,14 @@ type RouteFeeRequest struct {
 	// than the timeout if the HTLC becomes delayed or stuck. Canceling the context
 	// of this call will not cancel the payment loop, the duration is only
 	// controlled by the timeout parameter.
-	Timeout       uint32 `protobuf:"varint,4,opt,name=timeout,proto3" json:"timeout,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Timeout uint32 `protobuf:"varint,4,opt,name=timeout,proto3" json:"timeout,omitempty"`
+	// The channel ids of the channels that are allowed for the first hop. If
+	// empty, any channel may be used. This field is applicable to both
+	// graph-based fee estimation (using dest + amt_sat) and probe-based
+	// estimation (using payment_request).
+	OutgoingChanIds []uint64 `protobuf:"varint,5,rep,packed,name=outgoing_chan_ids,json=outgoingChanIds,proto3" json:"outgoing_chan_ids,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *RouteFeeRequest) Reset() {
@@ -923,6 +928,13 @@ func (x *RouteFeeRequest) GetTimeout() uint32 {
 		return x.Timeout
 	}
 	return 0
+}
+
+func (x *RouteFeeRequest) GetOutgoingChanIds() []uint64 {
+	if x != nil {
+		return x.OutgoingChanIds
+	}
+	return nil
 }
 
 type RouteFeeResponse struct {
@@ -3833,12 +3845,13 @@ const file_routerrpc_router_proto_rawDesc = "" +
 	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12.\n" +
 	"\x13no_inflight_updates\x18\x02 \x01(\bR\x11noInflightUpdates\"F\n" +
 	"\x14TrackPaymentsRequest\x12.\n" +
-	"\x13no_inflight_updates\x18\x01 \x01(\bR\x11noInflightUpdates\"\x81\x01\n" +
+	"\x13no_inflight_updates\x18\x01 \x01(\bR\x11noInflightUpdates\"\xad\x01\n" +
 	"\x0fRouteFeeRequest\x12\x12\n" +
 	"\x04dest\x18\x01 \x01(\fR\x04dest\x12\x17\n" +
 	"\aamt_sat\x18\x02 \x01(\x03R\x06amtSat\x12'\n" +
 	"\x0fpayment_request\x18\x03 \x01(\tR\x0epaymentRequest\x12\x18\n" +
-	"\atimeout\x18\x04 \x01(\rR\atimeout\"\xa8\x01\n" +
+	"\atimeout\x18\x04 \x01(\rR\atimeout\x12*\n" +
+	"\x11outgoing_chan_ids\x18\x05 \x03(\x04R\x0foutgoingChanIds\"\xa8\x01\n" +
 	"\x10RouteFeeResponse\x12(\n" +
 	"\x10routing_fee_msat\x18\x01 \x01(\x03R\x0eroutingFeeMsat\x12&\n" +
 	"\x0ftime_lock_delay\x18\x02 \x01(\x03R\rtimeLockDelay\x12B\n" +

--- a/lnrpc/routerrpc/router.proto
+++ b/lnrpc/routerrpc/router.proto
@@ -443,6 +443,14 @@ message RouteFeeRequest {
     controlled by the timeout parameter.
     */
     uint32 timeout = 4;
+
+    /*
+    The channel ids of the channels that are allowed for the first hop. If
+    empty, any channel may be used. This field is applicable to both
+    graph-based fee estimation (using dest + amt_sat) and probe-based
+    estimation (using payment_request).
+    */
+    repeated uint64 outgoing_chan_ids = 5;
 }
 
 message RouteFeeResponse {

--- a/lnrpc/routerrpc/router.swagger.json
+++ b/lnrpc/routerrpc/router.swagger.json
@@ -1972,6 +1972,14 @@
           "type": "integer",
           "format": "int64",
           "description": "A user preference of how long a probe payment should maximally be allowed to\ntake, denoted in seconds. The probing payment loop is aborted if this\ntimeout is reached. Note that the probing process itself can take longer\nthan the timeout if the HTLC becomes delayed or stuck. Canceling the context\nof this call will not cancel the payment loop, the duration is only\ncontrolled by the timeout parameter."
+        },
+        "outgoing_chan_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uint64"
+          },
+          "description": "The channel ids of the channels that are allowed for the first hop. If\nempty, any channel may be used. This field is applicable to both\ngraph-based fee estimation (using dest + amt_sat) and probe-based\nestimation (using payment_request)."
         }
       }
     },

--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -448,12 +448,15 @@ func (s *Server) EstimateRouteFee(ctx context.Context,
 			return nil, errors.New("amount must be greater than 0")
 
 		default:
-			return s.probeDestination(req.Dest, req.AmtSat)
+			return s.probeDestination(
+				req.Dest, req.AmtSat, req.OutgoingChanIds,
+			)
 		}
 
 	case isProbeInvoice:
 		return s.probePaymentRequest(
 			ctx, req.PaymentRequest, req.Timeout,
+			req.OutgoingChanIds,
 		)
 	}
 
@@ -462,8 +465,8 @@ func (s *Server) EstimateRouteFee(ctx context.Context,
 
 // probeDestination estimates fees along a route to a destination based on the
 // contents of the local graph.
-func (s *Server) probeDestination(dest []byte, amtSat int64) (*RouteFeeResponse,
-	error) {
+func (s *Server) probeDestination(dest []byte, amtSat int64,
+	outgoingChanIDs []uint64) (*RouteFeeResponse, error) {
 
 	destNode, err := route.NewVertexFromBytes(dest)
 	if err != nil {
@@ -478,14 +481,16 @@ func (s *Server) probeDestination(dest []byte, amtSat int64) (*RouteFeeResponse,
 	// that target amount, we'll only request a single route. Set a
 	// restriction for the default CLTV limit, otherwise we can find a route
 	// that exceeds it and is useless to us.
-	mc := s.cfg.RouterBackend.MissionControl
+	backend := s.cfg.RouterBackend
+	mc := backend.MissionControl
 	routeReq, err := routing.NewRouteRequest(
-		s.cfg.RouterBackend.SelfNode, &destNode, amtMsat, 0,
+		backend.SelfNode, &destNode, amtMsat, 0,
 		&routing.RestrictParams{
-			FeeLimit:          routeFeeLimitSat,
-			CltvLimit:         s.cfg.RouterBackend.MaxTotalTimelock,
-			ProbabilitySource: mc.GetProbability,
-		}, nil, nil, nil, s.cfg.RouterBackend.DefaultFinalCltvDelta,
+			FeeLimit:           routeFeeLimitSat,
+			CltvLimit:          backend.MaxTotalTimelock,
+			ProbabilitySource:  mc.GetProbability,
+			OutgoingChannelIDs: outgoingChanIDs,
+		}, nil, nil, nil, backend.DefaultFinalCltvDelta,
 	)
 	if err != nil {
 		return nil, err
@@ -522,7 +527,7 @@ func (s *Server) probeDestination(dest []byte, amtSat int64) (*RouteFeeResponse,
 // identify LSPs, the probe payment might use a different node id as the
 // final destination (the assumed LSP node id).
 func (s *Server) probePaymentRequest(ctx context.Context, paymentRequest string,
-	timeout uint32) (*RouteFeeResponse, error) {
+	timeout uint32, outgoingChanIDs []uint64) (*RouteFeeResponse, error) {
 
 	payReq, err := zpay32.Decode(
 		paymentRequest, s.cfg.RouterBackend.ActiveNetParams,
@@ -556,6 +561,7 @@ func (s *Server) probePaymentRequest(ctx context.Context, paymentRequest string,
 		FeeLimitSat:      routeFeeLimitSat,
 		FinalCltvDelta:   int32(payReq.MinFinalCLTVExpiry()),
 		DestFeatures:     MarshalFeatures(payReq.Features),
+		OutgoingChanIds:  outgoingChanIDs,
 	}
 
 	// If the payment addresses is specified, then we'll also populate that
@@ -625,6 +631,7 @@ func (s *Server) probePaymentRequest(ctx context.Context, paymentRequest string,
 			FeeLimitSat:      probeRequest.FeeLimitSat,
 			FinalCltvDelta:   int32(lspHint.CLTVExpiryDelta),
 			DestFeatures:     probeRequest.DestFeatures,
+			OutgoingChanIds:  probeRequest.OutgoingChanIds,
 		}
 
 		// Copy the payment address if present.


### PR DESCRIPTION
## Change Description
I needed the OutgoingChanIds field in EstateRouteFee. Fortunately, I was able to change it with a few modifications without core logic changes.

## Steps to Test
~~I didn't write a separate test because this change doesn't change the test coverage of the core route logic.~~
I checked that the test for the EstimateRouteFee command already exists.

So I added integration tests for `outgoing_chan_ids` in `EstimateRouteFee`.
- Estimation with a specific outgoing channel restriction
- Error handling when an invalid channel ID is specified
- Passed `make itest icase=estimate_route_fee`

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
