### PR TITLE
chanstate: migrate consumers to Store interface (PR 2 of channel-state decomposition)

### DIFF
--- a/channelnotifier/channelnotifier.go
+++ b/channelnotifier/channelnotifier.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/chanstate"
 	"github.com/lightningnetwork/lnd/subscribe"
 )
 
@@ -17,7 +18,7 @@ type ChannelNotifier struct {
 
 	ntfnServer *subscribe.Server
 
-	chanDB *channeldb.ChannelStateDB
+	chanDB chanstate.Store
 }
 
 // PendingOpenChannelEvent represents a new event where a new channel has
@@ -97,7 +98,7 @@ type FundingTimeoutEvent struct {
 // New creates a new channel notifier. The ChannelNotifier gets channel
 // events from peers and from the chain arbitrator, and dispatches them to
 // its clients.
-func New(chanDB *channeldb.ChannelStateDB) *ChannelNotifier {
+func New(chanDB chanstate.Store) *ChannelNotifier {
 	return &ChannelNotifier{
 		ntfnServer: subscribe.NewServer(),
 		chanDB:     chanDB,

--- a/chanrestore.go
+++ b/chanrestore.go
@@ -11,6 +11,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/chanbackup"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/chanstate"
 	"github.com/lightningnetwork/lnd/contractcourt"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -35,7 +36,7 @@ const (
 // need the secret key chain in order obtain the prior shachain root so we can
 // verify the DLP protocol as initiated by the remote node.
 type chanDBRestorer struct {
-	db *channeldb.ChannelStateDB
+	db chanstate.OpenChannelStore
 
 	secretKeys keychain.SecretKeyRing
 

--- a/contractcourt/breach_arbitrator.go
+++ b/contractcourt/breach_arbitrator.go
@@ -14,7 +14,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/chainntnfs"
-	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/chanstate"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	graphdb "github.com/lightningnetwork/lnd/graph/db"
 	"github.com/lightningnetwork/lnd/input"
@@ -140,10 +140,9 @@ type BreachConfig struct {
 	// a close type to be included in the channel close summary.
 	CloseLink func(*wire.OutPoint, ChannelCloseType)
 
-	// DB provides access to the user's channels, allowing the breach
-	// arbiter to determine the current state of a user's channels, and how
-	// it should respond to channel closure.
-	DB *channeldb.ChannelStateDB
+	// DB provides access to the user's closed channels, allowing the breach
+	// arbiter to determine how it should respond to channel closure.
+	DB chanstate.ClosedChannelStore
 
 	// Estimator is used by the breach arbiter to determine an appropriate
 	// fee level when generating, signing, and broadcasting sweep

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/chanacceptor"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/chanstate"
 	"github.com/lightningnetwork/lnd/discovery"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/graph"
@@ -384,8 +385,9 @@ type Config struct {
 	// so that the channel creation process can be completed.
 	Notifier chainntnfs.ChainNotifier
 
-	// ChannelDB is the database that keeps track of all channel state.
-	ChannelDB *channeldb.ChannelStateDB
+	// ChannelDB is the database that keeps track of channel state used by
+	// the funding flow.
+	ChannelDB chanstate.Store
 
 	// SignMessage signs an arbitrary message with a given public key. The
 	// actual digest signed is the double sha-256 of the message. In the

--- a/lnrpc/invoicesrpc/addinvoice.go
+++ b/lnrpc/invoicesrpc/addinvoice.go
@@ -18,6 +18,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/chanstate"
 	"github.com/lightningnetwork/lnd/graph/db/models"
 	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -70,9 +71,8 @@ type AddInvoiceConfig struct {
 	// specified.
 	DefaultCLTVExpiry uint32
 
-	// ChanDB is a global boltdb instance which is needed to access the
-	// channel graph.
-	ChanDB *channeldb.ChannelStateDB
+	// ChanDB is used to access open channel state.
+	ChanDB chanstate.OpenChannelStore
 
 	// Graph gives the invoice server access to various graph related
 	// queries.

--- a/lnrpc/invoicesrpc/config_active.go
+++ b/lnrpc/invoicesrpc/config_active.go
@@ -5,7 +5,7 @@ package invoicesrpc
 
 import (
 	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/chanstate"
 	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/macaroons"
@@ -55,9 +55,9 @@ type Config struct {
 	// graph.
 	Graph GraphSource
 
-	// ChanStateDB is a possibly replicated db instance which contains the
-	// channel state
-	ChanStateDB *channeldb.ChannelStateDB
+	// ChanStateDB is a possibly replicated db instance which contains open
+	// channel state.
+	ChanStateDB chanstate.OpenChannelStore
 
 	// GenInvoiceFeatures returns a feature containing feature bits that
 	// should be advertised on freshly generated invoices.

--- a/lnrpc/walletrpc/config_active.go
+++ b/lnrpc/walletrpc/config_active.go
@@ -6,7 +6,7 @@ package walletrpc
 import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcwallet/wallet"
-	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/chanstate"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
@@ -78,6 +78,6 @@ type Config struct {
 	// coins when funding a transaction.
 	CoinSelectionStrategy wallet.CoinSelectionStrategy
 
-	// ChanStateDB is the reference to the channel db.
-	ChanStateDB *channeldb.ChannelStateDB
+	// ChanStateDB is the reference to the open channel store.
+	ChanStateDB chanstate.OpenChannelStore
 }

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -26,6 +26,7 @@ import (
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/channelnotifier"
+	"github.com/lightningnetwork/lnd/chanstate"
 	"github.com/lightningnetwork/lnd/contractcourt"
 	"github.com/lightningnetwork/lnd/discovery"
 	"github.com/lightningnetwork/lnd/feature"
@@ -259,8 +260,8 @@ type Config struct {
 	// ChannelLinkConfig.
 	InterceptSwitch *htlcswitch.InterceptableSwitch
 
-	// ChannelDB is used to fetch opened channels, and closed channels.
-	ChannelDB *channeldb.ChannelStateDB
+	// ChannelDB is used to fetch channel state needed by the peer.
+	ChannelDB chanstate.Store
 
 	// ChannelGraph is a pointer to the channel graph which is used to
 	// query information about the set of known active channels.

--- a/server.go
+++ b/server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/lightningnetwork/lnd/chanfitness"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/channelnotifier"
+	"github.com/lightningnetwork/lnd/chanstate"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/cluster"
 	"github.com/lightningnetwork/lnd/contractcourt"
@@ -325,7 +326,8 @@ type server struct {
 	graphDB *graphdb.ChannelGraph
 	v1Graph *graphdb.VersionedGraph
 
-	chanStateDB *channeldb.ChannelStateDB
+	chanStateDB chanstate.Store
+	linkNodeDB  *channeldb.LinkNodeDB
 
 	addrSource channeldb.AddrSource
 
@@ -728,13 +730,15 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 	)
 
 	addrSource := channeldb.NewMultiAddrSource(dbs.ChanStateDB, v1Graph)
+	chanStateDB := dbs.ChanStateDB.ChannelStateDB()
 
 	s := &server{
 		cfg:            cfg,
 		implCfg:        implCfg,
 		graphDB:        dbs.GraphDB,
 		v1Graph:        v1Graph,
-		chanStateDB:    dbs.ChanStateDB.ChannelStateDB(),
+		chanStateDB:    chanStateDB,
+		linkNodeDB:     chanStateDB.LinkNodeDB(),
 		addrSource:     addrSource,
 		miscDB:         dbs.ChanStateDB,
 		invoicesDB:     dbs.InvoiceDB,
@@ -748,9 +752,7 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 		blockbeatDispatcher: chainio.NewBlockbeatDispatcher(
 			cc.ChainNotifier,
 		),
-		channelNotifier: channelnotifier.New(
-			dbs.ChanStateDB.ChannelStateDB(),
-		),
+		channelNotifier: channelnotifier.New(chanStateDB),
 
 		identityECDH:   nodeKeyECDH,
 		identityKeyLoc: nodeKeyDesc.KeyLocator,
@@ -3610,7 +3612,7 @@ func (s *server) establishPersistentConnections(ctx context.Context) error {
 	// Iterate through the list of LinkNodes to find addresses we should
 	// attempt to connect to based on our set of previous connections. Set
 	// the reconnection port to the default peer port.
-	linkNodes, err := s.chanStateDB.LinkNodeDB().FetchAllLinkNodes()
+	linkNodes, err := s.linkNodeDB.FetchAllLinkNodes()
 	if err != nil && !errors.Is(err, channeldb.ErrLinkNodesNotFound) {
 		return fmt.Errorf("failed to fetch all link nodes: %w", err)
 	}

--- a/subrpcserver_config.go
+++ b/subrpcserver_config.go
@@ -11,7 +11,7 @@ import (
 	"github.com/lightningnetwork/lnd/aliasmgr"
 	"github.com/lightningnetwork/lnd/autopilot"
 	"github.com/lightningnetwork/lnd/chainreg"
-	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/chanstate"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	graphdb "github.com/lightningnetwork/lnd/graph/db"
 	"github.com/lightningnetwork/lnd/htlcswitch"
@@ -115,7 +115,7 @@ func (s *subRPCServerConfigs) PopulateDependencies(cfg *Config,
 	routerBackend *routerrpc.RouterBackend,
 	nodeSigner *netann.NodeSigner,
 	graphDB *graphdb.ChannelGraph,
-	chanStateDB *channeldb.ChannelStateDB,
+	chanStateDB chanstate.Store,
 	sweeper *sweep.UtxoSweeper,
 	tower *watchtower.Standalone,
 	towerClientMgr *wtclient.Manager,


### PR DESCRIPTION
## Summary

Second PR in the channel-state decomposition series. Migrates every
in-tree consumer of `*channeldb.ChannelStateDB` over to the
[`chanstate.Store`](https://github.com/lightningnetwork/lnd/pull/10777)
interface introduced in PR 1, so subsequent PRs can swap in the
KV-backed and SQL-backed `Store` implementations without further churn
to call sites.

No data moves and no behavior changes — every commit is a pure
dependency-injection swap. The interface contract was sized in PR 1
exactly to cover the union of method calls touched by these consumers,
so each commit compiles against `Store` without expanding the
interface.

Stacked on top of #10777. Until that lands, this PR's diff includes
its 4 commits; once 10777 merges into
`elle-base-branch-channelstate-native-sql`, the diff here collapses to
the 8 commits below.

Seven consumer commits, one release-note commit:

1. `funding: depend on chanstate Store` — funding manager only uses
   methods covered by the store contract, including channel-opening
   state and initial forwarding policy persistence.
2. `peer: depend on chanstate Store` — Brontide only needs channel
   lookups, closed-channel lookup, and initial forwarding policy
   access.
3. `channelnotifier: depend on chanstate Store` — notifier only fetches
   open and closed channel records to populate event payloads.
4. `contractcourt: use chanstate Store in breach arb` — breach
   arbitrator only needs closed-channel reads and
   `MarkChanFullyClosed`.
5. `lnd: use chanstate Store for channel restore` — `chanDBRestorer`
   only needs `RestoreChannelShells`; it still builds `channeldb`
   channel-shell values.
6. `lnrpc: depend on chanstate Store` — invoices/wallet RPC configs
   and subserver wiring; only hop-hint and waiting-close paths are
   touched.
7. `server: depend on chanstate Store` — server now holds channel-state
   access as `chanstate.Store`. Link-node access stays a separate
   concrete `*channeldb.LinkNodeDB` field so `LinkNodeDB` does not leak
   into the channel-state contract.
8. `docs: release note for chanstate Store consumer migration` —
   sibling bullet under the existing v0.22 \"Native SQL migration of
   the channel state and switch data\" heading.

## Test plan

- [x] `go build ./...` clean
- [x] `make unit` passes for affected packages (`funding`, `peer`,
      `channelnotifier`, `contractcourt`, `lnrpc`, `chanstate`)
- [x] `make lint` clean
- [x] Compile-time assertion in `chanstate` (added in #10777) still
      catches any signature drift between `Store` and
      `*channeldb.ChannelStateDB`