### PR TITLE
ci: use haiku model for issue dedupe workflow

### DIFF
--- a/.github/workflows/claude-dedupe-issues.yml
+++ b/.github/workflows/claude-dedupe-issues.yml
@@ -30,5 +30,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_non_write_users: "*"
+          model: claude-haiku-4-5-20251001
           prompt: "/dedupe ${{ github.repository }}/issues/${{ github.event.issue.number || inputs.issue_number }}"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Switch the claude-dedupe-issues workflow from the default (most expensive) model to claude-haiku-4-5, which is significantly cheaper and sufficient for issue duplicate detection.

