### PR TITLE
kvdb/sqlbase: fix non-constant format strings

### DIFF
--- a/kvdb/sqlbase/schema.go
+++ b/kvdb/sqlbase/schema.go
@@ -21,7 +21,7 @@ func newKVSchemaCreationCmd(table, schema string,
 	)
 	if schema != "" {
 		finalCmd = fmt.Sprintf(
-			`CREATE SCHEMA IF NOT EXISTS ` + schema + `;`,
+			"%s", `CREATE SCHEMA IF NOT EXISTS `+schema+`;`,
 		)
 
 		tableInSchema = fmt.Sprintf("%s.%s", schema, table)
@@ -44,26 +44,26 @@ func newKVSchemaCreationCmd(table, schema string,
 	//
 	// The replacements map can be used to replace any sqlite keywords.
 	// Callers should note that the sqlite keywords are case-sensitive.
-	finalCmd += fmt.Sprintf(`
-CREATE TABLE IF NOT EXISTS ` + tableInSchema + `
+	finalCmd += fmt.Sprintf("%s", `
+CREATE TABLE IF NOT EXISTS `+tableInSchema+`
 (
     key BLOB NOT NULL,
     value BLOB,
     parent_id BIGINT,
     id INTEGER PRIMARY KEY,
     sequence BIGINT,
-    CONSTRAINT ` + table + `_parent FOREIGN KEY (parent_id)
-        REFERENCES ` + tableInSchema + ` (id)
+    CONSTRAINT `+table+`_parent FOREIGN KEY (parent_id)
+        REFERENCES `+tableInSchema+` (id)
         ON UPDATE NO ACTION
         ON DELETE CASCADE
 );
-CREATE INDEX IF NOT EXISTS ` + table + `_p
-    ON ` + tableInSchema + ` (parent_id);
-CREATE UNIQUE INDEX IF NOT EXISTS ` + table + `_up
-    ON ` + tableInSchema + `
+CREATE INDEX IF NOT EXISTS `+table+`_p
+    ON `+tableInSchema+` (parent_id);
+CREATE UNIQUE INDEX IF NOT EXISTS `+table+`_up
+    ON `+tableInSchema+`
     (parent_id, key) WHERE parent_id IS NOT NULL;
-CREATE UNIQUE INDEX IF NOT EXISTS ` + table + `_unp 
-    ON ` + tableInSchema + ` (key) WHERE parent_id IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS `+table+`_unp 
+    ON `+tableInSchema+` (key) WHERE parent_id IS NULL;
 `)
 
 	for from, to := range replacements {


### PR DESCRIPTION
## Change Description
When updating the Go version in kvdb to >= 1.24, schema.go no longer compiles due to non-constant format strings. This is invisible until:
- a new version of kvdb is tagged and imported in consumers
- kvdb is redirected to the local copy

This commit fixes the bug. I'm happy to add a release note to either the 0.21 or 0.22 version depending on when people want to merge this.

## Steps to Test
In the top-level `go.mod` file, add a KVDB redirect:
```
replace github.com/lightningnetwork/lnd/kvdb => ./kvdb
```

Run `make unit dbbackend=postgres` before and after this change. Before the change, you should get two errors similar to this:

```
# github.com/lightningnetwork/lnd/kvdb/sqlbase                                                                                          
kvdb/sqlbase/schema.go:25:5: non-constant format string in call to fmt.Sprintf                                                          
kvdb/sqlbase/schema.go:49:26: non-constant format string in call to fmt.Sprintf                                                         
FAIL    github.com/lightningnetwork/lnd/kvdb/sqlbase [build failed]                                                                     
FAIL                                                                                                                                    
```

After the change, the bug should be fixed.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
