### PR TITLE
rpcserver+routerrpc: allow overpayment of fixed-amount invoices

### DIFF
--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -384,6 +384,10 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testSingleHopInvoice,
 	},
 	{
+		Name:     "send payment overpay",
+		TestFunc: testSendPaymentOverpay,
+	},
+	{
 		Name:     "wipe forwarding packages",
 		TestFunc: testWipeForwardingPackages,
 	},

--- a/itest/lnd_send_overpayment_test.go
+++ b/itest/lnd_send_overpayment_test.go
@@ -1,0 +1,59 @@
+package itest
+
+import (
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
+	"github.com/lightningnetwork/lnd/lntest"
+	"github.com/stretchr/testify/require"
+)
+
+// testSendPaymentOverpay verifies that a payer can intentionally overpay a
+// fixed-amount BOLT11 invoice by specifying a larger amt_msat in the send
+// request.
+func testSendPaymentOverpay(ht *lntest.HarnessTest) {
+	// Open a channel with 100k satoshis between Alice and Bob.
+	chanAmt := btcutil.Amount(100_000)
+	_, nodes := ht.CreateSimpleNetwork(
+		[][]string{nil, nil},
+		lntest.OpenChannelParams{Amt: chanAmt},
+	)
+	alice, bob := nodes[0], nodes[1]
+
+	const invoiceAmtSat = 1_000
+	const overpayAmtSat = 1_100
+	const overpayAmtMsat = overpayAmtSat * 1000
+
+	// Create a fixed-amount invoice on Bob's side.
+	invoice := bob.RPC.AddInvoice(&lnrpc.Invoice{
+		Memo:  "overpay-test",
+		Value: invoiceAmtSat,
+	})
+
+	// Alice sends a payment with amt_msat larger than the invoice
+	// amount. This should succeed and deliver the overpaid amount.
+	payment := ht.SendPaymentAssertSettled(
+		alice, &routerrpc.SendPaymentRequest{
+			PaymentRequest: invoice.PaymentRequest,
+			AmtMsat:        overpayAmtMsat,
+			TimeoutSeconds: 60,
+			FeeLimitMsat:   noFeeLimitMsat,
+		},
+	)
+
+	// The payment value should reflect the overpaid amount.
+	require.Equal(
+		ht, int64(overpayAmtMsat), payment.ValueMsat,
+		"value_msat should equal the overpaid amount",
+	)
+
+	// The invoice on Bob's side should show the overpaid amount.
+	dbInvoice := bob.RPC.LookupInvoice(invoice.RHash)
+	require.Equal(
+		ht, lnrpc.Invoice_SETTLED, dbInvoice.State,
+	)
+	require.Equal(
+		ht, int64(overpayAmtMsat), dbInvoice.AmtPaidMsat,
+		"Bob should receive the overpaid amount",
+	)
+}

--- a/lnrpc/marshall_utils_test.go
+++ b/lnrpc/marshall_utils_test.go
@@ -1,0 +1,97 @@
+package lnrpc
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidatePayReqAmt tests the ValidatePayReqAmt helper for various
+// combinations of invoice amount and caller-specified amount.
+func TestValidatePayReqAmt(t *testing.T) {
+	t.Parallel()
+
+	invoiceAmt := lnwire.MilliSatoshi(1_000_000)
+
+	tests := []struct {
+		name       string
+		invoiceMsat *lnwire.MilliSatoshi
+		amtSat     int64
+		amtMsat    int64
+		wantAmt    lnwire.MilliSatoshi
+		wantErr    string
+	}{
+		{
+			name:        "zero-amount invoice with amt_msat",
+			invoiceMsat: nil,
+			amtMsat:     500_000,
+			wantAmt:     500_000,
+		},
+		{
+			name:        "zero-amount invoice with amt_sat",
+			invoiceMsat: nil,
+			amtSat:      500,
+			wantAmt:     500_000,
+		},
+		{
+			name:        "zero-amount invoice with no amount",
+			invoiceMsat: nil,
+			wantErr:     "amount must be specified",
+		},
+		{
+			name:        "fixed invoice, no caller amount",
+			invoiceMsat: &invoiceAmt,
+			wantAmt:     1_000_000,
+		},
+		{
+			name:        "fixed invoice, exact amount",
+			invoiceMsat: &invoiceAmt,
+			amtMsat:     1_000_000,
+			wantAmt:     1_000_000,
+		},
+		{
+			name:        "fixed invoice, overpayment via msat",
+			invoiceMsat: &invoiceAmt,
+			amtMsat:     1_100_000,
+			wantAmt:     1_100_000,
+		},
+		{
+			name:        "fixed invoice, overpayment via sat",
+			invoiceMsat: &invoiceAmt,
+			amtSat:      1100,
+			wantAmt:     1_100_000,
+		},
+		{
+			name:        "fixed invoice, underpayment rejected",
+			invoiceMsat: &invoiceAmt,
+			amtMsat:     999_999,
+			wantErr:     "must not be less than invoice amount",
+		},
+		{
+			name:        "sat and msat mutually exclusive",
+			invoiceMsat: &invoiceAmt,
+			amtSat:      1,
+			amtMsat:     1000,
+			wantErr:     "mutually exclusive",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ValidatePayReqAmt(
+				tc.invoiceMsat, tc.amtSat, tc.amtMsat,
+			)
+
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.wantAmt, got)
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/10541

Previously, sending a payment with `amt_msat` set alongside a fixed-amount
BOLT11 invoice did not work as expected. The `SendPaymentSync` path in
`rpcserver.go` silently ignored the `amt_msat` field and used the invoice
amount, while the `SendPaymentV2` path in `router_backend.go` rejected the
request outright with "amount must not be specified when paying a non-zero
amount invoice". Both behaviors prevented users from intentionally overpaying
an invoice, which is permitted by the BOLT spec.

This PR introduces a shared `ValidatePayReqAmt` helper in the `lnrpc` package
that consolidates the invoice-amount-vs-caller-amount validation logic. When a
caller specifies `amt_msat` (or `amt`) alongside a fixed-amount invoice, the
payment now proceeds as long as the specified amount is at least the invoice
amount. Underpayment is rejected with a clear error. For zero-amount invoices,
the existing behavior (caller must specify an amount) is preserved.

Both `extractPaymentIntent` (legacy `SendPayment`/`SendPaymentSync`) and
`extractIntentFromSendRequest` (`SendPaymentV2`) now use this shared helper,
eliminating duplicated logic and ensuring consistent behavior across both RPC
paths.

The change includes unit tests for the new helper covering overpayment, exact
payment, underpayment, zero-amount invoices, and sat/msat mutual exclusivity,
as well as an integration test that verifies end-to-end overpayment of a
fixed-amount invoice.