### PR TITLE
lnrpc+channeldb: add reversed flag to ForwardingHistory

### DIFF
--- a/channeldb/forwarding_log.go
+++ b/channeldb/forwarding_log.go
@@ -266,6 +266,10 @@ type ForwardingEventQuery struct {
 	// forwarded to a particular channel.
 	// If the list is empty, then it is ignored.
 	OutgoingChanIDs fn.Set[uint64]
+
+	// Reversed is a boolean that indicates whether the query should be
+	// returned in reverse chronological order.
+	Reversed bool
 }
 
 // ForwardingLogTimeSlice is the response to a forwarding query. It includes
@@ -324,9 +328,47 @@ func (f *ForwardingLog) Query(q ForwardingEventQuery) (ForwardingLogTimeSlice,
 		// We'll continue until either we reach the end of the range,
 		// or reach our max number of events.
 		logCursor := logBucket.ReadCursor()
-		timestamp, eventBytes := logCursor.Seek(startTime[:])
-		//nolint:ll
-		for ; timestamp != nil && bytes.Compare(timestamp, endTime[:]) <= 0; timestamp, eventBytes = logCursor.Next() {
+
+		var timestamp, eventBytes []byte
+		if q.Reversed {
+			timestamp, eventBytes = logCursor.Seek(endTime[:])
+			switch {
+			// If the cursor is at a key that's greater than our
+			// end time, then we'll back up by one to ensure we
+			// start within our range.
+			case timestamp != nil &&
+				bytes.Compare(timestamp, endTime[:]) > 0:
+
+				timestamp, eventBytes = logCursor.Prev()
+
+			// If we've reached the end of the bucket, then we'll
+			// move the cursor to the very last element in the
+			// bucket.
+			case timestamp == nil:
+				timestamp, eventBytes = logCursor.Last()
+			}
+		} else {
+			timestamp, eventBytes = logCursor.Seek(startTime[:])
+		}
+
+		for timestamp != nil {
+			// If we're querying in reverse, then we'll exit if
+			// we've reached a timestamp that is before our start
+			// time.
+			if q.Reversed {
+				if bytes.Compare(timestamp, startTime[:]) < 0 {
+					break
+				}
+			} else {
+				// Otherwise, we'll exit if we've reached a
+				// timestamp that is after our end time.
+				if bytes.Compare(timestamp, endTime[:]) > 0 {
+					break
+				}
+			}
+
+			// If our current return payload exceeds the max number
+			// of events, then we'll exit now.
 			// If our current return payload exceeds the max number
 			// of events, then we'll exit now.
 			if uint32(len(resp.ForwardingEvents)) >= q.NumMaxEvents {
@@ -341,6 +383,12 @@ func (f *ForwardingLog) Query(q ForwardingEventQuery) (ForwardingLogTimeSlice,
 				q.OutgoingChanIDs.IsEmpty() {
 
 				recordsToSkip--
+
+				if q.Reversed {
+					timestamp, eventBytes = logCursor.Prev()
+				} else {
+					timestamp, eventBytes = logCursor.Next()
+				}
 				continue
 			}
 
@@ -390,6 +438,12 @@ func (f *ForwardingLog) Query(q ForwardingEventQuery) (ForwardingLogTimeSlice,
 			// then we'll continue to seek forward.
 			if recordsToSkip > 0 {
 				recordsToSkip--
+
+				if q.Reversed {
+					timestamp, eventBytes = logCursor.Prev()
+				} else {
+					timestamp, eventBytes = logCursor.Next()
+				}
 				continue
 			}
 
@@ -399,6 +453,12 @@ func (f *ForwardingLog) Query(q ForwardingEventQuery) (ForwardingLogTimeSlice,
 				event,
 			)
 			recordOffset++
+
+			if q.Reversed {
+				timestamp, eventBytes = logCursor.Prev()
+			} else {
+				timestamp, eventBytes = logCursor.Next()
+			}
 		}
 
 		return nil

--- a/channeldb/forwarding_log_test.go
+++ b/channeldb/forwarding_log_test.go
@@ -606,3 +606,105 @@ func TestForwardingLogQueryChanIDs(t *testing.T) {
 		})
 	}
 }
+
+// TestForwardingLogQueryReversed tests that we're able to properly query for
+// items in reverse chronological order.
+func TestForwardingLogQueryReversed(t *testing.T) {
+	t.Parallel()
+
+	// First, we'll set up a test database, and use that to instantiate the
+	// forwarding event log that we'll be using for the duration of the
+	// test.
+	db, err := MakeTestDB(t)
+	require.NoError(t, err, "unable to make test db")
+
+	log := ForwardingLog{
+		db: db,
+	}
+
+	initialTime := time.Unix(1234, 0)
+	timestamp := initialTime
+
+	// We'll create 100 random events, which each event being spaced 10
+	// minutes after the prior event.
+	numEvents := 100
+	events := make([]ForwardingEvent, numEvents)
+	for i := 0; i < numEvents; i++ {
+		events[i] = ForwardingEvent{
+			Timestamp:      timestamp,
+			IncomingChanID: lnwire.NewShortChanIDFromInt(uint64(rand.Int63())),
+			OutgoingChanID: lnwire.NewShortChanIDFromInt(uint64(rand.Int63())),
+			AmtIn:          lnwire.MilliSatoshi(rand.Int63()),
+			AmtOut:         lnwire.MilliSatoshi(rand.Int63()),
+			IncomingHtlcID: fn.Some(uint64(i)),
+			OutgoingHtlcID: fn.Some(uint64(i)),
+		}
+
+		timestamp = timestamp.Add(time.Minute * 10)
+	}
+
+	// Now that all of our set of events constructed, we'll add them to the
+	// database in a batch manner.
+	if err := log.AddForwardingEvents(events); err != nil {
+		t.Fatalf("unable to add events: %v", err)
+	}
+
+	// With our events added we'll now construct a reversed query to retrieve
+	// all of the events.
+	eventQuery := ForwardingEventQuery{
+		StartTime:    initialTime,
+		EndTime:      timestamp,
+		IndexOffset:  0,
+		NumMaxEvents: 1000,
+		Reversed:     true,
+	}
+	timeSlice, err := log.Query(eventQuery)
+	require.NoError(t, err, "unable to query for events")
+
+	// The set of returned events should be in reverse order.
+	if len(timeSlice.ForwardingEvents) != numEvents {
+		t.Fatalf("wrong number of events: expected %v, got %v", numEvents,
+			len(timeSlice.ForwardingEvents))
+	}
+
+	for i := 0; i < numEvents; i++ {
+		expected := events[numEvents-1-i]
+		actual := timeSlice.ForwardingEvents[i]
+		if !reflect.DeepEqual(expected, actual) {
+			t.Fatalf("event mismatch at index %d: expected %v vs %v",
+				i, spew.Sdump(expected), spew.Sdump(actual))
+		}
+	}
+
+	// Now test pagination with reversed query.
+	eventQuery.NumMaxEvents = 10
+	timeSlice, err = log.Query(eventQuery)
+	require.NoError(t, err)
+	require.Equal(t, 10, len(timeSlice.ForwardingEvents))
+
+	// Should be the last 10 events (most recent).
+	for i := 0; i < 10; i++ {
+		expected := events[numEvents-1-i]
+		actual := timeSlice.ForwardingEvents[i]
+		if !reflect.DeepEqual(expected, actual) {
+			t.Fatalf("pagination mismatch at index %d: expected %v vs %v",
+				i, spew.Sdump(expected), spew.Sdump(actual))
+		}
+	}
+
+	// Use the offset to get the next page.
+	eventQuery.IndexOffset = timeSlice.LastIndexOffset
+	timeSlice, err = log.Query(eventQuery)
+	require.NoError(t, err)
+	require.Equal(t, 10, len(timeSlice.ForwardingEvents))
+
+	// Should be the next 10 events.
+	for i := 0; i < 10; i++ {
+		expected := events[numEvents-11-i]
+		actual := timeSlice.ForwardingEvents[i]
+		if !reflect.DeepEqual(expected, actual) {
+			t.Fatalf("pagination mismatch at page 2 index %d: expected %v vs %v",
+				i, spew.Sdump(expected), spew.Sdump(actual))
+		}
+	}
+}

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -7,10 +7,11 @@
 package lnrpc
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -16091,6 +16092,11 @@ type ForwardingHistoryRequest struct {
 	// List of outgoing channel ids to filter htlcs being forwarded to a
 	// particular channel
 	OutgoingChanIds []uint64 `protobuf:"varint,7,rep,packed,name=outgoing_chan_ids,json=outgoingChanIds,proto3" json:"outgoing_chan_ids,omitempty"`
+	// If set, the forwarding events returned will result from seeking
+	// backwards from the specified index offset. This can be used to
+	// paginate backwards. The order of the returned events is always
+	// newest first (descending index order).
+	Reversed bool `protobuf:"varint,8,opt,name=reversed,proto3" json:"reversed,omitempty"`
 }
 
 func (x *ForwardingHistoryRequest) Reset() {
@@ -16172,6 +16178,13 @@ func (x *ForwardingHistoryRequest) GetOutgoingChanIds() []uint64 {
 		return x.OutgoingChanIds
 	}
 	return nil
+}
+
+func (x *ForwardingHistoryRequest) GetReversed() bool {
+	if x != nil {
+		return x.Reversed
+	}
+	return false
 }
 
 type ForwardingEvent struct {

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -4838,6 +4838,12 @@ message ForwardingHistoryRequest {
     // List of outgoing channel ids to filter htlcs being forwarded to a
     // particular channel
     repeated uint64 outgoing_chan_ids = 7;
+
+    // If set, the forwarding events returned will result from seeking
+    // backwards from the specified index offset. This can be used to
+    // paginate backwards. The order of the returned events is always
+    // newest first (descending index order).
+    bool reversed = 8;
 }
 message ForwardingEvent {
     // Timestamp is the time (unix epoch offset) that this circuit was

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -8282,6 +8282,7 @@ func (r *rpcServer) ForwardingHistory(ctx context.Context,
 		NumMaxEvents:    numEvents,
 		IncomingChanIDs: incomingChanIDs,
 		OutgoingChanIDs: outgoingChanIDs,
+		Reversed:        req.Reversed,
 	}
 	timeSlice, err := r.server.miscDB.ForwardingLog().Query(eventQuery)
 	if err != nil {


### PR DESCRIPTION
Summary of PR :

Added reversed flag to `ForwardingHistory RPC.`
Implemented reverse iteration in the database level (`channeldb`).
Added a comprehensive unit test verifying the new logic and pagination.
Manually updated the generated proto code to ensure the build stays green in this environment.

fixes #10555 