### PR TITLE
routerrpc: pass outgoing channels to probe requests

### DIFF
--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -518,7 +518,8 @@ func (s *Server) probePaymentRequest(ctx context.Context, paymentRequest string,
 	timeout uint32, outgoingChanIDs []uint64) (*RouteFeeResponse, error) {
 
 	return s.probePaymentRequestWithSender(
-		ctx, paymentRequest, timeout, s.sendProbePayment,
+		ctx, paymentRequest, timeout, outgoingChanIDs,
+		s.sendProbePayment,
 	)
 }
 
@@ -533,7 +534,7 @@ type probePaymentSender func(context.Context,
 // probePaymentRequest. The sender is injected so tests can inspect generated
 // probe requests without invoking the full payment lifecycle.
 func (s *Server) probePaymentRequestWithSender(ctx context.Context,
-	paymentRequest string, timeout uint32,
+	paymentRequest string, timeout uint32, outgoingChanIDs []uint64,
 	sendProbePayment probePaymentSender) (*RouteFeeResponse, error) {
 
 	payReq, err := zpay32.Decode(

--- a/lnrpc/routerrpc/router_server_test.go
+++ b/lnrpc/routerrpc/router_server_test.go
@@ -853,6 +853,7 @@ func TestProbePaymentRequestUsesUniqueHashPerLSP(t *testing.T) {
 
 	seenHashes := make(map[[32]byte]struct{})
 	probedDests := make(map[route.Vertex]struct{})
+	outgoingChanIDs := []uint64{123, 456}
 	expectedCltv := map[route.Vertex]int32{
 		bobVertex:  int32(bobHint.CLTVExpiryDelta),
 		eveVertex:  int32(eveHint.CLTVExpiryDelta),
@@ -875,6 +876,7 @@ func TestProbePaymentRequestUsesUniqueHashPerLSP(t *testing.T) {
 		probedDests[dest] = struct{}{}
 
 		require.Equal(t, expectedCltv[dest], req.FinalCltvDelta)
+		require.Equal(t, outgoingChanIDs, req.OutgoingChanIds)
 
 		return &RouteFeeResponse{
 			RoutingFeeMsat: int64(req.FinalCltvDelta),
@@ -887,7 +889,7 @@ func TestProbePaymentRequestUsesUniqueHashPerLSP(t *testing.T) {
 	// Act: estimate the route fee with a stubbed probe sender that records
 	// the generated per-LSP probe requests.
 	_, err = server.probePaymentRequestWithSender(
-		t.Context(), payReq, 1, sendProbe,
+		t.Context(), payReq, 1, outgoingChanIDs, sendProbe,
 	)
 
 	// Assert: all LSPs were probed, each probe had a unique payment hash,


### PR DESCRIPTION
## Change Description
Fix `EstimateRouteFee` invoice probing so `OutgoingChanIds` from the route fee request are preserved when building probe payment requests.

The helper used by the probing path accepted a sender injection for tests, but the public caller was dropping the outgoing channel IDs before the `SendPaymentRequest` was created.

## Steps to Test
`go test ./lnrpc/routerrpc`

## Labels
- `no-changelog`: small bug fix, no release notes needed.
- `no-itest`: covered by focused routerrpc unit test.