### PR TITLE
fix: correct spelling in comments and generated files

### DIFF
--- a/graph/builder.go
+++ b/graph/builder.go
@@ -1093,7 +1093,7 @@ func (b *Builder) AddEdge(ctx context.Context, edge *models.ChannelEdgeInfo,
 // addEdge does some validation on the new channel edge against what we
 // currently have persisted in the graph, and then adds it to the graph. The
 // Chain View is updated with the new edge if it is successfully added to the
-// graph. We only persist the channel if we currently dont have it at all in
+// graph. We only persist the channel if we currently don't have it at all in
 // our graph.
 func (b *Builder) addEdge(ctx context.Context, edge *models.ChannelEdgeInfo,
 	op ...batch.SchedulerOption) error {

--- a/graph/db/migration1/sql_migration.go
+++ b/graph/db/migration1/sql_migration.go
@@ -1440,7 +1440,7 @@ func forEachClosedSCID(db kvdb.Backend,
 // SQL migration. No error is expected if the node already exists. Unlike the
 // main upsertNode function, this function does not require that a new node
 // update have a newer timestamp than the existing one. This is because we want
-// the migration to be idempotent and dont want to error out if we re-insert the
+// the migration to be idempotent and don't want to error out if we re-insert the
 // exact same node.
 func insertNodeSQLMig(ctx context.Context, db SQLQueries,
 	node *models.Node) (int64, error) {

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -644,7 +644,7 @@ const (
 	// All possible routes were tried and failed permanently. Or were no
 	// routes to the destination at all.
 	PaymentFailureReason_FAILURE_REASON_NO_ROUTE PaymentFailureReason = 2
-	// A non-recoverable error has occured.
+	// A non-recoverable error has occurred.
 	PaymentFailureReason_FAILURE_REASON_ERROR PaymentFailureReason = 3
 	// Payment details incorrect (unknown hash, invalid amt or
 	// invalid final cltv delta)

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -2453,7 +2453,7 @@ func testSpendUnconfirmed(miner *rpctest.Harness,
 	}
 
 	// Finally, send the remainder of bob's wallet balance back to him so
-	// that these money movements dont mess up later tests.
+	// that these money movements don't mess up later tests.
 	output = &wire.TxOut{
 		Value:    int64(bobBalance) - (btcutil.SatoshiPerBitcoin * 0.4),
 		PkScript: bobPkScript,

--- a/routing/blindedpath/blinded_path_test.go
+++ b/routing/blindedpath/blinded_path_test.go
@@ -924,7 +924,7 @@ func TestBuildBlindedPathWithDummyHops(t *testing.T) {
 	require.Equal(t, []byte{1, 2, 3}, data.PathID.UnwrapOrFail(t).Val)
 
 	// Demonstrate that BuildBlindedPaymentPaths continues to use any
-	// functioning paths even if some routes cant be used to build a blinded
+	// functioning paths even if some routes can't be used to build a blinded
 	// path. We do this by forcing FetchChannelEdgesByID to error out for
 	// the first 2 calls. FindRoutes returns 3 routes and so by the end, we
 	// still get 1 valid path.

--- a/watchtower/wtdb/client_db_test.go
+++ b/watchtower/wtdb/client_db_test.go
@@ -999,7 +999,7 @@ func testMarkChannelClosed(h *clientDBHarness) {
 	require.EqualValues(h.t, 1, lastApplied)
 	h.ackUpdate(&session1.ID, 2, 2, nil)
 
-	// Add an update for channel 3 in session 1. But dont ack it yet.
+	// Add an update for channel 3 in session 1. But don't ack it yet.
 	update = randCommittedUpdateForChannel(h.t, chanID2, 3)
 	lastApplied = h.commitUpdate(&session1.ID, update, nil)
 	require.EqualValues(h.t, 2, lastApplied)


### PR DESCRIPTION
## Description
Fixed spelling errors in comments and test files.

⚠️ **Note:** Comment and test changes only. No functional code modified.

## Changes
- Fix 'cant' → 'can't'
- Fix 'dont' → 'don't'

## Impact
- Comment clarity improvement only
- No functional changes