### PR TITLE
graph/db: make FilterKnownChanIDs version-aware

### DIFF
--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -316,6 +316,10 @@
   The v1 end-time bound is corrected from inclusive to exclusive to match the
   BOLT 07 `gossip_timestamp_filter` spec. New SQL queries and composite indexes
   are added for efficient v2 block-height range scans.
+* [Version `FilterKnownChanIDs` and fix `FetchChannelEdgesByID` zombie
+  fallback](https://github.com/lightningnetwork/lnd/pull/10717) so that gossip
+  channel filtering and zombie edge lookups use the correct gossip version
+  instead of hardcoding v1.
 * Updated waiting proof persistence for gossip upgrades by introducing typed
   waiting proof keys and payloads, with a DB migration to rewrite legacy
   waiting proof records to the new key/value format

--- a/graph/db/graph.go
+++ b/graph/db/graph.go
@@ -600,56 +600,6 @@ func (c *ChannelGraph) PruneGraphNodes(ctx context.Context) error {
 	return nil
 }
 
-// FilterKnownChanIDs takes a set of channel IDs and return the subset of chan
-// ID's that we don't know and are not known zombies of the passed set. In other
-// words, we perform a set difference of our set of chan ID's and the ones
-// passed in. This method can be used by callers to determine the set of
-// channels another peer knows of that we don't.
-func (c *ChannelGraph) FilterKnownChanIDs(ctx context.Context,
-	chansInfo []ChannelUpdateInfo,
-	isZombieChan func(ChannelUpdateInfo) bool) ([]uint64, error) {
-
-	unknown, knownZombies, err := c.db.FilterKnownChanIDs(ctx, chansInfo)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, info := range knownZombies {
-		// TODO(ziggie): Make sure that for the strict pruning case we
-		// compare the pubkeys and whether the right timestamp is not
-		// older than the `ChannelPruneExpiry`.
-		//
-		// NOTE: The timestamp data has no verification attached to it
-		// in the `ReplyChannelRange` msg so we are trusting this data
-		// at this point. However it is not critical because we are just
-		// removing the channel from the db when the timestamps are more
-		// recent. During the querying of the gossip msg verification
-		// happens as usual. However we should start punishing peers
-		// when they don't provide us honest data ?
-		if isZombieChan(info) {
-			continue
-		}
-
-		// If we have marked it as a zombie but the latest update
-		// info could bring it back from the dead, then we mark it
-		// alive, and we let it be added to the set of IDs to query our
-		// peer for.
-		err := c.db.MarkEdgeLive(
-			ctx, info.Version,
-			info.ShortChannelID.ToUint64(),
-		)
-		// Since there is a chance that the edge could have been marked
-		// as "live" between the FilterKnownChanIDs call and the
-		// MarkEdgeLive call, we ignore the error if the edge is already
-		// marked as live.
-		if err != nil && !errors.Is(err, ErrZombieEdgeNotFound) {
-			return nil, err
-		}
-	}
-
-	return unknown, nil
-}
-
 // MarkEdgeZombie attempts to mark a channel identified by its channel ID as a
 // zombie for the given gossip version. This method is used on an ad-hoc basis,
 // when channels need to be marked as zombies outside the normal pruning cycle.
@@ -794,6 +744,69 @@ func (c *VersionedGraph) FilterChannelRange(ctx context.Context,
 	return c.db.FilterChannelRange(
 		ctx, c.v, startHeight, endHeight, withTimestamps,
 	)
+}
+
+// FilterKnownChanIDs takes a set of channel IDs and returns the subset of chan
+// ID's that we don't know and are not known zombies of the passed set. In other
+// words, we perform a set difference of our set of chan ID's and the ones
+// passed in. This method can be used by callers to determine the set of
+// channels another peer knows of that we don't.
+func (c *VersionedGraph) FilterKnownChanIDs(ctx context.Context,
+	chansInfo []ChannelUpdateInfo,
+	isZombieChan func(ChannelUpdateInfo) bool) ([]uint64, error) {
+
+	unknown, knownZombies, err := c.db.FilterKnownChanIDs(
+		ctx, c.v, chansInfo,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, info := range knownZombies {
+		// Sanity check that the returned zombie channels are on the
+		// same gossip version as the one we passed in.
+		if info.Version != c.v {
+			return nil, fmt.Errorf("expected zombie channel's "+
+				"gossip version to be %v, got %v", c.v,
+				info.Version)
+		}
+
+		// TODO(ziggie): Make sure that for the strict pruning case
+		// we compare the pubkeys and whether the right timestamp
+		// is not older than the `ChannelPruneExpiry`.
+		//
+		// NOTE: The timestamp data has no verification attached
+		// to it in the `ReplyChannelRange` msg so we are trusting
+		// this data at this point. However it is not critical
+		// because we are just removing the channel from the db
+		// when the timestamps are more recent. During the querying
+		// of the gossip msg verification happens as usual. However
+		// we should start punishing peers when they don't provide
+		// us honest data?
+		if isZombieChan(info) {
+			continue
+		}
+
+		// If we have marked it as a zombie but the latest update
+		// info could bring it back from the dead, then we mark it
+		// alive, and we let it be added to the set of IDs to
+		// query our peer for.
+		err := c.db.MarkEdgeLive(
+			ctx, info.Version,
+			info.ShortChannelID.ToUint64(),
+		)
+		// Since there is a chance that the edge could have been
+		// marked as "live" between the FilterKnownChanIDs call
+		// and the MarkEdgeLive call, we ignore the error if the
+		// edge is already marked as live.
+		if err != nil &&
+			!errors.Is(err, ErrZombieEdgeNotFound) {
+
+			return nil, err
+		}
+	}
+
+	return unknown, nil
 }
 
 // FetchChanInfos returns the set of channel edges for the passed channel IDs.

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -239,6 +239,10 @@ var versionedTests = []versionedTest{
 		name: "filter known chan ids",
 		test: testFilterKnownChanIDs,
 	},
+	{
+		name: "fetch zombie edge versioning",
+		test: testFetchZombieEdgeVersioning,
+	},
 }
 
 // TestVersionedDBs runs various tests against both v1 and v2 versioned
@@ -5492,6 +5496,40 @@ func testGraphZombieIndex(t *testing.T, v lnwire.GossipVersion) {
 	require.NoError(t, err)
 	require.True(t, isZombie)
 	assertNumZombies(t, graph, v, 1)
+}
+
+// testFetchZombieEdgeVersioning verifies that when a zombie edge is fetched via
+// FetchChannelEdgesByID, the returned ChannelEdgeInfo carries the correct
+// gossip version.
+func testFetchZombieEdgeVersioning(t *testing.T, v lnwire.GossipVersion) {
+	t.Parallel()
+	ctx := t.Context()
+
+	graph := NewVersionedGraph(MakeTestGraph(t), v)
+
+	node1 := createTestVertex(t, v)
+	node2 := createTestVertex(t, v)
+
+	if bytes.Compare(node2.PubKeyBytes[:], node1.PubKeyBytes[:]) < 0 {
+		node1, node2 = node2, node1
+	}
+
+	edge, _, _ := createChannelEdge(node1, node2, v)
+	require.NoError(t, graph.AddChannelEdge(ctx, edge))
+
+	// Delete the edge and mark it as a zombie.
+	err := graph.DeleteChannelEdges(ctx, false, true, edge.ChannelID)
+	require.NoError(t, err)
+
+	// Fetch the zombie edge by ID. The returned edge info should carry
+	// the correct gossip version even though the channel data has been
+	// removed.
+	info, _, _, err := graph.FetchChannelEdgesByID(ctx, edge.ChannelID)
+	require.ErrorIs(t, err, ErrZombieEdge)
+	require.NotNil(t, info)
+	require.Equal(t, v, info.Version)
+	require.Equal(t, edge.NodeKey1Bytes, info.NodeKey1Bytes)
+	require.Equal(t, edge.NodeKey2Bytes, info.NodeKey2Bytes)
 }
 
 // compareNodes is used to compare two Nodes.

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -231,6 +231,14 @@ var versionedTests = []versionedTest{
 		name: "disconnect block at height",
 		test: testDisconnectBlockAtHeight,
 	},
+	{
+		name: "filter known chan ids zombie revival",
+		test: testFilterKnownChanIDsZombieRevival,
+	},
+	{
+		name: "filter known chan ids",
+		test: testFilterKnownChanIDs,
+	},
 }
 
 // TestVersionedDBs runs various tests against both v1 and v2 versioned
@@ -3613,14 +3621,16 @@ func TestChanUpdatesInHorizonV2(t *testing.T) {
 	})
 }
 
-// TestFilterKnownChanIDsZombieRevival tests that if a ChannelUpdateInfo is
+// testFilterKnownChanIDsZombieRevival tests that if a ChannelUpdateInfo is
 // passed to FilterKnownChanIDs that contains a channel that we have marked as
 // a zombie, then we will mark it as live again if the new ChannelUpdate has
 // timestamps that would make the channel be considered live again.
 //
-// NOTE: this tests focuses on zombie revival. The main logic of
-// FilterKnownChanIDs is tested in TestFilterKnownChanIDs.
-func TestFilterKnownChanIDsZombieRevival(t *testing.T) {
+// NOTE: this test focuses on zombie revival. The main logic of
+// FilterKnownChanIDs is tested in testFilterKnownChanIDs.
+func testFilterKnownChanIDsZombieRevival(t *testing.T,
+	v lnwire.GossipVersion) {
+
 	t.Parallel()
 	ctx := t.Context()
 
@@ -3632,9 +3642,11 @@ func TestFilterKnownChanIDsZombieRevival(t *testing.T) {
 		scid3 = lnwire.ShortChannelID{BlockHeight: 3}
 	)
 
-	v1Graph := NewVersionedGraph(graph, lnwire.GossipVersion1)
+	vGraph := NewVersionedGraph(graph, v)
 	isZombie := func(scid lnwire.ShortChannelID) bool {
-		zombie, _, _, err := v1Graph.IsZombieEdge(ctx, scid.ToUint64())
+		zombie, _, _, err := vGraph.IsZombieEdge(
+			ctx, scid.ToUint64(),
+		)
 		require.NoError(t, err)
 
 		return zombie
@@ -3642,13 +3654,11 @@ func TestFilterKnownChanIDsZombieRevival(t *testing.T) {
 
 	// Mark channel 1 and 2 as zombies.
 	err := graph.MarkEdgeZombie(
-		ctx, lnwire.GossipVersion1, scid1.ToUint64(),
-		[33]byte{}, [33]byte{},
+		ctx, v, scid1.ToUint64(), [33]byte{}, [33]byte{},
 	)
 	require.NoError(t, err)
 	err = graph.MarkEdgeZombie(
-		ctx, lnwire.GossipVersion1, scid2.ToUint64(),
-		[33]byte{}, [33]byte{},
+		ctx, v, scid2.ToUint64(), [33]byte{}, [33]byte{},
 	)
 	require.NoError(t, err)
 
@@ -3656,12 +3666,22 @@ func TestFilterKnownChanIDsZombieRevival(t *testing.T) {
 	require.True(t, isZombie(scid2))
 	require.False(t, isZombie(scid3))
 
+	// Build a freshness marker appropriate for the gossip version. V1
+	// uses unix timestamps, v2 uses block heights.
+	var revivalFreshness lnwire.Timestamp
+	switch v {
+	case lnwire.GossipVersion1:
+		revivalFreshness = lnwire.UnixTimestamp(1000)
+	case lnwire.GossipVersion2:
+		revivalFreshness = lnwire.BlockHeightTimestamp(1000)
+	}
+
 	// Call FilterKnownChanIDs with an isStillZombie call-back that would
 	// result in the current zombies still be considered as zombies.
-	_, err = graph.FilterKnownChanIDs(ctx, []ChannelUpdateInfo{
-		{ShortChannelID: scid1, Version: lnwire.GossipVersion1},
-		{ShortChannelID: scid2, Version: lnwire.GossipVersion1},
-		{ShortChannelID: scid3, Version: lnwire.GossipVersion1},
+	_, err = vGraph.FilterKnownChanIDs(ctx, []ChannelUpdateInfo{
+		{ShortChannelID: scid1, Version: v},
+		{ShortChannelID: scid2, Version: v},
+		{ShortChannelID: scid3, Version: v},
 	}, func(_ ChannelUpdateInfo) bool {
 		return true
 	})
@@ -3671,19 +3691,19 @@ func TestFilterKnownChanIDsZombieRevival(t *testing.T) {
 	require.True(t, isZombie(scid2))
 	require.False(t, isZombie(scid3))
 
-	// Now call it again but this time with a isStillZombie call-back that
-	// would result in channel with SCID 2 no longer being considered a
-	// zombie.
-	_, err = graph.FilterKnownChanIDs(ctx, []ChannelUpdateInfo{
-		{ShortChannelID: scid1, Version: lnwire.GossipVersion1},
+	// Now call it again but this time with an isStillZombie call-back
+	// that would result in channel with SCID 2 no longer being
+	// considered a zombie.
+	_, err = vGraph.FilterKnownChanIDs(ctx, []ChannelUpdateInfo{
+		{ShortChannelID: scid1, Version: v},
 		{
 			ShortChannelID: scid2,
-			Version:        lnwire.GossipVersion1,
-			Node1Freshness: lnwire.UnixTimestamp(1000),
+			Version:        v,
+			Node1Freshness: revivalFreshness,
 		},
-		{ShortChannelID: scid3, Version: lnwire.GossipVersion1},
+		{ShortChannelID: scid3, Version: v},
 	}, func(info ChannelUpdateInfo) bool {
-		return info.Node1Freshness != lnwire.UnixTimestamp(1000)
+		return info.Node1Freshness != revivalFreshness
 	})
 	require.NoError(t, err)
 
@@ -3693,17 +3713,30 @@ func TestFilterKnownChanIDsZombieRevival(t *testing.T) {
 	require.False(t, isZombie(scid3))
 }
 
-// TestFilterKnownChanIDs tests that we're able to properly perform the set
+// testFilterKnownChanIDs tests that we're able to properly perform the set
 // differences of an incoming set of channel ID's, and those that we already
 // know of on disk.
-func TestFilterKnownChanIDs(t *testing.T) {
+func testFilterKnownChanIDs(t *testing.T, v lnwire.GossipVersion) {
 	t.Parallel()
 	ctx := t.Context()
 
 	graph := MakeTestGraph(t)
+	vGraph := NewVersionedGraph(graph, v)
 
 	isZombieUpdate := func(_ ChannelUpdateInfo) bool {
 		return true
+	}
+
+	// newChanUpdateInfo builds a ChannelUpdateInfo for the given SCID with
+	// the test's gossip version and zero freshness.
+	newChanUpdateInfo := func(
+		scid lnwire.ShortChannelID,
+	) ChannelUpdateInfo {
+
+		return ChannelUpdateInfo{
+			ShortChannelID: scid,
+			Version:        v,
+		}
 	}
 
 	var (
@@ -3715,11 +3748,11 @@ func TestFilterKnownChanIDs(t *testing.T) {
 	// If we try to filter out a set of channel ID's before we even know of
 	// any channels, then we should get the entire set back.
 	preChanIDs := []ChannelUpdateInfo{
-		{ShortChannelID: scid1},
-		{ShortChannelID: scid2},
-		{ShortChannelID: scid3},
+		newChanUpdateInfo(scid1),
+		newChanUpdateInfo(scid2),
+		newChanUpdateInfo(scid3),
 	}
-	filteredIDs, err := graph.FilterKnownChanIDs(
+	filteredIDs, err := vGraph.FilterKnownChanIDs(
 		ctx, preChanIDs, isZombieUpdate,
 	)
 	require.NoError(t, err, "unable to filter chan IDs")
@@ -3730,9 +3763,9 @@ func TestFilterKnownChanIDs(t *testing.T) {
 	}, filteredIDs)
 
 	// We'll start by creating two nodes which will seed our test graph.
-	node1 := createTestVertex(t, lnwire.GossipVersion1)
+	node1 := createTestVertex(t, v)
 	require.NoError(t, graph.AddNode(ctx, node1))
-	node2 := createTestVertex(t, lnwire.GossipVersion1)
+	node2 := createTestVertex(t, v)
 	require.NoError(t, graph.AddNode(ctx, node2))
 
 	// Next, we'll add 5 channel ID's to the graph, each of them having a
@@ -3741,112 +3774,86 @@ func TestFilterKnownChanIDs(t *testing.T) {
 	chanIDs := make([]ChannelUpdateInfo, 0, numChans)
 	for i := 0; i < numChans; i++ {
 		channel, chanID := createEdge(
-			lnwire.GossipVersion1, uint32(i*10), 0, 0, 0,
-			node1, node2,
+			v, uint32(i*10), 0, 0, 0, node1, node2,
 		)
 		require.NoError(t, graph.AddChannelEdge(ctx, channel))
 
-		chanIDs = append(chanIDs, NewV1ChannelUpdateInfo(
-			chanID, time.Time{}, time.Time{},
-		))
+		chanIDs = append(chanIDs, newChanUpdateInfo(chanID))
 	}
 
 	const numZombies = 5
 	zombieIDs := make([]ChannelUpdateInfo, 0, numZombies)
 	for i := 0; i < numZombies; i++ {
 		channel, chanID := createEdge(
-			lnwire.GossipVersion1, uint32(i*10+1), 0, 0, 0,
-			node1, node2,
+			v, uint32(i*10+1), 0, 0, 0, node1, node2,
 		)
 		require.NoError(t, graph.AddChannelEdge(ctx, channel))
 		err := graph.DeleteChannelEdges(
-			ctx, lnwire.GossipVersion1, false, true,
-			channel.ChannelID,
+			ctx, v, false, true, channel.ChannelID,
 		)
 		require.NoError(t, err)
 
-		zombieIDs = append(
-			zombieIDs, ChannelUpdateInfo{ShortChannelID: chanID},
-		)
+		zombieIDs = append(zombieIDs, newChanUpdateInfo(chanID))
 	}
 
 	queryCases := []struct {
 		queryIDs []ChannelUpdateInfo
-
-		resp []ChannelUpdateInfo
+		resp     []ChannelUpdateInfo
 	}{
 		// If we attempt to filter out all chanIDs we know of, the
 		// response should be the empty set.
 		{
 			queryIDs: chanIDs,
 		},
-		// If we attempt to filter out all zombies that we know of, the
-		// response should be the empty set.
+		// If we attempt to filter out all zombies that we know of,
+		// the response should be the empty set.
 		{
 			queryIDs: zombieIDs,
 		},
-
 		// If we query for a set of ID's that we didn't insert, we
 		// should get the same set back.
 		{
 			queryIDs: []ChannelUpdateInfo{
-				{
-					ShortChannelID: lnwire.ShortChannelID{
-						BlockHeight: 99,
-					},
-				},
-				{
-					ShortChannelID: lnwire.ShortChannelID{
-						BlockHeight: 100,
-					},
-				},
+				newChanUpdateInfo(lnwire.ShortChannelID{
+					BlockHeight: 99,
+				}),
+				newChanUpdateInfo(lnwire.ShortChannelID{
+					BlockHeight: 100,
+				}),
 			},
 			resp: []ChannelUpdateInfo{
-				{
-					ShortChannelID: lnwire.ShortChannelID{
-						BlockHeight: 99,
-					},
-				},
-				{
-					ShortChannelID: lnwire.ShortChannelID{
-						BlockHeight: 100,
-					},
-				},
+				newChanUpdateInfo(lnwire.ShortChannelID{
+					BlockHeight: 99,
+				}),
+				newChanUpdateInfo(lnwire.ShortChannelID{
+					BlockHeight: 100,
+				}),
 			},
 		},
-
 		// If we query for a super-set of our the chan ID's inserted,
 		// we should only get those new chanIDs back.
 		{
 			queryIDs: append(chanIDs, []ChannelUpdateInfo{
-				{
-					ShortChannelID: lnwire.ShortChannelID{
-						BlockHeight: 99,
-					},
-				},
-				{
-					ShortChannelID: lnwire.ShortChannelID{
-						BlockHeight: 101,
-					},
-				},
+				newChanUpdateInfo(lnwire.ShortChannelID{
+					BlockHeight: 99,
+				}),
+				newChanUpdateInfo(lnwire.ShortChannelID{
+					BlockHeight: 101,
+				}),
 			}...),
 			resp: []ChannelUpdateInfo{
-				{
-					ShortChannelID: lnwire.ShortChannelID{
-						BlockHeight: 99,
-					},
-				},
-				{
-					ShortChannelID: lnwire.ShortChannelID{
-						BlockHeight: 101,
-					},
-				},
+				newChanUpdateInfo(lnwire.ShortChannelID{
+					BlockHeight: 99,
+				}),
+				newChanUpdateInfo(lnwire.ShortChannelID{
+					BlockHeight: 101,
+				}),
 			},
 		},
 	}
 
 	for _, queryCase := range queryCases {
-		resp, err := graph.FilterKnownChanIDs(
+		resp, err := vGraph.FilterKnownChanIDs(
 			ctx, queryCase.queryIDs, isZombieUpdate,
 		)
 		require.NoError(t, err)

--- a/graph/db/interfaces.go
+++ b/graph/db/interfaces.go
@@ -265,14 +265,14 @@ type Store interface { //nolint:interfacebloat
 		r ChanUpdateRange,
 		opts ...IteratorOption) iter.Seq2[ChannelEdge, error]
 
-	// FilterKnownChanIDs takes a set of channel IDs and return the subset
-	// of chan ID's that we don't know and are not known zombies of the
-	// passed set. In other words, we perform a set difference of our set
-	// of chan ID's and the ones passed in. This method can be used by
-	// callers to determine the set of channels another peer knows of that
-	// we don't. The ChannelUpdateInfos for the known zombies is also
-	// returned.
-	FilterKnownChanIDs(ctx context.Context,
+	// FilterKnownChanIDs takes a set of channel IDs for a given gossip
+	// version and returns the subset of chan ID's that we don't know and
+	// are not known zombies of the passed set. In other words, we perform
+	// a set difference of our set of chan ID's and the ones passed in.
+	// This method can be used by callers to determine the set of channels
+	// another peer knows of that we don't. The ChannelUpdateInfos for the
+	// known zombies is also returned.
+	FilterKnownChanIDs(ctx context.Context, v lnwire.GossipVersion,
 		chansInfo []ChannelUpdateInfo) ([]uint64, []ChannelUpdateInfo,
 		error)
 

--- a/graph/db/kv_store.go
+++ b/graph/db/kv_store.go
@@ -2723,7 +2723,12 @@ func (c *KVStore) NodeUpdatesInHorizon(_ context.Context,
 // channels another peer knows of that we don't. The ChannelUpdateInfos for the
 // known zombies is also returned.
 func (c *KVStore) FilterKnownChanIDs(_ context.Context,
+	v lnwire.GossipVersion,
 	chansInfo []ChannelUpdateInfo) ([]uint64, []ChannelUpdateInfo, error) {
+
+	if v != lnwire.GossipVersion1 {
+		return nil, nil, ErrVersionNotSupportedForKVDB
+	}
 
 	var (
 		newChanIDs   []uint64

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -3141,7 +3141,8 @@ func (s *SQLStore) FilterKnownChanIDs(ctx context.Context,
 	err := s.db.ExecTx(ctx, sqldb.ReadTxOpt(), func(db SQLQueries) error {
 		// The call-back function deletes known channels from
 		// infoLookup, so that we can later check which channels are
-		// zombies by only looking at the remaining channels in the set.
+		// zombies by only looking at the remaining channels in the
+		// set.
 		cb := func(ctx context.Context,
 			channel sqlc.GraphChannel) error {
 
@@ -3150,16 +3151,18 @@ func (s *SQLStore) FilterKnownChanIDs(ctx context.Context,
 			return nil
 		}
 
-		err := s.forEachChanInSCIDList(ctx, db, cb, chansInfo)
+		err := s.forEachChanInSCIDList(
+			ctx, db, lnwire.GossipVersion1, cb, chansInfo,
+		)
 		if err != nil {
-			return fmt.Errorf("unable to iterate through "+
+			return fmt.Errorf("unable to iterate "+
 				"channels: %w", err)
 		}
 
 		// We want to ensure that we deal with the channels in the
-		// same order that they were passed in, so we iterate over the
-		// original chansInfo slice and then check if that channel is
-		// still in the infoLookup map.
+		// same order that they were passed in, so we iterate over
+		// the original chansInfo slice and then check if that
+		// channel is still in the infoLookup map.
 		for _, chanInfo := range chansInfo {
 			channelID := chanInfo.ShortChannelID.ToUint64()
 			if _, ok := infoLookup[channelID]; !ok {
@@ -3168,17 +3171,21 @@ func (s *SQLStore) FilterKnownChanIDs(ctx context.Context,
 
 			isZombie, err := db.IsZombieChannel(
 				ctx, sqlc.IsZombieChannelParams{
-					Scid:    channelIDToBytes(channelID),
-					Version: int16(lnwire.GossipVersion1),
+					Scid: channelIDToBytes(channelID),
+					Version: int16(
+						chanInfo.Version,
+					),
 				},
 			)
 			if err != nil {
-				return fmt.Errorf("unable to fetch zombie "+
-					"channel: %w", err)
+				return fmt.Errorf("unable to fetch "+
+					"zombie channel: %w", err)
 			}
 
 			if isZombie {
-				knownZombies = append(knownZombies, chanInfo)
+				knownZombies = append(
+					knownZombies, chanInfo,
+				)
 
 				continue
 			}
@@ -3204,10 +3211,11 @@ func (s *SQLStore) FilterKnownChanIDs(ctx context.Context,
 }
 
 // forEachChanInSCIDList is a helper method that executes a paged query
-// against the database to fetch all channels that match the passed
-// ChannelUpdateInfo slice. The callback function is called for each channel
-// that is found.
+// against the database to fetch all channels of the given gossip version that
+// match the passed ChannelUpdateInfo slice. The callback function is called
+// for each channel that is found.
 func (s *SQLStore) forEachChanInSCIDList(ctx context.Context, db SQLQueries,
+	v lnwire.GossipVersion,
 	cb func(ctx context.Context, channel sqlc.GraphChannel) error,
 	chansInfo []ChannelUpdateInfo) error {
 
@@ -3216,7 +3224,7 @@ func (s *SQLStore) forEachChanInSCIDList(ctx context.Context, db SQLQueries,
 
 		return db.GetChannelsBySCIDs(
 			ctx, sqlc.GetChannelsBySCIDsParams{
-				Version: int16(lnwire.GossipVersion1),
+				Version: int16(v),
 				Scids:   scids,
 			},
 		)

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -2544,14 +2544,21 @@ func (s *SQLStore) FetchChannelEdgesByID(ctx context.Context,
 			if err != nil {
 				return err
 			}
-			zombieEdge, err := models.NewV1Channel(
-				0, chainhash.Hash{}, node1, node2,
-				&models.ChannelV1Fields{},
-			)
+			switch v {
+			case gossipV1:
+				edge, err = models.NewV1Channel(
+					0, chainhash.Hash{}, node1,
+					node2, &models.ChannelV1Fields{},
+				)
+			case gossipV2:
+				edge, err = models.NewV2Channel(
+					0, chainhash.Hash{}, node1,
+					node2, &models.ChannelV2Fields{},
+				)
+			}
 			if err != nil {
 				return err
 			}
-			edge = zombieEdge
 
 			return ErrZombieEdge
 		} else if err != nil {

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -3121,6 +3121,7 @@ func (s *SQLStore) forEachChanWithPoliciesInSCIDList(ctx context.Context,
 //
 // NOTE: part of the Store interface.
 func (s *SQLStore) FilterKnownChanIDs(ctx context.Context,
+	v lnwire.GossipVersion,
 	chansInfo []ChannelUpdateInfo) ([]uint64, []ChannelUpdateInfo, error) {
 
 	var (
@@ -3152,7 +3153,7 @@ func (s *SQLStore) FilterKnownChanIDs(ctx context.Context,
 		}
 
 		err := s.forEachChanInSCIDList(
-			ctx, db, lnwire.GossipVersion1, cb, chansInfo,
+			ctx, db, v, cb, chansInfo,
 		)
 		if err != nil {
 			return fmt.Errorf("unable to iterate "+
@@ -3171,10 +3172,8 @@ func (s *SQLStore) FilterKnownChanIDs(ctx context.Context,
 
 			isZombie, err := db.IsZombieChannel(
 				ctx, sqlc.IsZombieChannelParams{
-					Scid: channelIDToBytes(channelID),
-					Version: int16(
-						chanInfo.Version,
-					),
+					Scid:    channelIDToBytes(channelID),
+					Version: int16(v),
 				},
 			)
 			if err != nil {


### PR DESCRIPTION
## Summary

Make `FilterKnownChanIDs` and `FetchChannelEdgesByID` version-aware,
replacing hardcoded `GossipVersion1` references so that v2 channels
are handled correctly.

**Part of the gossip v2 epic:** https://github.com/lightningnetwork/lnd/issues/10293

### Changes by commit

1. **`graph/db: parameterize forEachChanInSCIDList with gossip version`** — replace the hardcoded `GossipVersion1` in `forEachChanInSCIDList` with an explicit version parameter.
2. **`graph/db: add gossip version parameter to FilterKnownChanIDs`** — add a `lnwire.GossipVersion` parameter to the `Store` interface, `SQLStore`, `KVStore`, and `ChannelGraph`. A convenience wrapper on `VersionedGraph` preserves the existing `ChanSeries` call-site signature. Convert `TestFilterKnownChanIDs` and `TestFilterKnownChanIDsZombieRevival` to versioned v1+v2 tests.
3. **`graph/db: fix FetchChannelEdgesByID zombie fallback versioning`** — the zombie fallback unconditionally constructed `NewV1Channel` regardless of the requested version. Use the passed version to select the correct constructor. Add `testFetchZombieEdgeVersioning` versioned test.

## Test plan

- [x] `TestVersionedDBs/filter_known_chan_ids/{v1,v2}` passes
- [x] `TestVersionedDBs/filter_known_chan_ids_zombie_revival/{v1,v2}` passes
- [x] `TestVersionedDBs/fetch_zombie_edge_versioning/{v1,v2}` passes
- [x] All commits compile independently (`go test -c` per commit)
- [x] `discovery/` package builds cleanly