### PR TITLE
routing: add RouteOrigin interface for multi-source pathfinding

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -25,6 +25,16 @@
 
 ## Functional Enhancements
 
+* Introduced a [`RouteOrigin`
+  interface](https://github.com/lightningnetwork/lnd/pull/10764) that
+  generalizes where routes can originate from. The pathfinder previously
+  terminated at a single concrete source vertex; `RouteOrigin` replaces this
+  with a predicate so the backward search can terminate at any vertex in a
+  caller-provided set, selecting whichever provides the cheapest path. The
+  default `singleOrigin` preserves existing behavior for all callers. This is
+  the source-end counterpart to `AdditionalEdge`, which extends the graph at
+  the destination end via route hints.
+
 ## RPC Additions
 
 ## lncli Additions

--- a/routing/graph.go
+++ b/routing/graph.go
@@ -46,7 +46,9 @@ func FetchAmountPairCapacity(graph Graph, source, nodeFrom, nodeTo route.Vertex,
 	//
 	// Note: Inbound fees are not used here because this method is only used
 	// by a deprecated router rpc.
-	u := newNodeEdgeUnifier(source, nodeTo, false, nil)
+	u := newNodeEdgeUnifier(
+		source, nodeTo, &singleOrigin{source: source}, false, nil,
+	)
 
 	err := u.addGraphPolicies(graph)
 	if err != nil {

--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -50,11 +50,12 @@ const (
 	fakeHopHintCapacity = btcutil.Amount(10 * btcutil.SatoshiPerBitcoin)
 )
 
-// pathFinder defines the interface of a path finding algorithm.
+// pathFinder defines the interface of a path finding algorithm. The first
+// return value is the source vertex of the computed path.
 type pathFinder = func(g *graphParams, r *RestrictParams,
 	cfg *PathFindingConfig, self, source, target route.Vertex,
 	amt lnwire.MilliSatoshi, timePref float64, finalHtlcExpiry int32) (
-	[]*unifiedEdge, float64, error)
+	route.Vertex, []*unifiedEdge, float64, error)
 
 var (
 	// DefaultEstimator is the default estimator used for computing
@@ -602,8 +603,8 @@ func getOutgoingBalance(node route.Vertex, outgoingChans map[uint64]struct{},
 // available bandwidth.
 func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 	self, source, target route.Vertex, amt lnwire.MilliSatoshi,
-	timePref float64, finalHtlcExpiry int32) ([]*unifiedEdge, float64,
-	error) {
+	timePref float64, finalHtlcExpiry int32) (route.Vertex, []*unifiedEdge,
+	float64, error) {
 
 	// Pathfinding can be a significant portion of the total payment
 	// latency, especially on low-powered devices. Log several metrics to
@@ -626,7 +627,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 			context.TODO(), target,
 		)
 		if err != nil {
-			return nil, 0, err
+			return route.Vertex{}, nil, 0, err
 		}
 	}
 
@@ -635,14 +636,14 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 	err := feature.ValidateRequired(features)
 	if err != nil {
 		log.Warnf("Pathfinding destination node features: %v", err)
-		return nil, 0, errUnknownRequiredFeature
+		return route.Vertex{}, nil, 0, errUnknownRequiredFeature
 	}
 
 	// Ensure that all transitive dependencies are set.
 	err = feature.ValidateDeps(features)
 	if err != nil {
 		log.Warnf("Pathfinding destination node features: %v", err)
-		return nil, 0, errMissingDependentFeature
+		return route.Vertex{}, nil, 0, errMissingDependentFeature
 	}
 
 	// Now that we know the feature vector is well-formed, we'll proceed in
@@ -652,7 +653,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 	if r.PaymentAddr.IsSome() &&
 		!features.HasFeature(lnwire.PaymentAddrOptional) {
 
-		return nil, 0, errNoPaymentAddr
+		return route.Vertex{}, nil, 0, errNoPaymentAddr
 	}
 
 	// Set up outgoing channel map for quicker access.
@@ -671,7 +672,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 			self, outgoingChanMap, g.bandwidthHints, g.graph,
 		)
 		if err != nil {
-			return nil, 0, err
+			return route.Vertex{}, nil, 0, err
 		}
 
 		// If the total outgoing balance isn't sufficient, it will be
@@ -681,13 +682,13 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 				"htlc of amount: %v, only have local "+
 				"balance: %v", amt, total)
 
-			return nil, 0, errInsufficientBalance
+			return route.Vertex{}, nil, 0, errInsufficientBalance
 		}
 
 		// If there is only not enough capacity on a single route, it
 		// may still be possible to complete the payment by splitting.
 		if max < amt {
-			return nil, 0, errNoPathFound
+			return route.Vertex{}, nil, 0, errNoPathFound
 		}
 	}
 
@@ -729,7 +730,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 	// and depends on whether the destination is blinded or not.
 	lastHopPayloadSize, err := lastHopPayloadSize(r, finalHtlcExpiry, amt)
 	if err != nil {
-		return nil, 0, err
+		return route.Vertex{}, nil, 0, err
 	}
 
 	// We can't always assume that the end destination is publicly
@@ -763,8 +764,10 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 
 	// Validate time preference value.
 	if math.Abs(timePref) > 1 {
-		return nil, 0, fmt.Errorf("time preference %v out of range "+
-			"[-1, 1]", timePref)
+		return route.Vertex{}, nil, 0, fmt.Errorf(
+			"time preference %v out of range [-1, 1]",
+			timePref,
+		)
 	}
 
 	// Scale to avoid the extremes -1 and 1 which run into infinity issues.
@@ -1066,7 +1069,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 
 		err := u.addGraphPolicies(g.graph)
 		if err != nil {
-			return nil, 0, err
+			return route.Vertex{}, nil, 0, err
 		}
 
 		// We add hop hints that were supplied externally.
@@ -1127,7 +1130,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 			// Get feature vector for fromNode.
 			fromFeatures, err := getGraphFeatures(fromNode)
 			if err != nil {
-				return nil, 0, err
+				return route.Vertex{}, nil, 0, err
 			}
 
 			// If there are no valid features, skip this node.
@@ -1166,7 +1169,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		if !ok {
 			// If the node doesn't have a next hop it means we
 			// didn't find a path.
-			return nil, 0, errNoPathFound
+			return route.Vertex{}, nil, 0, errNoPathFound
 		}
 
 		// Add the next hop to the list of path edges.
@@ -1200,7 +1203,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		distance[source].probability, len(pathEdges),
 		distance[source].netAmountReceived-amt)
 
-	return pathEdges, distance[source].probability, nil
+	return source, pathEdges, distance[source].probability, nil
 }
 
 // blindedPathRestrictions are a set of constraints to adhere to when

--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -50,11 +50,45 @@ const (
 	fakeHopHintCapacity = btcutil.Amount(10 * btcutil.SatoshiPerBitcoin)
 )
 
-// pathFinder defines the interface of a path finding algorithm. The first
-// return value is the source vertex of the computed path.
+// RouteOrigin determines where routes can originate from. The backward
+// Dijkstra terminates when it reaches any origin vertex. This is the
+// source-end counterpart to AdditionalEdge, which extends the graph at the
+// destination end. Standard lnd uses singleOrigin (one source node). A
+// multi-backend payment service can provide a multi-source implementation
+// that terminates at any of its gateway nodes.
+//
+// NOTE: Only include vertices the caller can actually dispatch payments
+// from.
+type RouteOrigin interface {
+	// IsOrigin reports whether the given vertex is a valid route
+	// starting point.
+	//
+	// NOTE: Implementations should be O(1). findPath calls IsOrigin
+	// once per heap pop and once per edge relaxation, so any per-call
+	// cost directly contributes to path-finding latency.
+	IsOrigin(v route.Vertex) bool
+}
+
+// singleOrigin is the default RouteOrigin: a single source vertex.
+type singleOrigin struct {
+	source route.Vertex
+}
+
+// IsOrigin reports whether v is the source vertex.
+func (s *singleOrigin) IsOrigin(v route.Vertex) bool {
+	return v == s.source
+}
+
+// pathFinder defines the interface of a path finding algorithm. The
+// first return value is the source vertex of the computed path. This
+// is typically the node's own key, but it may be an arbitrary source
+// or, for multi-origin callers, whichever origin provides the
+// cheapest path.
 type pathFinder = func(g *graphParams, r *RestrictParams,
-	cfg *PathFindingConfig, self, source, target route.Vertex,
-	amt lnwire.MilliSatoshi, timePref float64, finalHtlcExpiry int32) (
+	cfg *PathFindingConfig, self route.Vertex,
+	origin RouteOrigin, target route.Vertex,
+	amt lnwire.MilliSatoshi, timePref float64,
+	finalHtlcExpiry int32) (
 	route.Vertex, []*unifiedEdge, float64, error)
 
 var (
@@ -602,9 +636,9 @@ func getOutgoingBalance(node route.Vertex, outgoingChans map[uint64]struct{},
 // path and accurately check the amount to forward at every node against the
 // available bandwidth.
 func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
-	self, source, target route.Vertex, amt lnwire.MilliSatoshi,
-	timePref float64, finalHtlcExpiry int32) (route.Vertex, []*unifiedEdge,
-	float64, error) {
+	self route.Vertex, origin RouteOrigin, target route.Vertex,
+	amt lnwire.MilliSatoshi, timePref float64,
+	finalHtlcExpiry int32) (route.Vertex, []*unifiedEdge, float64, error) {
 
 	// Pathfinding can be a significant portion of the total payment
 	// latency, especially on low-powered devices. Log several metrics to
@@ -665,9 +699,9 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		}
 	}
 
-	// If we are routing from ourselves, check that we have enough local
-	// balance available.
-	if source == self {
+	// If we are routing from ourselves, check that we have enough
+	// local balance available.
+	if origin.IsOrigin(self) {
 		max, total, err := getOutgoingBalance(
 			self, outgoingChanMap, g.bandwidthHints, g.graph,
 		)
@@ -678,15 +712,16 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		// If the total outgoing balance isn't sufficient, it will be
 		// impossible to complete the payment.
 		if total < amt {
-			log.Warnf("Not enough outbound balance to send "+
-				"htlc of amount: %v, only have local "+
-				"balance: %v", amt, total)
+			log.Warnf("Not enough outbound balance to "+
+				"send htlc of amount: %v, only have "+
+				"local balance: %v", amt, total)
 
-			return route.Vertex{}, nil, 0, errInsufficientBalance
+			return route.Vertex{}, nil, 0,
+				errInsufficientBalance
 		}
 
-		// If there is only not enough capacity on a single route, it
-		// may still be possible to complete the payment by splitting.
+		// If there is not enough capacity on a single route, it may
+		// still be possible to complete the payment by splitting.
 		if max < amt {
 			return route.Vertex{}, nil, 0, errNoPathFound
 		}
@@ -764,10 +799,8 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 
 	// Validate time preference value.
 	if math.Abs(timePref) > 1 {
-		return route.Vertex{}, nil, 0, fmt.Errorf(
-			"time preference %v out of range [-1, 1]",
-			timePref,
-		)
+		return route.Vertex{}, nil, 0, fmt.Errorf("time preference %v "+
+			"out of range [-1, 1]", timePref)
 	}
 
 	// Scale to avoid the extremes -1 and 1 which run into infinity issues.
@@ -860,7 +893,11 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 			outboundFee   int64
 		)
 
-		if fromVertex != source {
+		// The route origin is fee-exempt and doesn't add a
+		// payload hop.
+		fromIsOrigin := origin.IsOrigin(fromVertex)
+
+		if !fromIsOrigin {
 			outboundFee = int64(
 				edge.policy.ComputeFee(amountToSend),
 			)
@@ -959,7 +996,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		// little inaccuracy here because we are over estimating by
 		// 1 hop.
 		var payloadSize uint64
-		if fromVertex != source {
+		if !fromIsOrigin {
 			// In case the unifiedEdge does not have a payload size
 			// function supplied we request a graceful shutdown
 			// because this should never happen.
@@ -1054,7 +1091,11 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		return fromFeatures, nil
 	}
 
-	routeToSelf := source == target
+	// Allow circular routes when the target is itself an origin.
+	// This lets path finding explore past the target on first visit
+	// rather than terminating immediately, enabling self-payments
+	// (e.g., rebalancing).
+	allowCircular := origin.IsOrigin(target)
 	for {
 		nodesVisited++
 
@@ -1104,10 +1145,10 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		for fromNode, edgeUnifier := range u.edgeUnifiers {
 			// The target node is not recorded in the distance map.
 			// Therefore we need to have this check to prevent
-			// creating a cycle. Only when we intend to route to
-			// self, we allow this cycle to form. In that case we'll
-			// also break out of the search loop below.
-			if !routeToSelf && fromNode == target {
+			// creating a cycle. When circular routes are
+			// permitted, we allow this cycle to form so
+			// Dijkstra can find the cheapest loop.
+			if !allowCircular && fromNode == target {
 				continue
 			}
 
@@ -1151,12 +1192,19 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		// from the heap.
 		partialPath = heap.Pop(&nodeHeap).(*nodeWithDist)
 
-		// If we've reached our source (or we don't have any incoming
-		// edges), then we're done here and can exit the graph
-		// traversal early.
-		if partialPath.node == source {
+		// If we've reached a valid origin (or we don't have any
+		// incoming edges), then we're done here and can exit the
+		// graph traversal early.
+		if origin.IsOrigin(partialPath.node) {
 			break
 		}
+	}
+
+	// The path finding loop exits either when it reaches a valid origin or
+	// when the heap empties. In the latter case, no path exists.
+	source := partialPath.node
+	if !origin.IsOrigin(source) {
+		return route.Vertex{}, nil, 0, errNoPathFound
 	}
 
 	// Use the distance map to unravel the forward path from source to

--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -1105,7 +1105,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		// Create unified policies for all incoming connections. Don't
 		// use inbound fees for the exit hop.
 		u := newNodeEdgeUnifier(
-			self, pivot, !isExitHop, outgoingChanMap,
+			self, pivot, origin, !isExitHop, outgoingChanMap,
 		)
 
 		err := u.addGraphPolicies(g.graph)

--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -1088,10 +1088,13 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		return fromFeatures, nil
 	}
 
-	// Check whether the target is also an origin, which indicates a
-	// circular payment. This allows the Dijkstra to explore past the
-	// target on first visit rather than terminating immediately.
-	routeToSelf := origin.IsOrigin(target)
+	// Allow circular routes only for single-origin self-payments
+	// (e.g., rebalancing). This lets Dijkstra explore past the target
+	// on first visit rather than terminating immediately. For
+	// multi-origin, the target may happen to be in the origin set
+	// but we still want a direct route from another origin.
+	_, isSingle := origin.(*singleOrigin)
+	routeToSelf := isSingle && origin.IsOrigin(target)
 	for {
 		nodesVisited++
 

--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -80,11 +80,15 @@ func (s *singleOrigin) IsOrigin(v route.Vertex) bool {
 	return v == s.source
 }
 
-// pathFinder defines the interface of a path finding algorithm.
+// pathFinder defines the interface of a path finding algorithm. The first
+// return value is the source vertex of the computed path. This is typically
+// the node's own key, but it may be an arbitrary source or, for multi-origin
+// callers, whichever origin provides the cheapest path.
 type pathFinder = func(g *graphParams, r *RestrictParams,
 	cfg *PathFindingConfig, self route.Vertex, origin RouteOrigin,
 	target route.Vertex, amt lnwire.MilliSatoshi, timePref float64,
-	finalHtlcExpiry int32) ([]*unifiedEdge, float64, error)
+	finalHtlcExpiry int32) (
+	route.Vertex, []*unifiedEdge, float64, error)
 
 var (
 	// DefaultEstimator is the default estimator used for computing
@@ -632,9 +636,8 @@ func getOutgoingBalance(node route.Vertex, outgoingChans map[uint64]struct{},
 // available bandwidth.
 func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 	self route.Vertex, origin RouteOrigin, target route.Vertex,
-	amt lnwire.MilliSatoshi,
-	timePref float64, finalHtlcExpiry int32) ([]*unifiedEdge, float64,
-	error) {
+	amt lnwire.MilliSatoshi, timePref float64,
+	finalHtlcExpiry int32) (route.Vertex, []*unifiedEdge, float64, error) {
 
 	// Pathfinding can be a significant portion of the total payment
 	// latency, especially on low-powered devices. Log several metrics to
@@ -657,7 +660,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 			context.TODO(), target,
 		)
 		if err != nil {
-			return nil, 0, err
+			return route.Vertex{}, nil, 0, err
 		}
 	}
 
@@ -666,14 +669,14 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 	err := feature.ValidateRequired(features)
 	if err != nil {
 		log.Warnf("Pathfinding destination node features: %v", err)
-		return nil, 0, errUnknownRequiredFeature
+		return route.Vertex{}, nil, 0, errUnknownRequiredFeature
 	}
 
 	// Ensure that all transitive dependencies are set.
 	err = feature.ValidateDeps(features)
 	if err != nil {
 		log.Warnf("Pathfinding destination node features: %v", err)
-		return nil, 0, errMissingDependentFeature
+		return route.Vertex{}, nil, 0, errMissingDependentFeature
 	}
 
 	// Now that we know the feature vector is well-formed, we'll proceed in
@@ -683,7 +686,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 	if r.PaymentAddr.IsSome() &&
 		!features.HasFeature(lnwire.PaymentAddrOptional) {
 
-		return nil, 0, errNoPaymentAddr
+		return route.Vertex{}, nil, 0, errNoPaymentAddr
 	}
 
 	// Set up outgoing channel map for quicker access.
@@ -696,13 +699,15 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 	}
 
 	// If we are routing from ourselves, check that we have enough local
-	// balance available.
+	// balance available. This check is skipped when self is not in the
+	// origin set (e.g. multi-origin), since local balance information is
+	// not available for remote origin nodes.
 	if origin.IsOrigin(self) {
 		max, total, err := getOutgoingBalance(
 			self, outgoingChanMap, g.bandwidthHints, g.graph,
 		)
 		if err != nil {
-			return nil, 0, err
+			return route.Vertex{}, nil, 0, err
 		}
 
 		// If the total outgoing balance isn't sufficient, it will be
@@ -712,13 +717,13 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 				"htlc of amount: %v, only have local "+
 				"balance: %v", amt, total)
 
-			return nil, 0, errInsufficientBalance
+			return route.Vertex{}, nil, 0, errInsufficientBalance
 		}
 
 		// If there is only not enough capacity on a single route, it
 		// may still be possible to complete the payment by splitting.
 		if max < amt {
-			return nil, 0, errNoPathFound
+			return route.Vertex{}, nil, 0, errNoPathFound
 		}
 	}
 
@@ -760,7 +765,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 	// and depends on whether the destination is blinded or not.
 	lastHopPayloadSize, err := lastHopPayloadSize(r, finalHtlcExpiry, amt)
 	if err != nil {
-		return nil, 0, err
+		return route.Vertex{}, nil, 0, err
 	}
 
 	// We can't always assume that the end destination is publicly
@@ -794,8 +799,9 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 
 	// Validate time preference value.
 	if math.Abs(timePref) > 1 {
-		return nil, 0, fmt.Errorf("time preference %v out of range "+
-			"[-1, 1]", timePref)
+		return route.Vertex{}, nil, 0, fmt.Errorf(
+			"time preference %v out of range [-1, 1]", timePref,
+		)
 	}
 
 	// Scale to avoid the extremes -1 and 1 which run into infinity issues.
@@ -1082,6 +1088,9 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		return fromFeatures, nil
 	}
 
+	// Check whether the target is also an origin, which indicates a
+	// circular payment. This allows the Dijkstra to explore past the
+	// target on first visit rather than terminating immediately.
 	routeToSelf := origin.IsOrigin(target)
 	for {
 		nodesVisited++
@@ -1097,7 +1106,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 
 		err := u.addGraphPolicies(g.graph)
 		if err != nil {
-			return nil, 0, err
+			return route.Vertex{}, nil, 0, err
 		}
 
 		// We add hop hints that were supplied externally.
@@ -1158,7 +1167,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 			// Get feature vector for fromNode.
 			fromFeatures, err := getGraphFeatures(fromNode)
 			if err != nil {
-				return nil, 0, err
+				return route.Vertex{}, nil, 0, err
 			}
 
 			// If there are no valid features, skip this node.
@@ -1191,7 +1200,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 	// when the heap empties. In the latter case, no path exists.
 	source := partialPath.node
 	if !origin.IsOrigin(source) {
-		return nil, 0, errNoPathFound
+		return route.Vertex{}, nil, 0, errNoPathFound
 	}
 
 	// Use the distance map to unravel the forward path from source to
@@ -1204,7 +1213,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		if !ok {
 			// If the node doesn't have a next hop it means we
 			// didn't find a path.
-			return nil, 0, errNoPathFound
+			return route.Vertex{}, nil, 0, errNoPathFound
 		}
 
 		// Add the next hop to the list of path edges.
@@ -1238,7 +1247,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		distance[source].probability, len(pathEdges),
 		distance[source].netAmountReceived-amt)
 
-	return pathEdges, distance[source].probability, nil
+	return source, pathEdges, distance[source].probability, nil
 }
 
 // blindedPathRestrictions are a set of constraints to adhere to when

--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -50,11 +50,41 @@ const (
 	fakeHopHintCapacity = btcutil.Amount(10 * btcutil.SatoshiPerBitcoin)
 )
 
+// RouteOrigin determines where routes can originate from. The backward
+// Dijkstra terminates when it reaches any origin vertex. This is the
+// source-end counterpart to AdditionalEdge, which extends the graph at the
+// destination end. Standard lnd uses singleOrigin (one source node). A
+// multi-backend payment service can provide a multi-source implementation
+// that terminates at any of its gateway nodes.
+//
+// NOTE: Only include vertices the caller can actually dispatch payments from.
+// Circular self-payments (route-to-self) are only supported with the built-in
+// singleOrigin.
+type RouteOrigin interface {
+	// IsOrigin reports whether the given vertex is a valid route starting
+	// point.
+	//
+	// NOTE: Implementations should be O(1). findPath calls IsOrigin once
+	// per heap pop and once per edge relaxation, so any per-call cost
+	// directly contributes to path-finding latency.
+	IsOrigin(v route.Vertex) bool
+}
+
+// singleOrigin is the default RouteOrigin: a single source vertex.
+type singleOrigin struct {
+	source route.Vertex
+}
+
+// IsOrigin reports whether v is the source vertex.
+func (s *singleOrigin) IsOrigin(v route.Vertex) bool {
+	return v == s.source
+}
+
 // pathFinder defines the interface of a path finding algorithm.
 type pathFinder = func(g *graphParams, r *RestrictParams,
-	cfg *PathFindingConfig, self, source, target route.Vertex,
-	amt lnwire.MilliSatoshi, timePref float64, finalHtlcExpiry int32) (
-	[]*unifiedEdge, float64, error)
+	cfg *PathFindingConfig, self route.Vertex, origin RouteOrigin,
+	target route.Vertex, amt lnwire.MilliSatoshi, timePref float64,
+	finalHtlcExpiry int32) ([]*unifiedEdge, float64, error)
 
 var (
 	// DefaultEstimator is the default estimator used for computing
@@ -601,7 +631,8 @@ func getOutgoingBalance(node route.Vertex, outgoingChans map[uint64]struct{},
 // path and accurately check the amount to forward at every node against the
 // available bandwidth.
 func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
-	self, source, target route.Vertex, amt lnwire.MilliSatoshi,
+	self route.Vertex, origin RouteOrigin, target route.Vertex,
+	amt lnwire.MilliSatoshi,
 	timePref float64, finalHtlcExpiry int32) ([]*unifiedEdge, float64,
 	error) {
 
@@ -666,7 +697,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 
 	// If we are routing from ourselves, check that we have enough local
 	// balance available.
-	if source == self {
+	if origin.IsOrigin(self) {
 		max, total, err := getOutgoingBalance(
 			self, outgoingChanMap, g.bandwidthHints, g.graph,
 		)
@@ -857,7 +888,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 			outboundFee   int64
 		)
 
-		if fromVertex != source {
+		if !origin.IsOrigin(fromVertex) {
 			outboundFee = int64(
 				edge.policy.ComputeFee(amountToSend),
 			)
@@ -956,7 +987,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		// little inaccuracy here because we are over estimating by
 		// 1 hop.
 		var payloadSize uint64
-		if fromVertex != source {
+		if !origin.IsOrigin(fromVertex) {
 			// In case the unifiedEdge does not have a payload size
 			// function supplied we request a graceful shutdown
 			// because this should never happen.
@@ -1051,7 +1082,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		return fromFeatures, nil
 	}
 
-	routeToSelf := source == target
+	routeToSelf := origin.IsOrigin(target)
 	for {
 		nodesVisited++
 
@@ -1148,12 +1179,19 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		// from the heap.
 		partialPath = heap.Pop(&nodeHeap).(*nodeWithDist)
 
-		// If we've reached our source (or we don't have any incoming
-		// edges), then we're done here and can exit the graph
-		// traversal early.
-		if partialPath.node == source {
+		// If we've reached a valid origin (or we don't have any
+		// incoming edges), then we're done here and can exit the
+		// graph traversal early.
+		if origin.IsOrigin(partialPath.node) {
 			break
 		}
+	}
+
+	// The path finding loop exits either when it reaches a valid origin or
+	// when the heap empties. In the latter case, no path exists.
+	source := partialPath.node
+	if !origin.IsOrigin(source) {
+		return nil, 0, errNoPathFound
 	}
 
 	// Use the distance map to unravel the forward path from source to

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -3325,27 +3325,28 @@ func dbFindPath(graph *graphdb.VersionedGraph,
 		return nil, err
 	}
 
-	var route []*unifiedEdge
+	var routeEdges []*unifiedEdge
 	err = graph.GraphSession(ctx, func(graph graphdb.NodeTraverser) error {
-		route, _, err = findPath(
+		_, routeEdges, _, err = findPath(
 			&graphParams{
 				additionalEdges: additionalEdges,
 				bandwidthHints:  bandwidthHints,
 				graph:           graph,
 			},
-			r, cfg, sourceNode.PubKeyBytes, source, target, amt,
+			r, cfg, sourceNode.PubKeyBytes,
+			source, target, amt,
 			timePref, finalHtlcExpiry,
 		)
 
 		return err
 	}, func() {
-		route = nil
+		routeEdges = nil
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	return route, nil
+	return routeEdges, nil
 }
 
 // dbFindBlindedPaths calls findBlindedPaths after getting a db transaction from

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -890,6 +890,15 @@ func TestPathFinding(t *testing.T) {
 		name: "route to self",
 		fn:   runRouteToSelf,
 	}, {
+		name: "multi origin",
+		fn:   runMultiOrigin,
+	}, {
+		name: "multi origin cheapest path",
+		fn:   runMultiOriginCheapestPath,
+	}, {
+		name: "multi origin circular route",
+		fn:   runMultiOriginCircularRoute,
+	}, {
 		name: "with metadata",
 		fn:   runFindPathWithMetadata,
 	}, {
@@ -3073,6 +3082,423 @@ func runRouteToSelf(t *testing.T, useCache bool) {
 	ctx.assertPath(path, []uint64{1, 3, 2})
 }
 
+// multiOrigin is a RouteOrigin that terminates at any vertex in the set. This
+// is the multi-source variant for external payment controllers that dispatch
+// from multiple gateway nodes.
+type multiOrigin struct {
+	sources map[route.Vertex]struct{}
+}
+
+func (m *multiOrigin) IsOrigin(v route.Vertex) bool {
+	_, ok := m.sources[v]
+
+	return ok
+}
+
+// findPathWithOrigin is a test helper that runs findPath with a given
+// RouteOrigin and returns the settled source vertex alongside the path.
+func findPathWithOrigin(t *testing.T, ctx *pathFindingTestContext,
+	origin RouteOrigin, target route.Vertex,
+	amt lnwire.MilliSatoshi) (route.Vertex, []*unifiedEdge, error) {
+
+	t.Helper()
+
+	sourceNode, err := ctx.v1Graph.SourceNode(t.Context())
+	require.NoError(t, err)
+
+	var (
+		source route.Vertex
+		path   []*unifiedEdge
+	)
+
+	err = ctx.v1Graph.GraphSession(
+		t.Context(),
+		func(graph graphdb.NodeTraverser) error {
+			source, path, _, err = findPath(
+				&graphParams{
+					bandwidthHints: ctx.bandwidthHints,
+					graph:          graph,
+				},
+				&ctx.restrictParams,
+				&ctx.pathFindingConfig,
+				sourceNode.PubKeyBytes,
+				origin, target,
+				amt, 0, 0,
+			)
+
+			return err
+		}, func() {
+			path = nil
+		},
+	)
+
+	return source, path, err
+}
+
+// runMultiOrigin tests that the pathfinder correctly terminates at the nearest
+// origin when given a RouteOrigin containing multiple valid source vertices.
+// This exercises the multi-source Dijkstra behavior needed by an external
+// payment controller that dispatches from multiple gateway nodes.
+func runMultiOrigin(t *testing.T, useCache bool) {
+	// Build a diamond-shaped network with two possible origins
+	// and a separate proxy node as self (no channels):
+	//
+	//   proxy (self, no channels)
+	//   gw1 ---- alice ---- dest
+	//   gw2 ---- bob ------/
+	//
+	// Both gw1 and gw2 are valid origins. Since origins are fee-exempt
+	// (the sender doesn't pay its own forwarding fee), we differentiate
+	// the paths by the intermediate hop's fee: alice charges 500 msat
+	// while bob charges 2000 msat.
+	testChannels := []*testChannel{
+		symmetricTestChannel("gw1", "alice", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 500,
+			}, 1,
+		),
+		symmetricTestChannel("gw2", "bob", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 500,
+			}, 2,
+		),
+		// alice->dest is cheap (500 msat).
+		symmetricTestChannel("alice", "dest", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 500,
+			}, 3,
+		),
+		// bob->dest is expensive (2000 msat).
+		symmetricTestChannel("bob", "dest", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 2000,
+			}, 4,
+		),
+	}
+
+	ctx := newPathFindingTestContext(t, useCache, testChannels, "proxy")
+
+	gw1 := ctx.keyFromAlias("gw1")
+	gw2 := ctx.keyFromAlias("gw2")
+	target := ctx.keyFromAlias("dest")
+	paymentAmt := lnwire.NewMSatFromSatoshis(100)
+
+	// With both gateways available, the pathfinder should select
+	// gw1->alice->dest since alice charges less than bob.
+	bothOrigins := &multiOrigin{sources: map[route.Vertex]struct{}{
+		gw1: {},
+		gw2: {},
+	}}
+	source, path, err := findPathWithOrigin(
+		t, ctx, bothOrigins, target, paymentAmt,
+	)
+	require.NoError(t, err, "unable to find multi-origin path")
+	require.Equal(t, gw1, source, "expected gw1 as selected route source")
+	assertExpectedPath(
+		t, ctx.testGraphInstance.aliasMap, path, "alice", "dest",
+	)
+
+	// Simulate gw1 going offline by removing it from the origin set.
+	// The pathfinder should fall back to gw2->bob->dest.
+	gw2Only := &multiOrigin{sources: map[route.Vertex]struct{}{
+		gw2: {},
+	}}
+	source, path, err = findPathWithOrigin(
+		t, ctx, gw2Only, target, paymentAmt,
+	)
+	require.NoError(t, err, "unable to find path via gw2")
+	require.Equal(t, gw2, source, "expected gw2 as selected route source")
+	assertExpectedPath(
+		t, ctx.testGraphInstance.aliasMap, path, "bob", "dest",
+	)
+
+	// An empty origin set should return errNoPathFound, since the
+	// path-finding loop will exhaust the heap without reaching any origin.
+	emptyOrigin := &multiOrigin{sources: map[route.Vertex]struct{}{}}
+	_, _, err = findPathWithOrigin(
+		t, ctx, emptyOrigin, target, paymentAmt,
+	)
+	require.ErrorIs(t, err, errNoPathFound)
+}
+
+// runMultiOriginCircularRoute tests that when the target is in the origin
+// set and a circular route physically exists, the pathfinder can find it.
+// The topology extends the diamond with a direct dest→gw2 channel so that
+// gw2→bob→dest→gw2 forms a valid cycle. With origins={gw1, gw2} and
+// target=gw2, the pathfinder should pick whichever path is cheaper:
+// cross-gateway (gw1→alice→dest→gw2) or circular (gw2→bob→dest→gw2).
+func runMultiOriginCircularRoute(t *testing.T, useCache bool) {
+	// Extended diamond topology with a closing channel (chan 5):
+	//
+	//   proxy (self, no channels)
+	//   gw1 ---- alice ---- dest    (chan 1, chan 3)
+	//   gw2 ---- bob ------/        (chan 2, chan 4)
+	//   gw2 --------- dest          (chan 5, direct)
+	//
+	// Fee structure makes the circular path (gw2→bob→dest→gw2) cheaper
+	// than the cross-gateway path (gw1→alice→dest→gw2): bob charges
+	// 500 msat, alice charges 2000 msat. The dest→gw2 hop on chan 5
+	// is cheap (100 msat) for both paths.
+	testChannels := []*testChannel{
+		symmetricTestChannel("gw1", "alice", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 2000,
+			}, 1,
+		),
+		symmetricTestChannel("gw2", "bob", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 500,
+			}, 2,
+		),
+		symmetricTestChannel("alice", "dest", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 2000,
+			}, 3,
+		),
+		symmetricTestChannel("bob", "dest", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 500,
+			}, 4,
+		),
+		symmetricTestChannel("dest", "gw2", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 100,
+			}, 5,
+		),
+	}
+
+	ctx := newPathFindingTestContext(t, useCache, testChannels, "proxy")
+
+	gw1 := ctx.keyFromAlias("gw1")
+	gw2 := ctx.keyFromAlias("gw2")
+	paymentAmt := lnwire.NewMSatFromSatoshis(100)
+
+	// With both gateways as origins and gw2 as target, the circular
+	// path through gw2 should win because it's cheaper.
+	bothOrigins := &multiOrigin{sources: map[route.Vertex]struct{}{
+		gw1: {},
+		gw2: {},
+	}}
+	source, path, err := findPathWithOrigin(
+		t, ctx, bothOrigins, gw2, paymentAmt,
+	)
+	require.NoError(t, err)
+	require.Equal(t, gw2, source,
+		"circular gw2→bob→dest→gw2 should win on cost")
+	require.Greater(t, len(path), 0,
+		"circular route should have real hops")
+
+	lastHop := path[len(path)-1].policy.ToNodePubKey()
+	require.Equal(t, gw2, lastHop,
+		"last hop should reach gw2")
+
+	// Cross-gateway path should be found when gw2 is removed from
+	// the origin set (only gw1 remains).
+	gw1Only := &multiOrigin{sources: map[route.Vertex]struct{}{
+		gw1: {},
+	}}
+	source, _, err = findPathWithOrigin(
+		t, ctx, gw1Only, gw2, paymentAmt,
+	)
+	require.NoError(t, err)
+	require.Equal(t, gw1, source,
+		"with only gw1, cross-gateway path should be found")
+}
+
+// runMultiOriginCheapestPath proves that multi-origin termination finds the
+// globally cheapest path by cross-validating against exhaustive single-origin
+// searches. This addresses the question: "is it enough to halt when you've
+// found one of the origin nodes?" The answer is yes, because Dijkstra's
+// min-heap ordering guarantees the first origin popped has the minimum cost.
+//
+// The test builds a network with three gateways at varying distances and fee
+// levels, runs findPath once with all three as a multi-origin set, then runs
+// findPath separately for each gateway as a single origin. The multi-origin
+// result must match the cheapest individual result.
+func runMultiOriginCheapestPath(t *testing.T, useCache bool) {
+	// Build a network where the cheapest origin is NOT the one with the
+	// fewest intermediate hops:
+	//
+	//   gw1 ---- cheap1 ---- cheap2 ---- dest    (2 intermediaries)
+	//   gw2 ---- expensive ---- dest              (1 intermediary)
+	//   gw3 ---- medium1 ---- medium2 ---- dest   (2 intermediaries)
+	//
+	// gw2's path has the fewest hops, but gw1's path is cheapest in fees.
+	// Origins are fee-exempt (the sender doesn't pay its own forwarding
+	// fee), so cost differentiation comes entirely from the intermediate
+	// hops. The cheap1/cheap2 edges each charge 100 msat base fee, the
+	// expensive edge charges 5000, and the medium edges charge 800 each.
+	testChannels := []*testChannel{
+		// gw1's path: cheap intermediaries.
+		symmetricTestChannel("gw1", "cheap1", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 100,
+			}, 1,
+		),
+		symmetricTestChannel("cheap1", "cheap2", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 100,
+			}, 2,
+		),
+		symmetricTestChannel("cheap2", "dest", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 100,
+			}, 3,
+		),
+		// gw2's path: fewest hops but expensive intermediary.
+		symmetricTestChannel("gw2", "expensive", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 5000,
+			}, 4,
+		),
+		symmetricTestChannel("expensive", "dest", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 5000,
+			}, 5,
+		),
+		// gw3's path: medium-cost intermediaries.
+		symmetricTestChannel("gw3", "medium1", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 800,
+			}, 6,
+		),
+		symmetricTestChannel("medium1", "medium2", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 800,
+			}, 7,
+		),
+		symmetricTestChannel("medium2", "dest", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 800,
+			}, 8,
+		),
+	}
+
+	ctx := newPathFindingTestContext(t, useCache, testChannels, "proxy")
+
+	gw1 := ctx.keyFromAlias("gw1")
+	gw2 := ctx.keyFromAlias("gw2")
+	gw3 := ctx.keyFromAlias("gw3")
+	target := ctx.keyFromAlias("dest")
+	paymentAmt := lnwire.NewMSatFromSatoshis(1000)
+
+	const (
+		startingHeight = 100
+		finalHopCLTV   = 1
+	)
+
+	// buildRoute converts a findPath result into a route so we can
+	// compare TotalFees across origins.
+	buildRoute := func(source route.Vertex,
+		path []*unifiedEdge) *route.Route {
+
+		r, err := newRoute(
+			source, path, startingHeight,
+			finalHopParams{
+				amt:       paymentAmt,
+				cltvDelta: finalHopCLTV,
+				records:   nil,
+			}, nil,
+		)
+		require.NoError(t, err)
+
+		return r
+	}
+
+	// Run multi-origin search with all three gateways.
+	allOrigins := &multiOrigin{sources: map[route.Vertex]struct{}{
+		gw1: {},
+		gw2: {},
+		gw3: {},
+	}}
+	multiSource, multiPath, err := findPathWithOrigin(
+		t, ctx, allOrigins, target, paymentAmt,
+	)
+	require.NoError(t, err, "multi-origin findPath failed")
+	multiRoute := buildRoute(multiSource, multiPath)
+
+	// Run single-origin search for each gateway independently
+	// and record the total fees for each.
+	type singleResult struct {
+		name   string
+		vertex route.Vertex
+		fees   lnwire.MilliSatoshi
+	}
+	gateways := []struct {
+		name   string
+		vertex route.Vertex
+	}{
+		{"gw1", gw1},
+		{"gw2", gw2},
+		{"gw3", gw3},
+	}
+
+	var results []singleResult
+	for _, gw := range gateways {
+		origin := &singleOrigin{source: gw.vertex}
+		src, path, err := findPathWithOrigin(
+			t, ctx, origin, target, paymentAmt,
+		)
+		require.NoError(t, err, "single-origin findPath failed for %s",
+			gw.name)
+
+		r := buildRoute(src, path)
+		results = append(results, singleResult{
+			name:   gw.name,
+			vertex: gw.vertex,
+			fees:   r.TotalFees(),
+		})
+	}
+
+	// Find the cheapest single-origin result.
+	cheapest := results[0]
+	for _, r := range results[1:] {
+		if r.fees < cheapest.fees {
+			cheapest = r
+		}
+	}
+
+	// Assert multi-origin picked the same gateway as the cheapest
+	// individual search. This is the core property: early termination in
+	// multi-origin Dijkstra finds the globally optimal origin.
+	require.Equal(t, cheapest.vertex, multiSource,
+		"multi-origin selected %s but cheapest individual origin is "+
+			"%s (fees: multi=%v, gw1=%v, gw2=%v, gw3=%v)",
+		multiSource, cheapest.name, multiRoute.TotalFees(),
+		results[0].fees, results[1].fees, results[2].fees,
+	)
+
+	// Assert the total fees match exactly.
+	require.Equal(t, cheapest.fees, multiRoute.TotalFees(),
+		"multi-origin fees should equal cheapest single-origin fees",
+	)
+
+	// Sanity check the expected winner and path.
+	require.Equal(t, gw1, multiSource,
+		"expected gw1 as cheapest origin")
+	assertExpectedPath(
+		t, ctx.testGraphInstance.aliasMap, multiPath,
+		"cheap1", "cheap2", "dest",
+	)
+}
+
 // runInboundFees tests whether correct routes are built when inbound fees
 // apply.
 func runInboundFees(t *testing.T, useCache bool) {
@@ -3334,7 +3760,7 @@ func dbFindPath(graph *graphdb.VersionedGraph,
 				graph:           graph,
 			},
 			r, cfg, sourceNode.PubKeyBytes,
-			source, target, amt,
+			&singleOrigin{source}, target, amt,
 			timePref, finalHtlcExpiry,
 		)
 

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -899,6 +899,9 @@ func TestPathFinding(t *testing.T) {
 		name: "multi origin circular route",
 		fn:   runMultiOriginCircularRoute,
 	}, {
+		name: "multi origin outgoing restriction",
+		fn:   runMultiOriginOutgoingRestriction,
+	}, {
 		name: "with metadata",
 		fn:   runFindPathWithMetadata,
 	}, {
@@ -3497,6 +3500,105 @@ func runMultiOriginCheapestPath(t *testing.T, useCache bool) {
 		t, ctx.testGraphInstance.aliasMap, multiPath,
 		"cheap1", "cheap2", "dest",
 	)
+}
+
+// runMultiOriginOutgoingRestriction tests that OutgoingChannelIDs correctly
+// restricts which gateway is selected in a multi-origin setup. This verifies
+// the decoupled isOriginEdge predicate in nodeEdgeUnifier: the restriction
+// fires for any origin edge, while the selection algorithm (getEdgeLocal vs
+// getEdgeNetwork) remains gated on localChan (self only).
+func runMultiOriginOutgoingRestriction(t *testing.T, useCache bool) {
+	// Same diamond topology as runMultiOrigin.
+	//
+	//   proxy (self, no channels)
+	//   gw1 ---- alice ---- dest    (chan 1, chan 3)
+	//   gw2 ---- bob ------/        (chan 2, chan 4)
+	//
+	// gw1→alice→dest is cheaper (alice=500) than gw2→bob→dest (bob=2000).
+	testChannels := []*testChannel{
+		symmetricTestChannel("gw1", "alice", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 500,
+			}, 1,
+		),
+		symmetricTestChannel("gw2", "bob", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 500,
+			}, 2,
+		),
+		symmetricTestChannel("alice", "dest", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 500,
+			}, 3,
+		),
+		symmetricTestChannel("bob", "dest", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 2000,
+			}, 4,
+		),
+	}
+
+	ctx := newPathFindingTestContext(t, useCache, testChannels, "proxy")
+
+	gw1 := ctx.keyFromAlias("gw1")
+	gw2 := ctx.keyFromAlias("gw2")
+	target := ctx.keyFromAlias("dest")
+	paymentAmt := lnwire.NewMSatFromSatoshis(100)
+
+	bothOrigins := &multiOrigin{sources: map[route.Vertex]struct{}{
+		gw1: {},
+		gw2: {},
+	}}
+
+	// Subtest 1: No restriction — cheapest gateway (gw1) wins.
+	ctx.restrictParams.OutgoingChannelIDs = nil
+	source, path, err := findPathWithOrigin(
+		t, ctx, bothOrigins, target, paymentAmt,
+	)
+	require.NoError(t, err)
+	require.Equal(t, gw1, source,
+		"unrestricted should pick cheapest gateway")
+	assertExpectedPath(
+		t, ctx.testGraphInstance.aliasMap, path, "alice", "dest",
+	)
+
+	// Subtest 2: Restrict to gw2's channel — forces the expensive path.
+	ctx.restrictParams.OutgoingChannelIDs = []uint64{2}
+	source, path, err = findPathWithOrigin(
+		t, ctx, bothOrigins, target, paymentAmt,
+	)
+	require.NoError(t, err)
+	require.Equal(t, gw2, source,
+		"restriction to chan 2 should force gw2")
+	assertExpectedPath(
+		t, ctx.testGraphInstance.aliasMap, path, "bob", "dest",
+	)
+
+	// Subtest 3: Restrict to gw1's channel — picks gw1 explicitly.
+	ctx.restrictParams.OutgoingChannelIDs = []uint64{1}
+	source, path, err = findPathWithOrigin(
+		t, ctx, bothOrigins, target, paymentAmt,
+	)
+	require.NoError(t, err)
+	require.Equal(t, gw1, source,
+		"restriction to chan 1 should force gw1")
+	assertExpectedPath(
+		t, ctx.testGraphInstance.aliasMap, path, "alice", "dest",
+	)
+
+	// Subtest 4: Restrict to invalid channel — no path found.
+	ctx.restrictParams.OutgoingChannelIDs = []uint64{999}
+	_, _, err = findPathWithOrigin(
+		t, ctx, bothOrigins, target, paymentAmt,
+	)
+	require.ErrorIs(t, err, errNoPathFound)
+
+	// Reset for other tests.
+	ctx.restrictParams.OutgoingChannelIDs = nil
 }
 
 // runInboundFees tests whether correct routes are built when inbound fees

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -893,6 +893,9 @@ func TestPathFinding(t *testing.T) {
 		name: "multi origin",
 		fn:   runMultiOrigin,
 	}, {
+		name: "multi origin cheapest path",
+		fn:   runMultiOriginCheapestPath,
+	}, {
 		name: "with metadata",
 		fn:   runFindPathWithMetadata,
 	}, {
@@ -3089,21 +3092,24 @@ func (m *multiOrigin) IsOrigin(v route.Vertex) bool {
 }
 
 // findPathWithOrigin is a test helper that runs findPath with a given
-// RouteOrigin and returns the path.
+// RouteOrigin and returns the settled source vertex alongside the path.
 func findPathWithOrigin(t *testing.T, ctx *pathFindingTestContext,
 	origin RouteOrigin, target route.Vertex,
-	amt lnwire.MilliSatoshi) ([]*unifiedEdge, error) {
+	amt lnwire.MilliSatoshi) (route.Vertex, []*unifiedEdge, error) {
 
 	t.Helper()
 
 	sourceNode, err := ctx.v1Graph.SourceNode(t.Context())
 	require.NoError(t, err)
 
-	var path []*unifiedEdge
+	var (
+		source route.Vertex
+		path   []*unifiedEdge
+	)
 	err = ctx.v1Graph.GraphSession(
 		t.Context(),
 		func(graph graphdb.NodeTraverser) error {
-			path, _, err = findPath(
+			source, path, _, err = findPath(
 				&graphParams{
 					bandwidthHints: ctx.bandwidthHints,
 					graph:          graph,
@@ -3121,7 +3127,7 @@ func findPathWithOrigin(t *testing.T, ctx *pathFindingTestContext,
 		},
 	)
 
-	return path, err
+	return source, path, err
 }
 
 // runMultiOrigin tests that the pathfinder correctly terminates at the nearest
@@ -3180,10 +3186,11 @@ func runMultiOrigin(t *testing.T, useCache bool) {
 		gw1: {},
 		gw2: {},
 	}}
-	path, err := findPathWithOrigin(
+	source, path, err := findPathWithOrigin(
 		t, ctx, bothOrigins, target, paymentAmt,
 	)
 	require.NoError(t, err, "unable to find multi-origin path")
+	require.Equal(t, gw1, source, "expected gw1 as selected route source")
 	assertExpectedPath(
 		t, ctx.testGraphInstance.aliasMap, path, "alice", "dest",
 	)
@@ -3193,13 +3200,229 @@ func runMultiOrigin(t *testing.T, useCache bool) {
 	gw2Only := &multiOrigin{sources: map[route.Vertex]struct{}{
 		gw2: {},
 	}}
-	path, err = findPathWithOrigin(
+	source, path, err = findPathWithOrigin(
 		t, ctx, gw2Only, target, paymentAmt,
 	)
 	require.NoError(t, err, "unable to find path via gw2")
+	require.Equal(t, gw2, source, "expected gw2 as selected route source")
 	assertExpectedPath(
 		t, ctx.testGraphInstance.aliasMap, path, "bob", "dest",
 	)
+
+	// An empty origin set should return errNoPathFound, since the
+	// path-finding loop will exhaust the heap without reaching any origin.
+	emptyOrigin := &multiOrigin{sources: map[route.Vertex]struct{}{}}
+	_, _, err = findPathWithOrigin(
+		t, ctx, emptyOrigin, target, paymentAmt,
+	)
+	require.ErrorIs(t, err, errNoPathFound)
+
+	// When the target is also an origin (circular payment scenario), the
+	// pathfinder should still find a valid route.
+	targetIsOrigin := &multiOrigin{sources: map[route.Vertex]struct{}{
+		gw1:    {},
+		target: {},
+	}}
+	source, path, err = findPathWithOrigin(
+		t, ctx, targetIsOrigin, target, paymentAmt,
+	)
+	require.NoError(t, err, "unable to find path when target is origin")
+	require.Equal(t, gw1, source, "expected gw1 as selected route source")
+	assertExpectedPath(
+		t, ctx.testGraphInstance.aliasMap, path, "alice", "dest",
+	)
+}
+
+// runMultiOriginCheapestPath proves that multi-origin termination finds the
+// globally cheapest path by cross-validating against exhaustive single-origin
+// searches. This addresses the question: "is it enough to halt when you've
+// found one of the origin nodes?" The answer is yes, because Dijkstra's
+// min-heap ordering guarantees the first origin popped has the minimum cost.
+//
+// The test builds a network with three gateways at varying distances and fee
+// levels, runs findPath once with all three as a multi-origin set, then runs
+// findPath separately for each gateway as a single origin. The multi-origin
+// result must match the cheapest individual result.
+func runMultiOriginCheapestPath(t *testing.T, useCache bool) {
+	// Build a network where the cheapest origin is NOT the one with the
+	// fewest intermediate hops:
+	//
+	//   gw1 ---- cheap1 ---- cheap2 ---- dest    (2 intermediaries)
+	//   gw2 ---- expensive ---- dest              (1 intermediary)
+	//   gw3 ---- medium1 ---- medium2 ---- dest   (2 intermediaries)
+	//
+	// gw2's path has the fewest hops, but gw1's path is cheapest in fees.
+	// Origins are fee-exempt (the sender doesn't pay its own forwarding
+	// fee), so cost differentiation comes entirely from the intermediate
+	// hops. The cheap1/cheap2 edges each charge 100 msat base fee, the
+	// expensive edge charges 5000, and the medium edges charge 800 each.
+	testChannels := []*testChannel{
+		// gw1's path: cheap intermediaries.
+		symmetricTestChannel("gw1", "cheap1", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 100,
+			}, 1,
+		),
+		symmetricTestChannel("cheap1", "cheap2", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 100,
+			}, 2,
+		),
+		symmetricTestChannel("cheap2", "dest", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 100,
+			}, 3,
+		),
+		// gw2's path: fewest hops but expensive intermediary.
+		symmetricTestChannel("gw2", "expensive", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 5000,
+			}, 4,
+		),
+		symmetricTestChannel("expensive", "dest", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 5000,
+			}, 5,
+		),
+		// gw3's path: medium-cost intermediaries.
+		symmetricTestChannel("gw3", "medium1", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 800,
+			}, 6,
+		),
+		symmetricTestChannel("medium1", "medium2", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 800,
+			}, 7,
+		),
+		symmetricTestChannel("medium2", "dest", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 800,
+			}, 8,
+		),
+	}
+
+	ctx := newPathFindingTestContext(t, useCache, testChannels, "gw1")
+
+	gw1 := ctx.keyFromAlias("gw1")
+	gw2 := ctx.keyFromAlias("gw2")
+	gw3 := ctx.keyFromAlias("gw3")
+	target := ctx.keyFromAlias("dest")
+	paymentAmt := lnwire.NewMSatFromSatoshis(1000)
+
+	const (
+		startingHeight = 100
+		finalHopCLTV   = 1
+	)
+
+	// buildRoute converts a findPath result into a route so we can
+	// compare TotalFees across origins.
+	buildRoute := func(source route.Vertex,
+		path []*unifiedEdge) *route.Route {
+
+		r, err := newRoute(
+			source, path, startingHeight,
+			finalHopParams{
+				amt:       paymentAmt,
+				cltvDelta: finalHopCLTV,
+				records:   nil,
+			}, nil,
+		)
+		require.NoError(t, err)
+
+		return r
+	}
+
+	// Run multi-origin search with all three gateways.
+	allOrigins := &multiOrigin{sources: map[route.Vertex]struct{}{
+		gw1: {},
+		gw2: {},
+		gw3: {},
+	}}
+	multiSource, multiPath, err := findPathWithOrigin(
+		t, ctx, allOrigins, target, paymentAmt,
+	)
+	require.NoError(t, err, "multi-origin findPath failed")
+	multiRoute := buildRoute(multiSource, multiPath)
+
+	// Run single-origin search for each gateway independently
+	// and record the total fees for each.
+	type singleResult struct {
+		name   string
+		vertex route.Vertex
+		fees   lnwire.MilliSatoshi
+	}
+	gateways := []struct {
+		name   string
+		vertex route.Vertex
+	}{
+		{"gw1", gw1},
+		{"gw2", gw2},
+		{"gw3", gw3},
+	}
+
+	var results []singleResult
+	for _, gw := range gateways {
+		origin := &singleOrigin{source: gw.vertex}
+		src, path, err := findPathWithOrigin(
+			t, ctx, origin, target, paymentAmt,
+		)
+		require.NoError(t, err, "single-origin findPath failed for %s",
+			gw.name)
+
+		r := buildRoute(src, path)
+		results = append(results, singleResult{
+			name:   gw.name,
+			vertex: gw.vertex,
+			fees:   r.TotalFees(),
+		})
+	}
+
+	// Find the cheapest single-origin result.
+	cheapest := results[0]
+	for _, r := range results[1:] {
+		if r.fees < cheapest.fees {
+			cheapest = r
+		}
+	}
+
+	// Assert multi-origin picked the same gateway as the cheapest
+	// individual search. This is the core property: early termination in
+	// multi-origin Dijkstra finds the globally optimal origin.
+	require.Equal(t, cheapest.vertex, multiSource,
+		"multi-origin selected %s but cheapest individual origin is "+
+			"%s (fees: multi=%v, gw1=%v, gw2=%v, gw3=%v)",
+		multiSource, cheapest.name, multiRoute.TotalFees(),
+		results[0].fees, results[1].fees, results[2].fees,
+	)
+
+	// Assert the total fees match exactly.
+	require.Equal(t, cheapest.fees, multiRoute.TotalFees(),
+		"multi-origin fees should equal cheapest single-origin fees",
+	)
+
+	// Sanity check the expected winner and path.
+	require.Equal(t, gw1, multiSource,
+		"expected gw1 as cheapest origin")
+	assertExpectedPath(
+		t, ctx.testGraphInstance.aliasMap, multiPath,
+		"cheap1", "cheap2", "dest",
+	)
+
+	// Log the fee comparison for visibility.
+	t.Logf("Multi-origin fees: %v (via %s)", multiRoute.TotalFees(),
+		cheapest.name)
+	for _, r := range results {
+		t.Logf("  %s single-origin fees: %v", r.name, r.fees)
+	}
 }
 
 // runInboundFees tests whether correct routes are built when inbound fees
@@ -3456,7 +3679,7 @@ func dbFindPath(graph *graphdb.VersionedGraph,
 
 	var route []*unifiedEdge
 	err = graph.GraphSession(ctx, func(graph graphdb.NodeTraverser) error {
-		route, _, err = findPath(
+		_, route, _, err = findPath(
 			&graphParams{
 				additionalEdges: additionalEdges,
 				bandwidthHints:  bandwidthHints,

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -890,6 +890,9 @@ func TestPathFinding(t *testing.T) {
 		name: "route to self",
 		fn:   runRouteToSelf,
 	}, {
+		name: "multi origin",
+		fn:   runMultiOrigin,
+	}, {
 		name: "with metadata",
 		fn:   runFindPathWithMetadata,
 	}, {
@@ -3073,6 +3076,132 @@ func runRouteToSelf(t *testing.T, useCache bool) {
 	ctx.assertPath(path, []uint64{1, 3, 2})
 }
 
+// multiOrigin is a RouteOrigin that terminates at any vertex in the set. This
+// is the multi-source variant for external payment controllers that dispatch
+// from multiple gateway nodes.
+type multiOrigin struct {
+	sources map[route.Vertex]struct{}
+}
+
+func (m *multiOrigin) IsOrigin(v route.Vertex) bool {
+	_, ok := m.sources[v]
+	return ok
+}
+
+// findPathWithOrigin is a test helper that runs findPath with a given
+// RouteOrigin and returns the path.
+func findPathWithOrigin(t *testing.T, ctx *pathFindingTestContext,
+	origin RouteOrigin, target route.Vertex,
+	amt lnwire.MilliSatoshi) ([]*unifiedEdge, error) {
+
+	t.Helper()
+
+	sourceNode, err := ctx.v1Graph.SourceNode(t.Context())
+	require.NoError(t, err)
+
+	var path []*unifiedEdge
+	err = ctx.v1Graph.GraphSession(
+		t.Context(),
+		func(graph graphdb.NodeTraverser) error {
+			path, _, err = findPath(
+				&graphParams{
+					bandwidthHints: ctx.bandwidthHints,
+					graph:          graph,
+				},
+				&ctx.restrictParams,
+				&ctx.pathFindingConfig,
+				sourceNode.PubKeyBytes,
+				origin, target,
+				amt, 0, 0,
+			)
+
+			return err
+		}, func() {
+			path = nil
+		},
+	)
+
+	return path, err
+}
+
+// runMultiOrigin tests that the pathfinder correctly terminates at the nearest
+// origin when given a RouteOrigin containing multiple valid source vertices.
+// This exercises the multi-source Dijkstra behavior needed by an external
+// payment controller that dispatches from multiple gateway nodes.
+func runMultiOrigin(t *testing.T, useCache bool) {
+	// Build a diamond-shaped network with two possible origins:
+	//
+	//   gw1 ---- alice ---- dest
+	//   gw2 ---- bob ------/
+	//
+	// Both gw1 and gw2 are valid origins. Since origins are fee-exempt
+	// (the sender doesn't pay its own forwarding fee), we differentiate
+	// the paths by the intermediate hop's fee: alice charges 500 msat
+	// while bob charges 2000 msat.
+	testChannels := []*testChannel{
+		symmetricTestChannel("gw1", "alice", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 500,
+			}, 1,
+		),
+		symmetricTestChannel("gw2", "bob", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 500,
+			}, 2,
+		),
+		// alice->dest is cheap (500 msat).
+		symmetricTestChannel("alice", "dest", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 500,
+			}, 3,
+		),
+		// bob->dest is expensive (2000 msat).
+		symmetricTestChannel("bob", "dest", 100000,
+			&testChannelPolicy{
+				Expiry:      144,
+				FeeBaseMsat: 2000,
+			}, 4,
+		),
+	}
+
+	ctx := newPathFindingTestContext(t, useCache, testChannels, "gw1")
+
+	gw1 := ctx.keyFromAlias("gw1")
+	gw2 := ctx.keyFromAlias("gw2")
+	target := ctx.keyFromAlias("dest")
+	paymentAmt := lnwire.NewMSatFromSatoshis(100)
+
+	// With both gateways available, the pathfinder should select
+	// gw1->alice->dest since alice charges less than bob.
+	bothOrigins := &multiOrigin{sources: map[route.Vertex]struct{}{
+		gw1: {},
+		gw2: {},
+	}}
+	path, err := findPathWithOrigin(
+		t, ctx, bothOrigins, target, paymentAmt,
+	)
+	require.NoError(t, err, "unable to find multi-origin path")
+	assertExpectedPath(
+		t, ctx.testGraphInstance.aliasMap, path, "alice", "dest",
+	)
+
+	// Simulate gw1 going offline by removing it from the origin set.
+	// The pathfinder should fall back to gw2->bob->dest.
+	gw2Only := &multiOrigin{sources: map[route.Vertex]struct{}{
+		gw2: {},
+	}}
+	path, err = findPathWithOrigin(
+		t, ctx, gw2Only, target, paymentAmt,
+	)
+	require.NoError(t, err, "unable to find path via gw2")
+	assertExpectedPath(
+		t, ctx.testGraphInstance.aliasMap, path, "bob", "dest",
+	)
+}
+
 // runInboundFees tests whether correct routes are built when inbound fees
 // apply.
 func runInboundFees(t *testing.T, useCache bool) {
@@ -3333,7 +3462,8 @@ func dbFindPath(graph *graphdb.VersionedGraph,
 				bandwidthHints:  bandwidthHints,
 				graph:           graph,
 			},
-			r, cfg, sourceNode.PubKeyBytes, source, target, amt,
+			r, cfg, sourceNode.PubKeyBytes,
+			&singleOrigin{source}, target, amt,
 			timePref, finalHtlcExpiry,
 		)
 

--- a/routing/payment_session.go
+++ b/routing/payment_session.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btclog/v2"
+	"github.com/lightningnetwork/lnd/fn/v2"
 	graphdb "github.com/lightningnetwork/lnd/graph/db"
 	"github.com/lightningnetwork/lnd/graph/db/models"
 	"github.com/lightningnetwork/lnd/lnutils"
@@ -195,6 +196,35 @@ type paymentSession struct {
 
 	// log is a payment session-specific logger.
 	log btclog.Logger
+
+	// opts holds optional configuration for the payment session.
+	opts sessionOptions
+}
+
+// sessionOptions holds optional configuration for a payment session.
+type sessionOptions struct {
+	// origin is an optional RouteOrigin that determines where routes can
+	// start. When set, the pathfinder terminates at any vertex for which
+	// IsOrigin returns true.
+	origin fn.Option[RouteOrigin]
+}
+
+// defaultSessionOptions returns sessionOptions with default values.
+func defaultSessionOptions() sessionOptions {
+	return sessionOptions{}
+}
+
+// sessionOption is a functional option for configuring a payment session.
+type sessionOption func(*sessionOptions)
+
+// withOrigin sets the RouteOrigin for this payment session.
+func withOrigin(o RouteOrigin) sessionOption {
+	return func(opts *sessionOptions) {
+		if o == nil {
+			return
+		}
+		opts.origin = fn.Some(o)
+	}
 }
 
 // newPaymentSession instantiates a new payment session.
@@ -202,7 +232,8 @@ func newPaymentSession(p *LightningPayment, selfNode route.Vertex,
 	getBandwidthHints func(Graph) (bandwidthHints, error),
 	graphSessFactory GraphSessionFactory,
 	missionControl MissionControlQuerier,
-	pathFindingConfig PathFindingConfig) (*paymentSession, error) {
+	pathFindingConfig PathFindingConfig,
+	options ...sessionOption) (*paymentSession, error) {
 
 	edges, err := RouteHintsToEdges(p.RouteHints, p.Target)
 	if err != nil {
@@ -223,6 +254,11 @@ func newPaymentSession(p *LightningPayment, selfNode route.Vertex,
 
 	logPrefix := fmt.Sprintf("PaymentSession(%x):", p.Identifier())
 
+	opts := defaultSessionOptions()
+	for _, o := range options {
+		o(&opts)
+	}
+
 	return &paymentSession{
 		selfNode:          selfNode,
 		additionalEdges:   edges,
@@ -234,6 +270,7 @@ func newPaymentSession(p *LightningPayment, selfNode route.Vertex,
 		missionControl:    missionControl,
 		minShardAmt:       DefaultShardMinAmt,
 		log:               log.WithPrefix(logPrefix),
+		opts:              opts,
 	}, nil
 }
 
@@ -326,6 +363,12 @@ func (p *paymentSession) RequestRoute(maxAmt, feeLimit lnwire.MilliSatoshi,
 
 		p.log.Debugf("pathfinding for amt=%v", maxAmt)
 
+		// Use the configured origin if one was provided,
+		// otherwise default to the session's own node.
+		origin := p.opts.origin.UnwrapOr(
+			&singleOrigin{p.selfNode},
+		)
+
 		// Find a route for the current amount.
 		sourceVertex, path, _, err = p.pathFinder(
 			&graphParams{
@@ -334,7 +377,7 @@ func (p *paymentSession) RequestRoute(maxAmt, feeLimit lnwire.MilliSatoshi,
 				graph:           graph,
 			},
 			restrictions, &p.pathFindingConfig,
-			p.selfNode, p.selfNode, p.payment.Target,
+			p.selfNode, origin, p.payment.Target,
 			maxAmt, p.payment.TimePref, finalHtlcExpiry,
 		)
 		if err != nil {

--- a/routing/payment_session.go
+++ b/routing/payment_session.go
@@ -308,7 +308,10 @@ func (p *paymentSession) RequestRoute(maxAmt, feeLimit lnwire.MilliSatoshi,
 		maxAmt = *p.payment.MaxShardAmt
 	}
 
-	var path []*unifiedEdge
+	var (
+		sourceVertex route.Vertex
+		path         []*unifiedEdge
+	)
 	findPath := func(graph graphdb.NodeTraverser) error {
 		// We'll also obtain a set of bandwidthHints from the lower
 		// layer for each of our outbound channels. This will allow the
@@ -324,7 +327,7 @@ func (p *paymentSession) RequestRoute(maxAmt, feeLimit lnwire.MilliSatoshi,
 		p.log.Debugf("pathfinding for amt=%v", maxAmt)
 
 		// Find a route for the current amount.
-		path, _, err = p.pathFinder(
+		sourceVertex, path, _, err = p.pathFinder(
 			&graphParams{
 				additionalEdges: p.additionalEdges,
 				bandwidthHints:  bandwidthHints,
@@ -347,6 +350,7 @@ func (p *paymentSession) RequestRoute(maxAmt, feeLimit lnwire.MilliSatoshi,
 		err := p.graphSessFactory.GraphSession(
 			context.TODO(),
 			findPath, func() {
+				sourceVertex = route.Vertex{}
 				path = nil
 			},
 		)
@@ -440,7 +444,7 @@ func (p *paymentSession) RequestRoute(maxAmt, feeLimit lnwire.MilliSatoshi,
 		// this into a route by applying the time-lock and fee
 		// requirements.
 		route, err := newRoute(
-			p.selfNode, path, height,
+			sourceVertex, path, height,
 			finalHopParams{
 				amt:         maxAmt,
 				totalAmt:    p.payment.Amount,

--- a/routing/payment_session.go
+++ b/routing/payment_session.go
@@ -331,7 +331,8 @@ func (p *paymentSession) RequestRoute(maxAmt, feeLimit lnwire.MilliSatoshi,
 				graph:           graph,
 			},
 			restrictions, &p.pathFindingConfig,
-			p.selfNode, p.selfNode, p.payment.Target,
+			p.selfNode, &singleOrigin{p.selfNode},
+			p.payment.Target,
 			maxAmt, p.payment.TimePref, finalHtlcExpiry,
 		)
 		if err != nil {

--- a/routing/payment_session.go
+++ b/routing/payment_session.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btclog/v2"
+	"github.com/lightningnetwork/lnd/fn/v2"
 	graphdb "github.com/lightningnetwork/lnd/graph/db"
 	"github.com/lightningnetwork/lnd/graph/db/models"
 	"github.com/lightningnetwork/lnd/lnutils"
@@ -195,6 +196,35 @@ type paymentSession struct {
 
 	// log is a payment session-specific logger.
 	log btclog.Logger
+
+	// opts holds optional configuration for the payment session.
+	opts sessionOptions
+}
+
+// sessionOptions holds optional configuration for a payment session.
+type sessionOptions struct {
+	// origin is an optional RouteOrigin that determines where routes can
+	// start. When set, the pathfinder terminates at any vertex for which
+	// IsOrigin returns true.
+	origin fn.Option[RouteOrigin]
+}
+
+// defaultSessionOptions returns sessionOptions with default values.
+func defaultSessionOptions() sessionOptions {
+	return sessionOptions{}
+}
+
+// sessionOption is a functional option for configuring a payment session.
+type sessionOption func(*sessionOptions)
+
+// withOrigin sets the RouteOrigin for this payment session.
+func withOrigin(o RouteOrigin) sessionOption {
+	return func(opts *sessionOptions) {
+		if o == nil {
+			return
+		}
+		opts.origin = fn.Some(o)
+	}
 }
 
 // newPaymentSession instantiates a new payment session.
@@ -202,7 +232,8 @@ func newPaymentSession(p *LightningPayment, selfNode route.Vertex,
 	getBandwidthHints func(Graph) (bandwidthHints, error),
 	graphSessFactory GraphSessionFactory,
 	missionControl MissionControlQuerier,
-	pathFindingConfig PathFindingConfig) (*paymentSession, error) {
+	pathFindingConfig PathFindingConfig,
+	options ...sessionOption) (*paymentSession, error) {
 
 	edges, err := RouteHintsToEdges(p.RouteHints, p.Target)
 	if err != nil {
@@ -223,6 +254,11 @@ func newPaymentSession(p *LightningPayment, selfNode route.Vertex,
 
 	logPrefix := fmt.Sprintf("PaymentSession(%x):", p.Identifier())
 
+	opts := defaultSessionOptions()
+	for _, o := range options {
+		o(&opts)
+	}
+
 	return &paymentSession{
 		selfNode:          selfNode,
 		additionalEdges:   edges,
@@ -234,6 +270,7 @@ func newPaymentSession(p *LightningPayment, selfNode route.Vertex,
 		missionControl:    missionControl,
 		minShardAmt:       DefaultShardMinAmt,
 		log:               log.WithPrefix(logPrefix),
+		opts:              opts,
 	}, nil
 }
 
@@ -308,7 +345,10 @@ func (p *paymentSession) RequestRoute(maxAmt, feeLimit lnwire.MilliSatoshi,
 		maxAmt = *p.payment.MaxShardAmt
 	}
 
-	var path []*unifiedEdge
+	var (
+		sourceVertex route.Vertex
+		path         []*unifiedEdge
+	)
 	findPath := func(graph graphdb.NodeTraverser) error {
 		// We'll also obtain a set of bandwidthHints from the lower
 		// layer for each of our outbound channels. This will allow the
@@ -323,16 +363,21 @@ func (p *paymentSession) RequestRoute(maxAmt, feeLimit lnwire.MilliSatoshi,
 
 		p.log.Debugf("pathfinding for amt=%v", maxAmt)
 
+		// Use the configured origin if one was provided,
+		// otherwise default to the session's own node.
+		origin := p.opts.origin.UnwrapOr(
+			&singleOrigin{p.selfNode},
+		)
+
 		// Find a route for the current amount.
-		path, _, err = p.pathFinder(
+		sourceVertex, path, _, err = p.pathFinder(
 			&graphParams{
 				additionalEdges: p.additionalEdges,
 				bandwidthHints:  bandwidthHints,
 				graph:           graph,
 			},
 			restrictions, &p.pathFindingConfig,
-			p.selfNode, &singleOrigin{p.selfNode},
-			p.payment.Target,
+			p.selfNode, origin, p.payment.Target,
 			maxAmt, p.payment.TimePref, finalHtlcExpiry,
 		)
 		if err != nil {
@@ -348,6 +393,7 @@ func (p *paymentSession) RequestRoute(maxAmt, feeLimit lnwire.MilliSatoshi,
 		err := p.graphSessFactory.GraphSession(
 			context.TODO(),
 			findPath, func() {
+				sourceVertex = route.Vertex{}
 				path = nil
 			},
 		)
@@ -441,7 +487,7 @@ func (p *paymentSession) RequestRoute(maxAmt, feeLimit lnwire.MilliSatoshi,
 		// this into a route by applying the time-lock and fee
 		// requirements.
 		route, err := newRoute(
-			p.selfNode, path, height,
+			sourceVertex, path, height,
 			finalHopParams{
 				amt:         maxAmt,
 				totalAmt:    p.payment.Amount,

--- a/routing/payment_session_source.go
+++ b/routing/payment_session_source.go
@@ -44,6 +44,11 @@ type SessionSource struct {
 	// PathFindingConfig defines global parameters that control the
 	// trade-off in path finding between fees and probability.
 	PathFindingConfig PathFindingConfig
+
+	// Origin is an optional RouteOrigin that determines where routes can
+	// start. When set, the pathfinder terminates at any vertex for which
+	// IsOrigin returns true. When unset, routes originate from SourceNode.
+	Origin fn.Option[RouteOrigin]
 }
 
 // NewPaymentSession creates a new payment session backed by the latest prune
@@ -62,9 +67,15 @@ func (m *SessionSource) NewPaymentSession(p *LightningPayment,
 		)
 	}
 
+	var options []sessionOption
+	m.Origin.WhenSome(func(o RouteOrigin) {
+		options = append(options, withOrigin(o))
+	})
+
 	session, err := newPaymentSession(
 		p, m.SourceNode.PubKeyBytes, getBandwidthHints,
 		m.GraphSessionFactory, m.MissionControl, m.PathFindingConfig,
+		options...,
 	)
 	if err != nil {
 		return nil, err

--- a/routing/payment_session_test.go
+++ b/routing/payment_session_test.go
@@ -209,7 +209,8 @@ func TestRequestRoute(t *testing.T) {
 
 	// Override pathfinder with a mock.
 	session.pathFinder = func(_ *graphParams, r *RestrictParams,
-		_ *PathFindingConfig, self, _, _ route.Vertex,
+		_ *PathFindingConfig, self route.Vertex,
+		_ RouteOrigin, _ route.Vertex,
 		_ lnwire.MilliSatoshi, _ float64,
 		_ int32) (route.Vertex, []*unifiedEdge, float64, error) {
 
@@ -251,6 +252,98 @@ func TestRequestRoute(t *testing.T) {
 		t.Fatalf("unexpected total time lock of %v",
 			route.TotalTimeLock)
 	}
+}
+
+// TestRequestRouteWithOrigin verifies that a custom IsRouteOrigin provided via
+// the withOrigin option is forwarded to the pathfinder and that the source
+// vertex it returns is used as the route's SourcePubKey.
+func TestRequestRouteWithOrigin(t *testing.T) {
+	t.Parallel()
+
+	// selfNode is the local coordinator node. It is deliberately different
+	// from the gateway vertex that the custom origin will select, so we
+	// can verify the returned route uses the gateway, not self.
+	selfNode := route.Vertex{0xaa}
+	gatewayNode := route.Vertex{0xbb}
+
+	payment := &LightningPayment{
+		Amount:   1000,
+		FeeLimit: 1000,
+	}
+
+	var paymentHash [32]byte
+	err := payment.SetPaymentHash(paymentHash)
+	require.NoError(t, err, "unable to set payment hash")
+
+	// Build a trivial one-hop path for the mock to return.
+	mockPath := []*unifiedEdge{
+		{
+			policy: &models.CachedEdgePolicy{
+				ToNodePubKey: func() route.Vertex {
+					return route.Vertex{0xcc}
+				},
+				ToNodeFeatures: lnwire.NewFeatureVector(
+					nil, nil,
+				),
+			},
+		},
+	}
+
+	// Create a custom origin that only accepts gatewayNode.
+	customOrigin := &singleOrigin{source: gatewayNode}
+
+	// Create a session with the withOrigin option.
+	session, err := newPaymentSession(
+		payment, selfNode,
+		func(Graph) (bandwidthHints, error) {
+			return &mockBandwidthHints{}, nil
+		},
+		&sessionGraph{},
+		&MissionControl{},
+		PathFindingConfig{},
+		withOrigin(customOrigin),
+	)
+	require.NoError(t, err, "unable to create payment session")
+
+	// Override the pathfinder with a mock that asserts the origin it
+	// receives is the custom one (not the default singleOrigin{selfNode})
+	// and returns gatewayNode as the settled source.
+	session.pathFinder = func(_ *graphParams, _ *RestrictParams,
+		_ *PathFindingConfig, self route.Vertex,
+		origin RouteOrigin, _ route.Vertex,
+		_ lnwire.MilliSatoshi, _ float64,
+		_ int32) (route.Vertex, []*unifiedEdge, float64, error) {
+
+		// The self parameter should still be the session's own node.
+		require.Equal(t, selfNode, self, "self should be selfNode")
+
+		// The origin must accept gatewayNode and reject selfNode.
+		require.True(
+			t, origin.IsOrigin(gatewayNode),
+			"origin should accept gatewayNode",
+		)
+		require.False(
+			t, origin.IsOrigin(selfNode),
+			"origin should reject selfNode",
+		)
+
+		return gatewayNode, mockPath, 1.0, nil
+	}
+
+	rt, err := session.RequestRoute(
+		payment.Amount, payment.FeeLimit, 0, 10,
+		lnwire.CustomRecords{
+			lnwire.MinCustomRecordsTlvType + 123: []byte{1, 2, 3},
+		},
+	)
+	require.NoError(t, err)
+
+	// The route's SourcePubKey must be the gateway returned by the
+	// pathfinder, not the session's selfNode.
+	require.Equal(
+		t, gatewayNode, rt.SourcePubKey,
+		"SourcePubKey should be the gateway, not selfNode",
+	)
 }
 
 type sessionGraph struct {

--- a/routing/payment_session_test.go
+++ b/routing/payment_session_test.go
@@ -209,9 +209,9 @@ func TestRequestRoute(t *testing.T) {
 
 	// Override pathfinder with a mock.
 	session.pathFinder = func(_ *graphParams, r *RestrictParams,
-		_ *PathFindingConfig, _, _, _ route.Vertex,
-		_ lnwire.MilliSatoshi, _ float64, _ int32) ([]*unifiedEdge,
-		float64, error) {
+		_ *PathFindingConfig, self, _, _ route.Vertex,
+		_ lnwire.MilliSatoshi, _ float64,
+		_ int32) (route.Vertex, []*unifiedEdge, float64, error) {
 
 		// We expect find path to receive a cltv limit excluding the
 		// final cltv delta (including the block padding).
@@ -232,7 +232,7 @@ func TestRequestRoute(t *testing.T) {
 			},
 		}
 
-		return path, 1.0, nil
+		return self, path, 1.0, nil
 	}
 
 	route, err := session.RequestRoute(

--- a/routing/payment_session_test.go
+++ b/routing/payment_session_test.go
@@ -209,7 +209,8 @@ func TestRequestRoute(t *testing.T) {
 
 	// Override pathfinder with a mock.
 	session.pathFinder = func(_ *graphParams, r *RestrictParams,
-		_ *PathFindingConfig, _, _, _ route.Vertex,
+		_ *PathFindingConfig, _ route.Vertex, _ RouteOrigin,
+		_ route.Vertex,
 		_ lnwire.MilliSatoshi, _ float64, _ int32) ([]*unifiedEdge,
 		float64, error) {
 

--- a/routing/payment_session_test.go
+++ b/routing/payment_session_test.go
@@ -209,10 +209,9 @@ func TestRequestRoute(t *testing.T) {
 
 	// Override pathfinder with a mock.
 	session.pathFinder = func(_ *graphParams, r *RestrictParams,
-		_ *PathFindingConfig, _ route.Vertex, _ RouteOrigin,
-		_ route.Vertex,
-		_ lnwire.MilliSatoshi, _ float64, _ int32) ([]*unifiedEdge,
-		float64, error) {
+		_ *PathFindingConfig, self route.Vertex, _ RouteOrigin,
+		_ route.Vertex, _ lnwire.MilliSatoshi, _ float64,
+		_ int32) (route.Vertex, []*unifiedEdge, float64, error) {
 
 		// We expect find path to receive a cltv limit excluding the
 		// final cltv delta (including the block padding).
@@ -233,7 +232,7 @@ func TestRequestRoute(t *testing.T) {
 			},
 		}
 
-		return path, 1.0, nil
+		return self, path, 1.0, nil
 	}
 
 	route, err := session.RequestRoute(
@@ -252,6 +251,97 @@ func TestRequestRoute(t *testing.T) {
 		t.Fatalf("unexpected total time lock of %v",
 			route.TotalTimeLock)
 	}
+}
+
+// TestRequestRouteWithOrigin verifies that a custom RouteOrigin provided via
+// the withOrigin option is forwarded to the pathfinder and that the source
+// vertex it returns is used as the route's SourcePubKey.
+func TestRequestRouteWithOrigin(t *testing.T) {
+	t.Parallel()
+
+	// selfNode is the local coordinator node. It is deliberately different
+	// from the gateway vertex that the custom origin will select, so we
+	// can verify the returned route uses the gateway, not self.
+	selfNode := route.Vertex{0xaa}
+	gatewayNode := route.Vertex{0xbb}
+
+	payment := &LightningPayment{
+		Amount:   1000,
+		FeeLimit: 1000,
+	}
+
+	var paymentHash [32]byte
+	err := payment.SetPaymentHash(paymentHash)
+	require.NoError(t, err, "unable to set payment hash")
+
+	// Build a trivial one-hop path for the mock to return.
+	mockPath := []*unifiedEdge{
+		{
+			policy: &models.CachedEdgePolicy{
+				ToNodePubKey: func() route.Vertex {
+					return route.Vertex{0xcc}
+				},
+				ToNodeFeatures: lnwire.NewFeatureVector(
+					nil, nil,
+				),
+			},
+		},
+	}
+
+	// Create a custom origin that only accepts gatewayNode.
+	customOrigin := &singleOrigin{source: gatewayNode}
+
+	// Create a session with the withOrigin option.
+	session, err := newPaymentSession(
+		payment, selfNode,
+		func(Graph) (bandwidthHints, error) {
+			return &mockBandwidthHints{}, nil
+		},
+		&sessionGraph{},
+		&MissionControl{},
+		PathFindingConfig{},
+		withOrigin(customOrigin),
+	)
+	require.NoError(t, err, "unable to create payment session")
+
+	// Override the pathfinder with a mock that asserts the origin it
+	// receives is the custom one (not the default singleOrigin{selfNode})
+	// and returns gatewayNode as the settled source.
+	session.pathFinder = func(_ *graphParams, _ *RestrictParams,
+		_ *PathFindingConfig, self route.Vertex, origin RouteOrigin,
+		_ route.Vertex, _ lnwire.MilliSatoshi, _ float64,
+		_ int32) (route.Vertex, []*unifiedEdge, float64, error) {
+
+		// The self parameter should still be the session's own node.
+		require.Equal(t, selfNode, self, "self should be selfNode")
+
+		// The origin must accept gatewayNode and reject selfNode.
+		require.True(
+			t, origin.IsOrigin(gatewayNode),
+			"origin should accept gatewayNode",
+		)
+		require.False(
+			t, origin.IsOrigin(selfNode),
+			"origin should reject selfNode",
+		)
+
+		return gatewayNode, mockPath, 1.0, nil
+	}
+
+	rt, err := session.RequestRoute(
+		payment.Amount, payment.FeeLimit, 0, 10,
+		lnwire.CustomRecords{
+			lnwire.MinCustomRecordsTlvType + 123: []byte{1, 2, 3},
+		},
+	)
+	require.NoError(t, err)
+
+	// The route's SourcePubKey must be the gateway returned by the
+	// pathfinder, not the session's selfNode.
+	require.Equal(
+		t, gatewayNode, rt.SourcePubKey,
+		"SourcePubKey should be the gateway, not selfNode",
+	)
 }
 
 type sessionGraph struct {

--- a/routing/router.go
+++ b/routing/router.go
@@ -600,7 +600,7 @@ func (r *ChannelRouter) FindRoute(req *RouteRequest) (*route.Route, float64,
 		return nil, 0, errors.New("time preference out of range")
 	}
 
-	path, probability, err := findPath(
+	source, path, probability, err := findPath(
 		&graphParams{
 			additionalEdges: req.RouteHints,
 			bandwidthHints:  bandwidthHints,
@@ -616,7 +616,7 @@ func (r *ChannelRouter) FindRoute(req *RouteRequest) (*route.Route, float64,
 
 	// Create the route with absolute time lock values.
 	route, err := newRoute(
-		req.Source, path, uint32(currentHeight),
+		source, path, uint32(currentHeight),
 		finalHopParams{
 			amt:       req.Amount,
 			totalAmt:  req.Amount,

--- a/routing/router.go
+++ b/routing/router.go
@@ -1735,7 +1735,8 @@ func getEdgeUnifiers(source route.Vertex, hops []route.Vertex,
 		// is not the last hop.
 		isExitHop := i == len(hops)-1
 		u := newNodeEdgeUnifier(
-			source, toNode, !isExitHop, outgoingChans,
+			source, toNode, &singleOrigin{source: source},
+			!isExitHop, outgoingChans,
 		)
 
 		err := u.addGraphPolicies(graph)

--- a/routing/router.go
+++ b/routing/router.go
@@ -477,6 +477,11 @@ type RouteRequest struct {
 	// parameters used to reach a target node blinded paths. This field is
 	// mutually exclusive with the Target field.
 	BlindedPathSet *BlindedPaymentPathSet
+
+	// Origin is an optional RouteOrigin that determines where the
+	// route can start. When set, it overrides Source for path-finding
+	// termination. When nil, a singleOrigin wrapping Source is used.
+	Origin RouteOrigin
 }
 
 // RouteHints is an alias type for a set of route hints, with the source node
@@ -600,6 +605,11 @@ func (r *ChannelRouter) FindRoute(req *RouteRequest) (*route.Route, float64,
 		return nil, 0, errors.New("time preference out of range")
 	}
 
+	origin := RouteOrigin(&singleOrigin{req.Source})
+	if req.Origin != nil {
+		origin = req.Origin
+	}
+
 	source, path, probability, err := findPath(
 		&graphParams{
 			additionalEdges: req.RouteHints,
@@ -607,8 +617,8 @@ func (r *ChannelRouter) FindRoute(req *RouteRequest) (*route.Route, float64,
 			graph:           r.cfg.RoutingGraph,
 		},
 		req.Restrictions, &r.cfg.PathFindingConfig,
-		r.cfg.SelfNode, req.Source, req.Target, req.Amount,
-		req.TimePreference, finalHtlcExpiry,
+		r.cfg.SelfNode, origin, req.Target,
+		req.Amount, req.TimePreference, finalHtlcExpiry,
 	)
 	if err != nil {
 		return nil, 0, err

--- a/routing/router.go
+++ b/routing/router.go
@@ -607,8 +607,8 @@ func (r *ChannelRouter) FindRoute(req *RouteRequest) (*route.Route, float64,
 			graph:           r.cfg.RoutingGraph,
 		},
 		req.Restrictions, &r.cfg.PathFindingConfig,
-		r.cfg.SelfNode, req.Source, req.Target, req.Amount,
-		req.TimePreference, finalHtlcExpiry,
+		r.cfg.SelfNode, &singleOrigin{req.Source}, req.Target,
+		req.Amount, req.TimePreference, finalHtlcExpiry,
 	)
 	if err != nil {
 		return nil, 0, err

--- a/routing/router.go
+++ b/routing/router.go
@@ -477,6 +477,11 @@ type RouteRequest struct {
 	// parameters used to reach a target node blinded paths. This field is
 	// mutually exclusive with the Target field.
 	BlindedPathSet *BlindedPaymentPathSet
+
+	// Origin is an optional RouteOrigin that determines where the route
+	// can start. When set, it overrides Source for path-finding
+	// termination. When nil, a singleOrigin wrapping Source is used.
+	Origin RouteOrigin
 }
 
 // RouteHints is an alias type for a set of route hints, with the source node
@@ -600,6 +605,11 @@ func (r *ChannelRouter) FindRoute(req *RouteRequest) (*route.Route, float64,
 		return nil, 0, errors.New("time preference out of range")
 	}
 
+	origin := RouteOrigin(&singleOrigin{req.Source})
+	if req.Origin != nil {
+		origin = req.Origin
+	}
+
 	source, path, probability, err := findPath(
 		&graphParams{
 			additionalEdges: req.RouteHints,
@@ -607,7 +617,7 @@ func (r *ChannelRouter) FindRoute(req *RouteRequest) (*route.Route, float64,
 			graph:           r.cfg.RoutingGraph,
 		},
 		req.Restrictions, &r.cfg.PathFindingConfig,
-		r.cfg.SelfNode, &singleOrigin{req.Source}, req.Target,
+		r.cfg.SelfNode, origin, req.Target,
 		req.Amount, req.TimePreference, finalHtlcExpiry,
 	)
 	if err != nil {

--- a/routing/unified_edges.go
+++ b/routing/unified_edges.go
@@ -20,6 +20,11 @@ type nodeEdgeUnifier struct {
 	// policy are different for local channels.
 	sourceNode route.Vertex
 
+	// origin identifies the set of vertices that are valid route
+	// starting points. Used to gate the outgoing channel restriction
+	// independently of the local-channel selection algorithm.
+	origin RouteOrigin
+
 	// toNode is the node for which the edge unifiers are instantiated.
 	toNode route.Vertex
 
@@ -33,7 +38,8 @@ type nodeEdgeUnifier struct {
 
 // newNodeEdgeUnifier instantiates a new nodeEdgeUnifier object. Channel
 // policies can be added to this object.
-func newNodeEdgeUnifier(sourceNode, toNode route.Vertex, useInboundFees bool,
+func newNodeEdgeUnifier(sourceNode, toNode route.Vertex,
+	origin RouteOrigin, useInboundFees bool,
 	outChanRestr map[uint64]struct{}) *nodeEdgeUnifier {
 
 	return &nodeEdgeUnifier{
@@ -41,6 +47,7 @@ func newNodeEdgeUnifier(sourceNode, toNode route.Vertex, useInboundFees bool,
 		toNode:         toNode,
 		useInboundFees: useInboundFees,
 		sourceNode:     sourceNode,
+		origin:         origin,
 		outChanRestr:   outChanRestr,
 	}
 }
@@ -54,10 +61,23 @@ func (u *nodeEdgeUnifier) addPolicy(fromNode route.Vertex,
 	capacity btcutil.Amount, hopPayloadSizeFn PayloadSizeFunc,
 	blindedPayment *BlindedPayment) {
 
+	// localChan indicates whether we have out-of-band knowledge
+	// about this channel's state (self's channels, where
+	// bandwidthHints has real-time data). Controls the selection
+	// algorithm: getEdgeLocal (bandwidth-aware) vs getEdgeNetwork
+	// (gossip heuristics).
 	localChan := fromNode == u.sourceNode
 
+	// isOriginEdge indicates whether this edge originates from a
+	// vertex in the RouteOrigin set. Controls the outgoing channel
+	// restriction. For vanilla lnd these coincide (self is the
+	// only origin), but for multi-origin routing they diverge:
+	// gateway edges are origin edges (restriction applies) but
+	// not local channels (no bandwidth data).
+	isOriginEdge := u.origin.IsOrigin(fromNode)
+
 	// Skip channels if there is an outgoing channel restriction.
-	if localChan && u.outChanRestr != nil {
+	if isOriginEdge && u.outChanRestr != nil {
 		if _, ok := u.outChanRestr[edge.ChannelID]; !ok {
 			log.Debugf("Skipped adding policy for restricted edge "+
 				"%v", edge.ChannelID)

--- a/routing/unified_edges_test.go
+++ b/routing/unified_edges_test.go
@@ -56,7 +56,11 @@ func TestNodeEdgeUnifier(t *testing.T) {
 		Rate: 10000,
 	}
 
-	unifierFilled := newNodeEdgeUnifier(source, toNode, false, nil)
+	sourceOrigin := &singleOrigin{source: source}
+
+	unifierFilled := newNodeEdgeUnifier(
+		source, toNode, sourceOrigin, false, nil,
+	)
 
 	unifierFilled.addPolicy(
 		fromNode, &p1, inboundFee1, c1, defaultHopPayloadSize, nil,
@@ -65,7 +69,9 @@ func TestNodeEdgeUnifier(t *testing.T) {
 		fromNode, &p2, inboundFee2, c2, defaultHopPayloadSize, nil,
 	)
 
-	unifierNoCapacity := newNodeEdgeUnifier(source, toNode, false, nil)
+	unifierNoCapacity := newNodeEdgeUnifier(
+		source, toNode, sourceOrigin, false, nil,
+	)
 	unifierNoCapacity.addPolicy(
 		fromNode, &p1, inboundFee1, 0, defaultHopPayloadSize, nil,
 	)
@@ -73,13 +79,17 @@ func TestNodeEdgeUnifier(t *testing.T) {
 		fromNode, &p2, inboundFee2, 0, defaultHopPayloadSize, nil,
 	)
 
-	unifierNoInfo := newNodeEdgeUnifier(source, toNode, false, nil)
+	unifierNoInfo := newNodeEdgeUnifier(
+		source, toNode, sourceOrigin, false, nil,
+	)
 	unifierNoInfo.addPolicy(
 		fromNode, &models.CachedEdgePolicy{}, models.InboundFee{},
 		0, defaultHopPayloadSize, nil,
 	)
 
-	unifierInboundFee := newNodeEdgeUnifier(source, toNode, true, nil)
+	unifierInboundFee := newNodeEdgeUnifier(
+		source, toNode, sourceOrigin, true, nil,
+	)
 	unifierInboundFee.addPolicy(
 		fromNode, &p1, inboundFee1, c1, defaultHopPayloadSize, nil,
 	)
@@ -87,7 +97,9 @@ func TestNodeEdgeUnifier(t *testing.T) {
 		fromNode, &p2, inboundFee2, c2, defaultHopPayloadSize, nil,
 	)
 
-	unifierLocal := newNodeEdgeUnifier(fromNode, toNode, true, nil)
+	unifierLocal := newNodeEdgeUnifier(
+		fromNode, toNode, &singleOrigin{source: fromNode}, true, nil,
+	)
 	unifierLocal.addPolicy(
 		fromNode, &p1, inboundFee1, c1, defaultHopPayloadSize, nil,
 	)
@@ -96,7 +108,9 @@ func TestNodeEdgeUnifier(t *testing.T) {
 	inboundFeeNegative := models.InboundFee{
 		Base: -150,
 	}
-	unifierNegInboundFee := newNodeEdgeUnifier(source, toNode, true, nil)
+	unifierNegInboundFee := newNodeEdgeUnifier(
+		source, toNode, sourceOrigin, true, nil,
+	)
 	unifierNegInboundFee.addPolicy(
 		fromNode, &p1, inboundFeeZero, c1, defaultHopPayloadSize, nil,
 	)


### PR DESCRIPTION
## Change Description

Path finding currently terminates at a single concrete source vertex, which assumes the node doing the routing is the node dispatching HTLCs. An external router controller that pathfinds centrally and dispatches from multiple **_lnd_** "gateway" backends needs routes that can originate from any of those backends.

This PR introduces a `RouteOrigin` interface that generalizes where routes can originate from. `RouteOrigin` replaces the concrete source parameter with an interface method (`IsOrigin(v) bool`) so the path-finding algorithm (a modified version of Dijkstra running from target to source) can terminate at any vertex in a caller-provided set, naturally selecting whichever provides the cheapest path.

This is the source-end counterpart to what `AdditionalEdge` does at the destination end. Route hints inject extra edges near the target so the pathfinder can reach nodes the graph doesn't know about. `RouteOrigin` works similarly at the source: it's equivalent to adding a virtual super-source `s*` with zero-weight edges to each origin and running single-source Dijkstra.

```
s* ---0--- gw1 -------- A -------- target
s* ---0--- gw2 -------- B -------/
s* ---0--- gw3 -------- C ------/
```

`RouteOrigin` achieves the same result without `s*` or extra edges in the graph by widening the termination check. Subpaths of shortest paths are shortest paths, so stripping the virtual edge leaves the optimal path from the selected origin. And the min-heap ensures the first origin popped has the smallest distance among all origins in the set (no cheaper one can remain in the queue).

The default `singleOrigin` wraps a _single_ vertex and produces identical behavior for all existing callers so should present no functional change for standard **_lnd_**.

- Add `RouteOrigin` interface and `singleOrigin` implementation.   Replace the concrete `source` parameter on `findPath` with  `origin RouteOrigin`.
- `findPath` returns the origin vertex it selected as its first return value. `RequestRoute` passes this to `newRoute` so `route.SourcePubKey` is set correctly regardless of origin type. `SessionSource` gains an optional `Origin` field, threaded to the payment session via functional options.
- `RouteRequest` accepts an optional `Origin` field so `FindRoute` (used by `QueryRoutes`) can use multi-origin, same as the payment session and the `SendPaymentV2` flow.
- Restrict `routeToSelf` to single-origin callers. When a multi-origin set includes the target vertex, circular routing is not the intent. Rather we want a direct route from another origin.
