### PR TITLE
gitignore: ignore `.worktrees`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ coverage.txt
 # Release build directory (to avoid build.vcs.modified Golang build tag to be
 # set to true by having untracked files in the working directory).
 /lnd-*/
+/.worktrees/
 
 .aider*
 


### PR DESCRIPTION
Ignore `.worktrees` so the different branches can live under the `lnd`.