### PR TITLE
docs: fix Contributors TOC anchor in v0.21.0 release notes

### DIFF
--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -17,7 +17,7 @@
     - [Database](#database)
     - [Code Health](#code-health)
     - [Tooling and Documentation](#tooling-and-documentation)
-- [Contributors (Alphabetical Order)](#contributors)
+- [Contributors (Alphabetical Order)](#contributors-alphabetical-order)
 
 # Bug Fixes
 


### PR DESCRIPTION
## Summary

The TOC link for the Contributors section in
`docs/release-notes/release-notes-0.21.0.md` pointed to `#contributors`,
but GitHub generates the anchor for `# Contributors (Alphabetical
Order)` as `#contributors-alphabetical-order`, leaving the link broken
when the rendered file is viewed on GitHub.

This updates the TOC to use the working anchor, matching the form
already used in `release-notes-0.18.0.md`.

## Test plan

- [x] Open the rendered file on GitHub and click the Contributors entry in the TOC — it now jumps to the section.