### PR TITLE
sqldb: gate postgres fixtures behind build tag

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -53,6 +53,10 @@
 
 ## Code Health
 
+* [Limited the Docker-backed Postgres test fixtures to `test_db_postgres`
+  builds](https://github.com/lightningnetwork/lnd/pull/10792), keeping
+  test-only Docker dependencies out of normal `sqldb` builds.
+
 ## Tooling and Documentation
 
 # Contributors (Alphabetical Order)

--- a/sqldb/postgres_fixture.go
+++ b/sqldb/postgres_fixture.go
@@ -1,4 +1,4 @@
-//go:build !js && !(windows && (arm || 386)) && !(linux && (ppc64 || mips || mipsle || mips64)) && !(netbsd || openbsd)
+//go:build test_db_postgres && !js && !(windows && (arm || 386)) && !(linux && (ppc64 || mips || mipsle || mips64)) && !(netbsd || openbsd)
 
 package sqldb
 

--- a/sqldb/postgres_fixture_stub.go
+++ b/sqldb/postgres_fixture_stub.go
@@ -1,0 +1,60 @@
+//go:build !test_db_postgres
+
+package sqldb
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+)
+
+const PostgresTag = "11"
+
+// TestPgFixture is only available when built with the test_db_postgres tag.
+type TestPgFixture struct {
+	db *sql.DB
+}
+
+// NewTestPgFixture constructs a new Postgres fixture when test_db_postgres is
+// enabled.
+func NewTestPgFixture(t testing.TB, _ time.Duration) *TestPgFixture {
+	postgresFixtureUnavailable(t)
+	return nil
+}
+
+// GetConfig returns the full config of the Postgres node.
+func (*TestPgFixture) GetConfig(string) *PostgresConfig {
+	panic("Postgres test fixture requires the test_db_postgres build tag")
+}
+
+// TearDown stops the underlying docker container.
+func (*TestPgFixture) TearDown(t testing.TB) {
+	t.Helper()
+}
+
+// randomDBName generates a random database name.
+func randomDBName(t testing.TB) string {
+	postgresFixtureUnavailable(t)
+	return ""
+}
+
+// NewTestPostgresDB is a helper function that creates a Postgres database for
+// testing using the given fixture.
+func NewTestPostgresDB(t testing.TB, _ *TestPgFixture) *PostgresStore {
+	postgresFixtureUnavailable(t)
+	return nil
+}
+
+// NewTestPostgresDBWithVersion is a helper function that creates a Postgres
+// database for testing and migrates it to the given version.
+func NewTestPostgresDBWithVersion(t *testing.T, _ *TestPgFixture,
+	_ uint) *PostgresStore {
+
+	postgresFixtureUnavailable(t)
+	return nil
+}
+
+func postgresFixtureUnavailable(t testing.TB) {
+	t.Helper()
+	t.Skip("Postgres test fixture requires the test_db_postgres build tag")
+}

--- a/sqldb/v2/docker_name.go
+++ b/sqldb/v2/docker_name.go
@@ -1,0 +1,34 @@
+//go:build test_db_postgres && !js && !(windows && (arm || 386)) && !(linux && (ppc64 || mips || mipsle || mips64)) && !(netbsd || openbsd)
+
+package sqldb
+
+import "strings"
+
+// sanitizeDockerName returns a Docker-safe container name.
+func sanitizeDockerName(name string) string {
+	sanitized := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z':
+			return r
+
+		case r >= 'A' && r <= 'Z':
+			return r
+
+		case r >= '0' && r <= '9':
+			return r
+
+		case r == '_', r == '-':
+			return r
+
+		default:
+			return '_'
+		}
+	}, name)
+
+	sanitized = strings.Trim(sanitized, "_.-")
+	if sanitized == "" {
+		return "postgresql-container"
+	}
+
+	return sanitized
+}

--- a/sqldb/v2/postgres_fixture.go
+++ b/sqldb/v2/postgres_fixture.go
@@ -1,4 +1,4 @@
-//go:build !js && !(windows && (arm || 386)) && !(linux && (ppc64 || mips || mipsle || mips64)) && !(netbsd || openbsd)
+//go:build test_db_postgres && !js && !(windows && (arm || 386)) && !(linux && (ppc64 || mips || mipsle || mips64)) && !(netbsd || openbsd)
 
 package sqldb
 
@@ -114,35 +114,6 @@ func NewTestPgFixture(t testing.TB, expiry time.Duration) *TestPgFixture {
 	fixture.resource = resource
 
 	return fixture
-}
-
-// sanitizeDockerName returns a Docker-safe container name.
-func sanitizeDockerName(name string) string {
-	sanitized := strings.Map(func(r rune) rune {
-		switch {
-		case r >= 'a' && r <= 'z':
-			return r
-
-		case r >= 'A' && r <= 'Z':
-			return r
-
-		case r >= '0' && r <= '9':
-			return r
-
-		case r == '_', r == '-':
-			return r
-
-		default:
-			return '_'
-		}
-	}, name)
-
-	sanitized = strings.Trim(sanitized, "_.-")
-	if sanitized == "" {
-		return "postgresql-container"
-	}
-
-	return sanitized
 }
 
 // GetConfig returns the full config of the Postgres node.

--- a/sqldb/v2/postgres_fixture_stub.go
+++ b/sqldb/v2/postgres_fixture_stub.go
@@ -1,0 +1,65 @@
+//go:build !test_db_postgres
+
+package sqldb
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+)
+
+const PostgresTag = "15"
+
+// TestPgFixture is only available when built with the test_db_postgres tag.
+type TestPgFixture struct{}
+
+// NewTestPgFixture constructs a new Postgres fixture when test_db_postgres is
+// enabled.
+func NewTestPgFixture(t testing.TB, _ time.Duration) *TestPgFixture {
+	postgresFixtureUnavailable(t)
+	return nil
+}
+
+// GetConfig returns the full config of the Postgres node.
+func (*TestPgFixture) GetConfig(string) *PostgresConfig {
+	panic("Postgres test fixture requires the test_db_postgres build tag")
+}
+
+// TearDown stops the underlying docker container.
+func (*TestPgFixture) TearDown(t testing.TB) {
+	t.Helper()
+}
+
+// DB returns the fixture database.
+func (*TestPgFixture) DB() *sql.DB {
+	panic("Postgres test fixture requires the test_db_postgres build tag")
+}
+
+// RandomDBName generates a random database name.
+func RandomDBName(t testing.TB) string {
+	postgresFixtureUnavailable(t)
+	return ""
+}
+
+// NewTestPostgresDB is a helper function that creates a Postgres database for
+// testing using the given fixture.
+func NewTestPostgresDB(t testing.TB, _ *TestPgFixture,
+	_ []MigrationSet) *PostgresStore {
+
+	postgresFixtureUnavailable(t)
+	return nil
+}
+
+// NewTestPostgresDBWithVersion is a helper function that creates a Postgres
+// database for testing and migrates it to the given version.
+func NewTestPostgresDBWithVersion(t testing.TB, _ *TestPgFixture,
+	_ MigrationSet, _ uint) *PostgresStore {
+
+	postgresFixtureUnavailable(t)
+	return nil
+}
+
+func postgresFixtureUnavailable(t testing.TB) {
+	t.Helper()
+	t.Skip("Postgres test fixture requires the test_db_postgres build tag")
+}

--- a/sqldb/v2/postgres_fixture_test.go
+++ b/sqldb/v2/postgres_fixture_test.go
@@ -1,4 +1,4 @@
-//go:build !js && !(windows && (arm || 386)) && !(linux && (ppc64 || mips || mipsle || mips64)) && !(netbsd || openbsd)
+//go:build test_db_postgres && !js && !(windows && (arm || 386)) && !(linux && (ppc64 || mips || mipsle || mips64)) && !(netbsd || openbsd)
 
 package sqldb
 


### PR DESCRIPTION
## Change Description

Limit the Docker-backed Postgres test fixtures to `test_db_postgres` builds.

The Postgres fixture helpers import `dockertest`, which pulls Docker client dependencies into normal `sqldb` builds. These helpers are only usable when running Postgres-backed tests, so this gates the real fixture implementations behind `test_db_postgres`.

  Non-Postgres stubs preserve the existing helper API for default builds while keeping Docker-only test dependencies out of the normal `sqldb` package graph.

This is complementary to #10791, which updates `github.com/opencontainers/runc` to a patched version. This PR instead keeps the Docker-backed Postgres test fixtures out of normal `sqldb` builds, so release builds do not include test-only Docker dependencies in their package graph.

  ## Steps to Test

  Run the default compile checks:

  ```bash
  go test -run '^$' ./batch ./invoices ./chainparams ./payments/db ./payments/db/migration1 ./graph/db ./graph/db/migration1

  cd sqldb
  go test -run '^$' ./...

  cd sqldb/v2
  go test -run '^$' ./...

  Run the Postgres-tagged compile checks:

  go test -run '^$' -tags='test_db_postgres' ./batch ./invoices ./chainparams ./payments/db ./payments/db/migration1 ./graph/db ./graph/db/migration1

  cd sqldb
  go test -run '^$' -tags='test_db_postgres' ./...

  cd sqldb/v2
  go test -run '^$' -tags='test_db_postgres' ./...

  Verify that release-tagged lnd/lncli builds no longer include
  dockertest or Docker client dependencies:

  go list -deps -tags='autopilotrpc signrpc walletrpc chainrpc invoicesrpc watchtowerrpc neutrinorpc monitoring peersrpc kvdb_postgres kvdb_etcd kvdb_sqlite' ./cmd/lnd ./cmd/lncli | rg 'ory/
  dockertest|docker/docker|opencontainers/runc'
  
  ```

  The command should produce no matches.

  ## Pull Request Checklist

  ### Testing

  - [ ] Your PR passes all CI checks.
  - [x] Tests covering the positive and negative (error paths) are included.
  - [x] Bug fixes contain tests triggering the bug to prevent regressions.

  ### Code Style and Documentation

  - [x] The change is not insubstantial (https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to
    fight bot spam.
  - [x] The change obeys the Code Documentation and Commenting (https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines,
    and lines wrap at 80.
  - [x] Commits follow the Ideal Git Commit Structure (https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
  - [x] Any new logging statements use an appropriate subsystem and logging level.
  - [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
  - [x] There is a change description in the release notes (https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or [skip ci] in the commit message for small changes.
