### PR TITLE
peer: unregister rbf closer router endpoints

### DIFF
--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -1100,6 +1100,15 @@ func (p *Brontide) rbfCoopCloseAllowed() bool {
 		bothHaveBit(lnwire.RbfCoopCloseOptionalStaging)
 }
 
+func (p *Brontide) unregisterMsgRouterEndpoint(name msgmux.EndpointName) {
+	p.msgRouter.WhenSome(func(router msgmux.Router) {
+		if err := router.UnregisterEndpoint(name); err != nil {
+			p.log.Debugf("unable to unregister msg router endpoint %s: %v",
+				name, err)
+		}
+	})
+}
+
 // QuitSignal is a method that should return a channel which will be sent upon
 // or closed once the backing peer exits. This allows callers using the
 // interface to cancel any processing in the event the backing implementation
@@ -3955,6 +3964,7 @@ func (p *Brontide) observeRbfCloseUpdates(chanCloser *chancloser.RbfChanCloser,
 				chanID := lnwire.NewChanIDFromOutPoint(
 					*closeReq.ChanPoint,
 				)
+				p.unregisterMsgRouterEndpoint(chanCloser.Name())
 				p.activeChanCloses.Delete(chanID)
 
 				return
@@ -5211,6 +5221,9 @@ func (p *Brontide) handleCloseMsg(msg *closeMsg) {
 			chanCloser.CloseRequest().Err <- err
 		}
 
+		chanCloser.WhenRight(func(rbfCloser *chancloser.RbfChanCloser) {
+			p.unregisterMsgRouterEndpoint(rbfCloser.Name())
+		})
 		p.activeChanCloses.Delete(msg.cid)
 
 		p.Disconnect(err)

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -2,6 +2,7 @@ package peer
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -20,6 +21,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chancloser"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/msgmux"
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/stretchr/testify/mock"
@@ -75,6 +77,37 @@ func TestPeerChannelClosureShutdownResponseLinkRemoved(t *testing.T) {
 	}
 
 	require.NotEqualValues(t, shutdownMsg.Address, dummyDeliveryScript)
+}
+
+type mockMsgRouter struct {
+	unregistered []msgmux.EndpointName
+}
+
+func (m *mockMsgRouter) RegisterEndpoint(msgmux.Endpoint) error { return nil }
+func (m *mockMsgRouter) UnregisterEndpoint(
+	name msgmux.EndpointName) error {
+
+	m.unregistered = append(m.unregistered, name)
+	return nil
+}
+
+func (m *mockMsgRouter) RouteMsg(msgmux.PeerMsg) error { return nil }
+func (m *mockMsgRouter) Start(context.Context)         {}
+func (m *mockMsgRouter) Stop()                         {}
+
+func TestUnregisterMsgRouterEndpoint(t *testing.T) {
+	t.Parallel()
+
+	router := &mockMsgRouter{}
+	p := &Brontide{
+		msgRouter: fn.Some[msgmux.Router](router),
+		log:       peerLog,
+	}
+
+	p.unregisterMsgRouterEndpoint("rbf-closer")
+
+	require.Equal(t, []msgmux.EndpointName{"rbf-closer"},
+		router.unregistered)
 }
 
 // TestPeerChannelClosureAcceptFeeResponder tests the shutdown responder's


### PR DESCRIPTION
## Summary
- unregister RBF cooperative close state-machine endpoints from the peer message router when the closer is cleaned up
- cover both the normal terminal close path and the error path that clears the active closer map
- add a focused unit test for the router-endpoint cleanup helper

## Testing
- `gofmt -w peer/brontide.go peer/brontide_test.go`
- `git diff --check`
- Unable to run `go test ./peer -run TestUnregisterMsgRouterEndpoint` locally because the available toolchain is `go1.19.5` while this repository currently declares `go 1.25.5` in `go.mod`

Related to #9775
