### PR TITLE
cmd: `addinvoice --qr` to print invoice QR

### DIFF
--- a/cmd/commands/cmd_invoice.go
+++ b/cmd/commands/cmd_invoice.go
@@ -124,6 +124,7 @@ var AddInvoiceCommand = cli.Command{
 				"id (separated by commas), starting from a " +
 				"channel which points to the self node.",
 		},
+		invoiceQRFlag,
 	},
 	Action: actionDecorator(addInvoice),
 }
@@ -201,6 +202,7 @@ func addInvoice(ctx *cli.Context) error {
 	}
 
 	printRespJSON(resp)
+	maybePrintInvoiceQR(ctx, resp.PaymentRequest)
 
 	return nil
 }

--- a/cmd/commands/invoicesrpc_active.go
+++ b/cmd/commands/invoicesrpc_active.go
@@ -198,6 +198,7 @@ var addHoldInvoiceCommand = cli.Command{
 				"private channels in order to assist the " +
 				"payer in reaching you",
 		},
+		invoiceQRFlag,
 	},
 	Action: actionDecorator(addHoldInvoice),
 }
@@ -259,6 +260,7 @@ func addHoldInvoice(ctx *cli.Context) error {
 	}
 
 	printRespJSON(resp)
+	maybePrintInvoiceQR(ctx, resp.PaymentRequest)
 
 	return nil
 }

--- a/cmd/commands/qr.go
+++ b/cmd/commands/qr.go
@@ -1,0 +1,174 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/urfave/cli"
+	"golang.org/x/term"
+	"rsc.io/qr"
+)
+
+const (
+	terminalQRQuietZone = 4
+
+	// Pin the foreground and background colors so the QR code has the
+	// required dark-on-light polarity regardless of the terminal theme.
+	terminalQRColors = "\x1b[30;107m"
+	terminalQRReset  = "\x1b[0m"
+)
+
+var invoiceQRFlag = cli.BoolFlag{
+	Name: "qr",
+	Usage: "display a QR code of the payment request " +
+		"in the terminal",
+}
+
+// maybePrintInvoiceQR prints an invoice's payment request as a QR code if the
+// user requested it. Rendering is presentation-only, so a failure is reported
+// without turning a successfully created invoice into a failed command.
+func maybePrintInvoiceQR(ctx *cli.Context, paymentRequest string) {
+	if !ctx.Bool(invoiceQRFlag.Name) {
+		return
+	}
+
+	printInvoiceQR(os.Stderr, paymentRequest)
+}
+
+// printInvoiceQR prints an invoice QR code to w, reporting any presentation
+// failure to the same writer.
+func printInvoiceQR(w io.Writer, paymentRequest string) {
+	_, _ = fmt.Fprintln(w)
+
+	err := writeInvoiceTerminalQR(w, paymentRequest)
+	if err != nil {
+		_, _ = fmt.Fprintf(
+			w, "warning: invoice created, but its QR code could "+
+				"not be displayed: %v\n", err,
+		)
+	}
+}
+
+// writeInvoiceTerminalQR encodes a BOLT 11 payment request as a
+// low-error-correction QR code and writes a compact, half-block representation
+// of it to w. BOLT 11 recommends upper case for QR encoding so the more compact
+// QR alphanumeric mode is used.
+func writeInvoiceTerminalQR(w io.Writer, paymentRequest string) error {
+	code, err := qr.Encode(strings.ToUpper(paymentRequest), qr.L)
+	if err != nil {
+		return fmt.Errorf("unable to encode QR code: %w", err)
+	}
+
+	width := code.Size + 2*terminalQRQuietZone
+	useColors, err := checkTerminalQRSize(w, width)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.WriteString(w, renderTerminalQR(code, useColors))
+	if err != nil {
+		return fmt.Errorf("unable to write QR code: %w", err)
+	}
+
+	return nil
+}
+
+// checkTerminalQRSize reports whether terminal colors should be used and makes
+// sure a QR code written directly to a terminal fits in its viewport.
+// Non-terminal writers have no intrinsic display size, so they are left
+// untouched and rendered without terminal escape sequences.
+func checkTerminalQRSize(w io.Writer, qrWidth int) (bool, error) {
+	fdWriter, ok := w.(interface {
+		Fd() uintptr
+	})
+	if !ok {
+		return false, nil
+	}
+
+	fd := int(fdWriter.Fd())
+	if !term.IsTerminal(fd) {
+		return false, nil
+	}
+
+	terminalWidth, terminalHeight, err := term.GetSize(fd)
+	if err != nil {
+		return true, nil
+	}
+
+	return true, validateTerminalQRSize(
+		qrWidth, terminalWidth, terminalHeight,
+	)
+}
+
+// validateTerminalQRSize returns an actionable error when a QR code would wrap
+// or extend beyond the terminal viewport.
+func validateTerminalQRSize(qrWidth, terminalWidth, terminalHeight int) error {
+	qrHeight := (qrWidth + 1) / 2
+
+	// Leave one terminal row for the shell prompt printed after the
+	// command.
+	if qrWidth <= terminalWidth && qrHeight < terminalHeight {
+		return nil
+	}
+
+	return fmt.Errorf("QR code is %d columns by %d rows, but the terminal "+
+		"is %d by %d; resize the terminal or reduce the font size",
+		qrWidth, qrHeight, terminalWidth, terminalHeight)
+}
+
+// renderTerminalQR renders two QR module rows per terminal row. White modules
+// use a fixed white background and black modules use a fixed black foreground
+// when withColors is true, making the QR code's polarity independent of the
+// terminal theme.
+func renderTerminalQR(code *qr.Code, withColors bool) string {
+	const (
+		bothBlack   = '█'
+		topBlack    = '▀'
+		bottomBlack = '▄'
+		bothWhite   = ' '
+	)
+
+	size := code.Size + 2*terminalQRQuietZone
+	height := (size + 1) / 2
+
+	var result strings.Builder
+	result.Grow(height * (len(terminalQRColors) + size*3 +
+		len(terminalQRReset) + 1))
+
+	lowerBound := -terminalQRQuietZone
+	upperBound := code.Size + terminalQRQuietZone
+	for y := lowerBound; y < upperBound; y += 2 {
+		if withColors {
+			result.WriteString(terminalQRColors)
+		}
+
+		for x := lowerBound; x < upperBound; x++ {
+			top := code.Black(x, y)
+			bottom := code.Black(x, y+1)
+
+			switch {
+			case top && bottom:
+				result.WriteRune(bothBlack)
+
+			case top:
+				result.WriteRune(topBlack)
+
+			case bottom:
+				result.WriteRune(bottomBlack)
+
+			default:
+				result.WriteRune(bothWhite)
+			}
+		}
+
+		if withColors {
+			result.WriteString(terminalQRReset)
+		}
+
+		result.WriteByte('\n')
+	}
+
+	return result.String()
+}

--- a/cmd/commands/qr_test.go
+++ b/cmd/commands/qr_test.go
@@ -1,0 +1,117 @@
+package commands
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"rsc.io/qr"
+)
+
+// TestRenderTerminalQR verifies the half-block mapping and the four-module
+// quiet zone around the QR code.
+func TestRenderTerminalQR(t *testing.T) {
+	t.Parallel()
+
+	code := &qr.Code{
+		Bitmap: []byte{
+			0b11000000,
+			0b10100000,
+			0b11000000,
+			0b10100000,
+		},
+		Size:   4,
+		Stride: 1,
+	}
+
+	quietRow := terminalQRColors + strings.Repeat(" ", 12) +
+		terminalQRReset + "\n"
+	contentRow := terminalQRColors + strings.Repeat(" ", 4) + "█▀▄ " +
+		strings.Repeat(" ", 4) + terminalQRReset + "\n"
+	expected := strings.Repeat(quietRow, 2) +
+		strings.Repeat(contentRow, 2) +
+		strings.Repeat(quietRow, 2)
+
+	require.Equal(t, expected, renderTerminalQR(code, true))
+}
+
+// TestRenderTerminalQRRealSize verifies the odd-sized QR geometry used in
+// production, including fully quiet first and last terminal rows.
+func TestRenderTerminalQRRealSize(t *testing.T) {
+	t.Parallel()
+
+	code, err := qr.Encode("TEST", qr.L)
+	require.NoError(t, err)
+
+	rendered := renderTerminalQR(code, true)
+	lines := strings.Split(strings.TrimSuffix(rendered, "\n"), "\n")
+	require.Len(t, lines, (code.Size+9)/2)
+
+	quietRow := terminalQRColors +
+		strings.Repeat(" ", code.Size+2*terminalQRQuietZone) +
+		terminalQRReset
+	require.Equal(t, quietRow, lines[0])
+	require.Equal(t, quietRow, lines[len(lines)-1])
+}
+
+// TestWriteInvoiceTerminalQR verifies BOLT 11 uppercasing and that encoder and
+// writer failures are returned to the caller.
+func TestWriteInvoiceTerminalQR(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	require.NoError(t, writeInvoiceTerminalQR(&output, "test"))
+	require.NotEmpty(t, output.String())
+	require.NotContains(t, output.String(), "\x1b[")
+
+	// Version 40-L can hold 4,296 alphanumeric characters. A valid lnd
+	// payment request is capped at 4,096 characters, so uppercasing it must
+	// remain encodable.
+	require.NoError(t, writeInvoiceTerminalQR(
+		&output, strings.Repeat("a", 4_096),
+	))
+
+	err := writeInvoiceTerminalQR(
+		&output, strings.Repeat("a", 4_297),
+	)
+	require.ErrorContains(t, err, "unable to encode QR code")
+
+	err = writeInvoiceTerminalQR(failingWriter{}, "test")
+	require.ErrorContains(t, err, "unable to write QR code")
+}
+
+// TestPrintInvoiceQR verifies that presentation failures are reported without
+// being returned to the command after the invoice has been created.
+func TestPrintInvoiceQR(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	printInvoiceQR(&output, strings.Repeat("a", 4_297))
+
+	require.Contains(t, output.String(), "warning: invoice created")
+}
+
+// TestValidateTerminalQRSize verifies that QR codes which would wrap or extend
+// beyond the viewport are rejected with an actionable error.
+func TestValidateTerminalQRSize(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, validateTerminalQRSize(80, 80, 41))
+	require.NoError(t, validateTerminalQRSize(79, 80, 41))
+
+	err := validateTerminalQRSize(81, 80, 42)
+	require.ErrorContains(t, err, "QR code is 81 columns by 41 rows")
+	require.ErrorContains(t, err, "terminal is 80 by 42")
+
+	err = validateTerminalQRSize(79, 80, 40)
+	require.ErrorContains(t, err, "QR code is 79 columns by 40 rows")
+	require.ErrorContains(t, err, "terminal is 80 by 40")
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}

--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -286,6 +286,13 @@
 * The `encryptdebugpackage` command now supports an `--include_log` flag. When
   set, the log file content is included in the encrypted debug package.
 
+* The `addinvoice` and `addholdinvoice` commands now support a
+  [`--qr` flag](https://github.com/lightningnetwork/lnd/pull/10638) that renders
+  the payment request as a QR code directly in the terminal, making it easy to
+  scan from a mobile wallet. The implementation uses `rsc.io/qr` with a small
+  local renderer, fixed black-on-white colors, and a terminal-width guard to
+  keep the output reliably scannable.
+
 ## Breaking Changes
 
 * [Increased MinCLTVDelta from 18 to

--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	gopkg.in/macaroon-bakery.v2 v2.0.1
 	gopkg.in/macaroon.v2 v2.0.0
 	pgregory.net/rapid v1.2.0
+	rsc.io/qr v0.2.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -636,5 +636,7 @@ modernc.org/token v1.1.0 h1:Xl7Ap9dKaEs5kLoOQeQmPWevfnk/DM5qcLcYlA8ys6Y=
 modernc.org/token v1.1.0/go.mod h1:UGzOrNV1mAFSEB63lOFHIpNRUVMvYTc6yu1SMY/XTDM=
 pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=
 pgregory.net/rapid v1.2.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=
+rsc.io/qr v0.2.0 h1:6vBLea5/NRMVTz8V66gipeLycZMl/+UlFmk8DvqQ6WY=
+rsc.io/qr v0.2.0/go.mod h1:IF+uZjkb9fqyeF/4tlBoynqmQxUoPfWEKh921coOuXs=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=


### PR DESCRIPTION
## Summary

Add a `--qr` option to `lncli addinvoice` that renders the returned payment
request as a compact QR code directly in the terminal. This allows an invoice
to be scanned by a mobile wallet without copying the payment request.

## Security and dependency posture

The terminal QR implementation deliberately keeps its dependency and attack
surface small:

- `rsc.io/qr v0.2.0` is the only new third-party module and is used solely for
  QR encoding.
- Terminal rendering is implemented locally using only small, auditable
  rendering and terminal-width helpers.
- The renderer emits fixed Unicode half-block output with a four-module quiet
  zone and fixed black-on-white colors.
- It only reads the terminal width to avoid wrapped output; it does not
  negotiate Sixel support or otherwise adapt to terminal capabilities.
- Encoding, output, and terminal-width failures are reported as warnings
  without changing the successful invoice-creation exit status.

Keeping the renderer local makes this security-sensitive, terminal-facing path
small, auditable, and predictable while avoiding a general-purpose terminal QR
dependency.

## User experience

Running:

    `lncli addinvoice --amt=1000 --qr`

continues to print the normal JSON response on stdout, while a scan-ready QR
code containing the BOLT 11 payment request is written to stderr.

<img width="1476" height="535" alt="image" src="https://github.com/user-attachments/assets/86125567-412d-457f-af56-94e88bc2af25" />
