### PR TITLE
peer: clarify rbf coop close flag errors

### DIFF
--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -1100,6 +1100,11 @@ func (p *Brontide) rbfCoopCloseAllowed() bool {
 		bothHaveBit(lnwire.RbfCoopCloseOptionalStaging)
 }
 
+func rbfCoopCloseDisabledError() error {
+	return fmt.Errorf("rbf coop close fee bump requires enabling " +
+		"--protocol.rbf-coop-close before starting lnd")
+}
+
 // QuitSignal is a method that should return a channel which will be sent upon
 // or closed once the backing peer exits. This allows callers using the
 // interface to cancel any processing in the event the backing implementation
@@ -5828,8 +5833,7 @@ func (p *Brontide) TriggerCoopCloseRbfBump(ctx context.Context,
 
 	// If RBF coop close isn't permitted, then we'll an error.
 	if !p.rbfCoopCloseAllowed() {
-		return nil, fmt.Errorf("rbf coop close not enabled for " +
-			"channel")
+		return nil, rbfCoopCloseDisabledError()
 	}
 
 	closeUpdates := &CoopCloseUpdates{

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -77,6 +77,14 @@ func TestPeerChannelClosureShutdownResponseLinkRemoved(t *testing.T) {
 	require.NotEqualValues(t, shutdownMsg.Address, dummyDeliveryScript)
 }
 
+func TestRbfCoopCloseDisabledError(t *testing.T) {
+	t.Parallel()
+
+	err := rbfCoopCloseDisabledError()
+	require.ErrorContains(t, err, "--protocol.rbf-coop-close")
+	require.ErrorContains(t, err, "before starting lnd")
+}
+
 // TestPeerChannelClosureAcceptFeeResponder tests the shutdown responder's
 // behavior if we can agree on the fee immediately.
 func TestPeerChannelClosureAcceptFeeResponder(t *testing.T) {


### PR DESCRIPTION
## Summary
- replace the generic disabled-flag RBF cooperative close bump error with an actionable message
- tell operators they must enable `--protocol.rbf-coop-close` before starting `lnd`
- add a focused regression test for the new error copy

## Testing
- `gofmt -w peer/brontide.go peer/brontide_test.go`
- `git diff --check`
- Unable to run `go test ./peer -run TestRbfCoopCloseDisabledError` locally because the available toolchain is `go1.19.5` while this repository currently declares `go 1.25.5` in `go.mod`

Part of #9775
