### PR TITLE
config: skip creating unnecessary directories for remote DB backends

### DIFF
--- a/config.go
+++ b/config.go
@@ -1438,21 +1438,13 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 		filepath.Dir(cfg.Tor.WatchtowerKeyPath),
 	}
 
-	// Only create the graph database directory if we're using a local
-	// database backend (bbolt). Remote backends like postgres don't
-	// need a local directory for the graph database.
+	// Only create the graph and watchtower directories if we're using a
+	// local database backend (e.g. bbolt or sqlite). Remote backends
+	// like postgres or etcd don't need local directories for these.
 	if cfg.DB.Backend != lncfg.PostgresBackend &&
 		cfg.DB.Backend != lncfg.EtcdBackend {
 
-		dirs = append(dirs, cfg.graphDatabaseDir())
-	}
-
-	// Only create the watchtower directory if we're using a local
-	// database backend. Remote backends store watchtower data remotely.
-	if cfg.DB.Backend != lncfg.PostgresBackend &&
-		cfg.DB.Backend != lncfg.EtcdBackend {
-
-		dirs = append(dirs, towerDir)
+		dirs = append(dirs, cfg.graphDatabaseDir(), towerDir)
 	}
 
 	// Only create the Let's Encrypt directory if the feature is actually

--- a/config.go
+++ b/config.go
@@ -1424,15 +1424,44 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 	// Create the lnd directory and all other sub-directories if they don't
 	// already exist. This makes sure that directory trees are also created
 	// for files that point to outside the lnddir.
+	//
+	// We conditionally skip certain directories that are not needed when
+	// using a remote database backend like postgres:
+	//   - The graph database directory (used by bbolt for channel graph)
+	//   - The watchtower directory (used by bbolt for watchtower state)
 	dirs := []string{
 		lndDir, cfg.DataDir, cfg.networkDir,
-		cfg.LetsEncryptDir, towerDir, cfg.graphDatabaseDir(),
 		filepath.Dir(cfg.TLSCertPath), filepath.Dir(cfg.TLSKeyPath),
 		filepath.Dir(cfg.AdminMacPath), filepath.Dir(cfg.ReadMacPath),
 		filepath.Dir(cfg.InvoiceMacPath),
 		filepath.Dir(cfg.Tor.PrivateKeyPath),
 		filepath.Dir(cfg.Tor.WatchtowerKeyPath),
 	}
+
+	// Only create the graph database directory if we're using a local
+	// database backend (bbolt). Remote backends like postgres don't
+	// need a local directory for the graph database.
+	if cfg.DB.Backend != lncfg.PostgresBackend &&
+		cfg.DB.Backend != lncfg.EtcdBackend {
+
+		dirs = append(dirs, cfg.graphDatabaseDir())
+	}
+
+	// Only create the watchtower directory if we're using a local
+	// database backend. Remote backends store watchtower data remotely.
+	if cfg.DB.Backend != lncfg.PostgresBackend &&
+		cfg.DB.Backend != lncfg.EtcdBackend {
+
+		dirs = append(dirs, towerDir)
+	}
+
+	// Only create the Let's Encrypt directory if the feature is actually
+	// being used. If no domain is configured, there's no need for the
+	// directory.
+	if cfg.LetsEncryptDomain != "" {
+		dirs = append(dirs, cfg.LetsEncryptDir)
+	}
+
 	for _, dir := range dirs {
 		if err := makeDirectory(dir); err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary

When using `--db.backend=postgres` (or etcd), lnd creates several empty directories under `~/.lnd` that are never used:

```
data/graph/<network>/      # local bbolt graph DB directory
data/watchtower/<chain>/<network>/  # local bbolt watchtower DB directory  
letsencrypt/               # Let's Encrypt certificate cache
```

These directories are unnecessary because:
- **graph directory**: Only used by the bbolt backend for the channel graph database. Remote backends (postgres, etcd) store graph data on the remote server.
- **watchtower directory**: Only used by the bbolt backend for watchtower client/server state. Remote backends handle this remotely.
- **letsencrypt directory**: Only needed when `--letsencryptdomain` is set. Without it, the directory serves no purpose.

## Changes

Modified `config.go` to conditionally skip creating these directories:

1. **Graph database directory** (`data/graph/<network>`): Skipped when `--db.backend` is `postgres` or `etcd`
2. **Watchtower directory** (`data/watchtower/<chain>/<network>`): Skipped when `--db.backend` is `postgres` or `etcd`
3. **Let's Encrypt directory** (`letsencrypt/`): Skipped when `--letsencryptdomain` is not set

The sqlite backend still creates local directories since it is a file-based backend.

## Testing

- `go build ./...` passes
- `go vet ./...` passes

Fixes #10598