### PR TITLE
routerrpc: add XFindBaseLocalChanAlias to macPermissions

### DIFF
--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -168,6 +168,10 @@ var (
 			Entity: "offchain",
 			Action: "write",
 		}},
+		"/routerrpc.Router/XFindBaseLocalChanAlias": {{
+			Entity: "offchain",
+			Action: "read",
+		}},
 		"/routerrpc.Router/DeleteForwardingHistory": {{
 			Entity: "offchain",
 			Action: "write",


### PR DESCRIPTION
This RPC was missing from the macaroon permissions map, so this commit simply adds it with the appropriate "read" permission.