### PR TITLE
funding: enforce BOLT-02 push_msat bound on fundee

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -47,6 +47,13 @@
 
 ## BOLT Spec Updates
 
+* The fundee now [enforces the BOLT-02 bound on
+  `push_msat`](https://github.com/lightningnetwork/lnd/pull/10765),
+  rejecting incoming `open_channel` messages where `push_msat` exceeds
+  `1000 * funding_satoshis`. Oversized pushes were previously caught
+  later in the reservation flow as a funder-balance-dust error; they now
+  surface a clearer, spec-aligned error string up front.
+
 ## Testing
 
 ## Database
@@ -56,3 +63,5 @@
 ## Tooling and Documentation
 
 # Contributors (Alphabetical Order)
+
+* Erick Cestari

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -1544,6 +1544,18 @@ func (f *Manager) fundeeProcessOpenChannel(peer lnpeer.Peer,
 		return
 	}
 
+	// Enforce BOLT-02: push_msat MUST be <= 1000 * funding_satoshis.
+	if msg.PushAmount > lnwire.NewMSatFromSatoshis(msg.FundingAmount) {
+		f.failFundingFlow(
+			peer, cid,
+			lnwallet.ErrPushAmountTooLarge(
+				msg.PushAmount, msg.FundingAmount,
+			),
+		)
+
+		return
+	}
+
 	// Send the OpenChannel request to the ChannelAcceptor to determine
 	// whether this node will accept the channel.
 	chanReq := &chanacceptor.ChannelAcceptRequest{

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -1438,13 +1438,63 @@ func (f *Manager) ProcessFundingMsg(msg lnwire.Message, peer lnpeer.Peer) {
 func (f *Manager) fundeeProcessOpenChannel(peer lnpeer.Peer,
 	msg *lnwire.OpenChannel) {
 
+	amt := msg.FundingAmount
+
+	// Create the channel identifier.
+	cid := newChanIdentifier(msg.PendingChannelID)
+
+	// Enforce BOLT-02: push_msat MUST be <= 1000 * funding_satoshis. We
+	// compare in satoshi space so neither side can overflow uint64 for
+	// any non-negative funding amount: split push_msat into its
+	// integer-satoshi and sub-satoshi parts and reject when it strictly
+	// exceeds the funding amount.
+	pushSat := uint64(msg.PushAmount) / 1000
+	pushSubSat := uint64(msg.PushAmount) % 1000
+	fundingSat := uint64(msg.FundingAmount)
+	if pushSat > fundingSat || (pushSat == fundingSat && pushSubSat > 0) {
+		f.failFundingFlow(
+			peer, cid,
+			lnwallet.ErrPushAmountTooLarge(
+				msg.PushAmount, msg.FundingAmount,
+			),
+		)
+
+		return
+	}
+
+	// If request specifies non-zero push amount and 'rejectpush' is set,
+	// signal an error.
+	if f.cfg.RejectPush && msg.PushAmount > 0 {
+		f.failFundingFlow(peer, cid, lnwallet.ErrNonZeroPushAmount())
+		return
+	}
+
+	// Ensure that the remote party respects our maximum channel size.
+	if amt > f.cfg.MaxChanSize {
+		f.failFundingFlow(
+			peer, cid,
+			lnwallet.ErrChanTooLarge(amt, f.cfg.MaxChanSize),
+		)
+
+		return
+	}
+
+	// We'll, also ensure that the remote party isn't attempting to propose
+	// a channel that's below our current min channel size.
+	if amt < f.cfg.MinChanSize {
+		f.failFundingFlow(
+			peer, cid,
+			lnwallet.ErrChanTooSmall(amt, f.cfg.MinChanSize),
+		)
+
+		return
+	}
+
 	// Check number of pending channels to be smaller than maximum allowed
 	// number and send ErrorGeneric to remote peer if condition is
 	// violated.
 	peerPubKey := peer.IdentityKey()
 	peerIDKey := newSerializedKey(peerPubKey)
-
-	amt := msg.FundingAmount
 
 	// We get all pending channels for this peer. This is the list of the
 	// active reservations and the channels pending open in the database.
@@ -1461,9 +1511,6 @@ func (f *Manager) fundeeProcessOpenChannel(peer lnpeer.Peer,
 		}
 	}
 	f.resMtx.RUnlock()
-
-	// Create the channel identifier.
-	cid := newChanIdentifier(msg.PendingChannelID)
 
 	// Also count the channels that are already pending. There we don't know
 	// the underlying intent anymore, unfortunately.
@@ -1515,32 +1562,6 @@ func (f *Manager) fundeeProcessOpenChannel(peer lnpeer.Peer,
 		}
 		err := errors.New("Synchronizing blockchain")
 		f.failFundingFlow(peer, cid, err)
-		return
-	}
-
-	// Ensure that the remote party respects our maximum channel size.
-	if amt > f.cfg.MaxChanSize {
-		f.failFundingFlow(
-			peer, cid,
-			lnwallet.ErrChanTooLarge(amt, f.cfg.MaxChanSize),
-		)
-		return
-	}
-
-	// We'll, also ensure that the remote party isn't attempting to propose
-	// a channel that's below our current min channel size.
-	if amt < f.cfg.MinChanSize {
-		f.failFundingFlow(
-			peer, cid,
-			lnwallet.ErrChanTooSmall(amt, f.cfg.MinChanSize),
-		)
-		return
-	}
-
-	// If request specifies non-zero push amount and 'rejectpush' is set,
-	// signal an error.
-	if f.cfg.RejectPush && msg.PushAmount > 0 {
-		f.failFundingFlow(peer, cid, lnwallet.ErrNonZeroPushAmount())
 		return
 	}
 

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -3887,6 +3887,78 @@ func TestFundingManagerRejectPush(t *testing.T) {
 	)
 }
 
+// TestFundingManagerPushAmountExceedsCapacity asserts that the fundee
+// rejects an incoming OpenChannel whose push_msat exceeds
+// 1000 * funding_satoshis, as required by BOLT-02.
+func TestFundingManagerPushAmountExceedsCapacity(t *testing.T) {
+	t.Parallel()
+
+	alice, bob := setupFundingManagers(t)
+	t.Cleanup(func() {
+		tearDownFundingManagers(t, alice, bob)
+	})
+
+	// Kick off a normal funding workflow so Alice produces a
+	// well-formed OpenChannel message that we can then tamper with.
+	updateChan := make(chan *lnrpc.OpenStatusUpdate)
+	errChan := make(chan error, 1)
+	initReq := &InitFundingMsg{
+		Peer:            bob,
+		TargetPubkey:    bob.privKey.PubKey(),
+		ChainHash:       *fundingNetParams.GenesisHash,
+		LocalFundingAmt: 500000,
+		PushAmt:         lnwire.NewMSatFromSatoshis(10),
+		Private:         true,
+		Updates:         updateChan,
+		Err:             errChan,
+	}
+
+	alice.fundingMgr.InitFundingWorkflow(initReq)
+
+	// Intercept Alice's OpenChannel.
+	var aliceMsg lnwire.Message
+	select {
+	case aliceMsg = <-alice.msgChan:
+	case err := <-initReq.Err:
+		t.Fatalf("error init funding workflow: %v", err)
+	case <-time.After(time.Second * 5):
+		t.Fatalf("alice did not send OpenChannel message")
+	}
+
+	openChannelReq, ok := aliceMsg.(*lnwire.OpenChannel)
+	if !ok {
+		errorMsg, gotError := aliceMsg.(*lnwire.Error)
+		if gotError {
+			t.Fatalf("expected OpenChannel to be sent "+
+				"from alice, instead got error: %v",
+				errorMsg.Error())
+		}
+		t.Fatalf("expected OpenChannel to be sent from "+
+			"alice, instead got %T", aliceMsg)
+	}
+
+	// Overwrite the push amount so it strictly exceeds
+	// 1000 * funding_satoshis. Alice's own funding flow would never
+	// produce this on the wire, so we inject it manually to exercise
+	// Bob's spec-level bound check.
+	openChannelReq.PushAmount = lnwire.NewMSatFromSatoshis(
+		openChannelReq.FundingAmount,
+	) + 1
+
+	// Hand the tampered message to Bob.
+	bob.fundingMgr.ProcessFundingMsg(openChannelReq, alice)
+
+	// Bob should respond with an Error that carries the
+	// ErrPushAmountTooLarge message.
+	msg := assertFundingMsgSent(t, bob.msgChan, "Error")
+	err, ok := msg.(*lnwire.Error)
+	require.True(t, ok, "expected *lnwire.Error, got %T", msg)
+	require.ErrorContains(
+		t, err, "exceeds funding amount",
+		"expected ErrPushAmountTooLarge error, got \"%v\"", err.Error(),
+	)
+}
+
 // TestFundingManagerMaxConfs ensures that we don't accept a funding proposal
 // that proposes a MinAcceptDepth greater than the maximum number of
 // confirmations we're willing to accept.

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -3887,6 +3887,87 @@ func TestFundingManagerRejectPush(t *testing.T) {
 	)
 }
 
+// TestFundingManagerPushAmountExceedsCapacity asserts that the fundee
+// rejects an incoming OpenChannel whose push_msat exceeds
+// 1000 * funding_satoshis, as required by BOLT-02.
+func TestFundingManagerPushAmountExceedsCapacity(t *testing.T) {
+	t.Parallel()
+
+	alice, bob := setupFundingManagers(t)
+	t.Cleanup(func() {
+		tearDownFundingManagers(t, alice, bob)
+	})
+
+	// Build an OpenChannel directly with a push amount that strictly
+	// exceeds 1000 * funding_satoshis. We only need the fields that
+	// Bob's fundeeProcessOpenChannel inspects before the BOLT-02 bound
+	// check, so other fields are left zero.
+	const fundingAmt = btcutil.Amount(500000)
+	openChannelReq := &lnwire.OpenChannel{
+		ChainHash:        *fundingNetParams.GenesisHash,
+		PendingChannelID: [32]byte{0x01},
+		FundingAmount:    fundingAmt,
+		PushAmount:       lnwire.NewMSatFromSatoshis(fundingAmt) + 1,
+	}
+
+	bob.fundingMgr.ProcessFundingMsg(openChannelReq, alice)
+
+	// Bob should respond with an Error that carries the
+	// ErrPushAmountTooLarge message.
+	msg := assertFundingMsgSent(t, bob.msgChan, "Error")
+	err, ok := msg.(*lnwire.Error)
+	require.True(t, ok, "expected *lnwire.Error, got %T", msg)
+
+	expected := lnwallet.ErrPushAmountTooLarge(
+		openChannelReq.PushAmount, openChannelReq.FundingAmount,
+	)
+	require.Equal(t, expected.Error(), string(err.Data))
+}
+
+// TestFundingManagerPushAmountAtCapacity asserts that the fundee does NOT
+// reject an incoming OpenChannel with the BOLT-02 push-bound error when
+// push_msat exactly equals 1000 * funding_satoshis. The spec permits this
+// boundary (push_msat MUST be <= 1000 * funding_satoshis), so the check
+// added in fundeeProcessOpenChannel must not fire on equality. The flow
+// may still fail downstream for unrelated reasons (e.g. funder balance
+// dust after fees), but never with ErrPushAmountTooLarge.
+func TestFundingManagerPushAmountAtCapacity(t *testing.T) {
+	t.Parallel()
+
+	alice, bob := setupFundingManagers(t)
+	t.Cleanup(func() {
+		tearDownFundingManagers(t, alice, bob)
+	})
+
+	const fundingAmt = btcutil.Amount(500000)
+	openChannelReq := &lnwire.OpenChannel{
+		ChainHash:        *fundingNetParams.GenesisHash,
+		PendingChannelID: [32]byte{0x01},
+		FundingAmount:    fundingAmt,
+		PushAmount:       lnwire.NewMSatFromSatoshis(fundingAmt),
+	}
+
+	bob.fundingMgr.ProcessFundingMsg(openChannelReq, alice)
+
+	// Whatever response Bob produces, it must not be the BOLT-02
+	// push-bound error: the boundary is spec-legal.
+	forbidden := lnwallet.ErrPushAmountTooLarge(
+		openChannelReq.PushAmount, openChannelReq.FundingAmount,
+	).Error()
+
+	select {
+	case msg := <-bob.msgChan:
+		errMsg, ok := msg.(*lnwire.Error)
+		if !ok {
+			return
+		}
+		require.NotEqual(t, forbidden, string(errMsg.Data),
+			"fundee rejected spec-legal boundary push_msat == "+
+				"1000 * funding_satoshis")
+	case <-time.After(time.Second):
+	}
+}
+
 // TestFundingManagerMaxConfs ensures that we don't accept a funding proposal
 // that proposes a MinAcceptDepth greater than the maximum number of
 // confirmations we're willing to accept.

--- a/lnwallet/errors.go
+++ b/lnwallet/errors.go
@@ -85,6 +85,18 @@ func ErrNonZeroPushAmount() ReservationError {
 	return ReservationError{errors.New("non-zero push amounts are disabled")}
 }
 
+// ErrPushAmountTooLarge is returned when the push amount exceeds the channel's
+// funding amount, which violates BOLT-02 (push_msat MUST be <=
+// 1000 * funding_satoshis).
+func ErrPushAmountTooLarge(pushAmt lnwire.MilliSatoshi,
+	fundingAmt btcutil.Amount) ReservationError {
+
+	return ReservationError{
+		fmt.Errorf("push amount %v exceeds funding amount %v",
+			pushAmt, lnwire.NewMSatFromSatoshis(fundingAmt)),
+	}
+}
+
 // ErrMinHtlcTooLarge returns an error indicating that the MinHTLC value the
 // remote required is too large to be accepted.
 func ErrMinHtlcTooLarge(minHtlc,


### PR DESCRIPTION
Reject incoming `OpenChannel` messages where push_msat exceeds 1000 * funding_satoshis, as required by BOLT-02. The existing `RejectPush` flag only gates on push_msat > 0 and does not cover the spec bound.

An over-sized push is eventually caught downstream in `reservation.go` when `theirBalance = capacity - fee - push_msat` goes negative and `ErrFunderBalanceDust` is returned. Rejecting it up front produces a clearer, spec-aligned error and avoids the `chanacceptor` and commitment type negotiation round-trips for a channel we will refuse anyway.