### PR TITLE
build: classify cmd/* as MEDIUM in PR severity bot

### DIFF
--- a/.github/workflows/pr-severity.yml
+++ b/.github/workflows/pr-severity.yml
@@ -95,6 +95,7 @@ jobs:
             - chainntnfs/*, chanacceptor/*, protofsm/*, sqldb/*
 
             **MEDIUM** (severity-medium) - Focused review:
+            - cmd/* - CLI client commands (do NOT inherit severity from server-side packages with similar names)
             - payments/*, autopilot/*, lncfg/*, chanfitness/*
             - netann/*, kvdb/*, chanbackup/*, aezeed/*, tor/*
             - zpay32/*, tlv/*, fn/*, record/*, amp/*
@@ -110,12 +111,16 @@ jobs:
             ## Classification Rules
 
             1. The HIGHEST severity file determines the PR severity
-            2. Bump severity UP one level if:
+            2. Classify files by their actual package path, NOT by filename keywords.
+               Files under cmd/* are CLI client code and should always be MEDIUM,
+               even if the filename contains a server-side package name (e.g.
+               cmd/commands/cmd_walletunlocker.go is MEDIUM, not HIGH).
+            3. Bump severity UP one level if:
                - PR touches >20 files (excluding tests and auto-generated files)
                - PR has >500 lines changed (excluding tests and auto-generated files)
                - PR touches multiple distinct critical packages
-            3. Check for override labels first (severity-override-*). If present, respect the override.
-            4. Database migrations (channeldb/migration*, sqldb/*, wtdb/*) are always CRITICAL
+            4. Check for override labels first (severity-override-*). If present, respect the override.
+            5. Database migrations (channeldb/migration*, sqldb/*, wtdb/*) are always CRITICAL
 
             ## Files to Exclude from Line/File Counting
             When calculating file count and lines changed for severity bumps, exclude:


### PR DESCRIPTION
## Summary
- Add `cmd/*` explicitly to the MEDIUM severity tier in the PR severity classifier
- Add classification rule to prevent filename-based false positives (e.g. `cmd/commands/cmd_walletunlocker.go` was being classified as HIGH because the filename matched the `walletunlocker/*` auth/security keyword)

## Context

The severity bot was misclassifying CLI client code as HIGH. For example, PR #10536 (`lncli unlock: wait until daemon can unlock`) only touches `cmd/commands/cmd_walletunlocker.go` — purely client-side CLI code — but the bot kept flagging it HIGH because `walletunlocker` is in the auth/security keyword list. Files under `cmd/*` are CLI client commands that just call RPCs; they don't implement server-side logic, handle key material, or manage wallet state.

## Test plan
- [ ] Verify the bot classifies PRs touching only `cmd/*` files as MEDIUM
- [ ] Verify PRs touching actual `walletunlocker/*` server-side code are still classified as HIGH