### PR TITLE
sqldb: validate query config in constructors

### DIFF
--- a/sqldb/config_validation_test.go
+++ b/sqldb/config_validation_test.go
@@ -1,0 +1,32 @@
+package sqldb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSqliteStoreRejectsInvalidQueryConfig(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewSqliteStore(&SqliteConfig{
+		QueryConfig: QueryConfig{
+			MaxBatchSize: 0,
+			MaxPageSize:  defaultSQLitePageSize,
+		},
+	}, t.TempDir()+"/invalid.db")
+	require.ErrorContains(t, err, "invalid query config")
+}
+
+func TestNewPostgresStoreRejectsInvalidQueryConfig(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewPostgresStore(&PostgresConfig{
+		Dsn: "postgres://localhost/testdb",
+		QueryConfig: QueryConfig{
+			MaxBatchSize: 0,
+			MaxPageSize:  defaultPostgresPageSize,
+		},
+	})
+	require.ErrorContains(t, err, "invalid query config")
+}

--- a/sqldb/postgres.go
+++ b/sqldb/postgres.go
@@ -95,6 +95,10 @@ type PostgresStore struct {
 // NewPostgresStore creates a new store that is backed by a Postgres database
 // backend.
 func NewPostgresStore(cfg *PostgresConfig) (*PostgresStore, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
 	sanitizedDSN, err := replacePasswordInDSN(cfg.Dsn)
 	if err != nil {
 		return nil, err

--- a/sqldb/sqlite.go
+++ b/sqldb/sqlite.go
@@ -56,6 +56,10 @@ type SqliteStore struct {
 // NewSqliteStore attempts to open a new sqlite database based on the passed
 // config.
 func NewSqliteStore(cfg *SqliteConfig, dbPath string) (*SqliteStore, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
 	// The set of pragma options are accepted using query options. For now
 	// we only want to ensure that foreign key constraints are properly
 	// enforced.

--- a/sqldb/v2/config_validation_test.go
+++ b/sqldb/v2/config_validation_test.go
@@ -1,0 +1,32 @@
+package sqldb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSqliteStoreRejectsInvalidQueryConfig(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewSqliteStore(&SqliteConfig{
+		QueryConfig: QueryConfig{
+			MaxBatchSize: 0,
+			MaxPageSize:  defaultSQLitePageSize,
+		},
+	}, t.TempDir()+"/invalid.db")
+	require.ErrorContains(t, err, "invalid query config")
+}
+
+func TestNewPostgresStoreRejectsInvalidQueryConfig(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewPostgresStore(&PostgresConfig{
+		Dsn: "postgres://localhost/testdb",
+		QueryConfig: QueryConfig{
+			MaxBatchSize: 0,
+			MaxPageSize:  defaultPostgresPageSize,
+		},
+	})
+	require.ErrorContains(t, err, "invalid query config")
+}

--- a/sqldb/v2/postgres.go
+++ b/sqldb/v2/postgres.go
@@ -129,6 +129,10 @@ func NewPostgresStore(cfg *PostgresConfig) (*PostgresStore, error) {
 		return nil, fmt.Errorf("postgres config is required")
 	}
 
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
 	// Copy the caller config so we can enforce RequireSSL on the DSN
 	// without mutating a config value that may be reused elsewhere.
 	effectiveCfg := *cfg

--- a/sqldb/v2/sqlite.go
+++ b/sqldb/v2/sqlite.go
@@ -56,6 +56,10 @@ type SqliteStore struct {
 // NewSqliteStore attempts to open a new sqlite database based on the passed
 // config.
 func NewSqliteStore(cfg *SqliteConfig, dbPath string) (*SqliteStore, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
 	// The set of pragma options are accepted using query options. For now
 	// we only want to ensure that foreign key constraints are properly
 	// enforced.


### PR DESCRIPTION
## Summary
- validate `QueryConfig` at each `sqldb` and `sqldb/v2` store constructor entrypoint
- fail fast on invalid batch/page limits before opening the database or entering query loops
- add focused constructor tests for invalid sqlite and postgres query configs in both packages

## Testing
- `gofmt -w sqldb/sqlite.go sqldb/postgres.go sqldb/v2/sqlite.go sqldb/v2/postgres.go sqldb/config_validation_test.go sqldb/v2/config_validation_test.go`
- `git diff --check`
- Unable to run `go test ./sqldb ./sqldb/v2 -run 'TestNew(Sqlite|Postgres)StoreRejectsInvalidQueryConfig'` locally because the available toolchain is `go1.19.5` while this repository currently declares `go 1.25.5` in `go.mod`

Part of #10698
