### PR TITLE
lnrpc: add scid filter to ListChannels RPC and lncli

### DIFF
--- a/cmd/commands/commands.go
+++ b/cmd/commands/commands.go
@@ -1855,6 +1855,11 @@ var ListChannelsCommand = cli.Command{
 				"particular peer, accepts 66-byte, " +
 				"hex-encoded pubkeys",
 		},
+		cli.Uint64Flag{
+			Name: "scid",
+			Usage: "(optional) only list a specific channel " +
+				"filtered by short channel id",
+		},
 		cli.BoolFlag{
 			Name: "skip_peer_alias_lookup",
 			Usage: "skip the peer alias lookup per channel in " +
@@ -1918,6 +1923,7 @@ func ListChannels(ctx *cli.Context) error {
 		PublicOnly:      ctx.Bool("public_only"),
 		PrivateOnly:     ctx.Bool("private_only"),
 		Peer:            peerKey,
+		Scid:            ctx.Uint64("scid"),
 		PeerAliasLookup: lookupPeerAlias,
 	}
 

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -5325,6 +5325,9 @@ type ListChannelsRequest struct {
 	// Filters the response for channels with a target peer's pubkey. If peer is
 	// empty, all channels will be returned.
 	Peer []byte `protobuf:"bytes,5,opt,name=peer,proto3" json:"peer,omitempty"`
+	// Filters the response for a channel with a target short channel id.
+	// If short channel_id and peer is empty, all channels will be returned.
+	Scid uint64 `protobuf:"varint,7,opt,name=scid,proto3" json:"scid,omitempty"`
 	// Informs the server if the peer alias lookup per channel should be
 	// enabled. It is turned off by default in order to avoid degradation of
 	// performance for existing clients.
@@ -5396,6 +5399,13 @@ func (x *ListChannelsRequest) GetPeer() []byte {
 		return x.Peer
 	}
 	return nil
+}
+
+func (x *ListChannelsRequest) GetScid() uint64 {
+	if x != nil {
+		return x.Scid
+	}
+	return 0
 }
 
 func (x *ListChannelsRequest) GetPeerAliasLookup() bool {
@@ -19168,7 +19178,7 @@ const file_lightning_proto_rawDesc = "" +
 	"peer_alias\x18\" \x01(\tR\tpeerAlias\x12*\n" +
 	"\x0fpeer_scid_alias\x18# \x01(\x04B\x020\x01R\rpeerScidAlias\x12\x12\n" +
 	"\x04memo\x18$ \x01(\tR\x04memo\x12.\n" +
-	"\x13custom_channel_data\x18% \x01(\fR\x11customChannelData\"\xdf\x01\n" +
+	"\x13custom_channel_data\x18% \x01(\fR\x11customChannelData\"\xf3\x01\n" +
 	"\x13ListChannelsRequest\x12\x1f\n" +
 	"\vactive_only\x18\x01 \x01(\bR\n" +
 	"activeOnly\x12#\n" +
@@ -19176,7 +19186,8 @@ const file_lightning_proto_rawDesc = "" +
 	"\vpublic_only\x18\x03 \x01(\bR\n" +
 	"publicOnly\x12!\n" +
 	"\fprivate_only\x18\x04 \x01(\bR\vprivateOnly\x12\x12\n" +
-	"\x04peer\x18\x05 \x01(\fR\x04peer\x12*\n" +
+	"\x04peer\x18\x05 \x01(\fR\x04peer\x12\x12\n" +
+	"\x04scid\x18\a \x01(\x04R\x04scid\x12*\n" +
 	"\x11peer_alias_lookup\x18\x06 \x01(\bR\x0fpeerAliasLookup\"B\n" +
 	"\x14ListChannelsResponse\x12*\n" +
 	"\bchannels\x18\v \x03(\v2\x0e.lnrpc.ChannelR\bchannels\"A\n" +

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -1755,6 +1755,12 @@ message ListChannelsRequest {
     */
     bytes peer = 5;
 
+    /*
+    Filters the response for a channel with a target short channel id.
+    If short channel_id and peer is empty, all channels will be returned.
+    */
+    uint64 scid = 7;
+
     // Informs the server if the peer alias lookup per channel should be
     // enabled. It is turned off by default in order to avoid degradation of
     // performance for existing clients.

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -154,6 +154,14 @@
             "format": "byte"
           },
           {
+            "name": "scid",
+            "description": "Filters the response for a channel with a target short channel id.\nIf short channel_id and peer is empty, all channels will be returned.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "format": "uint64"
+          },
+          {
             "name": "peer_alias_lookup",
             "description": "Informs the server if the peer alias lookup per channel should be\nenabled. It is turned off by default in order to avoid degradation of\nperformance for existing clients.",
             "in": "query",

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4818,7 +4818,8 @@ func (r *rpcServer) LookupHtlcResolution(
 }
 
 // ListChannels returns a description of all the open channels that this node
-// is a participant in.
+// is participating. Also provides options to filter open channel returns by
+// a specific node public key or short channel id
 func (r *rpcServer) ListChannels(ctx context.Context,
 	in *lnrpc.ListChannelsRequest) (*lnrpc.ListChannelsResponse, error) {
 
@@ -4851,10 +4852,17 @@ func (r *rpcServer) ListChannels(ctx context.Context,
 		nodePub := dbChannel.IdentityPub
 		nodePubBytes := nodePub.SerializeCompressed()
 		chanPoint := dbChannel.FundingOutpoint
+		chanScid := dbChannel.ShortChannelID.ToUint64()
 
-		// If the caller requested channels for a target node, skip any
+		// If the caller requested channels for a target node. Skip any
 		// that don't match the provided pubkey.
 		if len(in.Peer) > 0 && !bytes.Equal(nodePubBytes, in.Peer) {
+			continue
+		}
+
+		// If the caller requested a specific channel for a target
+		// short channel ID. Skip any that don't match the provided scid.
+		if in.Scid != 0 && chanScid != in.Scid {
 			continue
 		}
 


### PR DESCRIPTION
## Change Description
Adds optional scid filter to ListChannels RPC, allowing retrieval of information for a single channel. Fixes https://github.com/lightningnetwork/lnd/issues/5984

## Steps to Test
1. Start lnd
2. Open a least 2 channels
3. Run lncli listchannels -scid=x, which x is a short channel id of one of the channels opened
    3.1. Run again lncli listchannels (or with -scid=0) to check backward compatibility

## Pull Request Checklist
### Testing
- [ x] Your PR passes all CI checks.
- [ x] Tests covering the positive and negative (error paths) are included.

### Code Style and Documentation
- [ x] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
