### PR TITLE
switchrpc: wire MacService and NetworkDir in config setup

### DIFF
--- a/subrpcserver_config.go
+++ b/subrpcserver_config.go
@@ -321,6 +321,13 @@ func (s *subRPCServerConfigs) PopulateDependencies(cfg *Config,
 		case *switchrpc.Config:
 			subCfgValue := extractReflectValue(subCfg)
 
+			subCfgValue.FieldByName("NetworkDir").Set(
+				reflect.ValueOf(networkDir),
+			)
+			subCfgValue.FieldByName("MacService").Set(
+				reflect.ValueOf(macService),
+			)
+
 			subCfgValue.FieldByName("HtlcDispatcher").Set(
 				reflect.ValueOf(htlcSwitch),
 			)


### PR DESCRIPTION
## Change Description
The **_switchrpc_** config dispatcher in `PopulateDependencies` was missing the `MacService` and `NetworkDir` fields, which meant `cfg.MacService` was always nil when `switch_server.go`'s `New()` function ran, so `switch.macaroon` was never written to disk.

This brings _**switchrpc**_ server in line with the pattern used by every other sub-server (`signrpc`, `walletrpc`, `chainrpc`, `invoicesrpc`, etc.).

## Steps to Test
- Build **_lnd_** with `switchrpc` build tag and observe creation of file.