### PR TITLE
sweep: isolate bad inputs on mempool rejection

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -55,6 +55,12 @@
   the reported network statistics such as total network capacity, channel
   count and max out degree.
 
+* The sweeper now [isolates singleton
+  inputs](https://github.com/lightningnetwork/lnd/pull/10842) from a rejected
+  sweep batch when no-broadcast mempool probes show that an individual input
+  has a script or witness failure, avoiding fatal failure of the entire batch
+  when only one input is invalid.
+
 # New Features
 
 ## Functional Enhancements
@@ -159,3 +165,4 @@
 * Boris Nagaev
 * Erick Cestari
 * Jared Tobin
+* Yong Yu

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"regexp"
 	"sync"
 	"time"
 
@@ -74,6 +75,19 @@ var (
 		waddrmgr.KeyScopeBIP0084,
 		waddrmgr.KeyScopeBIP0086,
 	}
+
+	btcdNonStandardInputPattern = regexp.MustCompile(
+		`^transaction ([0-9a-f]{64}) has a non-standard input: ` +
+			`transaction input #[0-9]+ has a non-standard ` +
+			`script form$`,
+	)
+	btcdScriptInputPattern = regexp.MustCompile(
+		`^failed to (validate|parse) input ([0-9a-f]{64}):[0-9]+ ` +
+			`which references output [0-9a-f]{64}:[0-9]+ - .+ ` +
+			`\(input witness \[([0-9a-f]*( [0-9a-f]*)*)?\], ` +
+			`input script bytes ` +
+			`[0-9a-f]*, prev output script bytes [0-9a-f]*\)$`,
+	)
 
 	// errNoImportedAddrGen is an error returned when a new address is
 	// requested for the default imported account within the wallet.
@@ -1142,6 +1156,44 @@ func mapRpcclientError(err error) error {
 	return err
 }
 
+// normalizeMempoolAcceptError corrects exact raw btcd input rejections for the
+// transaction being tested that btcwallet cannot distinguish.
+func normalizeMempoolAcceptError(backend string, txHash chainhash.Hash,
+	rejectReason string, err error) error {
+
+	if backend != "btcd" {
+		return err
+	}
+
+	txid := txHash.String()
+	switch {
+	case errors.Is(err, chain.ErrNonStandardScript):
+		matches := btcdNonStandardInputPattern.FindStringSubmatch(
+			rejectReason,
+		)
+		if len(matches) != 2 || matches[1] != txid {
+			return err
+		}
+
+		return fmt.Errorf("%w: %s", chain.ErrNonStandardInputs,
+			rejectReason)
+
+	case errors.Is(err, chain.ErrUndefined):
+		matches := btcdScriptInputPattern.FindStringSubmatch(
+			rejectReason,
+		)
+		if len(matches) != 5 || matches[2] != txid {
+			return err
+		}
+
+		return fmt.Errorf("%w: %s", chain.ErrScriptVerifyFlag,
+			rejectReason)
+
+	default:
+		return err
+	}
+}
+
 // PublishTransaction performs cursory validation (dust checks, etc), then
 // finally broadcasts the passed transaction to the Bitcoin network. If
 // publishing the transaction fails, an error describing the reason is returned
@@ -1204,6 +1256,9 @@ func (b *BtcWallet) PublishTransaction(tx *wire.MsgTx, label string) error {
 	// We need to use the string to create an error type and map it to a
 	// btcwallet error.
 	err = b.chain.MapRPCErr(errors.New(result.RejectReason))
+	err = normalizeMempoolAcceptError(
+		b.chain.BackEnd(), tx.TxHash(), result.RejectReason, err,
+	)
 
 	//nolint:ll
 	// These two errors are ignored inside `PublishTransaction`:
@@ -1928,6 +1983,10 @@ func (b *BtcWallet) CheckMempoolAcceptance(tx *wire.MsgTx) error {
 	// error and return it.
 	if !result.Allowed {
 		err := b.chain.MapRPCErr(errors.New(result.RejectReason))
+		err = normalizeMempoolAcceptError(
+			b.chain.BackEnd(), tx.TxHash(), result.RejectReason,
+			err,
+		)
 
 		return fmt.Errorf("mempool rejection: %w", err)
 	}

--- a/lnwallet/btcwallet/btcwallet_test.go
+++ b/lnwallet/btcwallet/btcwallet_test.go
@@ -1,9 +1,11 @@
 package btcwallet
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/chain"
@@ -207,6 +209,7 @@ func TestCheckMempoolAcceptance(t *testing.T) {
 		results, nil).Once()
 	mockChain.On("MapRPCErr", mock.Anything).Return(
 		chain.ErrInsufficientFee).Once()
+	mockChain.On("BackEnd").Return("bitcoind").Once()
 
 	// Now call the method under test.
 	err = wallet.CheckMempoolAcceptance(tx)
@@ -224,4 +227,280 @@ func TestCheckMempoolAcceptance(t *testing.T) {
 	// Now call the method under test.
 	err = wallet.CheckMempoolAcceptance(tx)
 	rt.NoError(err)
+}
+
+// TestNormalizeMempoolAcceptError checks the narrow raw btcd rejection forms
+// that identify input failures, including negative controls for broad errors
+// and output standardness.
+func TestNormalizeMempoolAcceptError(t *testing.T) {
+	t.Parallel()
+
+	witnessCases := []struct {
+		name    string
+		witness wire.TxWitness
+		encoded string
+	}{
+		{"empty", nil, "[]"},
+		{"single", wire.TxWitness{{0x01, 0x02}}, "[0102]"},
+		{
+			"multiple", wire.TxWitness{{0x01, 0x02}, {0x03}},
+			"[0102 03]",
+		},
+		{
+			"empty elements", wire.TxWitness{{}, {0x03}, {}},
+			"[ 03 ]",
+		},
+	}
+	for _, testCase := range witnessCases {
+		actual := fmt.Sprintf("%x", testCase.witness)
+		require.Equal(
+			t, testCase.encoded, actual, testCase.name,
+		)
+	}
+
+	txHash := chainhash.Hash{1}
+	otherTxHash := chainhash.Hash{2}
+	outpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{3},
+		Index: 2,
+	}.String()
+	nonStandardReason := "transaction " + txHash.String() +
+		" has a non-standard input: transaction input #0 has a " +
+		"non-standard script form"
+	inputReason := func(kind string, hash chainhash.Hash,
+		witness string) string {
+
+		return kind + " " + hash.String() +
+			":0 which references output " + outpoint +
+			" - false stack entry at end of script execution " +
+			"(input witness " + witness +
+			", input script bytes 00, " +
+			"prev output script bytes 51)"
+	}
+	validateReason := inputReason(
+		"failed to validate input", txHash, "[0102]",
+	)
+	parseReason := inputReason(
+		"failed to parse input", txHash, "[0102 03]",
+	)
+	emptyWitnessReason := inputReason(
+		"failed to validate input", txHash, "[]",
+	)
+	emptyElementsReason := inputReason(
+		"failed to parse input", txHash, "[ 03 ]",
+	)
+
+	testCases := []struct {
+		name           string
+		backend        string
+		rejectReason   string
+		mappedErr      error
+		expectedErr    error
+		notExpectedErr error
+	}{
+		{
+			name:         "non-standard input",
+			backend:      "btcd",
+			rejectReason: nonStandardReason,
+			mappedErr:    chain.ErrNonStandardScript,
+			expectedErr:  chain.ErrNonStandardInputs,
+		},
+		{
+			name:         "failed to validate input",
+			backend:      "btcd",
+			rejectReason: validateReason,
+			mappedErr:    chain.ErrUndefined,
+			expectedErr:  chain.ErrScriptVerifyFlag,
+		},
+		{
+			name:         "failed to parse input",
+			backend:      "btcd",
+			rejectReason: parseReason,
+			mappedErr:    chain.ErrUndefined,
+			expectedErr:  chain.ErrScriptVerifyFlag,
+		},
+		{
+			name:         "empty witness",
+			backend:      "btcd",
+			rejectReason: emptyWitnessReason,
+			mappedErr:    chain.ErrUndefined,
+			expectedErr:  chain.ErrScriptVerifyFlag,
+		},
+		{
+			name:         "empty witness elements",
+			backend:      "btcd",
+			rejectReason: emptyElementsReason,
+			mappedErr:    chain.ErrUndefined,
+			expectedErr:  chain.ErrScriptVerifyFlag,
+		},
+		{
+			name:    "generic undefined",
+			backend: "btcd",
+			rejectReason: "transaction rejected for an " +
+				"unknown reason",
+			mappedErr:      chain.ErrUndefined,
+			expectedErr:    chain.ErrUndefined,
+			notExpectedErr: chain.ErrScriptVerifyFlag,
+		},
+		{
+			name:    "output non-standard script",
+			backend: "btcd",
+			rejectReason: "transaction " + txHash.String() +
+				" has a non-standard output: " +
+				"transaction output #0 " +
+				"has a non-standard script form",
+			mappedErr:      chain.ErrNonStandardScript,
+			expectedErr:    chain.ErrNonStandardScript,
+			notExpectedErr: chain.ErrNonStandardInputs,
+		},
+		{
+			name:           "other backend",
+			backend:        "bitcoind",
+			rejectReason:   nonStandardReason,
+			mappedErr:      chain.ErrNonStandardScript,
+			expectedErr:    chain.ErrNonStandardScript,
+			notExpectedErr: chain.ErrNonStandardInputs,
+		},
+		{
+			name:    "wrong transaction",
+			backend: "btcd",
+			rejectReason: inputReason(
+				"failed to validate input", otherTxHash, "[]",
+			),
+			mappedErr:      chain.ErrUndefined,
+			expectedErr:    chain.ErrUndefined,
+			notExpectedErr: chain.ErrScriptVerifyFlag,
+		},
+		{
+			name:    "wrong non-standard transaction",
+			backend: "btcd",
+			rejectReason: "transaction " + otherTxHash.String() +
+				" has a non-standard input: " +
+				"transaction input #0 " +
+				"has a non-standard script form",
+			mappedErr:      chain.ErrNonStandardScript,
+			expectedErr:    chain.ErrNonStandardScript,
+			notExpectedErr: chain.ErrNonStandardInputs,
+		},
+		{
+			name:           "prefixed rejection",
+			backend:        "btcd",
+			rejectReason:   "prefix: " + validateReason,
+			mappedErr:      chain.ErrUndefined,
+			expectedErr:    chain.ErrUndefined,
+			notExpectedErr: chain.ErrScriptVerifyFlag,
+		},
+		{
+			name:           "suffixed rejection",
+			backend:        "btcd",
+			rejectReason:   validateReason + ": suffix",
+			mappedErr:      chain.ErrUndefined,
+			expectedErr:    chain.ErrUndefined,
+			notExpectedErr: chain.ErrScriptVerifyFlag,
+		},
+		{
+			name:           "malformed rejection",
+			backend:        "btcd",
+			rejectReason:   validateReason[:len(validateReason)-1],
+			mappedErr:      chain.ErrUndefined,
+			expectedErr:    chain.ErrUndefined,
+			notExpectedErr: chain.ErrScriptVerifyFlag,
+		},
+		{
+			name:    "unbracketed witness",
+			backend: "btcd",
+			rejectReason: inputReason(
+				"failed to validate input", txHash, "0102",
+			),
+			mappedErr:      chain.ErrUndefined,
+			expectedErr:    chain.ErrUndefined,
+			notExpectedErr: chain.ErrScriptVerifyFlag,
+		},
+		{
+			name:    "missing witness bracket",
+			backend: "btcd",
+			rejectReason: inputReason(
+				"failed to validate input", txHash, "[0102",
+			),
+			mappedErr:      chain.ErrUndefined,
+			expectedErr:    chain.ErrUndefined,
+			notExpectedErr: chain.ErrScriptVerifyFlag,
+		},
+		{
+			name:    "invalid witness separator",
+			backend: "btcd",
+			rejectReason: inputReason(
+				"failed to validate input", txHash, "[0102,03]",
+			),
+			mappedErr:      chain.ErrUndefined,
+			expectedErr:    chain.ErrUndefined,
+			notExpectedErr: chain.ErrScriptVerifyFlag,
+		},
+		{
+			name:           "script failure mapping mismatch",
+			backend:        "btcd",
+			rejectReason:   validateReason,
+			mappedErr:      chain.ErrNonStandardScript,
+			expectedErr:    chain.ErrNonStandardScript,
+			notExpectedErr: chain.ErrScriptVerifyFlag,
+		},
+		{
+			name:           "non-standard mapping mismatch",
+			backend:        "btcd",
+			rejectReason:   nonStandardReason,
+			mappedErr:      chain.ErrUndefined,
+			expectedErr:    chain.ErrUndefined,
+			notExpectedErr: chain.ErrNonStandardInputs,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := normalizeMempoolAcceptError(
+				testCase.backend, txHash,
+				testCase.rejectReason, testCase.mappedErr,
+			)
+
+			require.ErrorIs(t, err, testCase.expectedErr)
+			if testCase.notExpectedErr != nil {
+				require.NotErrorIs(
+					t, err, testCase.notExpectedErr,
+				)
+			}
+		})
+	}
+}
+
+// TestCheckMempoolAcceptanceBtcdInputFailure checks that raw btcd script
+// failures are normalized on the wallet acceptance path.
+func TestCheckMempoolAcceptanceBtcdInputFailure(t *testing.T) {
+	t.Parallel()
+
+	mockChain := &lnmock.MockChain{}
+	defer mockChain.AssertExpectations(t)
+
+	tx := wire.NewMsgTx(2)
+	rejectReason := "failed to validate input " + tx.TxHash().String() +
+		":0 which references output " + wire.OutPoint{}.String() +
+		" - false stack entry at end of script execution " +
+		"(input witness [], input script bytes , " +
+		"prev output script bytes 51)"
+	results := []*btcjson.TestMempoolAcceptResult{{
+		Txid:         tx.TxHash().String(),
+		Allowed:      false,
+		RejectReason: rejectReason,
+	}}
+	mockChain.On("TestMempoolAccept", []*wire.MsgTx{tx}, float64(0)).Return(
+		results, nil,
+	).Once()
+	mockChain.On("MapRPCErr", mock.Anything).Return(
+		chain.ErrUndefined,
+	).Once()
+	mockChain.On("BackEnd").Return("btcd").Once()
+	wallet := &BtcWallet{chain: mockChain}
+
+	err := wallet.CheckMempoolAcceptance(tx)
+
+	require.ErrorIs(t, err, chain.ErrScriptVerifyFlag)
+	require.NotErrorIs(t, err, chain.ErrUndefined)
 }

--- a/sweep/README.md
+++ b/sweep/README.md
@@ -111,6 +111,29 @@ perform an RBF again in the coming blocks.
 for the first time, unless its budget has been used up, `TxPublisher` will
 guarantee that the initial publish meets the RBF requirements.
 
+`TxPublisher` is also responsible for diagnosing failures that require access to
+the exact transaction candidate and the chain backend's mempool acceptance
+oracle. If `testmempoolaccept` reports missing inputs or a mempool conflict,
+`TxPublisher` first uses spend notifications to identify inputs spent by another
+transaction and reports them as `TxUnknownSpend`. When no spend is immediately
+attributable in a multi-input batch, it uses no-broadcast probes to isolate a
+missing singleton and reports that input as `BadInput`. The same probes diagnose
+unattributed non-fee mempool or script errors. Required-output probes use only
+independently accepted normal inputs as funding companions. Probe transactions
+are only tested for mempool acceptance; they are not published, stored, or
+monitored.
+
+`UtxoSweeper` owns pending input state and applies these diagnoses. Attributed
+spends are removed through the existing `TxUnknownSpend` flow. For isolated
+missing inputs and diagnosed mempool/script failures, only singleton inputs
+reported as bad are marked fatal; the remaining inputs in the batch restart at
+a fresh starting fee and can be retried by normal clustering. If probing is
+skipped or completes without an attributable singleton, the whole set is
+unconditionally fatal. If probing aborts before completion, the unchanged set
+is retryable only after its starting fee advances. Any fee-advance error,
+including reaching the maximum fee-function position, is fatal. Initial
+publication and replacement attempts follow the same rules.
+
 #### `FeeFunction`
 
 `FeeFunction` is an interface that specifies a function over a starting fee
@@ -210,4 +233,3 @@ outputs minus the sum of their budgets. By default, 50% of this value is used
 as the budget, to customize it, either use
 `--sweeper.budget.anchorcpfp` to specify sats, or use
 `--sweeper.budget.anchorcpfpratio` to specify a ratio.
-

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -56,6 +56,10 @@ var (
 	// errProbeTxConstruction marks errors encountered before a probe tx can
 	// be submitted for mempool acceptance.
 	errProbeTxConstruction = errors.New("unable to construct probe tx")
+
+	// errBadInputNotFound is returned when bad-input diagnosis finishes
+	// without finding a singleton input that fails mempool acceptance.
+	errBadInputNotFound = errors.New("bad input not found")
 )
 
 var (
@@ -609,10 +613,6 @@ func (t *TxPublisher) createRBFCompliantTx(
 				}
 			}
 
-		// TODO(yy): suppose there's only one bad input, we can do a
-		// binary search to find out which input is causing this error
-		// by recreating a tx using half of the inputs and check its
-		// mempool acceptance.
 		default:
 			log.Debugf("Failed to create RBF-compliant tx: %v", err)
 			return nil, err
@@ -822,6 +822,103 @@ func isInputScriptFailure(err error) bool {
 		errors.Is(err, chain.ErrScriptSigNotPushOnly) ||
 		errors.Is(err, chain.ErrScriptSigSize) ||
 		errors.Is(err, chain.ErrNonStandardInputs)
+}
+
+// findBadInput locates a singleton input that fails a no-broadcast probe.
+func (t *TxPublisher) findBadInput(r *monitorRecord) (wire.OutPoint, error) {
+	return t.findBadInputInSet(r, r.req.Inputs)
+}
+
+// findBadInputInSet searches the given input set for a single input that fails
+// mempool acceptance by itself.
+func (t *TxPublisher) findBadInputInSet(r *monitorRecord,
+	inputs []input.Input) (wire.OutPoint, error) {
+
+	if len(inputs) > 1 {
+		mid := len(inputs) / 2
+		left := inputs[:mid]
+
+		err := t.probeInputSet(r, left)
+		switch {
+		case err == nil:
+			return t.findBadInputInSet(r, inputs[mid:])
+
+		case errors.Is(err, ErrInputMissing):
+			if len(left) == 1 {
+				return left[0].OutPoint(), ErrInputMissing
+			}
+
+			return t.findBadInputInSet(r, left)
+
+		case isInputScriptFailure(err):
+			if len(left) == 1 {
+				return left[0].OutPoint(), nil
+			}
+
+			return t.findBadInputInSet(r, left)
+
+		case errors.Is(err, errProbeTxConstruction):
+			return t.findBadInputBySingleton(r, inputs)
+
+		default:
+			return wire.OutPoint{}, err
+		}
+	}
+
+	if len(inputs) == 0 {
+		return wire.OutPoint{}, errBadInputNotFound
+	}
+
+	err := t.probeInputSet(r, inputs)
+	switch {
+	case err == nil:
+		return wire.OutPoint{}, errBadInputNotFound
+
+	case errors.Is(err, ErrInputMissing):
+		return inputs[0].OutPoint(), ErrInputMissing
+
+	case isInputScriptFailure(err):
+		return inputs[0].OutPoint(), nil
+
+	default:
+		return wire.OutPoint{}, err
+	}
+}
+
+// findBadInputBySingleton scans candidates after a subset cannot be built.
+func (t *TxPublisher) findBadInputBySingleton(r *monitorRecord,
+	inputs []input.Input) (wire.OutPoint, error) {
+
+	var constructionErr error
+	for _, inp := range inputs {
+		err := t.probeInputSet(r, []input.Input{inp})
+		switch {
+		case err == nil:
+			continue
+
+		case errors.Is(err, ErrInputMissing):
+			return inp.OutPoint(), ErrInputMissing
+
+		case isInputScriptFailure(err):
+			return inp.OutPoint(), nil
+
+		case errors.Is(err, errProbeTxConstruction):
+			if constructionErr == nil {
+				constructionErr = err
+			}
+
+			continue
+
+		default:
+			return wire.OutPoint{}, err
+		}
+	}
+
+	if constructionErr != nil {
+		return wire.OutPoint{}, constructionErr
+	}
+
+	return wire.OutPoint{}, errBadInputNotFound
 }
 
 // handleMissingInputs handles the case when the chain backend reports back a

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -2184,6 +2184,14 @@ func (t *TxPublisher) handleReplacementTxError(r *monitorRecord,
 		return fn.Some(*bumpResult)
 	}
 
+	// Initial and replacement mempool rejections use the same diagnosis.
+	if errors.Is(err, errMempoolRejected) {
+		bumpResult := t.handleBadInputs(r, err)
+		bumpResult.Tx = oldTx
+
+		return fn.Some(*bumpResult)
+	}
+
 	// Return a failed event to retry the sweep.
 	event := TxFailed
 

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -52,6 +52,10 @@ var (
 	// checks. It is used internally to avoid probing unrelated construction
 	// or signing errors.
 	errMempoolRejected = errors.New("mempool rejected tx")
+
+	// errProbeTxConstruction marks errors encountered before a probe tx can
+	// be submitted for mempool acceptance.
+	errProbeTxConstruction = errors.New("unable to construct probe tx")
 )
 
 var (
@@ -725,6 +729,88 @@ func (t *TxPublisher) shouldDiagnoseBadInputs(r *monitorRecord,
 	}
 
 	return true
+}
+
+// checkProbeTx tests a probe transaction without publishing, storing, or
+// monitoring it.
+func (t *TxPublisher) checkProbeTx(sweepCtx *sweepTxCtx) error {
+	err := t.cfg.Wallet.CheckMempoolAcceptance(sweepCtx.tx)
+	if err == nil {
+		return nil
+	}
+
+	// Missing-input failures use a dedicated sentinel so callers can run
+	// spend attribution instead of treating them as script failures.
+	if errors.Is(err, chain.ErrMissingInputs) ||
+		errors.Is(err, chain.ErrMempoolConflict) {
+
+		log.Debugf("Probe tx %v missing inputs", sweepCtx.tx.TxHash())
+
+		return ErrInputMissing
+	}
+
+	log.Infof("Probe tx=%v with %v inputs failed mempool check: %v",
+		sweepCtx.tx.TxHash(), len(sweepCtx.tx.TxIn), err)
+
+	return err
+}
+
+// probeInputSet builds and mempool-tests a sweep transaction for the given
+// inputs without publishing, storing, or monitoring it. Inputs that commit to
+// a required output may need an accepted normal input to pay the probe fee.
+func (t *TxPublisher) probeInputSet(r *monitorRecord,
+	inputs []input.Input) error {
+
+	feeRate := r.feeFunction.FeeRate()
+	createProbe := func(probeInputs []input.Input) (*sweepTxCtx, error) {
+		return t.createSweepTx(
+			probeInputs, r.req.DeliveryAddress, feeRate,
+		)
+	}
+
+	sweepCtx, err := createProbe(inputs)
+	if err == nil {
+		return t.checkProbeTx(sweepCtx)
+	}
+
+	needsFunding := fn.Any(inputs, func(inp input.Input) bool {
+		return inp.RequiredTxOut() != nil
+	})
+	if !needsFunding {
+		return fmt.Errorf("%w: %w", errProbeTxConstruction, err)
+	}
+
+	selected := fn.NewSet[wire.OutPoint]()
+	for _, inp := range inputs {
+		selected.Add(inp.OutPoint())
+	}
+
+	probeInputs := append([]input.Input(nil), inputs...)
+	for _, companion := range r.req.Inputs {
+		if companion.RequiredTxOut() != nil ||
+			selected.Contains(companion.OutPoint()) {
+
+			continue
+		}
+
+		// Establish that the companion is independently accepted before
+		// using it to fund a probe. Otherwise its own failure could be
+		// misattributed to the required-output input.
+		companionCtx, companionErr := createProbe(
+			[]input.Input{companion},
+		)
+		if companionErr != nil || t.checkProbeTx(companionCtx) != nil {
+			continue
+		}
+
+		probeInputs = append(probeInputs, companion)
+		sweepCtx, err = createProbe(probeInputs)
+		if err == nil {
+			return t.checkProbeTx(sweepCtx)
+		}
+	}
+
+	return fmt.Errorf("%w: %w", errProbeTxConstruction, err)
 }
 
 // handleMissingInputs handles the case when the chain backend reports back a

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -813,6 +813,17 @@ func (t *TxPublisher) probeInputSet(r *monitorRecord,
 	return fmt.Errorf("%w: %w", errProbeTxConstruction, err)
 }
 
+// isInputScriptFailure returns true for mempool failures that can be attributed
+// to a single input's script or witness data.
+func isInputScriptFailure(err error) bool {
+	return errors.Is(err, chain.ErrScriptVerifyFlag) ||
+		errors.Is(err, chain.ErrNonMandatoryScriptVerifyFlag) ||
+		errors.Is(err, chain.ErrBadWitnessNonStandard) ||
+		errors.Is(err, chain.ErrScriptSigNotPushOnly) ||
+		errors.Is(err, chain.ErrScriptSigSize) ||
+		errors.Is(err, chain.ErrNonStandardInputs)
+}
+
 // handleMissingInputs handles the case when the chain backend reports back a
 // missing inputs error, which could happen when one of the input has been spent
 // in another tx, or the input is referencing an orphan. When the input is

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -685,6 +685,48 @@ func (t *TxPublisher) createAndCheckTx(r *monitorRecord) (*sweepTxCtx, error) {
 		errMempoolRejected, sweepCtx.tx.TxHash(), err)
 }
 
+// shouldDiagnoseBadInputs returns true if a mempool rejection should be
+// isolated with no-broadcast subset probes.
+func (t *TxPublisher) shouldDiagnoseBadInputs(r *monitorRecord,
+	err error) bool {
+
+	// Bad-input probes must use the same fee rate as the rejected tx. A
+	// record can be missing its fee function if tx initialization failed
+	// before fee selection completed, which means any probe tx would use a
+	// made-up feerate. Skip diagnosis and let handleBadInputs keep the
+	// original error as a whole-set failure.
+	if r.feeFunction == nil {
+		return false
+	}
+
+	// Only a concrete mempool rejection proves the fully constructed tx was
+	// invalid under mempool policy. Construction, signing and fee-selection
+	// errors do not have a candidate tx to bisect, so handleBadInputs keeps
+	// them on the existing whole-set fatal path instead of probing subsets.
+	if !errors.Is(err, errMempoolRejected) {
+		return false
+	}
+
+	// A singleton rejection already identifies the only input in the batch.
+	// There is no subset left to probe, so the caller preserves existing
+	// singleton fatal behavior.
+	if len(r.req.Inputs) <= 1 {
+		return false
+	}
+
+	// Aux sweepers may derive addresses or other sweep details from the
+	// complete input set. Subset probes would bypass that logic and could
+	// misattribute aux failures, so keep them on the whole-set path.
+	if t.cfg.AuxSweeper.IsSome() {
+		log.Infof("Skipping bad-input diagnosis for requestID=%v: aux "+
+			"sweeper is active", r.requestID)
+
+		return false
+	}
+
+	return true
+}
+
 // handleMissingInputs handles the case when the chain backend reports back a
 // missing inputs error, which could happen when one of the input has been spent
 // in another tx, or the input is referencing an orphan. When the input is

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -47,6 +47,11 @@ var (
 	// ErrInputMissing is returned when a given input no longer exists,
 	// e.g., spending from an orphan tx.
 	ErrInputMissing = errors.New("input no longer exists")
+
+	// errMempoolRejected marks errors that came from mempool acceptance
+	// checks. It is used internally to avoid probing unrelated construction
+	// or signing errors.
+	errMempoolRejected = errors.New("mempool rejected tx")
 )
 
 var (
@@ -662,8 +667,11 @@ func (t *TxPublisher) createAndCheckTx(r *monitorRecord) (*sweepTxCtx, error) {
 	}
 
 	// If the inputs are spent by another tx, we will exit with the latest
-	// sweepCtx and an error.
-	if errors.Is(err, chain.ErrMissingInputs) {
+	// sweepCtx and an error. Btcd reports an unconfirmed spend as a mempool
+	// conflict; both errors need spend attribution.
+	if errors.Is(err, chain.ErrMissingInputs) ||
+		errors.Is(err, chain.ErrMempoolConflict) {
+
 		log.Debugf("Tx %v missing inputs, it's likely the input has "+
 			"been spent by others", sweepCtx.tx.TxHash())
 
@@ -673,8 +681,8 @@ func (t *TxPublisher) createAndCheckTx(r *monitorRecord) (*sweepTxCtx, error) {
 		return sweepCtx, ErrInputMissing
 	}
 
-	return sweepCtx, fmt.Errorf("tx=%v failed mempool check: %w",
-		sweepCtx.tx.TxHash(), err)
+	return sweepCtx, fmt.Errorf("%w: tx=%v failed mempool check: %w",
+		errMempoolRejected, sweepCtx.tx.TxHash(), err)
 }
 
 // handleMissingInputs handles the case when the chain backend reports back a

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -93,10 +93,10 @@ const (
 	// TxPublished is sent when the broadcast attempt is finished.
 	TxPublished BumpEvent = iota
 
-	// TxFailed is sent when the tx has encountered a fee-related error
-	// during its creation or broadcast, or an internal error from the fee
-	// bumper. In either case the inputs in this tx should be retried with
-	// either a different grouping strategy or an increased budget.
+	// TxFailed is sent when the current tx attempt cannot continue, but at
+	// least one input can be retried. If BadInput is set, that input is
+	// terminal or quarantined while the remaining inputs can be regrouped
+	// and retried.
 	//
 	// TODO(yy): Remove the above usage once we remove sweeping non-CPFP
 	// anchors.
@@ -119,9 +119,8 @@ const (
 	//   broadcast and confirmed.
 	TxUnknownSpend
 
-	// TxFatal is sent when the inputs in this tx cannot be retried. Txns
-	// will end up in this state if they have encountered a non-fee related
-	// error, which means they cannot be retried with increased budget.
+	// TxFatal is sent when none of the inputs in this tx can be retried. It
+	// is the whole-set outcome, unlike a TxFailed result with BadInput set.
 	TxFatal
 
 	// sentinelEvent is used to check if an event is unknown.
@@ -293,6 +292,10 @@ type BumpResult struct {
 	// SpentInputs are the inputs spent by another tx which caused the
 	// current tx to be failed.
 	SpentInputs map[wire.OutPoint]*wire.MsgTx
+
+	// BadInput is the input that failed a singleton mempool acceptance
+	// probe. It is nil if no bad input was diagnosed.
+	BadInput *wire.OutPoint
 
 	// requestID is the ID of the request that created this record.
 	requestID uint64
@@ -919,6 +922,41 @@ func (t *TxPublisher) findBadInputBySingleton(r *monitorRecord,
 	}
 
 	return wire.OutPoint{}, errBadInputNotFound
+}
+
+// inputDiagnosisOutcome describes whether diagnosis changed the input set or
+// left it unchanged, and whether an unchanged result is conclusive.
+type inputDiagnosisOutcome uint8
+
+const (
+	diagnosisSkipped inputDiagnosisOutcome = iota
+	diagnosisCompleted
+	diagnosisAborted
+	diagnosisAttributed
+)
+
+// inputDiagnosis carries the explicit result of singleton attribution.
+type inputDiagnosis struct {
+	outcome  inputDiagnosisOutcome
+	badInput wire.OutPoint
+}
+
+// diagnoseInputSet runs singleton attribution and classifies its outcome.
+func (t *TxPublisher) diagnoseInputSet(r *monitorRecord) inputDiagnosis {
+	badInput, err := t.findBadInput(r)
+	switch {
+	case err == nil, errors.Is(err, ErrInputMissing):
+		return inputDiagnosis{
+			outcome:  diagnosisAttributed,
+			badInput: badInput,
+		}
+
+	case errors.Is(err, errBadInputNotFound):
+		return inputDiagnosis{outcome: diagnosisCompleted}
+
+	default:
+		return inputDiagnosis{outcome: diagnosisAborted}
+	}
 }
 
 // handleMissingInputs handles the case when the chain backend reports back a

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -959,6 +959,25 @@ func (t *TxPublisher) diagnoseInputSet(r *monitorRecord) inputDiagnosis {
 	}
 }
 
+// resultForDiagnosis converts explicit diagnosis metadata into retry policy.
+func (t *TxPublisher) resultForDiagnosis(r *monitorRecord, err error,
+	diagnosis inputDiagnosis) *BumpResult {
+
+	result := &BumpResult{
+		Event:     TxFatal,
+		Err:       err,
+		requestID: r.requestID,
+	}
+	if diagnosis.outcome == diagnosisAttributed {
+		result.Event = TxFailed
+		result.BadInput = &diagnosis.badInput
+	} else if diagnosis.outcome == diagnosisAborted {
+		return t.createUnchangedSetRetryResult(r, err)
+	}
+
+	return result
+}
+
 // handleMissingInputs handles the case when the chain backend reports back a
 // missing inputs error, which could happen when one of the input has been spent
 // in another tx, or the input is referencing an orphan. When the input is
@@ -970,6 +989,14 @@ func (t *TxPublisher) handleMissingInputs(r *monitorRecord) *BumpResult {
 
 	// Attach the spending txns.
 	r.spentInputs = spends
+
+	if len(spends) == 0 && len(r.req.Inputs) > 1 &&
+		r.feeFunction != nil && !t.cfg.AuxSweeper.IsSome() {
+
+		return t.resultForDiagnosis(
+			r, ErrInputMissing, t.diagnoseInputSet(r),
+		)
+	}
 
 	// If there are no spending txns found and the input is missing, the
 	// input is referencing an orphan tx that's no longer valid, e.g., the
@@ -1372,6 +1399,40 @@ func (t *TxPublisher) handleTxConfirmed(r *monitorRecord) {
 	t.handleResult(result)
 }
 
+// createUnchangedSetRetryResult advances the fee or fails the unchanged set.
+func (t *TxPublisher) createUnchangedSetRetryResult(r *monitorRecord,
+	err error) *BumpResult {
+
+	result := &BumpResult{
+		Event:     TxFailed,
+		Err:       err,
+		requestID: r.requestID,
+	}
+
+	feeRate, feeErr := t.calculateRetryFeeRate(r)
+	if feeErr != nil {
+		result.Event = TxFatal
+		result.Err = feeErr
+	}
+	result.FeeRate = feeRate
+
+	return result
+}
+
+// handleBadInputs handles a non-fee mempool rejection by trying to identify a
+// single input that fails mempool acceptance by itself.
+func (t *TxPublisher) handleBadInputs(r *monitorRecord,
+	err error) *BumpResult {
+
+	if !t.shouldDiagnoseBadInputs(r, err) {
+		return t.resultForDiagnosis(r, err, inputDiagnosis{
+			outcome: diagnosisSkipped,
+		})
+	}
+
+	return t.resultForDiagnosis(r, err, t.diagnoseInputSet(r))
+}
+
 // handleInitialTxError takes the error from `initializeTx` and decides the
 // bump event. It will construct a BumpResult and handles it.
 func (t *TxPublisher) handleInitialTxError(r *monitorRecord, err error) {
@@ -1424,15 +1485,11 @@ func (t *TxPublisher) handleInitialTxError(r *monitorRecord, err error) {
 	case errors.Is(err, ErrInputMissing):
 		result = t.handleMissingInputs(r)
 
-	// Otherwise this is not a fee-related error and the tx cannot be
-	// retried. In that case we will fail ALL the inputs in this tx, which
-	// means they will be removed from the sweeper and never be tried
-	// again.
-	//
-	// TODO(yy): Find out which input is causing the failure and fail that
-	// one only.
+	// Otherwise this may be a non-fee mempool rejection. For multi-input
+	// batches, try to isolate singleton bad inputs before deciding whether
+	// the whole set is fatal.
 	default:
-		result.Event = TxFatal
+		result = t.handleBadInputs(r, err)
 	}
 
 	t.handleResult(result)
@@ -1563,18 +1620,6 @@ func (t *TxPublisher) createUnknownSpentBumpResult(
 		Err:         ErrUnknownSpent,
 		SpentInputs: r.spentInputs,
 	}
-
-	// Calculate the next fee rate for the retry.
-	feeRate, err := t.calculateRetryFeeRate(r)
-	if err != nil {
-		// Overwrite the event and error so the sweeper will
-		// remove this input.
-		result.Event = TxFatal
-		result.Err = err
-	}
-
-	// Attach the new fee rate to be used for the next sweeping attempt.
-	result.FeeRate = feeRate
 
 	return result
 }
@@ -2148,6 +2193,7 @@ func (t *TxPublisher) handleReplacementTxError(r *monitorRecord,
 		// If there's an error with the fee calculation, we need to
 		// abort the sweep.
 		event = TxFatal
+		err = ferr
 	}
 
 	// If the error is not fee related, we will return a `TxFailed` event so
@@ -2222,13 +2268,18 @@ func (t *TxPublisher) calculateRetryFeeRate(
 	// were RBFed. This new fee rate will be used as the starting fee rate
 	// if the upper system decides to continue sweeping the rest of the
 	// inputs.
-	_, err := feeFunc.Increment()
-	if err != nil {
-		// The fee function has reached its max position - nothing we
-		// can do here other than letting the user increase the budget.
-		log.Errorf("Failed to calculate the next fee rate for "+
-			"Record(%v): %v", r.requestID, err)
-	}
+	for {
+		increased, err := feeFunc.Increment()
+		if err != nil {
+			// The budget must increase after the final position.
+			log.Errorf("Failed to calculate the next fee rate for "+
+				"Record(%v): %v", r.requestID, err)
 
-	return feeFunc.FeeRate(), nil
+			return feeFunc.FeeRate(), err
+		}
+
+		if increased {
+			return feeFunc.FeeRate(), nil
+		}
+	}
 }

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -757,6 +757,105 @@ func TestCreateRBFCompliantTx(t *testing.T) {
 	}
 }
 
+// createBadInputTestRequest creates a bump request with the given number of
+// inputs and enough budget for subset probes.
+func createBadInputTestRequest(numInputs int) *BumpRequest {
+	inputs := make([]input.Input, 0, numInputs)
+	for i := 0; i < numInputs; i++ {
+		inp := createTestInput(10_000, input.WitnessKeyHash)
+		inputs = append(inputs, &inp)
+	}
+
+	return &BumpRequest{
+		DeliveryAddress: changePkScript,
+		Inputs:          inputs,
+		Budget:          btcutil.Amount(10_000),
+	}
+}
+
+// TestShouldDiagnoseBadInputs checks the eligibility rules for no-broadcast
+// subset diagnosis.
+func TestShouldDiagnoseBadInputs(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		numInputs int
+		withAux   bool
+		withFee   bool
+		err       error
+		diagnose  bool
+	}{
+		{
+			name:      "mempool rejection",
+			numInputs: 2,
+			withFee:   true,
+			err: fmt.Errorf(
+				"%w: %w", errMempoolRejected, errDummy,
+			),
+			diagnose: true,
+		},
+		{
+			name:      "missing fee function",
+			numInputs: 2,
+			err: fmt.Errorf(
+				"%w: %w", errMempoolRejected, errDummy,
+			),
+		},
+		{
+			name:      "construction error",
+			numInputs: 2,
+			withFee:   true,
+			err:       errDummy,
+		},
+		{
+			name:      "singleton",
+			numInputs: 1,
+			withFee:   true,
+			err: fmt.Errorf(
+				"%w: %w", errMempoolRejected, errDummy,
+			),
+		},
+		{
+			name:      "aux sweeper",
+			numInputs: 2,
+			withAux:   true,
+			withFee:   true,
+			err: fmt.Errorf(
+				"%w: %w", errMempoolRejected, errDummy,
+			),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var tp *TxPublisher
+			var m *mockers
+			if testCase.withAux {
+				tp, m = createTestPublisher(t)
+			} else {
+				tp, m = createTestPublisherNoAux(t)
+			}
+
+			record := &monitorRecord{
+				requestID: 1,
+				req: createBadInputTestRequest(
+					testCase.numInputs,
+				),
+			}
+			if testCase.withFee {
+				record.feeFunction = m.feeFunc
+			}
+
+			diagnose := tp.shouldDiagnoseBadInputs(
+				record, testCase.err,
+			)
+
+			require.Equal(t, testCase.diagnose, diagnose)
+		})
+	}
+}
+
 // TestTxPublisherBroadcast checks the internal `broadcast` method behaves as
 // expected.
 func TestTxPublisherBroadcast(t *testing.T) {

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -1155,6 +1155,58 @@ func TestFindBadInputContinuesAfterConstructionError(t *testing.T) {
 	m.wallet.AssertNumberOfCalls(t, "CheckMempoolAcceptance", 4)
 }
 
+// TestDiagnoseInputSetMetadata checks that attribution reports whether input
+// membership changed and whether an unchanged result was conclusive.
+func TestDiagnoseInputSetMetadata(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		probeErr error
+		outcome  inputDiagnosisOutcome
+		probes   int
+	}{
+		{
+			"attributed", chain.ErrScriptVerifyFlag,
+			diagnosisAttributed, 1,
+		},
+		{"completed", nil, diagnosisCompleted, 2},
+		{"aborted", chain.ErrInsufficientFee, diagnosisAborted, 1},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tp, m := createTestPublisherNoAux(t)
+			req := createBadInputTestRequest(2)
+			record := &monitorRecord{
+				requestID:   1,
+				req:         req,
+				feeFunction: m.feeFunc,
+			}
+			m.feeFunc.On("FeeRate").Return(
+				chainfee.SatPerKWeight(1000),
+			).Times(testCase.probes)
+			m.signer.On("ComputeInputScript", mock.Anything,
+				mock.Anything).Return(
+				&input.Script{}, nil,
+			).Times(testCase.probes)
+			m.wallet.On(
+				"CheckMempoolAcceptance", mock.Anything,
+			).Return(testCase.probeErr).Times(testCase.probes)
+
+			diagnosis := tp.diagnoseInputSet(record)
+
+			require.Equal(t, testCase.outcome, diagnosis.outcome)
+			if testCase.outcome == diagnosisAttributed {
+				require.Equal(
+					t, req.Inputs[0].OutPoint(),
+					diagnosis.badInput,
+				)
+			}
+		})
+	}
+}
+
 // TestTxPublisherBroadcast checks the internal `broadcast` method behaves as
 // expected.
 func TestTxPublisherBroadcast(t *testing.T) {

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -1043,6 +1043,118 @@ func TestIsInputScriptFailure(t *testing.T) {
 	}
 }
 
+// TestFindBadInputIdentifiesSingleton checks that the binary search returns the
+// first singleton input that fails a mempool probe.
+func TestFindBadInputIdentifiesSingleton(t *testing.T) {
+	t.Parallel()
+
+	tp, m := createTestPublisherNoAux(t)
+	req := createBadInputTestRequest(4)
+	record := &monitorRecord{
+		requestID:   1,
+		req:         req,
+		feeFunction: m.feeFunc,
+	}
+
+	m.feeFunc.On("FeeRate").Return(chainfee.SatPerKWeight(1000))
+	m.signer.On("ComputeInputScript", mock.Anything,
+		mock.Anything).Return(&input.Script{}, nil).Times(4)
+
+	inputs := req.Inputs
+	m.wallet.On(
+		"CheckMempoolAcceptance",
+		mock.MatchedBy(txSpendsInputs(inputs[0], inputs[1])),
+	).Return(
+		chain.ErrScriptVerifyFlag,
+	).Once()
+	m.wallet.On(
+		"CheckMempoolAcceptance",
+		mock.MatchedBy(txSpendsInputs(inputs[0])),
+	).Return(nil).Once()
+	m.wallet.On(
+		"CheckMempoolAcceptance",
+		mock.MatchedBy(txSpendsInputs(inputs[1])),
+	).Return(chain.ErrScriptVerifyFlag).Once()
+
+	badInput, err := tp.findBadInput(record)
+
+	require.NoError(t, err)
+	require.Equal(t, inputs[1].OutPoint(), badInput)
+	m.wallet.AssertNumberOfCalls(t, "CheckMempoolAcceptance", 3)
+}
+
+// TestFindBadInputStopsOnPolicyProbeError checks that a policy error found
+// during probing aborts diagnosis instead of marking the singleton input bad.
+func TestFindBadInputStopsOnPolicyProbeError(t *testing.T) {
+	t.Parallel()
+
+	tp, m := createTestPublisherNoAux(t)
+	req := createBadInputTestRequest(4)
+	record := &monitorRecord{
+		requestID:   1,
+		req:         req,
+		feeFunction: m.feeFunc,
+	}
+
+	m.feeFunc.On("FeeRate").Return(chainfee.SatPerKWeight(1000))
+	m.signer.On("ComputeInputScript", mock.Anything,
+		mock.Anything).Return(&input.Script{}, nil).Times(3)
+
+	inputs := req.Inputs
+	m.wallet.On(
+		"CheckMempoolAcceptance",
+		mock.MatchedBy(txSpendsInputs(inputs[0], inputs[1])),
+	).Return(nil).Once()
+	m.wallet.On(
+		"CheckMempoolAcceptance",
+		mock.MatchedBy(txSpendsInputs(inputs[2])),
+	).Return(chain.ErrInsufficientFee).Once()
+
+	badInput, err := tp.findBadInput(record)
+
+	require.ErrorIs(t, err, chain.ErrInsufficientFee)
+	require.Equal(t, wire.OutPoint{}, badInput)
+	m.wallet.AssertNumberOfCalls(t, "CheckMempoolAcceptance", 2)
+}
+
+// TestFindBadInputContinuesAfterConstructionError checks that an
+// unconstructible subset falls back to singleton probes across the full set.
+func TestFindBadInputContinuesAfterConstructionError(t *testing.T) {
+	t.Parallel()
+
+	tp, m := createTestPublisherNoAux(t)
+	req := createBadInputTestRequest(4)
+	record := &monitorRecord{
+		requestID:   1,
+		req:         req,
+		feeFunction: m.feeFunc,
+	}
+
+	m.feeFunc.On("FeeRate").Return(chainfee.SatPerKWeight(1000))
+	m.signer.On("ComputeInputScript", mock.Anything,
+		mock.Anything).Return(nil, ErrNotEnoughInputs).Once()
+	m.signer.On("ComputeInputScript", mock.Anything,
+		mock.Anything).Return(&input.Script{}, nil).Times(4)
+
+	inputs := req.Inputs
+	for _, inp := range inputs[:3] {
+		m.wallet.On(
+			"CheckMempoolAcceptance",
+			mock.MatchedBy(txSpendsInputs(inp)),
+		).Return(nil).Once()
+	}
+	m.wallet.On(
+		"CheckMempoolAcceptance",
+		mock.MatchedBy(txSpendsInputs(inputs[3])),
+	).Return(chain.ErrScriptVerifyFlag).Once()
+
+	badInput, err := tp.findBadInput(record)
+
+	require.NoError(t, err)
+	require.Equal(t, inputs[3].OutPoint(), badInput)
+	m.wallet.AssertNumberOfCalls(t, "CheckMempoolAcceptance", 4)
+}
+
 // TestTxPublisherBroadcast checks the internal `broadcast` method behaves as
 // expected.
 func TestTxPublisherBroadcast(t *testing.T) {

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -448,6 +448,38 @@ func createTestPublisherNoAux(t *testing.T) (*TxPublisher, *mockers) {
 	return createTestPublisherWithAux(t, fn.None[AuxSweeper]())
 }
 
+// txSpendsInputs returns a matcher that checks that a tx spends the exact input
+// set, regardless of ordering.
+func txSpendsInputs(inputs ...input.Input) func(*wire.MsgTx) bool {
+	want := make(map[wire.OutPoint]struct{}, len(inputs))
+	for _, inp := range inputs {
+		want[inp.OutPoint()] = struct{}{}
+	}
+
+	return func(tx *wire.MsgTx) bool {
+		if tx == nil || len(tx.TxIn) != len(want) {
+			return false
+		}
+
+		for _, txIn := range tx.TxIn {
+			if _, ok := want[txIn.PreviousOutPoint]; !ok {
+				return false
+			}
+		}
+
+		return true
+	}
+}
+
+type requiredOutputTestInput struct {
+	input.Input
+	requiredOutput *wire.TxOut
+}
+
+func (i *requiredOutputTestInput) RequiredTxOut() *wire.TxOut {
+	return i.requiredOutput
+}
+
 // TestCreateAndCheckTx checks `createAndCheckTx` behaves as expected.
 func TestCreateAndCheckTx(t *testing.T) {
 	t.Parallel()
@@ -854,6 +886,134 @@ func TestShouldDiagnoseBadInputs(t *testing.T) {
 			require.Equal(t, testCase.diagnose, diagnose)
 		})
 	}
+}
+
+// TestProbeInputSetScriptFailure checks that probe script failures stay
+// concrete so findBadInput owns bad-input attribution.
+func TestProbeInputSetScriptFailure(t *testing.T) {
+	t.Parallel()
+
+	tp, m := createTestPublisherNoAux(t)
+	req := createBadInputTestRequest(2)
+	record := &monitorRecord{
+		requestID:   1,
+		req:         req,
+		feeFunction: m.feeFunc,
+	}
+
+	inputs := req.Inputs
+	m.feeFunc.On("FeeRate").Return(chainfee.SatPerKWeight(1000))
+	m.signer.On("ComputeInputScript", mock.Anything,
+		mock.Anything).Return(&input.Script{}, nil).Times(2)
+	m.wallet.On(
+		"CheckMempoolAcceptance",
+		mock.MatchedBy(txSpendsInputs(inputs...)),
+	).Return(chain.ErrScriptVerifyFlag).Once()
+
+	err := tp.probeInputSet(record, inputs)
+
+	require.ErrorIs(t, err, chain.ErrScriptVerifyFlag)
+	require.NotErrorIs(t, err, errMempoolRejected)
+	m.wallet.AssertNotCalled(t, "PublishTransaction", mock.Anything,
+		mock.Anything)
+}
+
+// TestProbeInputSetPolicyError checks that non-script mempool failures remain
+// concrete errors and are not treated as bad-input probe failures.
+func TestProbeInputSetPolicyError(t *testing.T) {
+	t.Parallel()
+
+	tp, m := createTestPublisherNoAux(t)
+	req := createBadInputTestRequest(2)
+	record := &monitorRecord{
+		requestID:   1,
+		req:         req,
+		feeFunction: m.feeFunc,
+	}
+
+	inputs := req.Inputs
+	m.feeFunc.On("FeeRate").Return(chainfee.SatPerKWeight(1000))
+	m.signer.On("ComputeInputScript", mock.Anything,
+		mock.Anything).Return(&input.Script{}, nil).Times(2)
+	m.wallet.On(
+		"CheckMempoolAcceptance",
+		mock.MatchedBy(txSpendsInputs(inputs...)),
+	).Return(chain.ErrInsufficientFee).Once()
+
+	err := tp.probeInputSet(record, inputs)
+
+	require.ErrorIs(t, err, chain.ErrInsufficientFee)
+	require.NotErrorIs(t, err, errMempoolRejected)
+	m.wallet.AssertNotCalled(t, "PublishTransaction", mock.Anything,
+		mock.Anything)
+}
+
+// TestProbeInputSetConstructionError checks that failures before mempool
+// acceptance remain distinguishable from policy rejections.
+func TestProbeInputSetConstructionError(t *testing.T) {
+	t.Parallel()
+
+	tp, m := createTestPublisherNoAux(t)
+	req := createBadInputTestRequest(1)
+	record := &monitorRecord{
+		requestID:   1,
+		req:         req,
+		feeFunction: m.feeFunc,
+	}
+
+	m.feeFunc.On("FeeRate").Return(chainfee.SatPerKWeight(1000))
+	m.signer.On("ComputeInputScript", mock.Anything,
+		mock.Anything).Return(nil, errDummy).Once()
+
+	err := tp.probeInputSet(record, req.Inputs)
+
+	require.ErrorIs(t, err, errProbeTxConstruction)
+	require.ErrorIs(t, err, errDummy)
+	m.wallet.AssertNotCalled(t, "CheckMempoolAcceptance", mock.Anything)
+}
+
+// TestProbeInputSetFundsRequiredOutput checks that a required-output singleton
+// is paired only with an independently accepted normal funding input.
+func TestProbeInputSetFundsRequiredOutput(t *testing.T) {
+	t.Parallel()
+
+	tp, m := createTestPublisherNoAux(t)
+	requiredBase := createTestInput(10_000, input.WitnessKeyHash)
+	required := &requiredOutputTestInput{
+		Input: &requiredBase,
+		requiredOutput: &wire.TxOut{
+			Value: 10_000,
+		},
+	}
+	companionBase := createTestInput(10_000, input.WitnessKeyHash)
+	companion := input.Input(&companionBase)
+	record := &monitorRecord{
+		requestID: 1,
+		req: &BumpRequest{
+			DeliveryAddress: changePkScript,
+			Inputs:          []input.Input{required, companion},
+		},
+		feeFunction: m.feeFunc,
+	}
+
+	m.feeFunc.On("FeeRate").Return(chainfee.SatPerKWeight(1000)).Once()
+	m.signer.On("ComputeInputScript", mock.Anything,
+		mock.Anything).Return(&input.Script{}, nil).Times(3)
+	m.wallet.On(
+		"CheckMempoolAcceptance",
+		mock.MatchedBy(txSpendsInputs(companion)),
+	).Return(nil).Once()
+	m.wallet.On(
+		"CheckMempoolAcceptance",
+		mock.MatchedBy(txSpendsInputs(required, companion)),
+	).Return(chain.ErrMissingInputs).Once()
+
+	err := tp.probeInputSet(record, []input.Input{required})
+
+	require.ErrorIs(t, err, ErrInputMissing)
+	m.wallet.AssertNumberOfCalls(t, "CheckMempoolAcceptance", 2)
+	m.wallet.AssertNotCalled(t, "PublishTransaction", mock.Anything,
+		mock.Anything)
 }
 
 // TestTxPublisherBroadcast checks the internal `broadcast` method behaves as

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -824,6 +824,18 @@ func createBadInputTestRecord(tp *TxPublisher, req *BumpRequest,
 	return record, subscriber
 }
 
+func mockNoInputSpends(m *mockers, inputs []input.Input) {
+	for _, inp := range inputs {
+		op := inp.OutPoint()
+		spendEvent := &chainntnfs.SpendEvent{
+			Spend:  make(chan *chainntnfs.SpendDetail),
+			Cancel: func() {},
+		}
+		m.notifier.On("RegisterSpendNtfn", &op, mock.Anything,
+			mock.Anything).Return(spendEvent, nil).Once()
+	}
+}
+
 // TestShouldDiagnoseBadInputs checks the eligibility rules for no-broadcast
 // subset diagnosis.
 func TestShouldDiagnoseBadInputs(t *testing.T) {
@@ -1485,6 +1497,235 @@ func TestHandleMissingInputsIsolatesMissing(t *testing.T) {
 	m.notifier.AssertNumberOfCalls(t, "RegisterSpendNtfn", 4)
 }
 
+// TestHandleMissingInputsNoAttributionFatal checks that a completed diagnosis
+// without a rejected singleton is fatal for the complete set.
+func TestHandleMissingInputsNoAttributionFatal(t *testing.T) {
+	t.Parallel()
+
+	tp, m := createTestPublisherNoAux(t)
+	req := createBadInputTestRequest(2)
+	record := &monitorRecord{
+		requestID:   1,
+		req:         req,
+		feeFunction: m.feeFunc,
+		tx:          &wire.MsgTx{LockTime: 2},
+	}
+
+	mockNoInputSpends(m, req.Inputs)
+	m.feeFunc.On("FeeRate").Return(chainfee.SatPerKWeight(1000)).Times(2)
+	m.signer.On("ComputeInputScript", mock.Anything,
+		mock.Anything).Return(&input.Script{}, nil).Times(2)
+	m.wallet.On("CheckMempoolAcceptance", mock.Anything).Return(nil).Twice()
+
+	result := tp.handleMissingInputs(record)
+
+	require.Equal(t, TxFatal, result.Event)
+	require.ErrorIs(t, result.Err, ErrInputMissing)
+	require.Nil(t, result.BadInput)
+}
+
+// TestMissingInputRetryPolicy checks that initial and replacement attempts use
+// the same fee-advance rule when diagnosis aborts without changing membership.
+func TestMissingInputRetryPolicy(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		replacement bool
+		advanceErr  error
+		expected    BumpEvent
+	}{
+		{name: "initial advances", expected: TxFailed},
+		{
+			name:       "initial max fee is fatal",
+			advanceErr: ErrMaxPosition,
+			expected:   TxFatal,
+		},
+		{
+			name:        "replacement advances",
+			replacement: true,
+			expected:    TxFailed,
+		},
+		{
+			name:        "replacement max fee is fatal",
+			replacement: true,
+			advanceErr:  ErrMaxPosition,
+			expected:    TxFatal,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tp, m := createTestPublisherNoAux(t)
+			req := createBadInputTestRequest(2)
+			record, subscriber := createBadInputTestRecord(
+				tp, req, m.feeFunc,
+			)
+			record.tx = &wire.MsgTx{LockTime: 2}
+			mockNoInputSpends(m, req.Inputs)
+
+			rejectedFee := chainfee.SatPerKWeight(1000)
+			retryFee := chainfee.SatPerKWeight(1100)
+			m.feeFunc.On("FeeRate").Return(rejectedFee).Once()
+			m.signer.On(
+				"ComputeInputScript", mock.Anything,
+				mock.Anything,
+			).Return(&input.Script{}, nil).Once()
+			m.wallet.On(
+				"CheckMempoolAcceptance", mock.Anything,
+			).Return(chain.ErrInsufficientFee).Once()
+			if testCase.advanceErr == nil {
+				m.feeFunc.On("Increment").Return(
+					true, nil,
+				).Once()
+				m.feeFunc.On("FeeRate").Return(retryFee).Once()
+			} else {
+				m.feeFunc.On("Increment").Return(
+					false, testCase.advanceErr,
+				).Once()
+				m.feeFunc.On("FeeRate").Return(
+					rejectedFee,
+				).Once()
+			}
+
+			var result *BumpResult
+			if testCase.replacement {
+				resultOpt := tp.handleReplacementTxError(
+					record, record.tx, ErrInputMissing,
+				)
+				value := resultOpt.UnwrapOrFail(t)
+				result = &value
+			} else {
+				tp.handleInitialTxError(record, ErrInputMissing)
+				result = <-subscriber
+			}
+
+			require.Equal(t, testCase.expected, result.Event)
+			require.Nil(t, result.BadInput)
+			if testCase.advanceErr == nil {
+				require.Equal(t, retryFee, result.FeeRate)
+				require.ErrorIs(t, result.Err, ErrInputMissing)
+			} else {
+				require.ErrorIs(
+					t, result.Err, testCase.advanceErr,
+				)
+			}
+		})
+	}
+}
+
+// TestReplacementMempoolFailureDiagnosesInput checks that replacement
+// rejections use the same singleton attribution as initial publication.
+func TestReplacementMempoolFailureDiagnosesInput(t *testing.T) {
+	t.Parallel()
+
+	tp, m := createTestPublisherNoAux(t)
+	req := createBadInputTestRequest(2)
+	oldTx := &wire.MsgTx{LockTime: 2}
+	record := &monitorRecord{
+		requestID:   1,
+		req:         req,
+		feeFunction: m.feeFunc,
+		tx:          oldTx,
+	}
+	m.feeFunc.On("FeeRate").Return(chainfee.SatPerKWeight(1000)).Once()
+	m.signer.On("ComputeInputScript", mock.Anything,
+		mock.Anything).Return(&input.Script{}, nil).Once()
+	m.wallet.On("CheckMempoolAcceptance", mock.Anything).Return(
+		chain.ErrScriptVerifyFlag,
+	).Once()
+	err := fmt.Errorf(
+		"%w: %w", errMempoolRejected, chain.ErrScriptVerifyFlag,
+	)
+
+	result := tp.handleReplacementTxError(
+		record, oldTx, err,
+	).UnwrapOrFail(t)
+
+	require.Equal(t, TxFailed, result.Event)
+	require.Equal(t, oldTx, result.Tx)
+	require.NotNil(t, result.BadInput)
+	require.Equal(t, req.Inputs[0].OutPoint(), *result.BadInput)
+	require.Zero(t, result.FeeRate)
+}
+
+// TestInitialMempoolFailureSingletonFatal checks that singleton non-fee mempool
+// rejections keep the existing TxFatal behavior.
+func TestInitialMempoolFailureSingletonFatal(t *testing.T) {
+	t.Parallel()
+
+	tp, m := createTestPublisherNoAux(t)
+	req := createBadInputTestRequest(1)
+	record, subscriber := createBadInputTestRecord(tp, req, m.feeFunc)
+	initialErr := fmt.Errorf("%w: %w", errMempoolRejected, errDummy)
+
+	tp.handleInitialTxError(record, initialErr)
+	result := <-subscriber
+
+	require.Equal(t, TxFatal, result.Event)
+	require.Nil(t, result.BadInput)
+}
+
+// TestInitialMempoolFailureAuxSweeperSkipsDiagnosis checks that aux-enabled
+// sweep transactions preserve whole-set fatal behavior without subset probes.
+func TestInitialMempoolFailureAuxSweeperSkipsDiagnosis(t *testing.T) {
+	t.Parallel()
+
+	tp, m := createTestPublisher(t)
+	req := createBadInputTestRequest(4)
+	record, subscriber := createBadInputTestRecord(tp, req, m.feeFunc)
+	initialErr := fmt.Errorf("%w: %w", errMempoolRejected, errDummy)
+
+	tp.handleInitialTxError(record, initialErr)
+	result := <-subscriber
+
+	require.Equal(t, TxFatal, result.Event)
+	require.Nil(t, result.BadInput)
+	m.wallet.AssertNumberOfCalls(t, "CheckMempoolAcceptance", 0)
+}
+
+// TestInitialRetryFeeErrorFatal checks that every retry fee error, including
+// ErrMaxPosition, is fatal for an unchanged initial input set.
+func TestInitialRetryFeeErrorFatal(t *testing.T) {
+	t.Parallel()
+
+	tp, m := createTestPublisherNoAux(t)
+	record, subscriber := createBadInputTestRecord(
+		tp, createBadInputTestRequest(2), m.feeFunc,
+	)
+	feeRate := chainfee.SatPerKWeight(1000)
+	m.feeFunc.On("Increment").Return(false, ErrMaxPosition).Once()
+	m.feeFunc.On("FeeRate").Return(feeRate).Once()
+
+	tp.handleInitialTxError(record, ErrNotEnoughBudget)
+	result := <-subscriber
+
+	require.Equal(t, TxFatal, result.Event)
+	require.ErrorIs(t, result.Err, ErrMaxPosition)
+	require.Equal(t, feeRate, result.FeeRate)
+}
+
+// TestUnknownSpendDoesNotAdvanceFee checks that removing attributed spends
+// leaves survivors to restart from a fresh fee function.
+func TestUnknownSpendDoesNotAdvanceFee(t *testing.T) {
+	t.Parallel()
+
+	tp, m := createTestPublisherNoAux(t)
+	record := &monitorRecord{
+		requestID:   1,
+		req:         createBadInputTestRequest(2),
+		feeFunction: m.feeFunc,
+		spentInputs: map[wire.OutPoint]*wire.MsgTx{
+			{}: {LockTime: 2},
+		},
+	}
+
+	result := tp.createUnknownSpentBumpResult(record)
+
+	require.Equal(t, TxUnknownSpend, result.Event)
+	require.Zero(t, result.FeeRate)
+}
+
 // TestTxPublisherBroadcast checks the internal `broadcast` method behaves as
 // expected.
 func TestTxPublisherBroadcast(t *testing.T) {
@@ -1577,7 +1818,6 @@ func TestTxPublisherBroadcast(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			tc.setupMock()
 
@@ -1709,7 +1949,6 @@ func TestRemoveResult(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			requestID := tc.setupRecord()
 

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -1016,6 +1016,33 @@ func TestProbeInputSetFundsRequiredOutput(t *testing.T) {
 		mock.Anything)
 }
 
+// TestIsInputScriptFailure checks that only input script or standardness errors
+// are treated as identifying bad inputs.
+func TestIsInputScriptFailure(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		err      error
+		expected bool
+	}{
+		{chain.ErrScriptVerifyFlag, true},
+		{chain.ErrNonMandatoryScriptVerifyFlag, true},
+		{chain.ErrBadWitnessNonStandard, true},
+		{chain.ErrScriptSigNotPushOnly, true},
+		{chain.ErrScriptSigSize, true},
+		{chain.ErrNonStandardInputs, true},
+		{chain.ErrInsufficientFee, false},
+		{errDummy, false},
+	}
+
+	for _, testCase := range testCases {
+		require.Equal(
+			t, testCase.expected,
+			isInputScriptFailure(testCase.err),
+		)
+	}
+}
+
 // TestTxPublisherBroadcast checks the internal `broadcast` method behaves as
 // expected.
 func TestTxPublisherBroadcast(t *testing.T) {

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -388,8 +388,11 @@ type mockers struct {
 	feeFunc *MockFeeFunction
 }
 
-// createTestPublisher creates a new tx publisher using the provided mockers.
-func createTestPublisher(t *testing.T) (*TxPublisher, *mockers) {
+// createTestPublisherWithAux creates a new tx publisher using the provided
+// mockers and aux sweeper option.
+func createTestPublisherWithAux(t *testing.T,
+	auxSweeper fn.Option[AuxSweeper]) (*TxPublisher, *mockers) {
+
 	// Create a mock fee estimator.
 	estimator := &chainfee.MockEstimator{}
 
@@ -427,10 +430,22 @@ func createTestPublisher(t *testing.T) (*TxPublisher, *mockers) {
 		Signer:     m.signer,
 		Wallet:     m.wallet,
 		Notifier:   m.notifier,
-		AuxSweeper: fn.Some[AuxSweeper](&MockAuxSweeper{}),
+		AuxSweeper: auxSweeper,
 	})
 
 	return tp, m
+}
+
+// createTestPublisher creates a new tx publisher using the provided mockers.
+func createTestPublisher(t *testing.T) (*TxPublisher, *mockers) {
+	return createTestPublisherWithAux(
+		t, fn.Some[AuxSweeper](&MockAuxSweeper{}),
+	)
+}
+
+// createTestPublisherNoAux creates a new tx publisher without an aux sweeper.
+func createTestPublisherNoAux(t *testing.T) (*TxPublisher, *mockers) {
+	return createTestPublisherWithAux(t, fn.None[AuxSweeper]())
 }
 
 // TestCreateAndCheckTx checks `createAndCheckTx` behaves as expected.
@@ -463,9 +478,10 @@ func TestCreateAndCheckTx(t *testing.T) {
 		mock.Anything).Return(script, nil)
 
 	testCases := []struct {
-		name        string
-		req         *BumpRequest
-		expectedErr error
+		name                string
+		req                 *BumpRequest
+		expectedErr         error
+		expectedWrappedErrs []error
 	}{
 		{
 			// When the budget cannot cover the fee, an error
@@ -486,7 +502,8 @@ func TestCreateAndCheckTx(t *testing.T) {
 				Inputs:          []input.Input{&inp},
 				Budget:          btcutil.Amount(1000),
 			},
-			expectedErr: errDummy,
+			expectedErr:         errDummy,
+			expectedWrappedErrs: []error{errMempoolRejected},
 		},
 		{
 			// When the mempool accepts the transaction, no error
@@ -514,8 +531,45 @@ func TestCreateAndCheckTx(t *testing.T) {
 
 			// Check the result is as expected.
 			require.ErrorIs(t, err, tc.expectedErr)
+			for _, expectedErr := range tc.expectedWrappedErrs {
+				require.ErrorIs(t, err, expectedErr)
+			}
 		})
 	}
+}
+
+// TestCreateAndCheckTxMempoolConflict checks that an unconfirmed conflicting
+// spend enters missing-input attribution.
+func TestCreateAndCheckTxMempoolConflict(t *testing.T) {
+	t.Parallel()
+
+	tp, m := createTestPublisherNoAux(t)
+	inputs := make([]input.Input, 0, 2)
+	for i := 0; i < 2; i++ {
+		inp := createTestInput(10_000, input.WitnessKeyHash)
+		inputs = append(inputs, &inp)
+	}
+	record := &monitorRecord{
+		requestID: 1,
+		req: &BumpRequest{
+			DeliveryAddress: changePkScript,
+			Inputs:          inputs,
+			Budget:          btcutil.Amount(10_000),
+		},
+		feeFunction: m.feeFunc,
+	}
+
+	m.feeFunc.On("FeeRate").Return(chainfee.SatPerKWeight(1000))
+	m.signer.On("ComputeInputScript", mock.Anything,
+		mock.Anything).Return(&input.Script{}, nil).Times(2)
+	m.wallet.On("CheckMempoolAcceptance", mock.Anything).Return(
+		chain.ErrMempoolConflict,
+	).Once()
+
+	_, err := tp.createAndCheckTx(record)
+
+	require.ErrorIs(t, err, ErrInputMissing)
+	require.NotNil(t, record.tx)
 }
 
 // createTestBumpRequest creates a new bump request.

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -805,6 +805,25 @@ func createBadInputTestRequest(numInputs int) *BumpRequest {
 	}
 }
 
+// createBadInputTestRecord creates a monitored record and subscriber used by
+// initial-broadcast error tests.
+func createBadInputTestRecord(tp *TxPublisher, req *BumpRequest,
+	feeFunc FeeFunction) (*monitorRecord, chan *BumpResult) {
+
+	const requestID = uint64(1)
+	record := &monitorRecord{
+		requestID:   requestID,
+		req:         req,
+		feeFunction: feeFunc,
+	}
+
+	subscriber := make(chan *BumpResult, 1)
+	tp.subscriberChans.Store(requestID, subscriber)
+	tp.records.Store(requestID, record)
+
+	return record, subscriber
+}
+
 // TestShouldDiagnoseBadInputs checks the eligibility rules for no-broadcast
 // subset diagnosis.
 func TestShouldDiagnoseBadInputs(t *testing.T) {
@@ -1205,6 +1224,265 @@ func TestDiagnoseInputSetMetadata(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCalculateRetryFeeRateError checks that a retry cannot continue after the
+// fee function reaches its final position.
+func TestCalculateRetryFeeRateError(t *testing.T) {
+	t.Parallel()
+
+	tp, m := createTestPublisherNoAux(t)
+	record := &monitorRecord{
+		requestID:   1,
+		req:         createBadInputTestRequest(2),
+		feeFunction: m.feeFunc,
+	}
+	m.feeFunc.On("Increment").Return(false, ErrMaxPosition).Once()
+	currentFeeRate := chainfee.SatPerKWeight(1000)
+	m.feeFunc.On("FeeRate").Return(currentFeeRate).Once()
+
+	feeRate, err := tp.calculateRetryFeeRate(record)
+
+	require.ErrorIs(t, err, ErrMaxPosition)
+	require.Equal(t, currentFeeRate, feeRate)
+}
+
+// TestCalculateRetryFeeRateAdvances checks that retry selection never returns
+// the rejected fee when one fee-function position rounds to the same rate.
+func TestCalculateRetryFeeRateAdvances(t *testing.T) {
+	t.Parallel()
+
+	tp, m := createTestPublisherNoAux(t)
+	record := &monitorRecord{
+		requestID:   1,
+		req:         createBadInputTestRequest(2),
+		feeFunction: m.feeFunc,
+	}
+	m.feeFunc.On("Increment").Return(false, nil).Once()
+	m.feeFunc.On("Increment").Return(true, nil).Once()
+	retryFeeRate := chainfee.SatPerKWeight(1100)
+	m.feeFunc.On("FeeRate").Return(retryFeeRate).Once()
+
+	feeRate, err := tp.calculateRetryFeeRate(record)
+
+	require.NoError(t, err)
+	require.Equal(t, retryFeeRate, feeRate)
+}
+
+// TestHandleBadInputsDiagnosesBadInput checks that a multi-input mempool script
+// failure becomes TxFailed with the singleton input that fails its probe.
+func TestHandleBadInputsDiagnosesBadInput(t *testing.T) {
+	t.Parallel()
+
+	tp, m := createTestPublisherNoAux(t)
+	req := createBadInputTestRequest(4)
+	record := &monitorRecord{
+		requestID:   1,
+		req:         req,
+		feeFunction: m.feeFunc,
+	}
+
+	rejectedFeeRate := chainfee.SatPerKWeight(1000)
+	m.feeFunc.On("FeeRate").Return(rejectedFeeRate).Times(3)
+	m.signer.On("ComputeInputScript", mock.Anything,
+		mock.Anything).Return(&input.Script{}, nil).Times(4)
+
+	inputs := req.Inputs
+	badInput := inputs[1]
+	m.wallet.On(
+		"CheckMempoolAcceptance",
+		mock.MatchedBy(txSpendsInputs(inputs[0], inputs[1])),
+	).Return(
+		chain.ErrScriptVerifyFlag,
+	).Once()
+	m.wallet.On(
+		"CheckMempoolAcceptance",
+		mock.MatchedBy(txSpendsInputs(inputs[0])),
+	).Return(nil).Once()
+	m.wallet.On(
+		"CheckMempoolAcceptance",
+		mock.MatchedBy(txSpendsInputs(inputs[1])),
+	).Return(chain.ErrScriptVerifyFlag).Once()
+
+	initialErr := fmt.Errorf(
+		"%w: %w", errMempoolRejected, chain.ErrScriptVerifyFlag,
+	)
+
+	result := tp.handleBadInputs(record, initialErr)
+
+	require.Equal(t, TxFailed, result.Event)
+	require.ErrorIs(t, result.Err, chain.ErrScriptVerifyFlag)
+	require.NotNil(t, result.BadInput)
+	require.Equal(t, badInput.OutPoint(), *result.BadInput)
+	require.Zero(t, result.FeeRate)
+	m.wallet.AssertNotCalled(t, "PublishTransaction", mock.Anything,
+		mock.Anything)
+}
+
+// TestHandleBadInputsNoSingletonBadInput checks that diagnosis keeps BadInput
+// nil when no singleton input fails by itself.
+func TestHandleBadInputsNoSingletonBadInput(t *testing.T) {
+	t.Parallel()
+
+	tp, m := createTestPublisherNoAux(t)
+	req := createBadInputTestRequest(4)
+	record := &monitorRecord{
+		requestID:   1,
+		req:         req,
+		feeFunction: m.feeFunc,
+	}
+
+	feeRate := chainfee.SatPerKWeight(1000)
+	m.feeFunc.On("FeeRate").Return(feeRate)
+	m.signer.On("ComputeInputScript", mock.Anything,
+		mock.Anything).Return(&input.Script{}, nil).Times(4)
+
+	inputs := req.Inputs
+	m.wallet.On(
+		"CheckMempoolAcceptance",
+		mock.MatchedBy(txSpendsInputs(inputs[0], inputs[1])),
+	).Return(nil).Once()
+	m.wallet.On(
+		"CheckMempoolAcceptance",
+		mock.MatchedBy(txSpendsInputs(inputs[2])),
+	).Return(nil).Once()
+	m.wallet.On(
+		"CheckMempoolAcceptance",
+		mock.MatchedBy(txSpendsInputs(inputs[3])),
+	).Return(nil).Once()
+
+	initialErr := fmt.Errorf("%w: %w", errMempoolRejected, errDummy)
+
+	result := tp.handleBadInputs(record, initialErr)
+
+	require.Equal(t, TxFatal, result.Event)
+	require.ErrorIs(t, result.Err, errDummy)
+	require.Nil(t, result.BadInput)
+	require.Zero(t, result.FeeRate)
+}
+
+// TestHandleBadInputsProbeConstructionError checks that non-mempool probe
+// errors abort diagnosis and keep BadInput nil.
+func TestHandleBadInputsProbeConstructionError(t *testing.T) {
+	t.Parallel()
+
+	tp, m := createTestPublisherNoAux(t)
+	req := createBadInputTestRequest(4)
+	record := &monitorRecord{
+		requestID:   1,
+		req:         req,
+		feeFunction: m.feeFunc,
+	}
+
+	rejectedFeeRate := chainfee.SatPerKWeight(1000)
+	retryFeeRate := chainfee.SatPerKWeight(1100)
+	m.feeFunc.On("FeeRate").Return(rejectedFeeRate).Times(5)
+	m.feeFunc.On("Increment").Return(true, nil).Once()
+	m.feeFunc.On("FeeRate").Return(retryFeeRate).Once()
+	m.signer.On("ComputeInputScript", mock.Anything,
+		mock.Anything).Return(nil, errDummy).Times(5)
+
+	initialErr := fmt.Errorf("%w: %w", errMempoolRejected, errDummy)
+
+	result := tp.handleBadInputs(record, initialErr)
+
+	require.Equal(t, TxFailed, result.Event)
+	require.ErrorIs(t, result.Err, errDummy)
+	require.Nil(t, result.BadInput)
+	require.Equal(t, retryFeeRate, result.FeeRate)
+	m.wallet.AssertNumberOfCalls(t, "CheckMempoolAcceptance", 0)
+}
+
+// TestHandleBadInputsProbeMissingInputs checks that diagnosis fails only the
+// exact missing singleton and leaves the rest retryable.
+func TestHandleBadInputsProbeMissingInputs(t *testing.T) {
+	t.Parallel()
+
+	tp, m := createTestPublisherNoAux(t)
+	req := createBadInputTestRequest(4)
+	record := &monitorRecord{
+		requestID:   1,
+		req:         req,
+		feeFunction: m.feeFunc,
+	}
+
+	rejectedFeeRate := chainfee.SatPerKWeight(1000)
+	m.feeFunc.On("FeeRate").Return(rejectedFeeRate).Times(2)
+	m.signer.On("ComputeInputScript", mock.Anything,
+		mock.Anything).Return(&input.Script{}, nil).Times(3)
+
+	inputs := req.Inputs
+	m.wallet.On(
+		"CheckMempoolAcceptance",
+		mock.MatchedBy(txSpendsInputs(inputs[0], inputs[1])),
+	).Return(
+		chain.ErrMissingInputs,
+	).Once()
+	m.wallet.On(
+		"CheckMempoolAcceptance",
+		mock.MatchedBy(txSpendsInputs(inputs[0])),
+	).Return(chain.ErrMissingInputs).Once()
+
+	initialErr := fmt.Errorf("%w: %w", errMempoolRejected, errDummy)
+
+	result := tp.handleBadInputs(record, initialErr)
+
+	require.Equal(t, TxFailed, result.Event)
+	require.ErrorIs(t, result.Err, errDummy)
+	require.Zero(t, result.FeeRate)
+	require.NotNil(t, result.BadInput)
+	require.Equal(t, inputs[0].OutPoint(), *result.BadInput)
+	m.notifier.AssertNotCalled(t, "RegisterSpendNtfn", mock.Anything,
+		mock.Anything, mock.Anything)
+}
+
+// TestHandleMissingInputsIsolatesMissing checks that a full multi-input missing
+// result fails only the isolated terminal input.
+func TestHandleMissingInputsIsolatesMissing(t *testing.T) {
+	t.Parallel()
+
+	tp, m := createTestPublisherNoAux(t)
+	req := createBadInputTestRequest(4)
+	record := &monitorRecord{
+		requestID:   1,
+		req:         req,
+		feeFunction: m.feeFunc,
+		tx:          &wire.MsgTx{LockTime: 2},
+	}
+
+	rejectedFeeRate := chainfee.SatPerKWeight(1000)
+	m.feeFunc.On("FeeRate").Return(rejectedFeeRate).Times(2)
+	m.signer.On("ComputeInputScript", mock.Anything,
+		mock.Anything).Return(&input.Script{}, nil).Times(3)
+
+	inputs := req.Inputs
+	m.wallet.On(
+		"CheckMempoolAcceptance",
+		mock.MatchedBy(txSpendsInputs(inputs[0], inputs[1])),
+	).Return(chain.ErrMissingInputs).Once()
+	m.wallet.On(
+		"CheckMempoolAcceptance",
+		mock.MatchedBy(txSpendsInputs(inputs[0])),
+	).Return(chain.ErrMissingInputs).Once()
+
+	for _, inp := range inputs {
+		op := inp.OutPoint()
+		spendEvent := &chainntnfs.SpendEvent{
+			Spend:  make(chan *chainntnfs.SpendDetail, 1),
+			Cancel: func() {},
+		}
+		m.notifier.On("RegisterSpendNtfn", &op, mock.Anything,
+			mock.Anything).Return(spendEvent, nil).Once()
+	}
+
+	result := tp.handleMissingInputs(record)
+
+	require.Equal(t, TxFailed, result.Event)
+	require.ErrorIs(t, result.Err, ErrInputMissing)
+	require.Zero(t, result.FeeRate)
+	require.NotNil(t, result.BadInput)
+	require.Equal(t, inputs[0].OutPoint(), *result.BadInput)
+	m.notifier.AssertNumberOfCalls(t, "RegisterSpendNtfn", 4)
 }
 
 // TestTxPublisherBroadcast checks the internal `broadcast` method behaves as
@@ -2278,13 +2556,6 @@ func TestProcessRecordsSpent(t *testing.T) {
 	tp.subscriberChans.Store(requestID, subscriber)
 	tp.records.Store(requestID, recordConfirmed)
 
-	// Mock the fee function to increase feerate.
-	m.feeFunc.On("Increment").Return(true, nil).Once()
-
-	// Create a test feerate and return it from the mock fee function.
-	feerate := chainfee.SatPerKWeight(1000)
-	m.feeFunc.On("FeeRate").Return(feerate)
-
 	// Call processRecords and expect the results are notified back.
 	tp.processRecords()
 
@@ -2298,8 +2569,8 @@ func TestProcessRecordsSpent(t *testing.T) {
 		require.Equal(t, TxUnknownSpend, result.Event)
 		require.Equal(t, tx, result.Tx)
 
-		// We expect the fee rate to be updated.
-		require.Equal(t, feerate, result.FeeRate)
+		// Survivors restart at a fresh fee after membership changes.
+		require.Zero(t, result.FeeRate)
 
 		// No error should be set.
 		require.ErrorIs(t, result.Err, ErrUnknownSpent)

--- a/sweep/mock_test.go
+++ b/sweep/mock_test.go
@@ -233,8 +233,10 @@ func (m *MockInputSet) FeeRate() chainfee.SatPerKWeight {
 // AddWalletInputs adds wallet inputs to the set until a non-dust
 // change output can be made. Return an error if there are not enough
 // wallet inputs.
-func (m *MockInputSet) AddWalletInputs(wallet Wallet) error {
-	args := m.Called(wallet)
+func (m *MockInputSet) AddWalletInputs(wallet Wallet,
+	excludedInputs fn.Set[wire.OutPoint]) error {
+
+	args := m.Called(wallet, excludedInputs)
 
 	return args.Error(0)
 }

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -353,6 +353,10 @@ type UtxoSweeper struct {
 	// to sweep.
 	inputs InputsMap
 
+	// excludedWalletInputs contains wallet UTXOs diagnosed as invalid. They
+	// remain excluded from coin selection for the lifetime of the sweeper.
+	excludedWalletInputs fn.Set[wire.OutPoint]
+
 	currentOutputScript fn.Option[lnwallet.AddrWithKey]
 
 	relayFeeRate chainfee.SatPerKWeight
@@ -446,14 +450,15 @@ type sweepInputMessage struct {
 // New returns a new Sweeper instance.
 func New(cfg *UtxoSweeperConfig) *UtxoSweeper {
 	s := &UtxoSweeper{
-		cfg:               cfg,
-		newInputs:         make(chan *sweepInputMessage),
-		spendChan:         make(chan *chainntnfs.SpendDetail),
-		updateReqs:        make(chan *updateReq),
-		pendingSweepsReqs: make(chan *pendingSweepsReq),
-		quit:              make(chan struct{}),
-		inputs:            make(InputsMap),
-		bumpRespChan:      make(chan *bumpResp, 100),
+		cfg:                  cfg,
+		newInputs:            make(chan *sweepInputMessage),
+		spendChan:            make(chan *chainntnfs.SpendDetail),
+		updateReqs:           make(chan *updateReq),
+		pendingSweepsReqs:    make(chan *pendingSweepsReq),
+		quit:                 make(chan struct{}),
+		inputs:               make(InputsMap),
+		excludedWalletInputs: fn.NewSet[wire.OutPoint](),
+		bumpRespChan:         make(chan *bumpResp, 100),
 	}
 
 	// Mount the block consumer.
@@ -1592,7 +1597,9 @@ func (s *UtxoSweeper) sweepPendingInputs(inputs InputsMap) {
 	sweepWithLock := func(set InputSet) error {
 		return s.cfg.Wallet.WithCoinSelectLock(func() error {
 			// Try to add inputs from our wallet.
-			err := set.AddWalletInputs(s.cfg.Wallet)
+			err := set.AddWalletInputs(
+				s.cfg.Wallet, s.excludedWalletInputs,
+			)
 			if err != nil {
 				return err
 			}

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1668,30 +1668,37 @@ func (s *UtxoSweeper) monitorFeeBumpResult(set InputSet,
 				return
 			}
 
-			// The sweeping tx has been confirmed, we can exit the
-			// monitor now.
+			// Terminal results remove the publisher subscription.
+			// Exit instead of waiting forever.
 			//
 			// TODO(yy): can instead remove the spend subscription
 			// in sweeper and rely solely on this event to mark
 			// inputs as Swept?
-			if r.Event == TxConfirmed || r.Event == TxFailed {
-				// Exit if the tx is failed to be created.
-				if r.Tx == nil {
-					log.Debugf("Received %v for nil tx, "+
-						"exit monitor", r.Event)
+			switch r.Event {
+			case TxConfirmed, TxFailed, TxFatal, TxUnknownSpend:
+			default:
+				continue
+			}
 
-					return
-				}
-
-				log.Debugf("Received %v for sweep tx %v, exit "+
-					"fee bump monitor", r.Event,
-					r.Tx.TxHash())
-
-				// Cancel the rebroadcasting of the failed tx.
-				s.cfg.Wallet.CancelRebroadcast(r.Tx.TxHash())
+			// Exit if the tx failed before it was created.
+			if r.Tx == nil {
+				log.Debugf(
+					"Received %v for nil tx, exit monitor",
+					r.Event,
+				)
 
 				return
 			}
+
+			log.Debugf(
+				"Received %v for sweep tx %v, exit fee bump "+
+					"monitor", r.Event, r.Tx.TxHash(),
+			)
+
+			// The publisher no longer monitors this transaction.
+			s.cfg.Wallet.CancelRebroadcast(r.Tx.TxHash())
+
+			return
 
 		case <-s.quit:
 			log.Debugf("Sweeper shutting down, exit fee " +

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -123,6 +123,7 @@ const (
 	// state won't be retried. This could happen,
 	// - when a pending input has too many failed publish attempts;
 	// - the input has been spent by another party;
+	// - a singleton mempool probe isolated an input-attributable failure;
 	// - unknown broadcast error is returned.
 	Fatal
 )
@@ -970,11 +971,12 @@ func (s *UtxoSweeper) markInputsPublished(tr *TxRecord, set InputSet) error {
 
 // markInputsPublishFailed marks the list of inputs as failed to be published.
 func (s *UtxoSweeper) markInputsPublishFailed(set InputSet,
-	feeRate chainfee.SatPerKWeight) {
+	startingFeeRate fn.Option[chainfee.SatPerKWeight]) {
 
 	// Reschedule sweep.
 	for _, inp := range set.Inputs() {
 		op := inp.OutPoint()
+
 		pi, ok := s.inputs[op]
 		if !ok {
 			// It could be that this input is an additional wallet
@@ -1001,12 +1003,11 @@ func (s *UtxoSweeper) markInputsPublishFailed(set InputSet,
 
 		log.Debugf("Input(%v): updating params: starting fee rate "+
 			"[%v -> %v]", op, pi.params.StartingFeeRate,
-			feeRate)
+			startingFeeRate)
 
-		// Update the input using the fee rate specified from the
-		// BumpResult, which should be the starting fee rate to use for
-		// the next sweeping attempt.
-		pi.params.StartingFeeRate = fn.Some(feeRate)
+		// Unchanged sets keep their retry fee. Survivor sets restart
+		// because their aggregate weight and budget changed.
+		pi.params.StartingFeeRate = startingFeeRate
 	}
 }
 
@@ -1727,13 +1728,57 @@ func (s *UtxoSweeper) handleBumpEventTxFailed(resp *bumpResp) {
 			err)
 	}
 
+	// A diagnosed bad input means the publisher isolated one input via
+	// no-broadcast probes. Handle it separately so the bad input becomes
+	// fatal while the rest of the set can be retried.
+	if r.BadInput != nil {
+		s.handleBumpEventBadInputs(resp)
+		return
+	}
+
 	// NOTE: When marking the inputs as failed, we are using the input set
 	// instead of the inputs found in the tx. This is fine for current
 	// version of the sweeper because we always create a tx using ALL of
 	// the inputs specified by the set.
 	//
 	// TODO(yy): should we also remove the failed tx from db?
-	s.markInputsPublishFailed(resp.set, resp.result.FeeRate)
+	s.markInputsPublishFailed(resp.set, fn.Some(resp.result.FeeRate))
+}
+
+// handleBumpEventBadInputs handles a failed tx after the fee bumper diagnosed a
+// singleton bad input using no-broadcast mempool probes.
+func (s *UtxoSweeper) handleBumpEventBadInputs(resp *bumpResp) {
+	r := resp.result
+	inputs := resp.set.Inputs()
+
+	log.Warnf("Fee bump attempt failed for requestID=%v after "+
+		"bad-input diagnosis: %v; inputs:\n%v", r.requestID, r.Err,
+		inputTypeSummary(inputs))
+
+	badInput := *r.BadInput
+	s.markInputsPublishFailed(
+		resp.set, fn.None[chainfee.SatPerKWeight](),
+	)
+
+	// Wallet inputs are added only to the transient input set. Quarantine a
+	// diagnosed wallet UTXO so coin selection cannot recreate the same
+	// rejected batch every block.
+	pi, ok := s.inputs[badInput]
+	if !ok {
+		s.excludedWalletInputs.Add(badInput)
+		log.Warnf("Quarantined diagnosed wallet input %v", badInput)
+
+		return
+	}
+
+	if pi.terminated() {
+		log.Errorf("Skipped marking bad input=%v as fatal due to "+
+			"unexpected state=%v", badInput, pi.state)
+
+		return
+	}
+
+	s.markInputFatal(pi, nil, r.Err)
 }
 
 // handleBumpEventTxReplaced handles the case where the sweeping tx has been
@@ -1984,7 +2029,9 @@ func (s *UtxoSweeper) handleUnknownSpendTx(inp *SweeperInput, tx *wire.MsgTx) {
 func (s *UtxoSweeper) handleBumpEventTxUnknownSpend(r *bumpResp) {
 	// Mark the inputs as publish failed, which means they will be retried
 	// later.
-	s.markInputsPublishFailed(r.set, r.result.FeeRate)
+	s.markInputsPublishFailed(
+		r.set, fn.None[chainfee.SatPerKWeight](),
+	)
 
 	// Get all the inputs that are not spent in the current sweeping tx.
 	spentInputs := r.result.SpentInputs
@@ -2037,9 +2084,8 @@ func (s *UtxoSweeper) handleBumpEventTxUnknownSpend(r *bumpResp) {
 	// to the sweeping queue.
 	inputs := s.updateSweeperInputs()
 
-	// Immediately sweep the remaining inputs - the previous inputs should
-	// now be swept with the updated StartingFeeRate immediately. We may
-	// also include more inputs in the new sweeping tx if new ones with the
-	// same deadline are offered.
+	// Immediately sweep the remaining inputs from a fresh starting fee. We
+	// may also include more inputs in the new sweeping tx if new ones with
+	// the same deadline are offered.
 	s.sweepPendingInputs(inputs)
 }

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -644,7 +644,9 @@ func TestSweepPendingInputs(t *testing.T) {
 
 	// Mock this set to ask for wallet input.
 	setNeedWallet.On("NeedWalletInput").Return(true).Once()
-	setNeedWallet.On("AddWalletInputs", wallet).Return(nil).Once()
+	setNeedWallet.On(
+		"AddWalletInputs", wallet, s.excludedWalletInputs,
+	).Return(nil).Once()
 
 	// Mock the wallet to require the lock once.
 	wallet.On("WithCoinSelectLock", mock.Anything).Return(nil).Once()

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -237,7 +237,7 @@ func TestMarkInputsPublishFailed(t *testing.T) {
 	// Mark the test inputs. We expect the non-exist input and the
 	// inputInit to be skipped, and the final input to be marked as
 	// published.
-	s.markInputsPublishFailed(set, feeRate)
+	s.markInputsPublishFailed(set, fn.Some(feeRate))
 
 	// We expect unchanged number of pending inputs.
 	require.Len(s.inputs, 7)
@@ -717,6 +717,9 @@ func TestHandleBumpEventTxFailed(t *testing.T) {
 	op1 := input1.OutPoint()
 	op2 := input2.OutPoint()
 	op3 := input3.OutPoint()
+	oldFeeRate := fn.Some(chainfee.SatPerKWeight(99))
+	s.inputs[op1].params.StartingFeeRate = oldFeeRate
+	s.inputs[op3].params.StartingFeeRate = oldFeeRate
 
 	// Construct the initial state for the sweeper.
 	set.On("Inputs").Return([]input.Input{input1, input2, input3})
@@ -760,6 +763,84 @@ func TestHandleBumpEventTxFailed(t *testing.T) {
 
 	// Assert the non-existing input is not added to the pending inputs.
 	require.NotContains(t, s.inputs, opNotExist)
+}
+
+// TestHandleBumpEventTxFailedBadInputs checks that diagnosed bad inputs are
+// marked fatal while the rest of the set is retried.
+func TestHandleBumpEventTxFailedBadInputs(t *testing.T) {
+	t.Parallel()
+
+	set := &MockInputSet{}
+	defer set.AssertExpectations(t)
+
+	s := New(&UtxoSweeperConfig{})
+
+	var (
+		input1 = createMockInput(t, s, PendingPublish)
+		input2 = createMockInput(t, s, PendingPublish)
+		input3 = createMockInput(t, s, PendingPublish)
+	)
+
+	op1 := input1.OutPoint()
+	op2 := input2.OutPoint()
+	op3 := input3.OutPoint()
+
+	set.On("Inputs").Return([]input.Input{input1, input2, input3})
+
+	br := &BumpResult{
+		Event:    TxFailed,
+		Err:      errDummy,
+		BadInput: &op2,
+	}
+
+	err := s.handleBumpEvent(&bumpResp{
+		result: br,
+		set:    set,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, PublishFailed, s.inputs[op1].state)
+	require.Equal(t, Fatal, s.inputs[op2].state)
+	require.Equal(t, PublishFailed, s.inputs[op3].state)
+	require.True(t, s.inputs[op1].params.StartingFeeRate.IsNone())
+	require.True(t, s.inputs[op3].params.StartingFeeRate.IsNone())
+}
+
+// TestHandleBumpEventTxFailedWalletInput checks that a diagnosed wallet input
+// is quarantined while tracked inputs remain retryable.
+func TestHandleBumpEventTxFailedWalletInput(t *testing.T) {
+	t.Parallel()
+
+	set := &MockInputSet{}
+	defer set.AssertExpectations(t)
+
+	s := New(&UtxoSweeperConfig{})
+	trackedInput := createMockInput(t, s, PendingPublish)
+	trackedOp := trackedInput.OutPoint()
+	s.inputs[trackedOp].params.StartingFeeRate = fn.Some(
+		chainfee.SatPerKWeight(99),
+	)
+
+	walletInput := &input.MockInput{}
+	defer walletInput.AssertExpectations(t)
+	walletOp := wire.OutPoint{Hash: chainhash.Hash{9}, Index: 1}
+	walletInput.On("OutPoint").Return(walletOp)
+	walletInput.On("WitnessType").Return(input.WitnessKeyHash)
+
+	set.On("Inputs").Return([]input.Input{trackedInput, walletInput})
+	result := &BumpResult{
+		Event:    TxFailed,
+		Err:      errDummy,
+		BadInput: &walletOp,
+	}
+
+	err := s.handleBumpEvent(&bumpResp{result: result, set: set})
+
+	require.NoError(t, err)
+	require.Equal(t, PublishFailed, s.inputs[trackedOp].state)
+	require.True(t, s.inputs[trackedOp].params.StartingFeeRate.IsNone())
+	require.True(t, s.excludedWalletInputs.Contains(walletOp))
+	require.NotContains(t, s.inputs, walletOp)
 }
 
 // TestHandleBumpEventTxReplaced checks that the sweeper correctly handles the
@@ -1448,6 +1529,9 @@ func TestHandleBumpEventTxUnknownSpendWithRetry(t *testing.T) {
 
 	op1 := inp1.OutPoint()
 	op2 := inp2.OutPoint()
+	s.inputs[op2].params.StartingFeeRate = fn.Some(
+		chainfee.SatPerKWeight(99),
+	)
 
 	inp2.On("RequiredLockTime").Return(
 		uint32(s.currentHeight), false).Once()
@@ -1493,4 +1577,5 @@ func TestHandleBumpEventTxUnknownSpendWithRetry(t *testing.T) {
 
 	// Assert the state of the input is updated.
 	require.Equal(t, PublishFailed, s.inputs[op2].state)
+	require.True(t, s.inputs[op2].params.StartingFeeRate.IsNone())
 }

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -1011,6 +1011,53 @@ func TestMonitorFeeBumpResult(t *testing.T) {
 			shouldExit: true,
 		},
 		{
+			name: "tx fatal",
+			setupResultChan: func() <-chan *BumpResult {
+				resultChan := make(chan *BumpResult, 1)
+				resultChan <- &BumpResult{
+					Tx:    tx,
+					Event: TxFatal,
+					Err:   errDummy,
+				}
+				wallet.On(
+					"CancelRebroadcast", tx.TxHash(),
+				).Once()
+
+				return resultChan
+			},
+			shouldExit: true,
+		},
+		{
+			name: "tx unknown spend",
+			setupResultChan: func() <-chan *BumpResult {
+				resultChan := make(chan *BumpResult, 1)
+				resultChan <- &BumpResult{
+					Tx:    tx,
+					Event: TxUnknownSpend,
+					Err:   ErrUnknownSpent,
+				}
+				wallet.On(
+					"CancelRebroadcast", tx.TxHash(),
+				).Once()
+
+				return resultChan
+			},
+			shouldExit: true,
+		},
+		{
+			name: "tx fatal before creation",
+			setupResultChan: func() <-chan *BumpResult {
+				resultChan := make(chan *BumpResult, 1)
+				resultChan <- &BumpResult{
+					Event: TxFatal,
+					Err:   errDummy,
+				}
+
+				return resultChan
+			},
+			shouldExit: true,
+		},
+		{
 			// When processing non-confirmed events, the monitor
 			// should not exit.
 			name: "no exit on normal event",

--- a/sweep/tx_input_set.go
+++ b/sweep/tx_input_set.go
@@ -37,7 +37,8 @@ type InputSet interface {
 	// AddWalletInputs adds wallet inputs to the set until a non-dust
 	// change output can be made. Return an error if there are not enough
 	// wallet inputs.
-	AddWalletInputs(wallet Wallet) error
+	AddWalletInputs(wallet Wallet,
+		excludedInputs fn.Set[wire.OutPoint]) error
 
 	// NeedWalletInput returns true if the input set needs more wallet
 	// inputs.
@@ -347,7 +348,9 @@ func (b *BudgetInputSet) hasNormalInput() bool {
 // set to its initial state by removing any wallet inputs added.
 //
 // NOTE: must be called with the wallet lock held via `WithCoinSelectLock`.
-func (b *BudgetInputSet) AddWalletInputs(wallet Wallet) error {
+func (b *BudgetInputSet) AddWalletInputs(wallet Wallet,
+	excludedInputs fn.Set[wire.OutPoint]) error {
+
 	// Retrieve wallet utxos. Only consider confirmed utxos to prevent
 	// problems around RBF rules for unconfirmed inputs. This currently
 	// ignores the configured coin selection strategy.
@@ -369,6 +372,10 @@ func (b *BudgetInputSet) AddWalletInputs(wallet Wallet) error {
 
 	// Add wallet inputs to the set until the specified budget is covered.
 	for _, utxo := range utxos {
+		if excludedInputs.Contains(utxo.OutPoint) {
+			continue
+		}
+
 		err := b.addWalletInput(utxo)
 		if err != nil {
 			return err

--- a/sweep/tx_input_set_test.go
+++ b/sweep/tx_input_set_test.go
@@ -411,7 +411,7 @@ func TestAddWalletInputsReturnErr(t *testing.T) {
 
 	// Check that the error is returned from
 	// ListUnspentWitnessFromDefaultAccount.
-	err := set.AddWalletInputs(wallet)
+	err := set.AddWalletInputs(wallet, fn.NewSet[wire.OutPoint]())
 	require.ErrorIs(t, err, dummyErr)
 
 	// Create an utxo with unknown address type to trigger an error.
@@ -424,7 +424,7 @@ func TestAddWalletInputsReturnErr(t *testing.T) {
 		min, max).Return([]*lnwallet.Utxo{utxo}, nil).Once()
 
 	// Check that the error is returned from createWalletTxInput.
-	err = set.AddWalletInputs(wallet)
+	err = set.AddWalletInputs(wallet, fn.NewSet[wire.OutPoint]())
 	require.Error(t, err)
 
 	// Mock the wallet to return empty utxos.
@@ -432,7 +432,7 @@ func TestAddWalletInputsReturnErr(t *testing.T) {
 		min, max).Return([]*lnwallet.Utxo{}, nil).Once()
 
 	// Check that the error is returned from not having wallet inputs.
-	err = set.AddWalletInputs(wallet)
+	err = set.AddWalletInputs(wallet, fn.NewSet[wire.OutPoint]())
 	require.ErrorIs(t, err, ErrNotEnoughInputs)
 }
 
@@ -484,7 +484,7 @@ func TestAddWalletInputsNotEnoughInputs(t *testing.T) {
 
 	// Add wallet inputs to the input set, which should return no error
 	// although the wallet cannot cover the budget.
-	err := set.AddWalletInputs(wallet)
+	err := set.AddWalletInputs(wallet, fn.NewSet[wire.OutPoint]())
 	require.NoError(t, err)
 
 	// Check that the budget set is updated.
@@ -552,7 +552,7 @@ func TestAddWalletInputsEmptyWalletSuccess(t *testing.T) {
 
 	// Add wallet inputs to the input set, which should return no error
 	// although the wallet is empty.
-	err := set.AddWalletInputs(wallet)
+	err := set.AddWalletInputs(wallet, fn.NewSet[wire.OutPoint]())
 	require.NoError(t, err)
 }
 
@@ -611,7 +611,7 @@ func TestAddWalletInputsSuccess(t *testing.T) {
 
 	// Add wallet inputs to the input set, which should give us an error as
 	// the wallet cannot cover the budget.
-	err = set.AddWalletInputs(wallet)
+	err = set.AddWalletInputs(wallet, fn.NewSet[wire.OutPoint]())
 	require.NoError(t, err)
 
 	// Check that the budget set is updated.
@@ -632,4 +632,47 @@ func TestAddWalletInputsSuccess(t *testing.T) {
 	require.Equal(t, deadline, set.DeadlineHeight())
 	// Weak check, a strong check is to open the slice and check each item.
 	require.Len(t, set.inputs, 3)
+}
+
+// TestAddWalletInputsExcludesDiagnosedInputs checks that quarantined wallet
+// UTXOs are skipped during coin selection.
+func TestAddWalletInputsExcludesDiagnosedInputs(t *testing.T) {
+	t.Parallel()
+
+	wallet := &MockWallet{}
+	defer wallet.AssertExpectations(t)
+
+	const budget = btcutil.Amount(10_000)
+	requiredInput := &input.MockInput{}
+	defer requiredInput.AssertExpectations(t)
+	requiredInput.On("RequiredTxOut").Return(&wire.TxOut{})
+
+	set := &BudgetInputSet{
+		inputs: []*SweeperInput{{
+			Input:  requiredInput,
+			params: Params{Budget: budget},
+		}},
+	}
+
+	excludedUtxo := &lnwallet.Utxo{
+		AddressType: lnwallet.WitnessPubKey,
+		Value:       budget / 2,
+		OutPoint:    wire.OutPoint{Index: 1},
+	}
+	eligibleUtxo := &lnwallet.Utxo{
+		AddressType: lnwallet.WitnessPubKey,
+		Value:       budget,
+		OutPoint:    wire.OutPoint{Index: 2},
+	}
+	wallet.On(
+		"ListUnspentWitnessFromDefaultAccount",
+		int32(1), int32(math.MaxInt32),
+	).Return([]*lnwallet.Utxo{eligibleUtxo, excludedUtxo}, nil).Once()
+
+	excluded := fn.NewSet(excludedUtxo.OutPoint)
+	err := set.AddWalletInputs(wallet, excluded)
+
+	require.NoError(t, err)
+	require.Len(t, set.inputs, 2)
+	require.Equal(t, eligibleUtxo.OutPoint, set.inputs[1].OutPoint())
 }


### PR DESCRIPTION
## Summary

- isolate attributable singleton input failures with no-broadcast subset probes after immediate spend attribution
- fund required-output probes only with independently accepted normal inputs and normalize exact btcd input-rejection forms
- restart surviving inputs at a fresh fee while advancing unchanged-set retries, with fee-advance failures remaining fatal
- quarantine diagnosed wallet UTXOs and stop sweeper monitors after terminal publisher results
- document initial and replacement retry parity and add the v0.22.0 release note

Part of #10840.

## Testing

- `go test ./sweep ./lnwallet/btcwallet`
- `go test -race ./sweep ./lnwallet/btcwallet`
- `go vet ./sweep ./lnwallet/btcwallet`
- `make lint-source`
- `git diff 2c3e6ffccebc440f4d1b561324ecf4702feac1da..HEAD --check`