### PR TITLE
cmd/commands: read full stdin for lncli unlock --stdin

### DIFF
--- a/cmd/commands/cmd_walletunlocker.go
+++ b/cmd/commands/cmd_walletunlocker.go
@@ -543,11 +543,16 @@ func unlockWithDeps(ctx *cli.Context,
 	// password manager. If the user types the password instead, it will be
 	// echoed in the console.
 	case ctx.IsSet("stdin"):
-		reader := bufio.NewReader(stdin)
-		pw, err = reader.ReadBytes('\n')
-
-		// Remove carriage return and newline characters.
-		pw = bytes.Trim(pw, "\r\n")
+		// Read until EOF so passwords containing newline bytes are
+		// preserved. A single trailing newline (with optional CR) is
+		// stripped so the common `echo "pw" | lncli unlock --stdin`
+		// usage keeps working.
+		pw, err = io.ReadAll(stdin)
+		if err != nil {
+			return err
+		}
+		pw = bytes.TrimSuffix(pw, []byte{'\n'})
+		pw = bytes.TrimSuffix(pw, []byte{'\r'})
 
 	// Read the password from a terminal by default. This requires the
 	// terminal to be a real tty and will fail if a string is piped into

--- a/cmd/commands/cmd_walletunlocker_test.go
+++ b/cmd/commands/cmd_walletunlocker_test.go
@@ -266,6 +266,85 @@ func TestUnlock(t *testing.T) {
 			},
 		},
 
+		// Password piped via stdin contains an embedded newline.
+		// Reading must consume everything up to EOF, preserving the
+		// embedded newline byte.
+		{
+			name:       "success_stdin_embedded_newline",
+			args:       []string{"--stdin"},
+			stdinInput: "first\nsecond\n",
+			stateStreams: []stateStreamSpec{
+				{
+					states: []lnrpc.WalletState{
+						lnrpc.WalletState_LOCKED,
+					},
+				},
+				{
+					states: []lnrpc.WalletState{
+						lnrpc.WalletState_RPC_ACTIVE,
+					},
+				},
+			},
+			expectReadPasswordCalls: 0,
+			expectUnlockCalls:       1,
+			expectSubscribeCalls:    2,
+			expectReq: &lnrpc.UnlockWalletRequest{
+				WalletPassword: []byte("first\nsecond"),
+			},
+		},
+
+		// Password piped via stdin without any trailing newline (e.g.
+		// `printf %s pw | lncli unlock --stdin`).
+		{
+			name:       "success_stdin_no_trailing_newline",
+			args:       []string{"--stdin"},
+			stdinInput: "secret",
+			stateStreams: []stateStreamSpec{
+				{
+					states: []lnrpc.WalletState{
+						lnrpc.WalletState_LOCKED,
+					},
+				},
+				{
+					states: []lnrpc.WalletState{
+						lnrpc.WalletState_RPC_ACTIVE,
+					},
+				},
+			},
+			expectReadPasswordCalls: 0,
+			expectUnlockCalls:       1,
+			expectSubscribeCalls:    2,
+			expectReq: &lnrpc.UnlockWalletRequest{
+				WalletPassword: []byte("secret"),
+			},
+		},
+
+		// Password piped via stdin with a CRLF terminator: only the
+		// final \r\n pair is stripped.
+		{
+			name:       "success_stdin_crlf_terminator",
+			args:       []string{"--stdin"},
+			stdinInput: "secret\r\n",
+			stateStreams: []stateStreamSpec{
+				{
+					states: []lnrpc.WalletState{
+						lnrpc.WalletState_LOCKED,
+					},
+				},
+				{
+					states: []lnrpc.WalletState{
+						lnrpc.WalletState_RPC_ACTIVE,
+					},
+				},
+			},
+			expectReadPasswordCalls: 0,
+			expectUnlockCalls:       1,
+			expectSubscribeCalls:    2,
+			expectReq: &lnrpc.UnlockWalletRequest{
+				WalletPassword: []byte("secret"),
+			},
+		},
+
 		// Uses positional recovery window argument.
 		{
 			name:            "success_arg_recovery_window",

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -55,6 +55,10 @@
   the reported network statistics such as total network capacity, channel
   count and max out degree.
 
+* [`lncli unlock --stdin`](https://github.com/lightningnetwork/lnd/pull/10784)
+  now reads the password until EOF instead of stopping at the first newline,
+  so passwords containing embedded newline bytes are accepted.
+
 # New Features
 
 ## Functional Enhancements

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -47,6 +47,10 @@
   the reported network statistics such as total network capacity, channel
   count and max out degree.
 
+* [`lncli unlock --stdin`](https://github.com/lightningnetwork/lnd/pull/10784)
+  now reads the password until EOF instead of stopping at the first newline,
+  so passwords containing embedded newline bytes are accepted.
+
 # New Features
 
 ## Functional Enhancements


### PR DESCRIPTION
## Change Description

`lncli unlock --stdin` reads the password using `bufio.ReadBytes('\n')`, which terminates at the first newline byte. A wallet password that legitimately contains a newline (for example one generated from random bytes) gets silently truncated, and the unlock fails even though the same password works fine over REST/gRPC.

This switches the `--stdin` branch in `cmd/commands/cmd_walletunlocker.go` to `io.ReadAll(stdin)` so the password is consumed up to EOF, and trims a single trailing `\n` (with optional `\r`) so the common `echo "pw" | lncli unlock --stdin` invocation still works as before. Three new table-driven test cases cover an embedded newline, a stdin payload with no trailing newline, and a CRLF terminator.

Fixes #5584.

## Steps to Test

1. `go test ./cmd/commands/... -run TestUnlock -v` — all `success_stdin_*` subtests pass.
2. Manual end-to-end:
   ```
   printf 'first\nsecond' > /tmp/pw
   lncli create   # set wallet password to "first\nsecond" via this file
   lncli unlock --stdin < /tmp/pw   # previously rejected, now succeeds
   ```

## Pull Request Checklist

### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not insubstantial (typo fixes not accepted).
- [x] Adheres to Code Documentation and Commenting guidelines, 80-char line wraps.
- [x] Commits follow Ideal Git Commit Structure.
- [x] Any new logging statements use appropriate subsystem and level.
- [x] Any new lncli commands have tags in proto comments.
- [x] Release notes added (or [skip ci] in commit message for small changes).
