### PR TITLE
signal: ensure interceptor is closed on startup error paths

### DIFF
--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -75,6 +75,11 @@
   transitions during startup, avoiding lost unlocks during slow database
   initialization.
 
+* [Ensure that the interceptor is properly closed on failure paths in `lnd.Start`](https://github.com/lightningnetwork/lnd/pull/10587).
+  This is mostly relevant for mobile and lnd-as-a-lib use-cases where subsequent
+  attempts to start lnd would otherwise fail with "intercept already started"
+  errors as the state stays in-process.
+
 # New Features
 
 - Basic Support for [onion messaging forwarding](https://github.com/lightningnetwork/lnd/pull/9868) 
@@ -191,6 +196,7 @@
 * Boris Nagaev
 * Elle Mouton
 * Erick Cestari
+* Hampus Sjöberg
 * hieblmi
 * Matt Morehouse
 * Mohamed Awnallah

--- a/lnd_main_test.go
+++ b/lnd_main_test.go
@@ -1,0 +1,33 @@
+package lnd
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/lncfg"
+	"github.com/lightningnetwork/lnd/signal"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMainErrorShutsDownInterceptor asserts that Main error paths always close
+// the signal interceptor so startup can be retried in-process.
+func TestMainErrorShutsDownInterceptor(t *testing.T) {
+	interceptor, err := signal.Intercept()
+	require.NoError(t, err)
+
+	cfg := DefaultConfig()
+	cfg.Pprof = &lncfg.Pprof{}
+	cfg.RPCListeners = []net.Addr{
+		&net.UnixAddr{Net: "invalid-network"},
+	}
+	mainErr := Main(&cfg, ListenerCfg{}, nil, interceptor)
+	require.Error(t, mainErr)
+
+	select {
+	case <-interceptor.ShutdownChannel():
+	case <-time.After(5 * time.Second):
+		t.Fatalf("interceptor wasn't shut down after Main returned " +
+			"error")
+	}
+}


### PR DESCRIPTION
## Change Description

Hi, this PR makes sure that the interceptor is properly closed down on `lnd.Main`'s error paths as this is preventing subsequent startup attempts (fails with `interceptor already started`).
This is mostly relevant for mobile and lnd-as-a-lib users as the go runtime and state stays persistent.

We have seen in Blixt Wallet that the background sync job for Android sometimes fails with the error `localhost: no such host`, and subsequent sync tries will then fail with `interceptor already started`.
The root cause of this is still unknown (perhaps the device lost internet connection?), but this fix allows the sync job to continue as normal on the next attempt.

If you feel that this fix is too invasive I could perhaps request an interceptor shutdown inside `mobile/bindings.go` when `lnd.Start` returns back an error.

## Steps to Test

It's a bit tricky to test this as it happens occasionally on Blixt Android (though I have verified myself that the fix works).
But the provided test shows that the interceptor is properly closed down now.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [?] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
