### PR TITLE
scripts: fix flaky backwards compat test graph sync

### DIFF
--- a/scripts/bw-compatibility-test/network.sh
+++ b/scripts/bw-compatibility-test/network.sh
@@ -171,7 +171,11 @@ function open_channel() {
   echo "🔗 Opened channel between $node1 and $node2"
 }
 
-# Function to check if a node's graph has the expected number of channels
+# wait_graph_sync waits until the node's graph contains the expected number of
+# channels AND every channel has both direction policies populated. Seeing a
+# channel in the graph (via getnetworkinfo) does not guarantee that both
+# channel_update messages have arrived. Without both policies the pathfinder
+# cannot build a complete route, leading to NO_ROUTE failures.
 wait_graph_sync() {
   if [[ $# -ne 2 ]]; then
        echo "❌ Error: graph_synced requires exactly 2 arguments (node and num_chans)"
@@ -185,14 +189,23 @@ wait_graph_sync() {
   while :; do
     num_channels=$($node getnetworkinfo | jq -r '.num_channels')
 
-    # Ensure num_channels is a valid number before proceeding
-    if [[ "$num_channels" =~ ^[0-9]+$ ]]; then
-      echo -ne "⌛ $node sees $num_channels channels...\r"
+    # Ensure num_channels is a valid number before proceeding.
+    if [[ "$num_channels" =~ ^[0-9]+$ ]] && \
+       [[ "$num_channels" -eq num_chans ]]; then
 
-      if [[ "$num_channels" -eq num_chans ]]; then
-        echo "👀 $node sees all the channels!"
-        break  # Exit loop when num_channels reaches num_chans
+      # Also verify that every edge has both policies. An edge
+      # without both node1_policy and node2_policy means a
+      # channel_update is still in flight.
+      missing=$($node describegraph | jq '[.edges[] | select(.node1_policy == null or .node2_policy == null)] | length')
+
+      if [[ "$missing" -eq 0 ]]; then
+        echo "👀 $node sees all $num_chans channels with full policies!"
+        break
       fi
+
+      echo -ne "⌛ $node sees $num_channels channels ($missing missing policies)...\r"
+    else
+      echo -ne "⌛ $node sees ${num_channels:-0}/$num_chans channels...\r"
     fi
 
     sleep 1


### PR DESCRIPTION
## Summary

Fix an intermittent `NO_ROUTE` failure in the backwards compatibility test
caused by a race condition in `wait_graph_sync`.

The function previously only checked that the expected number of channels
appeared in `getnetworkinfo`. However, a channel can be visible in the graph
before both `channel_update` messages have arrived — meaning `node1_policy`
or `node2_policy` may still be `null`. When this happens, the pathfinder
cannot construct a complete route and payments fail with `NO_ROUTE`.

This updates `wait_graph_sync` to also call `describegraph` and verify that
every edge has both direction policies populated before declaring the graph
fully synced.

## Changes

- `scripts/bw-compatibility-test/network.sh`: After confirming the channel
  count matches, additionally check that no edge has a `null` policy via
  `describegraph | jq`. The loop continues polling until all policies are
  present.

## Test plan

- [x] `make backwards-compat-test` passes locally
- The fix addresses a CI-observed flake where `send_payment alice dave`
  failed with `FAILURE_REASON_NO_ROUTE` before any node upgrade occurred