### PR TITLE
htlcswitch/hop: require total_amount_msat for blinded final hops

### DIFF
--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -75,6 +75,12 @@
   transitions during startup, avoiding lost unlocks during slow database
   initialization.
 
+* [Required `total_amount_msat` for blinded final
+  hops](https://github.com/lightningnetwork/lnd/pull/10597). Per BOLT 4, when
+  `encrypted_recipient_data` is present on a final node, `total_amount_msat`
+  must be included. Validation is now performed explicitly at payload parsing 
+  time.
+
 # New Features
 
 - Basic Support for [onion messaging forwarding](https://github.com/lightningnetwork/lnd/pull/9868) 

--- a/htlcswitch/hop/payload.go
+++ b/htlcswitch/hop/payload.go
@@ -275,6 +275,7 @@ func ValidateParsedPayloadTypes(parsedTypes tlv.TypeMap,
 	_, hasAMP := parsedTypes[record.AMPOnionType]
 	_, hasEncryptedData := parsedTypes[record.EncryptedDataOnionType]
 	_, hasBlinding := parsedTypes[record.BlindingPointOnionType]
+	_, hasTotalAmtMsatBlinded := parsedTypes[record.TotalAmtMsatBlindedType]
 
 	// All cleartext hops (including final hop) and the final hop in a
 	// blinded path require the forwading amount and expiry TLVs to be set.
@@ -308,6 +309,15 @@ func ValidateParsedPayloadTypes(parsedTypes tlv.TypeMap,
 		return ErrInvalidPayload{
 			Type:      record.EncryptedDataOnionType,
 			Violation: IncludedViolation,
+			FinalHop:  isFinalHop,
+		}
+
+	// If encrypted data is present and is final hop, we require that
+	// total_amount_msat is set.
+	case isFinalHop && hasEncryptedData && !hasTotalAmtMsatBlinded:
+		return ErrInvalidPayload{
+			Type:      record.TotalAmtMsatBlindedType,
+			Violation: OmittedViolation,
 			FinalHop:  isFinalHop,
 		}
 

--- a/htlcswitch/hop/payload_test.go
+++ b/htlcswitch/hop/payload_test.go
@@ -377,6 +377,8 @@ var decodePayloadTests = []decodePayloadTest{
 			0x04, 0x00,
 			// encrypted data
 			0x0a, 0x03, 0x03, 0x02, 0x01,
+			// total_amount
+			0x12, 0x00,
 		},
 		shouldHaveEncData: true,
 	},
@@ -389,10 +391,31 @@ var decodePayloadTests = []decodePayloadTest{
 			0x04, 0x00,
 			// encrypted data
 			0x0a, 0x03, 0x03, 0x02, 0x01,
+			// total_amount
+			0x12, 0x00,
 		},
 		shouldHaveEncData: true,
 		expErr: hop.ErrInvalidPayload{
 			Type:      record.AmtOnionType,
+			Violation: hop.OmittedViolation,
+			FinalHop:  true,
+		},
+	},
+	{
+		name:             "final blinded missing total_amount",
+		isFinalHop:       true,
+		updateAddBlinded: true,
+		payload: []byte{
+			// amount
+			0x02, 0x00,
+			// cltv
+			0x04, 0x00,
+			// encrypted data
+			0x0a, 0x03, 0x03, 0x02, 0x01,
+		},
+		shouldHaveEncData: true,
+		expErr: hop.ErrInvalidPayload{
+			Type:      record.TotalAmtMsatBlindedType,
 			Violation: hop.OmittedViolation,
 			FinalHop:  true,
 		},
@@ -406,6 +429,8 @@ var decodePayloadTests = []decodePayloadTest{
 			0x02, 0x00,
 			// encrypted data
 			0x0a, 0x03, 0x03, 0x02, 0x01,
+			// total_amount
+			0x12, 0x00,
 		},
 		shouldHaveEncData: true,
 		expErr: hop.ErrInvalidPayload{


### PR DESCRIPTION
Per BOLT 4, when encrypted_recipient_data is present on a final node, total_amount_msat MUST be present. This adds explicit validation at payload parsing time.

Found by differential fuzzing using bitcoinfuzz.