### PR TITLE
wtclient: increase queue test wait budget

### DIFF
--- a/watchtower/wtclient/queue_test.go
+++ b/watchtower/wtclient/queue_test.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	maxInMemItems = 5
-	waitTime      = time.Second * 2
+	waitTime      = dbErrorBackoff + 2*time.Second
 )
 
 // TestDiskOverflowQueue tests that the DiskOverflowQueue behaves as expected.


### PR DESCRIPTION
## Summary
- align the `TestDiskOverflowQueue` wait budget with the queue's built-in `dbErrorBackoff`
- give the test enough time to survive the intended transient disk-load retry path
- keep the change limited to the test-only wait constant

## Testing
- `gofmt -w watchtower/wtclient/queue_test.go`
- `git diff --check`
- Unable to run `go test ./watchtower/wtclient -run TestDiskOverflowQueue` locally because the available toolchain is `go1.19.5` while this repository currently declares `go 1.25.5` in `go.mod`

Closes #9479
