### PR TITLE
.dockerignore: allowlist for copying into the Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# first, ignore everything
+*
+
+# allowlist for dev.Dockerfile
+!Makefile
+!**/*.mk
+!**/*.go
+!**/*.sql
+!**/go.mod
+!**/go.sum
+!scripts/*.sh
+!docker/lnd/start-lnd.sh


### PR DESCRIPTION
Without this change, any files in the project directory will be copied into the Docker context when using "docker build". Note this includes git-ignored and dirty files like passwords, wallets, possibly git history, and so on.

This uses quite a lot of disk space, causes unnecessary I/O and renders the Docker cache invalid even on the slightest change to the project.

The current `Dockerfile` doesn't use the context at all, and `dev.Dockerfile` only needs a fraction of it. So we ignore everything that isn't explicitly allowed.
