### PR TITLE
docs: explain rbf cooperative close flow

### DIFF
--- a/cmd/commands/commands.go
+++ b/cmd/commands/commands.go
@@ -1038,6 +1038,14 @@ var closeChannelCommand = cli.Command{
 	comparison is the end boundary of the fee negotiation, if not specified
 	it's always x3 of the starting value. Increasing this value increases
 	the chance of a successful negotiation.
+
+	RBF cooperative close fee bumping requires starting lnd with
+	--protocol.rbf-coop-close enabled and only works if the remote peer also
+	supports the protocol. When the initial cooperative close attempt is in
+	progress, the same closechannel RPC can be reissued with a higher fee
+	(via --conf_target, --sat_per_vbyte, or --max_fee_rate) to request an
+	RBF bump for the existing close negotiation.
+
 	Moreover if the channel has active HTLCs on it, the coop close will
 	wait until all HTLCs are resolved and will not allow any new HTLCs on
 	the channel. The channel will appear as disabled in the listchannels

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -249,6 +249,12 @@ service Lightning {
     then the user can specify either a target number of blocks until the
     closure transaction is confirmed, or a manual fee rate. If neither are
     specified, then a default lax, block confirmation target is used.
+
+    RBF cooperative close fee bumping requires starting lnd with
+    `--protocol.rbf-coop-close` enabled and only works if the remote peer also
+    supports the protocol. While a cooperative close is already in progress,
+    callers can reissue CloseChannel with a higher fee target or fee rate to
+    request an RBF bump for the existing negotiation.
     */
     rpc CloseChannel (CloseChannelRequest) returns (stream CloseStatusUpdate);
 
@@ -2261,6 +2267,10 @@ message CloseChannelRequest {
     uint64 sat_per_vbyte = 6;
 
     // The maximum fee rate the closer is willing to pay.
+    //
+    // For cooperative closes, this caps the negotiation range. During an RBF
+    // cooperative close retry, callers can increase this value (or the target
+    // fee rate) and reissue CloseChannel to request a higher-fee replacement.
     //
     // NOTE: This field is only respected if we're the initiator of the channel.
     uint64 max_fee_per_vbyte = 7;


### PR DESCRIPTION
## Summary
- document the RBF cooperative close flow on the canonical `closechannel` command and RPC surfaces
- explain the `--protocol.rbf-coop-close` requirement and the peer-support requirement
- clarify that callers can reissue `CloseChannel` with a higher fee target or fee rate to request an RBF bump, and what `max_fee_per_vbyte` means in that flow

## Testing
- `git diff --check`

Closes #9771
