### PR TITLE
lntest: disable bitcoind v2 P2P transport in itests

### DIFF
--- a/lntest/bitcoind_common.go
+++ b/lntest/bitcoind_common.go
@@ -173,6 +173,14 @@ func newBackend(miner string, netParams *chaincfg.Params, extraArgs []string,
 		"-debuglogfile=" + logFile,
 		"-blockfilterindex",
 		"-peerblockfilters",
+		// Disable v2 transport since the miner is btcd, which
+		// doesn't support v2 yet. Without this, bitcoind
+		// attempts a v2 handshake that hangs for 30s before
+		// falling back to v1, causing test flakes whenever a
+		// test reconnects to the miner under a timeout.
+		//
+		// TODO: Remove once btcd supports v2 P2P transport.
+		"-v2transport=0",
 	}
 	cmdArgs = append(cmdArgs, extraArgs...)
 	bitcoind := exec.Command("bitcoind", cmdArgs...)

--- a/lntest/miner/bitcoind_miner.go
+++ b/lntest/miner/bitcoind_miner.go
@@ -163,6 +163,13 @@ func (b *BitcoindMinerBackend) Start(setupChain bool,
 		"-debuglogfile=" + logFile,
 		// Set fallback fee for transaction creation.
 		"-fallbackfee=0.00001",
+		// Disable v2 transport since this backend may peer with
+		// btcd nodes that don't support v2 yet. Without this,
+		// bitcoind attempts a v2 handshake that hangs for 30s
+		// before falling back to v1.
+		//
+		// TODO: Remove once btcd supports v2 P2P transport.
+		"-v2transport=0",
 	}
 
 	cmdArgs = append(cmdArgs, b.extraArgs...)


### PR DESCRIPTION
## Summary

Fixes a flaky itest (`open_channel_reorg_test`) caused by bitcoind v29's
v2 P2P transport handshake timing out when connecting to the btcd miner.

btcd does not support v2 P2P transport. When bitcoind (the chain backend)
connects to the btcd miner, it first attempts a v2 handshake which btcd
silently ignores. After **30 seconds**, bitcoind gives up and retries with
v1, which succeeds immediately. This 30-second delay consumes the entire
`DefaultTimeout` for `WaitForNodeBlockHeight`, causing a race that
results in flaky test failures.

The unit test backend (`lntest/unittest/backend.go`) already disables v2
transport with `-v2transport=0` for the same reason. This PR applies the
same fix to:
- The itest chain backend (`lntest/bitcoind_common.go`)
- The bitcoind miner backend (`lntest/miner/bitcoind_miner.go`)

## Log analysis

[Example failing build](https://github.com/lightningnetwork/lnd/actions/runs/23478841560/job/68317432869?pr=10065)

The bitcoind chain backend log shows the issue clearly:

```
08:16:48 [net] trying v2 connection 127.0.0.1:10047 lastseen=0.0hrs
08:16:48 [net] Added connection peer=2
08:16:48 [net] send version message: version 70016, blocks=528, peer=2
08:16:48 [net] start sending v2 handshake to peer=2
           ... 30 second gap — v2 handshake hanging ...
08:17:18 [net] socket closed, disconnecting peer=2
08:17:18 [net] retrying with v1 transport protocol for peer=2
08:17:18 [net] trying v1 connection 127.0.0.1:10047 lastseen=0.0hrs
08:17:19 [net] receive version message: .../btcd:0.25.0/: blocks=533, peer=3
```

The v2 handshake hung for exactly 30s (08:16:48 → 08:17:18), then the v1
fallback connected instantly. Meanwhile, `WaitForNodeBlockHeight` started
at ~08:16:50 with a 30s timeout and expired at 08:17:20 — just 1 second
after the reorg blocks finally started flowing.

## Test plan

- [x] `go build -tags=bitcoind ./lntest/...` compiles
- [x] `go build ./lntest/miner/...` compiles
- [ ] CI itests pass (bitcoind backend)