### PR TITLE
channeldb: tombstone closed channels on KV-SQL backends

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -4000,13 +4000,16 @@ type ChannelCloseSummary struct {
 	LastChanSyncMsg *lnwire.ChannelReestablish
 }
 
-// CloseChannel closes a previously active Lightning channel. Closing a channel
-// entails deleting all saved state within the database concerning this
-// channel. This method also takes a struct that summarizes the state of the
-// channel at closing, this compact representation will be the only component
-// of a channel left over after a full closing. It takes an optional set of
-// channel statuses which will be written to the historical channel bucket.
-// These statuses are used to record close initiators.
+// CloseChannel closes a previously active Lightning channel. Closing a
+// channel entails persisting a record of the close while either purging the
+// nested per-channel state inline (synchronous backends like bbolt and etcd)
+// or skipping the cascading delete on tombstone-enabled backends, where the
+// outpoint-index flip to outpointClosed is the authoritative marker. The
+// compact summary written to closedChannelBucket and the historical record
+// under historicalChannelBucket are populated identically across both paths,
+// so historical reads remain uniform regardless of backend. The optional set
+// of channel statuses is OR'd into the chanStatus written to the historical
+// bucket and is used to record close initiators.
 func (c *OpenChannel) CloseChannel(summary *ChannelCloseSummary,
 	statuses ...ChannelStatus) error {
 
@@ -4016,19 +4019,27 @@ func (c *OpenChannel) CloseChannel(summary *ChannelCloseSummary,
 	return c.Db.CloseChannel(c, summary, statuses...)
 }
 
-// CloseChannel closes the supplied channel by deleting its per-channel state
-// — the revocation log, the per-channel forwarding-package bucket, and the
-// chanBucket itself — inline within a single write transaction, then
-// archiving the historical record and close summary.
+// CloseChannel closes the supplied channel via the strategy selected at DB
+// construction. On synchronous backends the channel's nested state — the
+// revocation log, the per-channel forwarding-package bucket, and the
+// chanBucket itself — is deleted inline. On tombstone-enabled backends none
+// of the bulk state is touched; the outpointBucket flip to outpointClosed
+// signals that the channel is logically closed.
 func (c *ChannelStateDB) CloseChannel(channel *OpenChannel,
 	summary *ChannelCloseSummary, statuses ...ChannelStatus) error {
+
+	if c.tombstoneClosedChannels {
+		return c.closeChannelTombstone(channel, summary, statuses...)
+	}
 
 	return c.closeChannelSync(channel, summary, statuses...)
 }
 
 // locateOpenChannel performs the open-channel-bucket descent for a
 // CloseChannel transaction: it returns the chain bucket, the channel bucket,
-// and the serialized chanKey for the supplied OpenChannel.
+// and the serialized chanKey for the supplied OpenChannel. A chanKey already
+// flipped to outpointClosed surfaces ErrChannelNotFound so a redundant
+// CloseChannel does not re-archive or re-flip the index.
 func locateOpenChannel(tx kvdb.RwTx, channel *OpenChannel) (kvdb.RwBucket,
 	kvdb.RwBucket, []byte, error) {
 
@@ -4061,6 +4072,18 @@ func locateOpenChannel(tx kvdb.RwTx, channel *OpenChannel) (kvdb.RwBucket,
 	chanBucket := chainBucket.NestedReadWriteBucket(chanKey)
 	if chanBucket == nil {
 		return nil, nil, nil, ErrNoActiveChannels
+	}
+
+	// A channel whose outpoint is already flipped to outpointClosed must
+	// not be re-closed: on tombstone backends the chanBucket survives a
+	// previous close, but the index flip is the authoritative record that
+	// the channel is gone from the open-channel view.
+	closed, err := isOutpointClosed(tx.ReadBucket(outpointBucket), chanKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if closed {
+		return nil, nil, nil, ErrChannelNotFound
 	}
 
 	return chainBucket, chanBucket, chanKey, nil
@@ -4125,10 +4148,11 @@ func archiveClosedChannel(tx kvdb.RwTx, chanKey []byte,
 	return putChannelCloseSummary(tx, chanKey, summary, chanState)
 }
 
-// closeChannelSync performs the synchronous close path: in a single write
-// transaction it wipes the forwarding-package state, deletes the channel
-// bucket and its nested revocation log entries, updates the outpoint index,
-// and archives the close summary.
+// closeChannelSync performs the historical synchronous close path: in a
+// single write transaction it wipes the forwarding-package state, deletes
+// the channel bucket and its nested revocation log entries, updates the
+// outpoint index, and archives the close summary. It is used by backends
+// where nested-bucket deletion is cheap (bbolt, etcd).
 func (c *ChannelStateDB) closeChannelSync(channel *OpenChannel,
 	summary *ChannelCloseSummary, statuses ...ChannelStatus) error {
 
@@ -4168,6 +4192,39 @@ func (c *ChannelStateDB) closeChannelSync(channel *OpenChannel,
 		}
 
 		if err := chainBucket.DeleteNestedBucket(chanKey); err != nil {
+			return err
+		}
+
+		if err := updateClosedOutpointIndex(tx, chanKey); err != nil {
+			return err
+		}
+
+		return archiveClosedChannel(
+			tx, chanKey, chanState, summary, statuses...,
+		)
+	}, func() {})
+}
+
+// closeChannelTombstone performs the tombstone close path used by
+// KV-over-SQL backends. The channel's per-channel state is left intact —
+// touching it would trigger the cascading nested-bucket delete this path
+// exists to avoid — and the outpointBucket flip from outpointOpen to
+// outpointClosed serves as the authoritative closed-channel marker. The
+// disk space is reclaimed wholesale by the upcoming native-SQL
+// channel-state migration.
+func (c *ChannelStateDB) closeChannelTombstone(channel *OpenChannel,
+	summary *ChannelCloseSummary, statuses ...ChannelStatus) error {
+
+	return kvdb.Update(c.backend, func(tx kvdb.RwTx) error {
+		_, chanBucket, chanKey, err := locateOpenChannel(tx, channel)
+		if err != nil {
+			return err
+		}
+
+		chanState, err := fetchOpenChannel(
+			chanBucket, &channel.FundingOutpoint,
+		)
+		if err != nil {
 			return err
 		}
 

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -1452,7 +1452,20 @@ func fetchChanBucket(tx kvdb.RTx, nodeKey *btcec.PublicKey,
 	if err := graphdb.WriteOutpoint(&chanPointBuf, outPoint); err != nil {
 		return nil, err
 	}
-	chanBucket := chainBucket.NestedReadBucket(chanPointBuf.Bytes())
+	chanKey := chanPointBuf.Bytes()
+
+	// Treat already-closed channels as gone. The chanBucket may still
+	// exist on tombstone-enabled backends; the outpoint flip is the
+	// source of truth.
+	closed, err := isOutpointClosed(tx.ReadBucket(outpointBucket), chanKey)
+	if err != nil {
+		return nil, err
+	}
+	if closed {
+		return nil, ErrChannelNotFound
+	}
+
+	chanBucket := chainBucket.NestedReadBucket(chanKey)
 	if chanBucket == nil {
 		return nil, ErrChannelNotFound
 	}
@@ -1499,7 +1512,20 @@ func fetchChanBucketRw(tx kvdb.RwTx, nodeKey *btcec.PublicKey,
 	if err := graphdb.WriteOutpoint(&chanPointBuf, outPoint); err != nil {
 		return nil, err
 	}
-	chanBucket := chainBucket.NestedReadWriteBucket(chanPointBuf.Bytes())
+	chanKey := chanPointBuf.Bytes()
+
+	// Treat already-closed channels as gone. The chanBucket may still
+	// exist on tombstone-enabled backends; the outpoint flip is the
+	// source of truth.
+	closed, err := isOutpointClosed(tx.ReadBucket(outpointBucket), chanKey)
+	if err != nil {
+		return nil, err
+	}
+	if closed {
+		return nil, ErrChannelNotFound
+	}
+
+	chanBucket := chainBucket.NestedReadWriteBucket(chanKey)
 	if chanBucket == nil {
 		return nil, ErrChannelNotFound
 	}

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -368,6 +368,37 @@ const (
 	outpointClosed indexStatus = 1
 )
 
+// isOutpointClosed reports whether the supplied chanKey has been flipped to
+// outpointClosed in the supplied outpointBucket. The flip is performed in the
+// same transaction as the rest of CloseChannel (sync and tombstone paths
+// alike), so a true result is the authoritative "this channel went through
+// CloseChannel" signal. On tombstone-enabled backends the chanBucket may still
+// exist on disk; readers consult this helper to skip those entries. Callers
+// fetch outpointBucket once and pass it in, which lets loop-style readers
+// hoist the bucket lookup out of the inner loop.
+func isOutpointClosed(opBucket kvdb.RBucket, chanKey []byte) (bool, error) {
+	if opBucket == nil {
+		return false, nil
+	}
+	raw := opBucket.Get(chanKey)
+	if raw == nil {
+		return false, nil
+	}
+
+	var status uint8
+	statusRecord := tlv.MakePrimitiveRecord(indexStatusType, &status)
+	stream, err := tlv.NewStream(statusRecord)
+	if err != nil {
+		return false, err
+	}
+	if err := stream.Decode(bytes.NewReader(raw)); err != nil {
+		return false, fmt.Errorf("decode outpoint status for "+
+			"chan_key=%x: %w", chanKey, err)
+	}
+
+	return indexStatus(status) == outpointClosed, nil
+}
+
 // ChannelType is an enum-like type that describes one of several possible
 // channel types. Each open channel is associated with a particular type as the
 // channel type may determine how higher level operations are conducted such as

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -3982,140 +3982,170 @@ func (c *OpenChannel) CloseChannel(summary *ChannelCloseSummary,
 	c.Lock()
 	defer c.Unlock()
 
-	return kvdb.Update(c.Db.backend, func(tx kvdb.RwTx) error {
-		openChanBucket := tx.ReadWriteBucket(openChannelBucket)
-		if openChanBucket == nil {
-			return ErrNoChanDBExists
-		}
+	return c.Db.CloseChannel(c, summary, statuses...)
+}
 
-		nodePub := c.IdentityPub.SerializeCompressed()
-		nodeChanBucket := openChanBucket.NestedReadWriteBucket(nodePub)
-		if nodeChanBucket == nil {
-			return ErrNoActiveChannels
-		}
+// CloseChannel closes the supplied channel by deleting its per-channel state
+// — the revocation log, the per-channel forwarding-package bucket, and the
+// chanBucket itself — inline within a single write transaction, then
+// archiving the historical record and close summary.
+func (c *ChannelStateDB) CloseChannel(channel *OpenChannel,
+	summary *ChannelCloseSummary, statuses ...ChannelStatus) error {
 
-		chainBucket := nodeChanBucket.NestedReadWriteBucket(c.ChainHash[:])
-		if chainBucket == nil {
-			return ErrNoActiveChannels
-		}
+	return c.closeChannelSync(channel, summary, statuses...)
+}
 
-		var chanPointBuf bytes.Buffer
-		err := graphdb.WriteOutpoint(&chanPointBuf, &c.FundingOutpoint)
+// locateOpenChannel performs the open-channel-bucket descent for a
+// CloseChannel transaction: it returns the chain bucket, the channel bucket,
+// and the serialized chanKey for the supplied OpenChannel.
+func locateOpenChannel(tx kvdb.RwTx, channel *OpenChannel) (kvdb.RwBucket,
+	kvdb.RwBucket, []byte, error) {
+
+	openChanBucket := tx.ReadWriteBucket(openChannelBucket)
+	if openChanBucket == nil {
+		return nil, nil, nil, ErrNoChanDBExists
+	}
+
+	nodePub := channel.IdentityPub.SerializeCompressed()
+	nodeChanBucket := openChanBucket.NestedReadWriteBucket(nodePub)
+	if nodeChanBucket == nil {
+		return nil, nil, nil, ErrNoActiveChannels
+	}
+
+	chainBucket := nodeChanBucket.NestedReadWriteBucket(
+		channel.ChainHash[:],
+	)
+	if chainBucket == nil {
+		return nil, nil, nil, ErrNoActiveChannels
+	}
+
+	var chanPointBuf bytes.Buffer
+	if err := graphdb.WriteOutpoint(
+		&chanPointBuf, &channel.FundingOutpoint,
+	); err != nil {
+		return nil, nil, nil, err
+	}
+	chanKey := chanPointBuf.Bytes()
+
+	chanBucket := chainBucket.NestedReadWriteBucket(chanKey)
+	if chanBucket == nil {
+		return nil, nil, nil, ErrNoActiveChannels
+	}
+
+	return chainBucket, chanBucket, chanKey, nil
+}
+
+// updateClosedOutpointIndex flips the outpoint index entry for chanKey from
+// open to closed. The index entry must already exist; it was placed there
+// when the channel was opened.
+func updateClosedOutpointIndex(tx kvdb.RwTx, chanKey []byte) error {
+	opBucket := tx.ReadWriteBucket(outpointBucket)
+	if opBucket == nil {
+		return ErrNoChanDBExists
+	}
+	if opBucket.Get(chanKey) == nil {
+		return ErrMissingIndexEntry
+	}
+
+	status := uint8(outpointClosed)
+	statusRecord := tlv.MakePrimitiveRecord(indexStatusType, &status)
+	opStream, err := tlv.NewStream(statusRecord)
+	if err != nil {
+		return err
+	}
+
+	var b bytes.Buffer
+	if err := opStream.Encode(&b); err != nil {
+		return err
+	}
+
+	return opBucket.Put(chanKey, b.Bytes())
+}
+
+// archiveClosedChannel writes the immutable close-time records of the
+// channel: a copy of the open-channel state under historicalChannelBucket
+// (with the supplied close statuses OR'd into chanStatus) and the close
+// summary under closeSummaryBucket.
+func archiveClosedChannel(tx kvdb.RwTx, chanKey []byte,
+	chanState *OpenChannel, summary *ChannelCloseSummary,
+	statuses ...ChannelStatus) error {
+
+	historicalBucket, err := tx.CreateTopLevelBucket(
+		historicalChannelBucket,
+	)
+	if err != nil {
+		return err
+	}
+	historicalChanBucket, err := historicalBucket.CreateBucketIfNotExists(
+		chanKey,
+	)
+	if err != nil {
+		return err
+	}
+
+	for _, s := range statuses {
+		chanState.chanStatus |= s
+	}
+
+	if err := putOpenChannel(historicalChanBucket, chanState); err != nil {
+		return err
+	}
+
+	return putChannelCloseSummary(tx, chanKey, summary, chanState)
+}
+
+// closeChannelSync performs the synchronous close path: in a single write
+// transaction it wipes the forwarding-package state, deletes the channel
+// bucket and its nested revocation log entries, updates the outpoint index,
+// and archives the close summary.
+func (c *ChannelStateDB) closeChannelSync(channel *OpenChannel,
+	summary *ChannelCloseSummary, statuses ...ChannelStatus) error {
+
+	return kvdb.Update(c.backend, func(tx kvdb.RwTx) error {
+		chainBucket, chanBucket, chanKey, err := locateOpenChannel(
+			tx, channel,
+		)
 		if err != nil {
 			return err
 		}
-		chanKey := chanPointBuf.Bytes()
-		chanBucket := chainBucket.NestedReadWriteBucket(
-			chanKey,
-		)
-		if chanBucket == nil {
-			return ErrNoActiveChannels
-		}
 
-		// Before we delete the channel state, we'll read out the full
-		// details, as we'll also store portions of this information
-		// for record keeping.
 		chanState, err := fetchOpenChannel(
-			chanBucket, &c.FundingOutpoint,
+			chanBucket, &channel.FundingOutpoint,
 		)
 		if err != nil {
 			return err
 		}
 
-		// Delete all the forwarding packages stored for this particular
-		// channel.
 		if err = chanState.Packager.Wipe(tx); err != nil {
 			return err
 		}
 
-		// Now that the index to this channel has been deleted, purge
-		// the remaining channel metadata from the database.
-		err = deleteOpenChannel(chanBucket)
-		if err != nil {
+		if err := deleteOpenChannel(chanBucket); err != nil {
 			return err
 		}
 
-		// We'll also remove the channel from the frozen channel bucket
-		// if we need to.
-		if c.ChanType.IsFrozen() || c.ChanType.HasLeaseExpiration() {
-			err := deleteThawHeight(chanBucket)
-			if err != nil {
+		if channel.ChanType.IsFrozen() ||
+			channel.ChanType.HasLeaseExpiration() {
+
+			if err := deleteThawHeight(chanBucket); err != nil {
 				return err
 			}
 		}
 
-		// With the base channel data deleted, attempt to delete the
-		// information stored within the revocation log.
 		if err := deleteLogBucket(chanBucket); err != nil {
 			return err
 		}
 
-		err = chainBucket.DeleteNestedBucket(chanPointBuf.Bytes())
-		if err != nil {
+		if err := chainBucket.DeleteNestedBucket(chanKey); err != nil {
 			return err
 		}
 
-		// Fetch the outpoint bucket to see if the outpoint exists or
-		// not.
-		opBucket := tx.ReadWriteBucket(outpointBucket)
-		if opBucket == nil {
-			return ErrNoChanDBExists
-		}
-
-		// Add the closed outpoint to our outpoint index. This should
-		// replace an open outpoint in the index.
-		if opBucket.Get(chanPointBuf.Bytes()) == nil {
-			return ErrMissingIndexEntry
-		}
-
-		status := uint8(outpointClosed)
-
-		// Write the IndexStatus of this outpoint as the first entry in a tlv
-		// stream.
-		statusRecord := tlv.MakePrimitiveRecord(indexStatusType, &status)
-		opStream, err := tlv.NewStream(statusRecord)
-		if err != nil {
+		if err := updateClosedOutpointIndex(tx, chanKey); err != nil {
 			return err
 		}
 
-		var b bytes.Buffer
-		if err := opStream.Encode(&b); err != nil {
-			return err
-		}
-
-		// Finally add the closed outpoint and tlv stream to the index.
-		if err := opBucket.Put(chanPointBuf.Bytes(), b.Bytes()); err != nil {
-			return err
-		}
-
-		// Add channel state to the historical channel bucket.
-		historicalBucket, err := tx.CreateTopLevelBucket(
-			historicalChannelBucket,
-		)
-		if err != nil {
-			return err
-		}
-
-		historicalChanBucket, err :=
-			historicalBucket.CreateBucketIfNotExists(chanKey)
-		if err != nil {
-			return err
-		}
-
-		// Apply any additional statuses to the channel state.
-		for _, status := range statuses {
-			chanState.chanStatus |= status
-		}
-
-		err = putOpenChannel(historicalChanBucket, chanState)
-		if err != nil {
-			return err
-		}
-
-		// Finally, create a summary of this channel in the closed
-		// channel bucket for this node.
-		return putChannelCloseSummary(
-			tx, chanPointBuf.Bytes(), summary, chanState,
+		return archiveClosedChannel(
+			tx, chanKey, chanState, summary, statuses...,
 		)
 	}, func() {})
 }

--- a/channeldb/close_channel_test.go
+++ b/channeldb/close_channel_test.go
@@ -1,0 +1,303 @@
+package channeldb
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/btcsuite/btcd/wire"
+	graphdb "github.com/lightningnetwork/lnd/graph/db"
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/tlv"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTestRevlogEntries writes n entries directly into the
+// revocationLogBucket of the given channel. The helper navigates the raw KV
+// tree so the test does not depend on the higher-level commit-chain
+// machinery.
+func writeTestRevlogEntries(t *testing.T, ch *OpenChannel, n int) {
+	t.Helper()
+
+	err := kvdb.Update(ch.Db.backend, func(tx kvdb.RwTx) error {
+		openChanBkt := tx.ReadWriteBucket(openChannelBucket)
+		require.NotNil(t, openChanBkt, "openChannelBucket missing")
+
+		nodePub := ch.IdentityPub.SerializeCompressed()
+		nodeBkt := openChanBkt.NestedReadWriteBucket(nodePub)
+		require.NotNil(t, nodeBkt, "node bucket missing")
+
+		chainBkt := nodeBkt.NestedReadWriteBucket(ch.ChainHash[:])
+		require.NotNil(t, chainBkt, "chain bucket missing")
+
+		var chanKeyBuf bytes.Buffer
+		err := graphdb.WriteOutpoint(&chanKeyBuf, &ch.FundingOutpoint)
+		require.NoError(t, err)
+
+		chanBkt := chainBkt.NestedReadWriteBucket(chanKeyBuf.Bytes())
+		require.NotNil(t, chanBkt, "channel bucket missing")
+
+		logBkt, err := chanBkt.CreateBucketIfNotExists(
+			revocationLogBucket,
+		)
+		require.NoError(t, err)
+
+		for i := range n {
+			commit := testChannelCommit
+			commit.CommitHeight = uint64(i)
+
+			err := putRevocationLog(logBkt, &commit, 0, 1, false)
+			require.NoError(t, err)
+		}
+
+		return nil
+	}, func() {})
+	require.NoError(t, err)
+}
+
+// writeTestForwardingPackages writes n empty forwarding packages for the
+// given channel using distinct remote commitment heights.
+func writeTestForwardingPackages(t *testing.T, ch *OpenChannel, n int) {
+	t.Helper()
+
+	packager := NewChannelPackager(ch.ShortChanID())
+	err := kvdb.Update(ch.Db.backend, func(tx kvdb.RwTx) error {
+		for i := range n {
+			pkg := NewFwdPkg(
+				ch.ShortChanID(), uint64(i), nil, nil,
+			)
+			if err := packager.AddFwdPkg(tx, pkg); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}, func() {})
+	require.NoError(t, err)
+}
+
+// countRevlogEntries returns the number of entries in the revocationLogBucket
+// for the given channel, or -1 if the channel bucket no longer exists in
+// openChannelBucket.
+func countRevlogEntries(t *testing.T, ch *OpenChannel) int {
+	t.Helper()
+
+	count := -1
+	err := kvdb.View(ch.Db.backend, func(tx kvdb.RTx) error {
+		openChanBkt := tx.ReadBucket(openChannelBucket)
+		if openChanBkt == nil {
+			return nil
+		}
+
+		nodePub := ch.IdentityPub.SerializeCompressed()
+		nodeBkt := openChanBkt.NestedReadBucket(nodePub)
+		if nodeBkt == nil {
+			return nil
+		}
+
+		chainBkt := nodeBkt.NestedReadBucket(ch.ChainHash[:])
+		if chainBkt == nil {
+			return nil
+		}
+
+		var chanKeyBuf bytes.Buffer
+		if err := graphdb.WriteOutpoint(
+			&chanKeyBuf, &ch.FundingOutpoint,
+		); err != nil {
+			return err
+		}
+
+		chanBkt := chainBkt.NestedReadBucket(chanKeyBuf.Bytes())
+		if chanBkt == nil {
+			return nil
+		}
+
+		logBkt := chanBkt.NestedReadBucket(revocationLogBucket)
+		if logBkt == nil {
+			count = 0
+			return nil
+		}
+
+		c := 0
+		if err := logBkt.ForEach(func(_, _ []byte) error {
+			c++
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		count = c
+
+		return nil
+	}, func() {})
+	require.NoError(t, err)
+
+	return count
+}
+
+// readOutpointStatus decodes the indexStatus TLV byte stored under
+// outpointBucket for the given outpoint. Used to verify the index flip
+// performed by the close path.
+func readOutpointStatus(t *testing.T, cdb *ChannelStateDB,
+	op wire.OutPoint) indexStatus {
+
+	t.Helper()
+
+	var chanKeyBuf bytes.Buffer
+	require.NoError(t, graphdb.WriteOutpoint(&chanKeyBuf, &op))
+
+	var status uint8
+	err := kvdb.View(cdb.backend, func(tx kvdb.RTx) error {
+		bkt := tx.ReadBucket(outpointBucket)
+		require.NotNil(t, bkt, "outpointBucket missing")
+
+		raw := bkt.Get(chanKeyBuf.Bytes())
+		require.NotNil(t, raw, "outpoint entry missing")
+
+		statusRecord := tlv.MakePrimitiveRecord(
+			indexStatusType, &status,
+		)
+		stream, err := tlv.NewStream(statusRecord)
+		if err != nil {
+			return err
+		}
+
+		return stream.Decode(bytes.NewReader(raw))
+	}, func() {})
+	require.NoError(t, err)
+
+	return indexStatus(status)
+}
+
+// closeChannelForTest invokes CloseChannel on a freshly created OpenChannel
+// using a minimal close summary derived from the channel state itself.
+func closeChannelForTest(t *testing.T, cdb *ChannelStateDB, ch *OpenChannel) {
+	t.Helper()
+
+	summary := &ChannelCloseSummary{
+		ChanPoint:   ch.FundingOutpoint,
+		RemotePub:   ch.IdentityPub,
+		ChainHash:   ch.ChainHash,
+		ShortChanID: ch.ShortChannelID,
+		CloseType:   CooperativeClose,
+	}
+	require.NoError(t, cdb.CloseChannel(ch, summary))
+}
+
+// TestCloseChannelTombstoneWritePath verifies the on-disk artefacts the
+// tombstone close path produces in a single write transaction: the outpoint
+// index flips from open to closed, the historical-channel record and close
+// summary are written, and the bulk per-channel state (revocation log,
+// forwarding packages) is left intact — that retention is the entire reason
+// for the tombstone path on these backends.
+func TestCloseChannelTombstoneWritePath(t *testing.T) {
+	t.Parallel()
+
+	fullDB, err := MakeTestDB(t, OptionTombstoneClosedChannels(true))
+	require.NoError(t, err)
+
+	cdb := fullDB.ChannelStateDB()
+	require.True(t, cdb.tombstoneClosedChannels)
+
+	ch := createTestChannel(t, cdb, openChannelOption())
+
+	const numRevlogEntries = 5
+	const numFwdPkgs = 3
+	writeTestRevlogEntries(t, ch, numRevlogEntries)
+	writeTestForwardingPackages(t, ch, numFwdPkgs)
+
+	closeChannelForTest(t, cdb, ch)
+
+	// Outpoint index flipped from open to closed — the authoritative
+	// closed-channel marker on tombstone backends.
+	require.Equal(t, outpointClosed, readOutpointStatus(
+		t, cdb, ch.FundingOutpoint,
+	))
+
+	// Historical-channel record exists for this chanKey.
+	histChan, err := cdb.FetchHistoricalChannel(&ch.FundingOutpoint)
+	require.NoError(t, err)
+	require.Equal(t, ch.FundingOutpoint, histChan.FundingOutpoint)
+
+	// Close summary readable via FetchClosedChannel.
+	closeSummary, err := cdb.FetchClosedChannel(&ch.FundingOutpoint)
+	require.NoError(t, err)
+	require.Equal(t, ch.FundingOutpoint, closeSummary.ChanPoint)
+
+	// Bulk state preserved on disk — tombstoning's whole point.
+	require.Equal(t, numRevlogEntries, countRevlogEntries(t, ch))
+
+	packager := NewChannelPackager(ch.ShortChanID())
+	var fwdPkgs []*FwdPkg
+	require.NoError(t, kvdb.View(cdb.backend, func(tx kvdb.RTx) error {
+		fwdPkgs, err = packager.LoadFwdPkgs(tx)
+		return err
+	}, func() {}))
+	require.Len(t, fwdPkgs, numFwdPkgs)
+}
+
+// TestCloseChannelTombstoneRedundantClose verifies that a second CloseChannel
+// call against an already-closed channel is rejected with ErrChannelNotFound
+// rather than silently re-archiving or re-flipping the outpoint. The guard
+// lives in locateOpenChannel.
+func TestCloseChannelTombstoneRedundantClose(t *testing.T) {
+	t.Parallel()
+
+	fullDB, err := MakeTestDB(t, OptionTombstoneClosedChannels(true))
+	require.NoError(t, err)
+
+	cdb := fullDB.ChannelStateDB()
+	ch := createTestChannel(t, cdb, openChannelOption())
+
+	closeChannelForTest(t, cdb, ch)
+
+	summary := &ChannelCloseSummary{
+		ChanPoint:   ch.FundingOutpoint,
+		RemotePub:   ch.IdentityPub,
+		ChainHash:   ch.ChainHash,
+		ShortChanID: ch.ShortChannelID,
+		CloseType:   CooperativeClose,
+	}
+	require.ErrorIs(t, cdb.CloseChannel(ch, summary), ErrChannelNotFound)
+}
+
+// TestCloseChannelSync exercises the synchronous one-shot close path used by
+// backends that do not opt in to tombstones (bbolt, etcd). It locks in the
+// invariant that after CloseChannel returns the channel bucket and its
+// revocation-log entries are already gone, and that the close summary,
+// historical record, and outpoint flip are all in place.
+func TestCloseChannelSync(t *testing.T) {
+	t.Parallel()
+
+	fullDB, err := MakeTestDB(t)
+	require.NoError(t, err)
+
+	cdb := fullDB.ChannelStateDB()
+	require.False(t, cdb.tombstoneClosedChannels)
+
+	ch := createTestChannel(t, cdb, openChannelOption())
+
+	const numRevlogEntries = 4
+	writeTestRevlogEntries(t, ch, numRevlogEntries)
+	writeTestForwardingPackages(t, ch, 3)
+
+	closeChannelForTest(t, cdb, ch)
+
+	// The synchronous path wipes the chanBucket inline, so
+	// countRevlogEntries must report -1 (bucket is gone, not just empty).
+	require.Equal(t, -1, countRevlogEntries(t, ch),
+		"channel bucket must be deleted after sync close")
+
+	// Forwarding packages are wiped inline.
+	var fwdPkgs []*FwdPkg
+	packager := NewChannelPackager(ch.ShortChanID())
+	require.NoError(t, kvdb.View(cdb.backend, func(tx kvdb.RTx) error {
+		fwdPkgs, err = packager.LoadFwdPkgs(tx)
+		return err
+	}, func() {}))
+	require.Empty(t, fwdPkgs)
+
+	// The outpoint index reflects the close.
+	require.Equal(t, outpointClosed, readOutpointStatus(
+		t, cdb, ch.FundingOutpoint,
+	))
+}

--- a/channeldb/close_channel_test.go
+++ b/channeldb/close_channel_test.go
@@ -260,6 +260,109 @@ func TestCloseChannelTombstoneRedundantClose(t *testing.T) {
 	require.ErrorIs(t, cdb.CloseChannel(ch, summary), ErrChannelNotFound)
 }
 
+// TestCloseChannelTombstoneRemovesFromOpenScans verifies that after a
+// tombstone close the channel disappears from every open-channel scan
+// (FetchAllChannels, FetchOpenChannels, FetchPermAndTempPeers) while the
+// outpoint index reflects the close. The bulk historical state remains on
+// disk — that is the entire point of the tombstone path.
+func TestCloseChannelTombstoneRemovesFromOpenScans(t *testing.T) {
+	t.Parallel()
+
+	fullDB, err := MakeTestDB(t, OptionTombstoneClosedChannels(true))
+	require.NoError(t, err)
+
+	cdb := fullDB.ChannelStateDB()
+	require.True(t, cdb.tombstoneClosedChannels)
+
+	// Two channels share an identity pubkey via createTestChannel, so we
+	// can verify the closed one disappears while the other is still
+	// surfaced by per-peer lookups.
+	ch1 := createTestChannel(t, cdb, openChannelOption())
+	ch2 := createTestChannel(t, cdb, openChannelOption())
+
+	const numRevlogEntries = 5
+	writeTestRevlogEntries(t, ch1, numRevlogEntries)
+
+	openChans, err := cdb.FetchAllChannels()
+	require.NoError(t, err)
+	require.Len(t, openChans, 2)
+
+	closeChannelForTest(t, cdb, ch1)
+
+	openChans, err = cdb.FetchAllChannels()
+	require.NoError(t, err)
+	require.Len(t, openChans, 1)
+	require.Equal(
+		t, ch2.FundingOutpoint, openChans[0].FundingOutpoint,
+	)
+
+	openChans, err = cdb.FetchOpenChannels(ch1.IdentityPub)
+	require.NoError(t, err)
+	require.Len(t, openChans, 1)
+	require.Equal(
+		t, ch2.FundingOutpoint, openChans[0].FundingOutpoint,
+	)
+
+	// FetchPermAndTempPeers should still mark the peer as having a closed
+	// channel (via the historical-channel second pass), even though the
+	// open-channel-bucket pass now skips the closed chanKey.
+	peers, err := cdb.FetchPermAndTempPeers(ch1.ChainHash[:])
+	require.NoError(t, err)
+	peerKey := string(ch1.IdentityPub.SerializeCompressed())
+	require.True(t, peers[peerKey].HasOpenOrClosedChan)
+
+	// The bulk historical state stays put — that is the whole point of
+	// the tombstone path on these backends.
+	require.Equal(t, numRevlogEntries, countRevlogEntries(t, ch1))
+
+	// The outpoint index for ch1 must flip to closed; ch2's stays open.
+	require.Equal(t, outpointClosed, readOutpointStatus(
+		t, cdb, ch1.FundingOutpoint,
+	))
+	require.Equal(t, outpointOpen, readOutpointStatus(
+		t, cdb, ch2.FundingOutpoint,
+	))
+}
+
+// TestClosedChannelHiddenFromFetchChannel verifies that a targeted
+// FetchChannel lookup returns ErrChannelNotFound for a closed channel.
+// FetchChannel goes through channelScanner, exercising the closed-state
+// check inside that iteration site rather than the direct fetchChanBucket
+// lookup path.
+func TestClosedChannelHiddenFromFetchChannel(t *testing.T) {
+	t.Parallel()
+
+	fullDB, err := MakeTestDB(t, OptionTombstoneClosedChannels(true))
+	require.NoError(t, err)
+
+	cdb := fullDB.ChannelStateDB()
+	ch := createTestChannel(t, cdb, openChannelOption())
+
+	closeChannelForTest(t, cdb, ch)
+
+	_, err = cdb.FetchChannel(ch.FundingOutpoint)
+	require.ErrorIs(t, err, ErrChannelNotFound)
+}
+
+// TestClosedChannelHiddenFromDirectMethods verifies that direct OpenChannel
+// methods which descend through fetchChanBucket / fetchChanBucketRw observe
+// the closed-state flip and return ErrChannelNotFound rather than reading
+// stale per-channel state.
+func TestClosedChannelHiddenFromDirectMethods(t *testing.T) {
+	t.Parallel()
+
+	fullDB, err := MakeTestDB(t, OptionTombstoneClosedChannels(true))
+	require.NoError(t, err)
+
+	cdb := fullDB.ChannelStateDB()
+	ch := createTestChannel(t, cdb, openChannelOption())
+
+	closeChannelForTest(t, cdb, ch)
+
+	require.ErrorIs(t, ch.Refresh(), ErrChannelNotFound)
+	require.ErrorIs(t, ch.MarkBorked(), ErrChannelNotFound)
+}
+
 // TestCloseChannelSync exercises the synchronous one-shot close path used by
 // backends that do not opt in to tombstones (bbolt, etcd). It locks in the
 // invariant that after CloseChannel returns the channel bucket and its

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -418,7 +418,8 @@ func CreateWithBackend(backend kvdb.Backend, modifiers ...OptionModifier) (*DB,
 			linkNodeDB: &LinkNodeDB{
 				backend: backend,
 			},
-			backend: backend,
+			backend:                 backend,
+			tombstoneClosedChannels: opts.tombstoneClosedChannels,
 		},
 		clock:                     opts.clock,
 		dryRun:                    opts.dryRun,
@@ -548,6 +549,12 @@ type ChannelStateDB struct {
 	// backend points to the actual backend holding the channel state
 	// database. This may be a real backend or a cache middleware.
 	backend kvdb.Backend
+
+	// tombstoneClosedChannels is set by OptionTombstoneClosedChannels.
+	// When true, CloseChannel skips deleting nested per-channel state and
+	// relies on the outpointBucket flip to outpointClosed as the
+	// authoritative closed-channel signal.
+	tombstoneClosedChannels bool
 }
 
 // GetParentDB returns the "main" channeldb.DB object that is the owner of this

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -628,7 +628,7 @@ func (c *ChannelStateDB) fetchOpenChannels(tx kvdb.RTx,
 
 		// Finally, we both of the necessary buckets retrieved, fetch
 		// all the active channels related to this node.
-		nodeChannels, err := c.fetchNodeChannels(chainBucket)
+		nodeChannels, err := c.fetchNodeChannels(tx, chainBucket)
 		if err != nil {
 			return fmt.Errorf("unable to read channel for "+
 				"chain_hash=%x, node_key=%x: %v",
@@ -644,11 +644,18 @@ func (c *ChannelStateDB) fetchOpenChannels(tx kvdb.RTx,
 
 // fetchNodeChannels retrieves all active channels from the target chainBucket
 // which is under a node's dedicated channel bucket. This function is typically
-// used to fetch all the active channels related to a particular node.
-func (c *ChannelStateDB) fetchNodeChannels(chainBucket kvdb.RBucket) (
-	[]*OpenChannel, error) {
+// used to fetch all the active channels related to a particular node. Channels
+// already flipped to outpointClosed in the outpoint index are skipped silently
+// — readers see only channels that are still considered open.
+func (c *ChannelStateDB) fetchNodeChannels(tx kvdb.RTx,
+	chainBucket kvdb.RBucket) ([]*OpenChannel, error) {
 
 	var channels []*OpenChannel
+
+	// Hoist the outpoint-bucket lookup so the closed-channel check inside
+	// the loop is a per-iteration map probe rather than a tx-level bucket
+	// resolve.
+	opBucket := tx.ReadBucket(outpointBucket)
 
 	// A node may have channels on several chains, so for each known chain,
 	// we'll extract all the channels.
@@ -658,12 +665,24 @@ func (c *ChannelStateDB) fetchNodeChannels(chainBucket kvdb.RBucket) (
 			return nil
 		}
 
+		// Skip already-closed channels. The chanBucket still exists
+		// on disk on tombstone-enabled backends; the outpoint flip is
+		// the sole signal that the channel should be treated as
+		// closed.
+		isClosed, err := isOutpointClosed(opBucket, chanPoint)
+		if err != nil {
+			return err
+		}
+		if isClosed {
+			return nil
+		}
+
 		// Once we've found a valid channel bucket, we'll extract it
 		// from the node's chain bucket.
 		chanBucket := chainBucket.NestedReadBucket(chanPoint)
 
 		var outPoint wire.OutPoint
-		err := graphdb.ReadOutpoint(
+		err = graphdb.ReadOutpoint(
 			bytes.NewReader(chanPoint), &outPoint,
 		)
 		if err != nil {
@@ -778,6 +797,11 @@ func (c *ChannelStateDB) FetchPermAndTempPeers(
 			return ErrNoChanDBExists
 		}
 
+		// Hoist the outpoint-bucket lookup so the closed-channel check
+		// inside the nested chainBucket.ForEach below is a per-channel
+		// map probe rather than a tx-level bucket resolve.
+		opBucket := tx.ReadBucket(outpointBucket)
+
 		openChanErr := openChanBucket.ForEach(func(nodePub,
 			v []byte) error {
 
@@ -808,6 +832,22 @@ func (c *ChannelStateDB) FetchPermAndTempPeers(
 
 				// If there is a value, this is not a bucket.
 				if val != nil {
+					return nil
+				}
+
+				// Skip already-closed channels: they are
+				// logically closed even though their
+				// per-channel state still resides under
+				// chainBucket. The closed peer's protected
+				// status is established below via the
+				// historical-channel scan.
+				isClosed, err := isOutpointClosed(
+					opBucket, chanPoint,
+				)
+				if err != nil {
+					return err
+				}
+				if isClosed {
 					return nil
 				}
 
@@ -983,6 +1023,11 @@ func (c *ChannelStateDB) channelScanner(tx kvdb.RTx,
 			return ErrNoActiveChannels
 		}
 
+		// Hoist the outpoint-bucket lookup so the closed-channel
+		// check inside the per-chain ForEach below pays one tx-level
+		// bucket resolve total instead of one per visited chanKey.
+		opBucket := tx.ReadBucket(outpointBucket)
+
 		// Within the node channel bucket, are the set of node pubkeys
 		// we have channels with, we don't know the entire set, so we'll
 		// check them all.
@@ -1029,6 +1074,19 @@ func (c *ChannelStateDB) channelScanner(tx kvdb.RTx,
 					return nil
 				} else if err != nil {
 					return err
+				}
+
+				// An already-closed channel is logically gone
+				// and must not be surfaced by lookup-style
+				// scans.
+				isClosed, err := isOutpointClosed(
+					opBucket, targetChanBytes,
+				)
+				if err != nil {
+					return err
+				}
+				if isClosed {
+					return nil
 				}
 
 				chanBucket := chainBucket.NestedReadBucket(
@@ -1194,7 +1252,9 @@ func fetchChannels(c *ChannelStateDB, filters ...fetchChannelsFilter) (
 						"bucket for chain=%x", chainHash[:])
 				}
 
-				nodeChans, err := c.fetchNodeChannels(chainBucket)
+				nodeChans, err := c.fetchNodeChannels(
+					tx, chainBucket,
+				)
 				if err != nil {
 					return fmt.Errorf("unable to read "+
 						"channel for chain_hash=%x, "+

--- a/channeldb/options.go
+++ b/channeldb/options.go
@@ -71,6 +71,16 @@ type Options struct {
 	// storeFinalHtlcResolutions determines whether to persistently store
 	// the final resolution of incoming htlcs.
 	storeFinalHtlcResolutions bool
+
+	// tombstoneClosedChannels, when true, instructs CloseChannel to skip
+	// the cascading deletion of nested per-channel state and rely on the
+	// outpoint-index flip to mark the channel as closed. KV-over-SQL
+	// backends (sqlite, postgres) opt in because nested-bucket deletes
+	// inside a write transaction translate into a long-running
+	// ON DELETE CASCADE that holds the database write-lock for many
+	// seconds on long-lived channels. bbolt and etcd leave this off; the
+	// synchronous delete is already cheap there.
+	tombstoneClosedChannels bool
 }
 
 // DefaultOptions returns an Options populated with default values.
@@ -149,5 +159,16 @@ func OptionWithDecayedLogDB(decayedLog kvdb.Backend) OptionModifier {
 func OptionGcDecayedLog(noGc bool) OptionModifier {
 	return func(o *Options) {
 		o.OptionalMiragtionConfig.MigrationFlags[1] = !noGc
+	}
+}
+
+// OptionTombstoneClosedChannels controls whether CloseChannel skips the
+// cascading deletion of nested per-channel state and relies on the
+// outpoint-index flip to mark the channel as closed. Set this to true on
+// KV-over-SQL backends (sqlite, postgres); leave it false for bbolt and
+// etcd.
+func OptionTombstoneClosedChannels(enabled bool) OptionModifier {
+	return func(o *Options) {
+		o.tombstoneClosedChannels = enabled
 	}
 }

--- a/config_builder.go
+++ b/config_builder.go
@@ -1072,6 +1072,15 @@ func (d *DefaultDatabaseBuilder) BuildDatabase(
 		)
 	}
 
+	// KV-over-SQL backends (sqlite, postgres) opt in to closing channels
+	// via tombstone markers because nested-bucket deletes inside a write
+	// transaction translate into a long-running ON DELETE CASCADE on the
+	// kvdb-on-SQL schema, holding the database write-lock for many seconds
+	// on long-lived channels. bbolt and etcd keep the synchronous one-shot
+	// close path, where nested-bucket deletion is already cheap.
+	tombstoneClosedChans := cfg.DB.Backend == lncfg.SqliteBackend ||
+		cfg.DB.Backend == lncfg.PostgresBackend
+
 	dbOptions := []channeldb.OptionModifier{
 		channeldb.OptionDryRunMigration(cfg.DryRunMigration),
 		channeldb.OptionStoreFinalHtlcResolutions(
@@ -1081,6 +1090,7 @@ func (d *DefaultDatabaseBuilder) BuildDatabase(
 		channeldb.OptionNoRevLogAmtData(cfg.DB.NoRevLogAmtData),
 		channeldb.OptionGcDecayedLog(cfg.DB.NoGcDecayedLog),
 		channeldb.OptionWithDecayedLogDB(dbs.DecayedLogDB),
+		channeldb.OptionTombstoneClosedChannels(tombstoneClosedChans),
 	}
 
 	// Otherwise, we'll open two instances, one for the state we only need

--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -285,6 +285,37 @@
     public-only path sees a ~42% speedup; on the previous code it could stall
     for minutes.
 
+* [Tombstone closed channels on KV-over-SQL
+  backends](https://github.com/lightningnetwork/lnd/pull/10780). Closing a
+  long-lived channel previously issued a single `DeleteNestedBucket` inside
+  the close transaction. On the kvdb-on-SQL schema (sqlite, postgres) that
+  delete fans out into a row-by-row `ON DELETE CASCADE` over the channel's
+  revocation log and forwarding-package bucket, holding the database
+  write-lock for many seconds — long enough on channels with millions of
+  states to stall HTLC forwarding, time out htlcswitch retries, and trigger
+  force-close cycles. `CloseChannel` now skips the cascading delete on
+  these backends; the outpoint-index flip from `outpointOpen` to
+  `outpointClosed` (already performed by the existing close path) is the
+  authoritative closed-channel marker, and every reader of the open-channel
+  bucket consults it before treating a channel as open. The bulk historical
+  state — the chanBucket itself, the revocation log, and the per-channel
+  forwarding-package bucket — remains on disk for the channel's lifetime in
+  this database and is reclaimed wholesale by the upcoming native-SQL
+  channel-state migration. bbolt and etcd retain the synchronous one-shot
+  close path, where nested-bucket deletion is already cheap.
+
+  > ⚠️ **Downgrade warning.** On sqlite/postgres, once a channel is
+  > closed under this build the chanBucket and its nested state remain
+  > on disk; the close is signalled only by the `outpointClosed` flip
+  > in the outpoint index. Earlier `lnd` releases do not consult that
+  > flip when iterating `openChannelBucket`, so downgrading to a
+  > pre-0.21 binary after closing channels on these backends will
+  > resurrect those channels as open in `listchannels`,
+  > `pendingchannels`, and the chain-watch path. Operators who close
+  > channels on sqlite/postgres after upgrading should treat the
+  > upgrade as one-way for that database; bbolt and etcd users are unaffected 
+  > because the close path on those backends still deletes the chanBucket.
+
 ## Deprecations
 
 ### ⚠️ **Warning:** Deprecated fields in `lnrpc.Hop` will be removed in release version **0.22**

--- a/itest/lnd_wipe_fwdpkgs_test.go
+++ b/itest/lnd_wipe_fwdpkgs_test.go
@@ -85,13 +85,28 @@ func testWipeForwardingPackages(ht *lntest.HarnessTest) {
 	// close channel should now become pending force closed channel.
 	pendingAB = ht.AssertChannelPendingForceClose(bob, chanPointAB).Channel
 
-	// Check the forwarding pacakges are deleted.
-	require.Zero(ht, pendingAB.NumForwardingPackages)
+	// On backends that close channels via tombstone markers (sqlite,
+	// postgres), the per-channel forwarding-package bucket is left on
+	// disk by design — the synchronous close path's nested-bucket
+	// delete is exactly what tombstoning avoids. The bytes are reclaimed
+	// by the upcoming native-SQL channel-state migration. The unit-test
+	// suite in channeldb covers the tombstone semantics directly, so
+	// here we just skip the post-close fwd-pkg assertions on those
+	// backends while still exercising the rest of the close flow for
+	// backend symmetry.
+	if !ht.UsesClosedChanTombstones() {
+		require.Zero(ht, pendingAB.NumForwardingPackages)
 
-	// For Alice, the forwarding packages should have been wiped too.
-	pending := ht.AssertChannelPendingForceClose(alice, chanPointAB)
-	pendingAB = pending.Channel
-	require.Zero(ht, pendingAB.NumForwardingPackages)
+		// For Alice, the forwarding packages should have been wiped
+		// too.
+		pending := ht.AssertChannelPendingForceClose(alice, chanPointAB)
+		pendingAB = pending.Channel
+		require.Zero(ht, pendingAB.NumForwardingPackages)
+	} else {
+		// Still drive Alice's pending-force-close lookup so the rest
+		// of the test stays backend-symmetric.
+		ht.AssertChannelPendingForceClose(alice, chanPointAB)
+	}
 
 	// Alice should one pending sweep.
 	ht.AssertNumPendingSweeps(alice, 1)

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -1444,6 +1444,18 @@ func (h *HarnessTest) IsPostgresBackend() bool {
 	return h.manager.dbBackend == node.BackendPostgres
 }
 
+// UsesClosedChanTombstones reports whether the test harness's database
+// backend closes channels via tombstone markers rather than cascading the
+// nested-bucket delete. This is true on the KV-over-SQL backends (sqlite,
+// postgres) and false on bbolt. Tests that observe forwarding-package or
+// revocation-log deletion immediately after a channel close should consult
+// this predicate; on tombstone backends the bulk state remains on disk
+// until the upcoming native-SQL channel-state migration reclaims it.
+func (h *HarnessTest) UsesClosedChanTombstones() bool {
+	return h.manager.dbBackend == node.BackendSqlite ||
+		h.manager.dbBackend == node.BackendPostgres
+}
+
 // fundCoins attempts to send amt satoshis from the internal mining node to the
 // targeted lightning node. The confirmed boolean indicates whether the
 // transaction that pays to the target should confirm. For neutrino backend,


### PR DESCRIPTION
## Problem

Closing a Lightning channel with millions of states issues a single
`chainBucket.DeleteNestedBucket(chanKey)` inside the close transaction.
On the kvdb-on-SQL schema (SQLite, Postgres) that delete fans out into
a row-by-row `ON DELETE CASCADE` over the channel's revocation log and
per-channel forwarding-package bucket, holding the database write-lock
for many seconds. Production reports from routing nodes (@warioishere,
@AuthenticityBTC on #10732) describe **30–45 minute stalls** on
channels with 1.5M+ states — long enough to time out HTLC forwarding,
miss revocations, and trigger force-close cycles on busy peers.

## Solution

Add `OptionTombstoneClosedChannels`. When enabled, `CloseChannel`
skips the cascading delete entirely: the chanBucket and its nested
state stay on disk, and the existing outpoint-index flip from
`outpointOpen` to `outpointClosed` (performed by the shared
`updateClosedOutpointIndex` helper) is the authoritative closed-channel
marker. Every reader of `openChannelBucket` consults that flip via
`isOutpointClosed` before treating a chanKey as open. The historical
record and close summary are written exactly as before — uniform shape
across both close strategies — so closed-channel and historical lookups
need no backend awareness.

The bulk historical state stays on disk for the channel's lifetime in
this database. Disk space is reclaimed wholesale by the upcoming
native-SQL channel-state migration, which can drop the legacy KV
tables without per-channel iteration.

bbolt and etcd retain the synchronous one-shot close path, where
nested-bucket deletion is already cheap.


## Relationship to #10732

This implements the design proposed by @yyforyongyu on #10732 in place
of the more complex async-cleanup approach. Disk-space reclamation was
identified as non-urgent by the affected operators (@warioishere,
@AuthenticityBTC); the urgent issue is the close-time stall, which a
logical-deletion approach resolves with substantially less surface
area than a cleanup worker. #10732 is superseded by this PR.

## Tombstone close path

`closeChannelTombstone` runs a single transaction:

1. Locate the chanBucket via `locateOpenChannel`. The helper rejects
   already-closed chanKeys (outpointClosed already set) with
   `ErrChannelNotFound`, so a redundant CloseChannel is a no-op.
2. Fetch the open-channel state for the historical archive.
3. Flip the outpoint index entry from `outpointOpen` to
   `outpointClosed` via `updateClosedOutpointIndex`.
4. Archive a copy of the chanState (with close-status flags OR'd in)
   under `historicalChannelBucket` and write the close summary under
   `closeSummaryBucket`.

Zero deletions. The chanBucket — `chanInfoKey`, both commitment heads,
`revocationStateKey`, `commitDiffKey`, the rev-log nested bucket, the
per-channel fwd-pkg bucket — is left byte-for-byte identical to its
state at the last commitment update.


## Operator-visible consequences on sqlite/postgres

Two trade-offs are documented in the release note:

- **Open-channel scans grow with closed-channel history.** Every full
  scan iterates the union of currently-open and ever-closed channels
  under each chainBucket and decodes the outpoint-index entry per
  chanKey. Cost grows monotonically with total channel history; the
  native-SQL migration restores `O(open)` by reclaiming closed-channel
  rows.
- **`NumForwardingPackages` may be non-zero for closed channels.** The
  forwarding-package bucket survives the close on tombstone backends,
  so `pendingchannels` may report non-zero for pending-force-close and
  waiting-close channels. The field is informational only and does not
  affect HTLC resolution; it goes to zero after the migration.

A `⚠️ Downgrade warning` in the release note also calls out that
rolling back to a pre-0.21 binary after closing channels on
sqlite/postgres will resurrect those channels as open (older releases
do not consult the outpoint flip). bbolt/etcd users are unaffected.

