### PR TITLE
CI: fix sweep flake

### DIFF
--- a/itest/lnd_sweep_test.go
+++ b/itest/lnd_sweep_test.go
@@ -689,8 +689,20 @@ func testSweepCPFPAnchorIncomingTimeout(ht *lntest.HarnessTest) {
 	// contractcourt will offer the HTLC to his sweeper. We are not testing
 	// the HTLC sweeping behaviors so we just perform a simple check and
 	// exit the test.
-	ht.AssertNumPendingSweeps(bob, 1)
-	ht.MineBlocksAndAssertNumTxes(1, 1)
+	htlcSweep := ht.AssertNumPendingSweeps(bob, 1)[0]
+	htlcSweepOutpointHash, err := chainhash.NewHashFromStr(
+		htlcSweep.Outpoint.TxidStr,
+	)
+	require.NoError(ht, err)
+	htlcSweepOutpoint := wire.OutPoint{
+		Hash:  *htlcSweepOutpointHash,
+		Index: htlcSweep.Outpoint.OutputIndex,
+	}
+
+	// The final sweep may be RBFed between the mempool check and block
+	// generation, so assert that the mined tx spends the pending sweep's
+	// outpoint instead of asserting the txid observed before mining.
+	ht.MineBlockAndAssertOutpointSpent(1, htlcSweepOutpoint)
 
 	// Finally, clean the mempool for the next test.
 	ht.CleanShutDown()

--- a/lntest/harness_miner.go
+++ b/lntest/harness_miner.go
@@ -121,6 +121,66 @@ func (h *HarnessTest) MineBlocksAndAssertNumTxes(num uint32,
 	return blocks
 }
 
+// MineBlockAndAssertOutpointSpent mines a block and asserts the given outpoint
+// was spent in it. Unlike MineBlocksAndAssertNumTxes, it does not require the
+// txids seen in the mempool before mining to be the txids that confirm. This is
+// useful for RBF-sensitive flows where a transaction may be replaced between
+// the mempool check and block generation.
+func (h *HarnessTest) MineBlockAndAssertOutpointSpent(numTxs int,
+	outpoint wire.OutPoint) *wire.MsgBlock {
+
+	// Update the harness's current height.
+	defer h.updateCurrentHeight()
+
+	// If we expect transactions to be included in the blocks we'll mine,
+	// wait until they are seen in the miner's mempool.
+	h.AssertNumTxsInMempool(numTxs)
+
+	// Mine a block.
+	block := h.miner.MineBlocks(1)[0]
+
+	// Assert that the expected number of non-coinbase transactions were
+	// included in the block.
+	require.Len(h, block.Transactions, numTxs+1)
+
+	// Assert that the expected outpoint was spent in the block.
+	h.assertOutpointSpentInBlock(block, outpoint)
+
+	// Finally, make sure all the active nodes are synced.
+	h.AssertActiveNodesSyncedTo(block.BlockHash())
+
+	return block
+}
+
+// assertOutpointSpentInBlock asserts that the given outpoint is spent by a
+// transaction in the passed block.
+func (h *HarnessTest) assertOutpointSpentInBlock(block *wire.MsgBlock,
+	outpoint wire.OutPoint) {
+
+	var txids []chainhash.Hash
+	var prevouts []wire.OutPoint
+
+	for _, tx := range block.Transactions {
+		if blockchain.IsCoinBaseTx(tx) {
+			continue
+		}
+
+		txids = append(txids, tx.TxHash())
+
+		for _, txIn := range tx.TxIn {
+			prevouts = append(prevouts, txIn.PreviousOutPoint)
+
+			if txIn.PreviousOutPoint == outpoint {
+				return
+			}
+		}
+	}
+
+	require.Failf(h, "outpoint was not spent in block",
+		"outpoint:%v, block:%v, txids:%v, prevouts:%v",
+		outpoint, block.BlockHash(), txids, prevouts)
+}
+
 // ConnectMiner connects the miner with the chain backend in the network.
 func (h *HarnessTest) ConnectMiner() {
 	err := h.manager.chainBackend.ConnectMiner()


### PR DESCRIPTION
Found in #10827 


Fix the itest [failure](https://github.com/lightningnetwork/lnd/actions/runs/26222505471/job/77160904913?pr=10827)
```
--- FAIL: TestLightningNetworkDaemon/tranche02/48-of-345/bitcoind/sweep_cpfp_anchor_incoming_timeout (54.74s)
        harness_node.go:395: Starting node (name=Alice) with PID=19244
        harness_node.go:395: Starting node (name=Bob) with PID=19286
        harness_node.go:395: Starting node (name=Carol) with PID=19317
        lnd_sweep_test.go:608: Bob(position=6): txWeight=722 wu, expected: [fee=5166, feerate=7155 sat/kw], got: [fee=5172, feerate=7163] in tx 334fc9a54af7c630c879b5b6f445d37e347eea3ca3afdb169770a72b6b54fdd1
        lnd_sweep_test.go:608: Bob(position=5): txWeight=722 wu, expected: [fee=8527, feerate=11810 sat/kw], got: [fee=8531, feerate=11799] in tx 1860f4ee1463a88ad4ee44966cfd539f80a788fa506a0a76eee2e5a842153b38
        lnd_sweep_test.go:608: Bob(position=4): txWeight=722 wu, expected: [fee=11888, feerate=16465 sat/kw], got: [fee=11891, feerate=16470] in tx 311b990f7a6fe09d6687f863e273a6b0ba9f8ff2163f5d01aa38a2778e5f1689
        lnd_sweep_test.go:608: Bob(position=3): txWeight=722 wu, expected: [fee=15249, feerate=21120 sat/kw], got: [fee=15251, feerate=21094] in tx 61475cf939f4690c34691583dc3ed22e99c9d377290d89c9638925c64e3a64e6
        lnd_sweep_test.go:608: Bob(position=2): txWeight=722 wu, expected: [fee=18610, feerate=25776 sat/kw], got: [fee=18610, feerate=25776] in tx b40ec707488e2449f0b26e87a52cc5f062d2ec85b0dd483200f46f9fff9c1db0
        lnd_sweep_test.go:608: Bob(position=1): txWeight=722 wu, expected: [fee=21971, feerate=30431 sat/kw], got: [fee=21970, feerate=30387] in tx 3e2a02e011a257a0dd0bf4b8f425a8dd10136b5978d97152e353c5c15fe38d5d
        miner.go:353: 
            	Error Trace:	/home/runner/work/lnd/lnd/lntest/miner/miner.go:353
            	            				/home/runner/work/lnd/lnd/lntest/harness_miner.go:111
            	            				/home/runner/work/lnd/lnd/itest/lnd_sweep_test.go:693
            	            				/home/runner/work/lnd/lnd/lntest/harness.go:320
            	            				/home/runner/work/lnd/lnd/itest/lnd_test.go:144
            	            				/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:1693
            	Error:      	tx was not included in block
            	Test:       	TestLightningNetworkDaemon/tranche02/48-of-345/bitcoind/sweep_cpfp_anchor_incoming_timeout
            	Messages:   	tx:ffb0ce83a0b5d0360efabd772773a84efbaebc83b26958e6451f1f45b206979c, block has:[168d21329b1edd5b33e5cf0ec2f7c23046a27e2374378db80f35828d1bcdf8c0 ac1344f64107108372c2a61154ed75a8b8afba1ce8acf451e63d47bbf2ce4c95]
        harness.go:398: finished test: sweep_cpfp_anchor_incoming_timeout, start height=461, end height=514, mined blocks=53
        harness.go:420: !============================================!
```

What happened:
- The test observed sweep tx `ffb0...979c` in the mempool before mining.
- Bob RBFed that sweep before the block was mined.
- The block correctly included the replacement tx `ac13...4c95`.
- The test failed because it asserted the old txid instead of the sweep outpoint.
- This PR asserts that the mined tx spends the pending sweep outpoint, which stays stable across RBF.


and fix the [compatibility test](https://github.com/lightningnetwork/lnd/actions/runs/26222505471/job/77160904897?pr=10827)
```
❌ Error: Payment failed from alice to dave
📜 Details: +------------+--------------+--------------+--------------+-----+----------+----------+-------+
| HTLC_STATE | ATTEMPT_TIME | RESOLVE_TIME | RECEIVER_AMT | FEE | TIMELOCK | CHAN_OUT | ROUTE |
+------------+--------------+--------------+--------------+-----+----------+----------+-------+
+------------+--------------+--------------+--------------+-----+----------+----------+-------+
Amount + fee:   0 + 0 sat
...
```

What happened:
- The compat test waited for graph channel counts to sync.
- Channel count sync does not guarantee edge policies are ready for routing.
- Alice knew the channels, but could not build a route to Dave yet.
- The payment failed with no route.
- This PR waits for `queryroutes` to succeed before sending each test payment.

