### PR TITLE
docs: use repo-relative sample-lnd.conf link

### DIFF
--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -162,7 +162,7 @@ Compiles the `lnrpc` proto files.
 
 `sample-conf-check`
 -------------------
-Checks whether all required options of `lnd --help` are included in [sample-lnd.conf](github.com/lightningnetwork/lnd/blob/master/sample-lnd.conf) and that the default values of `lnd --help` are also mentioned correctly.
+Checks whether all required options of `lnd --help` are included in [sample-lnd.conf](../sample-lnd.conf) and that the default values of `lnd --help` are also mentioned correctly.
 
 `scratch`
 ---------


### PR DESCRIPTION
## Summary
- update the `sample-lnd.conf` link in `docs/MAKEFILE.md` to a repo-relative path
- keep the existing command description unchanged

## Why
The current link omits the protocol and resolves poorly from the docs page. A repo-relative link points to the in-repo file directly and matches the repo's preferred docs style for local targets.