### PR TITLE
docs: fix kvdb_postgres build tag typo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,7 +96,7 @@ jobs:
 
             Our release binaries are fully reproducible. Third parties are able to verify that the release binaries were produced properly without having to trust the release manager(s). See our [reproducible builds guide](https://github.com/lightningnetwork/lnd/blob/master/docs/release.md) for how this can be achieved.
             The release binaries are compiled with `go${{ env.GO_VERSION }}`, which is required by verifiers to arrive at the same ones.
-            They include the following build tags: `autopilotrpc`, `signrpc`, `walletrpc`, `chainrpc`, `invoicesrpc`, `neutrinorpc`, `routerrpc`, `watchtowerrpc`, `monitoring`, `peersrpc`, `kvdb_postrgres`, `kvdb_etcd` and `kvdb_sqlite`. Note that these are already included in the release script, so they do not need to be provided.
+            They include the following build tags: `autopilotrpc`, `signrpc`, `walletrpc`, `chainrpc`, `invoicesrpc`, `neutrinorpc`, `routerrpc`, `watchtowerrpc`, `monitoring`, `peersrpc`, `kvdb_postgres`, `kvdb_etcd` and `kvdb_sqlite`. Note that these are already included in the release script, so they do not need to be provided.
 
             The `make release` command can be used to ensure one rebuilds with all the same flags used for the release. If one wishes to build for only a single platform, then `make release sys=<OS-ARCH> tag=<tag>` can be used. 
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -252,7 +252,7 @@ will have the following tags:
 - [watchtowerrpc](/lnrpc/watchtowerrpc/watchtower.proto)
 - [monitoring](/monitoring) (for Prometheus integration)
 - [peersrpc](/lnrpc/peersrpc/peers.proto)
-- [kvdb_postrgres](/docs/postgres.md)
+- [kvdb_postgres](/docs/postgres.md)
 - [kvdb_sqlite](/docs/sqlite.md)
 
 The `dev` tag is used for development builds, and is not included in the


### PR DESCRIPTION
## Summary
- fix the `kvdb_postgres` build tag typo in `docs/INSTALL.md`
- fix the same typo in the release workflow's reproducible-build notes
- keep the scope limited to the two user-facing references that drifted from the canonical build tag in CI

## Testing
- `git diff --check`
