### PR TITLE
docs: add missing protocol to sample-conf link

### DIFF
--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -162,7 +162,7 @@ Compiles the `lnrpc` proto files.
 
 `sample-conf-check`
 -------------------
-Checks whether all required options of `lnd --help` are included in [sample-lnd.conf](github.com/lightningnetwork/lnd/blob/master/sample-lnd.conf) and that the default values of `lnd --help` are also mentioned correctly.
+Checks whether all required options of `lnd --help` are included in [sample-lnd.conf](https://github.com/lightningnetwork/lnd/blob/master/sample-lnd.conf) and that the default values of `lnd --help` are also mentioned correctly.
 
 `scratch`
 ---------

--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -162,7 +162,7 @@ Compiles the `lnrpc` proto files.
 
 `sample-conf-check`
 -------------------
-Checks whether all required options of `lnd --help` are included in [sample-lnd.conf](../sample-lnd.conf) and that the default values of `lnd --help` are also mentioned correctly.
+Checks whether all required options from `lnd --help` are included in [`sample-lnd.conf`](../sample-lnd.conf) and whether the default values shown by `lnd --help` are documented correctly.
 
 `scratch`
 ---------

--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -162,7 +162,7 @@ Compiles the `lnrpc` proto files.
 
 `sample-conf-check`
 -------------------
-Checks whether all required options of `lnd --help` are included in [sample-lnd.conf](https://github.com/lightningnetwork/lnd/blob/master/sample-lnd.conf) and that the default values of `lnd --help` are also mentioned correctly.
+Checks whether all required options of `lnd --help` are included in [sample-lnd.conf](../sample-lnd.conf) and that the default values of `lnd --help` are also mentioned correctly.
 
 `scratch`
 ---------


### PR DESCRIPTION
## Summary
- add the missing `https://` protocol to the `sample-lnd.conf` link in `docs/MAKEFILE.md`
- keep the `sample-conf-check` description pointing at the same upstream file

## Testing
- not run (docs-only change)