### PR TITLE
scripts+GitHub: use bitcoind v30.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,8 @@ defaults:
     shell: bash
 
 env:
-  BITCOIN_VERSION: "29"
+  # Accepts either a major image tag like "30" or a patch tag like "29.1".
+  BITCOIN_VERSION: "30"
   
   # TRANCHES defines the number of tranches used in the itests.
   TRANCHES: 16

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ defaults:
 
 env:
   # Accepts either a major image tag like "30" or a patch tag like "29.1".
-  BITCOIN_VERSION: "30"
+  BITCOIN_VERSION: "31"
   
   # TRANCHES defines the number of tranches used in the itests.
   TRANCHES: 16

--- a/lntest/bitcoind_common.go
+++ b/lntest/bitcoind_common.go
@@ -181,6 +181,14 @@ func newBackend(miner string, netParams *chaincfg.Params, extraArgs []string,
 		//
 		// TODO: Remove once btcd supports v2 P2P transport.
 		"-v2transport=0",
+		// Pin the pre-v30 mempool policy defaults (1 sat/vB)
+		// so the itest suite keeps exercising the fee math it
+		// was written against. v30 lowered minrelaytxfee and
+		// incrementalrelayfee to 100 sat/kvB, which breaks
+		// integer sat/vByte assertions and alters RBF bump
+		// thresholds across the sweeper/bumpfee tests.
+		"-minrelaytxfee=0.00001",
+		"-incrementalrelayfee=0.00001",
 	}
 	cmdArgs = append(cmdArgs, extraArgs...)
 	bitcoind := exec.Command("bitcoind", cmdArgs...)

--- a/scripts/install_bitcoind.sh
+++ b/scripts/install_bitcoind.sh
@@ -4,9 +4,24 @@ set -ev
 
 BITCOIND_VERSION=$1
 
-# Useful for testing RCs: e.g. TAG_SUFFIX=.0rc1, DIR_SUFFIX=.0rc1
+# The docker image tag and the install directory version don't always use the
+# same format. Major-only tags like `29` or `30` install into
+# `/opt/bitcoin-29.0` and `/opt/bitcoin-30.0`, while tags that already carry a
+# dot (patch releases like `29.1` or release candidates like `30.0rc1`) install
+# into a directory that matches the tag verbatim (`/opt/bitcoin-29.1`,
+# `/opt/bitcoin-30.0rc1`). Testing an RC therefore just means passing the full
+# version string as the first argument, e.g. `install_bitcoind.sh 30.0rc1`.
+if [[ "$BITCOIND_VERSION" == *.* ]]; then
+  BITCOIND_DIR_VERSION="$BITCOIND_VERSION"
+else
+  BITCOIND_DIR_VERSION="${BITCOIND_VERSION}.0"
+fi
+
+# TAG_SUFFIX and DIR_SUFFIX are kept as escape hatches for one-off images that
+# diverge from the conventions above (e.g. a privately pushed build); they are
+# empty by default and should stay that way for normal releases.
 TAG_SUFFIX=
-DIR_SUFFIX=.0
+DIR_SUFFIX=
 
 # Useful for testing against an image pushed to a different Docker repo.
 REPO=lightninglabs/bitcoin-core
@@ -19,5 +34,5 @@ fi
 
 docker pull ${REPO}:${BITCOIND_VERSION}${TAG_SUFFIX}
 CONTAINER_ID=$(docker create ${REPO}:${BITCOIND_VERSION}${TAG_SUFFIX})
-sudo docker cp $CONTAINER_ID:/opt/bitcoin-${BITCOIND_VERSION}${DIR_SUFFIX}/bin/bitcoind /usr/local/bin/bitcoind
+sudo docker cp $CONTAINER_ID:/opt/bitcoin-${BITCOIND_DIR_VERSION}${DIR_SUFFIX}/bin/bitcoind /usr/local/bin/bitcoind
 docker rm $CONTAINER_ID


### PR DESCRIPTION
Bumps the pinned bitcoind version used in CI integration tests from v29 to v30.0, the current stable release of Bitcoin Core.