### PR TITLE
Implement peer storage (option_provide_storage)

### DIFF
--- a/chanbackup/pubsub.go
+++ b/chanbackup/pubsub.go
@@ -119,6 +119,11 @@ type SubSwapper struct {
 
 	Swapper
 
+	// PostBackupFunc is an optional callback that is invoked after each
+	// successful backup file update with the new packed multi-channel
+	// backup.
+	PostBackupFunc func(PackedMulti)
+
 	quit chan struct{}
 	wg   sync.WaitGroup
 
@@ -310,9 +315,16 @@ func (s *SubSwapper) updateBackupFile(closedChans ...wire.OutPoint) error {
 	// Finally, we'll swap out the old backup for this new one in a single
 	// atomic step, combining the file already on-disk with this set of new
 	// channels.
-	err = s.Swapper.UpdateAndSwap(PackedMulti(b.Bytes()))
+	packedBackup := PackedMulti(b.Bytes())
+	err = s.Swapper.UpdateAndSwap(packedBackup)
 	if err != nil {
 		return fmt.Errorf("unable to update multi backup: %w", err)
+	}
+
+	// If a post-backup callback is registered, invoke it with the new
+	// packed backup.
+	if s.PostBackupFunc != nil {
+		s.PostBackupFunc(packedBackup)
 	}
 
 	return nil

--- a/channeldb/peers.go
+++ b/channeldb/peers.go
@@ -29,6 +29,10 @@ var (
 	// the timestamp of a peer's last flap count and its all time flap
 	// count.
 	flapCountKey = []byte("flap-count")
+
+	// peerStorageKey is a key used in the peer pubkey sub-bucket that
+	// stores an encrypted backup blob on behalf of that peer.
+	peerStorageKey = []byte("peer-storage")
 )
 
 var (
@@ -126,4 +130,63 @@ func (d *DB) ReadFlapCount(pubkey route.Vertex) (*FlapCount, error) {
 	}
 
 	return &flapCount, nil
+}
+
+// StorePeerStorage stores an encrypted backup blob for a peer, replacing any
+// existing blob. The blob is keyed by the peer's compressed public key.
+func (d *DB) StorePeerStorage(pubkey route.Vertex, blob []byte) error {
+	return kvdb.Update(d, func(tx kvdb.RwTx) error {
+		peers := tx.ReadWriteBucket(peersBucket)
+
+		peerBucket, err := peers.CreateBucketIfNotExists(pubkey[:])
+		if err != nil {
+			return err
+		}
+
+		return peerBucket.Put(peerStorageKey, blob)
+	}, func() {})
+}
+
+// FetchPeerStorage retrieves the stored encrypted backup blob for a peer.
+func (d *DB) FetchPeerStorage(pubkey route.Vertex) ([]byte, error) {
+	var blob []byte
+
+	if err := kvdb.View(d, func(tx kvdb.RTx) error {
+		peers := tx.ReadBucket(peersBucket)
+
+		peerBucket := peers.NestedReadBucket(pubkey[:])
+		if peerBucket == nil {
+			return ErrNoPeerBucket
+		}
+
+		stored := peerBucket.Get(peerStorageKey)
+		if stored == nil {
+			return fmt.Errorf("no peer storage for: %v", pubkey)
+		}
+
+		blob = make([]byte, len(stored))
+		copy(blob, stored)
+
+		return nil
+	}, func() {
+		blob = nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return blob, nil
+}
+
+// DeletePeerStorage removes the stored encrypted backup blob for a peer.
+func (d *DB) DeletePeerStorage(pubkey route.Vertex) error {
+	return kvdb.Update(d, func(tx kvdb.RwTx) error {
+		peers := tx.ReadWriteBucket(peersBucket)
+
+		peerBucket := peers.NestedReadWriteBucket(pubkey[:])
+		if peerBucket == nil {
+			return nil
+		}
+
+		return peerBucket.Delete(peerStorageKey)
+	}, func() {})
 }

--- a/channeldb/peers_test.go
+++ b/channeldb/peers_test.go
@@ -8,6 +8,49 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestPeerStorage tests store, fetch, overwrite, and delete of peer storage
+// blobs.
+func TestPeerStorage(t *testing.T) {
+	db, err := MakeTestDB(t)
+	require.NoError(t, err)
+
+	peer := route.Vertex{1, 1, 1}
+
+	// Fetching from a peer with no bucket should fail.
+	_, err = db.FetchPeerStorage(peer)
+	require.ErrorIs(t, err, ErrNoPeerBucket)
+
+	// Store a blob and fetch it back.
+	blob := []byte("encrypted-backup-data")
+	err = db.StorePeerStorage(peer, blob)
+	require.NoError(t, err)
+
+	fetched, err := db.FetchPeerStorage(peer)
+	require.NoError(t, err)
+	require.Equal(t, blob, fetched)
+
+	// Overwrite with a new blob.
+	newBlob := []byte("updated-backup-data")
+	err = db.StorePeerStorage(peer, newBlob)
+	require.NoError(t, err)
+
+	fetched, err = db.FetchPeerStorage(peer)
+	require.NoError(t, err)
+	require.Equal(t, newBlob, fetched)
+
+	// Delete the blob.
+	err = db.DeletePeerStorage(peer)
+	require.NoError(t, err)
+
+	// Fetch should now fail.
+	_, err = db.FetchPeerStorage(peer)
+	require.Error(t, err)
+
+	// Delete on a non-existent blob should not error.
+	err = db.DeletePeerStorage(peer)
+	require.NoError(t, err)
+}
+
 // TestFlapCount tests lookup and writing of flap count to disk.
 func TestFlapCount(t *testing.T) {
 	db, err := MakeTestDB(t)

--- a/feature/default_sets.go
+++ b/feature/default_sets.go
@@ -115,4 +115,8 @@ var defaultSetDesc = setDesc{
 		SetInit:    {}, // I
 		SetNodeAnn: {}, // N
 	},
+	lnwire.ProvideStorageOptional: {
+		SetInit:    {}, // I
+		SetNodeAnn: {}, // N
+	},
 }

--- a/feature/manager.go
+++ b/feature/manager.go
@@ -81,6 +81,10 @@ type Config struct {
 	// messaging.
 	NoOnionMessages bool
 
+	// NoPeerStorage unsets any bits that signal support for storing
+	// encrypted backup data on behalf of channel peers.
+	NoPeerStorage bool
+
 	// CustomFeatures is a set of custom features to advertise in each
 	// set.
 	CustomFeatures map[Set][]lnwire.FeatureBit
@@ -228,6 +232,10 @@ func newManager(cfg Config, desc setDesc) (*Manager, error) {
 		if cfg.NoOnionMessages {
 			raw.Unset(lnwire.OnionMessagesOptional)
 			raw.Unset(lnwire.OnionMessagesRequired)
+		}
+		if cfg.NoPeerStorage {
+			raw.Unset(lnwire.ProvideStorageOptional)
+			raw.Unset(lnwire.ProvideStorageRequired)
 		}
 
 		for _, custom := range cfg.CustomFeatures[set] {

--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -325,6 +325,16 @@ const (
 	// that the node can forward onion messages.
 	OnionMessagesOptional = 39
 
+	// ProvideStorageRequired is a required feature bit that indicates
+	// that the node can store encrypted backup data on behalf of its
+	// channel peers.
+	ProvideStorageRequired FeatureBit = 42
+
+	// ProvideStorageOptional is an optional feature bit that indicates
+	// that the node can store encrypted backup data on behalf of its
+	// channel peers.
+	ProvideStorageOptional FeatureBit = 43
+
 	// MaxBolt11Feature is the maximum feature bit value allowed in bolt 11
 	// invoices.
 	//
@@ -405,6 +415,8 @@ var Features = map[FeatureBit]string{
 	RbfCoopCloseRequiredStaging:          "rbf-coop-close-x",
 	OnionMessagesOptional:                "onion-messages",
 	OnionMessagesRequired:                "onion-messages",
+	ProvideStorageOptional:               "option-provide-storage",
+	ProvideStorageRequired:               "option-provide-storage",
 }
 
 // RawFeatureVector represents a set of feature bits as defined in BOLT-09.  A

--- a/lnwire/lnwire.go
+++ b/lnwire/lnwire.go
@@ -209,6 +209,17 @@ func WriteElement(w *bytes.Buffer, element interface{}) error {
 			return err
 		}
 
+	case PeerStoragePayload:
+		var l [2]byte
+		binary.BigEndian.PutUint16(l[:], uint16(len(e)))
+		if _, err := w.Write(l[:]); err != nil {
+			return err
+		}
+
+		if _, err := w.Write(e[:]); err != nil {
+			return err
+		}
+
 	case PongPayload:
 		var l [2]byte
 		binary.BigEndian.PutUint16(l[:], uint16(len(e)))
@@ -631,6 +642,18 @@ func ReadElement(r io.Reader, element interface{}) error {
 		pingLen := binary.BigEndian.Uint16(l[:])
 
 		*e = PingPayload(make([]byte, pingLen))
+		if _, err := io.ReadFull(r, *e); err != nil {
+			return err
+		}
+
+	case *PeerStoragePayload:
+		var l [2]byte
+		if _, err := io.ReadFull(r, l[:]); err != nil {
+			return err
+		}
+		blobLen := binary.BigEndian.Uint16(l[:])
+
+		*e = PeerStoragePayload(make([]byte, blobLen))
 		if _, err := io.ReadFull(r, *e); err != nil {
 			return err
 		}

--- a/lnwire/message.go
+++ b/lnwire/message.go
@@ -28,6 +28,8 @@ type MessageType uint16
 const (
 	MsgWarning                 MessageType = 1
 	MsgStfu                                = 2
+	MsgPeerStorage                         = 7
+	MsgPeerStorageRetrieval                = 9
 	MsgInit                                = 16
 	MsgError                               = 17
 	MsgPing                                = 18
@@ -121,6 +123,10 @@ func (t MessageType) String() string {
 		return "Warning"
 	case MsgStfu:
 		return "Stfu"
+	case MsgPeerStorage:
+		return "PeerStorage"
+	case MsgPeerStorageRetrieval:
+		return "PeerStorageRetrieval"
 	case MsgInit:
 		return "Init"
 	case MsgOpenChannel:
@@ -287,6 +293,10 @@ func makeEmptyMessage(msgType MessageType) (Message, error) {
 		msg = &Warning{}
 	case MsgStfu:
 		msg = &Stfu{}
+	case MsgPeerStorage:
+		msg = &PeerStorage{}
+	case MsgPeerStorageRetrieval:
+		msg = &PeerStorageRetrieval{}
 	case MsgInit:
 		msg = &Init{}
 	case MsgOpenChannel:

--- a/lnwire/peer_storage.go
+++ b/lnwire/peer_storage.go
@@ -1,0 +1,118 @@
+package lnwire
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+)
+
+const (
+	// MaxPeerStorageBlob is the maximum size of a peer storage blob in
+	// bytes. This is 65531 bytes per the BOLT specification, which is
+	// the maximum message payload (65535) minus the 2-byte type and
+	// 2-byte length prefix.
+	MaxPeerStorageBlob = 65531
+)
+
+// PeerStoragePayload is a set of opaque bytes that represent an encrypted
+// backup blob stored by a peer on our behalf, or by us on behalf of a peer.
+type PeerStoragePayload []byte
+
+// PeerStorage is the message (type 7) that a node sends to a connected peer
+// to request storage of an encrypted backup blob. The blob is opaque to the
+// storing peer.
+type PeerStorage struct {
+	// Blob is the encrypted backup data to be stored.
+	Blob PeerStoragePayload
+}
+
+// A compile time check to ensure PeerStorage implements the lnwire.Message
+// interface.
+var _ Message = (*PeerStorage)(nil)
+
+// A compile time check to ensure PeerStorage implements the
+// lnwire.SizeableMessage interface.
+var _ SizeableMessage = (*PeerStorage)(nil)
+
+// Decode deserializes a serialized PeerStorage message stored in the passed
+// io.Reader observing the specified protocol version.
+//
+// This is part of the lnwire.Message interface.
+func (p *PeerStorage) Decode(r io.Reader, pver uint32) error {
+	return ReadElements(r, &p.Blob)
+}
+
+// Encode serializes the target PeerStorage into the passed io.Writer
+// observing the protocol version specified.
+//
+// This is part of the lnwire.Message interface.
+func (p *PeerStorage) Encode(w *bytes.Buffer, pver uint32) error {
+	if len(p.Blob) > MaxPeerStorageBlob {
+		return fmt.Errorf("peer storage blob of size %d exceeds max "+
+			"size of %d", len(p.Blob), MaxPeerStorageBlob)
+	}
+
+	return WritePeerStoragePayload(w, p.Blob)
+}
+
+// MsgType returns the integer uniquely identifying this message type on the
+// wire.
+//
+// This is part of the lnwire.Message interface.
+func (p *PeerStorage) MsgType() MessageType {
+	return MsgPeerStorage
+}
+
+// SerializedSize returns the serialized size of the message in bytes.
+//
+// This is part of the lnwire.SizeableMessage interface.
+func (p *PeerStorage) SerializedSize() (uint32, error) {
+	return MessageSerializedSize(p)
+}
+
+// PeerStorageRetrieval is the message (type 9) that a node sends to a
+// connected peer upon reconnection to return the most recently stored
+// encrypted backup blob.
+type PeerStorageRetrieval struct {
+	// Blob is the encrypted backup data being returned.
+	Blob PeerStoragePayload
+}
+
+// A compile time check to ensure PeerStorageRetrieval implements the
+// lnwire.Message interface.
+var _ Message = (*PeerStorageRetrieval)(nil)
+
+// A compile time check to ensure PeerStorageRetrieval implements the
+// lnwire.SizeableMessage interface.
+var _ SizeableMessage = (*PeerStorageRetrieval)(nil)
+
+// Decode deserializes a serialized PeerStorageRetrieval message stored in the
+// passed io.Reader observing the specified protocol version.
+//
+// This is part of the lnwire.Message interface.
+func (p *PeerStorageRetrieval) Decode(r io.Reader, pver uint32) error {
+	return ReadElements(r, &p.Blob)
+}
+
+// Encode serializes the target PeerStorageRetrieval into the passed io.Writer
+// observing the protocol version specified.
+//
+// This is part of the lnwire.Message interface.
+func (p *PeerStorageRetrieval) Encode(w *bytes.Buffer, pver uint32) error {
+	return WritePeerStoragePayload(w, p.Blob)
+}
+
+// MsgType returns the integer uniquely identifying this message type on the
+// wire.
+//
+// This is part of the lnwire.Message interface.
+func (p *PeerStorageRetrieval) MsgType() MessageType {
+	return MsgPeerStorageRetrieval
+}
+
+// SerializedSize returns the serialized size of the message in bytes.
+//
+// This is part of the lnwire.SizeableMessage interface.
+func (p *PeerStorageRetrieval) SerializedSize() (uint32, error) {
+	return MessageSerializedSize(p)
+}

--- a/lnwire/writer.go
+++ b/lnwire/writer.go
@@ -243,6 +243,13 @@ func WritePongPayload(buf *bytes.Buffer, payload PongPayload) error {
 	return writeDataWithLength(buf, payload)
 }
 
+// WritePeerStoragePayload appends the payload to the provided buffer.
+func WritePeerStoragePayload(buf *bytes.Buffer,
+	payload PeerStoragePayload) error {
+
+	return writeDataWithLength(buf, payload)
+}
+
 // WriteWarningData appends the data to the provided buffer.
 func WriteWarningData(buf *bytes.Buffer, data WarningData) error {
 	return writeDataWithLength(buf, data)

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -2354,6 +2354,19 @@ out:
 				},
 			)
 
+		case *lnwire.PeerStorage:
+			// TODO(peer-storage): Handle incoming peer_storage
+			// message — validate and store the blob.
+			p.log.Debugf("Received peer_storage (%d bytes)",
+				len(msg.Blob))
+
+		case *lnwire.PeerStorageRetrieval:
+			// TODO(peer-storage): Handle incoming
+			// peer_storage_retrieval — decrypt and process the
+			// returned backup blob.
+			p.log.Infof("Received peer_storage_retrieval (%d "+
+				"bytes)", len(msg.Blob))
+
 		case *lnwire.Custom:
 			err := p.handleCustomMessage(msg)
 			if err != nil {

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -420,6 +420,11 @@ type Config struct {
 	// that is accumulated before signing a new commitment.
 	ChannelCommitBatchSize uint32
 
+	// HandlePeerStorage is called when a peer_storage message is received
+	// from a remote peer requesting that we store their encrypted backup
+	// blob.
+	HandlePeerStorage func(peer [33]byte, blob []byte) error
+
 	// HandleCustomMessage is called whenever a custom message is received
 	// from the peer.
 	HandleCustomMessage func(peer [33]byte, msg *lnwire.Custom) error
@@ -2355,10 +2360,15 @@ out:
 			)
 
 		case *lnwire.PeerStorage:
-			// TODO(peer-storage): Handle incoming peer_storage
-			// message — validate and store the blob.
-			p.log.Debugf("Received peer_storage (%d bytes)",
-				len(msg.Blob))
+			if p.cfg.HandlePeerStorage != nil {
+				err := p.cfg.HandlePeerStorage(
+					p.cfg.PubKeyBytes, msg.Blob,
+				)
+				if err != nil {
+					p.log.Warnf("Failed to handle "+
+						"peer_storage: %v", err)
+				}
+			}
 
 		case *lnwire.PeerStorageRetrieval:
 			// TODO(peer-storage): Handle incoming

--- a/server.go
+++ b/server.go
@@ -1680,6 +1680,10 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 		return nil, err
 	}
 
+	// Register a callback to distribute the packed SCB to peers that
+	// support option_provide_storage after each backup update.
+	s.chanSubSwapper.PostBackupFunc = s.distributePeerStorage
+
 	// Assemble a peer notifier which will provide clients with subscriptions
 	// to peer online and offline events.
 	s.peerNotifier = peernotifier.New()
@@ -5383,6 +5387,39 @@ func (s *server) SendCustomMessage(ctx context.Context, peerPub [33]byte,
 	// Send the message as low-priority. For now we assume that all
 	// application-defined message are low priority.
 	return peer.SendMessageLazy(true, msg)
+}
+
+// distributePeerStorage sends our encrypted SCB backup to all connected peers
+// that advertise option_provide_storage. This is called after each backup
+// update by the SubSwapper via PostBackupFunc.
+func (s *server) distributePeerStorage(backup chanbackup.PackedMulti) {
+	// Pad the blob to MaxPeerStorageBlob for privacy per the spec.
+	padded := make([]byte, lnwire.MaxPeerStorageBlob)
+	copy(padded, backup)
+
+	msg := &lnwire.PeerStorage{
+		Blob: padded,
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for pubStr, p := range s.peersByPub {
+		features := p.RemoteFeatures()
+		if features == nil {
+			continue
+		}
+
+		if !features.HasFeature(lnwire.ProvideStorageOptional) {
+			continue
+		}
+
+		srvrLog.Debugf("Sending peer_storage to peer %x", pubStr)
+		if err := p.SendMessageLazy(true, msg); err != nil {
+			srvrLog.Warnf("Failed to send peer_storage to "+
+				"peer %x: %v", pubStr, err)
+		}
+	}
 }
 
 // SendOnionMessage sends a custom message to the peer with the specified

--- a/server.go
+++ b/server.go
@@ -4503,6 +4503,7 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 		ChannelCommitInterval:  s.cfg.ChannelCommitInterval,
 		PendingCommitInterval:  s.cfg.PendingCommitInterval,
 		ChannelCommitBatchSize: s.cfg.ChannelCommitBatchSize,
+		HandlePeerStorage:      s.handlePeerStorage,
 		HandleCustomMessage:    s.handleCustomMessage,
 		GetAliases:             s.aliasMgr.GetAliases,
 		RequestAlias:           s.aliasMgr.RequestAlias,
@@ -5387,6 +5388,17 @@ func (s *server) SendCustomMessage(ctx context.Context, peerPub [33]byte,
 	// Send the message as low-priority. For now we assume that all
 	// application-defined message are low priority.
 	return peer.SendMessageLazy(true, msg)
+}
+
+// handlePeerStorage handles an incoming peer_storage message from a remote
+// peer by storing the encrypted backup blob in the database.
+func (s *server) handlePeerStorage(peer [33]byte, blob []byte) error {
+	peerVertex := route.Vertex(peer)
+
+	srvrLog.Debugf("Storing peer_storage from %x (%d bytes)",
+		peer, len(blob))
+
+	return s.miscDB.StorePeerStorage(peerVertex, blob)
 }
 
 // distributePeerStorage sends our encrypted SCB backup to all connected peers


### PR DESCRIPTION
This PR aims to integrate Peer Storage (option_provide_storage) feature to LND. Addresses #8154 

This is a **draft PR**, storage persistence and retrieval logic are not yet implemented (marked with TODOs).

TODO:
  - Persisting peer storage blobs (incoming `PeerStorage` from peers)                                        
  - Sending `PeerStorageRetrieval` on reconnection
  - Recovery flow upon finding a missing channel