### PR TITLE
ci: use GITHUB_TOKEN instead of PAT for PR severity workflow

### DIFF
--- a/.github/workflows/pr-severity.yml
+++ b/.github/workflows/pr-severity.yml
@@ -35,7 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.PR_SEVERITY_BOT_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # Allow any user since this workflow only reads PR metadata via API
           # and doesn't execute any code from the PR. Tool permissions are


### PR DESCRIPTION
## Summary

Replaces the `PR_SEVERITY_BOT_TOKEN` PAT secret with the built-in
`GITHUB_TOKEN` in the PR severity classification workflow.

## Analysis

The workflow was audited against the `anthropics/claude-code-action@v1`
source to confirm `GITHUB_TOKEN` is sufficient:

- The workflow triggers on `pull_request_target`, which runs in the base
  repo context — so `GITHUB_TOKEN` has write access even for fork PRs.
- Claude's tool use is locked down to `gh pr view`, `gh pr edit`, and
  `gh pr comment` via `--allowedTools`, covering label management and
  comments.
- The existing permissions block (`contents: read`, `pull-requests: write`,
  `issues: write`) covers all internal action API calls. The only call that
  would need `contents: write` is branch deletion, which is never reached
  given the tool constraints.

This removes the dependency on the `PR_SEVERITY_BOT_TOKEN` PAT secret,
which can be removed from the repo settings once this lands.