### PR TITLE
routerrpc: isolate LSP route fee probes

### DIFF
--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -88,6 +88,10 @@
   RBF close state machine does not yet thread through the `AuxCloser` hook
   that overlay channels rely on to build aux-aware close transactions.
 
+* [Fixed `EstimateRouteFee`](https://github.com/lightningnetwork/lnd/pull/10771)
+  to use independent probe payment hashes when probing multiple LSPs, preventing
+  later probes from reusing the first probe's CLTV delta.
+
 # New Features
 
 - [Basic Support](https://github.com/lightningnetwork/lnd/pull/9868) for onion

--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -524,6 +524,25 @@ func (s *Server) probeDestination(dest []byte, amtSat int64) (*RouteFeeResponse,
 func (s *Server) probePaymentRequest(ctx context.Context, paymentRequest string,
 	timeout uint32) (*RouteFeeResponse, error) {
 
+	return s.probePaymentRequestWithSender(
+		ctx, paymentRequest, timeout, s.sendProbePayment,
+	)
+}
+
+// probePaymentSender dispatches a probe payment request and returns the
+// resulting fee estimate. It exists as a test seam so tests can inject a stub
+// sender and inspect generated probe requests without running the payment
+// lifecycle.
+type probePaymentSender func(context.Context,
+	*SendPaymentRequest) (*RouteFeeResponse, error)
+
+// probePaymentRequestWithSender contains the implementation of
+// probePaymentRequest. The sender is injected so tests can inspect generated
+// probe requests without invoking the full payment lifecycle.
+func (s *Server) probePaymentRequestWithSender(ctx context.Context,
+	paymentRequest string, timeout uint32,
+	sendProbePayment probePaymentSender) (*RouteFeeResponse, error) {
+
 	payReq, err := zpay32.Decode(
 		paymentRequest, s.cfg.RouterBackend.ActiveNetParams,
 	)
@@ -576,7 +595,8 @@ func (s *Server) probePaymentRequest(ctx context.Context, paymentRequest string,
 			probeRequest.Dest)
 
 		probeRequest.RouteHints = invoicesrpc.CreateRPCRouteHints(hints)
-		return s.sendProbePayment(ctx, probeRequest)
+
+		return sendProbePayment(ctx, probeRequest)
 	}
 
 	// If the heuristic indicates an LSP, we filter and group route hints by
@@ -612,6 +632,16 @@ func (s *Server) probePaymentRequest(ctx context.Context, paymentRequest string,
 
 		lspHint := group.LspHopHint
 
+		// Each LSP probe must use a unique payment hash, otherwise the
+		// payment lifecycle will treat later probes as attempts on the
+		// first probe's payment and reuse its payment-level parameters.
+		var lspPaymentHash lntypes.Hash
+		_, err := crand.Read(lspPaymentHash[:])
+		if err != nil {
+			return nil, fmt.Errorf("cannot generate random probe "+
+				"preimage: %w", err)
+		}
+
 		log.Infof("Probing LSP with destination: %v", lspKey)
 
 		// Create a new probe request for this LSP.
@@ -621,7 +651,7 @@ func (s *Server) probePaymentRequest(ctx context.Context, paymentRequest string,
 			MaxParts:         probeRequest.MaxParts,
 			AllowSelfPayment: probeRequest.AllowSelfPayment,
 			AmtMsat:          amtMsat,
-			PaymentHash:      probeRequest.PaymentHash,
+			PaymentHash:      lspPaymentHash[:],
 			FeeLimitSat:      probeRequest.FeeLimitSat,
 			FinalCltvDelta:   int32(lspHint.CLTVExpiryDelta),
 			DestFeatures:     probeRequest.DestFeatures,
@@ -652,7 +682,7 @@ func (s *Server) probePaymentRequest(ctx context.Context, paymentRequest string,
 		lspProbeRequest.AmtMsat += int64(hopFee)
 
 		// Dispatch the payment probe for this LSP.
-		resp, err := s.sendProbePayment(ctx, lspProbeRequest)
+		resp, err := sendProbePayment(ctx, lspProbeRequest)
 		if err != nil {
 			log.Warnf("Failed to probe LSP %v: %v", lspKey, err)
 			continue

--- a/lnrpc/routerrpc/router_server_test.go
+++ b/lnrpc/routerrpc/router_server_test.go
@@ -7,6 +7,9 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnwire"
 	paymentsdb "github.com/lightningnetwork/lnd/payments/db"
@@ -763,4 +766,136 @@ func TestPrepareLspRouteHints(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no public LSP nodes found")
 	})
+}
+
+// TestProbePaymentRequestUsesUniqueHashPerLSP verifies that each LSP probe is
+// isolated from the other probes by using a distinct payment hash.
+func TestProbePaymentRequestUsesUniqueHashPerLSP(t *testing.T) {
+	// Arrange: create three public LSPs and an invoice whose private
+	// destination can be reached through any of them.
+	destPrivKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	bobPrivKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	bobPubKey := bobPrivKey.PubKey()
+
+	evePrivKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	evePubKey := evePrivKey.PubKey()
+
+	davePrivKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	davePubKey := davePrivKey.PubKey()
+
+	bobVertex := route.NewVertex(bobPubKey)
+	eveVertex := route.NewVertex(evePubKey)
+	daveVertex := route.NewVertex(davePubKey)
+
+	publicNodes := map[route.Vertex]struct{}{
+		bobVertex:  {},
+		eveVertex:  {},
+		daveVertex: {},
+	}
+	hasNode := func(nodePub route.Vertex) (bool, error) {
+		_, ok := publicNodes[nodePub]
+
+		return ok, nil
+	}
+
+	server := &Server{
+		cfg: &Config{
+			RouterBackend: &RouterBackend{
+				ActiveNetParams: &chaincfg.RegressionNetParams,
+				HasNode:         hasNode,
+			},
+		},
+	}
+
+	lspHint := func(pubKey *btcec.PublicKey, chanID uint64,
+		cltv uint16) zpay32.HopHint {
+
+		return zpay32.HopHint{
+			NodeID:                    pubKey,
+			ChannelID:                 chanID,
+			FeeBaseMSat:               uint32(chanID * 1_000),
+			FeeProportionalMillionths: uint32(chanID),
+			CLTVExpiryDelta:           cltv,
+		}
+	}
+
+	bobHint := lspHint(bobPubKey, 1, 100)
+	eveHint := lspHint(evePubKey, 2, 200)
+	daveHint := lspHint(davePubKey, 3, 120)
+
+	var paymentHash [32]byte
+	paymentHash[0] = 1
+	invoice, err := zpay32.NewInvoice(
+		&chaincfg.RegressionNetParams, paymentHash, time.Unix(1, 0),
+		zpay32.Amount(lnwire.MilliSatoshi(100_000)),
+		zpay32.Description("multi lsp probe"),
+		zpay32.Destination(destPrivKey.PubKey()),
+		zpay32.RouteHint([]zpay32.HopHint{bobHint}),
+		zpay32.RouteHint([]zpay32.HopHint{eveHint}),
+		zpay32.RouteHint([]zpay32.HopHint{daveHint}),
+	)
+	require.NoError(t, err)
+
+	signer := zpay32.MessageSigner{
+		SignCompact: func(msg []byte) ([]byte, error) {
+			hash := chainhash.HashB(msg)
+
+			return ecdsa.SignCompact(destPrivKey, hash, true), nil
+		},
+	}
+	payReq, err := invoice.Encode(signer)
+	require.NoError(t, err)
+
+	seenHashes := make(map[[32]byte]struct{})
+	probedDests := make(map[route.Vertex]struct{})
+	expectedCltv := map[route.Vertex]int32{
+		bobVertex:  int32(bobHint.CLTVExpiryDelta),
+		eveVertex:  int32(eveHint.CLTVExpiryDelta),
+		daveVertex: int32(daveHint.CLTVExpiryDelta),
+	}
+
+	sendProbe := func(_ context.Context,
+		req *SendPaymentRequest) (*RouteFeeResponse, error) {
+
+		require.Len(t, req.PaymentHash, 32)
+
+		var reqHash [32]byte
+		copy(reqHash[:], req.PaymentHash)
+		_, hashExists := seenHashes[reqHash]
+		require.False(t, hashExists, "reused payment hash")
+		seenHashes[reqHash] = struct{}{}
+
+		var dest route.Vertex
+		copy(dest[:], req.Dest)
+		probedDests[dest] = struct{}{}
+
+		require.Equal(t, expectedCltv[dest], req.FinalCltvDelta)
+
+		return &RouteFeeResponse{
+			RoutingFeeMsat: int64(req.FinalCltvDelta),
+			TimeLockDelay:  int64(req.FinalCltvDelta),
+			FailureReason: lnrpc.
+				PaymentFailureReason_FAILURE_REASON_NONE,
+		}, nil
+	}
+
+	// Act: estimate the route fee with a stubbed probe sender that records
+	// the generated per-LSP probe requests.
+	_, err = server.probePaymentRequestWithSender(
+		t.Context(), payReq, 1, sendProbe,
+	)
+
+	// Assert: all LSPs were probed, each probe had a unique payment hash,
+	// and the probe request kept the CLTV delta for its target LSP.
+	require.NoError(t, err)
+	require.Len(t, seenHashes, MaxLspsToProbe)
+	require.Len(t, probedDests, MaxLspsToProbe)
+	require.Contains(t, probedDests, bobVertex)
+	require.Contains(t, probedDests, eveVertex)
+	require.Contains(t, probedDests, daveVertex)
 }


### PR DESCRIPTION
## Summary

- Use a fresh payment hash for each `EstimateRouteFee` LSP probe so later probes cannot reuse payment-level state from earlier probes.
- Add deterministic unit coverage that stubs probe dispatch and verifies each LSP probe has a distinct payment hash and the expected final CLTV delta.
- Add a release note for the multi-LSP `EstimateRouteFee` fix.

Fix #10677 

## Bug

CI flaked in PR #10689 on the `bitcoind-etcd` itest job:

https://github.com/lightningnetwork/lnd/actions/runs/24841352445/job/72716012767?pr=10689

Failed test:

```text
TestLightningNetworkDaemon/tranche03/141-of-347/bitcoind/estimate_route_fee/probe_based_estimate,_multiple_different_public_LSPs
```

Failure:

```text
Error:       Not equal:
             expected: 944
             actual  : 844
Messages:    cltv delta
```

The test creates three public LSP hints for a private destination:

- Bob: high-level expected final LSP CLTV delta `100`
- Eve: highest-fee LSP, final LSP CLTV delta `200`
- Dave: lower-fee LSP, final LSP CLTV delta `120`

The returned fee was Eve's fee, but the returned timelock was calculated with Bob's CLTV delta.

## Root Cause

`probePaymentRequest` generated one random payment hash for the overall invoice probe request, then reused that same hash for every per-LSP probe.

The payment lifecycle keys payment state by payment hash. If Bob is probed first, the payment record is initialized with Bob's `FinalCltvDelta=100`. When Eve is probed later with the same payment hash, the router treats it as another attempt for the same payment and can reuse payment-level state from the first probe. The route can then carry Eve's fee but Bob's CLTV delta.

This is order-dependent because LSPs are iterated from a Go map. If Eve is probed first, the test passes. If Bob is probed first, Eve can inherit Bob's CLTV delta and the test fails.

## Log Evidence

I downloaded the itest artifact `logs-itest-bitcoind-etcd.zip` from the failed run. Relevant log file:

```text
itest/.logs-tranche3/22-estimate_route_fee-Alice-0223edc2.log
```

Passing two-LSP case: Eve is probed first, uses expiry/cltv `864`, and the final result returns `timelock: 944`.

```text
1884: 2026-04-23 14:53:05.208 [INF] RRPC router_server.go:615: Probing LSP with destination: 024b44330ad86737ecaa6f8a8bf1b10b7ab0d14d94631934bc02e9d3d4716d8880
1891: 2026-04-23 14:53:05.216 [DBG] CRTR payment_lifecycle.go:734: Attempt 6 for payment 2f2c715fe2abb8fed05b39cb5ce57e06ccb694655a3191928fc6a11dfd051db2 successfully sent to switch, route: 630020162846720 (101001201 mSAT) -> 630020162912256 (101000100 mSAT), cltv 864
1895: 2026-04-23 14:53:05.216 [DBG] PEER brontide.go:2809: Peer(03b85df66a282b9bcc9a636fb7a7948f2b5377072d55cfc8e1b15ba18851bc920d): Sending UpdateAddHTLC(chan_id=075f4a0a9a0e5bdfc7371304ba2c5a22342aea5c900110a4e3481ab69c704c62, id=5, amt=101001201 mSAT, expiry=864, hash=2f2c715fe2abb8fed05b39cb5ce57e06ccb694655a3191928fc6a11dfd051db2, blinding_point=, custom_records=map[106823:[0]]) to 03b85df66a282b9bcc9a636fb7a7948f2b5377072d55cfc8e1b15ba18851bc920d@127.0.0.1:11145
1920: 2026-04-23 14:53:05.575 [INF] RRPC router_server.go:677: Probe to LSP 024b44330ad86737ecaa6f8a8bf1b10b7ab0d14d94631934bc02e9d3d4716d8880 succeeded with fee: 1001201 msat
1965: 2026-04-23 14:53:05.991 [INF] RRPC router_server.go:711: Returning worst-case route via LSP 024b44330ad86737ecaa6f8a8bf1b10b7ab0d14d94631934bc02e9d3d4716d8880 with fee: 1001201 msat, timelock: 944
```

Failing three-LSP case: Bob is probed first with payment hash `a539...` and `cltv 764`. Eve is probed next with the same payment hash, logs `Resuming HTLC attempt`, still uses `cltv 764`, succeeds with Eve's fee, and returns `timelock: 844`.

```text
1992: 2026-04-23 14:53:06.034 [INF] RRPC router_server.go:615: Probing LSP with destination: 031fea722979dc497b8f5cf6e3c240bfadcee7c1084636f6e2941676935ece12a9
1999: 2026-04-23 14:53:06.043 [DBG] CRTR payment_lifecycle.go:734: Attempt 8 for payment a5397f710a5edc3686412161ac38c38779b1f9ad4c62c15648feb883f6ea7743 successfully sent to switch, route: 630020162846720 (100002200 mSAT) -> 630020162977792 (100001100 mSAT), cltv 764
2003: 2026-04-23 14:53:06.043 [DBG] PEER brontide.go:2809: Peer(03b85df66a282b9bcc9a636fb7a7948f2b5377072d55cfc8e1b15ba18851bc920d): Sending UpdateAddHTLC(chan_id=075f4a0a9a0e5bdfc7371304ba2c5a22342aea5c900110a4e3481ab69c704c62, id=7, amt=100002200 mSAT, expiry=764, hash=a5397f710a5edc3686412161ac38c38779b1f9ad4c62c15648feb883f6ea7743, blinding_point=, custom_records=map[106823:[0]]) to 03b85df66a282b9bcc9a636fb7a7948f2b5377072d55cfc8e1b15ba18851bc920d@127.0.0.1:11145
2028: 2026-04-23 14:53:06.428 [INF] RRPC router_server.go:677: Probe to LSP 031fea722979dc497b8f5cf6e3c240bfadcee7c1084636f6e2941676935ece12a9 succeeded with fee: 2200 msat
2029: 2026-04-23 14:53:06.428 [INF] RRPC router_server.go:615: Probing LSP with destination: 024b44330ad86737ecaa6f8a8bf1b10b7ab0d14d94631934bc02e9d3d4716d8880
2031: 2026-04-23 14:53:06.432 [DBG] CRTR payment_lifecycle.go:1180: Payment a5397f710a5edc3686412161ac38c38779b1f9ad4c62c15648feb883f6ea7743: status=Initiated, active_shards=0, rem_value=101000100 mSAT, fee_limit=100000000000 mSAT
2037: 2026-04-23 14:53:06.439 [INF] CRTR payment_lifecycle.go:1153: Resuming HTLC attempt 9 for payment a5397f710a5edc3686412161ac38c38779b1f9ad4c62c15648feb883f6ea7743
2040: 2026-04-23 14:53:06.441 [DBG] CRTR payment_lifecycle.go:734: Attempt 9 for payment a5397f710a5edc3686412161ac38c38779b1f9ad4c62c15648feb883f6ea7743 successfully sent to switch, route: 630020162846720 (101001201 mSAT) -> 630020162977792 (101000100 mSAT), cltv 764
2043: 2026-04-23 14:53:06.441 [DBG] PEER brontide.go:2809: Peer(03b85df66a282b9bcc9a636fb7a7948f2b5377072d55cfc8e1b15ba18851bc920d): Sending UpdateAddHTLC(chan_id=075f4a0a9a0e5bdfc7371304ba2c5a22342aea5c900110a4e3481ab69c704c62, id=8, amt=101001201 mSAT, expiry=764, hash=a5397f710a5edc3686412161ac38c38779b1f9ad4c62c15648feb883f6ea7743, blinding_point=, custom_records=map[106823:[0]]) to 03b85df66a282b9bcc9a636fb7a7948f2b5377072d55cfc8e1b15ba18851bc920d@127.0.0.1:11145
2076: 2026-04-23 14:53:06.816 [INF] RRPC router_server.go:677: Probe to LSP 024b44330ad86737ecaa6f8a8bf1b10b7ab0d14d94631934bc02e9d3d4716d8880 succeeded with fee: 1001201 msat
2124: 2026-04-23 14:53:07.067 [INF] RRPC router_server.go:711: Returning worst-case route via LSP 024b44330ad86737ecaa6f8a8bf1b10b7ab0d14d94631934bc02e9d3d4716d8880 with fee: 1001201 msat, timelock: 844
```

The `100` delta between expected `944` and actual `844` matches Bob's LSP CLTV delta being used where Eve's `200` should have been used.

## Fix

Generate a fresh random payment hash for each LSP probe iteration. This makes each LSP probe an independent payment from the payment lifecycle's perspective, while keeping the existing single-hash behavior for the non-LSP probe path.

## Testing

- `GOWORK=off go test ./lnrpc/routerrpc`