### PR TITLE
chainreg: use getnetworkinfo to count outbound peers (bitcoind backend)

### DIFF
--- a/chainreg/chainregistry.go
+++ b/chainreg/chainregistry.go
@@ -521,7 +521,7 @@ func NewPartialChainControl(cfg *Config) (*PartialChainControl, func(), error) {
 			// Make sure the bitcoind chain backend maintains a
 			// healthy connection to the network by checking the
 			// number of outbound peers.
-			return checkOutboundPeers(chainConn)
+			return checkOutboundPeersBitcoind(chainConn)
 		}
 
 	case "btcd":
@@ -887,6 +887,24 @@ var (
 	}
 )
 
+// checkOutboundPeersBitcoind checks the number of outbound peers connected to
+// a bitcoind backend. If the number of outbound peers is below 6, a warning is
+// logged. This function is intended to ensure that the chain backend maintains
+// a healthy connection to the network.
+//
+// This helper is bitcoind-specific because btcd does not currently implement
+// getnetworkinfo.
+func checkOutboundPeersBitcoind(client *rpcclient.Client) error {
+	info, err := client.GetNetworkInfo()
+	if err != nil {
+		return err
+	}
+
+	logOutboundPeerCount(int(info.ConnectionsOut))
+
+	return nil
+}
+
 // checkOutboundPeers checks the number of outbound peers connected to the
 // provided RPC client. If the number of outbound peers is below 6, a warning
 // is logged. This function is intended to ensure that the chain backend
@@ -904,6 +922,14 @@ func checkOutboundPeers(client *rpcclient.Client) error {
 		}
 	}
 
+	logOutboundPeerCount(outboundPeers)
+
+	return nil
+}
+
+// logOutboundPeerCount logs a warning when the number of outbound peers is
+// below the minimum threshold.
+func logOutboundPeerCount(outboundPeers int) {
 	if outboundPeers < DefaultMinOutboundPeers {
 		log.Warnf("The chain backend has an insufficient number "+
 			"of connected outbound peers (%d connected, expected "+
@@ -911,6 +937,4 @@ func checkOutboundPeers(client *rpcclient.Client) error {
 			"Connect to more trusted nodes manually if necessary.",
 			outboundPeers, DefaultMinOutboundPeers)
 	}
-
-	return nil
 }

--- a/chainreg/chainregistry.go
+++ b/chainreg/chainregistry.go
@@ -2,7 +2,6 @@ package chainreg
 
 import (
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -452,18 +451,9 @@ func NewPartialChainControl(cfg *Config) (*PartialChainControl, func(), error) {
 				return nil, nil, err
 			}
 
-			// Fetch all active zmq notifications from the bitcoind client.
-			resp, err := chainConn.RawRequest("getzmqnotifications", nil)
+			// Fetch all active ZMQ notifications from bitcoind.
+			zmq, err := chainConn.GetZmqNotifications()
 			if err != nil {
-				return nil, nil, err
-			}
-
-			zmq := []struct {
-				Type    string `json:"type"`
-				Address string `json:"address"`
-			}{}
-
-			if err = json.Unmarshal([]byte(resp), &zmq); err != nil {
 				return nil, nil, err
 			}
 
@@ -472,31 +462,27 @@ func NewPartialChainControl(cfg *Config) (*PartialChainControl, func(), error) {
 
 			for i := range zmq {
 				if zmq[i].Type == "pubrawblock" {
-					url, err := url.Parse(zmq[i].Address)
-					if err != nil {
-						return nil, nil, err
-					}
-					if url.Port() != zmqPubRawBlockURL.Port() {
+					if zmq[i].Address.Port() !=
+						zmqPubRawBlockURL.Port() {
+
 						log.Warnf(
 							"unable to subscribe to zmq block events on "+
 								"%s (bitcoind is running on %s)",
 							zmqPubRawBlockURL.Host,
-							url.Host,
+							zmq[i].Address.Host,
 						)
 					}
 					pubRawBlockActive = true
 				}
 				if zmq[i].Type == "pubrawtx" {
-					url, err := url.Parse(zmq[i].Address)
-					if err != nil {
-						return nil, nil, err
-					}
-					if url.Port() != zmqPubRawTxURL.Port() {
+					if zmq[i].Address.Port() !=
+						zmqPubRawTxURL.Port() {
+
 						log.Warnf(
 							"unable to subscribe to zmq tx events on "+
 								"%s (bitcoind is running on %s)",
 							zmqPubRawTxURL.Host,
-							url.Host,
+							zmq[i].Address.Host,
 						)
 					}
 					pubRawTxActive = true

--- a/chainreg/chainregistry.go
+++ b/chainreg/chainregistry.go
@@ -802,16 +802,8 @@ func NewChainControl(walletConfig lnwallet.Config,
 // getblockchaininfo.
 func getBitcoindHealthCheckCmd(client *rpcclient.Client) (string, int64, error) {
 	// Query bitcoind to get our current version.
-	resp, err := client.RawRequest("getnetworkinfo", nil)
+	info, err := client.GetNetworkInfo()
 	if err != nil {
-		return "", 0, err
-	}
-
-	// Parse the response to retrieve bitcoind's version.
-	info := struct {
-		Version int64 `json:"version"`
-	}{}
-	if err := json.Unmarshal(resp, &info); err != nil {
 		return "", 0, err
 	}
 
@@ -822,10 +814,10 @@ func getBitcoindHealthCheckCmd(client *rpcclient.Client) (string, int64, error) 
 	// The uptime call was added in version 0.15.0, so we return it for
 	// any version value >= 150000, as per the above calculation.
 	if info.Version >= 150000 {
-		return "uptime", info.Version, nil
+		return "uptime", int64(info.Version), nil
 	}
 
-	return "getblockchaininfo", info.Version, nil
+	return "getblockchaininfo", int64(info.Version), nil
 }
 
 var (

--- a/chainreg/chainregistry.go
+++ b/chainreg/chainregistry.go
@@ -465,12 +465,14 @@ func NewPartialChainControl(cfg *Config) (*PartialChainControl, func(), error) {
 					if zmq[i].Address.Port() !=
 						zmqPubRawBlockURL.Port() {
 
-						log.Warnf(
-							"unable to subscribe to zmq block events on "+
-								"%s (bitcoind is running on %s)",
+						log.Warnf("zmq block port "+
+							"mismatch: lnd is "+
+							"using %s but "+
+							"bitcoind reports %s "+
+							"- ensure the port "+
+							"is correct",
 							zmqPubRawBlockURL.Host,
-							zmq[i].Address.Host,
-						)
+							zmq[i].Address.Host)
 					}
 					pubRawBlockActive = true
 				}
@@ -478,12 +480,14 @@ func NewPartialChainControl(cfg *Config) (*PartialChainControl, func(), error) {
 					if zmq[i].Address.Port() !=
 						zmqPubRawTxURL.Port() {
 
-						log.Warnf(
-							"unable to subscribe to zmq tx events on "+
-								"%s (bitcoind is running on %s)",
+						log.Warnf("zmq tx port "+
+							"mismatch: lnd is "+
+							"using %s but "+
+							"bitcoind reports %s "+
+							"- ensure the port "+
+							"is correct",
 							zmqPubRawTxURL.Host,
-							zmq[i].Address.Host,
-						)
+							zmq[i].Address.Host)
 					}
 					pubRawTxActive = true
 				}

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -21,6 +21,11 @@
 
 # Bug Fixes
 
+* Bitcoind outbound peer health checks [now use](https://github.com/lightningnetwork/lnd/pull/10686)
+  `getnetworkinfo.connections_out` instead of `getpeerinfo`. The same PR also
+  [clarifies](https://github.com/lightningnetwork/lnd/issues/10568) the ZMQ
+  port-mismatch warnings so they no longer suggest that the connection failed.
+
 # New Features
 
 ## Functional Enhancements
@@ -64,4 +69,5 @@
 
 # Contributors (Alphabetical Order)
 
+* Boris Nagaev
 * Erick Cestari


### PR DESCRIPTION
## Change Description

Use `getnetworkinfo.connections_out` for bitcoind outbound peer checks instead of `getpeerinfo`. This keeps the isolation-safety signal while avoiding heavier per-peer work. This helper is bitcoind-specific, btcd does not currently implement it.

Also made two unrelated cleanups to use structured rpcclient methods instead of RawRequest in the same file.

See https://github.com/lightningnetwork/lnd/issues/10641 This should partially address it, switching to lighter calls for health-checks. CC @jogc

Fixes https://github.com/lightningnetwork/lnd/issues/10568

## Steps to Test

Verification done in signet:

1. `lncli getinfo` works and shows correct `block_height`.
2. `grep -nE "Health check: chain backend failed after|SRVR: Health check|timed out after" ~/.lnd/logs/bitcoin/signet/lnd.log` returns nothing
3. `grep -nE "insufficient number of connected outbound peers|Skipping chain backend peer check" ~/.lnd/logs/bitcoin/signet/lnd.log` returns nothing

Also tested `loop out` and `loop in` on that node.


## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
