### PR TITLE
multi: expose local and remote spendable balance in listchannels

### DIFF
--- a/docs/release-notes/release-notes-0.20.1.md
+++ b/docs/release-notes/release-notes-0.20.1.md
@@ -115,10 +115,19 @@
    for conservative budgeting and includes griefing protection by limiting the
    number of probed LSPs. It enhances the previous LSP design by being more
    generic and more flexible.
+ 
+ * The `listchannels` RPC now [exposes the actual 
+   spendable balance](https://github.com/lightningnetwork/lnd/pull/10624)
+    by adding `local_spendable_msat` and `remote_spendable_msat` fields. 
+    This provides users with a precise view of their actionable liquidity by 
+    correctly accounting for channel reserves and funds currently tied up in 
+    in-flight HTLCs.
 
 ## lncli Updates
 
 ## Breaking Changes
+
+* The `RemoteBandwidth` method has been added to the `ChannelUpdateHandler` and `ChannelLink` interfaces in the `htlcswitch` package.
 
 ## Performance Improvements
 

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -129,10 +129,16 @@ type ChannelUpdateHandler interface {
 
 	// Bandwidth returns the amount of milli-satoshis which current link
 	// might pass through channel link. The value returned from this method
-	// represents the up to date available flow through the channel. This
-	// takes into account any forwarded but un-cleared HTLC's, and any
-	// HTLC's which have been set to the over flow queue.
+	// represents the up to date available flow through the channel for the
+	// local party. This takes into account any forwarded but un-cleared
+	// HTLC's, and any HTLC's which have been set to the over flow queue.
 	Bandwidth() lnwire.MilliSatoshi
+
+	// RemoteBandwidth returns the amount of milli-satoshis which the remote
+	// party can send through the channel. Similar to Bandwidth(), it takes
+	// into account reserves and commitment fees from the remote's
+	// perspective.
+	RemoteBandwidth() lnwire.MilliSatoshi
 
 	// EligibleToForward returns a bool indicating if the channel is able
 	// to actively accept requests to forward HTLC's. A channel may be

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -2171,6 +2171,16 @@ func (l *channelLink) Bandwidth() lnwire.MilliSatoshi {
 	return l.channel.AvailableBalance()
 }
 
+// RemoteBandwidth returns the total amount that the remote party can send
+// through the channel link at this given instance. The value returned is
+// expressed in millisatoshi.
+//
+// NOTE: Part of the ChannelLink interface.
+func (l *channelLink) RemoteBandwidth() lnwire.MilliSatoshi {
+	// Get the balance available for the remote party for new HTLCs.
+	return l.channel.RemoteAvailableBalance()
+}
+
 // MayAddOutgoingHtlc indicates whether we can add an outgoing htlc with the
 // amount provided to the link. This check does not reserve a space, since
 // forwards or other payments may use the available slot, so it should be

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -2177,7 +2177,6 @@ func (l *channelLink) Bandwidth() lnwire.MilliSatoshi {
 //
 // NOTE: Part of the ChannelLink interface.
 func (l *channelLink) RemoteBandwidth() lnwire.MilliSatoshi {
-	// Get the balance available for the remote party for new HTLCs.
 	return l.channel.RemoteAvailableBalance()
 }
 

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -2196,7 +2196,6 @@ func (l *channelLink) Bandwidth() lnwire.MilliSatoshi {
 //
 // NOTE: Part of the ChannelLink interface.
 func (l *channelLink) RemoteBandwidth() lnwire.MilliSatoshi {
-	// Get the balance available for the remote party for new HTLCs.
 	return l.channel.RemoteAvailableBalance()
 }
 

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -2190,6 +2190,16 @@ func (l *channelLink) Bandwidth() lnwire.MilliSatoshi {
 	return l.channel.AvailableBalance()
 }
 
+// RemoteBandwidth returns the total amount that the remote party can send
+// through the channel link at this given instance. The value returned is
+// expressed in millisatoshi.
+//
+// NOTE: Part of the ChannelLink interface.
+func (l *channelLink) RemoteBandwidth() lnwire.MilliSatoshi {
+	// Get the balance available for the remote party for new HTLCs.
+	return l.channel.RemoteAvailableBalance()
+}
+
 // MayAddOutgoingHtlc indicates whether we can add an outgoing htlc with the
 // amount provided to the link. This check does not reserve a space, since
 // forwards or other payments may use the available slot, so it should be

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -913,7 +913,17 @@ func (f *mockChannelLink) ShortChanID() lnwire.ShortChannelID {
 	return f.shortChanID
 }
 
+// Bandwidth returns a hardcoded amount of milli-satoshis for the mock link.
+//
+// NOTE: Part of the ChannelLink interface.
 func (f *mockChannelLink) Bandwidth() lnwire.MilliSatoshi {
+	return 99999999
+}
+
+// RemoteBandwidth returns a hardcoded amount of milli-satoshis for the mock link.
+//
+// NOTE: Part of the ChannelLink interface.
+func (f *mockChannelLink) RemoteBandwidth() lnwire.MilliSatoshi {
 	return 99999999
 }
 

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -168,7 +168,9 @@ type mockServer struct {
 
 var _ lnpeer.Peer = (*mockServer)(nil)
 
-func initSwitchWithDB(startingHeight uint32, db *channeldb.DB) (*Switch, error) {
+func initSwitchWithDB(startingHeight uint32, db *channeldb.DB) (
+	*Switch, error) {
+
 	signAliasUpdate := func(u *lnwire.ChannelUpdate1) (*ecdsa.Signature,
 		error) {
 
@@ -440,10 +442,11 @@ func (o *mockObfuscator) IntermediateEncrypt(reason lnwire.OpaqueReason) lnwire.
 	return reason
 }
 
-func (o *mockObfuscator) EncryptMalformedError(reason lnwire.OpaqueReason) lnwire.OpaqueReason {
+func (o *mockObfuscator) EncryptMalformedError(
+	reason lnwire.OpaqueReason) lnwire.OpaqueReason {
+
 	var b bytes.Buffer
 	b.Write(fakeHmac)
-
 	b.Write(reason)
 
 	return b.Bytes()
@@ -510,7 +513,9 @@ func (p *mockIteratorDecoder) DecodeHopIterator(r io.Reader, rHash []byte,
 		}
 
 		var nextHopBytes [8]byte
-		binary.BigEndian.PutUint64(nextHopBytes[:], f.NextHop.ToUint64())
+		binary.BigEndian.PutUint64(
+			nextHopBytes[:], f.NextHop.ToUint64(),
+		)
 
 		hops[i] = hop.NewLegacyPayload(&sphinx.HopData{
 			Realm:         [1]byte{}, // hop.BitcoinNetwork
@@ -920,7 +925,8 @@ func (f *mockChannelLink) Bandwidth() lnwire.MilliSatoshi {
 	return 99999999
 }
 
-// RemoteBandwidth returns a hardcoded amount of milli-satoshis for the mock link.
+// RemoteBandwidth returns a hardcoded amount of milli-satoshis for
+// the mock link.
 //
 // NOTE: Part of the ChannelLink interface.
 func (f *mockChannelLink) RemoteBandwidth() lnwire.MilliSatoshi {

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -168,7 +168,9 @@ type mockServer struct {
 
 var _ lnpeer.Peer = (*mockServer)(nil)
 
-func initSwitchWithDB(startingHeight uint32, db *channeldb.DB) (*Switch, error) {
+func initSwitchWithDB(startingHeight uint32, db *channeldb.DB) (
+	*Switch, error) {
+
 	signAliasUpdate := func(u *lnwire.ChannelUpdate1) (*ecdsa.Signature,
 		error) {
 
@@ -446,10 +448,11 @@ func (o *mockObfuscator) IntermediateEncrypt(reason lnwire.OpaqueReason) lnwire.
 	return reason
 }
 
-func (o *mockObfuscator) EncryptMalformedError(reason lnwire.OpaqueReason) lnwire.OpaqueReason {
+func (o *mockObfuscator) EncryptMalformedError(
+	reason lnwire.OpaqueReason) lnwire.OpaqueReason {
+
 	var b bytes.Buffer
 	b.Write(fakeHmac)
-
 	b.Write(reason)
 
 	return b.Bytes()
@@ -929,7 +932,8 @@ func (f *mockChannelLink) Bandwidth() lnwire.MilliSatoshi {
 	return 99999999
 }
 
-// RemoteBandwidth returns a hardcoded amount of milli-satoshis for the mock link.
+// RemoteBandwidth returns a hardcoded amount of milli-satoshis for
+// the mock link.
 //
 // NOTE: Part of the ChannelLink interface.
 func (f *mockChannelLink) RemoteBandwidth() lnwire.MilliSatoshi {

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -922,7 +922,17 @@ func (f *mockChannelLink) ShortChanID() lnwire.ShortChannelID {
 	return f.shortChanID
 }
 
+// Bandwidth returns a hardcoded amount of milli-satoshis for the mock link.
+//
+// NOTE: Part of the ChannelLink interface.
 func (f *mockChannelLink) Bandwidth() lnwire.MilliSatoshi {
+	return 99999999
+}
+
+// RemoteBandwidth returns a hardcoded amount of milli-satoshis for the mock link.
+//
+// NOTE: Part of the ChannelLink interface.
+func (f *mockChannelLink) RemoteBandwidth() lnwire.MilliSatoshi {
 	return 99999999
 }
 

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -4683,8 +4683,15 @@ type Channel struct {
 	Memo string `protobuf:"bytes,36,opt,name=memo,proto3" json:"memo,omitempty"`
 	// Custom channel data that might be populated in custom channels.
 	CustomChannelData []byte `protobuf:"bytes,37,opt,name=custom_channel_data,json=customChannelData,proto3" json:"custom_channel_data,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// The amount of funds in milli-satoshis that can be sent in the channel.
+	// This takes into account the channel reserve and any commitment fees.
+	LocalSpendableMsat int64 `protobuf:"varint,38,opt,name=local_spendable_msat,json=localSpendableMsat,proto3" json:"local_spendable_msat,omitempty"`
+	// The amount of funds in milli-satoshis that the remote party can send in
+	// the channel. This takes into account the channel reserve and any
+	// commitment fees.
+	RemoteSpendableMsat int64 `protobuf:"varint,39,opt,name=remote_spendable_msat,json=remoteSpendableMsat,proto3" json:"remote_spendable_msat,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *Channel) Reset() {
@@ -4978,6 +4985,20 @@ func (x *Channel) GetCustomChannelData() []byte {
 		return x.CustomChannelData
 	}
 	return nil
+}
+
+func (x *Channel) GetLocalSpendableMsat() int64 {
+	if x != nil {
+		return x.LocalSpendableMsat
+	}
+	return 0
+}
+
+func (x *Channel) GetRemoteSpendableMsat() int64 {
+	if x != nil {
+		return x.RemoteSpendableMsat
+	}
+	return 0
 }
 
 type ListChannelsRequest struct {
@@ -18742,7 +18763,7 @@ const file_lightning_proto_rawDesc = "" +
 	"\x0edust_limit_sat\x18\x03 \x01(\x04R\fdustLimitSat\x12/\n" +
 	"\x14max_pending_amt_msat\x18\x04 \x01(\x04R\x11maxPendingAmtMsat\x12\"\n" +
 	"\rmin_htlc_msat\x18\x05 \x01(\x04R\vminHtlcMsat\x12,\n" +
-	"\x12max_accepted_htlcs\x18\x06 \x01(\rR\x10maxAcceptedHtlcs\"\xdd\v\n" +
+	"\x12max_accepted_htlcs\x18\x06 \x01(\rR\x10maxAcceptedHtlcs\"\xc3\f\n" +
 	"\aChannel\x12\x16\n" +
 	"\x06active\x18\x01 \x01(\bR\x06active\x12#\n" +
 	"\rremote_pubkey\x18\x02 \x01(\tR\fremotePubkey\x12#\n" +
@@ -18787,7 +18808,9 @@ const file_lightning_proto_rawDesc = "" +
 	"peer_alias\x18\" \x01(\tR\tpeerAlias\x12*\n" +
 	"\x0fpeer_scid_alias\x18# \x01(\x04B\x020\x01R\rpeerScidAlias\x12\x12\n" +
 	"\x04memo\x18$ \x01(\tR\x04memo\x12.\n" +
-	"\x13custom_channel_data\x18% \x01(\fR\x11customChannelData\"\xdf\x01\n" +
+	"\x13custom_channel_data\x18% \x01(\fR\x11customChannelData\x120\n" +
+	"\x14local_spendable_msat\x18& \x01(\x03R\x12localSpendableMsat\x122\n" +
+	"\x15remote_spendable_msat\x18' \x01(\x03R\x13remoteSpendableMsat\"\xdf\x01\n" +
 	"\x13ListChannelsRequest\x12\x1f\n" +
 	"\vactive_only\x18\x01 \x01(\bR\n" +
 	"activeOnly\x12#\n" +

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -4683,12 +4683,13 @@ type Channel struct {
 	Memo string `protobuf:"bytes,36,opt,name=memo,proto3" json:"memo,omitempty"`
 	// Custom channel data that might be populated in custom channels.
 	CustomChannelData []byte `protobuf:"bytes,37,opt,name=custom_channel_data,json=customChannelData,proto3" json:"custom_channel_data,omitempty"`
-	// The amount of funds in milli-satoshis that can be sent in the channel.
-	// This takes into account the channel reserve and any commitment fees.
+	// The amount of funds in milli-satoshis that we can send in the channel,
+	// net of reserve and commitment fees. This field is only populated if the
+	// channel is active (has an active link).
 	LocalSpendableMsat int64 `protobuf:"varint,38,opt,name=local_spendable_msat,json=localSpendableMsat,proto3" json:"local_spendable_msat,omitempty"`
-	// The amount of funds in milli-satoshis that the remote party can send in
-	// the channel. This takes into account the channel reserve and any
-	// commitment fees.
+	// The amount of funds in milli-satoshis that the remote party can send to
+	// us (i.e., our inbound capacity), net of reserve and commitment fees.
+	// This field is only populated if the channel is active (has an active link).
 	RemoteSpendableMsat int64 `protobuf:"varint,39,opt,name=remote_spendable_msat,json=remoteSpendableMsat,proto3" json:"remote_spendable_msat,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -1588,6 +1588,19 @@ message Channel {
     Custom channel data that might be populated in custom channels.
     */
     bytes custom_channel_data = 37;
+
+    /*
+    The amount of funds in milli-satoshis that can be sent in the channel.
+    This takes into account the channel reserve and any commitment fees.
+    */
+    int64 local_spendable_msat = 38;
+
+    /*
+    The amount of funds in milli-satoshis that the remote party can send in
+    the channel. This takes into account the channel reserve and any
+    commitment fees.
+    */
+    int64 remote_spendable_msat = 39;
 }
 
 message ListChannelsRequest {

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -1590,15 +1590,16 @@ message Channel {
     bytes custom_channel_data = 37;
 
     /*
-    The amount of funds in milli-satoshis that can be sent in the channel.
-    This takes into account the channel reserve and any commitment fees.
+    The amount of funds in milli-satoshis that we can send in the channel,
+    net of reserve and commitment fees. This field is only populated if the
+    channel is active (has an active link).
     */
     int64 local_spendable_msat = 38;
 
     /*
-    The amount of funds in milli-satoshis that the remote party can send in
-    the channel. This takes into account the channel reserve and any
-    commitment fees.
+    The amount of funds in milli-satoshis that the remote party can send to
+    us (i.e., our inbound capacity), net of reserve and commitment fees.
+    This field is only populated if the channel is active (has an active link).
     */
     int64 remote_spendable_msat = 39;
 }

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -4034,6 +4034,16 @@
           "type": "string",
           "format": "byte",
           "description": "Custom channel data that might be populated in custom channels."
+        },
+        "local_spendable_msat": {
+          "type": "string",
+          "format": "int64",
+          "description": "The amount of funds in milli-satoshis that can be sent in the channel.\nThis takes into account the channel reserve and any commitment fees."
+        },
+        "remote_spendable_msat": {
+          "type": "string",
+          "format": "int64",
+          "description": "The amount of funds in milli-satoshis that the remote party can send in\nthe channel. This takes into account the channel reserve and any\ncommitment fees."
         }
       }
     },

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -4038,12 +4038,12 @@
         "local_spendable_msat": {
           "type": "string",
           "format": "int64",
-          "description": "The amount of funds in milli-satoshis that can be sent in the channel.\nThis takes into account the channel reserve and any commitment fees."
+          "description": "The amount of funds in milli-satoshis that we can send in the channel,\nnet of reserve and commitment fees. This field is only populated if the\nchannel is active (has an active link)."
         },
         "remote_spendable_msat": {
           "type": "string",
           "format": "int64",
-          "description": "The amount of funds in milli-satoshis that the remote party can send in\nthe channel. This takes into account the channel reserve and any\ncommitment fees."
+          "description": "The amount of funds in milli-satoshis that the remote party can send to\nus (i.e., our inbound capacity), net of reserve and commitment fees.\nThis field is only populated if the channel is active (has an active link)."
         }
       }
     },

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -3809,14 +3809,10 @@ func (b BufferType) String() string {
 	}
 }
 
-// applyCommitFee applies the commitFee including a buffer to the balance amount
-// and verifies that it does not become negative. This function returns the new
-// balance, the exact buffer amount (excluding the commitment fee) and the
-// commitment fee.
-// applyCommitFee subtracts the commitment fee from the given balance. If the
-// party is the initiator, then the fee buffer is also applied to ensure that
-// the initiator has enough funds to cover the commitment fee even if the fee
-// rate doubles in the future.
+// applyCommitFee deducts the commitment fee and an optional buffer from the
+// balance, ensuring it remains non-negative. If the party is the initiator,
+// a buffer is enforced to hedge against potential fee rate doubling. Returns:
+// the adjusted balance, the buffer (less the commit fee), and the commit fee.
 func (lc *LightningChannel) applyCommitFee(
 	balance lnwire.MilliSatoshi, commitWeight lntypes.WeightUnit,
 	feePerKw chainfee.SatPerKWeight,

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -3815,9 +3815,8 @@ func (b BufferType) String() string {
 // the adjusted balance, the buffer (less the commit fee), and the commit fee.
 func (lc *LightningChannel) applyCommitFee(
 	balance lnwire.MilliSatoshi, commitWeight lntypes.WeightUnit,
-	feePerKw chainfee.SatPerKWeight,
-	buffer BufferType, isInitiator bool) (lnwire.MilliSatoshi, lnwire.MilliSatoshi,
-	lnwire.MilliSatoshi, error) {
+	feePerKw chainfee.SatPerKWeight, buffer BufferType, isInitiator bool) (
+	lnwire.MilliSatoshi, lnwire.MilliSatoshi, lnwire.MilliSatoshi, error) {
 
 	commitFee := feePerKw.FeeForWeight(commitWeight)
 	commitFeeMsat := lnwire.NewMSatFromSatoshis(commitFee)
@@ -9188,6 +9187,7 @@ func (lc *LightningChannel) RemoteAvailableBalance() lnwire.MilliSatoshi {
 	defer lc.RUnlock()
 
 	bal, _ := lc.remoteAvailableBalance(FeeBuffer)
+
 	return bal
 }
 
@@ -9212,11 +9212,30 @@ func (lc *LightningChannel) remoteAvailableBalance(
 // calculate the available balance for either the local or remote party,
 // depending on the isRemote flag.
 func (lc *LightningChannel) availableBalanceGeneric(
-	buffer BufferType, isRemote bool) (lnwire.MilliSatoshi, lntypes.WeightUnit) {
+	buffer BufferType, isRemote bool) (
+	lnwire.MilliSatoshi, lntypes.WeightUnit) {
 
-	htlcView := lc.fetchHTLCView(
-		lc.updateLogs.Remote.logIndex, lc.updateLogs.Local.logIndex,
-	)
+	// We'll fetch the HTLC view based on the party whose balance we are
+	// computing.
+	//
+	// For the local party, we'll use the remote ACKed index from the local
+	// commitment tip to ensure we only include remote HTLCs that have
+	// been locked into a signed commitment.
+	//
+	// For the remote party, we'll use the local ACKed index from the remote
+	// commitment tip to ensure we only include local HTLCs they have ACKed.
+	var remoteLogIndex, localLogIndex uint64
+	if !isRemote {
+		remoteLogIndex = lc.commitChains.Local.
+			tip().messageIndices.Remote
+		localLogIndex = lc.updateLogs.Local.logIndex
+	} else {
+		remoteLogIndex = lc.updateLogs.Remote.logIndex
+		localLogIndex = lc.commitChains.Remote.
+			tip().messageIndices.Local
+	}
+
+	htlcView := lc.fetchHTLCView(remoteLogIndex, localLogIndex)
 
 	// Calculate the available balance from our local commitment.
 	ourLocalCommitBalance, commitWeight := lc.availableCommitmentBalance(
@@ -9326,7 +9345,11 @@ func (lc *LightningChannel) availableCommitmentBalance(view *HtlcView,
 		// declare bufferAmt beforehand.
 		var bufferAmt lnwire.MilliSatoshi
 		balance, bufferAmt, commitFee, err = lc.applyCommitFee(
-			balance, futureCommitWeight, feePerKw, buffer, initiator,
+			balance,
+			futureCommitWeight,
+			feePerKw,
+			buffer,
+			initiator,
 		)
 		if err != nil {
 			lc.log.Debugf("No available balance after "+

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -3813,10 +3813,14 @@ func (b BufferType) String() string {
 // and verifies that it does not become negative. This function returns the new
 // balance, the exact buffer amount (excluding the commitment fee) and the
 // commitment fee.
+// applyCommitFee subtracts the commitment fee from the given balance. If the
+// party is the initiator, then the fee buffer is also applied to ensure that
+// the initiator has enough funds to cover the commitment fee even if the fee
+// rate doubles in the future.
 func (lc *LightningChannel) applyCommitFee(
 	balance lnwire.MilliSatoshi, commitWeight lntypes.WeightUnit,
 	feePerKw chainfee.SatPerKWeight,
-	buffer BufferType) (lnwire.MilliSatoshi, lnwire.MilliSatoshi,
+	buffer BufferType, isInitiator bool) (lnwire.MilliSatoshi, lnwire.MilliSatoshi,
 	lnwire.MilliSatoshi, error) {
 
 	commitFee := feePerKw.FeeForWeight(commitWeight)
@@ -3831,7 +3835,7 @@ func (lc *LightningChannel) applyCommitFee(
 	case FeeBuffer:
 		// Make sure that we are the initiator of the channel before we
 		// apply the FeeBuffer.
-		if !lc.channelState.IsInitiator {
+		if !isInitiator {
 			return 0, 0, 0, ErrFeeBufferNotInitiator
 		}
 
@@ -3934,7 +3938,7 @@ func (lc *LightningChannel) validateCommitmentSanity(theirLogCounter,
 
 	if lc.channelState.IsInitiator {
 		ourBalance, bufferAmt, commitFee, err = lc.applyCommitFee(
-			ourBalance, commitWeight, feePerKw, buffer,
+			ourBalance, commitWeight, feePerKw, buffer, true,
 		)
 		if err != nil {
 			lc.log.Errorf("Cannot pay for the CommitmentFee of "+
@@ -3955,7 +3959,7 @@ func (lc *LightningChannel) validateCommitmentSanity(theirLogCounter,
 		// on the channel state. The FeeBuffer should ONLY be enforced
 		// if we locally pay for the commitment transaction.
 		theirBalance, bufferAmt, commitFee, err = lc.applyCommitFee(
-			theirBalance, commitWeight, feePerKw, NoBuffer,
+			theirBalance, commitWeight, feePerKw, NoBuffer, false,
 		)
 		if err != nil {
 			lc.log.Errorf("Cannot pay for the CommitmentFee "+
@@ -9180,6 +9184,17 @@ func (lc *LightningChannel) AvailableBalance() lnwire.MilliSatoshi {
 	return bal
 }
 
+// RemoteAvailableBalance returns the current balance available for the remote
+// party to send within the channel. This value takes into account the remote
+// party's channel reserve, and the commitment fee if they are the initiator.
+func (lc *LightningChannel) RemoteAvailableBalance() lnwire.MilliSatoshi {
+	lc.RLock()
+	defer lc.RUnlock()
+
+	bal, _ := lc.remoteAvailableBalance(FeeBuffer)
+	return bal
+}
+
 // availableBalance is the private, non mutexed version of AvailableBalance.
 // This method is provided so methods that already hold the lock can access
 // this method. Additionally, the total weight of the next to be created
@@ -9187,26 +9202,34 @@ func (lc *LightningChannel) AvailableBalance() lnwire.MilliSatoshi {
 func (lc *LightningChannel) availableBalance(
 	buffer BufferType) (lnwire.MilliSatoshi, lntypes.WeightUnit) {
 
-	// We'll grab the current set of log updates that the remote has
-	// ACKed.
-	remoteACKedIndex := lc.commitChains.Local.tip().messageIndices.Remote
-	htlcView := lc.fetchHTLCView(remoteACKedIndex,
-		lc.updateLogs.Local.logIndex)
+	return lc.availableBalanceGeneric(buffer, false)
+}
 
-	// Calculate our available balance from our local commitment.
-	// TODO(halseth): could reuse parts validateCommitmentSanity to do this
-	// balance calculation, as most of the logic is the same.
-	//
-	// NOTE: This is not always accurate, since the remote node can always
-	// add updates concurrently, causing our balance to go down if we're
-	// the initiator, but this is a problem on the protocol level.
+// remoteAvailableBalance is the private version of RemoteAvailableBalance.
+func (lc *LightningChannel) remoteAvailableBalance(
+	buffer BufferType) (lnwire.MilliSatoshi, lntypes.WeightUnit) {
+
+	return lc.availableBalanceGeneric(buffer, true)
+}
+
+// availableBalanceGeneric is a generic version of availableBalance that can
+// calculate the available balance for either the local or remote party,
+// depending on the isRemote flag.
+func (lc *LightningChannel) availableBalanceGeneric(
+	buffer BufferType, isRemote bool) (lnwire.MilliSatoshi, lntypes.WeightUnit) {
+
+	htlcView := lc.fetchHTLCView(
+		lc.updateLogs.Remote.logIndex, lc.updateLogs.Local.logIndex,
+	)
+
+	// Calculate the available balance from our local commitment.
 	ourLocalCommitBalance, commitWeight := lc.availableCommitmentBalance(
-		htlcView, lntypes.Local, buffer,
+		htlcView, lntypes.Local, buffer, isRemote,
 	)
 
 	// Do the same calculation from the remote commitment point of view.
 	ourRemoteCommitBalance, _ := lc.availableCommitmentBalance(
-		htlcView, lntypes.Remote, buffer,
+		htlcView, lntypes.Remote, buffer, isRemote,
 	)
 
 	// Return which ever balance is lowest.
@@ -9217,16 +9240,17 @@ func (lc *LightningChannel) availableBalance(
 	return ourLocalCommitBalance, commitWeight
 }
 
-// availableCommitmentBalance attempts to calculate the balance we have
-// available for HTLCs on the local/remote commitment given the HtlcView. To
-// account for sending HTLCs of different sizes, it will report the balance
-// available for sending non-dust HTLCs, which will be manifested on the
-// commitment, increasing the commitment fee we must pay as an initiator,
-// eating into our balance. It will make sure we won't violate the channel
-// reserve constraints for this amount.
+// availableCommitmentBalance attempts to calculate the balance the designated
+// party (local or remote, specified by the isRemote flag) has available for
+// HTLCs on the local/remote commitment (specified by whoseCommitChain) given
+// the HtlcView. To account for sending HTLCs of different sizes, it will
+// report the balance available for sending non-dust HTLCs, which will be
+// manifested on the commitment, increasing the commitment fee the initiator
+// must pay, eating into their balance. It will make sure the channel reserve
+// constraints are not violated for this amount.
 func (lc *LightningChannel) availableCommitmentBalance(view *HtlcView,
-	whoseCommitChain lntypes.ChannelParty, buffer BufferType) (
-	lnwire.MilliSatoshi, lntypes.WeightUnit) {
+	whoseCommitChain lntypes.ChannelParty, buffer BufferType,
+	isRemote bool) (lnwire.MilliSatoshi, lntypes.WeightUnit) {
 
 	// Compute the current balances for this commitment. This will take
 	// into account HTLCs to determine the commit weight, which the
@@ -9240,15 +9264,46 @@ func (lc *LightningChannel) availableCommitmentBalance(view *HtlcView,
 		return 0, 0
 	}
 
-	// We can never spend from the channel reserve, so we'll subtract it
-	// from our available balance.
-	ourReserve := lnwire.NewMSatFromSatoshis(
-		lc.channelState.LocalChanCfg.ChanReserve,
+	var (
+		initiator       bool
+		balance         lnwire.MilliSatoshi
+		otherBalance    lnwire.MilliSatoshi
+		reserveSat      btcutil.Amount
+		otherReserveSat btcutil.Amount
+		dustLimit       lnwire.MilliSatoshi
 	)
-	if ourReserve <= ourBalance {
-		ourBalance -= ourReserve
+
+	if !isRemote {
+		initiator = lc.channelState.IsInitiator
+		balance = ourBalance
+		otherBalance = theirBalance
+		reserveSat = lc.channelState.LocalChanCfg.ChanReserve
+		otherReserveSat = lc.channelState.RemoteChanCfg.ChanReserve
 	} else {
-		ourBalance = 0
+		initiator = !lc.channelState.IsInitiator
+		balance = theirBalance
+		otherBalance = ourBalance
+		reserveSat = lc.channelState.RemoteChanCfg.ChanReserve
+		otherReserveSat = lc.channelState.LocalChanCfg.ChanReserve
+	}
+
+	if whoseCommitChain.IsLocal() {
+		dustLimit = lnwire.NewMSatFromSatoshis(
+			lc.channelState.LocalChanCfg.DustLimit,
+		)
+	} else {
+		dustLimit = lnwire.NewMSatFromSatoshis(
+			lc.channelState.RemoteChanCfg.DustLimit,
+		)
+	}
+
+	// We can never spend from the channel reserve, so we'll subtract it
+	// from the available balance.
+	reserve := lnwire.NewMSatFromSatoshis(reserveSat)
+	if reserve <= balance {
+		balance -= reserve
+	} else {
+		balance = 0
 	}
 
 	// Calculate the commitment fee in the case where we would add another
@@ -9261,7 +9316,7 @@ func (lc *LightningChannel) availableCommitmentBalance(view *HtlcView,
 	commitFee := lnwire.NewMSatFromSatoshis(
 		feePerKw.FeeForWeight(commitWeight))
 
-	if lc.channelState.IsInitiator {
+	if initiator {
 		// When the buffer is of type `FeeBuffer` type we know we are
 		// going to send or forward an htlc over this channel therefore
 		// we account for an additional htlc output on the commitment
@@ -9271,48 +9326,44 @@ func (lc *LightningChannel) availableCommitmentBalance(view *HtlcView,
 			futureCommitWeight += input.HTLCWeight
 		}
 
-		// Make sure we do not overwrite `ourBalance` that's why we
+		// Make sure we do not overwrite `balance` that's why we
 		// declare bufferAmt beforehand.
 		var bufferAmt lnwire.MilliSatoshi
-		ourBalance, bufferAmt, commitFee, err = lc.applyCommitFee(
-			ourBalance, futureCommitWeight, feePerKw, buffer,
+		balance, bufferAmt, commitFee, err = lc.applyCommitFee(
+			balance, futureCommitWeight, feePerKw, buffer, initiator,
 		)
 		if err != nil {
-			lc.log.Debugf("No available local balance after "+
+			lc.log.Debugf("No available balance after "+
 				"applying the CommitmentFee of the new "+
-				"CommitmentState(%v): ourBalance would drop "+
+				"CommitmentState(%v): balance would drop "+
 				"below the reserve: "+
-				"ourBalance(w/o reserve)=%v, reserve=%v, "+
+				"balance(w/o reserve)=%v, reserve=%v, "+
 				"current commitFee(w/o additional htlc)=%v, "+
 				"feeBuffer=%v (type=%v) "+
-				"local_chan_initiator=%v", whoseCommitChain,
-				ourBalance, ourReserve, commitFee, bufferAmt,
-				buffer, lc.channelState.IsInitiator)
+				"initiator=%v", whoseCommitChain,
+				balance, reserve, commitFee, bufferAmt,
+				buffer, initiator)
 
 			return 0, commitWeight
 		}
 
-		return ourBalance, commitWeight
+		return balance, commitWeight
 	}
 
-	// If we're not the initiator, we must check whether the remote has
-	// enough balance to pay for the fee of our HTLC. We'll start by also
-	// subtracting our counterparty's reserve from their balance.
-	theirReserve := lnwire.NewMSatFromSatoshis(
-		lc.channelState.RemoteChanCfg.ChanReserve,
-	)
-	if theirReserve <= theirBalance {
-		theirBalance -= theirReserve
+	// If the party is not the initiator, we must check whether the
+	// initiator has enough balance to pay for the fee of the party's HTLC.
+	// We'll start by also subtracting the initiator's reserve from their
+	// balance.
+	otherReserve := lnwire.NewMSatFromSatoshis(otherReserveSat)
+	if otherReserve <= otherBalance {
+		otherBalance -= otherReserve
 	} else {
-		theirBalance = 0
+		otherBalance = 0
 	}
 
 	// We'll use the dustlimit and htlcFee to find the largest HTLC value
 	// that will be considered dust on the commitment.
-	dustlimit := lnwire.NewMSatFromSatoshis(
-		lc.channelState.LocalChanCfg.DustLimit,
-	)
-
+	//
 	// For an extra HTLC fee to be paid on our commitment, the HTLC must be
 	// large enough to make a non-dust HTLC timeout transaction.
 	htlcFee := lnwire.NewMSatFromSatoshis(
@@ -9322,9 +9373,6 @@ func (lc *LightningChannel) availableCommitmentBalance(view *HtlcView,
 	// If we are looking at the remote commitment, we must use the remote
 	// dust limit and the fee for adding an HTLC success transaction.
 	if whoseCommitChain.IsRemote() {
-		dustlimit = lnwire.NewMSatFromSatoshis(
-			lc.channelState.RemoteChanCfg.DustLimit,
-		)
 		htlcFee = lnwire.NewMSatFromSatoshis(
 			HtlcSuccessFee(lc.channelState.ChanType, feePerKw),
 		)
@@ -9332,27 +9380,27 @@ func (lc *LightningChannel) availableCommitmentBalance(view *HtlcView,
 
 	// The HTLC output will be manifested on the commitment if it
 	// is non-dust after paying the HTLC fee.
-	nonDustHtlcAmt := dustlimit + htlcFee
+	nonDustHtlcAmt := dustLimit + htlcFee
 
-	// commitFeeWithHtlc is the fee our peer has to pay in case we add
-	// another htlc to the commitment.
+	// commitFeeWithHtlc is the fee the initiator has to pay in case another
+	// htlc is added to the commitment.
 	commitFeeWithHtlc := commitFee + additionalHtlcFee
 
-	// If they cannot pay the fee if we add another non-dust HTLC, we'll
-	// report our available balance just below the non-dust amount, to
-	// avoid attempting HTLCs larger than this size.
-	if theirBalance < commitFeeWithHtlc && ourBalance >= nonDustHtlcAmt {
+	// If the initiator cannot pay the fee if we add another non-dust HTLC,
+	// we'll report our available balance just below the non-dust amount,
+	// to avoid attempting HTLCs larger than this size.
+	if otherBalance < commitFeeWithHtlc && balance >= nonDustHtlcAmt {
 		// see https://github.com/lightning/bolts/issues/728
-		ourReportedBalance := nonDustHtlcAmt - 1
-		lc.log.Infof("Reducing local (reported) balance "+
-			"(from %v to %v): remote side does not have enough "+
+		reportedBalance := nonDustHtlcAmt - 1
+		lc.log.Infof("Reducing (reported) balance "+
+			"(from %v to %v): initiator does not have enough "+
 			"funds (%v < %v) to pay for non-dust HTLC in case of "+
-			"unilateral close.", ourBalance, ourReportedBalance,
-			theirBalance, commitFeeWithHtlc)
-		ourBalance = ourReportedBalance
+			"unilateral close.", balance, reportedBalance,
+			otherBalance, commitFeeWithHtlc)
+		balance = reportedBalance
 	}
 
-	return ourBalance, commitWeight
+	return balance, commitWeight
 }
 
 // StateSnapshot returns a snapshot of the current fully committed state within

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -5736,6 +5736,66 @@ func TestChanAvailableBandwidth(t *testing.T) {
 	// TODO(roasbeef): additional tests from diff starting conditions
 }
 
+// TestChanRemoteAvailableBalance verifies that RemoteAvailableBalance correctly
+// returns the balance available for the remote party, taking into account
+// reserves and commitment fees. It also ensures that the local party's view of
+// the remote party's balance matches the remote party's own view of their
+// available balance.
+func TestChanRemoteAvailableBalance(t *testing.T) {
+	t.Parallel()
+
+	// Create a test channel which will be used for the duration of this
+	// unittest. The channel will be funded evenly with Alice having 5 BTC,
+	// and Bob having 5 BTC.
+	aliceChannel, bobChannel, err := CreateTestChannels(
+		t, channeldb.SingleFunderTweaklessBit,
+	)
+	require.NoError(t, err, "unable to create test channels")
+
+	assertRemoteBandwidthEstimateCorrect := func() {
+		t.Helper()
+
+		// Query the RemoteAvailableBalance from Alice's PoV.
+		// This should be what Bob can send.
+		aliceRemoteAvailableBalance := aliceChannel.RemoteAvailableBalance()
+
+		// Query the AvailableBalance from Bob's PoV.
+		bobAvailableBalance := bobChannel.AvailableBalance()
+
+		require.Equal(t, bobAvailableBalance, aliceRemoteAvailableBalance,
+			"Alice's view of Bob's balance should match Bob's own view")
+
+		// Also check from Bob's PoV.
+		bobRemoteAvailableBalance := bobChannel.RemoteAvailableBalance()
+		aliceAvailableBalance := aliceChannel.AvailableBalance()
+
+		require.Equal(t, aliceAvailableBalance, bobRemoteAvailableBalance,
+			"Bob's view of Alice's balance should match Alice's own view")
+	}
+
+	// Initially, both should be correct.
+	assertRemoteBandwidthEstimateCorrect()
+
+	// Alice sends an HTLC to Bob.
+	htlcAmt := lnwire.NewMSatFromSatoshis(1000000)
+	htlc, _ := createHTLC(0, htlcAmt)
+	addAndReceiveHTLC(t, aliceChannel, bobChannel, htlc, nil)
+
+	// After adding but before signing, balances should still be consistent.
+	assertRemoteBandwidthEstimateCorrect()
+
+	// Bob sends an HTLC to Alice.
+	htlc, _ = createHTLC(0, htlcAmt)
+	addAndReceiveHTLC(t, bobChannel, aliceChannel, htlc, nil)
+
+	assertRemoteBandwidthEstimateCorrect()
+
+	// Commit the state.
+	require.NoError(t, ForceStateTransition(aliceChannel, bobChannel))
+
+	assertRemoteBandwidthEstimateCorrect()
+}
+
 // TestChanAvailableBalanceNearHtlcFee checks that we get the expected reported
 // balance when it is close to the fee buffer.
 func TestChanAvailableBalanceNearHtlcFee(t *testing.T) {
@@ -6004,7 +6064,7 @@ func TestChanCommitWeightDustHtlcs(t *testing.T) {
 			lc.updateLogs.Local.logIndex)
 
 		_, w := lc.availableCommitmentBalance(
-			htlcView, lntypes.Remote, FeeBuffer,
+			htlcView, lntypes.Remote, FeeBuffer, false,
 		)
 
 		return w
@@ -10734,6 +10794,7 @@ func TestApplyCommitmentFee(t *testing.T) {
 			//nolint:ll
 			balance, bufferAmt, commitFee, err := tc.channel.applyCommitFee(
 				tc.balance, commitWeight, feePerKw, tc.buffer,
+				tc.channel.IsInitiator(),
 			)
 
 			require.ErrorIs(t, err, tc.expectedErr)

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -5752,25 +5752,81 @@ func TestChanRemoteAvailableBalance(t *testing.T) {
 	)
 	require.NoError(t, err, "unable to create test channels")
 
+	// Verify available balances against independently hand-computed
+	// expected values.
+	//
+	// The available balance for the initiator must account for the
+	// commitment fee difference after adding a new HTLC output, plus
+	// the reserve. The responder only pays the reserve.
+	aliceBalance := aliceChannel.channelState.LocalCommitment.LocalBalance
+	bobBalance := aliceChannel.channelState.LocalCommitment.RemoteBalance
+	aliceCommitFee := aliceChannel.channelState.LocalCommitment.CommitFee
+
+	aliceReserve := lnwire.NewMSatFromSatoshis(
+		aliceChannel.channelState.LocalChanCfg.ChanReserve,
+	)
+	bobReserve := lnwire.NewMSatFromSatoshis(
+		bobChannel.channelState.LocalChanCfg.ChanReserve,
+	)
+
+	feeRate := chainfee.SatPerKWeight(
+		aliceChannel.channelState.LocalCommitment.FeePerKw,
+	)
+	commitWeight := CommitWeight(channeldb.SingleFunderTweaklessBit)
+	feeBuffer := CalcFeeBuffer(feeRate, commitWeight+input.HTLCWeight)
+
+	// Alice is the initiator, so she pays the commitment fees and has a
+	// fee buffer.
+	aliceCommitMSat := lnwire.NewMSatFromSatoshis(aliceCommitFee)
+	expectedAliceBalance := aliceBalance + aliceCommitMSat -
+		aliceReserve - feeBuffer
+
+	// Bob is the responder, so he only pays the reserve.
+	expectedBobBalance := bobBalance - bobReserve
+
+	// Assert Alice's AvailableBalance matches expected.
+	require.Equal(t, expectedAliceBalance, aliceChannel.AvailableBalance(),
+		"Alice's available balance does not match expected")
+
+	// Assert Alice's RemoteAvailableBalance (which is Bob's available
+	// balance) matches expected.
+	require.Equal(
+		t, expectedBobBalance, aliceChannel.RemoteAvailableBalance(),
+		"Alice's view of Bob's balance does not match expected",
+	)
+
+	// Assert Bob's AvailableBalance matches expected.
+	require.Equal(t, expectedBobBalance, bobChannel.AvailableBalance(),
+		"Bob's available balance does not match expected")
+
+	// Assert Bob's RemoteAvailableBalance (which is Alice's available
+	// balance) matches expected.
+	require.Equal(
+		t, expectedAliceBalance, bobChannel.RemoteAvailableBalance(),
+		"Bob's view of Alice's balance does not match expected",
+	)
+
 	assertRemoteBandwidthEstimateCorrect := func() {
 		t.Helper()
 
 		// Query the RemoteAvailableBalance from Alice's PoV.
 		// This should be what Bob can send.
-		aliceRemoteAvailableBalance := aliceChannel.RemoteAvailableBalance()
+		aliceRemoteBalance := aliceChannel.RemoteAvailableBalance()
 
 		// Query the AvailableBalance from Bob's PoV.
 		bobAvailableBalance := bobChannel.AvailableBalance()
 
-		require.Equal(t, bobAvailableBalance, aliceRemoteAvailableBalance,
-			"Alice's view of Bob's balance should match Bob's own view")
+		require.Equal(t, bobAvailableBalance, aliceRemoteBalance,
+			"Alice's view of Bob's balance should match "+
+				"Bob's own view")
 
 		// Also check from Bob's PoV.
-		bobRemoteAvailableBalance := bobChannel.RemoteAvailableBalance()
+		bobRemoteBalance := bobChannel.RemoteAvailableBalance()
 		aliceAvailableBalance := aliceChannel.AvailableBalance()
 
-		require.Equal(t, aliceAvailableBalance, bobRemoteAvailableBalance,
-			"Bob's view of Alice's balance should match Alice's own view")
+		require.Equal(t, aliceAvailableBalance, bobRemoteBalance,
+			"Bob's view of Alice's balance should match "+
+				"Alice's own view")
 	}
 
 	// Initially, both should be correct.

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -5737,6 +5737,66 @@ func TestChanAvailableBandwidth(t *testing.T) {
 	// TODO(roasbeef): additional tests from diff starting conditions
 }
 
+// TestChanRemoteAvailableBalance verifies that RemoteAvailableBalance correctly
+// returns the balance available for the remote party, taking into account
+// reserves and commitment fees. It also ensures that the local party's view of
+// the remote party's balance matches the remote party's own view of their
+// available balance.
+func TestChanRemoteAvailableBalance(t *testing.T) {
+	t.Parallel()
+
+	// Create a test channel which will be used for the duration of this
+	// unittest. The channel will be funded evenly with Alice having 5 BTC,
+	// and Bob having 5 BTC.
+	aliceChannel, bobChannel, err := CreateTestChannels(
+		t, channeldb.SingleFunderTweaklessBit,
+	)
+	require.NoError(t, err, "unable to create test channels")
+
+	assertRemoteBandwidthEstimateCorrect := func() {
+		t.Helper()
+
+		// Query the RemoteAvailableBalance from Alice's PoV.
+		// This should be what Bob can send.
+		aliceRemoteAvailableBalance := aliceChannel.RemoteAvailableBalance()
+
+		// Query the AvailableBalance from Bob's PoV.
+		bobAvailableBalance := bobChannel.AvailableBalance()
+
+		require.Equal(t, bobAvailableBalance, aliceRemoteAvailableBalance,
+			"Alice's view of Bob's balance should match Bob's own view")
+
+		// Also check from Bob's PoV.
+		bobRemoteAvailableBalance := bobChannel.RemoteAvailableBalance()
+		aliceAvailableBalance := aliceChannel.AvailableBalance()
+
+		require.Equal(t, aliceAvailableBalance, bobRemoteAvailableBalance,
+			"Bob's view of Alice's balance should match Alice's own view")
+	}
+
+	// Initially, both should be correct.
+	assertRemoteBandwidthEstimateCorrect()
+
+	// Alice sends an HTLC to Bob.
+	htlcAmt := lnwire.NewMSatFromSatoshis(1000000)
+	htlc, _ := createHTLC(0, htlcAmt)
+	addAndReceiveHTLC(t, aliceChannel, bobChannel, htlc, nil)
+
+	// After adding but before signing, balances should still be consistent.
+	assertRemoteBandwidthEstimateCorrect()
+
+	// Bob sends an HTLC to Alice.
+	htlc, _ = createHTLC(0, htlcAmt)
+	addAndReceiveHTLC(t, bobChannel, aliceChannel, htlc, nil)
+
+	assertRemoteBandwidthEstimateCorrect()
+
+	// Commit the state.
+	require.NoError(t, ForceStateTransition(aliceChannel, bobChannel))
+
+	assertRemoteBandwidthEstimateCorrect()
+}
+
 // TestChanAvailableBalanceNearHtlcFee checks that we get the expected reported
 // balance when it is close to the fee buffer.
 func TestChanAvailableBalanceNearHtlcFee(t *testing.T) {
@@ -6005,7 +6065,7 @@ func TestChanCommitWeightDustHtlcs(t *testing.T) {
 			lc.updateLogs.Local.logIndex)
 
 		_, w := lc.availableCommitmentBalance(
-			htlcView, lntypes.Remote, FeeBuffer,
+			htlcView, lntypes.Remote, FeeBuffer, false,
 		)
 
 		return w
@@ -10735,6 +10795,7 @@ func TestApplyCommitmentFee(t *testing.T) {
 			//nolint:ll
 			balance, bufferAmt, commitFee, err := tc.channel.applyCommitFee(
 				tc.balance, commitWeight, feePerKw, tc.buffer,
+				tc.channel.IsInitiator(),
 			)
 
 			require.ErrorIs(t, err, tc.expectedErr)

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -5753,25 +5753,81 @@ func TestChanRemoteAvailableBalance(t *testing.T) {
 	)
 	require.NoError(t, err, "unable to create test channels")
 
+	// Verify available balances against independently hand-computed
+	// expected values.
+	//
+	// The available balance for the initiator must account for the
+	// commitment fee difference after adding a new HTLC output, plus
+	// the reserve. The responder only pays the reserve.
+	aliceBalance := aliceChannel.channelState.LocalCommitment.LocalBalance
+	bobBalance := aliceChannel.channelState.LocalCommitment.RemoteBalance
+	aliceCommitFee := aliceChannel.channelState.LocalCommitment.CommitFee
+
+	aliceReserve := lnwire.NewMSatFromSatoshis(
+		aliceChannel.channelState.LocalChanCfg.ChanReserve,
+	)
+	bobReserve := lnwire.NewMSatFromSatoshis(
+		bobChannel.channelState.LocalChanCfg.ChanReserve,
+	)
+
+	feeRate := chainfee.SatPerKWeight(
+		aliceChannel.channelState.LocalCommitment.FeePerKw,
+	)
+	commitWeight := CommitWeight(channeldb.SingleFunderTweaklessBit)
+	feeBuffer := CalcFeeBuffer(feeRate, commitWeight+input.HTLCWeight)
+
+	// Alice is the initiator, so she pays the commitment fees and has a
+	// fee buffer.
+	aliceCommitMSat := lnwire.NewMSatFromSatoshis(aliceCommitFee)
+	expectedAliceBalance := aliceBalance + aliceCommitMSat -
+		aliceReserve - feeBuffer
+
+	// Bob is the responder, so he only pays the reserve.
+	expectedBobBalance := bobBalance - bobReserve
+
+	// Assert Alice's AvailableBalance matches expected.
+	require.Equal(t, expectedAliceBalance, aliceChannel.AvailableBalance(),
+		"Alice's available balance does not match expected")
+
+	// Assert Alice's RemoteAvailableBalance (which is Bob's available
+	// balance) matches expected.
+	require.Equal(
+		t, expectedBobBalance, aliceChannel.RemoteAvailableBalance(),
+		"Alice's view of Bob's balance does not match expected",
+	)
+
+	// Assert Bob's AvailableBalance matches expected.
+	require.Equal(t, expectedBobBalance, bobChannel.AvailableBalance(),
+		"Bob's available balance does not match expected")
+
+	// Assert Bob's RemoteAvailableBalance (which is Alice's available
+	// balance) matches expected.
+	require.Equal(
+		t, expectedAliceBalance, bobChannel.RemoteAvailableBalance(),
+		"Bob's view of Alice's balance does not match expected",
+	)
+
 	assertRemoteBandwidthEstimateCorrect := func() {
 		t.Helper()
 
 		// Query the RemoteAvailableBalance from Alice's PoV.
 		// This should be what Bob can send.
-		aliceRemoteAvailableBalance := aliceChannel.RemoteAvailableBalance()
+		aliceRemoteBalance := aliceChannel.RemoteAvailableBalance()
 
 		// Query the AvailableBalance from Bob's PoV.
 		bobAvailableBalance := bobChannel.AvailableBalance()
 
-		require.Equal(t, bobAvailableBalance, aliceRemoteAvailableBalance,
-			"Alice's view of Bob's balance should match Bob's own view")
+		require.Equal(t, bobAvailableBalance, aliceRemoteBalance,
+			"Alice's view of Bob's balance should match "+
+				"Bob's own view")
 
 		// Also check from Bob's PoV.
-		bobRemoteAvailableBalance := bobChannel.RemoteAvailableBalance()
+		bobRemoteBalance := bobChannel.RemoteAvailableBalance()
 		aliceAvailableBalance := aliceChannel.AvailableBalance()
 
-		require.Equal(t, aliceAvailableBalance, bobRemoteAvailableBalance,
-			"Bob's view of Alice's balance should match Alice's own view")
+		require.Equal(t, aliceAvailableBalance, bobRemoteBalance,
+			"Bob's view of Alice's balance should match "+
+				"Alice's own view")
 	}
 
 	// Initially, both should be correct.

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -268,8 +268,8 @@ func TestPeerChannelClosureAcceptFeeInitiator(t *testing.T) {
 		msg: closingSigned,
 	}
 
-	// Alice should accept Bob's fee, broadcast the cooperative close tx, and
-	// send a ClosingSigned message back to Bob.
+	// Alice should accept Bob's fee, broadcast the cooperative close tx,
+	// and send a ClosingSigned message back to Bob.
 
 	// Alice should now broadcast the closing transaction.
 	select {
@@ -296,7 +296,8 @@ func TestPeerChannelClosureAcceptFeeInitiator(t *testing.T) {
 			bobFee, closingSignedMsg.FeeSatoshis)
 	}
 
-	// Alice should be waiting on a single confirmation for the coop close tx.
+	// Alice should be waiting on a single confirmation
+	// for the coop close tx.
 	notifier.ConfChan <- &chainntnfs.TxConfirmation{}
 }
 
@@ -379,10 +380,10 @@ func TestPeerChannelClosureFeeNegotiationsResponder(t *testing.T) {
 		msg: closingSigned,
 	}
 
-	// Alice will now see the new fee we propose, but with current settings it
-	// won't accept it immediately as it differs too much by its ideal fee. We
-	// should get a new proposal back, which should have the average fee rate
-	// proposed.
+	// Alice will now see the new fee we propose, but with current settings
+	// it won't accept it immediately as it differs too much by its ideal
+	// fee. We should get a new proposal back, which should have the average
+	// fee rate proposed.
 	select {
 	case outMsg := <-alicePeer.outgoingQueue:
 		msg = outMsg.msg
@@ -480,7 +481,8 @@ func TestPeerChannelClosureFeeNegotiationsResponder(t *testing.T) {
 		t.Fatalf("expected to receive closing signed message, got %T", msg)
 	}
 
-	// Alice should be waiting on a single confirmation for the coop close tx.
+	// Alice should be waiting on a single confirmation
+	// for the coop close tx.
 	notifier.ConfChan <- &chainntnfs.TxConfirmation{}
 }
 
@@ -676,7 +678,8 @@ func TestPeerChannelClosureFeeNegotiationsInitiator(t *testing.T) {
 		t.Fatalf("expected to receive closing signed message, got %T", msg)
 	}
 
-	// Alice should be waiting on a single confirmation for the coop close tx.
+	// Alice should be waiting on a single confirmation
+	// for the coop close tx.
 	notifier.ConfChan <- &chainntnfs.TxConfirmation{}
 }
 
@@ -773,8 +776,9 @@ func TestCustomShutdownScript(t *testing.T) {
 	tests := []struct {
 		name string
 
-		// update is a function used to set values on the channel set up for the
-		// test. It is used to set values for upfront shutdown addresses.
+		// update is a function used to set values on the channel
+		// set up for the test. It is used to set values for
+		// upfront shutdown addresses.
 		update func(a, b *chanstate.OpenChannel)
 
 		// userCloseScript is the address specified by the user.

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -393,8 +393,8 @@ func TestPeerChannelClosureAcceptFeeInitiator(t *testing.T) {
 		msg: closingSigned,
 	}
 
-	// Alice should accept Bob's fee, broadcast the cooperative close tx, and
-	// send a ClosingSigned message back to Bob.
+	// Alice should accept Bob's fee, broadcast the cooperative close tx,
+	// and send a ClosingSigned message back to Bob.
 
 	// Alice should now broadcast the closing transaction.
 	select {
@@ -421,7 +421,8 @@ func TestPeerChannelClosureAcceptFeeInitiator(t *testing.T) {
 			bobFee, closingSignedMsg.FeeSatoshis)
 	}
 
-	// Alice should be waiting on a single confirmation for the coop close tx.
+	// Alice should be waiting on a single confirmation
+	// for the coop close tx.
 	notifier.ConfChan <- &chainntnfs.TxConfirmation{}
 }
 
@@ -504,10 +505,10 @@ func TestPeerChannelClosureFeeNegotiationsResponder(t *testing.T) {
 		msg: closingSigned,
 	}
 
-	// Alice will now see the new fee we propose, but with current settings it
-	// won't accept it immediately as it differs too much by its ideal fee. We
-	// should get a new proposal back, which should have the average fee rate
-	// proposed.
+	// Alice will now see the new fee we propose, but with current settings
+	// it won't accept it immediately as it differs too much by its ideal
+	// fee. We should get a new proposal back, which should have the average
+	// fee rate proposed.
 	select {
 	case outMsg := <-alicePeer.outgoingQueue:
 		msg = outMsg.msg
@@ -605,7 +606,8 @@ func TestPeerChannelClosureFeeNegotiationsResponder(t *testing.T) {
 		t.Fatalf("expected to receive closing signed message, got %T", msg)
 	}
 
-	// Alice should be waiting on a single confirmation for the coop close tx.
+	// Alice should be waiting on a single confirmation
+	// for the coop close tx.
 	notifier.ConfChan <- &chainntnfs.TxConfirmation{}
 }
 
@@ -801,7 +803,8 @@ func TestPeerChannelClosureFeeNegotiationsInitiator(t *testing.T) {
 		t.Fatalf("expected to receive closing signed message, got %T", msg)
 	}
 
-	// Alice should be waiting on a single confirmation for the coop close tx.
+	// Alice should be waiting on a single confirmation
+	// for the coop close tx.
 	notifier.ConfChan <- &chainntnfs.TxConfirmation{}
 }
 
@@ -898,8 +901,9 @@ func TestCustomShutdownScript(t *testing.T) {
 	tests := []struct {
 		name string
 
-		// update is a function used to set values on the channel set up for the
-		// test. It is used to set values for upfront shutdown addresses.
+		// update is a function used to set values on the channel
+		// set up for the test. It is used to set values for
+		// upfront shutdown addresses.
 		update func(a, b *chanstate.OpenChannel)
 
 		// userCloseScript is the address specified by the user.

--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -417,12 +417,13 @@ func (m *mockUpdateHandler) MayAddOutgoingHtlc(lnwire.MilliSatoshi) error { retu
 type mockMessageConn struct {
 	t *testing.T
 
-	// MessageConn embeds our interface so that the mock does not need to
-	// implement every function. The mock will panic if an unspecified function
-	// is called.
+	// MessageConn embeds our interface so that
+	// the mock does not need to implement every function.
+	// The mock will panic if an unspecifiedfunction is called.
 	MessageConn
 
-	// writtenMessages is a channel that our mock pushes written messages into.
+	// writtenMessages is a channel that our mock pushes written messages
+	// into.
 	writtenMessages chan []byte
 
 	readMessages   chan []byte

--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -405,6 +405,9 @@ func (m *mockUpdateHandler) ChanID() lnwire.ChannelID { return m.cid }
 // Bandwidth currently returns a dummy value.
 func (m *mockUpdateHandler) Bandwidth() lnwire.MilliSatoshi { return 0 }
 
+// RemoteBandwidth currently returns a dummy value.
+func (m *mockUpdateHandler) RemoteBandwidth() lnwire.MilliSatoshi { return 0 }
+
 // EligibleToForward currently returns a dummy value.
 func (m *mockUpdateHandler) EligibleToForward() bool { return false }
 

--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -427,6 +427,9 @@ func (m *mockUpdateHandler) ChanID() lnwire.ChannelID { return m.cid }
 // Bandwidth currently returns a dummy value.
 func (m *mockUpdateHandler) Bandwidth() lnwire.MilliSatoshi { return 0 }
 
+// RemoteBandwidth currently returns a dummy value.
+func (m *mockUpdateHandler) RemoteBandwidth() lnwire.MilliSatoshi { return 0 }
+
 // EligibleToForward currently returns a dummy value.
 func (m *mockUpdateHandler) EligibleToForward() bool { return false }
 

--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -439,12 +439,13 @@ func (m *mockUpdateHandler) MayAddOutgoingHtlc(lnwire.MilliSatoshi) error { retu
 type mockMessageConn struct {
 	t *testing.T
 
-	// MessageConn embeds our interface so that the mock does not need to
-	// implement every function. The mock will panic if an unspecified function
-	// is called.
+	// MessageConn embeds our interface so that
+	// the mock does not need to implement every function.
+	// The mock will panic if an unspecifiedfunction is called.
 	MessageConn
 
-	// writtenMessages is a channel that our mock pushes written messages into.
+	// writtenMessages is a channel that our mock pushes written messages
+	// into.
 	writtenMessages chan []byte
 
 	readMessages   chan []byte

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -5096,6 +5096,15 @@ func createRPCOpenChannel(ctx context.Context, r *rpcServer,
 		RemoteChanReserveSat: int64(dbChannel.RemoteChanCfg.ChanReserve),
 	}
 
+	// Finally, we'll consult the htlcSwitch to see if there's an active
+	// link for this channel. If so, we'll populate the local and remote
+	// spendable balance fields.
+	link, _ := r.server.htlcSwitch.GetLink(chanID)
+	if link != nil {
+		channel.LocalSpendableMsat = int64(link.Bandwidth())
+		channel.RemoteSpendableMsat = int64(link.RemoteBandwidth())
+	}
+
 	// Look up our channel peer's node alias if the caller requests it.
 	if peerAliasLookup {
 		peerAlias, err := r.server.v1Graph.LookupAlias(ctx, nodePub)


### PR DESCRIPTION
## Change Description
This PR addresses the request to expose the actual "spendable" balance in the `listchannels` RPC. 
Currently, `local_balance` and `remote_balance` only show total funds, not considering:
- Channel reserves (`ChanReserve`).
- Commitment fees (paid by the initiator).
- The cost of adding new HTLCs.


Fixes: #4951

## Steps to Test
1. **Automated Tests**:
```
$ go test -v -run "TestChanRemoteAvailableBalance|TestApplyCommitmentFee" github.com/lightningnetwork/lnd/lnwallet
``` 


3. **Manual**: Build with `make install` and verify `local_spendable_msat` in `lncli listchannels`.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
