### PR TITLE
lncli: reject negative sat_per_vbyte in close/open channel commands (fixes #9834)

### DIFF
--- a/cmd/commands/cmd_open_channel.go
+++ b/cmd/commands/cmd_open_channel.go
@@ -171,7 +171,7 @@ var openChannelCommand = cli.Command{
 			Usage:  "Deprecated, use sat_per_vbyte instead.",
 			Hidden: true,
 		},
-		cli.Int64Flag{
+		cli.Uint64Flag{
 			Name: "sat_per_vbyte",
 			Usage: "(optional) a manual fee expressed in " +
 				"sat/vbyte that should be used when crafting " +
@@ -798,7 +798,7 @@ var batchOpenChannelCommand = cli.Command{
 				"transaction *should* confirm in, will be " +
 				"used for fee estimation",
 		},
-		cli.Int64Flag{
+		cli.Uint64Flag{
 			Name: "sat_per_vbyte",
 			Usage: "(optional) a manual fee expressed in " +
 				"sat/vByte that should be used when crafting " +

--- a/cmd/commands/commands.go
+++ b/cmd/commands/commands.go
@@ -1092,7 +1092,7 @@ var closeChannelCommand = cli.Command{
 			Usage:  "Deprecated, use sat_per_vbyte instead.",
 			Hidden: true,
 		},
-		cli.Int64Flag{
+		cli.Uint64Flag{
 			Name: "sat_per_vbyte",
 			Usage: "(optional) a manual fee expressed in " +
 				"sat/vbyte that should be used when crafting " +
@@ -1296,7 +1296,7 @@ var closeAllChannelsCommand = cli.Command{
 			Usage:  "Deprecated, use sat_per_vbyte instead.",
 			Hidden: true,
 		},
-		cli.Int64Flag{
+		cli.Uint64Flag{
 			Name: "sat_per_vbyte",
 			Usage: "(optional) a manual fee expressed in " +
 				"sat/vbyte that should be used when crafting " +


### PR DESCRIPTION
Fixes #9834

## Problem
The `--sat_per_vbyte` flag was declared as `cli.Int64Flag` but read via `ctx.Uint64()`, causing negative values to wrap to huge positive numbers (e.g., `-1` becomes `2^63 - 1`). This affects four commands:
- `lncli closechannel` 
- `lncli closeallchannels`
- `lncli openchannel`
- `lncli batchopenchannel`

A user passing `--sat_per_vbyte=-1` would get a transaction with an absurdly high fee rate instead of an error.

## Fix
Changed `cli.Int64Flag` → `cli.Uint64Flag` for `sat_per_vbyte` in all four commands. The `urfave/cli` library rejects negative values at parse time when the flag is `Uint64`, producing a clear error message.

## Testing
- Existing unit tests pass (no test changes needed — the flag type change only affects CLI parsing)
- Verified: `urfave/cli` `Uint64Flag` rejects negative inputs with "invalid value \"-1\" for flag -sat_per_vbyte: parse error"

## Files Changed
- `cmd/commands/cmd_open_channel.go` (2 changes: openchannel + batchopenchannel)
- `cmd/commands/commands.go` (2 changes: closechannel + closeallchannels)