### PR TITLE
multi: fix SIMPLE_TAPROOT_FINAL acceptor and overlay RBF auto-enable

### DIFF
--- a/chanacceptor/rpcacceptor.go
+++ b/chanacceptor/rpcacceptor.go
@@ -357,6 +357,30 @@ func (r *RPCAcceptor) sendAcceptRequests(errChan chan error,
 					commitmentType = lnrpc.CommitmentType_SIMPLE_TAPROOT
 
 				case channelFeatures.OnlyContains(
+					lnwire.SimpleTaprootChannelsRequiredFinal,
+					lnwire.ZeroConfRequired,
+					lnwire.ScidAliasRequired,
+				):
+					commitmentType = lnrpc.CommitmentType_SIMPLE_TAPROOT_FINAL
+
+				case channelFeatures.OnlyContains(
+					lnwire.SimpleTaprootChannelsRequiredFinal,
+					lnwire.ZeroConfRequired,
+				):
+					commitmentType = lnrpc.CommitmentType_SIMPLE_TAPROOT_FINAL
+
+				case channelFeatures.OnlyContains(
+					lnwire.SimpleTaprootChannelsRequiredFinal,
+					lnwire.ScidAliasRequired,
+				):
+					commitmentType = lnrpc.CommitmentType_SIMPLE_TAPROOT_FINAL
+
+				case channelFeatures.OnlyContains(
+					lnwire.SimpleTaprootChannelsRequiredFinal,
+				):
+					commitmentType = lnrpc.CommitmentType_SIMPLE_TAPROOT_FINAL
+
+				case channelFeatures.OnlyContains(
 					lnwire.SimpleTaprootOverlayChansRequired,
 					lnwire.ZeroConfRequired,
 					lnwire.ScidAliasRequired,

--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -78,6 +78,16 @@
   subscriptions and the hodl queue, preventing orphaned subscriptions from
   blocking invoice resolution.
 
+* [Fixed two follow-ups to the production taproot channels
+  work](https://github.com/lightningnetwork/lnd/pull/10763). The RPC channel
+  acceptor switch now maps `SIMPLE_TAPROOT_FINAL` (with every combination of
+  the `scid-alias` / `zero-conf` modifiers) so final-taproot opens are
+  reported to external acceptor clients with the correct commitment type
+  instead of `UNKNOWN_COMMITMENT_TYPE`. The taproot RBF cooperative-close
+  auto-enable is also narrowed to skip taproot-overlay channels, since the
+  RBF close state machine does not yet thread through the `AuxCloser` hook
+  that overlay channels rely on to build aux-aware close transactions.
+
 # New Features
 
 - [Basic Support](https://github.com/lightningnetwork/lnd/pull/9868) for onion

--- a/server.go
+++ b/server.go
@@ -670,11 +670,18 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 			"in a standalone lnd build")
 	}
 
-	// If either taproot channel type is enabled, we also need to enable
-	// the RBF cooperative close protocol, as it is required for taproot
-	// channel interoperability.
-	if cfg.ProtocolOptions.TaprootChans ||
-		cfg.ProtocolOptions.TaprootOverlayChans {
+	// If taproot channels are enabled, we also enable the RBF cooperative
+	// close protocol, as it is required for taproot channel
+	// interoperability.
+	//
+	// Exception: when taproot-overlay channels are enabled we do NOT
+	// auto-enable RBF, because the RBF coop close state machine does not
+	// yet thread through the AuxCloser hook that overlay channels rely on
+	// to build the aux-aware close transaction. Forcing RBF on for a
+	// node that holds overlay channels would silently break their coop
+	// closes.
+	if cfg.ProtocolOptions.TaprootChans &&
+		!cfg.ProtocolOptions.TaprootOverlayChans {
 
 		cfg.ProtocolOptions.RbfCoopClose = true
 	}


### PR DESCRIPTION
## Description

Adds the missing `SIMPLE_TAPROOT_FINAL` cases to the RPC acceptor switch so external acceptor clients no longer see `UNKNOWN_COMMITMENT_TYPE` for final-taproot channel opens, and narrows the taproot RBF auto-enable to skip taproot-overlay (where the RBF coop-close state machine does not yet thread through the `AuxCloser` hook).