### PR TITLE
Add raw transaction hex to `pendingsweeps` response

### DIFF
--- a/cmd/commands/walletrpc_active.go
+++ b/cmd/commands/walletrpc_active.go
@@ -266,6 +266,11 @@ var bumpFeeCommand = cli.Command{
 	Child-Pays-For-Parent (CPFP), where the child transaction pays for its
 	parent's fee. This can be done by specifying an outpoint within the low
 	fee transaction that is under the control of the wallet.
+
+	After bumping, use the pendingsweeps RPC to monitor the sweep and
+	obtain its raw transaction hex if needed. Note the raw hex is advisory
+	/ diagnostic only and may briefly be stale while a fee bump is in
+	flight, so it should not be blindly rebroadcast.
 	`,
 	Flags: []cli.Flag{
 		cli.Uint64Flag{

--- a/cmd/commands/walletrpc_types.go
+++ b/cmd/commands/walletrpc_types.go
@@ -22,6 +22,7 @@ type PendingSweep struct {
 	Budget               uint64       `json:"budget"`
 	DeadlineHeight       uint32       `json:"deadline_height"`
 	MaturityHeight       uint32       `json:"maturity_height"`
+	RawTxHex             string       `json:"raw_tx_hex"`
 
 	NextBroadcastHeight uint32 `json:"next_broadcast_height"`
 	RequestedConfTarget uint32 `json:"requested_conf_target"`
@@ -44,6 +45,7 @@ func NewPendingSweepFromProto(pendingSweep *walletrpc.PendingSweep) *PendingSwee
 		Budget:               pendingSweep.Budget,
 		DeadlineHeight:       pendingSweep.DeadlineHeight,
 		MaturityHeight:       pendingSweep.MaturityHeight,
+		RawTxHex:             pendingSweep.RawTxHex,
 
 		// Deprecated fields.
 		NextBroadcastHeight: pendingSweep.NextBroadcastHeight,

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -66,6 +66,15 @@
   the chain backend via bitcoind's `submitpackage`, allowing a zero-fee v3/TRUC
   parent to be accepted together with a fee-paying CPFP child.
 
+* [Added a `raw_tx_hex` field to the `PendingSweep`
+  response](https://github.com/lightningnetwork/lnd/pull/10670) returned by
+  `walletrpc.PendingSweeps`. The field contains the serialized hex of the most
+  recent sweep transaction lnd broadcast for the input, allowing callers
+  (notably consumers of `BumpFee`) to inspect the in-flight sweep without
+  having to scrape the mempool. As it can briefly lag behind an RBF
+  replacement, callers that rebroadcast should verify the txid against the
+  mempool first.
+
 ## lncli Additions
 
 * The `estimateroutefee` command now supports [restricting fee estimates to
@@ -85,6 +94,11 @@
 ## RPC Updates
 
 ## lncli Updates
+
+* The `lncli wallet bumpfee` command help now points users at `lncli wallet
+  pendingsweeps` to inspect the in-flight sweep transaction, including its
+  raw hex
+  ([#10670](https://github.com/lightningnetwork/lnd/pull/10670)).
 
 ## Breaking Changes
 

--- a/itest/lnd_bump_fee.go
+++ b/itest/lnd_bump_fee.go
@@ -1,6 +1,8 @@
 package itest
 
 import (
+	"bytes"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcutil/v2"
@@ -14,6 +16,38 @@ import (
 	"github.com/lightningnetwork/lnd/sweep"
 	"github.com/stretchr/testify/require"
 )
+
+// assertRawTxSpendsInput decodes the hex-encoded raw sweep transaction
+// returned by PendingSweeps and asserts it is a valid transaction that spends
+// the given outpoint.
+//
+// Note we deliberately don't assert an exact match against the sweep tx
+// currently in the mempool. The sweeper records the input's sweep tx
+// asynchronously from the fee bumper's broadcast, so while the tx is being
+// RBF-bumped the mempool and the RPC view can be one version apart. Every
+// version spends the same input though, so we assert that invariant instead.
+func assertRawTxSpendsInput(ht *lntest.HarnessTest, rawTxHex string,
+	outpoint wire.OutPoint) {
+
+	require.NotEmpty(ht, rawTxHex, "raw tx hex is empty")
+
+	rawBytes, err := hex.DecodeString(rawTxHex)
+	require.NoError(ht, err, "decode raw tx hex")
+
+	var sweepTx wire.MsgTx
+	require.NoError(ht, sweepTx.Deserialize(bytes.NewReader(rawBytes)),
+		"deserialize raw tx")
+
+	var found bool
+	for _, txIn := range sweepTx.TxIn {
+		if txIn.PreviousOutPoint == outpoint {
+			found = true
+			break
+		}
+	}
+	require.Truef(ht, found, "raw tx %v does not spend input %v",
+		sweepTx.TxHash(), outpoint)
+}
 
 // testBumpFeeLowBudget checks that when the requested ideal budget cannot be
 // met, the sweeper still sweeps the input with the actual budget.
@@ -62,31 +96,6 @@ func testBumpFeeLowBudget(ht *lntest.HarnessTest) {
 	assertPendingSweepResp := func(budget uint64,
 		deadline uint32) *wire.MsgTx {
 
-		// Alice should still have one pending sweep.
-		pendingSweep := ht.AssertNumPendingSweeps(alice, 1)[0]
-
-		// Validate all fields returned from `PendingSweeps` are as
-		// expected.
-		require.Equal(ht, op.TxidBytes, pendingSweep.Outpoint.TxidBytes)
-		require.Equal(ht, op.OutputIndex,
-			pendingSweep.Outpoint.OutputIndex)
-		require.Equal(ht, walletrpc.WitnessType_TAPROOT_PUB_KEY_SPEND,
-			pendingSweep.WitnessType)
-		require.EqualValuesf(ht, value, pendingSweep.AmountSat,
-			"amount not matched: want=%d, got=%d", value,
-			pendingSweep.AmountSat)
-		require.True(ht, pendingSweep.Immediate)
-
-		require.EqualValuesf(ht, budget, pendingSweep.Budget,
-			"budget not matched: want=%d, got=%d", budget,
-			pendingSweep.Budget)
-
-		// Since the request doesn't specify a deadline, we expect the
-		// existing deadline to be used.
-		require.Equalf(ht, deadline, pendingSweep.DeadlineHeight,
-			"deadline height not matched: want=%d, got=%d",
-			deadline, pendingSweep.DeadlineHeight)
-
 		// We expect to see Alice's original tx and her CPFP tx in the
 		// mempool.
 		txns := ht.GetNumTxsFromMempool(2)
@@ -97,6 +106,52 @@ func testBumpFeeLowBudget(ht *lntest.HarnessTest) {
 		if sweepTx.TxHash() == tx.TxHash() {
 			sweepTx = txns[1]
 		}
+
+		// Validate the pending sweep response. The RawTxHex field is
+		// populated asynchronously after the sweep is published, so we
+		// retry until it's set.
+		var ps *walletrpc.PendingSweep
+		err := wait.NoError(func() error {
+			// Alice should still have one pending sweep.
+			ps = ht.AssertNumPendingSweeps(alice, 1)[0]
+
+			// Validate all fields returned from `PendingSweeps`
+			// are as expected. These fields don't change during
+			// the test so we assert them without retrying.
+			require.Equal(ht, op.TxidBytes, ps.Outpoint.TxidBytes)
+			require.Equal(ht, op.OutputIndex,
+				ps.Outpoint.OutputIndex)
+			require.Equal(ht,
+				walletrpc.WitnessType_TAPROOT_PUB_KEY_SPEND,
+				ps.WitnessType)
+			require.EqualValuesf(ht, value, ps.AmountSat,
+				"amount not matched: want=%d, got=%d", value,
+				ps.AmountSat)
+			require.True(ht, ps.Immediate)
+			require.EqualValuesf(ht, budget, ps.Budget,
+				"budget not matched: want=%d, got=%d", budget,
+				ps.Budget)
+
+			// Since the request doesn't specify a deadline, we
+			// expect the existing deadline to be used.
+			require.Equalf(ht, deadline, ps.DeadlineHeight,
+				"deadline height not matched: want=%d, got=%d",
+				deadline, ps.DeadlineHeight)
+
+			if ps.RawTxHex == "" {
+				return fmt.Errorf("raw tx hex is empty")
+			}
+
+			return nil
+		}, wait.DefaultTimeout)
+		require.NoError(ht, err, "raw tx hex not populated")
+
+		// Validate that the raw tx hex decodes to a transaction that
+		// spends the input being swept.
+		assertRawTxSpendsInput(ht, ps.RawTxHex, wire.OutPoint{
+			Hash:  tx.TxHash(),
+			Index: op.OutputIndex,
+		})
 
 		return sweepTx
 	}
@@ -300,6 +355,27 @@ func runBumpFee(ht *lntest.HarnessTest, alice *node.HarnessNode) {
 		if sweepTx.TxHash() == tx.TxHash() {
 			sweepTx = txns[1]
 		}
+
+		// Validate that the raw tx hex is populated. The field is
+		// populated asynchronously after the sweep is published, so we
+		// retry until it's set.
+		var ps *walletrpc.PendingSweep
+		err = wait.NoError(func() error {
+			ps = ht.AssertNumPendingSweeps(alice, 1)[0]
+			if ps.RawTxHex == "" {
+				return fmt.Errorf("raw tx hex is empty")
+			}
+
+			return nil
+		}, wait.DefaultTimeout)
+		require.NoError(ht, err, "raw tx hex not populated")
+
+		// Validate that the raw tx hex decodes to a transaction that
+		// spends the input being swept.
+		assertRawTxSpendsInput(ht, ps.RawTxHex, wire.OutPoint{
+			Hash:  tx.TxHash(),
+			Index: op.OutputIndex,
+		})
 
 		return sweepTx
 	}

--- a/lnrpc/walletrpc/walletkit.pb.go
+++ b/lnrpc/walletrpc/walletkit.pb.go
@@ -2986,8 +2986,17 @@ type PendingSweep struct {
 	// The block height which the input's locktime will expire at. Zero if the
 	// input has no locktime.
 	MaturityHeight uint32 `protobuf:"varint,15,opt,name=maturity_height,json=maturityHeight,proto3" json:"maturity_height,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// The raw hex-encoded sweep transaction lnd most recently broadcast to spend
+	// this input. This field is advisory and intended for diagnostics only.
+	// Rebroadcasting it is not guaranteed to be safe: lnd may be actively
+	// fee-bumping this input, and during an RBF bump there is a brief window where
+	// this still reflects the previous version until the replacement is recorded.
+	// Re-injecting it can therefore conflict with lnd's in-flight RBF by
+	// resurfacing a superseded, lower-fee version. Empty when lnd has no sweep
+	// transaction on record for this input, e.g. none has been broadcast yet.
+	RawTxHex      string `protobuf:"bytes,16,opt,name=raw_tx_hex,json=rawTxHex,proto3" json:"raw_tx_hex,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PendingSweep) Reset() {
@@ -3128,6 +3137,13 @@ func (x *PendingSweep) GetMaturityHeight() uint32 {
 		return x.MaturityHeight
 	}
 	return 0
+}
+
+func (x *PendingSweep) GetRawTxHex() string {
+	if x != nil {
+		return x.RawTxHex
+	}
+	return ""
 }
 
 type PendingSweepsRequest struct {
@@ -4868,7 +4884,7 @@ const file_walletrpc_walletkit_proto_rawDesc = "" +
 	"\x13EstimateFeeResponse\x12\x1c\n" +
 	"\n" +
 	"sat_per_kw\x18\x01 \x01(\x03R\bsatPerKw\x125\n" +
-	"\x18min_relay_fee_sat_per_kw\x18\x02 \x01(\x03R\x13minRelayFeeSatPerKw\"\x90\x05\n" +
+	"\x18min_relay_fee_sat_per_kw\x18\x02 \x01(\x03R\x13minRelayFeeSatPerKw\"\xae\x05\n" +
 	"\fPendingSweep\x12+\n" +
 	"\boutpoint\x18\x01 \x01(\v2\x0f.lnrpc.OutPointR\boutpoint\x129\n" +
 	"\fwitness_type\x18\x02 \x01(\x0e2\x16.walletrpc.WitnessTypeR\vwitnessType\x12\x1d\n" +
@@ -4887,7 +4903,9 @@ const file_walletrpc_walletkit_proto_rawDesc = "" +
 	"\timmediate\x18\f \x01(\bR\timmediate\x12\x16\n" +
 	"\x06budget\x18\r \x01(\x04R\x06budget\x12'\n" +
 	"\x0fdeadline_height\x18\x0e \x01(\rR\x0edeadlineHeight\x12'\n" +
-	"\x0fmaturity_height\x18\x0f \x01(\rR\x0ematurityHeight\"\x16\n" +
+	"\x0fmaturity_height\x18\x0f \x01(\rR\x0ematurityHeight\x12\x1c\n" +
+	"\n" +
+	"raw_tx_hex\x18\x10 \x01(\tR\brawTxHex\"\x16\n" +
 	"\x14PendingSweepsRequest\"W\n" +
 	"\x15PendingSweepsResponse\x12>\n" +
 	"\x0epending_sweeps\x18\x01 \x03(\v2\x17.walletrpc.PendingSweepR\rpendingSweeps\"\x9f\x02\n" +

--- a/lnrpc/walletrpc/walletkit.proto
+++ b/lnrpc/walletrpc/walletkit.proto
@@ -1284,6 +1284,18 @@ message PendingSweep {
     input has no locktime.
     */
     uint32 maturity_height = 15;
+
+    /*
+    The raw hex-encoded sweep transaction lnd most recently broadcast to spend
+    this input. This field is advisory and intended for diagnostics only.
+    Rebroadcasting it is not guaranteed to be safe: lnd may be actively
+    fee-bumping this input, and during an RBF bump there is a brief window where
+    this still reflects the previous version until the replacement is recorded.
+    Re-injecting it can therefore conflict with lnd's in-flight RBF by
+    resurfacing a superseded, lower-fee version. Empty when lnd has no sweep
+    transaction on record for this input, e.g. none has been broadcast yet.
+    */
+    string raw_tx_hex = 16;
 }
 
 message PendingSweepsRequest {

--- a/lnrpc/walletrpc/walletkit.swagger.json
+++ b/lnrpc/walletrpc/walletkit.swagger.json
@@ -2031,6 +2031,10 @@
           "type": "integer",
           "format": "int64",
           "description": "The block height which the input's locktime will expire at. Zero if the\ninput has no locktime."
+        },
+        "raw_tx_hex": {
+          "type": "string",
+          "description": "The raw hex-encoded sweep transaction lnd most recently broadcast to spend\nthis input. This field is advisory and intended for diagnostics only.\nRebroadcasting it is not guaranteed to be safe: lnd may be actively\nfee-bumping this input, and during an RBF bump there is a brief window where\nthis still reflects the previous version until the replacement is recorded.\nRe-injecting it can therefore conflict with lnd's in-flight RBF by\nresurfacing a superseded, lower-fee version. Empty when lnd has no sweep\ntransaction on record for this input, e.g. none has been broadcast yet."
         }
       }
     },

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"maps"
@@ -994,6 +995,22 @@ func (w *WalletKit) PendingSweeps(ctx context.Context,
 				return uint64(feeRate.FeePerVByte())
 			})
 
+		// Serialize the sweep transaction to hex if available. A
+		// serialization failure for a single input shouldn't abort the
+		// whole listing, so we just log it and leave raw_tx_hex empty
+		// for that input.
+		var rawTxHex string
+		if inp.SweepTx != nil {
+			var txBuf bytes.Buffer
+			err := inp.SweepTx.Serialize(&txBuf)
+			if err != nil {
+				log.Errorf("Failed to serialize sweep tx for "+
+					"input %v: %v", inp.OutPoint, err)
+			} else {
+				rawTxHex = hex.EncodeToString(txBuf.Bytes())
+			}
+		}
+
 		ps := &PendingSweep{
 			Outpoint:             op,
 			WitnessType:          witnessType,
@@ -1005,6 +1022,7 @@ func (w *WalletKit) PendingSweeps(ctx context.Context,
 			DeadlineHeight:       inp.DeadlineHeight,
 			RequestedSatPerVbyte: startingFeeRate,
 			MaturityHeight:       inp.MaturityHeight,
+			RawTxHex:             rawTxHex,
 		}
 		rpcPendingSweeps = append(rpcPendingSweeps, ps)
 	}

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -204,6 +204,11 @@ type SweeperInput struct {
 	// different from the DeadlineHeight in its params as it's an actual
 	// value than an option.
 	DeadlineHeight int32
+
+	// sweepTx is the most recent sweep transaction that spends this
+	// input. This is set when the sweep transaction is published or
+	// replaced via RBF.
+	sweepTx *wire.MsgTx
 }
 
 // String returns a human readable interpretation of the pending input.
@@ -309,6 +314,11 @@ type PendingInputResponse struct {
 	// MaturityHeight is the block height that this input's locktime will
 	// be expired at. For inputs with no locktime this value is zero.
 	MaturityHeight uint32
+
+	// SweepTx is the most recent sweep transaction that spends this
+	// input. This may be nil if the input has not yet been included in a
+	// published sweep transaction.
+	SweepTx *wire.MsgTx
 }
 
 // updateReq is an internal message we'll use to represent an external caller's
@@ -919,7 +929,8 @@ func (s *UtxoSweeper) markInputsPendingPublish(set InputSet) {
 
 // markInputsPublished updates the sweeping tx in db and marks the list of
 // inputs as published.
-func (s *UtxoSweeper) markInputsPublished(tr *TxRecord, set InputSet) error {
+func (s *UtxoSweeper) markInputsPublished(tr *TxRecord, tx *wire.MsgTx,
+	set InputSet) error {
 	// Mark this tx in db once successfully published.
 	//
 	// NOTE: this will behave as an overwrite, which is fine as the record
@@ -928,6 +939,17 @@ func (s *UtxoSweeper) markInputsPublished(tr *TxRecord, set InputSet) error {
 	err := s.cfg.Store.StoreTx(tr)
 	if err != nil {
 		return fmt.Errorf("store tx: %w", err)
+	}
+
+	// Collect the outpoints actually spent by this tx so we only attach it
+	// to inputs it really contains. By construction set.Inputs() belong to
+	// tx, but this guards against ever storing a sweep tx that omits the
+	// input it's recorded against.
+	spentByTx := make(map[wire.OutPoint]struct{})
+	if tx != nil {
+		for _, txIn := range tx.TxIn {
+			spentByTx[txIn.PreviousOutPoint] = struct{}{}
+		}
 	}
 
 	// Reschedule sweep.
@@ -944,9 +966,11 @@ func (s *UtxoSweeper) markInputsPublished(tr *TxRecord, set InputSet) error {
 			continue
 		}
 
-		// Valdiate that the input is in an expected state.
-		if pi.state != PendingPublish {
-			// We may get a Published if this is a replacement tx.
+		// Validate that the input is in an expected state. We may
+		// get a Published input if this is a replacement tx, in
+		// which case we still want to update its fee rate and sweep
+		// tx below.
+		if pi.state != PendingPublish && pi.state != Published {
 			log.Debugf("Expect input %v to have %v, instead it "+
 				"has %v", op, PendingPublish, pi.state)
 
@@ -956,8 +980,20 @@ func (s *UtxoSweeper) markInputsPublished(tr *TxRecord, set InputSet) error {
 		// Update the input's state.
 		pi.state = Published
 
-		// Update the input's latest fee rate.
-		pi.lastFeeRate = chainfee.SatPerKWeight(tr.FeeRate)
+		// Update the input's latest fee rate. Real publish/replace
+		// events always carry a fee rate; guard against a zero value so
+		// we never clobber a valid rate (and the RPC's sat_per_vbyte)
+		// with zero.
+		if tr.FeeRate != 0 {
+			pi.lastFeeRate = chainfee.SatPerKWeight(tr.FeeRate)
+		}
+
+		// Store the sweep transaction on the input so it can be
+		// returned via PendingSweeps, but only if the tx actually
+		// spends this input.
+		if _, ok := spentByTx[op]; ok {
+			pi.sweepTx = tx
+		}
 	}
 
 	return nil
@@ -993,6 +1029,16 @@ func (s *UtxoSweeper) markInputsPublishFailed(set InputSet,
 
 		// Update the input's state.
 		pi.state = PublishFailed
+
+		// We intentionally keep pi.sweepTx here. It's only ever set
+		// to a tx we've successfully broadcast, so when a bump
+		// attempt fails (e.g. the new fee rate can't be covered by
+		// the budget) the previously broadcast tx is still the live
+		// sweep in the mempool and remains the correct one to surface
+		// via PendingSweeps as raw_tx_hex. The exception is the
+		// unknown-spend path, where the caller clears it for retried
+		// inputs as the old tx conflicts with the confirmed
+		// third-party spend.
 
 		log.Debugf("Input(%v): updating params: starting fee rate "+
 			"[%v -> %v]", op, pi.params.StartingFeeRate,
@@ -1083,6 +1129,14 @@ func (s *UtxoSweeper) handlePendingSweepsReq(
 	for _, inp := range s.inputs {
 		_, maturityHeight := inp.isMature(uint32(s.currentHeight))
 
+		// Deep-copy the sweep tx before handing it to the caller's
+		// goroutine so the response never shares a mutable transaction
+		// with the sweeper's internal state.
+		var sweepTx *wire.MsgTx
+		if inp.sweepTx != nil {
+			sweepTx = inp.sweepTx.Copy()
+		}
+
 		// Only the exported fields are set, as we expect the response
 		// to only be consumed externally.
 		op := inp.OutPoint()
@@ -1097,6 +1151,7 @@ func (s *UtxoSweeper) handlePendingSweepsReq(
 			Params:            inp.params,
 			DeadlineHeight:    uint32(inp.DeadlineHeight),
 			MaturityHeight:    maturityHeight,
+			SweepTx:           sweepTx,
 		}
 	}
 
@@ -1255,18 +1310,24 @@ func (s *UtxoSweeper) handleNewInput(input *sweepInputMessage) error {
 
 	// This is a new input, and we want to query the mempool to see if this
 	// input has already been spent. If so, we'll start the input with the
-	// RBFInfo.
-	rbfInfo := s.decideRBFInfo(input.input.OutPoint())
+	// RBFInfo and the recovered sweep tx.
+	rbfInfo, sweepTx := s.decideRBFInfo(input.input.OutPoint())
 
 	// Create a new pendingInput and initialize the listeners slice with
 	// the passed in result channel. If this input is offered for sweep
 	// again, the result channel will be appended to this slice.
+	//
+	// When the input's sweep is already in the mempool (e.g. recovered on
+	// restart), sweepTx carries it so PendingSweeps can surface its
+	// raw_tx_hex right away instead of returning empty until the next
+	// publish.
 	pi = &SweeperInput{
 		state:     Init,
 		listeners: []chan Result{input.resultChan},
 		Input:     input.input,
 		params:    input.params,
 		rbf:       rbfInfo,
+		sweepTx:   sweepTx,
 	}
 
 	// Set the starting fee rate if a previous sweeping tx is found.
@@ -1307,19 +1368,22 @@ func (s *UtxoSweeper) handleNewInput(input *sweepInputMessage) error {
 }
 
 // decideRBFInfo queries the mempool to see whether the given input has already
-// been spent. When spent, it will query the sweeper store to fetch the fee info
-// of the spending transction, and construct an RBFInfo based on it. Suppose an
-// error occurs, fn.None is returned.
-func (s *UtxoSweeper) decideRBFInfo(
-	op wire.OutPoint) fn.Option[RBFInfo] {
+// been spent. When spent by a tx we broadcast, it queries the sweeper store to
+// fetch the fee info of the spending transaction and constructs an RBFInfo
+// based on it, returning that tx so it can be tracked as the input's sweep tx.
+// Suppose an error occurs, fn.None and a nil tx are returned.
+func (s *UtxoSweeper) decideRBFInfo(op wire.OutPoint) (fn.Option[RBFInfo],
+	*wire.MsgTx) {
 
 	// Check if we can find the spending tx of this input in mempool.
 	txOption := s.mempoolLookup(op)
 
-	// Extract the spending tx from the option.
+	// Extract the spending tx from the option. Deep-copy it so the stored
+	// sweep tx is owned by the sweeper and cannot alias memory owned by
+	// the mempool backend.
 	var tx *wire.MsgTx
 	txOption.WhenSome(func(t wire.MsgTx) {
-		tx = &t
+		tx = t.Copy()
 	})
 
 	// Exit early if it's not found.
@@ -1329,7 +1393,7 @@ func (s *UtxoSweeper) decideRBFInfo(
 	// - for neutrino we don't have a mempool.
 	// - for btcd below v0.24.1 we don't have `gettxspendingprevout`.
 	if tx == nil {
-		return fn.None[RBFInfo]()
+		return fn.None[RBFInfo](), nil
 	}
 
 	// Otherwise the input is already spent in the mempool, so eventually
@@ -1349,7 +1413,7 @@ func (s *UtxoSweeper) decideRBFInfo(
 	// this tx is confirmed, we will remove the input from our inputs.
 	if errors.Is(err, ErrTxNotFound) {
 		log.Warnf("Spending tx %v not found in sweeper store", txid)
-		return fn.None[RBFInfo]()
+		return fn.None[RBFInfo](), nil
 	}
 
 	// Exit if we get an db error.
@@ -1357,17 +1421,18 @@ func (s *UtxoSweeper) decideRBFInfo(
 		log.Errorf("Unable to get tx %v from sweeper store: %v",
 			txid, err)
 
-		return fn.None[RBFInfo]()
+		return fn.None[RBFInfo](), nil
 	}
 
-	// Prepare the fee info and return it.
+	// Prepare the fee info and return it along with the recovered tx so the
+	// input tracks it as its sweep tx.
 	rbf := fn.Some(RBFInfo{
 		Txid:    txid,
 		Fee:     btcutil.Amount(tr.Fee),
 		FeeRate: chainfee.SatPerKWeight(tr.FeeRate),
 	})
 
-	return rbf
+	return rbf, tx
 }
 
 // handleExistingInput processes an input that is already known to the sweeper.
@@ -1765,7 +1830,7 @@ func (s *UtxoSweeper) handleBumpEventTxReplaced(resp *bumpResp) error {
 	}
 
 	// Mark the inputs as published using the replacing tx.
-	return s.markInputsPublished(tr, resp.set)
+	return s.markInputsPublished(tr, newTx, resp.set)
 }
 
 // handleBumpEventTxPublished handles the case where the sweeping tx has been
@@ -1781,7 +1846,7 @@ func (s *UtxoSweeper) handleBumpEventTxPublished(resp *bumpResp) error {
 
 	// Inputs have been successfully published so we update their
 	// states.
-	err := s.markInputsPublished(tr, resp.set)
+	err := s.markInputsPublished(tr, tx, resp.set)
 	if err != nil {
 		return err
 	}
@@ -2006,6 +2071,11 @@ func (s *UtxoSweeper) handleBumpEventTxUnknownSpend(r *bumpResp) {
 
 		log.Debugf("Input(%v): updating params: immediate [%v -> true]",
 			op, r.result.FeeRate, input.params.Immediate)
+
+		// Clear the stored sweep tx: it also spent the input(s)
+		// taken by the third party, so it conflicts with the
+		// confirmed spend and can never confirm.
+		input.sweepTx = nil
 
 		input.params.Immediate = true
 		inputsToRetry = append(inputsToRetry, input)

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -117,7 +117,8 @@ func TestMarkInputsPendingPublish(t *testing.T) {
 }
 
 // TestMarkInputsPublished checks that given a list of inputs with different
-// states, only the state `PendingPublish` will be marked as `Published`.
+// states, only the inputs in `PendingPublish` and `Published` will have their
+// state, fee rate and sweep tx updated.
 func TestMarkInputsPublished(t *testing.T) {
 	t.Parallel()
 
@@ -139,18 +140,29 @@ func TestMarkInputsPublished(t *testing.T) {
 		Store: mockStore,
 	})
 
-	// Create two inputs with different states.
+	// Create three inputs with different states.
 	// - inputInit specifies a newly created input.
 	// - inputPendingPublish specifies an input about to be published.
+	// - inputPublished specifies an input that was published before and
+	//   is now being swept by a replacement tx.
+	// inputNotInTx is in the input set but is not actually spent by the
+	// published tx, so its sweep tx must not be stored.
 	var (
 		inputInit           = createMockInput(t, s, Init)
 		inputPendingPublish = createMockInput(t, s, PendingPublish)
+		inputPublished      = createMockInput(t, s, Published)
+		inputNotInTx        = createMockInput(t, s, PendingPublish)
 	)
+
+	// Attach a stale sweep tx to the published input to assert it's
+	// refreshed when the replacement tx is published.
+	staleTx := &wire.MsgTx{LockTime: 1}
+	s.inputs[inputPublished.OutPoint()].sweepTx = staleTx
 
 	// First, check that when an error is returned from db, it's properly
 	// returned here.
 	mockStore.On("StoreTx", dummyTR).Return(dummyErr).Once()
-	err := s.markInputsPublished(dummyTR, nil)
+	err := s.markInputsPublished(dummyTR, nil, nil)
 	require.ErrorIs(err, dummyErr)
 
 	// We also expect the record has been marked as published.
@@ -162,16 +174,25 @@ func TestMarkInputsPublished(t *testing.T) {
 	// Mock the store to return nil
 	mockStore.On("StoreTx", dummyTR).Return(nil).Once()
 
-	// Mark the test inputs. We expect the non-exist input and the
-	// inputInit to be skipped, and the final input to be marked as
-	// published.
-	set.On("Inputs").Return([]input.Input{inputInit, inputPendingPublish})
+	// Mark the test inputs. We expect the inputInit to be skipped, and
+	// the pending-publish and published inputs to be updated.
+	set.On("Inputs").Return([]input.Input{
+		inputInit, inputPendingPublish, inputPublished, inputNotInTx,
+	})
 
-	err = s.markInputsPublished(dummyTR, set)
+	// The published tx only spends the pending-publish and published
+	// inputs, so only those should have the sweep tx attached.
+	dummyTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{
+			{PreviousOutPoint: inputPendingPublish.OutPoint()},
+			{PreviousOutPoint: inputPublished.OutPoint()},
+		},
+	}
+	err = s.markInputsPublished(dummyTR, dummyTx, set)
 	require.NoError(err)
 
 	// We expect unchanged number of pending inputs.
-	require.Len(s.inputs, 2)
+	require.Len(s.inputs, 4)
 
 	// We expect the init input's state to stay unchanged.
 	require.Equal(Init,
@@ -180,6 +201,24 @@ func TestMarkInputsPublished(t *testing.T) {
 	// We expect the pending-publish input's is now marked as published.
 	require.Equal(Published,
 		s.inputs[inputPendingPublish.OutPoint()].state)
+
+	// We expect the sweep tx to be stored on the published input.
+	require.Equal(dummyTx,
+		s.inputs[inputPendingPublish.OutPoint()].sweepTx)
+
+	// We expect the already-published input to stay in Published and
+	// have its stale sweep tx replaced by the new one.
+	require.Equal(Published,
+		s.inputs[inputPublished.OutPoint()].state)
+	require.Equal(dummyTx,
+		s.inputs[inputPublished.OutPoint()].sweepTx)
+
+	// We expect the input that's marked published but isn't spent by the
+	// tx to be updated in state, yet have no sweep tx attached, as the tx
+	// doesn't contain it.
+	require.Equal(Published,
+		s.inputs[inputNotInTx.OutPoint()].state)
+	require.Nil(s.inputs[inputNotInTx.OutPoint()].sweepTx)
 
 	// Assert mocked statements are executed as expected.
 	mockStore.AssertExpectations(t)
@@ -226,6 +265,13 @@ func TestMarkInputsPublishFailed(t *testing.T) {
 		inputFatal          = createMockInput(t, s, Fatal)
 	)
 
+	// Attach a sweep tx to the inputs that will transition to
+	// PublishFailed, to assert it's retained so the last broadcast tx is
+	// still surfaced via PendingSweeps.
+	broadcastTx := &wire.MsgTx{LockTime: 1}
+	s.inputs[inputPendingPublish.OutPoint()].sweepTx = broadcastTx
+	s.inputs[inputPublished.OutPoint()].sweepTx = broadcastTx
+
 	// Gather all inputs.
 	set.On("Inputs").Return([]input.Input{
 		inputInit, inputPendingPublish, inputPublished,
@@ -248,15 +294,18 @@ func TestMarkInputsPublishFailed(t *testing.T) {
 	require.True(pi.params.StartingFeeRate.IsNone())
 
 	// We expect the pending-publish input's is now marked as publish
-	// failed.
+	// failed, with its broadcast sweep tx retained.
 	pi = s.inputs[inputPendingPublish.OutPoint()]
 	require.Equal(PublishFailed, pi.state)
 	require.Equal(feeRate, pi.params.StartingFeeRate.UnsafeFromSome())
+	require.Equal(broadcastTx, pi.sweepTx)
 
-	// We expect the published input's is now marked as publish failed.
+	// We expect the published input's is now marked as publish failed,
+	// with its broadcast sweep tx retained.
 	pi = s.inputs[inputPublished.OutPoint()]
 	require.Equal(PublishFailed, pi.state)
 	require.Equal(feeRate, pi.params.StartingFeeRate.UnsafeFromSome())
+	require.Equal(broadcastTx, pi.sweepTx)
 
 	// We expect the publish failed input to stay unchanged.
 	pi = s.inputs[inputPublishFailed.OutPoint()]
@@ -535,9 +584,10 @@ func TestDecideRBFInfo(t *testing.T) {
 	mockMempool.On("LookupInputMempoolSpend", op).Return(
 		fn.None[wire.MsgTx]()).Once()
 
-	// Since the mempool lookup failed, we expect no RBFInfo.
-	rbf := s.decideRBFInfo(op)
+	// Since the mempool lookup failed, we expect no RBFInfo and no tx.
+	rbf, sweepTx := s.decideRBFInfo(op)
 	require.True(rbf.IsNone())
+	require.Nil(sweepTx)
 
 	// Mock the mempool lookup to return a tx three times as we are calling
 	// attachAvailableRBFInfo three times.
@@ -548,17 +598,19 @@ func TestDecideRBFInfo(t *testing.T) {
 	// Mock the store to return an error saying the tx cannot be found.
 	mockStore.On("GetTx", tx.TxHash()).Return(nil, ErrTxNotFound).Once()
 
-	// The db lookup failed, we expect no RBFInfo.
-	rbf = s.decideRBFInfo(op)
+	// The db lookup failed, we expect no RBFInfo and no tx.
+	rbf, sweepTx = s.decideRBFInfo(op)
 	require.True(rbf.IsNone())
+	require.Nil(sweepTx)
 
 	// Mock the store to return a db error.
 	dummyErr := errors.New("dummy error")
 	mockStore.On("GetTx", tx.TxHash()).Return(nil, dummyErr).Once()
 
-	// The db lookup failed, we expect no RBFInfo.
-	rbf = s.decideRBFInfo(op)
+	// The db lookup failed, we expect no RBFInfo and no tx.
+	rbf, sweepTx = s.decideRBFInfo(op)
 	require.True(rbf.IsNone())
+	require.Nil(sweepTx)
 
 	// Mock the store to return a record.
 	tr := &TxRecord{
@@ -568,7 +620,7 @@ func TestDecideRBFInfo(t *testing.T) {
 	mockStore.On("GetTx", tx.TxHash()).Return(tr, nil).Once()
 
 	// Call the method again.
-	rbf = s.decideRBFInfo(op)
+	rbf, sweepTx = s.decideRBFInfo(op)
 
 	// Assert that the RBF info is returned.
 	rbfInfo := fn.Some(RBFInfo{
@@ -577,6 +629,12 @@ func TestDecideRBFInfo(t *testing.T) {
 		FeeRate: chainfee.SatPerKWeight(tr.FeeRate),
 	})
 	require.Equal(rbfInfo, rbf)
+
+	// We also expect the recovered mempool tx to be returned so the input
+	// can track it as its sweep tx. The returned tx is a sweeper-owned
+	// deep copy, so compare by txid.
+	require.NotNil(sweepTx)
+	require.Equal(tx.TxHash(), sweepTx.TxHash())
 }
 
 // TestMarkInputFatal checks that the input is marked as expected.
@@ -863,6 +921,100 @@ func TestHandleBumpEventTxReplaced(t *testing.T) {
 
 	// Assert the state of the input is updated.
 	require.Equal(t, Published, s.inputs[op].state)
+}
+
+// TestHandleBumpEventTxReplacedOnPublished checks that when a sweeping tx is
+// replaced via an automatic RBF, an input that's already in the state
+// `Published` has its fee rate and sweep tx updated to the replacement tx.
+func TestHandleBumpEventTxReplacedOnPublished(t *testing.T) {
+	t.Parallel()
+
+	// Create a mock store.
+	store := &MockSweeperStore{}
+	defer store.AssertExpectations(t)
+
+	// Create a mock wallet.
+	wallet := &MockWallet{}
+	defer wallet.AssertExpectations(t)
+
+	// Create a mock input set.
+	set := &MockInputSet{}
+	defer set.AssertExpectations(t)
+
+	// Create a test sweeper.
+	s := New(&UtxoSweeperConfig{
+		Store:  store,
+		Wallet: wallet,
+	})
+
+	// Create a mock input that's already published - the initial sweeping
+	// tx was broadcast and is now being fee bumped via RBF.
+	inp := createMockInput(t, s, Published)
+	set.On("Inputs").Return([]input.Input{inp})
+
+	op := inp.OutPoint()
+
+	// Create a testing tx that spends the input.
+	tx := &wire.MsgTx{
+		LockTime: 1,
+		TxIn: []*wire.TxIn{
+			{PreviousOutPoint: op},
+		},
+	}
+
+	// Attach the old sweeping tx to the input to mimic the state after
+	// the initial publish.
+	s.inputs[op].sweepTx = tx
+
+	// Create a replacement tx with a higher fee rate.
+	replacementTx := &wire.MsgTx{
+		LockTime: 2,
+		TxIn: []*wire.TxIn{
+			{PreviousOutPoint: op},
+		},
+	}
+	newFeeRate := chainfee.SatPerKWeight(1000)
+
+	// Create a testing bump result.
+	br := &BumpResult{
+		Tx:         replacementTx,
+		ReplacedTx: tx,
+		Event:      TxReplaced,
+		FeeRate:    newFeeRate,
+	}
+
+	// Create a testing bump response.
+	resp := &bumpResp{
+		result: br,
+		set:    set,
+	}
+
+	// Mock the store to return the old tx record and delete it without
+	// error.
+	store.On("GetTx", tx.TxHash()).Return(&TxRecord{
+		Txid: tx.TxHash(),
+	}, nil).Once()
+	store.On("DeleteTx", tx.TxHash()).Return(nil).Once()
+
+	// Mock the store to save the new tx record.
+	store.On("StoreTx", &TxRecord{
+		Txid:      replacementTx.TxHash(),
+		FeeRate:   uint64(newFeeRate),
+		Published: true,
+	}).Return(nil).Once()
+
+	// We expect to cancel rebroadcasting the replaced tx.
+	wallet.On("CancelRebroadcast", tx.TxHash()).Once()
+
+	// Call the method under test.
+	err := s.handleBumpEventTxReplaced(resp)
+	require.NoError(t, err)
+
+	// Assert the input stays in Published, and its fee rate and sweep tx
+	// reflect the replacement tx instead of the replaced one.
+	require.Equal(t, Published, s.inputs[op].state)
+	require.Equal(t, newFeeRate, s.inputs[op].lastFeeRate)
+	require.Equal(t, replacementTx, s.inputs[op].sweepTx)
 }
 
 // TestHandleBumpEventTxPublished checks that the sweeper correctly handles the
@@ -1423,6 +1575,10 @@ func TestHandleBumpEventTxUnknownSpendWithRetry(t *testing.T) {
 		},
 	}
 
+	// Attach a previously published sweep tx to the retried input to
+	// assert it gets cleared below.
+	s.inputs[op2].sweepTx = tx
+
 	// Create a testing bump response.
 	resp := &bumpResp{
 		result: br,
@@ -1444,4 +1600,8 @@ func TestHandleBumpEventTxUnknownSpendWithRetry(t *testing.T) {
 
 	// Assert the state of the input is updated.
 	require.Equal(t, PublishFailed, s.inputs[op2].state)
+
+	// Assert the stale sweep tx is cleared on the retried input as it
+	// conflicts with the confirmed third-party spend.
+	require.Nil(t, s.inputs[op2].sweepTx)
 }


### PR DESCRIPTION
Fixes #8470 

## Change Description
Add raw transaction hex to pendingsweeps response

## Steps to Test
1. Start lnd on testnet/regtest
2. Create an unconfirmed output and bump it:
  `lncli wallet bumpfee --sat_per_vbyte 10 --immediate <outpoint>`
3. Expect the new informational message pointing to pendingsweeps.
4. Query pending sweeps: `lncli wallet pendingsweeps`
5. Verify raw_tx_hex is populated for the bumped input.
6. Decode and verify: `bitcoin-cli decoderawtransaction <raw_tx_hex>`
7. Confirm it matches the expected sweep tx.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
