### PR TITLE
rpcserver: enforce max_events limit of 50000 for ForwardingHistory

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -8240,10 +8240,9 @@ func (r *rpcServer) ForwardingHistory(ctx context.Context,
 		numEvents = 100
 	}
 
-	// Cap at 50000 as documented in the API.
-	const maxForwardingEvents = 50000
-	if numEvents > maxForwardingEvents {
-		numEvents = maxForwardingEvents
+	// Cap at the maximum number of events as documented in the API.
+	if numEvents > channeldb.MaxResponseEvents {
+		numEvents = channeldb.MaxResponseEvents
 	}
 
 	// Create sets of incoming and outgoing channel IDs from the request


### PR DESCRIPTION
## Summary
- Enforces the documented 50k limit on ForwardingHistory responses
- Caps `num_max_events` at 50000 as stated in the proto documentation

## Background
The API documentation states "each response can only contain 50k records" but this limit was not actually enforced. This PR implements the documented behavior.

## Test plan
- [x] Verified logic caps events at 50000 when higher values requested
- [x] Default of 100 still works when not specified

Closes #10496

🤖 Generated with [Claude Code](https://claude.com/claude-code)