### PR TITLE
sweep: handle zero fee rate delta in LinearFeeFunction

### DIFF
--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -21,6 +21,13 @@
 
 # Bug Fixes
 
+* [Fixed the sweeper's fee function](https://github.com/lightningnetwork/lnd/pull/10614)
+  to handle the case where the estimated fee rate exceeds the budget-derived
+  max, causing both starting and ending fee rates to be equal (delta=0). Instead
+  of rejecting the sweep entirely, the sweeper now creates a flat-rate fee
+  function and attempts the sweep at the max budget rate. This prevents UTXOs
+  with tight budgets from being stuck in a perpetual retry loop.
+
 * [Fixed `OpenChannel` with
   `fund_max`](https://github.com/lightningnetwork/lnd/pull/10488) to use the
   protocol-level maximum channel size instead of the user-configured

--- a/sweep/fee_function.go
+++ b/sweep/fee_function.go
@@ -162,17 +162,19 @@ func NewLinearFeeFunction(maxFeeRate chainfee.SatPerKWeight,
 	delta := btcutil.Amount(end - start).MulF64(1000 / float64(l.width))
 	l.deltaFeeRate = mSatPerKWeight(delta)
 
-	// We only allow the delta to be zero if the width is one - when the
-	// delta is zero, it means the starting and ending fee rates are the
-	// same, which means there's nothing to increase, so any width greater
-	// than 1 doesn't provide any utility. This could happen when the
-	// budget is too small.
+	// When the delta is zero, the starting and ending fee rates are the
+	// same, which means fee bumping isn't possible. This typically happens
+	// when the estimated fee rate exceeds the budget-derived max and both
+	// get clamped to the same value. We still want to attempt the sweep
+	// at this rate, so we set the width to zero to signal that the fee
+	// function is already at its maximum and Increment() should
+	// immediately return ErrMaxPosition.
 	if l.deltaFeeRate == 0 && l.width != 1 {
-		log.Errorf("Failed to init fee function: startingFeeRate=%v, "+
-			"endingFeeRate=%v, width=%v, delta=%v", start, end,
-			l.width, l.deltaFeeRate)
+		log.Warnf("Fee function delta is zero (start=%v, end=%v, "+
+			"width=%v), fee bumping disabled", start, end,
+			l.width)
 
-		return nil, ErrZeroFeeRateDelta
+		l.width = 0
 	}
 
 	// Attach the calculated values to the fee function.

--- a/sweep/fee_function_test.go
+++ b/sweep/fee_function_test.go
@@ -47,7 +47,8 @@ func TestLinearFeeFunctionNewMaxFeeRateUsed(t *testing.T) {
 }
 
 // TestLinearFeeFunctionNewZeroFeeRateDelta tests when the fee rate delta is
-// zero, it will return an error except when the width is one.
+// zero, a flat-rate fee function should be returned with width set to zero
+// when width > 1, or kept as-is when width is one.
 func TestLinearFeeFunctionNewZeroFeeRateDelta(t *testing.T) {
 	t.Parallel()
 
@@ -63,8 +64,9 @@ func TestLinearFeeFunctionNewZeroFeeRateDelta(t *testing.T) {
 	confTarget := uint32(6)
 	noStartFeeRate := fn.None[chainfee.SatPerKWeight]()
 
-	// When the calculated fee rate delta is 0, an error should be returned
-	// when the width is not one.
+	// When the calculated fee rate delta is 0 and the width is greater
+	// than one, a flat-rate fee function should be returned with width
+	// set to zero (fee bumping disabled).
 	//
 	// Mock the fee estimator to return the fee rate.
 	estimator.On("EstimateFeePerKW", confTarget).Return(
@@ -75,8 +77,22 @@ func TestLinearFeeFunctionNewZeroFeeRateDelta(t *testing.T) {
 	f, err := NewLinearFeeFunction(
 		maxFeeRate, confTarget, estimator, noStartFeeRate,
 	)
-	rt.ErrorContains(err, "fee rate delta is zero")
-	rt.Nil(f)
+	rt.NoError(err)
+	rt.NotNil(f)
+
+	// Assert the internal state - width should be set to 0 since fee
+	// bumping is not possible.
+	rt.Equal(maxFeeRate, f.startingFeeRate)
+	rt.Equal(maxFeeRate, f.endingFeeRate)
+	rt.Equal(maxFeeRate, f.currentFeeRate)
+	rt.Zero(f.deltaFeeRate)
+	rt.Zero(f.width)
+
+	// Increment should immediately return ErrMaxPosition since width
+	// is 0.
+	increased, err := f.Increment()
+	rt.ErrorIs(err, ErrMaxPosition)
+	rt.False(increased)
 
 	// When the calculated fee rate delta is 0, an error should NOT be
 	// returned when the width is one, and the starting feerate is capped


### PR DESCRIPTION
Fix `NewLinearFeeFunction` to handle the case where starting and ending fee rates are equal (delta=0) by creating a flat-rate fee function instead of returning `ErrZeroFeeRateDelta`

### Problem

When the fee estimator returns a rate higher than the budget-derived max fee rate, both the starting fee rate (estimated, clamped to max) and ending fee rate (budget max) become equal. This causes `delta = (end - start) / width = 0,` and `NewLinearFeeFunction` rejects the initialization with `ErrZeroFeeRateDelta`.

This means the sweep is never even attempted, even though the budget is sufficient to pay the fee at the max budget rate. The sweeper logs repeated errors like:

```
Failed to init fee function: startingFeeRate=742 sat/kw, endingFeeRate=742 sat/kw, width=1004, delta=0 mSAT/kw
```

This can happen in practice when:

- A small UTXO has a tight budget, resulting in a low max fee rate
- The fee estimator returns a rate above this budget max
- Both rates get clamped to the budget max

### Fix 

Instead of returning an error when `delta == 0 && width > 1`, we now:

1. Log a warning that fee bumping is disabled
2. Set width = 0 so the fee function is considered already at its maximum
3. Return a valid fee function that will use the flat rate for the initial sweep attempt

The sweep will be attempted at the budget-max fee rate. If it passes mempool acceptance, it succeeds. If a fee bump is needed later, `Increment()` immediately returns `ErrMaxPosition`, which the fee bumper handles by retrying with a different grouping strategy.