### PR TITLE
discovery/test: assert ProcessSyncTransition error in sync transition test

### DIFF
--- a/discovery/syncer_test.go
+++ b/discovery/syncer_test.go
@@ -2321,7 +2321,8 @@ func TestGossipSyncerSyncTransitions(t *testing.T) {
 			syncer.Start()
 			defer syncer.Stop()
 
-			syncer.ProcessSyncTransition(test.finalSyncType)
+			err := syncer.ProcessSyncTransition(test.finalSyncType)
+			require.NoError(t, err)
 
 			// The syncer should now have the expected final
 			// SyncerType that the test expects.

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/lightninglabs/neutrino v0.16.2
 	github.com/lightninglabs/neutrino/cache v1.1.3
 	github.com/lightningnetwork/lightning-onion v1.3.0
-	github.com/lightningnetwork/lnd/actor v0.0.5
+	github.com/lightningnetwork/lnd/actor v0.0.6
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/clock v1.1.1
 	github.com/lightningnetwork/lnd/fn/v2 v2.0.9
@@ -209,10 +209,6 @@ replace github.com/lightningnetwork/lnd/queue => ./queue
 
 // TODO(elle): remove once the gossip V2 sqldb changes have been made.
 replace github.com/lightningnetwork/lnd/sqldb => ./sqldb
-
-// Use local actor module to pick up CompleteWith/AwaitFuture helpers added
-// as part of the discovery errChan -> Future[error] migration.
-replace github.com/lightningnetwork/lnd/actor => ./actor
 
 // This replace is for https://github.com/advisories/GHSA-25xm-hr59-7c27
 replace github.com/ulikunitz/xz => github.com/ulikunitz/xz v0.5.11

--- a/go.sum
+++ b/go.sum
@@ -374,6 +374,8 @@ github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display h1:Y2WiPkBS
 github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 github.com/lightningnetwork/lightning-onion v1.3.0 h1:FqILgHjD6euc/Muo1VOzZ4+XDPuFnw6EYROBq0rR/5c=
 github.com/lightningnetwork/lightning-onion v1.3.0/go.mod h1:nP85zMHG7c0si/eHBbSQpuDCtnIXfSvFrK3tW6YWzmU=
+github.com/lightningnetwork/lnd/actor v0.0.6 h1:Ge8N2wivARG+27qJBwTlB0vwsypStZYZy8vk4Zl38sU=
+github.com/lightningnetwork/lnd/actor v0.0.6/go.mod h1:YAsoniSbY/cAM9HTVNfZLvt7RI6swDxy6wzPspTcMZg=
 github.com/lightningnetwork/lnd/cert v1.2.2 h1:71YK6hogeJtxSxw2teq3eGeuy4rHGKcFf0d0Uy4qBjI=
 github.com/lightningnetwork/lnd/cert v1.2.2/go.mod h1:jQmFn/Ez4zhDgq2hnYSw8r35bqGVxViXhX6Cd7HXM6U=
 github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsDIBjgjWdZgA0=


### PR DESCRIPTION
## Summary
- `TestGossipSyncerSyncTransitions` calls `ProcessSyncTransition` but discards the returned error. If the function ever regresses and returns an error on the happy path, the test would silently pass.
- Assert that the returned error is nil.

## Test plan
- [ ] `go test -run TestGossipSyncerSyncTransitions ./discovery/`