### PR TITLE
itest+lntest: harden sweep and watchtower flakes

### DIFF
--- a/itest/lnd_revocation_test.go
+++ b/itest/lnd_revocation_test.go
@@ -279,8 +279,10 @@ func revokedCloseRetributionZeroValueRemoteOutputCase(ht *lntest.HarnessTest,
 	// backup.
 	ht.EnsureConnected(dave, carol)
 
-	// Once connected, give Dave some time to enable the channel again.
+	// Once connected, wait for both channel links to be active again.
 	ht.AssertChannelInGraph(dave, chanPoint)
+	ht.AssertChannelActive(dave, chanPoint)
+	ht.AssertChannelActive(carol, chanPoint)
 
 	// Finally, send payments from Dave to Carol, consuming Carol's
 	// remaining payment hashes.
@@ -507,8 +509,10 @@ func revokedCloseRetributionRemoteHodlCase(ht *lntest.HarnessTest,
 	// backup.
 	ht.EnsureConnected(dave, carol)
 
-	// Once connected, give Dave some time to enable the channel again.
+	// Once connected, wait for both channel links to be active again.
 	ht.AssertChannelInGraph(dave, chanPoint)
+	ht.AssertChannelActive(dave, chanPoint)
+	ht.AssertChannelActive(carol, chanPoint)
 
 	// Finally, send payments from Dave to Carol, consuming Carol's
 	// remaining payment hashes.

--- a/itest/lnd_watchtower_test.go
+++ b/itest/lnd_watchtower_test.go
@@ -448,8 +448,10 @@ func testRevokedCloseRetributionAltruistWatchtowerCase(ht *lntest.HarnessTest,
 	// backup.
 	ht.EnsureConnected(dave, carol)
 
-	// Once connected, give Dave some time to enable the channel again.
+	// Once connected, wait for both channel links to be active again.
 	ht.AssertChannelInGraph(dave, chanPoint)
+	ht.AssertChannelActive(dave, chanPoint)
+	ht.AssertChannelActive(carol, chanPoint)
 
 	// Finally, send payments from Dave to Carol, consuming Carol's
 	// remaining payment hashes.

--- a/lntest/miner/miner.go
+++ b/lntest/miner/miner.go
@@ -589,13 +589,29 @@ func (h *HarnessMiner) AssertOutpointInMempool(op wire.OutPoint) *wire.MsgTx {
 // GetNumTxsFromMempool polls until finding the desired number of transactions
 // in the miner's mempool and returns the full transactions to the caller.
 func (h *HarnessMiner) GetNumTxsFromMempool(n int) []*wire.MsgTx {
-	txids := h.AssertNumTxsInMempool(n)
-
 	var txes []*wire.MsgTx
-	for _, txid := range txids {
-		tx := h.GetRawTransaction(txid)
-		txes = append(txes, tx.MsgTx())
-	}
+
+	err := wait.NoError(func() error {
+		txids := h.AssertNumTxsInMempool(n)
+
+		txes = nil
+		for _, txid := range txids {
+			// The mempool can change between listing its txids
+			// and fetching a transaction. For example, sweep
+			// tests may RBF-replace a tx while we iterate over
+			// the snapshot. Retry with a fresh snapshot when
+			// that happens.
+			tx, err := h.backend.GetRawTransaction(&txid)
+			if err != nil {
+				return err
+			}
+
+			txes = append(txes, tx.MsgTx())
+		}
+
+		return nil
+	}, wait.MinerMempoolTimeout)
+	require.NoError(h, err, "get txs from mempool")
 
 	return txes
 }


### PR DESCRIPTION
Fix the two flakes,
```
--- FAIL: TestLightningNetworkDaemon/tranche02/114-of-325/bitcoind/watchtower-revoked_close_retribution_altruist (176.15s)
        --- FAIL: TestLightningNetworkDaemon/tranche02/114-of-325/bitcoind/watchtower-revoked_close_retribution_altruist/LEGACY (176.15s)
            harness_node.go:395: Starting node (name=Carol) with PID=73180
            harness_node.go:395: Starting node (name=Willy) with PID=73703
            harness_node.go:395: Starting node (name=Dave) with PID=73974
            harness_node.go:395: Starting node (name=Carol) with PID=74574
            harness.go:1681: 
                	Error Trace:	/home/runner/work/lnd/lnd/lntest/harness.go:1681
                	            				/home/runner/work/lnd/lnd/itest/lnd_watchtower_test.go:456
                	            				/home/runner/work/lnd/lnd/itest/lnd_watchtower_test.go:345
                	            				/home/runner/work/lnd/lnd/lntest/harness.go:320
                	            				/home/runner/work/lnd/lnd/itest/lnd_watchtower_test.go:353
                	            				/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:1693
                	Error:      	Received unexpected error:
                	            	Dave: channel:funding_txid_bytes:"L|\x96\xbf.\xc4\x1fGe\x89\x84\xa1\x85\xfe\xff\xa3\x9dҒ\xe6\xeb7\xe0+MOS\xef\xefY 0" waiting for HTLCs, added: 0/6
                	Test:       	TestLightningNetworkDaemon/tranche02/114-of-325/bitcoind/watchtower-revoked_close_retribution_altruist/LEGACY
                	Messages:   	timeout while waiting for HTLCs to lock in
            harness.go:398: finished test: watchtower-revoked_close_retribution_altruist, start height=880, end height=882, mined blocks=2
            harness.go:357: test failed, skipped cleanup
        lnd_watchtower_test.go:362: Failure time: 2026-04-01 16:45:07.934
        harness.go:398: finished test: watchtower-revoked_close_retribution_altruist, start height=880, end height=882, mined blocks=2
        harness.go:357: test failed, skipped cleanup
    lnd_test.go:152: Failure time: 2026-04-01 16:45:07.935
```

and
```
--- FAIL: TestLightningNetworkDaemon/tranche01/79-of-325/bitcoind/sweep_htlcs (131.80s)
        harness_node.go:395: Starting node (name=Alice) with PID=80521
        harness_node.go:395: Starting node (name=Bob) with PID=80935
        harness_node.go:395: Starting node (name=Carol) with PID=81379
        lnd_sweep_test.go:962: Bob's Outgoing HTLC (deadline=22): txWeight=1066 wu, want feerate=4525 sat/kw, got feerate=4524 sat/kw, delta=2018 sat/kw in tx 76ed2f9ad1989a20ec7db5c7172193e197fcacd1c6b5330d6f491ceff96eb578
        lnd_sweep_test.go:962: Bob's Outgoing HTLC (deadline=21): txWeight=1066 wu, want feerate=6543 sat/kw, got feerate=6543 sat/kw, delta=2018 sat/kw in tx 54dce9450014a94afa969a5a893904316e17838969fc8299b0ad79828243fbfa
        lnd_sweep_test.go:962: Bob's Outgoing HTLC (deadline=20): txWeight=1066 wu, want feerate=8561 sat/kw, got feerate=8569 sat/kw, delta=2018 sat/kw in tx 92122774e8b14853c091208873841e75cad16725db30bf4277ed30a22bfc19eb
        lnd_sweep_test.go:962: Bob's Outgoing HTLC (deadline=19): txWeight=1066 wu, want feerate=10579 sat/kw, got feerate=10579 sat/kw, delta=2018 sat/kw in tx 9d870940fd3a80bc2f0853c2117ce9c0be5e501be5162ab336ff56c726fee90d
        lnd_sweep_test.go:962: Bob's Outgoing HTLC (deadline=18): txWeight=1066 wu, want feerate=12597 sat/kw, got feerate=12597 sat/kw, delta=2018 sat/kw in tx e5830799d0711aa0f8955c5233067e3524c584b1bf1962c09e5f464b1c4b22c3
        lnd_sweep_test.go:962: Bob's Outgoing HTLC (deadline=17): txWeight=1066 wu, want feerate=14615 sat/kw, got feerate=14628 sat/kw, delta=2018 sat/kw in tx c9269b299ddc9253263e9c661e802bb44e3e58907181615d0e97bf334acdac1b
        miner.go:384: 
            	Error Trace:	/home/runner/work/lnd/lnd/lntest/miner/miner.go:384
            	            				/home/runner/work/lnd/lnd/lntest/miner/miner.go:596
            	            				/home/runner/work/lnd/lnd/lntest/harness_miner.go:240
            	            				/home/runner/work/lnd/lnd/itest/lnd_sweep_test.go:1060
            	            				/home/runner/work/lnd/lnd/lntest/harness.go:320
            	            				/home/runner/work/lnd/lnd/itest/lnd_test.go:144
            	Error:      	Received unexpected error:
            	            	-5: No information available about transaction c7fd8b8fddbaad8aab62d749a293a75b4197fd78b9b83c1f0277eb7b5bc323f3
            	Test:       	TestLightningNetworkDaemon/tranche01/79-of-325/bitcoind/sweep_htlcs
            	Messages:   	failed to get raw tx: c7fd8b8fddbaad8aab62d749a293a75b4197fd78b9b83c1f0277eb7b5bc323f3
        harness.go:398: finished test: sweep_htlcs, start height=984, end height=1028, mined blocks=44
```