### PR TITLE
Increase default recovery window to 31000

### DIFF
--- a/cmd/commands/commands.go
+++ b/cmd/commands/commands.go
@@ -38,7 +38,7 @@ import (
 
 // TODO(roasbeef): expose all fee conf targets
 
-const defaultRecoveryWindow int32 = 2500
+const defaultRecoveryWindow int32 = 31000
 
 const (
 	defaultUtxoMinConf = 1


### PR DESCRIPTION
Increase the default recovery windows for OGs Lightning runners.

I tested 2500, 10000, 20000, 30000 and 31000 and with the last value I recover all my funds finally.

Or maybe add a value in docs between 2500 to XXXXXX.

Thank you.