### PR TITLE
itest: fix flake in testIntroductionNodeError

### DIFF
--- a/itest/lnd_route_blinding_test.go
+++ b/itest/lnd_route_blinding_test.go
@@ -704,6 +704,13 @@ func testIntroductionNodeError(ht *lntest.HarnessTest) {
 	// at the introduction node.
 	testCase.drainCarolLiquidity(true)
 
+	// NOTE: The drain above causes Bob to originate a payment, producing
+	// SEND-type HTLC events that may still be in-flight when we subscribe.
+	// Wait for the commitment dance to finish so those events are flushed
+	// before we subscribe, preventing them from corrupting the assertion
+	// below.
+	flakePaymentStreamReturnEarly()
+
 	// Subscribe to Bob's HTLC events so that we can observe the payment
 	// coming in.
 	bobEvents := bob.RPC.SubscribeHtlcEvents()


### PR DESCRIPTION
## Change Description

`testRelayingBlindedError` already calls `flakePaymentStreamReturnEarly`
after draining Carol's outgoing liquidity. The reason is documented in
`itest/flakes.go`: `drainCarolLiquidity` causes the draining node to
originate a payment. `SendPaymentV2` returns `SUCCEEDED` before the
commitment dance (revoke-and-ack exchange) completes, so SEND-type HTLC
notifier events can still be in-flight when the test immediately
subscribes to HTLC events afterwards.

The htlc notifier's `subscribe.Server` uses a single handler goroutine
that processes both subscribe registrations and event updates via an
unbuffered-channel `select`. When a pending `SendUpdate` (stale SEND
event) and a `Subscribe` call race, Go's random select may register the
client first, causing the stale SEND event to land on the new subscriber
and corrupt the subsequent FORWARD-type assertion.

`testIntroductionNodeError` has the exact same pattern — Bob drains
Carol's incoming liquidity by originating a payment — but was missing
the `flakePaymentStreamReturnEarly()` call. This caused an intermittent
failure observed in CI:

```
--- FAIL: TestLightningNetworkDaemon/tranche06/.../introduction_blinded_error
    Error: []routerrpc.HtlcEvent_EventType{3, 0} does not contain 1
    Messages: wrong event type, want FORWARD, got SEND
```

Seen in: https://github.com/lightningnetwork/lnd/actions/runs/24278289474/job/70895848920

## Steps to Test

Run `testIntroductionNodeError` repeatedly:
```
make itest icase=introduction_blinded_error
```

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only).