### PR TITLE
chanstate: introduce Store interface (PR 1 of channel-state decomposition)

### DIFF
--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -729,9 +729,8 @@ func (c *ChannelStateDB) FetchChannel(chanPoint wire.OutPoint) (*OpenChannel,
 
 // FetchChannelByID attempts to locate a channel specified by the passed channel
 // ID. If the channel cannot be found, then an error will be returned.
-// Optionally an existing db tx can be supplied.
-func (c *ChannelStateDB) FetchChannelByID(tx kvdb.RTx, id lnwire.ChannelID) (
-	*OpenChannel, error) {
+func (c *ChannelStateDB) FetchChannelByID(id lnwire.ChannelID) (*OpenChannel,
+	error) {
 
 	selector := func(chainBkt walletdb.ReadBucket) ([]byte, *wire.OutPoint,
 		error) {
@@ -774,7 +773,7 @@ func (c *ChannelStateDB) FetchChannelByID(tx kvdb.RTx, id lnwire.ChannelID) (
 		return targetChanPointBytes, targetChanPoint, nil
 	}
 
-	return c.channelScanner(tx, selector)
+	return c.channelScanner(nil, selector)
 }
 
 // ChanCount is used by the server in determining access control.

--- a/channeldb/db_test.go
+++ b/channeldb/db_test.go
@@ -253,7 +253,7 @@ func TestFetchChannel(t *testing.T) {
 
 	// Next, attempt to fetch the channel by its channel ID.
 	chanID := lnwire.NewChanIDFromOutPoint(channelState.FundingOutpoint)
-	dbChannel, err = cdb.FetchChannelByID(nil, chanID)
+	dbChannel, err = cdb.FetchChannelByID(chanID)
 	require.NoError(t, err, "unable to fetch channel")
 
 	// The decoded channel state should be identical to what we stored
@@ -272,7 +272,7 @@ func TestFetchChannel(t *testing.T) {
 	require.ErrorIs(t, err, ErrChannelNotFound)
 
 	chanID2 := lnwire.NewChanIDFromOutPoint(channelState2.FundingOutpoint)
-	_, err = cdb.FetchChannelByID(nil, chanID2)
+	_, err = cdb.FetchChannelByID(chanID2)
 	require.ErrorIs(t, err, ErrChannelNotFound)
 }
 

--- a/chanstate/interface.go
+++ b/chanstate/interface.go
@@ -1,0 +1,228 @@
+package chanstate
+
+import (
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/graph/db/models"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+// Store is the full persistence contract for the channel-state subsystem.
+// Consumers depend on this interface rather than the concrete
+// channeldb.ChannelStateDB so the underlying storage can be swapped without
+// touching call sites.
+//
+// NOTE: This is named Store instead of DB to avoid confusion with the existing
+// concrete channeldb.ChannelStateDB type during the migration. Once the channel
+// state implementation moves into this package and the old concrete type is no
+// longer part of consumer-facing code, this name can be revisited.
+type Store interface {
+	// OpenChannelStore owns open-channel records.
+	OpenChannelStore
+
+	// HistoricalChannelStore owns the post-close historical channel view.
+	HistoricalChannelStore
+
+	// ClosedChannelStore owns closed-channel summaries and lifecycle
+	// mutations.
+	ClosedChannelStore
+
+	// FinalHTLCStore owns final HTLC outcome data.
+	FinalHTLCStore
+
+	// ChannelSetupStore owns temporary state used while setting up a
+	// channel.
+	ChannelSetupStore
+
+	// LinkNodeMaintainer owns link-node maintenance derived from channel
+	// state.
+	LinkNodeMaintainer
+}
+
+// OpenChannelStore owns open-channel records.
+type OpenChannelStore interface {
+	// FetchOpenChannels starts a new database transaction and returns
+	// all stored currently active/open channels associated with the
+	// target nodeID. In the case that no active channels are known to
+	// have been created with this node, then a zero-length slice is
+	// returned.
+	FetchOpenChannels(nodeID *btcec.PublicKey) (
+		[]*channeldb.OpenChannel, error)
+
+	// FetchChannel attempts to locate a channel specified by the passed
+	// channel point. If the channel cannot be found, then an error will
+	// be returned.
+	FetchChannel(chanPoint wire.OutPoint) (*channeldb.OpenChannel, error)
+
+	// FetchChannelByID attempts to locate a channel specified by the
+	// passed channel ID. If the channel cannot be found, then an error
+	// will be returned.
+	FetchChannelByID(id lnwire.ChannelID) (*channeldb.OpenChannel, error)
+
+	// FetchAllChannels attempts to retrieve all open channels currently
+	// stored within the database, including pending open, fully open and
+	// channels waiting for a closing transaction to confirm.
+	FetchAllChannels() ([]*channeldb.OpenChannel, error)
+
+	// FetchAllOpenChannels will return all channels that have the
+	// funding transaction confirmed, and is not waiting for a closing
+	// transaction to be confirmed.
+	FetchAllOpenChannels() ([]*channeldb.OpenChannel, error)
+
+	// FetchPendingChannels will return channels that have completed the
+	// process of generating and broadcasting funding transactions, but
+	// whose funding transactions have yet to be confirmed on the
+	// blockchain.
+	FetchPendingChannels() ([]*channeldb.OpenChannel, error)
+
+	// FetchWaitingCloseChannels will return all channels that have been
+	// opened, but are now waiting for a closing transaction to be
+	// confirmed.
+	//
+	// NOTE: This includes channels that are also pending to be opened.
+	FetchWaitingCloseChannels() ([]*channeldb.OpenChannel, error)
+
+	// FetchPermAndTempPeers returns a map where the key is the remote
+	// node's public key and the value is a struct that has a tally of
+	// the pending-open channels and whether the peer has an open or
+	// closed channel with us.
+	FetchPermAndTempPeers(chainHash []byte) (
+		map[string]channeldb.ChanCount, error)
+
+	// RestoreChannelShells reconstructs the state of an OpenChannel from
+	// the ChannelShell. We'll attempt to write the new channel to disk,
+	// create a LinkNode instance with the passed node addresses, and
+	// finally create an edge within the graph for the channel as well.
+	// This method is idempotent, so repeated calls with the same set of
+	// channel shells won't modify the database after the initial call.
+	RestoreChannelShells(channelShells ...*channeldb.ChannelShell) error
+}
+
+// HistoricalChannelStore owns the post-close historical channel view.
+type HistoricalChannelStore interface {
+	// FetchHistoricalChannel fetches open channel data from the
+	// historical channel bucket.
+	FetchHistoricalChannel(outPoint *wire.OutPoint) (
+		*channeldb.OpenChannel, error)
+}
+
+// ClosedChannelStore owns closed-channel summaries and lifecycle mutations.
+type ClosedChannelStore interface {
+	// FetchClosedChannels attempts to fetch all closed channels from the
+	// database. The pendingOnly bool toggles if channels that aren't yet
+	// fully closed should be returned in the response or not. When a
+	// channel was cooperatively closed, it becomes fully closed after a
+	// single confirmation. When a channel was forcibly closed, it will
+	// become fully closed after _all_ the pending funds (if any) have
+	// been swept.
+	FetchClosedChannels(pendingOnly bool) (
+		[]*channeldb.ChannelCloseSummary, error)
+
+	// FetchClosedChannel queries for a channel close summary using the
+	// channel point of the channel in question.
+	FetchClosedChannel(chanID *wire.OutPoint) (
+		*channeldb.ChannelCloseSummary, error)
+
+	// FetchClosedChannelForID queries for a channel close summary using
+	// the channel ID of the channel in question.
+	FetchClosedChannelForID(cid lnwire.ChannelID) (
+		*channeldb.ChannelCloseSummary, error)
+
+	// MarkChanFullyClosed marks a channel as fully closed within the
+	// database. A channel should be marked as fully closed if the
+	// channel was initially cooperatively closed and it's reached a
+	// single confirmation, or after all the pending funds in a channel
+	// that has been forcibly closed have been swept.
+	MarkChanFullyClosed(chanPoint *wire.OutPoint) error
+
+	// CloseChannel marks the given channel as closed: the open-channel
+	// record is removed and the supplied ChannelCloseSummary is
+	// archived so the channel becomes retrievable via
+	// FetchClosedChannel and FetchClosedChannelForID. Any ChannelStatus
+	// values are merged into the archived summary. Returns
+	// ErrChannelCloseSummaryNil if summary is nil.
+	CloseChannel(channel *channeldb.OpenChannel,
+		summary *channeldb.ChannelCloseSummary,
+		statuses ...channeldb.ChannelStatus) error
+
+	// AbandonChannel attempts to remove the target channel from the open
+	// channel database. If the channel was already removed (has a closed
+	// channel entry), then we'll return a nil error. Otherwise, we'll
+	// insert a new close summary into the database.
+	AbandonChannel(chanPoint *wire.OutPoint, bestHeight uint32) error
+}
+
+// FinalHTLCStore owns final HTLC outcome data.
+type FinalHTLCStore interface {
+	// LookupFinalHtlc retrieves a final htlc resolution from the
+	// database. If the htlc has no final resolution yet, ErrHtlcUnknown
+	// is returned.
+	LookupFinalHtlc(chanID lnwire.ShortChannelID,
+		htlcIndex uint64) (*channeldb.FinalHtlcInfo, error)
+
+	// PutOnchainFinalHtlcOutcome stores the final on-chain outcome of an
+	// htlc in the database.
+	PutOnchainFinalHtlcOutcome(chanID lnwire.ShortChannelID,
+		htlcID uint64, settled bool) error
+}
+
+// ChannelSetupStore owns temporary state used while setting up a channel. This
+// state should be deleted once the link comes up.
+type ChannelSetupStore interface {
+	// SaveChannelOpeningState saves the serialized channel state for the
+	// provided chanPoint to the channelOpeningStateBucket.
+	SaveChannelOpeningState(outPoint, serializedState []byte) error
+
+	// GetChannelOpeningState fetches the serialized channel state for
+	// the provided outPoint from the database, or returns
+	// ErrChannelNotFound if the channel is not found.
+	GetChannelOpeningState(outPoint []byte) ([]byte, error)
+
+	// DeleteChannelOpeningState removes any state for outPoint from the
+	// database.
+	DeleteChannelOpeningState(outPoint []byte) error
+
+	// SaveInitialForwardingPolicy saves the serialized forwarding policy
+	// for the provided permanent channel id.
+	SaveInitialForwardingPolicy(chanID lnwire.ChannelID,
+		forwardingPolicy *models.ForwardingPolicy) error
+
+	// GetInitialForwardingPolicy fetches the serialized forwarding policy
+	// for the provided channel id from the database, or returns
+	// ErrChannelNotFound if a forwarding policy for this channel id is not
+	// found.
+	GetInitialForwardingPolicy(chanID lnwire.ChannelID) (
+		*models.ForwardingPolicy, error)
+
+	// DeleteInitialForwardingPolicy removes the forwarding policy for a
+	// given channel from the database.
+	DeleteInitialForwardingPolicy(chanID lnwire.ChannelID) error
+}
+
+// LinkNodeMaintainer owns link-node maintenance derived from channel state.
+type LinkNodeMaintainer interface {
+	// PruneLinkNodes attempts to prune all link nodes found within the
+	// database with whom we no longer have any open channels with.
+	PruneLinkNodes() error
+
+	// RepairLinkNodes scans all channels in the database and ensures
+	// that a link node exists for each remote peer. This should be
+	// called on startup to ensure that our database is consistent.
+	RepairLinkNodes(network wire.BitcoinNet) error
+}
+
+// Compile-time assertion that channeldb.ChannelStateDB satisfies the Store
+// contract. If a method signature drifts on the concrete type,
+// this assertion will fail to build before any consumer migration.
+//
+// NOTE: This assertion lives in the interface file as a temporary exception to
+// the established pattern (see invoices/sql_store.go, payments/db/kv_store.go,
+// graph/db/kv_store.go), where each implementation asserts itself in its own
+// file. The implementation still lives in channeldb/, and channeldb must not
+// import chanstate to avoid a cycle, so the assertion has no local
+// implementation file to live in yet. When the KV implementation moves into
+// this package (chanstate/kv_store.go), this assertion MUST be removed from
+// here and re-stated next to the local implementation, matching the precedent
+// packages.
+var _ Store = (*channeldb.ChannelStateDB)(nil)

--- a/chanstate/log.go
+++ b/chanstate/log.go
@@ -1,0 +1,31 @@
+package chanstate
+
+import (
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightningnetwork/lnd/build"
+)
+
+// log is a logger that is initialized with no output filters.  This means the
+// package will not perform any logging by default until the caller requests
+// it.
+//
+//nolint:unused
+var log btclog.Logger
+
+// init initializes the package-global logger instance.
+func init() {
+	UseLogger(build.NewSubLogger("CHST", nil))
+}
+
+// DisableLog disables all library log output.  Logging output is disabled by
+// default until UseLogger is called.
+func DisableLog() {
+	UseLogger(btclog.Disabled)
+}
+
+// UseLogger uses a specified Logger to output package logging info. This
+// should be used in preference to SetLogWriter if the caller is also using
+// btclog.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -1118,7 +1118,7 @@ func assertConfirmationHeight(t *testing.T, node *testNode,
 
 	err := wait.NoError(func() error {
 		pendingChannel, err := node.fundingMgr.cfg.Wallet.Cfg.Database.
-			FetchChannelByID(nil, chanID)
+			FetchChannelByID(chanID)
 		if err != nil {
 			return fmt.Errorf("unable to fetch pending channel: %w",
 				err)

--- a/log.go
+++ b/log.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lightningnetwork/lnd/chanfitness"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/channelnotifier"
+	"github.com/lightningnetwork/lnd/chanstate"
 	"github.com/lightningnetwork/lnd/cluster"
 	"github.com/lightningnetwork/lnd/contractcourt"
 	"github.com/lightningnetwork/lnd/discovery"
@@ -177,6 +178,7 @@ func SetupLoggers(root *build.SubLoggerManager, interceptor signal.Interceptor) 
 	AddSubLogger(root, "IRPC", interceptor, invoicesrpc.UseLogger)
 	AddSubLogger(root, "CHNF", interceptor, channelnotifier.UseLogger)
 	AddSubLogger(root, "CHBU", interceptor, chanbackup.UseLogger)
+	AddSubLogger(root, "CHST", interceptor, chanstate.UseLogger)
 	AddSubLogger(root, "PROM", interceptor, monitoring.UseLogger)
 	AddSubLogger(root, "WTCL", interceptor, wtclient.UseLogger)
 	AddSubLogger(root, "PRNF", interceptor, peernotifier.UseLogger)

--- a/server.go
+++ b/server.go
@@ -1760,9 +1760,7 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 			commitHeight uint64) (*lnwallet.BreachRetribution,
 			channeldb.ChannelType, error) {
 
-			channel, err := s.chanStateDB.FetchChannelByID(
-				nil, chanID,
-			)
+			channel, err := s.chanStateDB.FetchChannelByID(chanID)
 			if err != nil {
 				return nil, 0, err
 			}


### PR DESCRIPTION
## Summary

First PR in the channel-state decomposition series. Introduces the
`chanstate.Store` interface as the seam between the channel-state subsystem
and its consumers, mirroring the pattern in `invoices/`, `payments/db/`, and
`graph/db/`. No consumer migrates, no data moves, no behavior changes.

`Store` is composed of two embedded sub-interfaces — `ChannelStore` for core
channel-state operations and `InitialForwardingPolicyStore` for the
per-channel forwarding policy chosen at channel-open time — so future
decomposition PRs can extend the contract without inflating a single
monolithic interface.

Four commits:

1. `channeldb: drop unused kvdb.RTx parameter from FetchChannelByID` —
   prerequisite so the interface stays free of `kvdb` types. All four call
   sites already pass `nil`.
2. `chanstate: introduce Store interface` — new package with `Store` and its
   `ChannelStore` sub-interface, a package logger, and the compile-time
   assertion `var _ Store = (*channeldb.ChannelStateDB)(nil)` that guards
   against signature drift. `GetParentDB` (test-only) and `LinkNodeDB`
   (separate domain) are intentionally excluded.
3. `chanstate: add InitialForwardingPolicyStore sub-interface` — adds the
   second sub-interface for the initial-forwarding-policy methods, embedded
   into `Store`.
4. `docs: release note for chanstate Store interface` — seeds the v0.22
   "Native SQL migration of the channel state and switch data" series so
   follow-up PRs (consumer swap, KV/SQL stores, revocation log, forwarding
   package, etc.) hang off the same heading.

## Test plan

- [x] `go build ./...` clean
- [x] Compile-time assertion catches any interface ↔ concrete drift
- [x] `make unit pkg=channeldb` and `make lint` pass