### PR TITLE
workflows/pr-severity: use pull_request_target for fork PRs

### DIFF
--- a/.github/workflows/pr-severity.yml
+++ b/.github/workflows/pr-severity.yml
@@ -1,7 +1,10 @@
 name: PR Severity Classification
 
 on:
-  pull_request:
+  # Use pull_request_target to allow running on fork PRs with access to secrets.
+  # This is safe because we don't checkout or execute any code from the PR -
+  # we only read PR metadata (changed files, labels) via the GitHub API.
+  pull_request_target:
     types: [opened, synchronize, labeled]
 
 permissions:


### PR DESCRIPTION
Switch from pull_request to pull_request_target to allow the workflow to run on PRs from forks. The pull_request trigger runs in the fork's context which cannot access repository secrets.

This is safe because the workflow only reads PR metadata via the GitHub API (changed files, labels) and doesn't checkout or execute any code from the PR itself.


We'll now this works if after the merge, we can add the `reclassify` label and it'll run the bot. 