### PR TITLE
htlcswitch+lnwallet: log signer-side commit tx on invalid commit sig

### DIFF
--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -4553,6 +4553,26 @@ func (l *channelLink) processRemoteError(msg *lnwire.Error) {
 	// Error received from remote, MUST fail channel, but should only print
 	// the contents of the error message if all characters are printable
 	// ASCII.
+
+	// Before tearing the link down, attempt to re-derive the commitment
+	// transaction and sighash we last computed for the remote party. If
+	// the peer sent a rejected-commitment error, logging our view alongside
+	// theirs makes it possible to compare the two transactions
+	// byte-for-byte and immediately identify any discrepancy.
+	commitTx, err := l.channel.BuildLastSignedRemoteCommitTx()
+	switch {
+	case err != nil:
+		l.log.Errorf("ChannelPoint(%v): unable to re-derive last "+
+			"signed remote commit tx: %v",
+			l.channel.ChannelPoint(), err)
+
+	case commitTx != nil:
+		l.log.Errorf("ChannelPoint(%v): signer-side commit_tx=%x "+
+			"(compare with commit_tx in the peer error if present "+
+			"to identify any state divergence)",
+			l.channel.ChannelPoint(), commitTx)
+	}
+
 	l.failf(
 		// TODO(halseth): we currently don't fail the channel
 		// permanently, as there are some sync issues with other

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -4303,6 +4303,40 @@ func (lc *LightningChannel) SignNextCommitment(
 	}, nil
 }
 
+// BuildLastSignedRemoteCommitTx returns the serialized commitment transaction
+// most recently signed for the remote party. The remote commit chain holds
+// all commitments we have signed but the remote has not yet revoked. Its tip
+// is the newest entry — added by the last SignNextCommitment call — and is
+// only removed once the remote sends a RevokeAndAck for the preceding
+// commitment. On the error path the remote sends an Error instead of a
+// RevokeAndAck, so the tip is guaranteed to be the commitment the remote
+// rejected.
+//
+// This method is intended exclusively for error-path diagnostics. When the
+// remote rejects our CommitSig, logging our commit TX alongside the one
+// embedded in the peer's error message makes it possible to determine
+// immediately whether the two sides derived different transactions (state
+// divergence) or agreed on the same transaction but the signature still
+// failed (signing bug).
+func (lc *LightningChannel) BuildLastSignedRemoteCommitTx() ([]byte, error) {
+	lc.RLock()
+	defer lc.RUnlock()
+
+	// tip() is the back of the list — the most recently signed
+	// commitment.
+	lastCommit := lc.commitChains.Remote.tip()
+	if lastCommit == nil {
+		return nil, nil
+	}
+
+	var buf bytes.Buffer
+	if err := lastCommit.txn.Serialize(&buf); err != nil {
+		return nil, fmt.Errorf("serializing remote commit tx: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
 // resignMusigCommit is used to resign a commitment transaction for taproot
 // channels when we need to retransmit a signature after a channel reestablish
 // message. Taproot channels use musig2, which means we must use fresh nonces


### PR DESCRIPTION
## Problem

When a peer rejects our `CommitSig` with an `Error` message, the
`InvalidCommitSigError` it sends back contains the commitment
transaction the peer built on their side (logged via the existing error
handling). We never logged the commitment transaction **we** signed,
making it impossible to determine whether the failure was caused by a
state divergence (the two peers derived different transactions) or a
genuine signing bug.

This gap was observed in a CI failure on
[#10628](https://github.com/lightningnetwork/lnd/pull/10628)
([run](https://github.com/lightningnetwork/lnd/actions/runs/24372618188/job/71461112768):
the `zero_conf-channel_policy_update_public_zero_conf` itest got stuck
with a payment `IN_FLIGHT` due to an `InvalidCommitSigError` at
`commit_height=5` on Carol's side. Carol's `commit_tx` was visible in
the error log, but Dave's was not, leaving the root cause unresolvable.

## Solution

Add `BuildLastSignedRemoteCommitTx` to `LightningChannel`. The method
re-derives the commitment transaction most recently signed for the
remote party by mirroring the exact index snapshot used in
`SignNextCommitment`. It must be called before a subsequent
`RevokeAndAck` from the remote rotates `RemoteNextRevocation` to a new
commitment point (which is guaranteed on the error path since the peer
sends `Error` instead of `RevokeAndAck`).

`processRemoteError` in the htlcswitch now calls this method and logs
the result alongside the peer's error. Comparing the two `commit_tx`
fields immediately reveals any state divergence without requiring a
live debugger or a second reproduction of the failure.

## Identifying divergence from logs

With this change, a future failure would log:

```
# Carol's side (existing):
invalid_commit_sig commit_tx=<carol_tx> sig_hash=<h> ...

# Dave's side (new):
signer-side commit_tx=<dave_tx> (compare with commit_tx in the peer error above ...)
```

If `<carol_tx> != <dave_tx>` the two peers derived different
transactions from the same state — that is the root cause. If they
match, the signature itself is broken and the sighash / signing path
needs investigation.