### PR TITLE
ci: add tool constraints to pr-severity prompt

### DIFF
--- a/.github/workflows/pr-severity.yml
+++ b/.github/workflows/pr-severity.yml
@@ -49,6 +49,18 @@ jobs:
           prompt: |
             You are a PR severity classifier for the lnd (Lightning Network Daemon) repository.
 
+            ## Tool Constraints
+
+            You ONLY have access to these commands:
+            - `gh pr view` - to read PR metadata
+            - `gh pr edit` - to add/remove labels
+            - `gh pr comment` - to post comments
+
+            You do NOT have access to `gh api`, `gh label`, or any other
+            `gh` subcommand. Do not attempt to use them. For ALL label
+            operations, use `gh pr edit` with `--add-label` or
+            `--remove-label`.
+
             ## Your Task
 
             Analyze PR #${{ github.event.pull_request.number }} and:


### PR DESCRIPTION
The pr-severity workflow has been posting severity classification comments on PRs but never actually applying the labels. Every single run shows the same pattern: Claude tries to use `gh api` to add labels, the allowed tools restriction correctly denies it, but then Claude silently gives up instead of retrying with the permitted `gh pr edit --add-label` command.

You can see this across multiple PRs -- #10529, #10472, #10538, #10540 all have severity comments but zero severity labels. The permission_denials array in the run output confirms `gh api` attempts were blocked each time.

This adds an explicit "Tool Constraints" section at the top of the prompt that tells Claude upfront it only has `gh pr view`, `gh pr edit`, and `gh pr comment`. By making the available tools clear before any instructions, Claude should use `gh pr edit --add-label` directly instead of attempting `gh api` first.

Failed run that surfaced this: https://github.com/lightningnetwork/lnd/actions/runs/21614145381/job/62289184152