### PR TITLE
build+docs: bump minimum Go version to 1.25.5

### DIFF
--- a/actor/go.mod
+++ b/actor/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/actor
 
-go 1.24.9
+go 1.25.5
 
 require (
 	github.com/btcsuite/btclog/v2 v2.0.1-0.20250602222548-9967d19bb084

--- a/cert/go.mod
+++ b/cert/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/cert
 
-go 1.24.11
+go 1.25.5
 
 require github.com/stretchr/testify v1.8.2
 

--- a/clock/go.mod
+++ b/clock/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/clock
 
-go 1.24.11
+go 1.25.5
 
 require github.com/stretchr/testify v1.8.2
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -93,7 +93,7 @@ following build dependencies are required:
 
 ### Installing Go
 
-`lnd` is written in Go, with a minimum version of `1.24.11` (or, in case this
+`lnd` is written in Go, with a minimum version of `1.25.5` (or, in case this
 document gets out of date, whatever the Go version in the main `go.mod` file
 requires). To install, run one of the following commands for your OS:
 
@@ -101,15 +101,15 @@ requires). To install, run one of the following commands for your OS:
   <summary>Linux (x86-64)</summary>
 
   ```
-  wget https://dl.google.com/go/go1.24.11.linux-amd64.tar.gz
-  echo "bceca00afaac856bc48b4cc33db7cd9eb383c81811379faed3bdbc80edb0af65  go1.24.11.linux-amd64.tar.gz" | sha256sum --check
+  wget https://dl.google.com/go/go1.25.5.linux-amd64.tar.gz
+  echo "9e9b755d63b36acf30c12a9a3fc379243714c1c6d3dd72861da637f336ebb35b  go1.25.5.linux-amd64.tar.gz" | sha256sum --check
   ```
 
-  The command above should output `go1.24.11.linux-amd64.tar.gz: OK`. If it
+  The command above should output `go1.25.5.linux-amd64.tar.gz: OK`. If it
   doesn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
   this version of Go. If it matches, then proceed to install Go:
   ```
-  sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.24.11.linux-amd64.tar.gz
+  sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.25.5.linux-amd64.tar.gz
   export PATH=$PATH:/usr/local/go/bin
   ```
 </details>
@@ -118,15 +118,15 @@ requires). To install, run one of the following commands for your OS:
   <summary>Linux (ARMv6)</summary>
 
   ```
-  wget https://dl.google.com/go/go1.24.11.linux-armv6l.tar.gz
-  echo "24d712a7e8ea2f429c05bc67287249e0291f2fe0ea6d6ff268f11b7343ad0f47  go1.24.11.linux-armv6l.tar.gz" | sha256sum --check
+  wget https://dl.google.com/go/go1.25.5.linux-armv6l.tar.gz
+  echo "0b27e3dec8d04899d6941586d2aa2721c3dee67c739c1fc1b528188f3f6e8ab5  go1.25.5.linux-armv6l.tar.gz" | sha256sum --check
   ```
 
-  The command above should output `go1.24.11.linux-armv6l.tar.gz: OK`. If it
+  The command above should output `go1.25.5.linux-armv6l.tar.gz: OK`. If it
   isn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
   this version of Go. If it matches, then proceed to install Go:
   ```
-  sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.24.11.linux-armv6l.tar.gz
+  sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.25.5.linux-armv6l.tar.gz
   export PATH=$PATH:/usr/local/go/bin
   ```
 

--- a/fn/go.mod
+++ b/fn/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/fn/v2
 
-go 1.24.11
+go 1.25.5
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -219,6 +219,6 @@ replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-d
 // If you change this please also update docs/INSTALL.md and GO_VERSION in
 // Makefile (then run `make lint` to see where else it needs to be updated as
 // well).
-go 1.24.11
+go 1.25.5
 
 retract v0.0.2

--- a/healthcheck/go.mod
+++ b/healthcheck/go.mod
@@ -24,4 +24,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.24.11
+go 1.25.5

--- a/kvdb/go.mod
+++ b/kvdb/go.mod
@@ -147,4 +147,4 @@ replace github.com/ulikunitz/xz => github.com/ulikunitz/xz v0.5.11
 // https://deps.dev/advisory/OSV/GO-2021-0053?from=%2Fgo%2Fgithub.com%252Fgogo%252Fprotobuf%2Fv1.3.1
 replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 
-go 1.24.11
+go 1.25.5

--- a/queue/go.mod
+++ b/queue/go.mod
@@ -4,4 +4,4 @@ require github.com/lightningnetwork/lnd/ticker v1.0.0
 
 replace github.com/lightningnetwork/lnd/ticker v1.0.0 => ../ticker
 
-go 1.24.11
+go 1.25.5

--- a/sqldb/go.mod
+++ b/sqldb/go.mod
@@ -75,4 +75,4 @@ require (
 	modernc.org/token v1.1.0 // indirect
 )
 
-go 1.24.11
+go 1.25.5

--- a/ticker/go.mod
+++ b/ticker/go.mod
@@ -1,3 +1,3 @@
 module github.com/lightningnetwork/lnd/ticker
 
-go 1.24.11
+go 1.25.5

--- a/tlv/go.mod
+++ b/tlv/go.mod
@@ -22,4 +22,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.24.11
+go 1.25.5

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/tools
 
-go 1.24.11
+go 1.25.5
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0 // indirect

--- a/tools/linters/go.mod
+++ b/tools/linters/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/tools/linters
 
-go 1.24.11
+go 1.25.5
 
 require (
 	github.com/golangci/plugin-module-register v0.1.1

--- a/tor/go.mod
+++ b/tor/go.mod
@@ -23,4 +23,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.24.11
+go 1.25.5


### PR DESCRIPTION
## Summary

Bump the minimum required Go version from 1.24.11 to 1.25.5. The build
system (Dockerfiles, Makefile, CI) was already using 1.25.5; this change
aligns the go.mod minimum version and updates the installation docs
(download links + SHA256 hashes).

With Go 1.26 now released, Go 1.25 becomes the recommended stable version.

### Notable Go 1.25 Features

**Runtime**
- Container-aware `GOMAXPROCS`: automatically considers cgroup CPU bandwidth
  limits on Linux and periodically updates if limits change.
- Experimental green-tea GC (`GOEXPERIMENT=greenteagc`): 10-40% reduction
  in GC overhead for GC-heavy workloads, improved locality and CPU
  scalability.
- Trace flight recorder (`runtime/trace.FlightRecorder`): captures runtime
  traces in an in-memory ring buffer, snapshot with `WriteTo()`.

**Standard Library**
- `testing/synctest` graduated to stable: test concurrent code with
  virtualized time.
- `sync.WaitGroup.Go()`: convenient goroutine launch method.
- `net/http.CrossOriginProtection`: built-in CSRF defense using Fetch
  metadata.
- `encoding/json/v2` (experimental, `GOEXPERIMENT=jsonv2`): substantially
  faster JSON decoding.
- `crypto/rsa` key generation 3x faster; `crypto/sha3` 2x faster on
  Apple M chips; `crypto/ecdsa` and `crypto/ed25519` FIPS signing 4x faster.

**Toolchain**
- `go doc -http`: starts a local documentation server.
- `go.mod` `ignore` directive: specify directories the go command should
  skip.
- New vet analyzers: `waitgroup` (misplaced Add calls), `hostport`
  (incorrect IPv6 address construction).
- DWARF5 default debug format: smaller binaries, faster linking.
- Compiler allocates slice backing stores on stack in more situations.

**Bug Fixes**
- Fixes Go 1.21-1.24 bug that incorrectly delayed nil pointer checks.