### PR TITLE
5522: warn users when connecting watchtower client to local watchtower

### DIFF
--- a/lnd.go
+++ b/lnd.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	proxy "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/lightningnetwork/lnd/autopilot"
@@ -623,13 +624,18 @@ func Main(cfg *Config, lisCfg ListenerCfg, implCfg *ImplementationCfg,
 		multiAcceptor = chanacceptor.NewChainedAcceptor()
 	}
 
+	var localTowerPubKey *btcec.PublicKey
+	if tower != nil {
+		localTowerPubKey = tower.PubKey()
+	}
+
 	// Set up the core server which will listen for incoming peer
 	// connections.
 	server, err := newServer(
 		ctx, cfg, cfg.Listeners, dbs, activeChainControl, &idKeyDesc,
 		activeChainControl.Cfg.WalletUnlockParams.ChansToRestore,
 		multiAcceptor, torController, tlsManager, leaderElector,
-		implCfg,
+		implCfg, localTowerPubKey,
 	)
 	if err != nil {
 		return mkErr("unable to create server", err)

--- a/server.go
+++ b/server.go
@@ -617,7 +617,8 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 	chanPredicate chanacceptor.ChannelAcceptor,
 	torController *tor.Controller, tlsManager *TLSManager,
 	leaderElector cluster.LeaderElector,
-	implCfg *ImplementationCfg) (*server, error) {
+	implCfg *ImplementationCfg,
+	localTowerPubKey *btcec.PublicKey) (*server, error) {
 
 	var (
 		err         error
@@ -1830,6 +1831,7 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 			MinBackoff:         10 * time.Second,
 			MaxBackoff:         5 * time.Minute,
 			MaxTasksInMemQueue: cfg.WtClient.MaxTasksInMemQueue,
+			LocalTowerPubKey:   localTowerPubKey,
 		}, policy, anchorPolicy, taprootPolicy, taprootFinalPolicy)
 		if err != nil {
 			return nil, err

--- a/watchtower/wtclient/manager.go
+++ b/watchtower/wtclient/manager.go
@@ -155,8 +155,10 @@ type Config struct {
 	// be kept in-memory. Any more tasks will overflow to disk.
 	MaxTasksInMemQueue uint64
 
-	// Public key of the local tower if running local watchtower.
-	// Used to check if client is connecting to local node
+	// LocalTowerPubKey is the public key of the watchtower server running
+	// in the same process, or nil if no local tower is active. When set,
+	// AddTower will warn if the client attempts to register the local tower,
+	// since it shares the same failure domain as this node.
 	LocalTowerPubKey *btcec.PublicKey
 }
 

--- a/watchtower/wtclient/manager.go
+++ b/watchtower/wtclient/manager.go
@@ -154,6 +154,10 @@ type Config struct {
 	// MaxTasksInMemQueue is the maximum number of backup tasks that should
 	// be kept in-memory. Any more tasks will overflow to disk.
 	MaxTasksInMemQueue uint64
+
+	// Public key of the local tower if running local watchtower.
+	// Used to check if client is connecting to local node
+	LocalTowerPubKey *btcec.PublicKey
 }
 
 // Manager manages the various tower clients that are active. A client is
@@ -359,6 +363,14 @@ func (m *Manager) Stop() error {
 // included will be considered when dialing it for session negotiations and
 // backups.
 func (m *Manager) AddTower(address *lnwire.NetAddress) error {
+	if m.cfg.LocalTowerPubKey != nil &&
+		address.IdentityKey.IsEqual(m.cfg.LocalTowerPubKey) {
+
+		log.Warnf("Connecting to local watchtower: " +
+			"if this node goes offline the tower will " +
+			"also be unavailable")
+	}
+
 	// We'll start by updating our persisted state, followed by the
 	// in-memory state of each client, with the new tower. This might not
 	// actually be a new tower, but it might include a new address at which


### PR DESCRIPTION
## Change Description
https://github.com/lightningnetwork/lnd/issues/5522

Adding local watchtower pub key to watchtower client config so that it can warn users if connecting to the local watchtower node.

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
