### PR TITLE
onionmessage+peer: rate-limit incoming onion messages per-peer and globally

### DIFF
--- a/config.go
+++ b/config.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"os"
 	"os/user"
@@ -41,6 +42,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnutils"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/onionmessage"
 	"github.com/lightningnetwork/lnd/routing"
 	"github.com/lightningnetwork/lnd/signal"
 	"github.com/lightningnetwork/lnd/tor"
@@ -583,6 +585,43 @@ type GRPCConfig struct {
 	ClientAllowPingWithoutStream bool `long:"client-allow-ping-without-stream" description:"If true, the server allows keepalive pings from the client even when there are no active gRPC streams. This might be useful to keep the underlying HTTP/2 connection open for future requests."`
 }
 
+// maxOnionMsgWireSize is the largest on-the-wire size in bytes, including
+// the 2-byte message type prefix, that an OnionMessage can take. This is
+// the value the rate limiter charges via OnionMessage.WireSize() for a
+// max-sized message and therefore the tightest meaningful lower bound on
+// the configured burst: anything smaller would reject every max-sized
+// message even though the configured rate is positive.
+const maxOnionMsgWireSize = 2 + lnwire.MaxMsgBody
+
+// validateOnionMsgLimiter validates a single onion message rate limiter
+// kbps/burst-bytes pair. Both zero means "disabled"; both strictly positive
+// means "enabled"; a mismatched pair is rejected so that operator typos
+// surface at startup instead of silently disabling the limiter via the
+// constructor fallback path. When enabled, burst-bytes must also be at
+// least maxOnionMsgWireSize so that a single max-sized onion message
+// (lnwire.MaxMsgBody bytes of body plus the 2-byte message-type prefix
+// that WireSize charges for) can always fit in the token bucket;
+// otherwise rate.Limiter.AllowN would reject every call and silently
+// disable onion message forwarding.
+func validateOnionMsgLimiter(name string, kbps, burstBytes uint64) error {
+	if (kbps > 0) != (burstBytes > 0) {
+		return fmt.Errorf("%s kbps and burst-bytes must both be "+
+			"positive or both be zero; got kbps=%v "+
+			"burst-bytes=%v", name, kbps, burstBytes)
+	}
+	if burstBytes > 0 && burstBytes < maxOnionMsgWireSize {
+		return fmt.Errorf("%s burst-bytes=%v must be at least %v "+
+			"so a single max-sized onion message can fit in "+
+			"the bucket", name, burstBytes, maxOnionMsgWireSize)
+	}
+	if burstBytes > uint64(math.MaxInt) {
+		return fmt.Errorf("%s burst-bytes=%v exceeds maximum %v",
+			name, burstBytes, math.MaxInt)
+	}
+
+	return nil
+}
+
 // DefaultConfig returns all default values for the Config struct.
 //
 //nolint:ll
@@ -726,6 +765,16 @@ func DefaultConfig() Config {
 				Attempts: defaultLeaderCheckAttempts,
 				Backoff:  defaultLeaderCheckBackoff,
 			},
+		},
+		// Only the onion message rate limiter fields are explicitly
+		// initialized here; all other ProtocolOptions fields rely on
+		// Go zero values, which happen to be the historical defaults
+		// for those flags.
+		ProtocolOptions: &lncfg.ProtocolOptions{
+			OnionMsgPeerKbps:         onionmessage.DefaultPeerOnionMsgKbps,
+			OnionMsgPeerBurstBytes:   onionmessage.DefaultPeerOnionMsgBurstBytes,
+			OnionMsgGlobalKbps:       onionmessage.DefaultGlobalOnionMsgKbps,
+			OnionMsgGlobalBurstBytes: onionmessage.DefaultGlobalOnionMsgBurstBytes,
 		},
 		Gossip: &lncfg.Gossip{
 			MaxChannelUpdateBurst: discovery.DefaultMaxChannelUpdateBurst,
@@ -1074,6 +1123,27 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 
 	if _, err := validateAtplCfg(cfg.Autopilot); err != nil {
 		return nil, mkErr("error validating autopilot: %v", err)
+	}
+
+	// Validate the onion message rate limiter configuration. We reject
+	// the mismatched case where one of kbps/burst-bytes is strictly
+	// positive but the other is zero, which would silently disable the
+	// limiter and leave the operator unprotected. Both zero is fine and
+	// explicitly means "disabled"; both positive is fine and enables
+	// the limiter.
+	if err := validateOnionMsgLimiter(
+		"protocol.onion-msg-peer",
+		cfg.ProtocolOptions.OnionMsgPeerKbps,
+		cfg.ProtocolOptions.OnionMsgPeerBurstBytes,
+	); err != nil {
+		return nil, mkErr("%s", err)
+	}
+	if err := validateOnionMsgLimiter(
+		"protocol.onion-msg-global",
+		cfg.ProtocolOptions.OnionMsgGlobalKbps,
+		cfg.ProtocolOptions.OnionMsgGlobalBurstBytes,
+	); err != nil {
+		return nil, mkErr("%s", err)
 	}
 
 	// Ensure that --maxchansize is properly handled when set by user.

--- a/config_onion_ratelimit_test.go
+++ b/config_onion_ratelimit_test.go
@@ -1,0 +1,90 @@
+package lnd
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateOnionMsgLimiter exercises every branch of
+// validateOnionMsgLimiter: the happy-path cases (both zero, both positive
+// with adequate burst) and every rejection branch (mismatched pair and
+// undersized burst). Startup config validation is the first line of
+// defense against a typo silently disabling the limiter, so every branch
+// is exercised explicitly.
+func TestValidateOnionMsgLimiter(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		kbps       uint64
+		burstBytes uint64
+		wantErr    string
+	}{
+		{
+			name:       "both zero disables",
+			kbps:       0,
+			burstBytes: 0,
+		},
+		{
+			name:       "both positive enables",
+			kbps:       512,
+			burstBytes: 8 * 32 * 1024,
+		},
+		{
+			name:       "large values pass",
+			kbps:       1_000_000,
+			burstBytes: 1_000_000,
+		},
+		{
+			name:       "burst exactly at min allowed",
+			kbps:       1,
+			burstBytes: 2 + lnwire.MaxMsgBody,
+		},
+		{
+			name: "burst one below min max-msg wire size " +
+				"rejected",
+			kbps:       1,
+			burstBytes: 1 + lnwire.MaxMsgBody,
+			wantErr:    "must be at least 65535",
+		},
+		{
+			name:       "positive kbps zero burst rejected",
+			kbps:       512,
+			burstBytes: 0,
+			wantErr: "kbps and burst-bytes must both be " +
+				"positive or both be zero",
+		},
+		{
+			name:       "zero kbps positive burst rejected",
+			kbps:       0,
+			burstBytes: 65_536,
+			wantErr: "kbps and burst-bytes must both be " +
+				"positive or both be zero",
+		},
+		{
+			name: "burst below maxOnionMsgWireSize " +
+				"rejected",
+			kbps:       512,
+			burstBytes: 1024,
+			wantErr: "burst-bytes=1024 must be at least " +
+				"65535",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateOnionMsgLimiter(
+				"test", tc.kbps, tc.burstBytes,
+			)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}

--- a/docs/onion_message_rate_limiting.md
+++ b/docs/onion_message_rate_limiting.md
@@ -1,0 +1,221 @@
+# Onion Message Rate Limiting
+
+Your node forwards an onion message. The peer on the other side paid
+nothing. You paid for the bandwidth that carried it, the CPU that peeled
+one Sphinx layer off it, and the disk I/O that checked its HMAC against
+the replay database. That asymmetry is the whole problem this document
+is about.
+
+This guide explains how lnd bounds the cost of forwarded onion messages
+and why each piece of the defense exists. The audience is operators who
+want to understand what the knobs do before turning them, and
+contributors who want the shape of the system before they read the code.
+
+## The adversary
+
+Picture a peer that sends you a maximum-size onion message as fast as
+its link allows. Nothing in the protocol asks it to pay per message, so
+it keeps going. Forwarding is the escape hatch a spammer wants: free
+bandwidth, reachable anywhere on the network, impossible to charge for
+individually.
+
+Now picture a peer that does this from a thousand identities at once. A
+single-peer bandwidth cap does not stop it. Ten thousand peers each
+sending a modest trickle can still saturate any aggregate cap you
+choose, if new identities are free to mint.
+
+lnd's defense runs in two layers. The first turns peer identity into a
+capital cost so that mint-at-will stops working. The second caps the
+bandwidth any one peer and the node as a whole can burn on onion
+messages. The two layers compose: cheap Sybils hit the first gate, a
+legitimate peer that goes off the rails hits the second.
+
+## Layer one: the channel-presence gate
+
+Before the rate limiters see an incoming onion message, lnd asks a
+blunt question about the peer that sent it: does this peer have at
+least one fully open channel with us? If not, the message is dropped.
+No tokens debited, no Sphinx work done, no replay lookup issued.
+
+A funded channel is the cheapest thing lnd has that an attacker cannot
+fake. Opening one costs an on-chain transaction fee and locks up
+capital in a funding output. That cost is small for an honest peer
+that plans to use the channel; it is prohibitive for an attacker that
+wants ten thousand disposable identities. The gate inherits that
+economic property for free.
+
+Pending channels do not satisfy the gate. They are deliberately
+excluded: a pending channel is one where we have sent or received a
+funding transaction but the channel is not yet confirmed, so the
+capital is not yet locked in. Pending channels are also cheap to open
+and, under adversarial conditions, easy to leave stuck. Counting them
+would hand the attacker the same free-identity primitive the gate
+exists to remove.
+
+The gate runs on a hot path — every onion message pays its cost. It
+reads one atomic counter that shadows the count of fully-open channels
+for the peer, which keeps the check to a single `Load` instruction. No
+map iteration, no lock.
+
+## Layer two: the rate limiters
+
+Past the gate, two token-bucket limiters bound the bandwidth onion
+messages can consume.
+
+- The **per-peer** limiter draws from one bucket per peer key. A peer
+  that opens its throttle to the wall hits this first.
+- The **global** limiter draws from a single bucket shared across the
+  whole node. A thousand peers each sending just under their per-peer
+  cap hit this.
+
+The two run in series: per-peer first, global second. A peer whose
+own bucket is empty never gets to debit the global bucket on a
+rejected attempt, so a hostile peer cannot drain the shared budget by
+sending messages it knows will be dropped.
+
+### Tokens are bytes, not messages
+
+The buckets hold bytes. Each onion message debits its on-the-wire
+size. A small control message pays proportionally less of the budget
+than a spec-maximum 32 KiB one. The configured limits therefore
+reflect bandwidth, not message counts — which is the thing operators
+actually care about when they decide how much of their pipe to give
+away.
+
+The alternative — counting raw messages — lets an attacker choose the
+worst cost profile and pay a fixed count for it. Byte accounting
+denies the attacker that optimization.
+
+### Per-peer state lives across disconnect
+
+The per-peer bucket does not reset when the peer disconnects. If it
+did, a hostile peer could cycle the connection to roll its bucket
+back to full. Instead, the bucket is keyed by the peer's compressed
+public key and retained. The memory footprint is bounded by the
+channel-presence gate: only peers with a channel ever allocate a
+per-peer bucket in the first place, so the set cannot grow
+unboundedly through connection churn.
+
+## The escape hatch: `protocol.onion-msg-relay-all`
+
+Some operators run nodes that are supposed to accept onion messages
+from everywhere: test nodes, public relays, research nodes. For those
+cases `protocol.onion-msg-relay-all=true` disables the
+channel-presence gate. Messages from peers with no channel are
+admitted into the rate-limiter pipeline as if the gate were not
+there. The rate limiters still apply.
+
+The tradeoff is explicit: you trade the Sybil-resistance property of
+the gate for reachability. With `relay-all=true`, a peer that costs
+nothing to spin up can now burn a full per-peer byte budget on each
+identity. The global limiter is the only line of defense left. Only
+enable this if you understand that and are willing to sit behind the
+global cap alone.
+
+The default is `false`. For an ordinary routing or personal node,
+leaving it off is the right choice.
+
+## The knobs
+
+All four onion-message rate-limit settings live under the `protocol`
+section.
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `protocol.onion-msg-peer-kbps` | `512` | Per-peer sustained rate in decimal kilobits per second. |
+| `protocol.onion-msg-peer-burst-bytes` | `262144` | Per-peer token bucket depth in bytes. |
+| `protocol.onion-msg-global-kbps` | `5120` | Global sustained rate in decimal kilobits per second. |
+| `protocol.onion-msg-global-burst-bytes` | `1638400` | Global token bucket depth in bytes. |
+| `protocol.onion-msg-relay-all` | `false` | If true, skip the channel-presence gate. |
+
+### Rules at startup
+
+A few configurations are invalid and rejected before the node starts:
+
+- A rate with a zero burst, or a burst with a zero rate, is rejected.
+  Either both are positive (the limiter is enabled) or both are zero
+  (the limiter is disabled). Mixing the two would silently disable
+  the limiter and leave the operator thinking they had protection.
+- A burst smaller than the maximum-sized onion message wire size
+  (65535 bytes) is rejected. A bucket that cannot fit a single valid
+  message would reject every call, regardless of the rate.
+
+Both of these are startup errors, not runtime ones — the node fails
+fast so that the operator sees the mistake immediately.
+
+### Default sizing
+
+The defaults assume a routing node that wants onion-message forwarding
+to be present but not dominant.
+
+- `0.5 Mbps` per peer, `5 Mbps` globally. An individual peer is
+  capped well below a typical residential uplink; the aggregate is
+  sized so onion message forwarding cannot dwarf the bandwidth a
+  routing node uses for payments.
+- `256 KiB` per-peer burst, `1.6 MiB` global burst. Both are many
+  multiples of a spec-max message, so short bursts of legitimate
+  traffic are absorbed without rejection, and the long-term rate
+  remains bounded by the kbps settings.
+- At default rates, ten peers pushing their per-peer allowance
+  simultaneously exactly fills the global budget. Push the per-peer
+  rate down or the global rate up if you expect many onion-active
+  peers.
+
+## Operator recipes
+
+**I want to disable the per-peer limiter, keep only the global cap.**
+Set both per-peer values to zero:
+
+```
+protocol.onion-msg-peer-kbps=0
+protocol.onion-msg-peer-burst-bytes=0
+```
+
+The global limiter still runs. Be aware you have given up the per-peer
+fairness: one loud peer can consume the entire global budget.
+
+**I want to disable all rate limiting on this feature.** Set all four
+values to zero. Read the adversary section above first; if you are not
+sure whether you want this, you do not want this.
+
+**I want to run a public relay that accepts onion messages from
+anyone.** Enable the relay-all flag and raise the global cap:
+
+```
+protocol.onion-msg-relay-all=true
+protocol.onion-msg-global-kbps=51200
+protocol.onion-msg-global-burst-bytes=16384000
+```
+
+You are now defended by the global cap alone. Monitor traffic.
+
+**I run a hobbyist node and never use onion messages myself.**
+Leave the defaults. Onion-message traffic will land below the caps
+and you will never notice them.
+
+## What happens when a limiter trips
+
+The first time either limiter trips, lnd emits a one-shot info log so
+you can tell that a cap has become load-bearing.
+
+- Per-peer trips log with the peer's own log prefix, so you know
+  which peer drove it.
+- Global trips log without a peer prefix — the shared bucket is not
+  attributable to any single peer.
+
+Subsequent drops are logged at trace level. A sustained attack
+therefore does not flood your logs; the single info line already tells
+you the system is engaged.
+
+The limiter tracks a per-limiter drop counter you can read from the
+logs or through diagnostics. Rising drop counts on the per-peer side
+usually mean you should look at which peer is responsible; rising
+drops on the global side usually mean the aggregate cap is too tight
+for your traffic.
+
+## Further reading
+
+- Release notes for the feature:
+  [#10713](https://github.com/lightningnetwork/lnd/pull/10713).
+- Onion message specification in the BOLTs:
+  [BOLT 4](https://github.com/lightning/bolts/blob/master/04-onion-routing.md).

--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -116,6 +116,28 @@
   protocol state machine and invalidating nonces after each signing round
   completes.
 
+* [Added rate limiting and a channel-presence gate for incoming onion
+  messages](https://github.com/lightningnetwork/lnd/pull/10713). Two new
+  byte-denominated token-bucket limiters run at ingress — one per peer, one
+  global — so small onion messages pay proportionally less of the budget
+  than spec-max ones. Defaults are `0.5 Mbps` (512 Kbps, 256 KiB burst) per
+  peer and `5 Mbps` (5120 Kbps, 1600 KiB burst) globally, tunable via
+  `protocol.onion-msg-peer-kbps`,
+  `protocol.onion-msg-peer-burst-bytes`,
+  `protocol.onion-msg-global-kbps`, and
+  `protocol.onion-msg-global-burst-bytes`. Setting both the rate and the
+  burst of a given limiter to `0` disables it; setting only one to `0`, or
+  a burst smaller than a maximum-sized onion message, is rejected at
+  startup. Incoming onion messages from peers with no fully open channel
+  are also dropped at ingress as a Sybil-resistance layer; pending
+  channels are excluded. Operators who want to accept onion messages
+  from peers regardless of channel state can set
+  `protocol.onion-msg-relay-all=true` to skip the channel-presence gate;
+  the rate limiters still apply. See
+  [docs/onion_message_rate_limiting.md](../onion_message_rate_limiting.md)
+  for the adversary model, the layers, the defaults, and operator
+  recipes.
+
 ## RPC Additions
 
 * [Added `DeleteForwardingHistory`

--- a/itest/lnd_onion_message_forward_test.go
+++ b/itest/lnd_onion_message_forward_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/lnrpc"
@@ -40,14 +41,22 @@ type onionMessageTestCase struct {
 // multiple scenarios including forwarding by node ID, by SCID, and with
 // concatenated blinded paths.
 func testOnionMessageForwarding(ht *lntest.HarnessTest) {
-	// Spin up three nodes for the test network.
-	alice := ht.NewNodeWithCoins("Alice", nil)
-	bob := ht.NewNodeWithCoins("Bob", nil)
-	carol := ht.NewNode("Carol", nil)
-
-	// Connect nodes so they can share gossip and forward messages.
-	ht.ConnectNodesPerm(alice, bob)
-	ht.ConnectNodesPerm(bob, carol)
+	// Spin up a three-node chain Alice -> Bob -> Carol, with both
+	// channels opened up front via CreateSimpleNetwork. Opening the
+	// channels before any forwarding run matters because onion message
+	// ingress is gated on having at least one fully open channel with
+	// the sending peer, so without these channels every hop would
+	// silently drop the message. The Bob -> Carol channel also doubles
+	// as the SCID source for the "forward via scid" test case, which
+	// keeps the per-test setup minimal.
+	chanPoints, nodes := ht.CreateSimpleNetwork(
+		[][]string{nil, nil, nil},
+		lntest.OpenChannelParams{
+			Amt: btcutil.Amount(100_000),
+		},
+	)
+	alice, bob, carol := nodes[0], nodes[1], nodes[2]
+	bobCarolChan := chanPoints[1]
 
 	testCases := []onionMessageTestCase{
 		{
@@ -69,16 +78,10 @@ func testOnionMessageForwarding(ht *lntest.HarnessTest) {
 			setup: func(ht *lntest.HarnessTest, alice, bob,
 				carol *node.HarnessNode) {
 
-				// Open a channel between Bob and Carol so we
-				// have an SCID to use.
-				chanPoint := ht.OpenChannel(
-					bob, carol,
-					lntest.OpenChannelParams{Amt: 100000},
-				)
-
-				// Wait for the channel to be in the graph so
-				// the SCID can be resolved.
-				ht.AssertChannelInGraph(bob, chanPoint)
+				// The Bob -> Carol channel was opened up
+				// front; just wait for it to be in the graph
+				// so the SCID can be resolved.
+				ht.AssertChannelInGraph(bob, bobCarolChan)
 			},
 			buildPath: func(ht *lntest.HarnessTest, alice, bob,
 				carol *node.HarnessNode) (

--- a/itest/lnd_onion_message_test.go
+++ b/itest/lnd_onion_message_test.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lntest"
@@ -15,7 +16,11 @@ import (
 
 // testOnionMessage tests sending and receiving of the onion message type.
 func testOnionMessage(ht *lntest.HarnessTest) {
-	alice := ht.NewNode("Alice", nil)
+	// Alice needs coins to fund a channel with Bob: onion message ingress
+	// is gated on the sender and receiver sharing at least one fully open
+	// channel as the Sybil-resistance layer on top of the byte-granular
+	// rate limiter.
+	alice := ht.NewNodeWithCoins("Alice", nil)
 	bob := ht.NewNode("Bob", nil)
 
 	// Subscribe Alice to onion messages before we send any, so that we
@@ -45,8 +50,14 @@ func testOnionMessage(ht *lntest.HarnessTest) {
 		}
 	}()
 
-	// Connect alice and bob so that they can exchange messages.
+	// Connect alice and bob and open a channel between them. Onion message
+	// ingress is gated on having at least one fully open channel with the
+	// sending peer, so without a channel Alice would silently drop Bob's
+	// message and the test would time out.
 	ht.EnsureConnected(alice, bob)
+	ht.OpenChannel(alice, bob, lntest.OpenChannelParams{
+		Amt: btcutil.Amount(100_000),
+	})
 
 	// Build a valid onion message destined for Alice.
 	alicePubKey, err := btcec.ParsePubKey(alice.PubKey[:])

--- a/lncfg/protocol.go
+++ b/lncfg/protocol.go
@@ -97,6 +97,16 @@ type ProtocolOptions struct {
 	// with a zero rate, disables the global limiter.
 	OnionMsgGlobalBurstBytes uint64 `long:"onion-msg-global-burst-bytes" description:"token bucket burst for the global onion message limiter, in bytes; set both this and onion-msg-global-kbps to 0 to disable the global limiter"`
 
+	// OnionMsgRelayAll disables the channel-presence gate on the onion
+	// message ingress path. When false (the default), incoming onion
+	// messages from peers that do not have at least one fully open
+	// channel with us are dropped before the rate limiters are
+	// consulted: without a funded channel, a new peer identity is free
+	// and the global rate limiter alone is easy to saturate. Setting
+	// this to true admits onion messages from any peer into the
+	// limiter pipeline, at the cost of that Sybil-resistance property.
+	OnionMsgRelayAll bool `long:"onion-msg-relay-all" description:"accept incoming onion messages from peers with no fully open channel; by default only peers with at least one active channel are admitted to the onion message ingress path"`
+
 	// NoExperimentalAccountabilityOption disables experimental accountability.
 	NoExperimentalAccountabilityOption bool `long:"no-experimental-accountability" description:"do not forward experimental accountability signals"`
 

--- a/lncfg/protocol.go
+++ b/lncfg/protocol.go
@@ -74,6 +74,29 @@ type ProtocolOptions struct {
 	// NoOnionMessagesOption disables onion message forwarding.
 	NoOnionMessagesOption bool `long:"no-onion-messages" description:"disable support for onion messaging"`
 
+	// OnionMsgPeerKbps is the maximum sustained onion message ingress
+	// bandwidth, in decimal kilobits per second (1 Kbps = 1000 bits/s),
+	// that will be accepted from any single peer. Setting this to zero,
+	// together with a zero burst, disables the per-peer onion message
+	// rate limiter.
+	OnionMsgPeerKbps uint64 `long:"onion-msg-peer-kbps" description:"max onion message ingress rate from a single peer, in decimal kilobits per second; set both this and onion-msg-peer-burst-bytes to 0 to disable the per-peer limiter"`
+
+	// OnionMsgPeerBurstBytes is the token bucket depth, in bytes, used
+	// by the per-peer onion message rate limiter. A value of zero,
+	// paired with a zero rate, disables the per-peer limiter.
+	OnionMsgPeerBurstBytes uint64 `long:"onion-msg-peer-burst-bytes" description:"token bucket burst for the per-peer onion message limiter, in bytes; set both this and onion-msg-peer-kbps to 0 to disable the per-peer limiter"`
+
+	// OnionMsgGlobalKbps is the maximum sustained onion message ingress
+	// bandwidth, in decimal kilobits per second, that will be accepted
+	// across all peers combined. Setting this to zero, together with a
+	// zero burst, disables the global onion message rate limiter.
+	OnionMsgGlobalKbps uint64 `long:"onion-msg-global-kbps" description:"max onion message ingress rate across all peers combined, in decimal kilobits per second; set both this and onion-msg-global-burst-bytes to 0 to disable the global limiter"`
+
+	// OnionMsgGlobalBurstBytes is the token bucket depth, in bytes, used
+	// by the global onion message rate limiter. A value of zero, paired
+	// with a zero rate, disables the global limiter.
+	OnionMsgGlobalBurstBytes uint64 `long:"onion-msg-global-burst-bytes" description:"token bucket burst for the global onion message limiter, in bytes; set both this and onion-msg-global-kbps to 0 to disable the global limiter"`
+
 	// NoExperimentalAccountabilityOption disables experimental accountability.
 	NoExperimentalAccountabilityOption bool `long:"no-experimental-accountability" description:"do not forward experimental accountability signals"`
 

--- a/lncfg/protocol_integration.go
+++ b/lncfg/protocol_integration.go
@@ -77,6 +77,29 @@ type ProtocolOptions struct {
 	// NoOnionMessagesOption disables onion message forwarding.
 	NoOnionMessagesOption bool `long:"no-onion-messages" description:"disable support for onion messaging"`
 
+	// OnionMsgPeerKbps is the maximum sustained onion message ingress
+	// bandwidth, in decimal kilobits per second (1 Kbps = 1000 bits/s),
+	// that will be accepted from any single peer. Setting this to zero,
+	// together with a zero burst, disables the per-peer onion message
+	// rate limiter.
+	OnionMsgPeerKbps uint64 `long:"onion-msg-peer-kbps" description:"max onion message ingress rate from a single peer, in decimal kilobits per second; set both this and onion-msg-peer-burst-bytes to 0 to disable the per-peer limiter"`
+
+	// OnionMsgPeerBurstBytes is the token bucket depth, in bytes, used
+	// by the per-peer onion message rate limiter. A value of zero,
+	// paired with a zero rate, disables the per-peer limiter.
+	OnionMsgPeerBurstBytes uint64 `long:"onion-msg-peer-burst-bytes" description:"token bucket burst for the per-peer onion message limiter, in bytes; set both this and onion-msg-peer-kbps to 0 to disable the per-peer limiter"`
+
+	// OnionMsgGlobalKbps is the maximum sustained onion message ingress
+	// bandwidth, in decimal kilobits per second, that will be accepted
+	// across all peers combined. Setting this to zero, together with a
+	// zero burst, disables the global onion message rate limiter.
+	OnionMsgGlobalKbps uint64 `long:"onion-msg-global-kbps" description:"max onion message ingress rate across all peers combined, in decimal kilobits per second; set both this and onion-msg-global-burst-bytes to 0 to disable the global limiter"`
+
+	// OnionMsgGlobalBurstBytes is the token bucket depth, in bytes, used
+	// by the global onion message rate limiter. A value of zero, paired
+	// with a zero rate, disables the global limiter.
+	OnionMsgGlobalBurstBytes uint64 `long:"onion-msg-global-burst-bytes" description:"token bucket burst for the global onion message limiter, in bytes; set both this and onion-msg-global-kbps to 0 to disable the global limiter"`
+
 	// NoExperimentalAccountabilityOption disables experimental accountability.
 	NoExperimentalAccountabilityOption bool `long:"no-experimental-accountability" description:"do not forward experimental accountability signals"`
 

--- a/lncfg/protocol_integration.go
+++ b/lncfg/protocol_integration.go
@@ -100,6 +100,16 @@ type ProtocolOptions struct {
 	// with a zero rate, disables the global limiter.
 	OnionMsgGlobalBurstBytes uint64 `long:"onion-msg-global-burst-bytes" description:"token bucket burst for the global onion message limiter, in bytes; set both this and onion-msg-global-kbps to 0 to disable the global limiter"`
 
+	// OnionMsgRelayAll disables the channel-presence gate on the onion
+	// message ingress path. When false (the default), incoming onion
+	// messages from peers that do not have at least one fully open
+	// channel with us are dropped before the rate limiters are
+	// consulted: without a funded channel, a new peer identity is free
+	// and the global rate limiter alone is easy to saturate. Setting
+	// this to true admits onion messages from any peer into the
+	// limiter pipeline, at the cost of that Sybil-resistance property.
+	OnionMsgRelayAll bool `long:"onion-msg-relay-all" description:"accept incoming onion messages from peers with no fully open channel; by default only peers with at least one active channel are admitted to the onion message ingress path"`
+
 	// NoExperimentalAccountabilityOption disables experimental accountability.
 	NoExperimentalAccountabilityOption bool `long:"no-experimental-accountability" description:"do not forward experimental accountability signals"`
 

--- a/lnutils/sync_map.go
+++ b/lnutils/sync_map.go
@@ -96,3 +96,24 @@ func (m *SyncMap[K, V]) LoadOrStore(key K, value V) (V, bool) {
 
 	return item, loaded
 }
+
+// Swap stores value for the given key and returns the previously stored
+// value (if any). The second return value reports whether a previous
+// value was present. It is a thin typed wrapper around sync.Map.Swap so
+// callers that need to atomically read-modify-write a map entry — for
+// example, to update an atomic counter that shadows the map's
+// membership — can do so without dropping down to untyped interface{}
+// assertions.
+func (m *SyncMap[K, V]) Swap(key K, value V) (V, bool) {
+	prev, loaded := m.Map.Swap(key, value)
+	if !loaded {
+		return *new(V), false
+	}
+
+	item, ok := prev.(V)
+	if !ok {
+		return *new(V), false
+	}
+
+	return item, true
+}

--- a/lnutils/sync_map_test.go
+++ b/lnutils/sync_map_test.go
@@ -202,3 +202,46 @@ func TestSyncMapLoadOrStore(t *testing.T) {
 	require.True(t, loaded)
 	require.Equal(t, "two", item)
 }
+
+// TestSyncMapSwap tests the Swap method of the SyncMap type.
+func TestSyncMapSwap(t *testing.T) {
+	t.Parallel()
+
+	// Create a new SyncMap of string keys and integer values.
+	m := &lnutils.SyncMap[string, int]{}
+
+	// Swapping into an empty key should store the value and report no
+	// previous entry.
+	prev, loaded := m.Swap("foo", 42)
+	require.False(t, loaded)
+	require.Equal(t, 0, prev)
+
+	// The value should now be retrievable via Load.
+	value, ok := m.Load("foo")
+	require.True(t, ok)
+	require.Equal(t, 42, value)
+
+	// Swapping an existing key should return the previous value and
+	// report that it was present.
+	prev, loaded = m.Swap("foo", 99)
+	require.True(t, loaded)
+	require.Equal(t, 42, prev)
+
+	// Load should now return the new value.
+	value, ok = m.Load("foo")
+	require.True(t, ok)
+	require.Equal(t, 99, value)
+
+	// Swapping a second key should not affect the first.
+	prev, loaded = m.Swap("bar", 7)
+	require.False(t, loaded)
+	require.Equal(t, 0, prev)
+
+	value, ok = m.Load("foo")
+	require.True(t, ok)
+	require.Equal(t, 99, value)
+
+	value, ok = m.Load("bar")
+	require.True(t, ok)
+	require.Equal(t, 7, value)
+}

--- a/lnwire/onion_message.go
+++ b/lnwire/onion_message.go
@@ -82,9 +82,26 @@ func (o *OnionMessage) MsgType() MessageType {
 	return MsgOnionMessage
 }
 
+// WireSize returns the on-the-wire size of the message in bytes, including
+// the 2-byte message type prefix, the 33-byte compressed path key, the
+// 2-byte onion blob length prefix, and the onion blob itself. It computes
+// the size directly from the in-memory fields rather than round-tripping
+// through Encode, so callers in the hot ingress path — notably the onion
+// message rate limiter — can charge the right number of byte tokens
+// without paying for a full serialization.
+func (o *OnionMessage) WireSize() int {
+	const (
+		msgTypeBytes  = 2
+		pathKeyBytes  = 33
+		onionLenBytes = 2
+	)
+
+	return msgTypeBytes + pathKeyBytes + onionLenBytes + len(o.OnionBlob)
+}
+
 // SerializedSize returns the serialized size of the message in bytes.
 //
 // This is part of the lnwire.SizeableMessage interface.
 func (o *OnionMessage) SerializedSize() (uint32, error) {
-	return MessageSerializedSize(o)
+	return uint32(o.WireSize()), nil
 }

--- a/lnwire/onion_message_test.go
+++ b/lnwire/onion_message_test.go
@@ -1,0 +1,39 @@
+package lnwire
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// TestOnionMessageWireSizeMatchesEncode verifies that the value produced by
+// OnionMessage.WireSize — the value fed to the onion message rate limiter on
+// every incoming packet — matches the number of bytes WriteMessage actually
+// emits for that same message. WireSize computes its result directly from the
+// in-memory fields without round-tripping through Encode, which is fast but
+// creates a risk of silent divergence if the OnionMessage wire format ever
+// gains an optional TLV extension or extra field. This test is the
+// compile-time-cheap regression guard that divergence does not go undetected.
+func TestOnionMessageWireSizeMatchesEncode(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		msg, ok := (*OnionMessage)(nil).RandTestMessage(
+			rt,
+		).(*OnionMessage)
+		require.True(
+			rt, ok, "RandTestMessage did "+
+				"not return an OnionMessage",
+		)
+
+		var buf bytes.Buffer
+		written, err := WriteMessage(&buf, msg, 0)
+		require.NoError(rt, err, "WriteMessage error")
+		require.Equal(rt, written, msg.WireSize(),
+			"WireSize=%d, WriteMessage wrote=%d bytes",
+			msg.WireSize(), written,
+		)
+	})
+}

--- a/onionmessage/actor.go
+++ b/onionmessage/actor.go
@@ -25,11 +25,48 @@ const (
 	// messages are dropped. Must be strictly less than
 	// DefaultOnionMailboxSize.
 	DefaultMinREDThreshold = 40
+
+	// DefaultPeerOnionMsgKbps is the default sustained per-peer onion
+	// message ingress rate, in decimal kilobits per second (1 Kbps =
+	// 1000 bits/s). Sizing is expressed against a 32 KiB onion_message
+	// packet (the BOLT 4 spec cap on the sphinx-level payload inside
+	// onion_message), not the 65 KiB lnwire envelope cap — at ~32 KiB
+	// per packet this is roughly two such messages per second per peer.
+	// A value of zero disables the per-peer limiter entirely.
+	DefaultPeerOnionMsgKbps = 512
+
+	// DefaultPeerOnionMsgBurstBytes is the default per-peer token bucket
+	// depth, in bytes. Sized to hold approximately eight 32 KiB onion
+	// message packets (see DefaultPeerOnionMsgKbps for why we measure
+	// against 32 KiB rather than the 65 KiB lnwire envelope cap) so a
+	// peer can briefly burst above the sustained rate without drops.
+	DefaultPeerOnionMsgBurstBytes = 8 * 32 * 1024
+
+	// DefaultGlobalOnionMsgKbps is the default sustained aggregate onion
+	// message ingress rate across all peers, in decimal kilobits per
+	// second. Targets ~5 Mbps worst-case ingress so that onion message
+	// bandwidth cannot dwarf a typical routing node's payment traffic.
+	// A value of zero disables the global limiter entirely.
+	DefaultGlobalOnionMsgKbps = 5120
+
+	// DefaultGlobalOnionMsgBurstBytes is the default global token bucket
+	// depth, in bytes. Sized to hold approximately fifty 32 KiB onion
+	// message packets, measured against the BOLT 4 onion_message_packet
+	// cap rather than the 65 KiB lnwire envelope cap (see
+	// DefaultPeerOnionMsgKbps).
+	DefaultGlobalOnionMsgBurstBytes = 50 * 32 * 1024
 )
 
 // Compile-time assertion: DefaultMinREDThreshold must be strictly less than
 // DefaultOnionMailboxSize. If this overflows, the constants are misconfigured.
 const _ = uint(DefaultOnionMailboxSize - DefaultMinREDThreshold - 1)
+
+// Compile-time assertions: the default burst sizes must be able to hold at
+// least one maximum-sized wire message, otherwise every AllowN call on a
+// freshly constructed limiter would fail and the limiter would silently
+// drop all onion traffic.
+const _ = uint(DefaultPeerOnionMsgBurstBytes - lnwire.MaxMsgBody)
+const _ = uint(DefaultGlobalOnionMsgBurstBytes - lnwire.MaxMsgBody)
 
 // Request is a message sent to an OnionPeerActor when an onion message is
 // received from the peer. The actor processes the message through the full

--- a/onionmessage/ratelimit.go
+++ b/onionmessage/ratelimit.go
@@ -1,0 +1,320 @@
+package onionmessage
+
+import (
+	"errors"
+	"sync/atomic"
+	"time"
+
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/lnutils"
+	"golang.org/x/time/rate"
+)
+
+var (
+	// ErrPeerRateLimit is the sentinel error returned by
+	// IngressLimiter.AllowN when the per-peer token bucket rejects an
+	// incoming onion message. Callers match on it with errors.Is to
+	// distinguish per-peer drops from global drops.
+	ErrPeerRateLimit = errors.New("per-peer rate limit exceeded")
+
+	// ErrGlobalRateLimit is the sentinel error returned by
+	// IngressLimiter.AllowN when the global token bucket rejects an
+	// incoming onion message. Callers match on it with errors.Is to
+	// distinguish global drops from per-peer drops.
+	ErrGlobalRateLimit = errors.New("global rate limit exceeded")
+)
+
+// kbpsToBytesPerSecond converts a configured kilobits-per-second value into
+// bytes-per-second, suitable for passing to rate.NewLimiter. A Kbps value is
+// decimal (1 Kbps = 1000 bits/second) so the conversion factor is 125.
+func kbpsToBytesPerSecond(kbps uint64) float64 {
+	return float64(kbps) * 125.0
+}
+
+// RateLimiter is the minimal token-bucket interface used at the onion message
+// ingress path. Tokens are bytes: each call reports whether a message of size
+// n bytes is permitted to proceed, and on success consumes n bytes from the
+// underlying bucket. The interface is satisfied by *rate.Limiter (via a small
+// counting wrapper) and a noop implementation used when a limit is configured
+// as zero (disabled). It exists so that callers and tests can substitute
+// alternate implementations without taking a hard dependency on the
+// x/time/rate package.
+//
+// Implementations of AllowN must be safe for concurrent use by multiple
+// goroutines; the ingress call site invokes it from per-peer readHandler
+// goroutines without additional synchronization.
+type RateLimiter interface {
+	// AllowN reports whether an onion message of n bytes is permitted
+	// to proceed at the current instant. It must be non-blocking and
+	// safe for concurrent use.
+	AllowN(n int) bool
+}
+
+// noopLimiter is a RateLimiter that always allows traffic. It is returned by
+// NewGlobalLimiter when the configured rate or burst is zero, meaning rate
+// limiting is disabled and all messages are permitted without restriction.
+// Using a noopLimiter avoids branching at the call site. PeerRateLimiter
+// does not use this type directly; it short-circuits via its own disabled()
+// helper.
+type noopLimiter struct{}
+
+// AllowN always returns true regardless of the requested byte count.
+func (noopLimiter) AllowN(int) bool { return true }
+
+// countingLimiter wraps a *rate.Limiter and tracks how many calls to AllowN
+// have been rejected. The counter is exposed via Dropped for observability,
+// and a one-shot flag records whether a log line has been emitted for the
+// first rejection so operators can see that the limiter actually fired.
+type countingLimiter struct {
+	limiter  *rate.Limiter
+	dropped  atomic.Uint64
+	firstLog atomic.Bool
+}
+
+// AllowN consults the underlying token bucket for n bytes and increments
+// the dropped counter on rejection.
+func (c *countingLimiter) AllowN(n int) bool {
+	if c.limiter.AllowN(time.Now(), n) {
+		return true
+	}
+	c.dropped.Add(1)
+
+	return false
+}
+
+// FirstDropClaim atomically returns true exactly once, on the first call.
+// The caller is responsible for only invoking it after a rejection has
+// actually occurred; the method itself does not inspect the dropped
+// counter. It exists so that the ingress call site can emit a single
+// info-level log line when a limiter first trips, without spamming the
+// log on every subsequent drop.
+func (c *countingLimiter) FirstDropClaim() bool {
+	return c.firstLog.CompareAndSwap(false, true)
+}
+
+// Dropped returns the total number of onion messages this limiter has
+// rejected since process start.
+func (c *countingLimiter) Dropped() uint64 {
+	return c.dropped.Load()
+}
+
+// NewGlobalLimiter constructs a process-wide onion message rate limiter.
+// kbps is the sustained rate in kilobits per second (1 Kbps = 1000 bits/s);
+// burstBytes is the token bucket depth in bytes. A zero rate or a zero
+// burst disables limiting and returns a noopLimiter. Otherwise the returned
+// RateLimiter is a token bucket whose tokens are bytes.
+func NewGlobalLimiter(kbps uint64, burstBytes uint64) RateLimiter {
+	if kbps == 0 || burstBytes == 0 {
+		return noopLimiter{}
+	}
+
+	bps := kbpsToBytesPerSecond(kbps)
+
+	return &countingLimiter{
+		limiter: rate.NewLimiter(rate.Limit(bps), int(burstBytes)),
+	}
+}
+
+// PeerRateLimiter is a registry of per-peer onion message token buckets,
+// keyed by the peer's compressed public key. Tokens are bytes: callers pass
+// the on-the-wire size of each message to AllowN and the per-peer bucket is
+// debited accordingly. Buckets are created lazily on the first call to
+// AllowN for a given peer and retained for the lifetime of the process.
+// When the configured rate or burst is zero the registry operates in
+// disabled mode and AllowN is a no-op.
+//
+// Retention across disconnect is load-bearing. Without it, a peer could
+// drain its burst, disconnect, reconnect, and get a fresh full-burst
+// bucket on every cycle, effectively promoting the global limiter into
+// its per-peer rate and using the shared budget as a personal allowance
+// until the global bucket trips. By keeping the bucket, a drained peer
+// stays drained until its bucket naturally refills regardless of how
+// often it cycles the connection, and the per-peer rate becomes a real
+// ceiling rather than a per-connection ceiling.
+//
+// The memory cost of retention is bounded by the number of channel
+// peers that have ever sent an onion message: the ingress call site
+// gates AllowN on the peer having at least one open channel before
+// touching this registry, so random connecting strangers never allocate
+// a bucket. At a realistic few hundred to few thousand channel partners
+// and ~200 bytes per entry (rate.Limiter plus SyncMap overhead), the
+// registry stays comfortably sub-megabyte for the lifetime of the
+// process.
+//
+// The underlying bucket registry is an lnutils.SyncMap rather than a plain
+// map guarded by a mutex. Per-peer keys are stable for the lifetime of the
+// connection and the common path is a Load hit, which sync.Map serves
+// without any write contention across peers. A plain map would serialize
+// every hot-path AllowN call behind a single mutex even though rate.Limiter
+// is already safe for concurrent use.
+type PeerRateLimiter struct {
+	rate     rate.Limit
+	burst    int
+	peers    lnutils.SyncMap[[33]byte, *rate.Limiter]
+	dropped  atomic.Uint64
+	firstLog atomic.Bool
+}
+
+// FirstDropClaim atomically returns true exactly once, on the first call.
+// The caller is responsible for only invoking it after a rejection has
+// actually occurred. The ingress site uses this to emit a single
+// info-level log line when per-peer rate limiting first trips, rather
+// than spamming the log on every drop.
+func (p *PeerRateLimiter) FirstDropClaim() bool {
+	return p.firstLog.CompareAndSwap(false, true)
+}
+
+// NewPeerRateLimiter constructs a per-peer onion message rate limiter.
+// kbps is the per-peer sustained rate in kilobits per second and burstBytes
+// is the per-peer token bucket depth in bytes. A zero rate or a zero burst
+// disables limiting; in that case AllowN always returns true and no
+// per-peer state is retained.
+func NewPeerRateLimiter(kbps uint64, burstBytes uint64) *PeerRateLimiter {
+	p := &PeerRateLimiter{}
+	if kbps > 0 && burstBytes > 0 {
+		p.rate = rate.Limit(kbpsToBytesPerSecond(kbps))
+		p.burst = int(burstBytes)
+	}
+
+	return p
+}
+
+// disabled reports whether the limiter has been configured to permit all
+// traffic.
+func (p *PeerRateLimiter) disabled() bool {
+	return p.rate == 0 || p.burst <= 0
+}
+
+// AllowN reports whether an onion message of n bytes from the given peer
+// is permitted at the current instant. The peer's bucket is created on
+// first use. Rejected calls are counted and visible via Dropped.
+func (p *PeerRateLimiter) AllowN(peer [33]byte, n int) bool {
+	if p.disabled() {
+		return true
+	}
+
+	lim, ok := p.peers.Load(peer)
+	if !ok {
+		// Allocate a fresh limiter and race for ownership via
+		// LoadOrStore: if a concurrent caller inserted one first,
+		// we discard ours and use theirs so that every peer ends
+		// up with a single authoritative bucket.
+		newLim := rate.NewLimiter(p.rate, p.burst)
+		lim, _ = p.peers.LoadOrStore(peer, newLim)
+	}
+
+	if lim.AllowN(time.Now(), n) {
+		return true
+	}
+	p.dropped.Add(1)
+
+	return false
+}
+
+// Dropped returns the total number of onion messages this registry has
+// rejected since process start, summed across all peers.
+func (p *PeerRateLimiter) Dropped() uint64 {
+	return p.dropped.Load()
+}
+
+// IngressLimiter is the combined per-peer + global rate limiter surface
+// consumed by the onion message ingress path. It hides the split between
+// the two underlying buckets so callers in peer/brontide.go only need to
+// thread a single object through Config and call a single method on every
+// incoming onion message. The per-peer bucket is always checked first so
+// that a hostile peer whose own budget is already empty cannot burn
+// global tokens on every rejected attempt and starve legitimate peers.
+//
+// Implementations must be safe for concurrent use from per-peer
+// readHandler goroutines. A nil IngressLimiter is a valid "disabled"
+// sentinel at call sites and means "accept everything".
+type IngressLimiter interface {
+	// AllowN reports whether an onion message of n bytes from the
+	// given peer is permitted. A successful result wraps fn.Unit; a
+	// rejection wraps either ErrPeerRateLimit or ErrGlobalRateLimit
+	// depending on which bucket fired. Callers use errors.Is against
+	// those sentinels to pick their log / metric / drop path.
+	//
+	// Per-peer state is retained for the lifetime of the process so
+	// that a peer cannot reset its bucket by cycling the connection;
+	// see the PeerRateLimiter doc for the memory-bound argument.
+	AllowN(peer [33]byte, n int) fn.Result[fn.Unit]
+
+	// FirstPeerDropClaim atomically returns true exactly once, on
+	// the first call, and is intended to gate a one-shot info log
+	// when the per-peer limiter first trips.
+	FirstPeerDropClaim() bool
+
+	// FirstGlobalDropClaim atomically returns true exactly once, on
+	// the first call, and is intended to gate a one-shot info log
+	// when the global limiter first trips.
+	FirstGlobalDropClaim() bool
+}
+
+// ingressLimiter is the stock IngressLimiter implementation that
+// composes a PeerRateLimiter with a global RateLimiter. Either side may
+// be nil / disabled independently.
+type ingressLimiter struct {
+	peer   *PeerRateLimiter
+	global RateLimiter
+}
+
+// NewIngressLimiter constructs an IngressLimiter that first consults the
+// given per-peer limiter and then the given global limiter for each
+// incoming onion message. Either argument may be nil (or the zero-value
+// disabled limiter returned by the constructors in this package) in
+// which case that side of the check is skipped.
+func NewIngressLimiter(peer *PeerRateLimiter,
+	global RateLimiter) IngressLimiter {
+
+	return &ingressLimiter{
+		peer:   peer,
+		global: global,
+	}
+}
+
+// AllowN checks per-peer then global, returning the drop reason as a
+// sentinel error wrapped in a fn.Result on rejection. The ordering is
+// load-bearing: consulting the per-peer bucket first means over-limit
+// traffic from one peer is rejected before it can touch the global
+// bucket, so the global bucket only accounts for traffic that was
+// within its source peer's allowance and a single hostile peer cannot
+// drain the shared budget via rejected attempts.
+func (l *ingressLimiter) AllowN(peer [33]byte,
+	n int) fn.Result[fn.Unit] {
+
+	if l.peer != nil && !l.peer.AllowN(peer, n) {
+		return fn.Err[fn.Unit](ErrPeerRateLimit)
+	}
+	if l.global != nil && !l.global.AllowN(n) {
+		return fn.Err[fn.Unit](ErrGlobalRateLimit)
+	}
+
+	return fn.Ok(fn.Unit{})
+}
+
+// FirstPeerDropClaim delegates to the per-peer limiter's one-shot
+// claim. Returns false if the per-peer limiter is nil (disabled).
+func (l *ingressLimiter) FirstPeerDropClaim() bool {
+	if l.peer == nil {
+		return false
+	}
+
+	return l.peer.FirstDropClaim()
+}
+
+// FirstGlobalDropClaim atomically returns true exactly once, on the
+// first call, when the global limiter is an enabled countingLimiter
+// that has just recorded its first rejection. A noop (disabled) global
+// limiter, a nil global limiter, and a countingLimiter whose flag has
+// already been claimed all return false. The type assertion is inlined
+// here because the global limiter is consulted through the RateLimiter
+// interface and only the countingLimiter implementation tracks drops.
+func (l *ingressLimiter) FirstGlobalDropClaim() bool {
+	cl, ok := l.global.(*countingLimiter)
+	if !ok {
+		return false
+	}
+
+	return cl.FirstDropClaim()
+}

--- a/onionmessage/ratelimit_test.go
+++ b/onionmessage/ratelimit_test.go
@@ -1,0 +1,247 @@
+package onionmessage
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// msgBytes is the byte count used as the per-Allow token charge across the
+// tests. It is intentionally close to the spec-max onion message size so
+// that burst budgets in tests closely match real-world worst-case behavior.
+const msgBytes = 32 * 1024
+
+// TestGlobalLimiterDisabled verifies that constructing a global limiter with
+// a zero rate or zero burst yields a noop limiter that always allows
+// traffic regardless of the requested byte count.
+func TestGlobalLimiterDisabled(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		kbps       uint64
+		burstBytes uint64
+	}{
+		{"zero kbps", 0, 1024},
+		{"zero burst", 1024, 0},
+		{"both zero", 0, 0},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			lim := NewGlobalLimiter(tc.kbps, tc.burstBytes)
+			for i := 0; i < 1000; i++ {
+				require.True(t, lim.AllowN(msgBytes))
+			}
+			// Disabled limiters must be noopLimiters, not
+			// countingLimiters, so the disabled sentinel is
+			// observable at the type level.
+			_, isNoop := lim.(noopLimiter)
+			require.True(t, isNoop)
+		})
+	}
+}
+
+// TestGlobalLimiterBurstExhaustion verifies that the global limiter permits
+// exactly the configured burst worth of immediate bytes and rejects
+// subsequent calls until the bucket refills.
+func TestGlobalLimiterBurstExhaustion(t *testing.T) {
+	t.Parallel()
+
+	// Burst just large enough for five max-size messages; a very low rate
+	// ensures the bucket does not refill within the test window so the
+	// burst boundary is observable.
+	const burstMessages = 5
+	lim := NewGlobalLimiter(1, burstMessages*msgBytes)
+
+	for i := 0; i < burstMessages; i++ {
+		require.True(t, lim.AllowN(msgBytes),
+			"burst slot %d should pass", i)
+	}
+	require.False(t, lim.AllowN(msgBytes), "post-burst call should drop")
+
+	cl, ok := lim.(*countingLimiter)
+	require.True(t, ok)
+	require.Equal(t, uint64(1), cl.Dropped())
+}
+
+// TestPeerRateLimiterDisabled verifies that a per-peer limiter constructed
+// with a zero rate or zero burst permits all traffic and never allocates
+// per-peer state.
+func TestPeerRateLimiterDisabled(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		kbps       uint64
+		burstBytes uint64
+	}{
+		{"zero kbps", 0, 1024},
+		{"zero burst", 1024, 0},
+		{"both zero", 0, 0},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := NewPeerRateLimiter(tc.kbps, tc.burstBytes)
+			var peer [33]byte
+			peer[0] = 0x02
+
+			for i := 0; i < 1000; i++ {
+				require.True(t, p.AllowN(peer, msgBytes))
+			}
+			require.Equal(t, uint64(0), p.Dropped())
+			// No state should have been recorded for the peer.
+			require.Equal(t, 0, peerMapLen(p))
+		})
+	}
+}
+
+// TestPeerRateLimiterIsolation verifies that exhausting one peer's bucket
+// does not affect a different peer's allowance.
+func TestPeerRateLimiterIsolation(t *testing.T) {
+	t.Parallel()
+
+	const burstMessages = 3
+	p := NewPeerRateLimiter(1, burstMessages*msgBytes)
+
+	var peerA, peerB [33]byte
+	peerA[0] = 0x02
+	peerB[0] = 0x03
+
+	// Drain peer A's bucket.
+	for i := 0; i < burstMessages; i++ {
+		require.True(t, p.AllowN(peerA, msgBytes))
+	}
+	require.False(t, p.AllowN(peerA, msgBytes),
+		"peer A should be exhausted")
+
+	// Peer B should still have its full burst.
+	for i := 0; i < burstMessages; i++ {
+		require.True(t, p.AllowN(peerB, msgBytes),
+			"peer B slot %d", i)
+	}
+	require.False(t, p.AllowN(peerB, msgBytes))
+
+	require.Equal(t, uint64(2), p.Dropped())
+}
+
+// TestCountingLimiterFirstDropClaimOnce verifies that FirstDropClaim on a
+// countingLimiter returns true exactly once and false on every subsequent
+// call, across concurrent goroutines, so that the first-drop info log is
+// emitted at most once.
+func TestCountingLimiterFirstDropClaimOnce(t *testing.T) {
+	t.Parallel()
+
+	// A tiny bucket so that repeated AllowN calls quickly produce drops.
+	lim, ok := NewGlobalLimiter(1, msgBytes).(*countingLimiter)
+	require.True(t, ok)
+
+	// Drain the bucket.
+	require.True(t, lim.AllowN(msgBytes))
+	require.False(t, lim.AllowN(msgBytes))
+
+	const workers = 32
+	var wins atomic.Uint64
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if lim.FirstDropClaim() {
+				wins.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, uint64(1), wins.Load(),
+		"FirstDropClaim must be winnable exactly once")
+
+	// A subsequent serial call must also return false.
+	require.False(t, lim.FirstDropClaim())
+}
+
+// TestPeerRateLimiterFirstDropClaimOnce verifies the same single-win
+// guarantee for the per-peer limiter's FirstDropClaim.
+func TestPeerRateLimiterFirstDropClaimOnce(t *testing.T) {
+	t.Parallel()
+
+	p := NewPeerRateLimiter(1, msgBytes)
+
+	const workers = 32
+	var wins atomic.Uint64
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if p.FirstDropClaim() {
+				wins.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, uint64(1), wins.Load())
+	require.False(t, p.FirstDropClaim())
+}
+
+// TestFirstGlobalDropClaimNoopLimiter verifies that
+// IngressLimiter.FirstGlobalDropClaim returns false when the composed
+// global limiter is a noop (disabled) limiter: a disabled limiter never
+// produces drops and must not claim the first-drop flag.
+func TestFirstGlobalDropClaimNoopLimiter(t *testing.T) {
+	t.Parallel()
+
+	ingress := NewIngressLimiter(nil, NewGlobalLimiter(0, 0))
+	require.False(t, ingress.FirstGlobalDropClaim())
+}
+
+// TestPeerRateLimiterConcurrentAllowN exercises concurrent AllowN calls
+// across many distinct peers to give the race detector an opportunity to
+// observe any missing synchronization around the per-peer registry's
+// Load / LoadOrStore path. With the registry now retained for the
+// process lifetime, the final entry count should equal the number of
+// distinct peers exactly.
+func TestPeerRateLimiterConcurrentAllowN(t *testing.T) {
+	t.Parallel()
+
+	p := NewPeerRateLimiter(100_000, 8*msgBytes)
+
+	const workers = 8
+	const iters = 200
+
+	var wg sync.WaitGroup
+	var ops atomic.Uint64
+	for w := 0; w < workers; w++ {
+		w := w
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var key [33]byte
+			key[0] = byte(w)
+			for i := 0; i < iters; i++ {
+				p.AllowN(key, msgBytes)
+				ops.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, uint64(workers*iters), ops.Load())
+	// Each worker uses a distinct peer key and entries are never
+	// removed, so the registry must contain exactly one entry per
+	// worker.
+	require.Equal(t, workers, peerMapLen(p))
+}
+
+// peerMapLen returns the number of entries in the per-peer registry. It
+// exists solely for tests; production code has no need for the registry
+// size since each per-peer bucket's own AllowN call already tracks the
+// accounting it cares about.
+func peerMapLen(p *PeerRateLimiter) int {
+	return p.peers.Len()
+}

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -315,6 +315,19 @@ type Config struct {
 	// message actor. If nil, onion messaging is disabled.
 	SpawnOnionActor onionmessage.OnionActorFactory
 
+	// OnionLimiter is the combined per-peer + global onion message
+	// ingress rate limiter. It hides the split between the two
+	// underlying buckets behind a single interface: callers invoke
+	// OnionLimiter.AllowN on every incoming onion message and it
+	// consults the per-peer bucket first (so a hostile peer whose own
+	// budget is empty cannot drain the shared budget on rejected
+	// attempts) and then the global bucket. Per-peer state is retained
+	// across disconnect so a peer cannot reset its bucket by cycling
+	// the connection; see the PeerRateLimiter doc for the memory-bound
+	// argument. A nil value means onion message rate limiting is
+	// disabled.
+	OnionLimiter onionmessage.IngressLimiter
+
 	// OnionActorOpts returns ActorOptions for the onion peer actor
 	// being spawned for the given peer. This allows per-peer
 	// customization of mailbox size, drop predicates, etc.
@@ -2331,6 +2344,32 @@ out:
 			discStream.AddMsg(msg)
 
 		case *lnwire.OnionMessage:
+			// Charge the limiter the on-the-wire size of the
+			// message so the byte-granular bucket reflects
+			// actual ingress bandwidth rather than raw message
+			// counts. A rejection surfaces as a sentinel error
+			// wrapped in fn.Result; errors.Is lets us pick the
+			// right first-drop log path.
+			result := allowOnionMessage(
+				p.cfg.OnionLimiter, p.PubKey(),
+				msg.WireSize(),
+			)
+			if err := result.Err(); err != nil {
+				logFirstOnionDrop(
+					peerLog, p.log, err,
+					p.cfg.OnionLimiter,
+				)
+				// Keep repeated drops at trace so a
+				// sustained attack does not flood debug;
+				// the first-drop info log above already
+				// gives operators a clear "limiter
+				// engaged" signal.
+				p.log.Tracef("dropping onion message: %v",
+					err)
+
+				break
+			}
+
 			p.onionActorRef.WhenSome(
 				func(ref onionmessage.OnionPeerActorRef) {
 					// TODO(elle): thread contexts through

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -328,6 +328,15 @@ type Config struct {
 	// disabled.
 	OnionLimiter onionmessage.IngressLimiter
 
+	// OnionRelayAll, when true, disables the channel-presence gate on
+	// incoming onion messages: messages from peers with no fully open
+	// channel are admitted to the rate-limiter pipeline instead of
+	// being dropped at ingress. The default (false) keeps the gate in
+	// place so that a no-cost Sybil identity cannot burn a full
+	// per-peer byte budget on each of many connections and saturate
+	// the global limiter through sheer identity count.
+	OnionRelayAll bool
+
 	// OnionActorOpts returns ActorOptions for the onion peer actor
 	// being spawned for the given peer. This allows per-peer
 	// customization of mailbox size, drop predicates, etc.
@@ -2366,6 +2375,7 @@ out:
 			result := allowOnionMessage(
 				p.cfg.OnionLimiter, p.PubKey(),
 				msg.WireSize(), p.hasActiveChannels(),
+				p.cfg.OnionRelayAll,
 			)
 			if err := result.Err(); err != nil {
 				logFirstOnionDrop(

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -613,6 +613,17 @@ type Brontide struct {
 	activeChannels *lnutils.SyncMap[
 		lnwire.ChannelID, *lnwallet.LightningChannel]
 
+	// numActiveChans shadows the count of non-pending entries in
+	// activeChannels as an atomic integer. It exists so that hot-path
+	// callers — notably the onion message ingress gate, which runs on
+	// every incoming onion packet — can ask "does this peer have any
+	// active channel with us" in O(1) instead of iterating the
+	// activeChannels registry. It is maintained in lockstep with
+	// activeChannels via Swap and LoadAndDelete at every mutation
+	// site, so transitions from pending (nil value) to active and
+	// from active to closed are reflected atomically.
+	numActiveChans atomic.Int32
+
 	// addedChannels tracks any new channels opened during this peer's
 	// lifecycle. We use this to filter out these new channels when the time
 	// comes to request a reenable for active channels, since they will have
@@ -1339,7 +1350,7 @@ func (p *Brontide) loadActiveChannels(chans []*channeldb.OpenChannel) (
 		// channels. Adding them here would just be extra work as we'll
 		// tear them down when creating + adding the final link.
 		if lnChan.IsPending() {
-			p.activeChannels.Store(chanID, nil)
+			p.markPendingChannel(chanID)
 
 			continue
 		}
@@ -1430,7 +1441,7 @@ func (p *Brontide) loadActiveChannels(chans []*channeldb.OpenChannel) (
 				"switch: %v", chanPoint, err)
 		}
 
-		p.activeChannels.Store(chanID, lnChan)
+		p.storeActiveChannel(chanID, lnChan)
 
 		// We're using the old co-op close, so we don't need to init
 		// the new RBF chan closer.
@@ -2347,12 +2358,14 @@ out:
 			// Charge the limiter the on-the-wire size of the
 			// message so the byte-granular bucket reflects
 			// actual ingress bandwidth rather than raw message
-			// counts. A rejection surfaces as a sentinel error
-			// wrapped in fn.Result; errors.Is lets us pick the
-			// right first-drop log path.
+			// counts. The channel-gate hint is sourced from the
+			// atomic active-channel counter so the check is
+			// O(1) on the hot path. A rejection surfaces as a
+			// sentinel error wrapped in fn.Result; errors.Is
+			// lets us pick the right first-drop log path.
 			result := allowOnionMessage(
 				p.cfg.OnionLimiter, p.PubKey(),
-				msg.WireSize(),
+				msg.WireSize(), p.hasActiveChannels(),
 			)
 			if err := result.Err(); err != nil {
 				logFirstOnionDrop(
@@ -2484,6 +2497,51 @@ func (p *Brontide) isPendingChannel(chanID lnwire.ChannelID) bool {
 func (p *Brontide) hasChannel(chanID lnwire.ChannelID) bool {
 	_, ok := p.activeChannels.Load(chanID)
 	return ok
+}
+
+// hasActiveChannels reports whether this peer has at least one fully open
+// (non-pending) channel with us. Pending channels are excluded because
+// they do not yet provide the Sybil-resistance guarantees the onion
+// message ingress gate relies on. The check reads an atomic counter
+// maintained alongside activeChannels at every mutation site, so it is
+// O(1) and cheap enough to run on every incoming onion message without
+// iterating a map.
+func (p *Brontide) hasActiveChannels() bool {
+	return p.numActiveChans.Load() > 0
+}
+
+// markPendingChannel records chanID in activeChannels as a pending (nil)
+// entry; numActiveChans is unchanged.
+func (p *Brontide) markPendingChannel(chanID lnwire.ChannelID) {
+	p.activeChannels.Store(chanID, nil)
+}
+
+// storeActiveChannel installs lnChan under chanID and bumps
+// numActiveChans iff the prior entry was absent or pending (nil).
+func (p *Brontide) storeActiveChannel(chanID lnwire.ChannelID,
+	lnChan *lnwallet.LightningChannel) {
+
+	prev, loaded := p.activeChannels.Swap(chanID, lnChan)
+	if !loaded || prev == nil {
+		p.numActiveChans.Add(1)
+	}
+}
+
+// removeActiveChannel deletes chanID and decrements numActiveChans only
+// when the removed entry was a fully open (non-nil) channel.
+func (p *Brontide) removeActiveChannel(chanID lnwire.ChannelID) {
+	prev, loaded := p.activeChannels.LoadAndDelete(chanID)
+	if loaded && prev != nil {
+		p.numActiveChans.Add(-1)
+	}
+}
+
+// deletePendingChannel deletes a pending entry owned by the
+// channelManager goroutine; no counter check since pending entries never
+// contribute to numActiveChans. External callers must use
+// removeActiveChannel so a racing promotion is handled correctly.
+func (p *Brontide) deletePendingChannel(chanID lnwire.ChannelID) {
+	p.activeChannels.Delete(chanID)
 }
 
 // storeError stores an error in our peer's buffer of recent errors with the
@@ -4712,7 +4770,10 @@ func WaitForChanToClose(bestHeight uint32, notifier chainntnfs.ChainNotifier,
 func (p *Brontide) WipeChannel(chanPoint *wire.OutPoint) {
 	chanID := lnwire.NewChanIDFromOutPoint(*chanPoint)
 
-	p.activeChannels.Delete(chanID)
+	// Remove the entry and adjust the active-channel counter atomically
+	// via the helper; it skips the decrement for pending (nil) entries
+	// since they never contributed to the counter in the first place.
+	p.removeActiveChannel(chanID)
 
 	// Instruct the HtlcSwitch to close this link as the channel is no
 	// longer active.
@@ -5433,8 +5494,11 @@ func (p *Brontide) addActiveChannel(c *lnpeer.NewChannel) error {
 		return fmt.Errorf("unable to create LightningChannel: %w", err)
 	}
 
-	// Store the channel in the activeChannels map.
-	p.activeChannels.Store(chanID, lnChan)
+	// Install the channel via the helper so the active-channel counter
+	// stays in lockstep: new inserts and pending-to-active promotions
+	// both bump the counter by exactly one, while the rare
+	// already-present case is a no-op.
+	p.storeActiveChannel(chanID, lnChan)
 
 	p.log.Infof("New channel active ChannelPoint(%v) with peer", chanPoint)
 
@@ -5557,7 +5621,7 @@ func (p *Brontide) handleNewPendingChannel(req *newChannelMsg) {
 	// This is a new channel, we now add it to the map `activeChannels`
 	// with nil value and mark it as a newly added channel in
 	// `addedChannels`.
-	p.activeChannels.Store(chanID, nil)
+	p.markPendingChannel(chanID)
 	p.addedChannels.Store(chanID, struct{}{})
 }
 
@@ -5584,8 +5648,16 @@ func (p *Brontide) handleRemovePendingChannel(req *newChannelMsg) {
 		p.log.Warnf("Channel(%v) not found, removing it anyway", chanID)
 	}
 
-	// Remove the record of this pending channel.
-	p.activeChannels.Delete(chanID)
+	// Delete the pending entry. handleRemovePendingChannel and
+	// handleNewActiveChannel are both arms of the channelManager
+	// select loop, so the Go runtime serializes them and the entry we
+	// delete here is guaranteed to be the pending (nil) one we stored
+	// via markPendingChannel — it cannot have been promoted behind our
+	// back. That rules out any numActiveChans decrement on this path,
+	// so we drop the defensive LoadAndDelete + conditional check the
+	// refactor left in place and use a plain Delete via
+	// deletePendingChannel.
+	p.deletePendingChannel(chanID)
 	p.addedChannels.Delete(chanID)
 }
 

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -1767,3 +1767,79 @@ func TestCreateHtlcValidator(t *testing.T) {
 		})
 	}
 }
+
+// TestHasActiveChannels exercises the atomic active-channel counter that
+// backs hasActiveChannels(). hasActiveChannels is on the hot path for
+// every incoming onion message — the onion message ingress gate calls
+// it per packet — so a correct, O(1) shadow of activeChannels is a
+// load-bearing invariant. This test walks the three state transitions
+// that have to keep numActiveChans in lockstep with activeChannels:
+// initial emptiness, pending entries (nil values) that must not count,
+// and pending-delete paths that must not decrement.
+func TestHasActiveChannels(t *testing.T) {
+	t.Parallel()
+
+	peer := NewBrontide(Config{})
+
+	// Initial state: no channels, counter is zero, gate is closed.
+	require.False(t, peer.hasActiveChannels())
+	require.Equal(t, int32(0), peer.numActiveChans.Load())
+
+	// Simulate the loadActiveChannels active-channel path: the entry
+	// is stored and the counter is incremented in lockstep. After
+	// this, hasActiveChannels must flip to true because the peer now
+	// holds a non-pending channel.
+	activeID := lnwire.ChannelID{0x01}
+	peer.activeChannels.Store(activeID, &lnwallet.LightningChannel{})
+	peer.numActiveChans.Add(1)
+	require.True(t, peer.hasActiveChannels())
+	require.Equal(t, int32(1), peer.numActiveChans.Load())
+
+	// Simulate the loadActiveChannels pending path: the entry is
+	// stored as nil and the counter must NOT move. This is the
+	// invariant the onion message gate relies on — pending channels
+	// are cheap to open and get stuck, so they must not satisfy the
+	// Sybil-resistance gate on their own.
+	pendingID := lnwire.ChannelID{0x02}
+	peer.activeChannels.Store(pendingID, nil)
+	require.Equal(t, int32(1), peer.numActiveChans.Load())
+	require.True(t, peer.hasActiveChannels())
+
+	// handleRemovePendingChannel walks the pending-delete path. It
+	// uses LoadAndDelete and must skip the counter decrement when
+	// the previous value was nil (pending). If this invariant ever
+	// broke, the counter would underflow every time a pending
+	// channel was cancelled and hasActiveChannels would return the
+	// wrong answer until the next reconnect.
+	errChan := make(chan error, 1)
+	peer.handleRemovePendingChannel(&newChannelMsg{
+		channelID: pendingID,
+		err:       errChan,
+	})
+	require.Equal(t, int32(1), peer.numActiveChans.Load())
+	require.True(t, peer.hasActiveChannels())
+
+	// The pending entry must have been removed from the map.
+	_, found := peer.activeChannels.Load(pendingID)
+	require.False(t, found)
+
+	// Drain the request error channel so the test leaves no loose
+	// ends. handleRemovePendingChannel closes the err chan via
+	// defer, so we expect a closed-channel receive here.
+	_, reqOk := <-errChan
+	require.False(t, reqOk)
+
+	// Finally, simulate WipeChannel's decrement path directly via
+	// LoadAndDelete. We cannot call WipeChannel in this
+	// dummy-config harness because it also calls
+	// p.cfg.Switch.RemoveLink, but the counter-maintenance half of
+	// WipeChannel is exactly the LoadAndDelete + conditional Add(-1)
+	// we exercise here.
+	prev, loaded := peer.activeChannels.LoadAndDelete(activeID)
+	require.True(t, loaded)
+	require.NotNil(t, prev)
+	peer.numActiveChans.Add(-1)
+
+	require.False(t, peer.hasActiveChannels())
+	require.Equal(t, int32(0), peer.numActiveChans.Load())
+}

--- a/peer/onion_ratelimit.go
+++ b/peer/onion_ratelimit.go
@@ -26,15 +26,21 @@ var ErrNoChannel = errors.New("peer has no open channel")
 // onionmessage.ErrPeerRateLimit, or onionmessage.ErrGlobalRateLimit so
 // that callers can distinguish the drop reason via errors.Is.
 //
+// When relayAll is true, the channel gate is skipped entirely and the
+// message is admitted to the IngressLimiter regardless of hasChannel.
+// This is the opt-in policy for operators who want to accept onion
+// messages from peers with no channel, trading the Sybil-resistance
+// property of the gate for broader reachability.
+//
 // A nil IngressLimiter is treated as "disabled" and always accepts the
 // message once the channel gate passes. This preserves the behavior of
 // test and disabled-onion-messaging configurations without forcing
 // callers to construct a real limiter.
 func allowOnionMessage(limiter onionmessage.IngressLimiter,
 	peerKey [33]byte, msgBytes int,
-	hasChannel bool) fn.Result[fn.Unit] {
+	hasChannel, relayAll bool) fn.Result[fn.Unit] {
 
-	if !hasChannel {
+	if !relayAll && !hasChannel {
 		return fn.Err[fn.Unit](ErrNoChannel)
 	}
 	if limiter == nil {

--- a/peer/onion_ratelimit.go
+++ b/peer/onion_ratelimit.go
@@ -1,0 +1,56 @@
+package peer
+
+import (
+	"errors"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/onionmessage"
+)
+
+// allowOnionMessage delegates to the IngressLimiter for the
+// per-peer-then-global byte-granular rate limit check. A successful
+// result wraps fn.Unit; a rejection wraps one of the sentinel errors
+// onionmessage.ErrPeerRateLimit or onionmessage.ErrGlobalRateLimit so
+// that callers can distinguish the drop reason via errors.Is.
+//
+// A nil IngressLimiter is treated as "disabled" and always accepts the
+// message. This preserves the behavior of test and disabled-onion-
+// messaging configurations without forcing callers to construct a real
+// limiter.
+func allowOnionMessage(limiter onionmessage.IngressLimiter,
+	peerKey [33]byte, msgBytes int) fn.Result[fn.Unit] {
+
+	if limiter == nil {
+		return fn.Ok(fn.Unit{})
+	}
+
+	return limiter.AllowN(peerKey, msgBytes)
+}
+
+// logFirstOnionDrop emits a one-shot info log the first time the limiter
+// identified by err trips. Per-peer drops go to peerLog (caller's
+// peer-prefixed log) so the operator can see which peer first tripped
+// the limiter; global drops go to pkgLog (typically the package-level
+// peerLog) since they are not attributable to any single peer.
+func logFirstOnionDrop(pkgLog, peerLog btclog.Logger, err error,
+	limiter onionmessage.IngressLimiter) {
+
+	if limiter == nil {
+		return
+	}
+
+	switch {
+	case errors.Is(err, onionmessage.ErrGlobalRateLimit):
+		if limiter.FirstGlobalDropClaim() {
+			pkgLog.Infof("onion message global rate limiter " +
+				"engaged; further drops logged at trace")
+		}
+
+	case errors.Is(err, onionmessage.ErrPeerRateLimit):
+		if limiter.FirstPeerDropClaim() {
+			peerLog.Infof("onion message per-peer rate limiter " +
+				"engaged; further drops logged at trace")
+		}
+	}
+}

--- a/peer/onion_ratelimit.go
+++ b/peer/onion_ratelimit.go
@@ -8,19 +8,35 @@ import (
 	"github.com/lightningnetwork/lnd/onionmessage"
 )
 
-// allowOnionMessage delegates to the IngressLimiter for the
-// per-peer-then-global byte-granular rate limit check. A successful
-// result wraps fn.Unit; a rejection wraps one of the sentinel errors
-// onionmessage.ErrPeerRateLimit or onionmessage.ErrGlobalRateLimit so
+// ErrNoChannel is the sentinel error returned by allowOnionMessage when
+// the incoming peer has no fully open channel with us. It is the
+// primary Sybil-resistance layer on top of the byte-granular rate
+// limiters: an attacker that can cheaply spin up new identities cannot
+// burn any per-peer or global token budget because the channel gate
+// runs before the IngressLimiter is consulted at all.
+var ErrNoChannel = errors.New("peer has no open channel")
+
+// allowOnionMessage applies the channel-presence gate and then, if the
+// peer has at least one fully open channel with us, delegates to the
+// IngressLimiter for the per-peer-then-global byte-granular rate limit
+// check. The channel gate runs first on purpose: if it rejects, no rate
+// limiter state is allocated for the no-channel peer and neither bucket
+// is debited. A successful result wraps fn.Unit; a rejection wraps one
+// of the sentinel errors ErrNoChannel,
+// onionmessage.ErrPeerRateLimit, or onionmessage.ErrGlobalRateLimit so
 // that callers can distinguish the drop reason via errors.Is.
 //
 // A nil IngressLimiter is treated as "disabled" and always accepts the
-// message. This preserves the behavior of test and disabled-onion-
-// messaging configurations without forcing callers to construct a real
-// limiter.
+// message once the channel gate passes. This preserves the behavior of
+// test and disabled-onion-messaging configurations without forcing
+// callers to construct a real limiter.
 func allowOnionMessage(limiter onionmessage.IngressLimiter,
-	peerKey [33]byte, msgBytes int) fn.Result[fn.Unit] {
+	peerKey [33]byte, msgBytes int,
+	hasChannel bool) fn.Result[fn.Unit] {
 
+	if !hasChannel {
+		return fn.Err[fn.Unit](ErrNoChannel)
+	}
 	if limiter == nil {
 		return fn.Ok(fn.Unit{})
 	}

--- a/peer/onion_ratelimit_log_test.go
+++ b/peer/onion_ratelimit_log_test.go
@@ -2,7 +2,6 @@ package peer
 
 import (
 	"bytes"
-	"errors"
 	"testing"
 
 	"github.com/btcsuite/btclog/v2"
@@ -110,7 +109,7 @@ func TestLogFirstOnionDropUnknownReason(t *testing.T) {
 	peerLog, peerBuf := newCapturingLogger()
 	limiter := newRealIngressLimiter(t)
 
-	logFirstOnionDrop(pkgLog, peerLog, errors.New("unknown"), limiter)
+	logFirstOnionDrop(pkgLog, peerLog, ErrNoChannel, limiter)
 	require.Empty(t, pkgBuf.String())
 	require.Empty(t, peerBuf.String())
 

--- a/peer/onion_ratelimit_log_test.go
+++ b/peer/onion_ratelimit_log_test.go
@@ -1,0 +1,123 @@
+package peer
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightningnetwork/lnd/onionmessage"
+	"github.com/stretchr/testify/require"
+)
+
+// newCapturingLogger builds a btclog.Logger backed by an in-memory buffer
+// so tests can assert whether a given log line was emitted.
+func newCapturingLogger() (btclog.Logger, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	handler := btclog.NewDefaultHandler(buf, btclog.WithNoTimestamp())
+	return btclog.NewSLogger(handler), buf
+}
+
+// newRealIngressLimiter constructs a real ingressLimiter backed by real
+// per-peer and global limiters sized so the first message passes and
+// every subsequent one trips the named side of the limiter. It is used
+// by the log tests to exercise the one-shot claim path against real
+// FirstDropClaim bookkeeping rather than a stub.
+func newRealIngressLimiter(t *testing.T) onionmessage.IngressLimiter {
+	t.Helper()
+
+	// Burst == one max-sized message for both sides; rate of 1 Kbps
+	// ensures neither bucket refills within the test window.
+	peerLim := onionmessage.NewPeerRateLimiter(1, testMsgBytes)
+	globalLim := onionmessage.NewGlobalLimiter(1, testMsgBytes)
+
+	return onionmessage.NewIngressLimiter(peerLim, globalLim)
+}
+
+// TestLogFirstOnionDropGlobalOneShot verifies that logFirstOnionDrop
+// emits exactly one info-level line for the global limiter's first
+// drop and is silent on subsequent drops, so operators get a single
+// "engaged" signal without log flooding under sustained attack. The
+// global first-drop line must land on the package-level logger, not
+// the per-peer one, since a global drop is not attributable to any
+// single peer.
+func TestLogFirstOnionDropGlobalOneShot(t *testing.T) {
+	t.Parallel()
+
+	pkgLog, pkgBuf := newCapturingLogger()
+	peerLog, peerBuf := newCapturingLogger()
+	limiter := newRealIngressLimiter(t)
+
+	// First drop log: must emit to the package-level logger.
+	logFirstOnionDrop(
+		pkgLog, peerLog, onionmessage.ErrGlobalRateLimit, limiter,
+	)
+	require.Contains(t, pkgBuf.String(), "global rate limiter")
+	require.Empty(t, peerBuf.String(),
+		"global drop must not land on the peer-prefix log")
+
+	// Second drop log: must be silent (both buffer sizes unchanged).
+	sizeAfterFirst := pkgBuf.Len()
+	logFirstOnionDrop(
+		pkgLog, peerLog, onionmessage.ErrGlobalRateLimit, limiter,
+	)
+	require.Equal(t, sizeAfterFirst, pkgBuf.Len(),
+		"second drop must not re-log the first-drop line")
+	require.Empty(t, peerBuf.String())
+}
+
+// TestLogFirstOnionDropPeerOneShot verifies the same one-shot property
+// for the per-peer limiter and that the nil-limiter guard prevents a
+// panic when onion message rate limiting is entirely disabled. The
+// per-peer first-drop line must land on the peer-prefix logger so
+// operators can see which peer tripped the limiter.
+func TestLogFirstOnionDropPeerOneShot(t *testing.T) {
+	t.Parallel()
+
+	pkgLog, pkgBuf := newCapturingLogger()
+	peerLog, peerBuf := newCapturingLogger()
+
+	// Nil limiter: must not panic and must not log to either logger.
+	logFirstOnionDrop(
+		pkgLog, peerLog, onionmessage.ErrPeerRateLimit, nil,
+	)
+	require.Empty(t, pkgBuf.String())
+	require.Empty(t, peerBuf.String())
+
+	// Real limiter: emit once to the peer logger, then silent.
+	limiter := newRealIngressLimiter(t)
+	logFirstOnionDrop(
+		pkgLog, peerLog, onionmessage.ErrPeerRateLimit, limiter,
+	)
+	require.Contains(t, peerBuf.String(), "per-peer rate limiter")
+	require.Empty(t, pkgBuf.String(),
+		"per-peer drop must not land on the package-level log")
+	sizeAfterFirst := peerBuf.Len()
+	logFirstOnionDrop(
+		pkgLog, peerLog, onionmessage.ErrPeerRateLimit, limiter,
+	)
+	require.Equal(t, sizeAfterFirst, peerBuf.Len())
+}
+
+// TestLogFirstOnionDropUnknownReason verifies that an error that does
+// not match any known drop reason is a no-op — neither limiter's
+// first-drop flag is consumed. This guards against a typo or a new
+// drop reason being added without a matching log case.
+func TestLogFirstOnionDropUnknownReason(t *testing.T) {
+	t.Parallel()
+
+	pkgLog, pkgBuf := newCapturingLogger()
+	peerLog, peerBuf := newCapturingLogger()
+	limiter := newRealIngressLimiter(t)
+
+	logFirstOnionDrop(pkgLog, peerLog, errors.New("unknown"), limiter)
+	require.Empty(t, pkgBuf.String())
+	require.Empty(t, peerBuf.String())
+
+	// Both limiters' first-drop flags must still be unclaimed, so a
+	// follow-up call with a valid reason still emits the info line.
+	logFirstOnionDrop(
+		pkgLog, peerLog, onionmessage.ErrGlobalRateLimit, limiter,
+	)
+	require.Contains(t, pkgBuf.String(), "global rate limiter")
+}

--- a/peer/onion_ratelimit_test.go
+++ b/peer/onion_ratelimit_test.go
@@ -1,0 +1,263 @@
+package peer
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/onionmessage"
+	"github.com/stretchr/testify/require"
+)
+
+// testMsgBytes is the on-the-wire size we charge the bucket per call in
+// these tests. It is sized to approximate a spec-max onion message so
+// that burst budgets scale naturally with the per-message cost.
+const testMsgBytes = 32 * 1024
+
+// stubIngressLimiter is a test double for onionmessage.IngressLimiter
+// that records every call and delegates the accept/reject decision to a
+// caller-supplied predicate.
+type stubIngressLimiter struct {
+	// decide is invoked for every AllowN call. It receives the peer
+	// key and byte count and returns the error to embed in the
+	// fn.Result — nil for accept.
+	decide func(peer [33]byte, n int) error
+
+	calls atomic.Uint64
+}
+
+// AllowN records the call and dispatches to the configured predicate.
+func (s *stubIngressLimiter) AllowN(peer [33]byte,
+	n int) fn.Result[fn.Unit] {
+
+	s.calls.Add(1)
+	if err := s.decide(peer, n); err != nil {
+		return fn.Err[fn.Unit](err)
+	}
+
+	return fn.Ok(fn.Unit{})
+}
+
+// FirstPeerDropClaim always returns true so the log-path test can
+// observe the one-shot dispatch. Tests that care about the one-shot
+// invariant use a real IngressLimiter instead.
+func (s *stubIngressLimiter) FirstPeerDropClaim() bool { return true }
+
+// FirstGlobalDropClaim always returns true for the same reason.
+func (s *stubIngressLimiter) FirstGlobalDropClaim() bool { return true }
+
+// TestAllowOnionMessageNilLimiter verifies that allowOnionMessage treats
+// a nil IngressLimiter as "disabled" and unconditionally accepts
+// messages.
+func TestAllowOnionMessageNilLimiter(t *testing.T) {
+	t.Parallel()
+
+	var peer [33]byte
+	result := allowOnionMessage(nil, peer, testMsgBytes)
+	require.NoError(t, result.Err())
+}
+
+// TestAllowOnionMessagePeerRejectsFirst verifies that a real
+// IngressLimiter consults the per-peer limiter before the global
+// limiter: once the per-peer bucket is drained, the global bucket
+// must not be touched on subsequent calls, preserving the shared
+// budget against a hostile peer burning global tokens via rejected
+// attempts.
+func TestAllowOnionMessagePeerRejectsFirst(t *testing.T) {
+	t.Parallel()
+
+	// Real per-peer limiter with burst of exactly one message; very
+	// low rate so it does not refill during the test.
+	peerLim := onionmessage.NewPeerRateLimiter(1, testMsgBytes)
+
+	// Stub "global" that records whether it was consulted. It wraps
+	// the global side of the IngressLimiter.
+	globalCalls := atomic.Uint64{}
+	global := &countingGlobalStub{
+		allow: func() bool { return true },
+		calls: &globalCalls,
+	}
+
+	limiter := onionmessage.NewIngressLimiter(peerLim, global)
+
+	var key [33]byte
+	key[0] = 0x03
+
+	// First call drains the per-peer bucket; both limiters are
+	// consulted so global.calls bumps to 1.
+	result := allowOnionMessage(limiter, key, testMsgBytes)
+	require.NoError(t, result.Err())
+	require.Equal(t, uint64(1), globalCalls.Load())
+
+	// Second call trips the per-peer limiter and must NOT consult
+	// the global limiter — globalCalls stays at 1.
+	result = allowOnionMessage(limiter, key, testMsgBytes)
+	require.Error(t, result.Err())
+	require.True(t,
+		errors.Is(result.Err(), onionmessage.ErrPeerRateLimit),
+	)
+	require.Equal(t, uint64(1), peerLim.Dropped())
+	require.Equal(t, uint64(1), globalCalls.Load(),
+		"global limiter must not be consulted when per-peer rejects")
+}
+
+// countingGlobalStub is a minimal RateLimiter test double that counts
+// calls to AllowN and delegates the accept/reject decision to a
+// caller-supplied predicate. It exists so tests can feed a real
+// ingressLimiter a controllable global side.
+type countingGlobalStub struct {
+	allow func() bool
+	calls *atomic.Uint64
+}
+
+func (s *countingGlobalStub) AllowN(_ int) bool {
+	s.calls.Add(1)
+
+	return s.allow()
+}
+
+// TestAllowOnionMessageGlobalRejects verifies that when the per-peer
+// limiter permits traffic but the global bucket is exhausted,
+// allowOnionMessage surfaces ErrGlobalRateLimit.
+func TestAllowOnionMessageGlobalRejects(t *testing.T) {
+	t.Parallel()
+
+	peerLim := onionmessage.NewPeerRateLimiter(
+		1_000_000, 100*testMsgBytes,
+	)
+
+	globalCalls := atomic.Uint64{}
+	global := &countingGlobalStub{
+		allow: func() bool { return false },
+		calls: &globalCalls,
+	}
+	limiter := onionmessage.NewIngressLimiter(peerLim, global)
+
+	var key [33]byte
+	key[0] = 0x02
+
+	result := allowOnionMessage(limiter, key, testMsgBytes)
+	require.Error(t, result.Err())
+	require.True(t,
+		errors.Is(result.Err(), onionmessage.ErrGlobalRateLimit),
+	)
+	require.Equal(t, uint64(0), peerLim.Dropped())
+	require.Equal(t, uint64(1), globalCalls.Load())
+}
+
+// TestAllowOnionMessageHappyPath verifies that a fully-configured
+// IngressLimiter accepts a stream of messages when neither bucket is
+// under pressure.
+func TestAllowOnionMessageHappyPath(t *testing.T) {
+	t.Parallel()
+
+	peerLim := onionmessage.NewPeerRateLimiter(
+		1_000_000, 100*testMsgBytes,
+	)
+	globalCalls := atomic.Uint64{}
+	global := &countingGlobalStub{
+		allow: func() bool { return true },
+		calls: &globalCalls,
+	}
+	limiter := onionmessage.NewIngressLimiter(peerLim, global)
+
+	var key [33]byte
+	key[0] = 0x04
+
+	for i := 0; i < 10; i++ {
+		result := allowOnionMessage(limiter, key, testMsgBytes)
+		require.NoError(t, result.Err(), "iter %d", i)
+	}
+	require.Equal(t, uint64(0), peerLim.Dropped())
+}
+
+// TestAllowOnionMessagePeerIsolation verifies at the peer-package level
+// that exhausting one peer's bucket through allowOnionMessage does not
+// affect a different peer's allowance — guarding against a regression
+// where the helper might key the bucket incorrectly.
+func TestAllowOnionMessagePeerIsolation(t *testing.T) {
+	t.Parallel()
+
+	peerLim := onionmessage.NewPeerRateLimiter(1, 2*testMsgBytes)
+	globalCalls := atomic.Uint64{}
+	global := &countingGlobalStub{
+		allow: func() bool { return true },
+		calls: &globalCalls,
+	}
+	limiter := onionmessage.NewIngressLimiter(peerLim, global)
+
+	var keyA, keyB [33]byte
+	keyA[0] = 0x02
+	keyB[0] = 0x03
+
+	// Drain peer A.
+	for i := 0; i < 2; i++ {
+		result := allowOnionMessage(limiter, keyA, testMsgBytes)
+		require.NoError(t, result.Err())
+	}
+	result := allowOnionMessage(limiter, keyA, testMsgBytes)
+	require.Error(t, result.Err())
+
+	// Peer B must still have its full burst available.
+	for i := 0; i < 2; i++ {
+		result := allowOnionMessage(limiter, keyB, testMsgBytes)
+		require.NoError(t, result.Err(), "peer B slot %d", i)
+	}
+}
+
+// TestAllowOnionMessageConcurrent exercises concurrent access to
+// allowOnionMessage across many goroutines. It asserts that the sum of
+// accepted calls plus the per-peer dropped counter equals the total
+// number of attempts, and that no race or panic occurs. Run with -race
+// for the strongest signal.
+func TestAllowOnionMessageConcurrent(t *testing.T) {
+	t.Parallel()
+
+	const burstMessages = 32
+	peerLim := onionmessage.NewPeerRateLimiter(
+		1, burstMessages*testMsgBytes,
+	)
+	globalCalls := atomic.Uint64{}
+	global := &countingGlobalStub{
+		allow: func() bool { return true },
+		calls: &globalCalls,
+	}
+	limiter := onionmessage.NewIngressLimiter(peerLim, global)
+
+	var key [33]byte
+	key[0] = 0x05
+
+	const workers = 16
+	const perWorker = 64
+	var wg sync.WaitGroup
+	var accepted atomic.Uint64
+
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				result := allowOnionMessage(
+					limiter, key, testMsgBytes,
+				)
+				if result.Err() == nil {
+					accepted.Add(1)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	total := uint64(workers * perWorker)
+	require.Equal(
+		t, total, accepted.Load()+peerLim.Dropped(),
+		"every attempt must be counted as accepted or dropped",
+	)
+	// With a near-zero refill rate the bucket can only issue at most
+	// burstMessages accepts before refill; since the test runs much
+	// faster than the refill interval, accepted should equal the
+	// burst.
+	require.Equal(t, uint64(burstMessages), accepted.Load())
+}

--- a/peer/onion_ratelimit_test.go
+++ b/peer/onion_ratelimit_test.go
@@ -64,7 +64,7 @@ func TestAllowOnionMessageNilLimiter(t *testing.T) {
 	t.Parallel()
 
 	var peer [33]byte
-	result := allowOnionMessage(nil, peer, testMsgBytes, true)
+	result := allowOnionMessage(nil, peer, testMsgBytes, true, false)
 	require.NoError(t, result.Err())
 }
 
@@ -82,7 +82,7 @@ func TestAllowOnionMessageNoChannel(t *testing.T) {
 	var key [33]byte
 	key[0] = 0x07
 
-	result := allowOnionMessage(limiter, key, testMsgBytes, false)
+	result := allowOnionMessage(limiter, key, testMsgBytes, false, false)
 	require.Error(t, result.Err())
 	require.True(t, errors.Is(result.Err(), ErrNoChannel))
 	require.Equal(t, uint64(0), limiter.calls.Load(),
@@ -90,9 +90,48 @@ func TestAllowOnionMessageNoChannel(t *testing.T) {
 
 	// Once the channel gate flips, the same key is accepted and the
 	// limiter is now consulted exactly once.
-	result = allowOnionMessage(limiter, key, testMsgBytes, true)
+	result = allowOnionMessage(limiter, key, testMsgBytes, true, false)
 	require.NoError(t, result.Err())
 	require.Equal(t, uint64(1), limiter.calls.Load())
+}
+
+// TestAllowOnionMessageRelayAll verifies that enabling relayAll skips
+// the channel-presence gate: a peer with no fully open channel is
+// admitted into the IngressLimiter instead of being rejected at the
+// gate. Exercising the same (key, hasChannel=false) input with
+// relayAll flipped on and off proves the flag is the only thing that
+// decides the gate outcome.
+func TestAllowOnionMessageRelayAll(t *testing.T) {
+	t.Parallel()
+
+	limiter := acceptAll()
+
+	var key [33]byte
+	key[0] = 0x08
+
+	// Gate enforced: no-channel peer is rejected without consulting
+	// the IngressLimiter.
+	result := allowOnionMessage(limiter, key, testMsgBytes, false, false)
+	require.Error(t, result.Err())
+	require.True(t, errors.Is(result.Err(), ErrNoChannel))
+	require.Equal(t, uint64(0), limiter.calls.Load())
+
+	// Gate skipped: the same no-channel peer is now admitted and the
+	// IngressLimiter is consulted.
+	result = allowOnionMessage(limiter, key, testMsgBytes, false, true)
+	require.NoError(t, result.Err())
+	require.Equal(t, uint64(1), limiter.calls.Load())
+
+	// relayAll with a peer that also has a channel: the gate is
+	// trivially satisfied and the limiter is consulted again.
+	result = allowOnionMessage(limiter, key, testMsgBytes, true, true)
+	require.NoError(t, result.Err())
+	require.Equal(t, uint64(2), limiter.calls.Load())
+
+	// Nil limiter with relayAll is still accepted: disabled limiter +
+	// skipped gate = unconditional accept.
+	result = allowOnionMessage(nil, key, testMsgBytes, false, true)
+	require.NoError(t, result.Err())
 }
 
 // TestAllowOnionMessagePeerRejectsFirst verifies that a real
@@ -123,13 +162,13 @@ func TestAllowOnionMessagePeerRejectsFirst(t *testing.T) {
 
 	// First call drains the per-peer bucket; both limiters are
 	// consulted so global.calls bumps to 1.
-	result := allowOnionMessage(limiter, key, testMsgBytes, true)
+	result := allowOnionMessage(limiter, key, testMsgBytes, true, false)
 	require.NoError(t, result.Err())
 	require.Equal(t, uint64(1), globalCalls.Load())
 
 	// Second call trips the per-peer limiter and must NOT consult
 	// the global limiter — globalCalls stays at 1.
-	result = allowOnionMessage(limiter, key, testMsgBytes, true)
+	result = allowOnionMessage(limiter, key, testMsgBytes, true, false)
 	require.Error(t, result.Err())
 	require.True(t,
 		errors.Is(result.Err(), onionmessage.ErrPeerRateLimit),
@@ -174,7 +213,7 @@ func TestAllowOnionMessageGlobalRejects(t *testing.T) {
 	var key [33]byte
 	key[0] = 0x02
 
-	result := allowOnionMessage(limiter, key, testMsgBytes, true)
+	result := allowOnionMessage(limiter, key, testMsgBytes, true, false)
 	require.Error(t, result.Err())
 	require.True(t,
 		errors.Is(result.Err(), onionmessage.ErrGlobalRateLimit),
@@ -204,7 +243,7 @@ func TestAllowOnionMessageHappyPath(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		result := allowOnionMessage(
-			limiter, key, testMsgBytes, true,
+			limiter, key, testMsgBytes, true, false,
 		)
 		require.NoError(t, result.Err(), "iter %d", i)
 	}
@@ -233,17 +272,17 @@ func TestAllowOnionMessagePeerIsolation(t *testing.T) {
 	// Drain peer A.
 	for i := 0; i < 2; i++ {
 		result := allowOnionMessage(
-			limiter, keyA, testMsgBytes, true,
+			limiter, keyA, testMsgBytes, true, false,
 		)
 		require.NoError(t, result.Err())
 	}
-	result := allowOnionMessage(limiter, keyA, testMsgBytes, true)
+	result := allowOnionMessage(limiter, keyA, testMsgBytes, true, false)
 	require.Error(t, result.Err())
 
 	// Peer B must still have its full burst available.
 	for i := 0; i < 2; i++ {
 		result := allowOnionMessage(
-			limiter, keyB, testMsgBytes, true,
+			limiter, keyB, testMsgBytes, true, false,
 		)
 		require.NoError(t, result.Err(), "peer B slot %d", i)
 	}
@@ -282,7 +321,7 @@ func TestAllowOnionMessageConcurrent(t *testing.T) {
 			defer wg.Done()
 			for i := 0; i < perWorker; i++ {
 				result := allowOnionMessage(
-					limiter, key, testMsgBytes, true,
+					limiter, key, testMsgBytes, true, false,
 				)
 				if result.Err() == nil {
 					accepted.Add(1)

--- a/peer/onion_ratelimit_test.go
+++ b/peer/onion_ratelimit_test.go
@@ -18,7 +18,9 @@ const testMsgBytes = 32 * 1024
 
 // stubIngressLimiter is a test double for onionmessage.IngressLimiter
 // that records every call and delegates the accept/reject decision to a
-// caller-supplied predicate.
+// caller-supplied predicate. It is used to exercise allowOnionMessage's
+// composition logic (channel gate → limiter) without standing up a
+// real token bucket.
 type stubIngressLimiter struct {
 	// decide is invoked for every AllowN call. It receives the peer
 	// key and byte count and returns the error to embed in the
@@ -48,15 +50,49 @@ func (s *stubIngressLimiter) FirstPeerDropClaim() bool { return true }
 // FirstGlobalDropClaim always returns true for the same reason.
 func (s *stubIngressLimiter) FirstGlobalDropClaim() bool { return true }
 
+// acceptAll constructs a stubIngressLimiter whose AllowN always accepts.
+func acceptAll() *stubIngressLimiter {
+	return &stubIngressLimiter{
+		decide: func(_ [33]byte, _ int) error { return nil },
+	}
+}
+
 // TestAllowOnionMessageNilLimiter verifies that allowOnionMessage treats
 // a nil IngressLimiter as "disabled" and unconditionally accepts
-// messages.
+// messages, as long as the channel gate passes.
 func TestAllowOnionMessageNilLimiter(t *testing.T) {
 	t.Parallel()
 
 	var peer [33]byte
-	result := allowOnionMessage(nil, peer, testMsgBytes)
+	result := allowOnionMessage(nil, peer, testMsgBytes, true)
 	require.NoError(t, result.Err())
+}
+
+// TestAllowOnionMessageNoChannel verifies that messages from a peer
+// that does not have a fully open channel with us are dropped
+// unconditionally with ErrNoChannel, even when a real IngressLimiter
+// is configured. The stub records whether AllowN was consulted; it
+// must remain at zero to prove the channel gate runs before the
+// IngressLimiter.
+func TestAllowOnionMessageNoChannel(t *testing.T) {
+	t.Parallel()
+
+	limiter := acceptAll()
+
+	var key [33]byte
+	key[0] = 0x07
+
+	result := allowOnionMessage(limiter, key, testMsgBytes, false)
+	require.Error(t, result.Err())
+	require.True(t, errors.Is(result.Err(), ErrNoChannel))
+	require.Equal(t, uint64(0), limiter.calls.Load(),
+		"no-channel drop must not consult the IngressLimiter")
+
+	// Once the channel gate flips, the same key is accepted and the
+	// limiter is now consulted exactly once.
+	result = allowOnionMessage(limiter, key, testMsgBytes, true)
+	require.NoError(t, result.Err())
+	require.Equal(t, uint64(1), limiter.calls.Load())
 }
 
 // TestAllowOnionMessagePeerRejectsFirst verifies that a real
@@ -87,13 +123,13 @@ func TestAllowOnionMessagePeerRejectsFirst(t *testing.T) {
 
 	// First call drains the per-peer bucket; both limiters are
 	// consulted so global.calls bumps to 1.
-	result := allowOnionMessage(limiter, key, testMsgBytes)
+	result := allowOnionMessage(limiter, key, testMsgBytes, true)
 	require.NoError(t, result.Err())
 	require.Equal(t, uint64(1), globalCalls.Load())
 
 	// Second call trips the per-peer limiter and must NOT consult
 	// the global limiter — globalCalls stays at 1.
-	result = allowOnionMessage(limiter, key, testMsgBytes)
+	result = allowOnionMessage(limiter, key, testMsgBytes, true)
 	require.Error(t, result.Err())
 	require.True(t,
 		errors.Is(result.Err(), onionmessage.ErrPeerRateLimit),
@@ -138,7 +174,7 @@ func TestAllowOnionMessageGlobalRejects(t *testing.T) {
 	var key [33]byte
 	key[0] = 0x02
 
-	result := allowOnionMessage(limiter, key, testMsgBytes)
+	result := allowOnionMessage(limiter, key, testMsgBytes, true)
 	require.Error(t, result.Err())
 	require.True(t,
 		errors.Is(result.Err(), onionmessage.ErrGlobalRateLimit),
@@ -167,7 +203,9 @@ func TestAllowOnionMessageHappyPath(t *testing.T) {
 	key[0] = 0x04
 
 	for i := 0; i < 10; i++ {
-		result := allowOnionMessage(limiter, key, testMsgBytes)
+		result := allowOnionMessage(
+			limiter, key, testMsgBytes, true,
+		)
 		require.NoError(t, result.Err(), "iter %d", i)
 	}
 	require.Equal(t, uint64(0), peerLim.Dropped())
@@ -194,15 +232,19 @@ func TestAllowOnionMessagePeerIsolation(t *testing.T) {
 
 	// Drain peer A.
 	for i := 0; i < 2; i++ {
-		result := allowOnionMessage(limiter, keyA, testMsgBytes)
+		result := allowOnionMessage(
+			limiter, keyA, testMsgBytes, true,
+		)
 		require.NoError(t, result.Err())
 	}
-	result := allowOnionMessage(limiter, keyA, testMsgBytes)
+	result := allowOnionMessage(limiter, keyA, testMsgBytes, true)
 	require.Error(t, result.Err())
 
 	// Peer B must still have its full burst available.
 	for i := 0; i < 2; i++ {
-		result := allowOnionMessage(limiter, keyB, testMsgBytes)
+		result := allowOnionMessage(
+			limiter, keyB, testMsgBytes, true,
+		)
 		require.NoError(t, result.Err(), "peer B slot %d", i)
 	}
 }
@@ -240,7 +282,7 @@ func TestAllowOnionMessageConcurrent(t *testing.T) {
 			defer wg.Done()
 			for i := 0; i < perWorker; i++ {
 				result := allowOnionMessage(
-					limiter, key, testMsgBytes,
+					limiter, key, testMsgBytes, true,
 				)
 				if result.Err() == nil {
 					accepted.Add(1)

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1502,6 +1502,14 @@
 ; protocol.onion-msg-global-kbps to 0.
 ; protocol.onion-msg-global-burst-bytes=1638400
 
+; If set, accept incoming onion messages from peers that do not have a
+; fully open channel with us. By default only peers with at least one
+; active channel are admitted to the onion message ingress path, so
+; that a new peer identity cannot burn onion bandwidth without first
+; paying the capital cost of opening a channel. Enable this only if
+; you want your node to accept onion messages from arbitrary peers.
+; protocol.onion-msg-relay-all=false
+
 ; Set to handle messages of a particular type that falls outside of the
 ; custom message number range (i.e. 513 is onion messages). Note that you can
 ; set this option as many times as you want to support more than one custom

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1458,6 +1458,50 @@
 ; set to disable onion message support.
 ; protocol.no-onion-messages=false
 
+; Maximum sustained onion message ingress bandwidth from any single peer,
+; in decimal kilobits per second (1 Kbps = 1000 bits/s). Tokens in the
+; underlying bucket are bytes, so small onion messages pay less of the
+; budget than spec-max ones. To disable the per-peer limiter, set both
+; this and protocol.onion-msg-peer-burst-bytes to 0; setting only one of
+; the pair to 0 is rejected at startup as a configuration error. Defaults
+; to ~0.5 Mbps (roughly two spec-max onion messages per second).
+; protocol.onion-msg-peer-kbps=512
+
+; Token bucket depth for the per-peer onion message rate limiter, in
+; bytes. Must be at least 65535 (max on-the-wire onion message size:
+; 2-byte type prefix + lnwire.MaxMsgBody) so that a single maximum-sized
+; wire message can always fit in the bucket; otherwise the limiter would
+; reject every call and silently disable onion forwarding.
+; The default is 8 * 32 KiB = 262144, enough to absorb a small burst of
+; spec-max messages. To disable the per-peer limiter, set both this and
+; protocol.onion-msg-peer-kbps to 0.
+; protocol.onion-msg-peer-burst-bytes=262144
+
+; Maximum sustained aggregate onion message ingress bandwidth across all
+; peers combined, in decimal kilobits per second. To disable the global
+; limiter, set both this and protocol.onion-msg-global-burst-bytes to 0;
+; setting only one of the pair to 0 is rejected at startup as a
+; configuration error. The default of ~5 Mbps is sized so that onion
+; message traffic cannot dwarf a typical routing node's payment traffic.
+;
+; Note on starvation: the global limit is shared across all peers, so if
+; you run a routing node with many well-behaved peers simultaneously
+; sending at their full per-peer allowance the global budget can be
+; saturated. With the default 0.5 Mbps peer and 5 Mbps global, 10 peers
+; at their full per-peer rate exactly fill the global budget. If you
+; expect many concurrent onion-message-active peers, scale this value up
+; (or the per-peer rate down) to preserve headroom.
+; protocol.onion-msg-global-kbps=5120
+
+; Token bucket depth for the global onion message rate limiter, in
+; bytes. Must be at least 65535 (max on-the-wire onion message size:
+; 2-byte type prefix + lnwire.MaxMsgBody). The default is
+; 50 * 32 KiB = 1638400, enough to absorb a burst of spec-max messages
+; while keeping the long-term rate bounded by onion-msg-global-kbps. To
+; disable the global limiter, set both this and
+; protocol.onion-msg-global-kbps to 0.
+; protocol.onion-msg-global-burst-bytes=1638400
+
 ; Set to handle messages of a particular type that falls outside of the
 ; custom message number range (i.e. 513 is onion messages). Note that you can
 ; set this option as many times as you want to support more than one custom

--- a/server.go
+++ b/server.go
@@ -442,6 +442,15 @@ type server struct {
 		*onionmessage.Request, *onionmessage.Response,
 	]
 
+	// onionLimiter is the combined per-peer + global onion message
+	// ingress limiter. It hides the split between the two underlying
+	// buckets behind a single interface so peer.Config only needs to
+	// carry one field and brontide.readHandler only needs one call
+	// per incoming onion message. Nil means onion message rate
+	// limiting is disabled (e.g. when onion messaging itself is
+	// turned off).
+	onionLimiter onionmessage.IngressLimiter
+
 	// txPublisher is a publisher with fee-bumping capability.
 	txPublisher *sweep.TxPublisher
 
@@ -2410,6 +2419,28 @@ func (s *server) Start(ctx context.Context) error {
 
 			s.defaultOnionActorOpts = onionmessage.
 				DefaultOnionActorOpts()
+
+			// Build the global and per-peer onion message rate
+			// limiters from the configured values, then compose
+			// them behind a single IngressLimiter so the peer
+			// package only needs to carry one field. A zero
+			// kbps or a zero burst-bytes disables the
+			// corresponding bucket; rates are expressed in
+			// decimal kilobits per second and bursts in bytes
+			// so operators can reason about onion message
+			// ingress in terms of bandwidth rather than raw
+			// message counts.
+			onionPeerLim := onionmessage.NewPeerRateLimiter(
+				s.cfg.ProtocolOptions.OnionMsgPeerKbps,
+				s.cfg.ProtocolOptions.OnionMsgPeerBurstBytes,
+			)
+			onionGlobalLim := onionmessage.NewGlobalLimiter(
+				s.cfg.ProtocolOptions.OnionMsgGlobalKbps,
+				s.cfg.ProtocolOptions.OnionMsgGlobalBurstBytes,
+			)
+			s.onionLimiter = onionmessage.NewIngressLimiter(
+				onionPeerLim, onionGlobalLim,
+			)
 		}
 
 		cleanup = cleanup.add(s.chanStatusMgr.Stop)
@@ -4479,6 +4510,7 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 		RoutingPolicy:           s.cc.RoutingPolicy,
 		SphinxPayment:           s.sphinxPayment,
 		SpawnOnionActor:         s.onionActorFactory,
+		OnionLimiter:            s.onionLimiter,
 		OnionActorOpts: func(_ [33]byte) []actor.ActorOption[
 			*onionmessage.Request, *onionmessage.Response,
 		] {

--- a/server.go
+++ b/server.go
@@ -4511,6 +4511,7 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 		SphinxPayment:           s.sphinxPayment,
 		SpawnOnionActor:         s.onionActorFactory,
 		OnionLimiter:            s.onionLimiter,
+		OnionRelayAll:           s.cfg.ProtocolOptions.OnionMsgRelayAll,
 		OnionActorOpts: func(_ [33]byte) []actor.ActorOption[
 			*onionmessage.Request, *onionmessage.Response,
 		] {


### PR DESCRIPTION
In this PR, we add two token-bucket rate limiters on the incoming onion
message path: one per-peer, one process-global. Both sit in front of the
existing actor mailbox so that over-limit traffic is dropped at ingress
before we spend any Sphinx unwrap CPU or replay-DB writes on it.

The current defense is the 50-slot per-peer actor mailbox with Random
Early Drop kicking in at depth 40. That's a _backpressure_ mechanism: it
bounds how much work can pile up waiting on the actor, and it keeps a
slow consumer from blowing up memory. What it doesn't bound is
throughput. A peer whose actor drains fast (which is the common case,
since the actor mostly just decodes, routes, and forwards) never goes
near the RED threshold no matter how much traffic it sends us. RED only
trips when the consumer is slow, not when the producer is hostile.

So the mailbox handles the "slow consumer" case and these new limiters
handle the "fast hostile producer" case. They're complementary, not
redundant: the mailbox protects against actor stalls, the limiters
protect against unpaid-traffic flooding.

## Why bother

Onion messages are unpaid, source-routed, and forwarded on behalf of
whoever asks. Assuming spec-max packets (~32 KiB each) and a peer that
drains quickly, a single peer on the default ~50-slot mailbox can push
multiple Mbps of forwarded traffic through us without ever tripping
RED. Fan-in from many peers multiplies that into tens of Mbps. For a
routing node operator, 13 Mbps sustained is about 4.2 TB/month of
unpaid egress (at AWS prices, ~$380/month if saturated), and it's
30x the existing gossip budget. That's very much out of proportion for
a side channel on a payment router, and it's exactly the kind of
surface rate-limiting exists for.

## Defaults

The knobs target roughly ~5 Mbps worst-case ingress at spec-max
message sizes:

- Per-peer: 2 msg/s, burst 8 (~130 KB/s at spec-max)
- Global:  20 msg/s, burst 50 (~650 KB/s, ~1.7 TB/month worst case)

5 Mbps is one HD video stream, within an order of magnitude of our
existing gossip budget, and easily above anything BOLT-12 or
async-payment flows hit in practice. All four values are tunable via
`protocol.onion-msg-peer-rate`, `protocol.onion-msg-peer-burst`,
`protocol.onion-msg-global-rate`, and `protocol.onion-msg-global-burst`.
To disable a limiter entirely, set both its rate and burst to zero;
setting only one of the pair to zero is rejected at startup so a typo
can't silently turn protection off.

## How it works

The primitives live in `onionmessage/ratelimit.go`: a small
`RateLimiter` interface, a `noopLimiter` for the disabled case, a
`countingLimiter` wrapping `x/time/rate.Limiter` with an atomic drop
counter, and a `PeerRateLimiter` registry that lazily creates a bucket
per peer on first use and evicts on `Forget`. The usage pattern mirrors
the existing gossiper rate-limiter in `discovery/gossiper.go`.

At the brontide ingress, `readHandler`'s `*lnwire.OnionMessage` case
calls a small `allowOnionMessage` helper that consults the per-peer
limiter first, then the global limiter. The ordering matters: if we
checked global first, a peer whose own bucket was already empty would
still burn a global token on every rejected attempt, letting a single
hostile peer drain the shared budget and starve legitimate peers.
Checking per-peer first means over-limit traffic from one peer is
rejected before it can touch the global bucket, and the global bucket
only ever accounts for traffic that was within its source peer's own
allowance.

On peer disconnect, `Brontide.Disconnect` calls `Forget` on the
per-peer registry so its memory footprint stays bounded across the
lifetime of the process. There's an acknowledged edge case where a
peer that cycles disconnect+reconnect rapidly can amplify its effective
per-peer rate (each reconnect yields a fresh full-burst bucket). The
global limiter is the hard ceiling that catches this. We document the
interaction in `sample-lnd.conf` so operators understand how the two
limits relate.

When a limiter first trips, `logFirstOnionDrop` emits a one-shot
info-level line so operators get a visible "rate limiting engaged"
signal without log flooding. Subsequent drops fall through to debug.

## Commits

See each commit message for a detailed description w.r.t the
incremental changes:

- `onionmessage`: add token-bucket rate limiter primitives
- `lncfg+config`: add tunable onion message rate limit options
- `peer`: enforce onion message rate limits at ingress
- `server+docs`: construct onion message rate limiters and document config

## Out of scope (follow-ups)

A few items came up in review that I've left for follow-up PRs:

- Wiring `Dropped()` counters into Prometheus metrics. Counters exist;
  exposing them is a separate plumbing change.
- Upper bounds on rate/burst to catch "effectively disabled" settings
  like `burst=2147483647`. Not a correctness issue, just hardening.
- Clamping `OnionBlob` to the BOLT spec max of 32,834 bytes. Right now
  `lnwire.MaxMsgBody` (~65 KiB) is the only ceiling, which doubles the
  worst-case bandwidth math. Would need a spec conversation first.

## Test plan

- [x] Unit tests for the limiter primitives, including table-driven
      disabled-mode, burst exhaustion, per-peer isolation, and a
      concurrent Forget+Allow stress test under `-race`.
- [x] Unit tests for the ingress `allowOnionMessage` helper, including
      nil-limiter, ordering (per-peer rejects first without touching
      global), peer isolation, and a concurrent stress test asserting
      every attempt is accounted for.
- [x] Unit tests for `FirstDropClaim` / `FirstGlobalDropClaim` and for
      `logFirstOnionDrop` (one-shot, nil-peer, unknown-reason).
- [x] Table-driven tests for `validateOnionMsgLimiter` covering NaN,
      ±Inf, negatives, mismatched rate/burst pairs, both-zero, and
      both-positive.
- [ ] Run existing onion message itests to confirm defaults don't
      interfere with happy-path traffic.