### PR TITLE
lnwallet/rpcwallet: keep zero-value prev outputs in remote-sign PSBT

### DIFF
--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -22,6 +22,17 @@
 
 # Bug Fixes
 
+* The [remote-signer PSBT prep](https://github.com/lightningnetwork/lnd/pull/10815)
+  now accepts zero-value entries from a sign descriptor's
+  `PrevOutputFetcher` when populating `WitnessUtxo` on non-signed
+  inputs. This unblocks signing flows that reference virtual prev
+  outputs whose value is mandated to be zero, most notably BIP-322's
+  `to_spend` output (the prev of input 0 of every BIP-322 `to_sign`
+  transaction). Previously the prep stage silently skipped such
+  inputs and the resulting PSBT was rejected downstream by
+  `walletkit.SignPsbt` with `input (index=N) doesn't specify any
+  UTXO info`.
+
 * [Fixed `OpenChannel` with
   `fund_max`](https://github.com/lightningnetwork/lnd/pull/10488) to use the
   protocol-level maximum channel size instead of the user-configured

--- a/lnwallet/rpcwallet/rpcwallet.go
+++ b/lnwallet/rpcwallet/rpcwallet.go
@@ -951,42 +951,9 @@ func (r *RPCKeyRing) remoteSign(tx *wire.MsgTx, signDesc *input.SignDescriptor,
 
 	// We need to add witness information for all inputs! Otherwise, we'll
 	// have a problem when attempting to sign a taproot input!
-	for idx := range packet.Inputs {
-		// Skip the input we're signing for, that will get a special
-		// treatment later on.
-		if idx == signDesc.InputIndex {
-			continue
-		}
-
-		txIn := tx.TxIn[idx]
-		info, err := r.WalletController.FetchOutpointInfo(
-			&txIn.PreviousOutPoint,
-		)
-		if err != nil {
-			// Maybe we have an UTXO in the previous output fetcher?
-			if signDesc.PrevOutputFetcher != nil {
-				utxo := signDesc.PrevOutputFetcher.FetchPrevOutput(
-					txIn.PreviousOutPoint,
-				)
-				if utxo != nil && utxo.Value != 0 &&
-					len(utxo.PkScript) > 0 {
-
-					packet.Inputs[idx].WitnessUtxo = utxo
-					continue
-				}
-			}
-
-			log.Warnf("No UTXO info found for index %d "+
-				"(prev_outpoint=%v), won't be able to sign "+
-				"for taproot output!", idx,
-				txIn.PreviousOutPoint)
-			continue
-		}
-		packet.Inputs[idx].WitnessUtxo = &wire.TxOut{
-			Value:    int64(info.Value),
-			PkScript: info.PkScript,
-		}
-	}
+	populateNonSignedInputWitnessUtxos(
+		packet, tx, signDesc, r.WalletController.FetchOutpointInfo,
+	)
 
 	// Catch incorrect signing input index, just in case.
 	if signDesc.InputIndex < 0 || signDesc.InputIndex >= len(packet.Inputs) {
@@ -1370,6 +1337,72 @@ func connectRPC(hostPort, tlsCertPath, macaroonPath string,
 	}
 
 	return conn, nil
+}
+
+// fetchOutpointInfoFn looks up the wallet's local knowledge of an outpoint.
+// Mirrors lnwallet.WalletController.FetchOutpointInfo so the helper below can
+// be exercised in unit tests without standing up a full wallet.
+type fetchOutpointInfoFn func(*wire.OutPoint) (*lnwallet.Utxo, error)
+
+// populateNonSignedInputWitnessUtxos walks every non-signed PSBT input and
+// fills in its WitnessUtxo. The signing path that ultimately ships this PSBT
+// to the remote signer is walletkit.SignPsbt, which rejects any PSBT that
+// has an input without a WitnessUtxo or NonWitnessUtxo set — even when the
+// remote signer is only being asked to sign one of the inputs — because
+// taproot sighash computation requires all prev outputs.
+//
+// Resolution order for each non-signed input:
+//
+//  1. fetchInfo (the local wallet's knowledge of the outpoint).
+//  2. signDesc.PrevOutputFetcher, when the local wallet does not own or
+//     track the outpoint (e.g. funding-flow channel TXs that haven't been
+//     published yet, or BIP-322 virtual to_spend outputs).
+//
+// A zero Value is accepted from the fetcher. BIP-322 mandates that the
+// to_spend output is exactly value=0 with the message commitment as
+// pk_script, and that output is referenced as input 0 of every BIP-322
+// to_sign transaction. Refusing zero-value fetched outputs would silently
+// leave that input's WitnessUtxo unpopulated, causing walletkit.SignPsbt
+// to later reject the resulting PSBT with "input (index=N) doesn't specify
+// any UTXO info".
+func populateNonSignedInputWitnessUtxos(packet *psbt.Packet, tx *wire.MsgTx,
+	signDesc *input.SignDescriptor, fetchInfo fetchOutpointInfoFn) {
+
+	for idx := range packet.Inputs {
+		// Skip the input we're signing for, that will get a special
+		// treatment by the caller.
+		if idx == signDesc.InputIndex {
+			continue
+		}
+
+		txIn := tx.TxIn[idx]
+		info, err := fetchInfo(&txIn.PreviousOutPoint)
+		if err != nil {
+			// The wallet doesn't know about this outpoint. Fall
+			// back to the caller-supplied PrevOutputFetcher.
+			if signDesc.PrevOutputFetcher != nil {
+				fetcher := signDesc.PrevOutputFetcher
+				utxo := fetcher.FetchPrevOutput(
+					txIn.PreviousOutPoint,
+				)
+				if utxo != nil && len(utxo.PkScript) > 0 {
+					packet.Inputs[idx].WitnessUtxo = utxo
+					continue
+				}
+			}
+
+			log.Warnf("No UTXO info found for index %d "+
+				"(prev_outpoint=%v), won't be able to sign "+
+				"for taproot output!", idx,
+				txIn.PreviousOutPoint)
+
+			continue
+		}
+		packet.Inputs[idx].WitnessUtxo = &wire.TxOut{
+			Value:    int64(info.Value),
+			PkScript: info.PkScript,
+		}
+	}
 }
 
 // packetFromTx creates a PSBT from a tx that potentially already contains

--- a/lnwallet/rpcwallet/rpcwallet_test.go
+++ b/lnwallet/rpcwallet/rpcwallet_test.go
@@ -1,0 +1,231 @@
+package rpcwallet
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/stretchr/testify/require"
+)
+
+// errNotMine mirrors lnwallet.ErrNotMine for the parts of these tests that
+// just need *some* "wallet doesn't know this outpoint" sentinel.
+var errNotMine = errors.New("not mine")
+
+// makeOutPoint returns a wire.OutPoint with a unique, deterministic hash so
+// each test case can build inputs without colliding.
+func makeOutPoint(t *testing.T, idx uint32) wire.OutPoint {
+	t.Helper()
+	var h chainhash.Hash
+	h[0] = byte(idx + 1)
+
+	return wire.OutPoint{Hash: h, Index: idx}
+}
+
+// makeTxAndPacket builds a wire tx with the given outpoints and the matching
+// empty PSBT skeleton ready for WitnessUtxo to be filled in per input.
+func makeTxAndPacket(t *testing.T,
+	outpoints []wire.OutPoint) (*wire.MsgTx, *psbt.Packet) {
+
+	t.Helper()
+	tx := wire.NewMsgTx(2)
+	for _, op := range outpoints {
+		tx.AddTxIn(&wire.TxIn{PreviousOutPoint: op})
+	}
+	// At least one output is required by psbt.NewFromUnsignedTx.
+	tx.AddTxOut(&wire.TxOut{Value: 1000, PkScript: []byte{0x51}})
+
+	packet, err := psbt.NewFromUnsignedTx(tx)
+	require.NoError(t, err)
+
+	return tx, packet
+}
+
+// TestPopulateNonSignedInputWitnessUtxosFromWallet verifies that an input
+// whose outpoint is known to the wallet is annotated with the wallet's
+// view of the prev output.
+func TestPopulateNonSignedInputWitnessUtxosFromWallet(t *testing.T) {
+	t.Parallel()
+
+	walletOp := makeOutPoint(t, 0)
+	signingOp := makeOutPoint(t, 1)
+
+	tx, packet := makeTxAndPacket(
+		t, []wire.OutPoint{walletOp, signingOp},
+	)
+
+	walletPkScript := []byte{0x51, 0x20, 0xaa, 0xbb}
+	fetchInfo := func(op *wire.OutPoint) (*lnwallet.Utxo, error) {
+		if *op == walletOp {
+			return &lnwallet.Utxo{
+				Value:    12345,
+				PkScript: walletPkScript,
+			}, nil
+		}
+
+		return nil, errNotMine
+	}
+
+	signDesc := &input.SignDescriptor{InputIndex: 1}
+	populateNonSignedInputWitnessUtxos(packet, tx, signDesc, fetchInfo)
+
+	require.NotNil(t, packet.Inputs[0].WitnessUtxo)
+	require.Equal(t, int64(12345), packet.Inputs[0].WitnessUtxo.Value)
+	require.Equal(t, walletPkScript, packet.Inputs[0].WitnessUtxo.PkScript)
+
+	// The signed input must be untouched.
+	require.Nil(t, packet.Inputs[1].WitnessUtxo)
+}
+
+// TestPopulateNonSignedInputWitnessUtxosFromFetcher verifies that when the
+// wallet does not know about an outpoint, the helper falls back to the
+// sign descriptor's PrevOutputFetcher.
+func TestPopulateNonSignedInputWitnessUtxosFromFetcher(t *testing.T) {
+	t.Parallel()
+
+	externalOp := makeOutPoint(t, 0)
+	signingOp := makeOutPoint(t, 1)
+
+	tx, packet := makeTxAndPacket(
+		t, []wire.OutPoint{externalOp, signingOp},
+	)
+
+	externalUtxo := &wire.TxOut{
+		Value:    50000,
+		PkScript: []byte{0x51, 0x20, 0xcc, 0xdd},
+	}
+	prevFetcher := txscript.NewMultiPrevOutFetcher(
+		map[wire.OutPoint]*wire.TxOut{externalOp: externalUtxo},
+	)
+
+	fetchInfo := func(*wire.OutPoint) (*lnwallet.Utxo, error) {
+		return nil, errNotMine
+	}
+
+	signDesc := &input.SignDescriptor{
+		InputIndex:        1,
+		PrevOutputFetcher: prevFetcher,
+	}
+	populateNonSignedInputWitnessUtxos(packet, tx, signDesc, fetchInfo)
+
+	require.NotNil(t, packet.Inputs[0].WitnessUtxo)
+	require.Equal(
+		t, externalUtxo.Value, packet.Inputs[0].WitnessUtxo.Value,
+	)
+	require.True(t, bytes.Equal(
+		externalUtxo.PkScript, packet.Inputs[0].WitnessUtxo.PkScript,
+	))
+}
+
+// TestPopulateNonSignedInputWitnessUtxosZeroValueFromFetcher is the
+// regression test for the BIP-322 case. The to_spend output is mandated
+// by BIP-322 to have value=0 with the message commitment as its pk_script,
+// and that output is referenced as input 0 of every BIP-322 to_sign tx.
+// The helper must accept that zero-value entry — otherwise the resulting
+// PSBT is rejected by walletkit.SignPsbt with "input (index=N) doesn't
+// specify any UTXO info".
+func TestPopulateNonSignedInputWitnessUtxosZeroValueFromFetcher(t *testing.T) {
+	t.Parallel()
+
+	bip322ToSpendOp := makeOutPoint(t, 0)
+	signingOp := makeOutPoint(t, 1)
+
+	tx, packet := makeTxAndPacket(
+		t, []wire.OutPoint{bip322ToSpendOp, signingOp},
+	)
+
+	// The BIP-322 to_spend output: value=0, pk_script is the message
+	// commitment script (P2WSH of OP_0 <msg_hash>). For the purposes of
+	// this test the exact script bytes don't matter; only that we have
+	// a non-empty pk_script with a zero Value.
+	msgCommitment := []byte{0x00, 0x20, 0xde, 0xad, 0xbe, 0xef}
+	zeroValueUtxo := &wire.TxOut{Value: 0, PkScript: msgCommitment}
+
+	prevFetcher := txscript.NewMultiPrevOutFetcher(
+		map[wire.OutPoint]*wire.TxOut{bip322ToSpendOp: zeroValueUtxo},
+	)
+
+	fetchInfo := func(*wire.OutPoint) (*lnwallet.Utxo, error) {
+		return nil, errNotMine
+	}
+
+	signDesc := &input.SignDescriptor{
+		InputIndex:        1,
+		PrevOutputFetcher: prevFetcher,
+	}
+	populateNonSignedInputWitnessUtxos(packet, tx, signDesc, fetchInfo)
+
+	require.NotNil(t, packet.Inputs[0].WitnessUtxo,
+		"BIP-322 to_spend output must populate WitnessUtxo "+
+			"despite its zero Value")
+	require.Equal(t, int64(0), packet.Inputs[0].WitnessUtxo.Value)
+	require.Equal(
+		t, msgCommitment, packet.Inputs[0].WitnessUtxo.PkScript,
+	)
+}
+
+// TestPopulateNonSignedInputWitnessUtxosNoFallback verifies the helper
+// leaves an input bare when neither the wallet nor a fetcher can resolve
+// the outpoint. The caller logs a warning; the unsigned PSBT will still
+// fail downstream validation, but that failure should be exposed to the
+// caller rather than silently masked.
+func TestPopulateNonSignedInputWitnessUtxosNoFallback(t *testing.T) {
+	t.Parallel()
+
+	unknownOp := makeOutPoint(t, 0)
+	signingOp := makeOutPoint(t, 1)
+
+	tx, packet := makeTxAndPacket(
+		t, []wire.OutPoint{unknownOp, signingOp},
+	)
+
+	fetchInfo := func(*wire.OutPoint) (*lnwallet.Utxo, error) {
+		return nil, errNotMine
+	}
+	// No PrevOutputFetcher on the sign descriptor.
+	signDesc := &input.SignDescriptor{InputIndex: 1}
+
+	populateNonSignedInputWitnessUtxos(packet, tx, signDesc, fetchInfo)
+
+	require.Nil(t, packet.Inputs[0].WitnessUtxo)
+}
+
+// TestPopulateNonSignedInputWitnessUtxosEmptyPkScript guards the helper
+// against fetchers that return a non-nil TxOut with an empty PkScript.
+// Such an entry is not a usable WitnessUtxo (a PSBT WitnessUtxo with an
+// empty PkScript is malformed at serialization), so the helper should
+// treat it as unknown and skip the input.
+func TestPopulateNonSignedInputWitnessUtxosEmptyPkScript(t *testing.T) {
+	t.Parallel()
+
+	bogusOp := makeOutPoint(t, 0)
+	signingOp := makeOutPoint(t, 1)
+
+	tx, packet := makeTxAndPacket(
+		t, []wire.OutPoint{bogusOp, signingOp},
+	)
+
+	prevFetcher := txscript.NewMultiPrevOutFetcher(
+		map[wire.OutPoint]*wire.TxOut{
+			bogusOp: {Value: 100, PkScript: nil},
+		},
+	)
+
+	fetchInfo := func(*wire.OutPoint) (*lnwallet.Utxo, error) {
+		return nil, errNotMine
+	}
+	signDesc := &input.SignDescriptor{
+		InputIndex:        1,
+		PrevOutputFetcher: prevFetcher,
+	}
+
+	populateNonSignedInputWitnessUtxos(packet, tx, signDesc, fetchInfo)
+
+	require.Nil(t, packet.Inputs[0].WitnessUtxo)
+}


### PR DESCRIPTION
In this PR, we fix a sharp edge in `RPCKeyRing.remoteSign` that silently
broke any signing flow whose `to_sign` tx references a zero-value prev
output. The canonical hitter is BIP-322 message signing, which mandates
that the virtual `to_spend` output is exactly `value=0` with the message
commitment as `pk_script`, and that output is referenced as input 0 of
every `to_sign` tx handed to `SignOutputRaw`.

Before forwarding the request, `remoteSign` rebuilds a PSBT from the
unsigned tx and annotates every non-signed input with a `WitnessUtxo`,
so the downstream `walletkit.SignPsbt` call can proceed (taproot sighash
needs every prev output, not just the one being signed). When the watch-
only wallet doesn't know an outpoint, the prep stage falls back to the
sign descriptor's `PrevOutputFetcher`. That fallback used to require
`utxo.Value != 0`, which silently dropped legitimate zero-value entries
on the floor. The remote signer would then reject the resulting PSBT
with `input (index=N) doesn't specify any UTXO info`, raised in
`walletkit.SignPsbt` precisely because input N had neither a
`WitnessUtxo` nor a `NonWitnessUtxo`.

## The fix

We drop the `Value != 0` guard. The only condition that actually matters
is that the fetched entry is usable as a `WitnessUtxo`: non-nil with a
non-empty `PkScript`. A zero-value `WitnessUtxo` with a well-formed
`PkScript` serializes cleanly into a PSBT, so there's nothing else to
validate at this layer.

We also lift the population loop out of `remoteSign` into a package-
level helper, `populateNonSignedInputWitnessUtxos`, so the resolution
policy can be exercised in unit tests without standing up a full wallet
+ remote signer pair. The helper takes a `fetchOutpointInfoFn` callback
that mirrors `lnwallet.WalletController.FetchOutpointInfo`. No behavior
change for the wallet-owns-it path or the no-fallback path.

## Tests

New unit tests in `lnwallet/rpcwallet/rpcwallet_test.go` walk through
each resolution branch. The wallet-owns-it case exercises the
`FetchOutpointInfo` happy path and cross-checks that the signed input
itself is left untouched. The external-fallback case has the wallet
return `ErrNotMine` and resolves the prev via the fetcher. The zero-
value-fallback case is the BIP-322 regression: same shape as external-
fallback, but the fetcher entry has `Value=0`, and the test asserts
that `WitnessUtxo` lands on the PSBT instead of being silently skipped.
Two more cover the unhappy paths: no fetcher attached (input left bare,
warning logged) and a fetcher entry with an empty `PkScript` (rejected
as unusable, since a PSBT `WitnessUtxo` with empty script is malformed
at serialization).

## Compat

No behavior change for the wallet-owns-it path, the no-fallback path,
or the non-zero-value fallback path. The only new behavior is that
legitimately zero-value entries from the supplied `PrevOutputFetcher`
land in the PSBT instead of being silently skipped.