### PR TITLE
Fix linter issue in brontide.go

### DIFF
--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -4335,6 +4335,7 @@ func (p *Brontide) handleLocalCloseReq(req *htlcswitch.ChanClose) {
 			"unknown", chanID)
 		p.log.Errorf(err.Error())
 		req.Err <- err
+
 		return
 	}
 


### PR DESCRIPTION
Post merge of #10089, a linter issue was introduced in `brontide.go`. This PR fixes that issue.