### PR TITLE
docs: add missing 0.21.0 contributors

### DIFF
--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -456,15 +456,32 @@
 
 # Contributors (Alphabetical Order)
 
+* Abdulkbk
+* AbelLykens
+* ajaysehwal
+* Andras Banki-Horvath
 * bitromortac
 * Boris Nagaev
+* Calvin Zachman
+* Dario Anongba
 * Elle Mouton
+* elnosh
 * Erick Cestari
+* Euler-B
+* ffranr
+* George Tsagkarelis
 * Gijs van Dam
 * hieblmi
+* Liongrass
+* Matt Morehouse
 * Matthew Zipkin
 * Mohamed Awnallah
 * Nishant Bansal
+* Olaoluwa Osuntokun
+* Oliver Gugger
 * Pins
 * Suheb
+* ViktorT-11
+* Yash Bhutwala
+* Yong Yu
 * Ziggie


### PR DESCRIPTION
## Summary

Cross-checked the contributor list in `release-notes-0.21.0.md` against all
PRs merged between `v0.20.0-beta` (Nov 11 2025) and `v0.21.0-beta.rc1`
(Apr 17 2026). Seventeen contributors whose PRs landed in the 0.21 window
were missing — this patch adds them. No entries were removed.

Additions:
- Ten authors whose PRs are explicitly cited in the release notes:
  Andras Banki-Horvath, Calvin Zachman, Dario Anongba, Euler-B, Oliver Gugger,
  Olaoluwa Osuntokun, Yash Bhutwala, Yong Yu, ajaysehwal, elnosh.
- Seven authors who merged PRs in-window but aren't individually cited:
  Abdulkbk, AbelLykens, ffranr, George Tsagkarelis, Liongrass,
  Matt Morehouse, ViktorT-11.

Display-name convention follows the existing list (real names where known,
GitHub handles otherwise).

## Test plan
- [x] `docs/release-notes/release-notes-0.21.0.md` renders cleanly
- [x] Contributor list remains alphabetical (case-insensitive by first letter)