### PR TITLE
[WIP] MPP record support for QueryRoutes/SendToRoute (#9952)

### DIFF
--- a/CHANGE-9952.md
+++ b/CHANGE-9952.md
@@ -1,0 +1,35 @@
+# LND #9952 Implementation Guide
+
+## Changes Needed
+
+### 1. lnrpc/routerrpc/router.proto
+Add to `QueryRoutesRequest`:
+```protobuf
+bytes payment_addr = 15;
+```
+
+Add to `SendToRouteRequest`:
+```protobuf
+MPPRecord mpp_record = 3;
+```
+
+### 2. lnrpc/lightning.proto
+Ensure MPPRecord is defined:
+```protobuf
+message MPPRecord {
+    bytes payment_addr = 1;
+    uint64 total_amt_msat = 2;
+}
+```
+
+### 3. routing/router.go
+Update `QueryRoutes` to include MPP record.
+
+### 4. cmd/lncli/commands.go
+Add flags for payment_addr.
+
+## Generate & Test
+```bash
+make rpc
+make check
+```

--- a/cmd/commands/cmd_payments.go
+++ b/cmd/commands/cmd_payments.go
@@ -1187,6 +1187,12 @@ var queryRoutesCommand = cli.Command{
 				`"fee_proportional_millionths":3,` +
 				`"cltv_expiry_delta":4}]}]'`,
 		},
+		cli.StringFlag{
+			Name: "payment_addr",
+			Usage: "(optional) the 32-byte payment address for MPP " +
+				"payments. When provided, the route will include " +
+				"the MPP record with this payment address.",
+		},
 	},
 	Action: actionDecorator(queryRoutes),
 }
@@ -1278,6 +1284,16 @@ func queryRoutes(ctx *cli.Context) error {
 		TimePref:            ctx.Float64(timePrefFlag.Name),
 		IgnoredPairs:        ignoredPairs,
 		BlindedPaymentPaths: blindedRoutes,
+	}
+
+	// Parse payment_addr if provided
+	if ctx.IsSet("payment_addr") {
+		paymentAddrHex := ctx.String("payment_addr")
+		paymentAddr, err := hex.DecodeString(paymentAddrHex)
+		if err != nil {
+			return fmt.Errorf("unable to decode payment_addr: %w", err)
+		}
+		req.PaymentAddr = paymentAddr
 	}
 
 	outgoingChanIds := ctx.StringSlice("outgoing_chan_id")

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -3360,6 +3360,13 @@ message QueryRoutesRequest {
     channel may be used.
     */
     repeated uint64 outgoing_chan_ids = 20;
+
+    /*
+    An optional payment address to be included in the MPP record for the
+    queried route. This is used for multi-path payments where the same
+    payment_addr must be used across all subpayments.
+    */
+    bytes payment_addr = 21;
 }
 
 message NodePair {

--- a/lnrpc/routerrpc/router.proto
+++ b/lnrpc/routerrpc/router.proto
@@ -489,6 +489,13 @@ message SendToRouteRequest {
     base64.
     */
     map<uint64, bytes> first_hop_custom_records = 4;
+
+    /*
+    An optional MPP record to include with the payment. This allows sending
+    multi-path payments via SendToRoute by specifying the payment address
+    and total amount.
+    */
+    lnrpc.MPPRecord mpp_record = 5;
 }
 
 message SendToRouteResponse {


### PR DESCRIPTION
## Work in Progress

Adds MPP record support to QueryRoutes and SendToRoute RPC calls.

## TODO
- [ ] Update router.proto
- [ ] Update lightning.proto (if needed)
- [ ] Regenerate Go code
- [ ] Update router implementation
- [ ] Update lncli
- [ ] Add tests

See CHANGE-9952.md for implementation guide.

Relates-to: #9952

---
🍊 Contributed via [Code Orange Dev School](https://github.com/code-orange-dev)