### PR TITLE
docs: remove gossiper deadlock fix entry from 0.21.0 release notes

### DIFF
--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -50,12 +50,6 @@
   millisecond if set to zero or a negative value, preventing `time.NewTicker`
   from panicking.
 
-- [Fixed a shutdown
-  deadlock](https://github.com/lightningnetwork/lnd/pull/10540) in the gossiper.
-  Certain gossip messages could cause multiple error messages to be sent on a
-  channel that was only expected to be used for a single message. The erring
-  goroutine would block on the second send, leading to a deadlock at shutdown.
-
 * [Fixed `lncli unlock` to wait until the wallet is ready to be
   unlocked](https://github.com/lightningnetwork/lnd/pull/10536)
   before sending the unlock request. The command now reports wallet state
@@ -302,7 +296,6 @@
 * Erick Cestari
 * Gijs van Dam
 * hieblmi
-* Matt Morehouse
 * Mohamed Awnallah
 * Nishant Bansal
 * Pins


### PR DESCRIPTION
## Summary

- Removes the gossiper shutdown deadlock fix entry (PR #10540) from the 0.21.0 release notes.
- This fix was already shipped in v0.20.1, so it should not appear again in the 0.21.0 notes.