### PR TITLE
chainio: add defer b.Stop() to fix goroutine leak in tests

### DIFF
--- a/chainio/dispatcher_test.go
+++ b/chainio/dispatcher_test.go
@@ -183,6 +183,7 @@ func TestRegisterQueue(t *testing.T) {
 
 	// Create a new dispatcher.
 	b := NewBlockbeatDispatcher(mockNotifier)
+	defer b.Stop()
 
 	// Register the consumers.
 	b.RegisterQueue(consumers)
@@ -208,6 +209,7 @@ func TestStartDispatcher(t *testing.T) {
 
 	// Create a new dispatcher.
 	b := NewBlockbeatDispatcher(mockNotifier)
+	defer b.Stop()
 
 	// Start the dispatcher without consumers should return an error.
 	err := b.Start()
@@ -247,6 +249,7 @@ func TestDispatchBlocks(t *testing.T) {
 
 	// Create a new dispatcher.
 	b := NewBlockbeatDispatcher(mockNotifier)
+	defer b.Stop()
 
 	// Create the beat and attach it to the dispatcher.
 	epoch := chainntnfs.BlockEpoch{Height: 1}
@@ -323,6 +326,7 @@ func TestNotifyQueuesSuccess(t *testing.T) {
 
 	// Create a new dispatcher.
 	b := NewBlockbeatDispatcher(mockNotifier)
+	defer b.Stop()
 
 	// Register the queues.
 	b.RegisterQueue(queue1)
@@ -366,6 +370,7 @@ func TestNotifyQueuesError(t *testing.T) {
 
 	// Create a new dispatcher.
 	b := NewBlockbeatDispatcher(mockNotifier)
+	defer b.Stop()
 
 	// Register the queues.
 	b.RegisterQueue(queue)
@@ -408,6 +413,7 @@ func TestCurrentHeight(t *testing.T) {
 
 	// Create a new dispatcher.
 	b := NewBlockbeatDispatcher(mockNotifier)
+	defer b.Stop()
 
 	// Register the queues.
 	b.RegisterQueue(queue)


### PR DESCRIPTION
## Description

This PR fixes the goroutine leak in the chainio package's BlockbeatDispatcher by adding defer b.Stop() to test cleanup.

## Fixes

Fixes #10505

## Details

The BlockbeatDispatcher.Start() method launches a goroutine that waits indefinitely on a channel. Tests were calling Start() but never calling Stop() to properly shut down the dispatcher. This caused goroutines to hang at test completion, creating memory leaks.

The fix adds `defer b.Stop()` immediately after creating the dispatcher instance, ensuring proper cleanup when the test ends.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Testing

- [x] I have tested this change with `make test`
- [x] No test failures introduced