### PR TITLE
docs: fix release notes formatting guidelines link

### DIFF
--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -188,8 +188,8 @@ Please upgrade to `lnd v0.15.3-beta` or later directly!
   added](https://github.com/lightningnetwork/lnd/pull/6681) to autoconfigure
   most text editors to respect the 80 character line length and to use 8 spaces
   as the tab size. Rules for Visual Studio Code were also added. And finally,
-  the code formatting rules were extracted into their [own
-  document](../code_formatting_rules.md).
+  the code formatting rules were documented in the
+  [development guidelines](../development_guidelines.md#additional-style-constraints).
 
 # Contributors (Alphabetical Order)
 


### PR DESCRIPTION
## Summary
- replace the stale `../code_formatting_rules.md` link in `release-notes-0.15.1.md`
- point the note to the current formatting rules section in `docs/development_guidelines.md`
- keep the release note wording aligned with the current docs layout

## Testing
- not run (docs-only change)