### PR TITLE
cmd: show mission control help defaults

### DIFF
--- a/cmd/commands/cmd_mission_control.go
+++ b/cmd/commands/cmd_mission_control.go
@@ -52,12 +52,14 @@ var setCfgCommand = cli.Command{
 	Flags: []cli.Flag{
 		// General settings.
 		cli.UintFlag{
-			Name: "pmtnr",
+			Name:  "pmtnr",
+			Value: routing.DefaultMaxMcHistory,
 			Usage: "the number of payments mission control " +
 				"should store",
 		},
 		cli.DurationFlag{
-			Name: "failrelax",
+			Name:  "failrelax",
+			Value: routing.DefaultMinFailureRelaxInterval,
 			Usage: "the amount of time to wait after a failure " +
 				"before raising failure amount",
 		},
@@ -70,23 +72,27 @@ var setCfgCommand = cli.Command{
 		},
 		// Apriori config.
 		cli.DurationFlag{
-			Name: "apriorihalflife",
+			Name:  "apriorihalflife",
+			Value: routing.DefaultAprioriConfig().PenaltyHalfLife,
 			Usage: "the amount of time taken to restore a node " +
 				"or channel to 50% probability of success.",
 		},
 		cli.Float64Flag{
-			Name: "apriorihopprob",
+			Name:  "apriorihopprob",
+			Value: routing.DefaultAprioriConfig().AprioriHopProbability,
 			Usage: "the probability of success assigned " +
 				"to hops that we have no information about",
 		},
 		cli.Float64Flag{
-			Name: "aprioriweight",
+			Name:  "aprioriweight",
+			Value: routing.DefaultAprioriConfig().AprioriWeight,
 			Usage: "the degree to which mission control should " +
 				"rely on historical results, expressed as " +
 				"value in [0, 1]",
 		},
 		cli.Float64Flag{
-			Name: "aprioricapacityfraction",
+			Name:  "aprioricapacityfraction",
+			Value: routing.DefaultAprioriConfig().CapacityFraction,
 			Usage: "the fraction of channels' capacities that is " +
 				"considered liquid in pathfinding, a value " +
 				"between [0.75-1.0]. a value of 1.0 disables " +
@@ -94,19 +100,22 @@ var setCfgCommand = cli.Command{
 		},
 		// Bimodal config.
 		cli.DurationFlag{
-			Name: "bimodaldecaytime",
+			Name:  "bimodaldecaytime",
+			Value: routing.DefaultBimodalConfig().BimodalDecayTime,
 			Usage: "the time span after which we phase out " +
 				"learnings from previous payment attempts",
 		},
 		cli.Uint64Flag{
-			Name: "bimodalscale",
+			Name:  "bimodalscale",
+			Value: uint64(routing.DefaultBimodalConfig().BimodalScaleMsat),
 			Usage: "controls the assumed channel liquidity " +
 				"imbalance in the network, measured in msat. " +
 				"a low value (compared to typical channel " +
 				"capacity) anticipates unbalanced channels.",
 		},
 		cli.Float64Flag{
-			Name: "bimodalweight",
+			Name:  "bimodalweight",
+			Value: routing.DefaultBimodalConfig().BimodalNodeWeight,
 			Usage: "controls the degree to which the probability " +
 				"estimator takes into account other channels " +
 				"of a router",

--- a/cmd/commands/cmd_mission_control_test.go
+++ b/cmd/commands/cmd_mission_control_test.go
@@ -1,0 +1,88 @@
+package commands
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/routing"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli"
+)
+
+func TestSetCfgCommandFlagDefaults(t *testing.T) {
+	t.Parallel()
+
+	aprioriDefaults := routing.DefaultAprioriConfig()
+	bimodalDefaults := routing.DefaultBimodalConfig()
+
+	require.Equal(t, uint(routing.DefaultMaxMcHistory),
+		findUintFlag(t, setCfgCommand.Flags, "pmtnr").Value)
+	require.Equal(t, routing.DefaultMinFailureRelaxInterval,
+		findDurationFlag(t, setCfgCommand.Flags, "failrelax").Value)
+	require.Equal(t, aprioriDefaults.PenaltyHalfLife,
+		findDurationFlag(t, setCfgCommand.Flags, "apriorihalflife").Value)
+	require.Equal(t, aprioriDefaults.AprioriHopProbability,
+		findFloat64Flag(t, setCfgCommand.Flags, "apriorihopprob").Value)
+	require.Equal(t, aprioriDefaults.AprioriWeight,
+		findFloat64Flag(t, setCfgCommand.Flags, "aprioriweight").Value)
+	require.Equal(t, aprioriDefaults.CapacityFraction,
+		findFloat64Flag(t, setCfgCommand.Flags, "aprioricapacityfraction").Value)
+	require.Equal(t, bimodalDefaults.BimodalDecayTime,
+		findDurationFlag(t, setCfgCommand.Flags, "bimodaldecaytime").Value)
+	require.Equal(t, uint64(bimodalDefaults.BimodalScaleMsat),
+		findUint64Flag(t, setCfgCommand.Flags, "bimodalscale").Value)
+	require.Equal(t, bimodalDefaults.BimodalNodeWeight,
+		findFloat64Flag(t, setCfgCommand.Flags, "bimodalweight").Value)
+}
+
+func findUintFlag(t *testing.T, flags []cli.Flag, name string) cli.UintFlag {
+	t.Helper()
+
+	for _, flag := range flags {
+		if typed, ok := flag.(cli.UintFlag); ok && typed.Name == name {
+			return typed
+		}
+	}
+
+	t.Fatalf("uint flag %q not found", name)
+	return cli.UintFlag{}
+}
+
+func findUint64Flag(t *testing.T, flags []cli.Flag, name string) cli.Uint64Flag {
+	t.Helper()
+
+	for _, flag := range flags {
+		if typed, ok := flag.(cli.Uint64Flag); ok && typed.Name == name {
+			return typed
+		}
+	}
+
+	t.Fatalf("uint64 flag %q not found", name)
+	return cli.Uint64Flag{}
+}
+
+func findFloat64Flag(t *testing.T, flags []cli.Flag, name string) cli.Float64Flag {
+	t.Helper()
+
+	for _, flag := range flags {
+		if typed, ok := flag.(cli.Float64Flag); ok && typed.Name == name {
+			return typed
+		}
+	}
+
+	t.Fatalf("float64 flag %q not found", name)
+	return cli.Float64Flag{}
+}
+
+func findDurationFlag(t *testing.T, flags []cli.Flag, name string) cli.DurationFlag {
+	t.Helper()
+
+	for _, flag := range flags {
+		if typed, ok := flag.(cli.DurationFlag); ok && typed.Name == name {
+			return typed
+		}
+	}
+
+	t.Fatalf("duration flag %q not found", name)
+	return cli.DurationFlag{Value: time.Duration(0)}
+}


### PR DESCRIPTION
## Summary
- set `setmccfg` flag defaults from the existing mission control routing defaults
- make `lncli setmccfg --help` show real default values instead of zero-value sentinels
- add a focused regression test that asserts the command flags carry the expected defaults

## Testing
- `gofmt -w cmd/commands/cmd_mission_control.go cmd/commands/cmd_mission_control_test.go`
- `git diff --check`
- Unable to run `go test ./cmd/commands -run TestSetCfgCommandFlagDefaults` locally because the available toolchain is `go1.19.5` while this repository currently declares `go 1.25.5` in `go.mod`

Closes #7555
