### PR TITLE
scripts/bw-compat: fix log collection

### DIFF
--- a/scripts/bw-compatibility-test/network.sh
+++ b/scripts/bw-compatibility-test/network.sh
@@ -307,9 +307,7 @@ function collect_logs() {
 
   for node in alice bob charlie dave bob-pr dave-pr; do
     if docker ps -a --format '{{.Names}}' | grep -q "^${node}$"; then
-      mkdir -p "$log_dir/$node"
-      docker cp "$node:/root/.lnd/logs/bitcoin/regtest/lnd.log" \
-        "$log_dir/$node/lnd.log" 2>/dev/null || true
+      docker logs "$node" > "$log_dir/${node}.log" 2>&1 || true
     fi
   done
 


### PR DESCRIPTION
## Summary

- `collect_logs` was using `docker cp` to copy lnd log files from inside
  named volumes, but this silently fails in CI — the directory gets
  created and the success echo prints, but no files are ever copied,
  causing `upload-artifact` to report "No files were found".
- Switch to `docker logs` which reads directly from Docker's captured
  stdout/stderr buffer, bypassing the volume entirely.
- Add a temporary `exit 1` after `setup_network` to deliberately fail
  the test and verify that log artifacts are actually uploaded before
  removing it.

## Test plan

- [x] Confirm CI fails at `exit 1` and the `bw-compat-logs` artifact
  is non-empty
- [x] Remove `exit 1` and open the real fix PR