### PR TITLE
rpcserver: filter backup subscription events

### DIFF
--- a/channelnotifier/channelnotifier.go
+++ b/channelnotifier/channelnotifier.go
@@ -131,6 +131,11 @@ func (c *ChannelNotifier) Stop() error {
 // any time the Server is made aware of a new event. The subscription provides
 // channel events from the point of subscription onwards.
 //
+// NOTE: This subscription includes both channel lifecycle events and higher
+// frequency channel state updates, such as ChannelUpdateEvent. Callers that
+// only need lifecycle updates should explicitly filter for the event types they
+// consume.
+//
 // TODO(carlaKC): update  to allow subscriptions to specify a block height from
 // which we would like to subscribe to events.
 func (c *ChannelNotifier) SubscribeChannelEvents() (*subscribe.Client, error) {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -8048,23 +8048,33 @@ func (r *rpcServer) SubscribeChannelBackups(req *lnrpc.ChannelBackupSubscription
 		select {
 		// A new event has been sent by the channel notifier, we'll
 		// assemble, then sling out a new event to the client.
-		case e := <-chanSubscription.Updates():
+		case e, ok := <-chanSubscription.Updates():
+			if !ok {
+				// The subscription server closes the updates
+				// channel during shutdown or cancellation, so
+				// end the stream gracefully.
+				return nil
+			}
+
 			// TODO(roasbeef): batch dispatch ntnfs
 
 			switch e.(type) {
 
-			// We only care about new/closed channels, so we'll
-			// skip any events for active/inactive channels.
-			// To make the subscription behave the same way as the
-			// synchronous call and the file based backup, we also
-			// include pending channels in the update.
-			case channelnotifier.ActiveChannelEvent:
-				continue
-			case channelnotifier.InactiveChannelEvent:
-				continue
-			case channelnotifier.ActiveLinkEvent:
-				continue
-			case channelnotifier.InactiveLinkEvent:
+			// Only channel lifecycle events should trigger this
+			// subscription. Commitment updates can affect
+			// close-tx inputs embedded in an exported SCB, but
+			// emitting on that frequency would make this stream
+			// too noisy. To make the subscription behave the same
+			// way as the synchronous call and the file based
+			// backup, we also include pending channels in the
+			// update.
+			case channelnotifier.PendingOpenChannelEvent,
+				channelnotifier.OpenChannelEvent,
+				channelnotifier.ClosedChannelEvent,
+				channelnotifier.FullyResolvedChannelEvent,
+				channelnotifier.FundingTimeoutEvent:
+
+			default:
 				continue
 			}
 


### PR DESCRIPTION
ChannelUpdate events where introduced in https://github.com/lightningnetwork/lnd/pull/10543

## Change Description

Channel update notifications now flow through `ChannelNotifier`, so the
existing `SubscribeChannelBackups` deny-list started treating commitment
updates as backup-relevant events. That makes the backup stream emit on every
channel update, which is much noisier than the lifecycle events this stream
historically tracked.

This PR switches `SubscribeChannelBackups` to an allow-list of lifecycle events
that should trigger a backup snapshot. It also documents that `ChannelNotifier`
includes higher-frequency channel state updates, so lifecycle-only consumers
should explicitly filter for the event types they consume.

## Steps to Test

```sh
go test ./channelnotifier
go test .
```
