### PR TITLE
peer: fix MarkCoopBroadcasted to correctly use local parameter

### DIFF
--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -45,11 +45,17 @@
   has been removed from the public key parsing methods, and proper mutex
   protection has been added to the cache access in `DisconnectBlockAtHeight`.
 
-- [Fixed TLV decoders to reject malformed records with incorrect lengths](https://github.com/lightningnetwork/lnd/pull/10249). 
+- [Fixed TLV decoders to reject malformed records with incorrect lengths](https://github.com/lightningnetwork/lnd/pull/10249).
   TLV decoders now strictly enforce fixed-length requirements for Fee (8 bytes),
   Musig2Nonce (66 bytes), ShortChannelID (8 bytes), Vertex (33 bytes), and
   DBytes33 (33 bytes) records, preventing malformed TLV data from being
   accepted.
+
+- [Fixed `MarkCoopBroadcasted` to correctly use the `local`
+  parameter](https://github.com/lightningnetwork/lnd/pull/10532). The method was
+  ignoring the `local` parameter and always marking cooperative close
+  transactions as locally initiated, even when they were initiated by the remote
+  peer.
 
 # New Features
 

--- a/peer/chan_observer.go
+++ b/peer/chan_observer.go
@@ -119,7 +119,12 @@ func (l *chanObserver) DisableOutgoingAdds() error {
 // MarkCoopBroadcasted persistently marks that the channel close transaction
 // has been broadcast.
 func (l *chanObserver) MarkCoopBroadcasted(tx *wire.MsgTx, local bool) error {
-	return l.chanView.MarkCoopBroadcasted(tx, lntypes.Local)
+	party := lntypes.Remote
+	if local {
+		party = lntypes.Local
+	}
+
+	return l.chanView.MarkCoopBroadcasted(tx, party)
 }
 
 // MarkShutdownSent persists the given ShutdownInfo. The existence of the


### PR DESCRIPTION
This commit fixes a bug in `chanObserver.MarkCoopBroadcasted` where the local parameter was being ignored. The function always passed `lntypes.Local` to the underlying `MarkCoopBroadcasted` call, regardless of which party actually initiated the cooperative close.

This caused the channel status to incorrectly include `ChanStatusLocalCloseInitiator` even on the remote node, resulting in incorrect `close_initiator` values in RPC responses.

The fix converts the local bool parameter to the appropriate `lntypes.ChannelParty` before passing it through.