### PR TITLE
config: store-final-htlc-resolutions enabled by default

### DIFF
--- a/config.go
+++ b/config.go
@@ -420,7 +420,9 @@ type Config struct {
 
 	KeepFailedPaymentAttempts bool `long:"keep-failed-payment-attempts" description:"Keeps persistent record of all failed payment attempts for successfully settled payments."`
 
-	StoreFinalHtlcResolutions bool `long:"store-final-htlc-resolutions" description:"Persistently store the final resolution of incoming htlcs."`
+	StoreFinalHtlcResolutions bool `long:"store-final-htlc-resolutions" description:"DEPRECATED: This option is now enabled by default. Use --no-store-final-htlc-resolutions to disable." hidden:"true"`
+
+	NoStoreFinalHtlcResolutions bool `long:"no-store-final-htlc-resolutions" description:"Disable the persistent storage of final HTLC resolutions."`
 
 	DefaultRemoteMaxHtlcs uint16 `long:"default-remote-max-htlcs" description:"The default max_htlc applied when opening or accepting channels. This value limits the number of concurrent HTLCs that the remote party can add to the commitment. The maximum possible value is 483."`
 
@@ -663,6 +665,7 @@ func DefaultConfig() Config {
 		DefaultRemoteMaxHtlcs:         defaultRemoteMaxHtlcs,
 		NumGraphSyncPeers:             defaultMinPeers,
 		HistoricalSyncInterval:        discovery.DefaultHistoricalSyncInterval,
+		StoreFinalHtlcResolutions:     true,
 		Tor: &lncfg.Tor{
 			SOCKS:   defaultTorSOCKS,
 			DNS:     defaultTorDNS,
@@ -1022,6 +1025,12 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 	cfg.WalletUnlockPasswordFile = CleanAndExpandPath(
 		cfg.WalletUnlockPasswordFile,
 	)
+
+	// If the user explicitly disabled storing final HTLC resolutions,
+	// override the default value.
+	if cfg.NoStoreFinalHtlcResolutions {
+		cfg.StoreFinalHtlcResolutions = false
+	}
 
 	// Ensure that the user didn't attempt to specify negative values for
 	// any of the autopilot params.

--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -99,9 +99,16 @@
 
 ## Breaking Changes
 
+* [Enabled `--store-final-htlc-resolutions` by default](https://github.com/lightningnetwork/lnd/pull/10524).
+  LND now persists final HTLC outcomes. Use `--no-store-final-htlc-resolutions`
+  to disable.
+
 ## Performance Improvements
 
 ## Deprecations
+
+* The `--store-final-htlc-resolutions` flag is now deprecated as this behavior
+  is enabled by default. Use `--no-store-final-htlc-resolutions` to disable.
 
 ### ⚠️ **Warning:** The deprecated fee rate option `--sat_per_byte` will be removed in release version **0.22**
 

--- a/itest/lnd_htlc_test.go
+++ b/itest/lnd_htlc_test.go
@@ -14,10 +14,10 @@ import (
 func testLookupHtlcResolution(ht *lntest.HarnessTest) {
 	const chanAmt = btcutil.Amount(1000000)
 
-	alice := ht.NewNodeWithCoins("Alice", nil)
-	carol := ht.NewNode("Carol", []string{
-		"--store-final-htlc-resolutions",
+	alice := ht.NewNodeWithCoins("Alice", []string{
+		"--no-store-final-htlc-resolutions",
 	})
+	carol := ht.NewNode("Carol", nil)
 	ht.EnsureConnected(alice, carol)
 
 	// Open a channel between Alice and Carol.

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -409,8 +409,9 @@
 ; settled payments.
 ; keep-failed-payment-attempts=false
 
-; Persistently store the final resolution of incoming htlcs.
-; store-final-htlc-resolutions=false
+; Disable the persistent storage of final HTLC resolutions. This is enabled
+; by default.
+; no-store-final-htlc-resolutions=false
 
 ; The default max_htlc applied when opening or accepting channels. This value
 ; limits the number of concurrent HTLCs that the remote party can add to the


### PR DESCRIPTION
Enable `--store-final-htlc-resolutions` by default in LND so `LookupHtlcResolution` works out-of-the-box.

**Motivation**

Taproot-assets `ForwardingHistory` reconciliation relies on `LookupHtlcResolution` to reconcile pending forwards after restarts. The RPC currently fails unless `store-final-htlc-resolutions` is enabled, which is off by default. Flipping the default makes reconciliation reliable without extra configuration, while still allowing users to opt out by explicitly disabling the flag.
