### PR TITLE
sweep: avoid fatal input state on mempool check failure

### DIFF
--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -47,6 +47,11 @@ var (
 	// ErrInputMissing is returned when a given input no longer exists,
 	// e.g., spending from an orphan tx.
 	ErrInputMissing = errors.New("input no longer exists")
+
+	// ErrMempoolAcceptance is returned when a transaction fails
+	// testmempoolaccept for a reason that doesn't have a more specific
+	// sweeper error type.
+	ErrMempoolAcceptance = errors.New("mempool acceptance check failed")
 )
 
 var (
@@ -673,8 +678,8 @@ func (t *TxPublisher) createAndCheckTx(r *monitorRecord) (*sweepTxCtx, error) {
 		return sweepCtx, ErrInputMissing
 	}
 
-	return sweepCtx, fmt.Errorf("tx=%v failed mempool check: %w",
-		sweepCtx.tx.TxHash(), err)
+	return sweepCtx, fmt.Errorf("%w: tx=%v: %w",
+		ErrMempoolAcceptance, sweepCtx.tx.TxHash(), err)
 }
 
 // handleMissingInputs handles the case when the chain backend reports back a
@@ -1141,6 +1146,21 @@ func (t *TxPublisher) handleInitialTxError(r *monitorRecord, err error) {
 	// result here so the rest of the inputs can be retried.
 	case errors.Is(err, ErrInputMissing):
 		result = t.handleMissingInputs(r)
+
+	// If testmempoolaccept rejects the initial sweep tx for a
+	// non-fee-related reason, don't terminally fail the entire input set.
+	// The failure may be caused by a single bad witness in a larger batch,
+	// so let the sweeper retry and re-cluster the inputs instead.
+	case errors.Is(err, ErrMempoolAcceptance):
+		result.Event = TxFailed
+
+		feeRate, err := t.calculateRetryFeeRate(r)
+		if err != nil {
+			result.Event = TxFatal
+			result.Err = err
+		}
+
+		result.FeeRate = feeRate
 
 	// Otherwise this is not a fee-related error and the tx cannot be
 	// retried. In that case we will fail ALL the inputs in this tx, which

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -1944,8 +1944,10 @@ func TestHandleInitialBroadcastFail(t *testing.T) {
 		t.Fatal("timeout waiting for subscriber to receive result")
 
 	case result := <-resultChan:
-		// We expect the first result to be TxFatal.
-		require.Equal(t, TxFatal, result.Event)
+		// A non-fee-related testmempoolaccept failure should be
+		// retried by the sweeper instead of terminally failing all
+		// inputs in the initial batch.
+		require.Equal(t, TxFailed, result.Event)
 	}
 
 	// Validate the record was NOT stored.


### PR DESCRIPTION
## Change Description

When an initial sweep transaction fails `testmempoolaccept` for a non-fee-related reason, `TxPublisher` currently lets that error fall through to `TxFatal`. The sweeper then marks every input in the batch as fatal, even though the rejection may be caused by only one witness/input in the sweep transaction.

This change introduces a typed `ErrMempoolAcceptance` wrapper for generic mempool-check failures and handles that case as `TxFailed` during the initial broadcast path. That lets the sweeper keep the inputs eligible for retry/re-clustering instead of terminally removing the whole batch.

## Steps to Test

```bash
go test ./sweep
```

## Pull Request Checklist

- [x] All commits are signed-off by the author.
- [x] To the best of my knowledge, this change does not introduce a new dependency.
- [x] The relevant tests pass locally.

Fixes #10840

_The batch failed once; the coins should not be sentenced in chorus._