### PR TITLE
ci: fix claude action severity labeling

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -52,10 +52,13 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
+          # Supplementary instructions for Claude alongside the user's
+          # @claude comment.
+          prompt: |
+            When adding or removing labels on PRs or issues, always use
+            `gh pr edit` with `--add-label` or `--remove-label`. Never use
+            `gh api` for label operations.
 
-          # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'


### PR DESCRIPTION
The Claude Code GitHub Action was failing to add severity labels to PRs. The root cause was a permission denial at two levels: Claude was using `gh api` to hit the issues labels endpoint, but the action's default allowed tools only permit `gh pr view`, `gh pr edit`, and `gh pr comment`. So the tool call was rejected before it ever reached GitHub.

Even if the tool call had gone through, it would have failed anyway. The workflow's GitHub token permissions were set to read-only for both `issues` and `pull-requests`, meaning any write operation against the labels API would return a 403.

This change bumps the `issues` and `pull-requests` permissions to `write` so the token can actually modify labels. It also adds a prompt instruction telling Claude to use `gh pr edit --add-label` for labeling instead of `gh api`, which keeps the allowed tools as restricted as possible without needing to open up arbitrary API access.

The failed run that surfaced this: https://github.com/lightningnetwork/lnd/actions/runs/21614145381/job/62289184152. You can see in the output that the `gh api` call shows up in the `permission_denials` array, confirming the tool was blocked by Claude Code's own sandboxing before the GitHub API was ever contacted.