### PR TITLE
docs: migrate package readmes to pkg.go.dev

### DIFF
--- a/brontide/README.md
+++ b/brontide/README.md
@@ -3,7 +3,7 @@ brontide
 
 [![Build Status](http://img.shields.io/travis/lightningnetwork/lnd.svg)](https://travis-ci.org/lightningnetwork/lnd) 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/lightningnetwork/lnd/brontide)
+[![Go Reference](https://pkg.go.dev/badge/github.com/lightningnetwork/lnd/brontide)](https://pkg.go.dev/github.com/lightningnetwork/lnd/brontide)
 
 The brontide package implements a secure crypto messaging protocol based off of
 the [Noise Protocol Framework](http://noiseprotocol.org/noise.html). The

--- a/chainntnfs/README.md
+++ b/chainntnfs/README.md
@@ -3,7 +3,7 @@ chainntnfs
 
 [![Build Status](http://img.shields.io/travis/lightningnetwork/lnd.svg)](https://travis-ci.org/lightningnetwork/lnd) 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/lightningnetwork/lnd/chainntnfs)
+[![Go Reference](https://pkg.go.dev/badge/github.com/lightningnetwork/lnd/chainntnfs)](https://pkg.go.dev/github.com/lightningnetwork/lnd/chainntnfs)
 
 The chainntnfs package implements a set of interfaces which allow callers to
 receive notifications in response to specific on-chain events. The set of

--- a/channeldb/README.md
+++ b/channeldb/README.md
@@ -3,7 +3,7 @@ channeldb
 
 [![Build Status](http://img.shields.io/travis/lightningnetwork/lnd.svg)](https://travis-ci.org/lightningnetwork/lnd) 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/lightningnetwork/lnd/channeldb)
+[![Go Reference](https://pkg.go.dev/badge/github.com/lightningnetwork/lnd/channeldb)](https://pkg.go.dev/github.com/lightningnetwork/lnd/channeldb)
 
 The channeldb implements the persistent storage engine for `lnd` and
 generically a data storage layer for the required state within the Lightning

--- a/lnrpc/README.md
+++ b/lnrpc/README.md
@@ -2,7 +2,7 @@ lnrpc
 =====
 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/lightningnetwork/lnd/lnrpc)
+[![Go Reference](https://pkg.go.dev/badge/github.com/lightningnetwork/lnd/lnrpc)](https://pkg.go.dev/github.com/lightningnetwork/lnd/lnrpc)
 
 This lnrpc package implements both a client and server for `lnd`s RPC system
 which is based off of the high-performance cross-platform

--- a/lnwallet/README.md
+++ b/lnwallet/README.md
@@ -3,7 +3,7 @@ lnwallet
 
 [![Build Status](http://img.shields.io/travis/lightningnetwork/lnd.svg)](https://travis-ci.org/lightningnetwork/lnd) 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/lightningnetwork/lnd/lnwallet)
+[![Go Reference](https://pkg.go.dev/badge/github.com/lightningnetwork/lnd/lnwallet)](https://pkg.go.dev/github.com/lightningnetwork/lnd/lnwallet)
 
 The lnwallet package implements an abstracted wallet controller that is able to
 drive channel funding workflows, a number of script utilities, witness

--- a/lnwire/README.md
+++ b/lnwire/README.md
@@ -3,7 +3,7 @@ lnwire
 
 [![Build Status](http://img.shields.io/travis/lightningnetwork/lnd.svg)](https://travis-ci.org/lightningnetwork/lnd) 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/lightningnetwork/lnd/lnwire)
+[![Go Reference](https://pkg.go.dev/badge/github.com/lightningnetwork/lnd/lnwire)](https://pkg.go.dev/github.com/lightningnetwork/lnd/lnwire)
 
 The lnwire package implements the Lightning Network wire protocol.
 

--- a/routing/README.md
+++ b/routing/README.md
@@ -3,7 +3,7 @@ routing
 
 [![Build Status](http://img.shields.io/travis/lightningnetwork/lnd.svg)](https://travis-ci.org/lightningnetwork/lnd) 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/lightningnetwork/lnd/routing)
+[![Go Reference](https://pkg.go.dev/badge/github.com/lightningnetwork/lnd/routing)](https://pkg.go.dev/github.com/lightningnetwork/lnd/routing)
 
 The routing package implements authentication+validation of channel
 announcements, pruning of the channel graph, path finding within the network,

--- a/zpay32/README.md
+++ b/zpay32/README.md
@@ -3,7 +3,7 @@ zpay32
 
 [![Build Status](http://img.shields.io/travis/lightningnetwork/lnd.svg)](https://travis-ci.org/lightningnetwork/lnd) 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/lightningnetwork/lnd/zpay32)
+[![Go Reference](https://pkg.go.dev/badge/github.com/lightningnetwork/lnd/zpay32)](https://pkg.go.dev/github.com/lightningnetwork/lnd/zpay32)
 
 The zpay32 package implements a basic scheme for the encoding of payment
 requests between two `lnd` nodes within the Lightning Network. The zpay32


### PR DESCRIPTION
## Summary
- migrate the remaining package README Go reference badges from `godoc.org` to `pkg.go.dev`
- align the badge alt text with `Go Reference`
- keep the scope limited to the package readmes that still pointed at the old docs host

## Testing
- `git diff --check`
