### PR TITLE
docs: update README pkg.go.dev link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Release build](https://github.com/lightningnetwork/lnd/actions/workflows/release.yaml/badge.svg)](https://github.com/lightningnetwork/lnd/actions/workflows/release.yaml)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
 [![Irc](https://img.shields.io/badge/chat-on%20libera-brightgreen.svg)](https://web.libera.chat/#lnd)
-[![Godoc](https://godoc.org/github.com/lightningnetwork/lnd?status.svg)](https://godoc.org/github.com/lightningnetwork/lnd)
+[![pkg.go.dev](https://pkg.go.dev/badge/github.com/lightningnetwork/lnd.svg)](https://pkg.go.dev/github.com/lightningnetwork/lnd)
 [![Go Report Card](https://goreportcard.com/badge/github.com/lightningnetwork/lnd)](https://goreportcard.com/report/github.com/lightningnetwork/lnd)
 
 <img src="logo.png">

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Release build](https://github.com/lightningnetwork/lnd/actions/workflows/release.yaml/badge.svg)](https://github.com/lightningnetwork/lnd/actions/workflows/release.yaml)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
 [![Irc](https://img.shields.io/badge/chat-on%20libera-brightgreen.svg)](https://web.libera.chat/#lnd)
-[![pkg.go.dev](https://pkg.go.dev/badge/github.com/lightningnetwork/lnd.svg)](https://pkg.go.dev/github.com/lightningnetwork/lnd)
+[![Go Reference](https://pkg.go.dev/badge/github.com/lightningnetwork/lnd.svg)](https://pkg.go.dev/github.com/lightningnetwork/lnd)
 [![Go Report Card](https://goreportcard.com/badge/github.com/lightningnetwork/lnd)](https://goreportcard.com/report/github.com/lightningnetwork/lnd)
 
 <img src="logo.png">


### PR DESCRIPTION
## Summary
- replace the README Godoc badge and link with the current `pkg.go.dev` target for `github.com/lightningnetwork/lnd`
- keep the change limited to the top-level README badge row
- avoid sending readers through the deprecated `godoc.org` redirect when the canonical package docs now live on `pkg.go.dev`
