### PR TITLE
htlcswitch: fix hodlQueue deadlock by stopping htlcManager first

### DIFF
--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -70,6 +70,13 @@
   the chain watch filter on restart. This was a pre-existing bug since
   private taproot channels were first introduced.
 
+* [Fixed a shutdown race in the 
+  channel link](https://github.com/lightningnetwork/lnd/pull/10719)
+  that could deadlock the invoice registry during concurrent peer disconnect.
+  The link now waits for `htlcManager` to fully exit before tearing down hodl
+  subscriptions and the hodl queue, preventing orphaned subscriptions from
+  blocking invoice resolution.
+
 # New Features
 
 - [Basic Support](https://github.com/lightningnetwork/lnd/pull/9868) for onion

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -629,8 +629,20 @@ func (l *channelLink) Stop() {
 
 	l.log.Info("stopping")
 
-	// As the link is stopping, we are no longer interested in htlc
-	// resolutions coming from the invoice registry.
+	// Stop the htlcManager goroutine first. This is critical: htlcManager
+	// is the sole caller of NotifyExitHopHtlc, which registers new hodl
+	// subscriptions. We must guarantee it has fully exited before we
+	// remove subscriptions and stop the hodlQueue. Without this ordering,
+	// a RevokeAndAck processed in the race window between hodlQueue.Stop()
+	// and cg.Quit() can register an orphaned subscription against a dead
+	// queue, causing notifyHodlSubscribers to block permanently and
+	// deadlock the entire invoice registry.
+	l.cg.Quit()
+	l.cg.WgWait()
+
+	// htlcManager has fully exited — no new hodl subscriptions can be
+	// registered from this point on. It is now safe to remove all
+	// subscriptions and tear down the queue.
 	l.cfg.Registry.HodlUnsubscribeAll(l.hodlQueue.ChanIn())
 
 	if l.cfg.ChainEvents.Cancel != nil {
@@ -650,9 +662,6 @@ func (l *channelLink) Stop() {
 	if l.hodlQueue != nil {
 		l.hodlQueue.Stop()
 	}
-
-	l.cg.Quit()
-	l.cg.WgWait()
 
 	// Now that the htlcManager has completely exited, reset the packet
 	// courier. This allows the mailbox to revaluate any lingering Adds that


### PR DESCRIPTION
## Summary

This PR fixes a deadlock in the invoice registry caused by an inverted
teardown order in `channelLink.Stop()`.

Closes #10718

## Root Cause

The previous `Stop()` sequence was:

```
① HodlUnsubscribeAll(hodlQueue.ChanIn())   -- removes subscriptions
② hodlQueue.Stop()                          -- kills queue goroutine
③ cg.Quit()                                 -- signals htlcManager
④ cg.WgWait()                               -- waits for htlcManager
```

Steps ② and ③ create a race window where `htlcManager` is still alive
but `hodlQueue` is dead. A `RevokeAndAck` arriving in this window
drives:

```
processRemoteAdds → processExitHop → NotifyExitHopHtlc
```

This registers a **new** hodl subscription backed by a dead
`hodlQueue.ChanIn()` (its internal goroutine has exited, so the
unbuffered channel has no reader).

The orphaned subscription then causes a deadlock cascade:

- Any call to `notifyHodlSubscribers` (MPP auto-release timer, expiry
  watcher, or explicit settle/cancel) blocks on the dead `ChanIn()`,
  holding `hodlSubscriptionsMux`.
- Concurrent `NotifyExitHopHtlc` calls waiting for that lock stall.
- Callers holding the invoice-level lock `i.Lock()` waiting on those
  freeze the entire registry.

There is no recovery path short of a daemon restart.

**The risk is amplified** when `channeldb` is backed by bbolt (KV
store) because bbolt's global write lock increases the latency of
`processRemoteRevokeAndAck`, widening the race window and raising the
probability of the scheduler preempting between steps ② and ③.

## Fix

Stop `htlcManager` first, before touching hodl subscription state:

```
① cg.Quit() + cg.WgWait()                  -- htlcManager fully gone
② HodlUnsubscribeAll(hodlQueue.ChanIn())   -- safe: no new subscribers
③ hodlQueue.Stop()                          -- queue is idle
```

`htlcManager` is the sole caller of `NotifyExitHopHtlc`. Once
`cg.WgWait()` returns, no new subscriptions can be registered and the
remaining teardown is race-free.

There are no ordering dependencies that prevent this reorder:
- `ChainEvents.Cancel()` has no dependency on `htlcManager` running.
- The timer drain is harmless after `htlcManager` has exited.
- `htlcManager` reads `hodlQueue.ChanOut()` in a `select` that also
  handles `cg.Done()`, so it exits cleanly when signalled.

## Testing

The existing `htlcswitch` tests pass. A targeted regression test for
the race would require a concurrency harness that synchronises a
`RevokeAndAck` delivery with the `Stop()` window; this is left for a
follow-up alongside the broader hodl-channel redesign tracked in the
companion issue.