### PR TITLE
sqldb: remove unused randRetryDelay helper

### DIFF
--- a/sqldb/interfaces.go
+++ b/sqldb/interfaces.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	prand "math/rand"
 	"time"
 
 	"github.com/lightningnetwork/lnd/sqldb/sqlc"
@@ -132,12 +131,6 @@ func defaultTxExecutorOptions() *txExecutorOptions {
 		numRetries: DefaultNumTxRetries,
 		retryDelay: DefaultRetryDelay,
 	}
-}
-
-// randRetryDelay returns a random retry delay between 0 and the configured max
-// delay.
-func (t *txExecutorOptions) randRetryDelay() time.Duration {
-	return time.Duration(prand.Int63n(int64(t.retryDelay))) //nolint:gosec
 }
 
 // TxExecutorOption is a functional option that allows us to pass in optional


### PR DESCRIPTION
## Summary
- remove the unused `txExecutorOptions.randRetryDelay` helper from `sqldb/interfaces.go`
- keep the package-level `randRetryDelay` function as the only retry-delay implementation in use
- leave `sqldb/v2` unchanged because `master` no longer contains the unused method there

## Testing
- `gofmt -w sqldb/interfaces.go`
- Unable to run `go test ./sqldb ./sqldb/v2` locally because the available toolchain is `go1.19.5` while this repository currently declares `go 1.25.5` in `go.mod`

Closes #10698
