### PR TITLE
scripts: use ephemeral gocache in check-each-commit

### DIFF
--- a/scripts/check-each-commit.sh
+++ b/scripts/check-each-commit.sh
@@ -12,4 +12,13 @@ if [[ "$(git log --pretty="%H %D" | grep "^[0-9a-f]*.* $1")" = "" ]]; then
 	echo "It seems like the current checked-out commit is not based on $1"
 	exit 1
 fi
+
+# Keep build cache ephemeral for this run to avoid long-term disk growth.
+TMP_GOCACHE=$(mktemp -d -t lnd-check-commit-gocache.XXXXXX)
+cleanup() {
+	rm -rf "$TMP_GOCACHE"
+}
+trap cleanup EXIT
+export GOCACHE="$TMP_GOCACHE"
+
 git rebase --exec scripts/check-commit.sh $1


### PR DESCRIPTION
## Summary
- set a temporary `GOCACHE` in `scripts/check-each-commit.sh`
- reuse that cache for the full rebase/check run
- clean the temporary cache directory on exit

## Why
`check-each-commit.sh` executes `check-commit.sh` for each commit via `git rebase --exec`, and each run invokes `make unit`. That can grow the persistent Go build cache significantly over time. This change keeps cache usage ephemeral for the script run while still allowing cache reuse across commits in the same run.

## Testing
- `bash -n scripts/check-each-commit.sh`
