### PR TITLE
routerrpc: prioritize highest-cost lsp probes

### DIFF
--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync/atomic"
 	"time"
 
@@ -604,12 +605,14 @@ func (s *Server) probePaymentRequest(ctx context.Context, paymentRequest string,
 		probeCount       int
 	)
 
-	for lspKey, group := range lspGroups {
+	for _, target := range sortedLspProbeTargets(lspGroups, amtMsat) {
 		if probeCount >= MaxLspsToProbe {
 			break
 		}
 		probeCount++
 
+		lspKey := target.dest
+		group := target.group
 		lspHint := group.LspHopHint
 
 		log.Infof("Probing LSP with destination: %v", lspKey)
@@ -814,6 +817,44 @@ type LspRouteGroup struct {
 
 	// AdjustedRouteHints are the route hints with the LSP hop stripped off.
 	AdjustedRouteHints [][]zpay32.HopHint
+}
+
+type lspProbeTarget struct {
+	dest  route.Vertex
+	group *LspRouteGroup
+}
+
+func sortedLspProbeTargets(lspGroups map[route.Vertex]*LspRouteGroup,
+	amt lnwire.MilliSatoshi) []lspProbeTarget {
+
+	targets := make([]lspProbeTarget, 0, len(lspGroups))
+	for dest, group := range lspGroups {
+		targets = append(targets, lspProbeTarget{
+			dest:  dest,
+			group: group,
+		})
+	}
+
+	sort.Slice(targets, func(i, j int) bool {
+		left := targets[i]
+		right := targets[j]
+
+		leftFee := left.group.LspHopHint.HopFee(amt)
+		rightFee := right.group.LspHopHint.HopFee(amt)
+		if leftFee != rightFee {
+			return leftFee > rightFee
+		}
+
+		leftCltv := left.group.LspHopHint.CLTVExpiryDelta
+		rightCltv := right.group.LspHopHint.CLTVExpiryDelta
+		if leftCltv != rightCltv {
+			return leftCltv > rightCltv
+		}
+
+		return string(left.dest[:]) < string(right.dest[:])
+	})
+
+	return targets
 }
 
 // prepareLspRouteHints assumes that the isLsp heuristic returned true for the

--- a/lnrpc/routerrpc/router_server_test.go
+++ b/lnrpc/routerrpc/router_server_test.go
@@ -764,3 +764,43 @@ func TestPrepareLspRouteHints(t *testing.T) {
 		require.Contains(t, err.Error(), "no public LSP nodes found")
 	})
 }
+
+func TestSortedLspProbeTargets(t *testing.T) {
+	t.Parallel()
+
+	makeVertex := func(seed byte) route.Vertex {
+		var v route.Vertex
+		v[0] = seed
+		return v
+	}
+
+	amt := lnwire.MilliSatoshi(1_000_000)
+	targets := sortedLspProbeTargets(map[route.Vertex]*LspRouteGroup{
+		makeVertex(3): {
+			LspHopHint: &zpay32.HopHint{
+				FeeBaseMSat:               100,
+				FeeProportionalMillionths: 500,
+				CLTVExpiryDelta:           144,
+			},
+		},
+		makeVertex(1): {
+			LspHopHint: &zpay32.HopHint{
+				FeeBaseMSat:               200,
+				FeeProportionalMillionths: 500,
+				CLTVExpiryDelta:           40,
+			},
+		},
+		makeVertex(2): {
+			LspHopHint: &zpay32.HopHint{
+				FeeBaseMSat:               200,
+				FeeProportionalMillionths: 500,
+				CLTVExpiryDelta:           80,
+			},
+		},
+	}, amt)
+
+	require.Len(t, targets, 3)
+	require.Equal(t, byte(2), targets[0].dest[0])
+	require.Equal(t, byte(1), targets[1].dest[0])
+	require.Equal(t, byte(3), targets[2].dest[0])
+}


### PR DESCRIPTION
@/tmp/lnd-pr-lsp-order-body.md