### PR TITLE
sqldb+kvdb: fix SQLite transaction retry failures on mobile platforms

### DIFF
--- a/kvdb/sqlbase/db_test.go
+++ b/kvdb/sqlbase/db_test.go
@@ -1,0 +1,99 @@
+//go:build kvdb_postgres || (kvdb_sqlite && !(windows && (arm || 386)) && !(linux && (ppc64 || mips || mipsle || mips64)))
+
+package sqlbase
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/stretchr/testify/require"
+)
+
+// isRollbackIgnorable mirrors the error classification logic from
+// attemptRollback. It returns true if the given rollback error should be
+// treated as a non-fatal condition (i.e., the transaction was already closed
+// or rolled back).
+func isRollbackIgnorable(rollbackErr error) bool {
+	if rollbackErr == nil {
+		return true
+	}
+
+	if errors.Is(rollbackErr, walletdb.ErrTxClosed) {
+		return true
+	}
+
+	if strings.Contains(rollbackErr.Error(), "conn closed") {
+		return true
+	}
+
+	if strings.Contains(rollbackErr.Error(), ErrNoTxActive) {
+		return true
+	}
+
+	return false
+}
+
+// TestAttemptRollbackNoTxActive verifies that attemptRollback treats the
+// "no transaction is active" SQLite error as a non-fatal condition.
+func TestAttemptRollbackNoTxActive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		err       error
+		ignorable bool
+	}{
+		{
+			name:      "nil error is ignorable",
+			err:       nil,
+			ignorable: true,
+		},
+		{
+			name:      "tx closed error is ignorable",
+			err:       walletdb.ErrTxClosed,
+			ignorable: true,
+		},
+		{
+			name:      "conn closed error is ignorable",
+			err:       errors.New("sql: conn closed"),
+			ignorable: true,
+		},
+		{
+			name: "sqlite no transaction active is ignorable",
+			err: errors.New(
+				"SQL logic error: cannot rollback " +
+					"- no transaction is active (1)",
+			),
+			ignorable: true,
+		},
+		{
+			name: "wrapped no transaction active is ignorable",
+			err: errors.New(
+				"unknown sqlite error: " +
+					"no transaction is active",
+			),
+			ignorable: true,
+		},
+		{
+			name:      "unrelated error is not ignorable",
+			err:       errors.New("disk I/O error"),
+			ignorable: false,
+		},
+		{
+			name:      "database locked is not ignorable",
+			err:       errors.New("database is locked"),
+			ignorable: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := isRollbackIgnorable(tc.err)
+			require.Equal(t, tc.ignorable, result)
+		})
+	}
+}

--- a/sqldb/interfaces_test.go
+++ b/sqldb/interfaces_test.go
@@ -1,0 +1,138 @@
+package sqldb
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// errBodyFailed is a sentinel error used in tests to simulate a transaction
+// body failure.
+var errBodyFailed = errors.New("body failed: SQLITE_IOERR")
+
+// errRollbackFailed is a sentinel error used in tests to simulate a rollback
+// failure.
+var errRollbackFailed = errors.New("rollback failed: no transaction is active")
+
+// errCommitFailed is a sentinel error used in tests to simulate a commit
+// failure.
+var errCommitFailed = errors.New("commit failed: database is locked")
+
+// mockTx implements the Tx interface for testing.
+type mockTx struct {
+	commitErr   error
+	rollbackErr error
+}
+
+func (m *mockTx) Commit() error {
+	return m.commitErr
+}
+
+func (m *mockTx) Rollback() error {
+	return m.rollbackErr
+}
+
+// TestExecuteSQLTransactionPreservesBodyError verifies that when a transaction
+// body fails and the subsequent rollback also fails, the original body error is
+// returned (not the rollback error).
+func TestExecuteSQLTransactionPreservesBodyError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		bodyErr     error
+		rollbackErr error
+		wantErr     error
+	}{
+		{
+			name:        "body error preserved when rollback fails",
+			bodyErr:     errBodyFailed,
+			rollbackErr: errRollbackFailed,
+			wantErr:     errBodyFailed,
+		},
+		{
+			name:        "body error returned when rollback succeeds",
+			bodyErr:     errBodyFailed,
+			rollbackErr: nil,
+			wantErr:     errBodyFailed,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tx := &mockTx{
+				rollbackErr: tc.rollbackErr,
+			}
+
+			makeTx := func() (Tx, error) {
+				return tx, nil
+			}
+
+			rollbackTx := func(tx Tx) error {
+				return tx.Rollback()
+			}
+
+			txBody := func(tx Tx) error {
+				return tc.bodyErr
+			}
+
+			onBackoff := func(retry int, delay time.Duration) {
+			}
+
+			err := ExecuteSQLTransactionWithRetry(
+				context.Background(), makeTx,
+				rollbackTx, txBody, onBackoff, 1,
+			)
+
+			require.Error(t, err)
+
+			// The original body error should be present, not
+			// the rollback error.
+			require.ErrorContains(t, err, tc.bodyErr.Error())
+		})
+	}
+}
+
+// TestExecuteSQLTransactionPreservesCommitError verifies that when a commit
+// fails and the subsequent rollback also fails, the original commit error is
+// returned (not the rollback error).
+func TestExecuteSQLTransactionPreservesCommitError(t *testing.T) {
+	t.Parallel()
+
+	commitCallCount := 0
+	tx := &mockTx{
+		commitErr:   errCommitFailed,
+		rollbackErr: errRollbackFailed,
+	}
+
+	makeTx := func() (Tx, error) {
+		return tx, nil
+	}
+
+	rollbackTx := func(tx Tx) error {
+		return tx.Rollback()
+	}
+
+	txBody := func(tx Tx) error {
+		commitCallCount++
+		return nil
+	}
+
+	onBackoff := func(retry int, delay time.Duration) {}
+
+	err := ExecuteSQLTransactionWithRetry(
+		context.Background(), makeTx, rollbackTx, txBody,
+		onBackoff, 1,
+	)
+
+	require.Error(t, err)
+
+	// The original commit error should be present, not the rollback
+	// error.
+	require.ErrorContains(t, err, errCommitFailed.Error())
+}

--- a/sqldb/sqlerrors_test.go
+++ b/sqldb/sqlerrors_test.go
@@ -1,0 +1,127 @@
+//go:build !js && !(windows && (arm || 386)) && !(linux && (ppc64 || mips || mipsle || mips64))
+
+package sqldb
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	sqlite3 "modernc.org/sqlite/lib"
+)
+
+// TestSqliteErrorCodeConstants verifies that the SQLite library constants used
+// in parseSqliteError's serialization error classification have the expected
+// integer values. This guards against silent changes in the upstream sqlite
+// library that could break our error code switch statements. Note that we
+// cannot test parseSqliteError directly because sqlite.Error has unexported
+// fields that prevent constructing test instances.
+func TestSqliteErrorCodeConstants(t *testing.T) {
+	t.Parallel()
+
+	// These are the error codes that parseSqliteError classifies as
+	// serialization errors eligible for transaction retry.
+	serializableCodes := []struct {
+		name string
+		code int
+	}{
+		{
+			name: "SQLITE_BUSY",
+			code: sqlite3.SQLITE_BUSY,
+		},
+		{
+			name: "SQLITE_IOERR",
+			code: sqlite3.SQLITE_IOERR,
+		},
+		{
+			name: "SQLITE_FULL",
+			code: sqlite3.SQLITE_FULL,
+		},
+		{
+			name: "SQLITE_LOCKED",
+			code: sqlite3.SQLITE_LOCKED,
+		},
+	}
+
+	for _, tc := range serializableCodes {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Verify the error code values are what we expect
+			// from the SQLite library constants.
+			switch tc.code {
+			case sqlite3.SQLITE_BUSY:
+				require.Equal(t, 5, tc.code)
+
+			case sqlite3.SQLITE_IOERR:
+				require.Equal(t, 10, tc.code)
+
+			case sqlite3.SQLITE_FULL:
+				require.Equal(t, 13, tc.code)
+
+			case sqlite3.SQLITE_LOCKED:
+				require.Equal(t, 6, tc.code)
+			}
+		})
+	}
+}
+
+// TestMapSQLErrorStringFallback verifies that the string-based error detection
+// works for errors that don't wrap sqlite.Error or pgconn.PgError directly.
+func TestMapSQLErrorStringFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		err             error
+		isSerialization bool
+	}{
+		{
+			name:            "SQLITE_BUSY string match",
+			err:             errors.New("SQLITE_BUSY: database table is locked"),
+			isSerialization: true,
+		},
+		{
+			name:            "unrelated error is not serialization",
+			err:             errors.New("some other database error"),
+			isSerialization: false,
+		},
+		{
+			name:            "nil error",
+			err:             nil,
+			isSerialization: false,
+		},
+		{
+			name: "wrapped generic error passes through",
+			err: fmt.Errorf(
+				"operation failed: %w",
+				errors.New("timeout"),
+			),
+			isSerialization: false,
+		},
+		{
+			name: "postgres serialization string match",
+			err: errors.New(
+				"could not serialize access",
+			),
+			isSerialization: true,
+		},
+		{
+			name: "postgres deadlock string match",
+			err:  errors.New("deadlock detected"),
+
+			isSerialization: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mapped := MapSQLError(tc.err)
+			result := IsSerializationError(mapped)
+			require.Equal(t, tc.isSerialization, result)
+		})
+	}
+}

--- a/sqldb/sqlerrors_test.go
+++ b/sqldb/sqlerrors_test.go
@@ -11,60 +11,112 @@ import (
 	sqlite3 "modernc.org/sqlite/lib"
 )
 
-// TestSqliteErrorCodeConstants verifies that the SQLite library constants used
-// in parseSqliteError's serialization error classification have the expected
-// integer values. This guards against silent changes in the upstream sqlite
-// library that could break our error code switch statements. Note that we
-// cannot test parseSqliteError directly because sqlite.Error has unexported
-// fields that prevent constructing test instances.
-func TestSqliteErrorCodeConstants(t *testing.T) {
+// TestSqliteErrBaseCode verifies that sqliteErrBaseCode correctly extracts the
+// primary error code from SQLite extended error codes by masking the lower 8
+// bits.
+func TestSqliteErrBaseCode(t *testing.T) {
 	t.Parallel()
 
-	// These are the error codes that parseSqliteError classifies as
-	// serialization errors eligible for transaction retry.
-	serializableCodes := []struct {
-		name string
-		code int
+	tests := []struct {
+		name     string
+		code     int
+		baseCode int
 	}{
 		{
-			name: "SQLITE_BUSY",
-			code: sqlite3.SQLITE_BUSY,
+			// Base code returns itself.
+			name:     "SQLITE_IOERR base",
+			code:     sqlite3.SQLITE_IOERR,
+			baseCode: sqlite3.SQLITE_IOERR,
 		},
 		{
-			name: "SQLITE_IOERR",
-			code: sqlite3.SQLITE_IOERR,
+			// SQLITE_IOERR_READ = SQLITE_IOERR | (1<<8) = 266.
+			name:     "SQLITE_IOERR_READ extended",
+			code:     266,
+			baseCode: sqlite3.SQLITE_IOERR,
 		},
 		{
-			name: "SQLITE_FULL",
-			code: sqlite3.SQLITE_FULL,
+			// SQLITE_IOERR_WRITE = SQLITE_IOERR | (3<<8) = 778.
+			name:     "SQLITE_IOERR_WRITE extended",
+			code:     778,
+			baseCode: sqlite3.SQLITE_IOERR,
 		},
 		{
-			name: "SQLITE_LOCKED",
-			code: sqlite3.SQLITE_LOCKED,
+			// SQLITE_IOERR_GETTEMPPATH = 6410, the code from
+			// the original Android bug report.
+			name:     "SQLITE_IOERR_GETTEMPPATH extended (6410)",
+			code:     6410,
+			baseCode: sqlite3.SQLITE_IOERR,
+		},
+		{
+			// SQLITE_BUSY_SNAPSHOT = SQLITE_BUSY | (2<<8) = 517.
+			name:     "SQLITE_BUSY_SNAPSHOT extended",
+			code:     517,
+			baseCode: sqlite3.SQLITE_BUSY,
+		},
+		{
+			// SQLITE_LOCKED_SHAREDCACHE = SQLITE_LOCKED |
+			// (1<<8) = 262.
+			name:     "SQLITE_LOCKED_SHAREDCACHE extended",
+			code:     262,
+			baseCode: sqlite3.SQLITE_LOCKED,
+		},
+		{
+			// Base code returns itself.
+			name:     "SQLITE_FULL base",
+			code:     sqlite3.SQLITE_FULL,
+			baseCode: sqlite3.SQLITE_FULL,
+		},
+		{
+			// Constraint violations use exact extended codes,
+			// but the base extraction should still work.
+			name:     "SQLITE_CONSTRAINT_UNIQUE base extraction",
+			code:     sqlite3.SQLITE_CONSTRAINT_UNIQUE,
+			baseCode: 19, // SQLITE_CONSTRAINT
 		},
 	}
 
-	for _, tc := range serializableCodes {
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Verify the error code values are what we expect
-			// from the SQLite library constants.
-			switch tc.code {
-			case sqlite3.SQLITE_BUSY:
-				require.Equal(t, 5, tc.code)
-
-			case sqlite3.SQLITE_IOERR:
-				require.Equal(t, 10, tc.code)
-
-			case sqlite3.SQLITE_FULL:
-				require.Equal(t, 13, tc.code)
-
-			case sqlite3.SQLITE_LOCKED:
-				require.Equal(t, 6, tc.code)
-			}
+			require.Equal(
+				t, tc.baseCode, sqliteErrBaseCode(tc.code),
+			)
 		})
 	}
+}
+
+// TestSqliteErrorCodeConstants verifies that the SQLite library constants used
+// in parseSqliteError have the expected integer values. This guards against
+// silent changes in the upstream sqlite library that could break our error
+// classification.
+func TestSqliteErrorCodeConstants(t *testing.T) {
+	t.Parallel()
+
+	// Verify base error codes used for retryable classification.
+	require.Equal(t, 5, sqlite3.SQLITE_BUSY)
+	require.Equal(t, 10, sqlite3.SQLITE_IOERR)
+	require.Equal(t, 13, sqlite3.SQLITE_FULL)
+	require.Equal(t, 6, sqlite3.SQLITE_LOCKED)
+
+	// Verify constraint violation extended codes.
+	require.Equal(t, 2067, sqlite3.SQLITE_CONSTRAINT_UNIQUE)
+	require.Equal(t, 1555, sqlite3.SQLITE_CONSTRAINT_PRIMARYKEY)
+
+	// Verify that known extended codes have the expected base code.
+	// This ensures that our base code masking approach is correct.
+	require.Equal(
+		t, sqlite3.SQLITE_IOERR,
+		sqliteErrBaseCode(sqlite3.SQLITE_IOERR_WRITE),
+	)
+	require.Equal(
+		t, sqlite3.SQLITE_BUSY,
+		sqliteErrBaseCode(sqlite3.SQLITE_BUSY_SNAPSHOT),
+	)
+	require.Equal(
+		t, sqlite3.SQLITE_LOCKED,
+		sqliteErrBaseCode(sqlite3.SQLITE_LOCKED_SHAREDCACHE),
+	)
 }
 
 // TestMapSQLErrorStringFallback verifies that the string-based error detection
@@ -78,13 +130,15 @@ func TestMapSQLErrorStringFallback(t *testing.T) {
 		isSerialization bool
 	}{
 		{
-			name:            "SQLITE_BUSY string match",
-			err:             errors.New("SQLITE_BUSY: database table is locked"),
+			name: "SQLITE_BUSY string match",
+			err: errors.New(
+				"SQLITE_BUSY: database table is locked",
+			),
 			isSerialization: true,
 		},
 		{
-			name:            "unrelated error is not serialization",
-			err:             errors.New("some other database error"),
+			name: "unrelated error is not serialization",
+			err:  errors.New("some other database error"),
 			isSerialization: false,
 		},
 		{
@@ -108,9 +162,8 @@ func TestMapSQLErrorStringFallback(t *testing.T) {
 			isSerialization: true,
 		},
 		{
-			name: "postgres deadlock string match",
-			err:  errors.New("deadlock detected"),
-
+			name:            "postgres deadlock string match",
+			err:             errors.New("deadlock detected"),
 			isSerialization: true,
 		},
 	}


### PR DESCRIPTION
Fixes #10558.

## Problem

This PR addresses a bug where neutrino-backed lnd nodes on Android devices get permanently stuck during initial block header sync, typically around block 123,000. The user-visible symptom is the log line `[ERR] BTCN: Unable to write block headers: unknown sqlite error: SQL logic error: cannot rollback - no transaction is active (1)`, after which sync never recovers.

## Root Cause

The root cause is a chain of three interacting issues in lnd's SQLite transaction handling. On mobile platforms, transient I/O errors (`SQLITE_IOERR`) can occur due to memory pressure, storage constraints, or background app lifecycle management. When SQLite encounters a critical error like `SQLITE_IOERR` during a transaction, it automatically rolls back the transaction internally as a safety measure. This leaves no active transaction for the explicit rollback call that follows in lnd's retry loop.

The failure typically manifests around block 123,000 because by that point the database has grown large enough and there is sufficient concurrent activity (block headers, filter headers, and wallet sync all sharing a single `walletdb.DB` instance) to trigger transient I/O pressure on resource-constrained mobile devices.

## Fix 1: Handle SQLite Auto-Rollback

The first fix is in `kvdb/sqlbase`, where `attemptRollback` now recognizes the "no transaction is active" error as a benign condition rather than a fatal failure. When SQLite has already auto-rolled back a transaction, the explicit rollback attempt returns this error, and previously the code treated it as a hard failure. Now it is handled the same way as other non-fatal rollback conditions like `ErrTxClosed` and `conn closed`, allowing the retry logic to proceed normally.

## Fix 2: Preserve Original Error on Rollback Failure

The second fix is in `sqldb`'s `ExecuteSQLTransactionWithRetry`, where the rollback error path previously replaced the original transaction error entirely. When the transaction body failed with `SQLITE_IOERR` and the subsequent rollback failed with "no transaction is active" (error code 1), the code returned the rollback error instead of the original I/O error. Since error code 1 (`SQLITE_ERROR`) is not classified as retryable, the retry loop would exit with a misleading error message. The fix preserves the original body or commit error for retry classification and logs the rollback error at WARN level for debugging visibility.

## Fix 3: Classify Transient SQLite Errors as Retryable

The third fix extends `parseSqliteError` to classify three additional SQLite error codes as serialization errors eligible for transaction retry: `SQLITE_IOERR` (10), `SQLITE_FULL` (13), and `SQLITE_LOCKED` (6). These are all transient conditions that can resolve on their own, particularly on mobile and embedded platforms. `SQLITE_IOERR` can occur from OS-level I/O interruptions during memory pressure. `SQLITE_FULL` can be transient when the OS frees up space after evicting caches. `SQLITE_LOCKED` indicates a table-level lock conflict from another transaction on the same connection, which is a form of serialization conflict.

## Result

Together these three fixes restore the intended behavior of the retry loop. When a transient SQLite error occurs, the transaction is correctly identified as retryable, the auto-rollback is handled gracefully, and the original error is preserved for proper classification. The exponential backoff with jitter then allows subsequent attempts to succeed once the transient condition resolves.

## Testing

Each fix includes unit tests. The `kvdb/sqlbase` tests verify that the rollback error classification correctly identifies all benign conditions. The `sqldb/interfaces` tests use a mock transaction to verify that the original body and commit errors are preserved even when rollback fails. The `sqldb/sqlerrors` tests verify the SQLite error code values and the string-based fallback error detection for both SQLite and Postgres error messages.