### PR TITLE
onionmessage: drop onion messages cycling back to the sending peer

### DIFF
--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -16,6 +16,7 @@
     - [Testing](#testing)
     - [Database](#database)
     - [Code Health](#code-health)
+    - [Robustness](#robustness)
     - [Tooling and Documentation](#tooling-and-documentation)
 - [Contributors (Alphabetical Order)](#contributors)
 
@@ -422,6 +423,16 @@
   deferred message copy was re-enqueued and processed a second time. A new
   `lnutils.ContextFromQuit` helper bridges the existing `quit` channels to
   `context.Context`, so all gossip awaits now respect shutdown uniformly.
+
+## Robustness
+
+* [Drop onion messages that would cycle back to the sending
+  peer](https://github.com/lightningnetwork/lnd/pull/10754). When the
+  resolved next hop of an incoming onion message is the same peer that
+  delivered it, the message is now dropped instead of being forwarded
+  back over the connection it arrived on. This closes a trivial
+  traffic-amplification vector and covers both the direct next-node-ID
+  and SCID-resolved paths.
 
 ## Tooling and Documentation
 

--- a/onionmessage/actor.go
+++ b/onionmessage/actor.go
@@ -188,6 +188,32 @@ func (a *OnionPeerActor) Receive(ctx context.Context,
 		return fn.Err[*Response](err)
 	}
 
+	// Block same-peer cycles: do not forward a message back to
+	// the peer that sent it.
+	routingAction.WhenLeft(func(fwdAction forwardAction) {
+		var nextNodeIDBytes [33]byte
+		copy(
+			nextNodeIDBytes[:],
+			fwdAction.nextNodeID.SerializeCompressed(),
+		)
+
+		if nextNodeIDBytes == a.peerPubKey {
+			log.WarnS(logCtx,
+				"Dropping cyclic onion message",
+				ErrSamePeerCycle,
+				lnutils.LogPubKey(
+					"next_node_id",
+					fwdAction.nextNodeID,
+				),
+			)
+
+			err = ErrSamePeerCycle
+		}
+	})
+	if err != nil {
+		return fn.Err[*Response](err)
+	}
+
 	// Handle the routing action.
 	payload := fn.ElimEither(routingAction,
 		func(fwdAction forwardAction) *lnwire.OnionMessagePayload {

--- a/onionmessage/actor_test.go
+++ b/onionmessage/actor_test.go
@@ -474,6 +474,105 @@ func TestOnionPeerActorRouting(t *testing.T) {
 	}
 }
 
+// TestOnionPeerActorSamePeerCycle verifies that the actor rejects onion
+// messages whose next hop is the same peer that sent them. Both the direct
+// next-node-ID and the SCID-resolved paths are covered.
+func TestOnionPeerActorSamePeerCycle(t *testing.T) {
+	t.Parallel()
+
+	type nextNodeFn func(h *actorHarness,
+		pub *btcec.PublicKey) fn.Either[*btcec.PublicKey,
+		lnwire.ShortChannelID]
+
+	tests := []struct {
+		name     string
+		nextNode nextNodeFn
+	}{
+		{
+			name: "via next node ID",
+			nextNode: func(_ *actorHarness,
+				pub *btcec.PublicKey) fn.Either[
+				*btcec.PublicKey, lnwire.ShortChannelID] {
+
+				return fn.NewLeft[*btcec.PublicKey,
+					lnwire.ShortChannelID](pub)
+			},
+		},
+		{
+			name: "via SCID",
+			nextNode: func(h *actorHarness,
+				pub *btcec.PublicKey) fn.Either[
+				*btcec.PublicKey, lnwire.ShortChannelID] {
+
+				scid := lnwire.NewShortChanIDFromInt(999)
+				h.resolver.addPeer(scid, pub)
+
+				return fn.NewRight[*btcec.PublicKey](scid)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newActorHarness(t)
+
+			// Generate a key for the next hop, then set the
+			// actor's peerPubKey to the same key to simulate
+			// the message arriving from that peer.
+			nextNodeKey, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+			nextNodePub := nextNodeKey.PubKey()
+
+			h.actor.peerPubKey = pubKeyToArray(nextNodePub)
+
+			nextNode := tc.nextNode(h, nextNodePub)
+			rdA := record.NewNonFinalBlindedRouteDataOnionMessage(
+				nextNode, nil, nil,
+			)
+			rdB := &record.BlindedRouteData{}
+
+			plainA := EncodeBlindedRouteData(t, rdA)
+			plainB := EncodeBlindedRouteData(t, rdB)
+			hops := []*sphinx.HopInfo{
+				{
+					NodePub:   h.nodeKey.PubKey(),
+					PlainText: plainA,
+				},
+				{NodePub: nextNodePub, PlainText: plainB},
+			}
+
+			blindedPath := BuildBlindedPath(t, hops)
+			onionMsg, _ := BuildOnionMessage(t, blindedPath, nil)
+
+			req := &Request{msg: *onionMsg}
+			result := h.actor.Receive(t.Context(), req)
+
+			// The actor must return an error.
+			require.True(t, result.IsErr())
+			result.WhenErr(func(err error) {
+				require.ErrorIs(t, err, ErrSamePeerCycle)
+			})
+
+			// No message should have been forwarded.
+			select {
+			case <-h.sender.sent:
+				require.FailNow(t, "message should not have "+
+					"been forwarded back to the sending "+
+					"peer")
+			default:
+			}
+
+			// No update should have been dispatched.
+			select {
+			case <-h.dispatcher.updates:
+				require.FailNow(t, "update should not be "+
+					"dispatched for a cyclic message")
+			default:
+			}
+		})
+	}
+}
+
 // TestOnionPeerActorReceiveContextCanceled tests that OnionPeerActor.Receive
 // returns an error when the context is canceled.
 func TestOnionPeerActorReceiveContextCanceled(t *testing.T) {

--- a/onionmessage/errors.go
+++ b/onionmessage/errors.go
@@ -14,4 +14,9 @@ var (
 	// ErrSCIDEmpty is returned when the short channel ID is missing from
 	// the route data.
 	ErrSCIDEmpty = errors.New("short channel ID empty")
+
+	// ErrSamePeerCycle is returned when a forwarding onion message
+	// would be sent back to the same peer it was received from.
+	ErrSamePeerCycle = errors.New("onion message cycle: next " +
+		"hop is the sending peer")
 )


### PR DESCRIPTION
Block forwarding of an onion message when the resolved next hop is the same peer that delivered it. Such a forward would immediately bounce the message back over the connection it arrived on, which is never useful and can be abused to amplify traffic against a peer (or to have us unknowingly participate in a trivial loop between two malicious neighbours).

The check runs after the routing action has been resolved, so it catches both the direct next-node-ID case and the SCID-resolved case. When a cycle is detected a new sentinel `ErrSamePeerCycle` is returned and the drop is logged at warn level.

### Note on HTLC cycle hardening

It may be worth applying a similar hardening to HTLC forwarding. The current HTLC cycle check prevents forwarding back over the same channel, but it would still allow a cycle if the return hop goes over a *parallel* channel to the same peer. LND supports multiple channels per peer, so a peer-level check (in addition to the existing channel-level one) would be a natural next step.