### PR TITLE
keychain: cache derived priv key in BtcWalletKeyRing.ECDH to avoid per-call DB txn

### DIFF
--- a/keychain/btcwallet.go
+++ b/keychain/btcwallet.go
@@ -2,6 +2,7 @@ package keychain
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -12,6 +13,8 @@ import (
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/lightninglabs/neutrino/cache"
+	"github.com/lightninglabs/neutrino/cache/lru"
 )
 
 const (
@@ -22,6 +25,13 @@ const (
 	// CoinTypeTestnet specifies the BIP44 coin type for all testnet key
 	// derivation.
 	CoinTypeTestnet = 1
+
+	// ecdhPrivKeyCacheSize bounds the number of derived ECDH private keys
+	// that we'll keep memoized at any one time. In practice ECDH is only
+	// invoked against a handful of our own keys (one per key family used
+	// for onion decryption), so this size is well above the expected
+	// working set.
+	ecdhPrivKeyCacheSize = 1000
 )
 
 var (
@@ -57,6 +67,28 @@ type BtcWalletKeyRing struct {
 	// lightningScope is a pointer to the scope that we'll be using as a
 	// sub key manager to derive all the keys that we require.
 	lightningScope *waddrmgr.ScopedKeyManager
+
+	// ecdhPrivKeyCache memoizes the private keys derived for ECDH so that
+	// each subsequent ECDH call against the same key avoids the read-write
+	// wallet DB transaction (and the bbolt fdatasync that transaction
+	// forces). The cache is keyed by the compressed-serialized public key
+	// and bounded by ecdhPrivKeyCacheSize via an LRU eviction policy.
+	ecdhPrivKeyCache *lru.Cache[
+		[btcec.PubKeyBytesLenCompressed]byte, *cachedPrivKey,
+	]
+}
+
+// cachedPrivKey stores a btcec.PrivateKey by value so it can be stored in the
+// LRU cache, which requires values to implement the cache.Value interface.
+type cachedPrivKey struct {
+	key btcec.PrivateKey
+}
+
+// Size returns the "size" of an entry. We return 1 so that the LRU cache
+// bounds the total number of entries rather than doing byte-accurate
+// accounting.
+func (c *cachedPrivKey) Size() (uint64, error) {
+	return 1, nil
 }
 
 // NewBtcWalletKeyRing creates a new implementation of the
@@ -76,6 +108,21 @@ func NewBtcWalletKeyRing(w wallet.Interface, coinType uint32) SecretKeyRing {
 	return &BtcWalletKeyRing{
 		wallet:        w,
 		chainKeyScope: chainKeyScope,
+		ecdhPrivKeyCache: lru.NewCache(
+			ecdhPrivKeyCacheSize,
+			// Wipe the cache's copy of the private key on
+			// eviction. Note this only scrubs the copy held here,
+			// not the copies handed back to callers; fully zeroing
+			// those (and btcwallet's upstream key cache) is left to
+			// a follow-up. See TODO below.
+			lru.WithDeleteCallback(
+				func(_ [btcec.PubKeyBytesLenCompressed]byte,
+					v *cachedPrivKey) {
+
+					v.key.Zero()
+				},
+			),
+		),
 	}
 }
 
@@ -270,6 +317,20 @@ func (b *BtcWalletKeyRing) DerivePrivKey(keyDesc KeyDescriptor) (
 	// First, attempt to see if we can read the key directly from
 	// btcwallet's internal cache, if we can then we can skip all the
 	// operations below (fast path).
+	//
+	// TODO(erickcestari): the PubKey == nil guard exists because when a
+	// descriptor carries a non-nil PubKey we can't tell whether
+	// KeyLocator.Index was set explicitly to 0 or just left at the Go
+	// zero value. The PubKey-set branch below defensively scans up to
+	// MaxKeyRangeScan derivations for a PubKey match rather than trusting
+	// the path, so the fast DeriveFromKeyPathCache path is also gated on
+	// PubKey == nil. As a result, hot callers like the node identity key
+	// (Family=NodeKey, Index=0, PubKey populated by DeriveKey) always
+	// miss this cache and take the read-write wallet DB transaction path
+	// on every call. Once we have a way to mark a descriptor's path as
+	// authoritative (or btcwallet exposes a key-cache lookup by PubKey),
+	// the per-ECDH cache in derivePrivKeyForECDH below can be dropped in
+	// favor of this path.
 	if keyDesc.PubKey == nil {
 		keyPath := waddrmgr.DerivationPath{
 			InternalAccount: uint32(keyDesc.Family),
@@ -385,11 +446,15 @@ func (b *BtcWalletKeyRing) DerivePrivKey(keyDesc KeyDescriptor) (
 //
 //	sx := k*P s := sha256(sx.SerializeCompressed())
 //
+// The derived private key for keyDesc is memoized after the first call so
+// repeated ECDH operations against the same key avoid reopening a read-write
+// wallet DB transaction (and the bbolt fdatasync per call) on the hot path.
+//
 // NOTE: This is part of the keychain.ECDHRing interface.
 func (b *BtcWalletKeyRing) ECDH(keyDesc KeyDescriptor,
 	pub *btcec.PublicKey) ([32]byte, error) {
 
-	privKey, err := b.DerivePrivKey(keyDesc)
+	privKey, err := b.derivePrivKeyForECDH(keyDesc)
 	if err != nil {
 		return [32]byte{}, err
 	}
@@ -406,6 +471,68 @@ func (b *BtcWalletKeyRing) ECDH(keyDesc KeyDescriptor,
 	h := sha256.Sum256(sPubKey.SerializeCompressed())
 
 	return h, nil
+}
+
+// derivePrivKeyForECDH returns the private key for keyDesc, consulting and
+// populating the per-keyring ECDH cache. The cache is keyed by the
+// compressed-serialized public key, which uniquely identifies the private key
+// regardless of whether DerivePrivKey takes the path-based or the PubKey-scan
+// branch. When the descriptor has no public key set we cannot cache (we have
+// nothing collision-free to key on without first deriving) and forward to
+// DerivePrivKey directly. Production ECDH callers always supply a PubKey, so
+// the no-PubKey path is not on the hot path.
+//
+// NOTE: we assume the KeyDescriptor passed here is always valid, in the sense
+// that its KeyLocator and PubKey are consistent (i.e. the key derived from the
+// KeyLocator has the public key in PubKey). This lets us cache the derived key
+// without re-checking priv.PubKey().IsEqual(keyDesc.PubKey) on every call. Such
+// an inconsistency should never happen, but the assumption is called out
+// explicitly given this is a critical area.
+//
+// TODO(erickcestari): this cache only exists because btcwallet's internal
+// DeriveFromKeyPathCache is skipped when KeyDescriptor.PubKey is set
+// (see DerivePrivKey above). The hot ECDH callers (node identity key,
+// per-channel revocation/base-encryption keys, signrpc descriptors)
+// always supply a PubKey, so they never hit btcwallet's cache and
+// each call opens a read-write wallet DB transaction. When btcwallet
+// gains a cache lookup path that handles the PubKey-populated
+// descriptor case (or unambiguously distinguishes an explicit Index=0
+// from the Go zero value), this whole helper and the ecdhPrivKeyCache
+// field on BtcWalletKeyRing should be removed and ECDH can call
+// DerivePrivKey directly.
+func (b *BtcWalletKeyRing) derivePrivKeyForECDH(keyDesc KeyDescriptor) (
+	*btcec.PrivateKey, error) {
+
+	if keyDesc.PubKey == nil {
+		return b.DerivePrivKey(keyDesc)
+	}
+
+	var cacheKey [btcec.PubKeyBytesLenCompressed]byte
+	copy(cacheKey[:], keyDesc.PubKey.SerializeCompressed())
+
+	if v, err := b.ecdhPrivKeyCache.Get(cacheKey); err == nil {
+		privKey := v.key
+		return &privKey, nil
+	} else if !errors.Is(err, cache.ErrElementNotFound) {
+		return nil, err
+	}
+
+	priv, err := b.DerivePrivKey(keyDesc)
+	if err != nil {
+		return nil, err
+	}
+
+	// A Put failure here is not expected: each entry has size 1, so it
+	// can never exceed the cache capacity. If it ever does, surface it
+	// rather than silently swallowing it, since it means an invariant we
+	// rely on has been broken.
+	if _, err := b.ecdhPrivKeyCache.Put(
+		cacheKey, &cachedPrivKey{key: *priv},
+	); err != nil {
+		return nil, err
+	}
+
+	return priv, nil
 }
 
 // SignMessage signs the given message, single or double SHA256 hashing it

--- a/keychain/btcwallet_test.go
+++ b/keychain/btcwallet_test.go
@@ -1,0 +1,155 @@
+package keychain
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestBtcWalletKeyRing spins up a btcwallet-backed keyring and returns it as
+// the concrete *BtcWalletKeyRing type so the unexported ECDH helpers can be
+// exercised directly.
+func newTestBtcWalletKeyRing(t *testing.T) *BtcWalletKeyRing {
+	t.Helper()
+
+	wallet, err := createTestBtcWallet(t, CoinTypeBitcoin)
+	require.NoError(t, err)
+
+	keyRing, ok := NewBtcWalletKeyRing(
+		wallet, CoinTypeBitcoin,
+	).(*BtcWalletKeyRing)
+	require.True(t, ok, "expected *BtcWalletKeyRing")
+
+	return keyRing
+}
+
+// TestDerivePrivKeyForECDHCaching ensures that derivePrivKeyForECDH returns the
+// private key matching the descriptor's public key, populates the cache on the
+// first call, and serves subsequent calls from the cache while handing back an
+// independent copy.
+func TestDerivePrivKeyForECDHCaching(t *testing.T) {
+	t.Parallel()
+
+	keyRing := newTestBtcWalletKeyRing(t)
+
+	keyDesc, err := keyRing.DeriveKey(KeyLocator{
+		Family: KeyFamilyNodeKey,
+		Index:  0,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, keyDesc.PubKey)
+
+	// The cache starts empty.
+	require.Equal(t, 0, keyRing.ecdhPrivKeyCache.Len())
+
+	// The first call derives the key and must return the private key that
+	// corresponds to the descriptor's public key.
+	priv, err := keyRing.derivePrivKeyForECDH(keyDesc)
+	require.NoError(t, err)
+	require.True(t, priv.PubKey().IsEqual(keyDesc.PubKey))
+
+	// The derived key is now cached.
+	require.Equal(t, 1, keyRing.ecdhPrivKeyCache.Len())
+
+	// A second call returns the same key material, but as an independent
+	// copy so a caller mutating it can't corrupt the cached entry.
+	priv2, err := keyRing.derivePrivKeyForECDH(keyDesc)
+	require.NoError(t, err)
+	require.Equal(t, priv.Serialize(), priv2.Serialize())
+	require.NotSame(t, priv, priv2)
+
+	// The cache copy must also be distinct from what we hand back.
+	var cacheKey [btcec.PubKeyBytesLenCompressed]byte
+	copy(cacheKey[:], keyDesc.PubKey.SerializeCompressed())
+	cached, err := keyRing.ecdhPrivKeyCache.Get(cacheKey)
+	require.NoError(t, err)
+	require.NotSame(t, &cached.key, priv2)
+}
+
+// TestDerivePrivKeyForECDHNoPubKey ensures that descriptors without a public
+// key bypass the cache and forward to DerivePrivKey directly.
+func TestDerivePrivKeyForECDHNoPubKey(t *testing.T) {
+	t.Parallel()
+
+	keyRing := newTestBtcWalletKeyRing(t)
+
+	keyLoc := KeyLocator{
+		Family: KeyFamilyNodeKey,
+		Index:  0,
+	}
+
+	priv, err := keyRing.derivePrivKeyForECDH(KeyDescriptor{
+		KeyLocator: keyLoc,
+	})
+	require.NoError(t, err)
+
+	// The no-PubKey path must not populate the cache.
+	require.Equal(t, 0, keyRing.ecdhPrivKeyCache.Len())
+
+	// It must return the same key DerivePrivKey would.
+	want, err := keyRing.DerivePrivKey(KeyDescriptor{KeyLocator: keyLoc})
+	require.NoError(t, err)
+	require.Equal(t, want.Serialize(), priv.Serialize())
+}
+
+// TestDerivePrivKeyForECDHConsistentWithDerivePrivKey ensures the cached helper
+// always agrees with a direct DerivePrivKey, both on the deriving call and on
+// subsequent cache hits.
+func TestDerivePrivKeyForECDHConsistentWithDerivePrivKey(t *testing.T) {
+	t.Parallel()
+
+	keyRing := newTestBtcWalletKeyRing(t)
+
+	for _, fam := range []KeyFamily{
+		KeyFamilyNodeKey, KeyFamilyMultiSig, KeyFamilyBaseEncryption,
+	} {
+		keyDesc, err := keyRing.DeriveKey(KeyLocator{
+			Family: fam,
+			Index:  0,
+		})
+		require.NoError(t, err)
+
+		want, err := keyRing.DerivePrivKey(keyDesc)
+		require.NoError(t, err)
+
+		// Deriving call.
+		got, err := keyRing.derivePrivKeyForECDH(keyDesc)
+		require.NoError(t, err)
+		require.Equal(t, want.Serialize(), got.Serialize())
+
+		// Cache hit.
+		got, err = keyRing.derivePrivKeyForECDH(keyDesc)
+		require.NoError(t, err)
+		require.Equal(t, want.Serialize(), got.Serialize())
+	}
+}
+
+// TestDerivePrivKeyForECDHZeroesOnEvict ensures the delete callback wipes the
+// cache's copy of the private key when an entry leaves the cache.
+func TestDerivePrivKeyForECDHZeroesOnEvict(t *testing.T) {
+	t.Parallel()
+
+	keyRing := newTestBtcWalletKeyRing(t)
+
+	keyDesc, err := keyRing.DeriveKey(KeyLocator{
+		Family: KeyFamilyNodeKey,
+		Index:  0,
+	})
+	require.NoError(t, err)
+
+	_, err = keyRing.derivePrivKeyForECDH(keyDesc)
+	require.NoError(t, err)
+
+	var cacheKey [btcec.PubKeyBytesLenCompressed]byte
+	copy(cacheKey[:], keyDesc.PubKey.SerializeCompressed())
+
+	// Grab the actual cached entry, confirm it holds key material, then
+	// evict it and confirm the callback zeroed that material.
+	cached, err := keyRing.ecdhPrivKeyCache.Get(cacheKey)
+	require.NoError(t, err)
+	require.NotEqual(t, make([]byte, 32), cached.key.Serialize())
+
+	keyRing.ecdhPrivKeyCache.Delete(cacheKey)
+	require.Equal(t, make([]byte, 32), cached.key.Serialize())
+}

--- a/onionmessage/actor_bench_test.go
+++ b/onionmessage/actor_bench_test.go
@@ -1,0 +1,190 @@
+package onionmessage
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcwallet/snacl"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet"
+	"github.com/btcsuite/btcwallet/walletdb"
+	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
+	sphinx "github.com/lightningnetwork/lightning-onion"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/record"
+	"github.com/lightningnetwork/lnd/routing/route"
+	"github.com/stretchr/testify/require"
+)
+
+// noopDispatcher is a zero-overhead OnionMessageUpdateDispatcher used for
+// benchmarks so the dispatch path does not perturb timing.
+type noopDispatcher struct{}
+
+func (noopDispatcher) SendUpdate(any) error { return nil }
+
+// noopSender is a zero-overhead PeerMessageSender used for benchmarks.
+type noopSender struct{}
+
+func (noopSender) SendToPeer([33]byte, *lnwire.OnionMessage) error {
+	return nil
+}
+
+// testHDSeed is the deterministic seed used to create the benchmark wallet.
+var testHDSeed = chainhash.Hash{
+	0xb7, 0x94, 0x38, 0x5f, 0x2d, 0x1e, 0xf7, 0xab,
+	0x4d, 0x92, 0x73, 0xd1, 0x90, 0x63, 0x81, 0xb4,
+	0x4f, 0x2f, 0x6f, 0x25, 0x98, 0xa3, 0xef, 0xb9,
+	0x69, 0x49, 0x18, 0x83, 0x31, 0x98, 0x47, 0x53,
+}
+
+// lightningAddrSchema mirrors keychain/btcwallet.go (unexported there).
+var lightningAddrSchema = waddrmgr.ScopeAddrSchema{
+	ExternalAddrType: waddrmgr.WitnessPubKey,
+	InternalAddrType: waddrmgr.WitnessPubKey,
+}
+
+// waddrmgrNamespaceKey mirrors keychain/btcwallet.go (unexported there).
+var waddrmgrNamespaceKey = []byte("waddrmgr")
+
+// createBenchBtcWallet builds a real on-disk btcwallet (simnet, fast scrypt)
+// suitable for driving keychain.BtcWalletKeyRing in benchmarks. It mirrors
+// the unexported createTestBtcWallet in keychain/interface_test.go so the
+// onionmessage bench can construct keychain.PubKeyECDH against a real
+// SecretKeyRing — exactly as server.go does in production.
+func createBenchBtcWallet(b *testing.B) *wallet.Wallet {
+	b.Helper()
+
+	fast := waddrmgr.FastScryptOptions
+	waddrmgr.SetSecretKeyGen(func(passphrase *[]byte,
+		_ *waddrmgr.ScryptOptions) (*snacl.SecretKey, error) {
+
+		return snacl.NewSecretKey(passphrase, fast.N, fast.R, fast.P)
+	})
+
+	loader := wallet.NewLoader(
+		&chaincfg.SimNetParams, b.TempDir(), true, time.Second*10, 0,
+	)
+
+	pass := []byte("test")
+	w, err := loader.CreateNewWallet(
+		pass, pass, testHDSeed[:], time.Time{},
+	)
+	require.NoError(b, err)
+	require.NoError(b, w.Unlock(pass, nil))
+
+	scope := waddrmgr.KeyScope{
+		Purpose: keychain.BIP0043Purpose,
+		Coin:    keychain.CoinTypeBitcoin,
+	}
+	if _, err := w.Manager.FetchScopedKeyManager(scope); err != nil {
+		require.NoError(b, walletdb.Update(w.Database(),
+			func(tx walletdb.ReadWriteTx) error {
+				ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+				_, err := w.Manager.NewScopedKeyManager(
+					ns, scope, lightningAddrSchema,
+				)
+
+				return err
+			}))
+	}
+
+	b.Cleanup(func() { w.Lock() })
+
+	return w
+}
+
+// BenchmarkOnionMessagePipeline measures OnionPeerActor.Receive end to end on
+// the deliver path: decode -> sphinx process -> routing decision -> dispatch.
+// It isolates the actor + pipeline overhead on top of sphinx.
+// ProcessOnionPacket.
+func BenchmarkOnionMessagePipeline(b *testing.B) {
+	// Mirror server.go: derive the node key from a real BtcWalletKeyRing
+	// and wrap it in keychain.NewPubKeyECDH. This is the exact onion-key
+	// type the production sphinx router uses.
+	w := createBenchBtcWallet(b)
+	keyRing := keychain.NewBtcWalletKeyRing(w, keychain.CoinTypeBitcoin)
+
+	nodeKeyDesc, err := keyRing.DeriveKey(keychain.KeyLocator{
+		Family: keychain.KeyFamilyNodeKey,
+		Index:  0,
+	})
+	require.NoError(b, err)
+
+	nodeKeyECDH := keychain.NewPubKeyECDH(nodeKeyDesc, keyRing)
+
+	router := sphinx.NewRouter(nodeKeyECDH, sphinx.NewNoOpReplayLog())
+	require.NoError(b, router.Start())
+	b.Cleanup(func() { router.Stop() })
+
+	var peerPubKey [33]byte
+	copy(peerPubKey[:], nodeKeyDesc.PubKey.SerializeCompressed())
+
+	a := &OnionPeerActor{
+		peerPubKey:       peerPubKey,
+		peerSender:       noopSender{},
+		router:           router,
+		resolver:         newMockNodeIDResolver(),
+		updateDispatcher: noopDispatcher{},
+	}
+
+	// Build a single-hop "deliver" onion message addressed to nodeKey.
+	plain, err := record.EncodeBlindedRouteData(&record.BlindedRouteData{})
+	require.NoError(b, err)
+
+	hops := []*sphinx.HopInfo{
+		{NodePub: nodeKeyDesc.PubKey, PlainText: plain},
+	}
+
+	sessionKey, err := btcec.NewPrivateKey()
+	require.NoError(b, err)
+
+	blindedPath, err := sphinx.BuildBlindedPath(sessionKey, hops)
+	require.NoError(b, err)
+
+	sphinxPath, err := route.OnionMessageBlindedPathToSphinxPath(
+		blindedPath.Path, nil, nil,
+	)
+	require.NoError(b, err)
+
+	onionSessionKey, err := btcec.NewPrivateKey()
+	require.NoError(b, err)
+
+	pkt, err := sphinx.NewOnionPacket(
+		sphinxPath, onionSessionKey, nil,
+		sphinx.DeterministicPacketFiller,
+		sphinx.WithMaxPayloadSize(sphinx.MaxRoutingPayloadSize),
+	)
+	require.NoError(b, err)
+
+	var buf bytes.Buffer
+	require.NoError(b, pkt.Encode(&buf))
+
+	onionBlob := buf.Bytes()
+	pathKey := blindedPath.SessionKey.PubKey()
+
+	ctx := b.Context()
+
+	newReq := func() *Request {
+		return &Request{msg: lnwire.OnionMessage{
+			PathKey:   pathKey,
+			OnionBlob: onionBlob,
+		}}
+	}
+
+	// Make sure we're benchmarking the success path and not silently
+	// timing an error path.
+	require.NoError(b, a.Receive(ctx, newReq()).Err())
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		if err := a.Receive(ctx, newReq()).Err(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
`BtcWalletKeyRing.ECDH` is on the hot path of every onion-message hop:
the sphinx router holds the local node's `keychain.PubKeyECDH` as its
`onionKey` and calls into it from `ProcessOnionPacket`,
`DecryptBlindedHopData`, and `NextEphemeral`, three calls per message
in the deliver path. Each call dispatches through `ECDHRing.ECDH` to
`BtcWalletKeyRing.ECDH`, which calls `DerivePrivKey`. Because
`nodeKeyDesc.PubKey` is set in `server.go`, the in-memory `waddrmgr`
fast path is skipped and the call falls through to a `walletdb.Update`
read-write transaction. Each transaction forces a bbolt meta-page write
and an `fdatasync` per ECDH operation.

The derivation is deterministic for a given key descriptor, so this PR
memoizes the derived private key on the keyring itself, keyed by the
descriptor's compressed-serialized public key. After the first ECDH
against a given key every subsequent call (every brontide handshake
against the node identity key, every onion message decrypt, every
watchtower session ECDH) stays entirely in memory.

The cache lives on `BtcWalletKeyRing` rather than on `PubKeyECDH` so
the private material stays behind the type that already owns it: the
wrapper stays a pure `ECDHRing` adapter, and any direct caller of
`ECDHRing.ECDH` benefits without going through the wrapper. Keying by
the serialized compressed public key is unambiguous regardless of
whether `DerivePrivKey` takes the path-based or the `PubKey`-scan
branch, the same `priv.PubKey()` always maps to the same cache slot,
with no cross-key collision risk. Descriptors without a `PubKey`
(uncommon on the ECDH hot path) bypass the cache and forward to
`DerivePrivKey` unchanged. Remote-signer deployments use `RPCKeyRing`,
whose `ECDH` continues to forward over RPC; the cache lives on the
watch-only `BtcWalletKeyRing` it wraps and is never hit on that path.

The cache is a neutrino LRU bounded at 1000 entries with a wrapper
type that reports Size 1 so the cap is on entry count rather than
bytes. The bound is defense-in-depth: cache keys are only ever
populated from descriptors the local node itself supplies (the node
identity key, per-channel revocation roots, base-encryption keys,
locally-allocated watchtower session indices, signrpc-supplied
descriptors), and are never derived from remote input, so there is
no remote-driven growth vector. 1000 entries comfortably covers the
working set across every ECDH caller in the codebase while keeping
memory bounded against any future caller that drives an unusually
wide range of descriptors. On capacity the LRU evicts the least
recently used entry, so the onion-message hot-path keys (which are
touched on every hop) stay resident.

The benchmark commit (`onionmessage: add OnionPeerActor.Receive
pipeline benchmark`) lands first so the before/after can be reproduced
by checking out either commit.

## Measured impact

### Microbenchmark (`BenchmarkOnionMessagePipeline`, deliver path, real `BtcWalletKeyRing` + `keychain.PubKeyECDH`, single goroutine)

| Metric           | Before     | After    | Delta        |
|------------------|------------|----------|--------------|
| ns/op            | 3,008,424  | 732,200  | 4.11× faster |
| B/op             | 110,574    | 27,750   | 4.0× smaller |
| allocs/op        | 1,177      | 145      | 8.1× fewer   |
| msg/s/goroutine  | ~332       | ~1,366   | +311%        |

The ~1,032 alloc/op reduction is the structural fingerprint of three
bbolt R/W transactions per message disappearing, confirming the three
keychain-routed ECDH call sites collapse to the in-memory fast path.

<details>
<summary>Raw <code>go test</code> output</summary>

Before:

```
goos: linux
goarch: amd64
pkg: github.com/lightningnetwork/lnd/onionmessage
cpu: 12th Gen Intel(R) Core(TM) i5-12500H
BenchmarkOnionMessagePipeline        799           3008424 ns/op          110574 B/op       1177 allocs/op
PASS
ok      github.com/lightningnetwork/lnd/onionmessage    2.732s

1 / 3008424 ns ≈ 332 msg/s
```

After:

```
goos: linux
goarch: amd64
pkg: github.com/lightningnetwork/lnd/onionmessage
cpu: 12th Gen Intel(R) Core(TM) i5-12500H
BenchmarkOnionMessagePipeline       3255            732200 ns/op           27750 B/op        145 allocs/op
PASS
ok      github.com/lightningnetwork/lnd/onionmessage    2.488s

1 / 732200 ns ≈ 1,366 msg/s
```

</details>

### End-to-end (regtest forwarding scenario, `monitor-drops.sh alice`, sustained ~28 s window, 0.0% drops in both runs)

| Metric           | Before        | After         | Delta         |
|------------------|---------------|---------------|---------------|
| recv/s (avg)     | ~69           | ~870          | ~12.6× faster |
| Sustained range  | 63–73 recv/s  | 830–930 recv/s|               |

<details>
<summary>Raw <code>monitor-drops.sh alice</code> output</summary>

Before:

```
elapsed   time                     recv/s      fwd/s fwd_fail/s   drop_b/s  drop_nb/s   drop%         Δrecv        Δfwd   Δfwd_fail     Δdrop_b    Δdrop_nb
1.0    s  2026-04-29 15:13:59       69.38      69.38       0.00       0.00       0.00    0.0%             70           70            0            0            0
2.0    s  2026-04-29 15:14:00       62.96      62.96       0.00       0.00       0.00    0.0%            134          134            0            0            0
3.0    s  2026-04-29 15:14:01       73.23      73.23       0.00       0.00       0.00    0.0%            208          208            0            0            0
4.0    s  2026-04-29 15:14:02       71.13      71.13       0.00       0.00       0.00    0.0%            280          280            0            0            0
5.1    s  2026-04-29 15:14:03       69.98      69.98       0.00       0.00       0.00    0.0%            351          351            0            0            0
6.1    s  2026-04-29 15:14:04       69.74      69.74       0.00       0.00       0.00    0.0%            422          422            0            0            0
7.1    s  2026-04-29 15:14:05       69.06      69.06       0.00       0.00       0.00    0.0%            492          492            0            0            0
8.1    s  2026-04-29 15:14:06       68.96      68.96       0.00       0.00       0.00    0.0%            562          562            0            0            0
9.1    s  2026-04-29 15:14:08       70.14      70.14       0.00       0.00       0.00    0.0%            634          634            0            0            0
10.1   s  2026-04-29 15:14:09       73.03      73.03       0.00       0.00       0.00    0.0%            708          708            0            0            0
11.2   s  2026-04-29 15:14:10       69.21      69.21       0.00       0.00       0.00    0.0%            778          778            0            0            0
12.2   s  2026-04-29 15:14:11       65.07      65.07       0.00       0.00       0.00    0.0%            844          844            0            0            0
13.2   s  2026-04-29 15:14:12       71.36      71.36       0.00       0.00       0.00    0.0%            916          916            0            0            0
14.2   s  2026-04-29 15:14:13       67.07      67.07       0.00       0.00       0.00    0.0%            984          984            0            0            0
15.2   s  2026-04-29 15:14:14       69.21      69.21       0.00       0.00       0.00    0.0%           1054         1054            0            0            0
16.2   s  2026-04-29 15:14:15       67.06      67.06       0.00       0.00       0.00    0.0%           1122         1122            0            0            0
17.2   s  2026-04-29 15:14:16       67.91      67.91       0.00       0.00       0.00    0.0%           1191         1191            0            0            0
18.3   s  2026-04-29 15:14:17       69.07      69.07       0.00       0.00       0.00    0.0%           1261         1261            0            0            0
19.3   s  2026-04-29 15:14:18       66.01      66.01       0.00       0.00       0.00    0.0%           1328         1328            0            0            0
20.3   s  2026-04-29 15:14:19       63.13      63.13       0.00       0.00       0.00    0.0%           1392         1392            0            0            0
21.3   s  2026-04-29 15:14:20       68.81      68.81       0.00       0.00       0.00    0.0%           1462         1462            0            0            0
22.3   s  2026-04-29 15:14:21       69.26      69.26       0.00       0.00       0.00    0.0%           1532         1532            0            0            0
23.3   s  2026-04-29 15:14:22       68.12      68.12       0.00       0.00       0.00    0.0%           1601         1601            0            0            0
24.3   s  2026-04-29 15:14:23       71.15      71.15       0.00       0.00       0.00    0.0%           1673         1673            0            0            0
25.3   s  2026-04-29 15:14:24       67.01      67.01       0.00       0.00       0.00    0.0%           1741         1741            0            0            0
26.4   s  2026-04-29 15:14:25       70.26      70.26       0.00       0.00       0.00    0.0%           1813         1813            0            0            0
27.4   s  2026-04-29 15:14:26       67.10      67.10       0.00       0.00       0.00    0.0%           1881         1881            0            0            0
```

After:

```
./lightning-scenarios/monitor-drops.sh alice
elapsed   time                     recv/s      fwd/s fwd_fail/s   drop_b/s  drop_nb/s   drop%         Δrecv        Δfwd   Δfwd_fail     Δdrop_b    Δdrop_nb
1.0    s  2026-04-29 14:11:30      865.12     865.12       0.00       0.00       0.00    0.0%            873          873            0            0            0
2.0    s  2026-04-29 14:11:31      930.86     930.86       0.00       0.00       0.00    0.0%           1813         1813            0            0            0
3.0    s  2026-04-29 14:11:32      875.45     875.45       0.00       0.00       0.00    0.0%           2698         2698            0            0            0
4.0    s  2026-04-29 14:11:33      872.01     872.01       0.00       0.00       0.00    0.0%           3579         3579            0            0            0
5.1    s  2026-04-29 14:11:34      883.89     883.89       0.00       0.00       0.00    0.0%           4472         4472            0            0            0
6.1    s  2026-04-29 14:11:35      867.01     867.01       0.00       0.00       0.00    0.0%           5348         5348            0            0            0
7.1    s  2026-04-29 14:11:36      836.89     836.89       0.00       0.00       0.00    0.0%           6194         6194            0            0            0
8.1    s  2026-04-29 14:11:37      905.46     905.46       0.00       0.00       0.00    0.0%           7109         7109            0            0            0
9.1    s  2026-04-29 14:11:38      878.38     878.38       0.00       0.00       0.00    0.0%           7997         7997            0            0            0
10.1   s  2026-04-29 14:11:39      888.11     888.11       0.00       0.00       0.00    0.0%           8894         8894            0            0            0
11.1   s  2026-04-29 14:11:40      845.53     845.53       0.00       0.00       0.00    0.0%           9747         9747            0            0            0
12.1   s  2026-04-29 14:11:41      885.22     885.22       0.00       0.00       0.00    0.0%          10640        10640            0            0            0
13.1   s  2026-04-29 14:11:42      874.99     874.99       0.00       0.00       0.00    0.0%          11524        11524            0            0            0
14.1   s  2026-04-29 14:11:43      889.28     889.28       0.00       0.00       0.00    0.0%          12423        12423            0            0            0
15.2   s  2026-04-29 14:11:44      832.37     832.37       0.00       0.00       0.00    0.0%          13264        13264            0            0            0
16.2   s  2026-04-29 14:11:45      878.71     878.71       0.00       0.00       0.00    0.0%          14152        14152            0            0            0
17.2   s  2026-04-29 14:11:46      863.66     863.66       0.00       0.00       0.00    0.0%          15025        15025            0            0            0
18.2   s  2026-04-29 14:11:47      882.69     882.69       0.00       0.00       0.00    0.0%          15916        15916            0            0            0
19.2   s  2026-04-29 14:11:48      831.92     831.92       0.00       0.00       0.00    0.0%          16757        16757            0            0            0
20.2   s  2026-04-29 14:11:49      835.85     835.85       0.00       0.00       0.00    0.0%          17602        17602            0            0            0
21.2   s  2026-04-29 14:11:50      832.98     832.98       0.00       0.00       0.00    0.0%          18444        18444            0            0            0
22.2   s  2026-04-29 14:11:51      841.40     841.40       0.00       0.00       0.00    0.0%          19293        19293            0            0            0
23.2   s  2026-04-29 14:11:52      887.89     887.89       0.00       0.00       0.00    0.0%          20190        20190            0            0            0
24.2   s  2026-04-29 14:11:53      845.71     845.71       0.00       0.00       0.00    0.0%          21044        21044            0            0            0
25.3   s  2026-04-29 14:11:54      864.52     864.52       0.00       0.00       0.00    0.0%          21916        21916            0            0            0
26.3   s  2026-04-29 14:11:55      885.28     885.28       0.00       0.00       0.00    0.0%          22809        22809            0            0            0
27.3   s  2026-04-29 14:11:56      868.00     868.00       0.00       0.00       0.00    0.0%          23685        23685            0            0            0
28.3   s  2026-04-29 14:11:57      888.71     888.71       0.00       0.00       0.00    0.0%          24583        24583            0            0            0
```

</details>

The end-to-end gain exceeds the microbenchmark gain because the bench's
`b.TempDir()` sits on tmpfs, where `fdatasync` is effectively a no-op.
Prod runs on durable storage, so every bbolt read-write transaction
pays a real `fdatasync` syscall and with the bbolt single-writer lock
serializing the three per-message ECDH txns against concurrent wallet
writers (chain sync, channel state), the syscall overhead dominates.
Caching the derived priv key removes those transactions entirely,
which is why prod sees a much larger speedup than the in-memory
microbench.

### Syscall profile during the onion-message blast

Before:

<img width="1910" height="928" alt="Screenshot From 2026-04-28 16-55-44" src="https://github.com/user-attachments/assets/79496f13-1060-4bed-bfd9-f7d1759e502a" />


After:

<img width="1920" height="496" alt="Screenshot From 2026-04-29 13-57-19" src="https://github.com/user-attachments/assets/eeb50301-a06b-4d88-8b2b-b8edf4021159" />

Thanks to @Morehouse for reporting the performance issues with LND onion message routing.