### PR TITLE
lnrpc: added weight field to the transaction return for getTransactio…

### DIFF
--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -810,6 +810,9 @@ message Transaction {
 
     // PreviousOutpoints/Inputs of this transaction.
     repeated PreviousOutPoint previous_outpoints = 12;
+
+    // The weight of the transaction in weight units.
+    int64 weight = 13;
 }
 
 message GetTransactionsRequest {

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -7976,6 +7976,11 @@
             "$ref": "#/definitions/lnrpcPreviousOutPoint"
           },
           "description": "PreviousOutpoints/Inputs of this transaction."
+        },
+        "weight": {
+          "type": "string",
+          "format": "int64",
+          "description": "The weight of the transaction in weight units."
         }
       }
     },

--- a/lnrpc/rpc_utils.go
+++ b/lnrpc/rpc_utils.go
@@ -1,12 +1,16 @@
 package lnrpc
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"sort"
 
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/sweep"
@@ -62,6 +66,18 @@ func RPCTransaction(tx *lnwallet.TransactionDetail) *Transaction {
 	var destAddresses []string
 	// Re-package destination output information.
 	var outputDetails []*OutputDetail
+
+	var txWeight int64
+
+	if len(tx.RawTx) > 0 {
+		reader := bytes.NewReader(tx.RawTx)
+		var msgTx wire.MsgTx
+		if err := msgTx.Deserialize(reader); err == nil {
+			txWeight = blockchain.GetTransactionWeight(
+				btcutil.NewTx(&msgTx),
+			)
+		}
+	}
 	for _, o := range tx.OutputDetails {
 		// Note: DestAddresses is deprecated but we keep
 		// populating it with addresses for backwards
@@ -113,6 +129,7 @@ func RPCTransaction(tx *lnwallet.TransactionDetail) *Transaction {
 		RawTxHex:          hex.EncodeToString(tx.RawTx),
 		Label:             tx.Label,
 		PreviousOutpoints: previousOutpoints,
+		Weight:            txWeight,
 	}
 }
 
@@ -226,7 +243,7 @@ func GetChannelOutPoint(chanPoint *ChannelPoint) (*OutPoint, error) {
 		OutputIndex: chanPoint.OutputIndex,
 	}, nil
 }
-
+								
 // CalculateFeeRate uses either satPerByte or satPerVByte, but not both, from a
 // request to calculate the fee rate. It provides compatibility for the
 // deprecated field, satPerByte. Once the field is safe to be removed, the

--- a/lnrpc/walletrpc/walletkit.swagger.json
+++ b/lnrpc/walletrpc/walletkit.swagger.json
@@ -1156,6 +1156,11 @@
             "$ref": "#/definitions/lnrpcPreviousOutPoint"
           },
           "description": "PreviousOutpoints/Inputs of this transaction."
+        },
+        "weight": {
+          "type": "string",
+          "format": "int64",
+          "description": "The weight of the transaction in weight units."
         }
       }
     },


### PR DESCRIPTION
## Change Description
Added a "weight" field to the transactions returned by the RPCs like `listchaintxns` for cli and other related RPC in gRPC and REST. This can be used to calculate fee_per_vbyte for unconfirmed transactions. This PR solves the issue #9833.

## Steps to Test
1) Run `make rpc` to ensure that the generated files are according to  new definitions edited in protobuf file.
2) Run `make install` to update the lnd and lncli binaries with new RPC definitions.
3) Make dummy transactions on either `regtest` network or any other network.
4) Use `lncli --network=<your_selected_network> listchaintxns` to get all the transactions. The listed transactions should have "Weights" field

##Implementation Method
1) Added the required field in lnrpc/lightning.proto file so that the field is added to all the RPC response structs at once.
2) In` lnrpc/rpc_util.go` in RPCTransaction function, used `blockchain.GetTransactionWeight() `to get the weight involved and populated the corresponding field.