### PR TITLE
routerrpc: keep LSP route hint fields paired

### DIFF
--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -886,16 +886,16 @@ func prepareLspRouteHints(routeHints [][]zpay32.HopHint,
 			lspGroups[lspKey] = group
 		}
 
-		// Update the LSP hop hint with worst-case (max) fees and CLTV.
+		// Keep fee and CLTV paired from the same hint so we don't
+		// synthesize an impossible combination across multiple routes.
 		hopFee := destHop.HopFee(amt)
 		currentMaxFee := group.LspHopHint.HopFee(amt)
-		if hopFee > currentMaxFee {
+		if hopFee > currentMaxFee || (hopFee == currentMaxFee &&
+			destHop.CLTVExpiryDelta > group.LspHopHint.CLTVExpiryDelta) {
+
 			group.LspHopHint.FeeBaseMSat = destHop.FeeBaseMSat
 			group.LspHopHint.FeeProportionalMillionths = destHop.
 				FeeProportionalMillionths
-		}
-
-		if destHop.CLTVExpiryDelta > group.LspHopHint.CLTVExpiryDelta {
 			group.LspHopHint.CLTVExpiryDelta = destHop.
 				CLTVExpiryDelta
 		}

--- a/lnrpc/routerrpc/router_server_test.go
+++ b/lnrpc/routerrpc/router_server_test.go
@@ -503,6 +503,14 @@ func TestPrepareLspRouteHints(t *testing.T) {
 		ChannelID:                 2,
 	}
 
+	aliceHopHint3 := zpay32.HopHint{
+		NodeID:                    alicePubKey,
+		FeeBaseMSat:               300,
+		FeeProportionalMillionths: 3_000,
+		CLTVExpiryDelta:           60,
+		ChannelID:                 8,
+	}
+
 	bobHopHint := zpay32.HopHint{
 		NodeID:                    bobPubKey,
 		FeeBaseMSat:               500,
@@ -644,6 +652,37 @@ func TestPrepareLspRouteHints(t *testing.T) {
 
 				// Should use worst-case CLTV delta.
 				require.Equal(t, aliceHopHint2.CLTVExpiryDelta,
+					group.LspHopHint.CLTVExpiryDelta)
+			},
+		},
+		{
+			name: "single LSP keeps fee and cltv paired to highest fee hint",
+			routeHints: [][]zpay32.HopHint{
+				{bobHopHint, aliceHopHint2},
+				{carolHopHint, aliceHopHint3},
+			},
+			expectedGrps: 1,
+			validateFunc: func(t *testing.T,
+				groups map[route.Vertex]*LspRouteGroup) {
+
+				aliceKey := route.NewVertex(alicePubKey)
+				group, ok := groups[aliceKey]
+				require.True(t, ok, "alice group not found")
+
+				fee2 := aliceHopHint2.HopFee(amt)
+				fee3 := aliceHopHint3.HopFee(amt)
+				require.Greater(t, fee3, fee2,
+					"hint3 should have higher fees")
+				require.Greater(t, aliceHopHint2.CLTVExpiryDelta,
+					aliceHopHint3.CLTVExpiryDelta,
+					"hint2 should have the higher cltv")
+
+				require.Equal(t, aliceHopHint3.FeeBaseMSat,
+					group.LspHopHint.FeeBaseMSat)
+				require.Equal(t,
+					aliceHopHint3.FeeProportionalMillionths,
+					group.LspHopHint.FeeProportionalMillionths)
+				require.Equal(t, aliceHopHint3.CLTVExpiryDelta,
 					group.LspHopHint.CLTVExpiryDelta)
 			},
 		},


### PR DESCRIPTION
## Summary
- keep the LSP fee and CLTV fields paired to the same route hint in `prepareLspRouteHints`
- prefer the higher-fee hint, and only use CLTV as a tiebreaker when the fee matches
- add a regression test covering the case where the highest-fee hint has a lower CLTV than another hint for the same LSP

## Testing
- `gofmt -w lnrpc/routerrpc/router_server.go lnrpc/routerrpc/router_server_test.go`
- `git diff --check`
- Unable to run `go test ./lnrpc/routerrpc -run TestPrepareLspRouteHints` locally because the available toolchain is `go1.19.5` while this repository currently declares `go 1.25.5` in `go.mod`

Closes #10677
