### PR TITLE
scripts: add tag-release.sh to safely cut release tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: build release for all architectures
-        run: SKIP_VERSION_CHECK=1 make release tag=${{ env.RELEASE_VERSION }}
+        run: make release tag=${{ env.RELEASE_VERSION }}
 
       - name: Create Release
         uses: lightninglabs/gh-actions/action-gh-release@c7149b6a7818d1c39b36b69e727569897b6f2c5a

--- a/docs/release_branch_management.md
+++ b/docs/release_branch_management.md
@@ -73,11 +73,12 @@ When ready to begin a major release:
 
 ### Release Candidate Cycle
 
-Create the first release candidate by tagging the version bump commit:
+Create the first release candidate by tagging the version bump commit with the
+release tagging helper:
 
 ```bash
-git tag -s v0.21.0-beta.rc1 -m "lnd v0.21.0-beta.rc1"
-git push origin v0.21.0-beta.rc1
+./scripts/tag-release.sh v0.21.0-beta.rc1 --branch v0.21.x-branch
+git push <upstream-remote> v0.21.0-beta.rc1
 ```
 
 This triggers CI to build release artifacts and Docker images.
@@ -90,8 +91,10 @@ conflicts occur, CI creates backport PRs for manual resolution.
 When ready for the next release candidate:
 
 1. Create a pull request against the release branch to update `build/version.go` to `0.21.0-beta.rc2`
-2. After merging the PR, tag the merge commit on the release branch: `git tag -s v0.21.0-beta.rc2 -m "lnd v0.21.0-beta.rc2"`
-3. Push the new tag: `git push origin v0.21.0-beta.rc2`
+2. After merging the PR, check out the release branch and tag the merge commit:
+   `./scripts/tag-release.sh v0.21.0-beta.rc2 --branch v0.21.x-branch`
+3. Push the new tag to the upstream remote printed by the helper:
+   `git push <upstream-remote> v0.21.0-beta.rc2`
 
 Repeat this cycle (rc3, rc4, etc.) until the release is stable.
 
@@ -100,11 +103,19 @@ Repeat this cycle (rc3, rc4, etc.) until the release is stable.
 For the final release, remove the RC suffix:
 
 1. Create a pull request against the release branch to update `build/version.go` to `0.21.0-beta`
-2. After merging the PR, tag the merge commit on the release branch: `git tag -s v0.21.0-beta -m "lnd v0.21.0-beta"`
-3. Push the new tag: `git push origin v0.21.0-beta`
+2. After merging the PR, check out the release branch and tag the merge commit:
+   `./scripts/tag-release.sh v0.21.0-beta --branch v0.21.x-branch`
+3. Push the new tag to the upstream remote printed by the helper:
+   `git push <upstream-remote> v0.21.0-beta`
 
 The `v0.21.x-branch` branch now enters maintenance mode for future patch
 releases.
+
+### Release Tagging Helper
+
+Use `scripts/tag-release.sh` whenever creating release tags. The helper performs
+the required safety checks before creating the signed tag, then prints the push
+command to run as the final explicit maintainer step.
 
 ## Minor Release Process
 
@@ -119,8 +130,10 @@ When a critical fix is needed for version 0.21.0:
 2. Tag the PR with the `v0.21.1` milestone
 3. CI automation backports to `v0.21.x-branch`
 4. Create a pull request against the release branch to update `build/version.go` to `0.21.1-beta.rc1`
-5. After merging the PR, tag the merge commit: `git tag -s v0.21.1-beta.rc1 -m "lnd v0.21.1-beta.rc1"`
-6. Push the new tag: `git push origin v0.21.1-beta.rc1`
+5. After merging the PR, check out the release branch and tag the merge commit:
+   `./scripts/tag-release.sh v0.21.1-beta.rc1 --branch v0.21.x-branch`
+6. Push the new tag to the upstream remote printed by the helper:
+   `git push <upstream-remote> v0.21.1-beta.rc1`
 
 If additional fixes are needed, follow the same process, incrementing through
 rc2, rc3, etc.
@@ -128,8 +141,10 @@ rc2, rc3, etc.
 For the final patch release:
 
 1. Create a pull request against the release branch to update `build/version.go` to `0.21.1-beta`
-2. After merging the PR, tag the merge commit: `git tag -s v0.21.1-beta -m "lnd v0.21.1-beta"`
-3. Push the new tag: `git push origin v0.21.1-beta`
+2. After merging the PR, check out the release branch and tag the merge commit:
+   `./scripts/tag-release.sh v0.21.1-beta --branch v0.21.x-branch`
+3. Push the new tag to the upstream remote printed by the helper:
+   `git push <upstream-remote> v0.21.1-beta`
 
 Multiple patch releases (0.21.1, 0.21.2, 0.21.3) can be created on the same
 `v0.21.x-branch` branch throughout the version's lifetime.

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+#
+# tag-release.sh creates a signed annotated git tag for an lnd release after
+# verifying (a) HEAD is in sync with the upstream lightningnetwork/lnd
+# branch, and (b) build/version.go at HEAD matches the requested tag. Guards
+# against tagging a commit that has not been merged upstream yet, or one
+# whose embedded version disagrees with the tag.
+
+set -euo pipefail
+
+VERSION_FILE="build/version.go"
+
+# Match the canonical upstream URL across https / git@ / ssh:// forms, with or
+# without a `.git` suffix. We identify the remote by URL because `origin` is
+# conventionally the fork in a `gh repo fork` setup.
+UPSTREAM_URL_REGEX='[:/]lightningnetwork/lnd(\.git)?$'
+
+usage() {
+  cat >&2 <<EOF
+Usage: $(basename "$0") <tag-name> [--branch <branch>]
+
+  <tag-name>          Release tag, e.g. v0.21.0-beta.rc3. Must match the
+                      constants defined in ${VERSION_FILE} at HEAD.
+  --branch <branch>   Upstream branch to verify HEAD against. Defaults to
+                      the currently checked-out branch (typically a release
+                      branch such as v0.21.x-branch).
+EOF
+  exit 1
+}
+
+TAG=""
+UPSTREAM_BRANCH=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)   usage ;;
+    --branch)    [[ $# -ge 2 ]] || usage; UPSTREAM_BRANCH="$2"; shift 2 ;;
+    --branch=*)  UPSTREAM_BRANCH="${1#--branch=}"; shift ;;
+    -*)          echo "Unknown flag: $1" >&2; usage ;;
+    *)           [[ -z "${TAG}" ]] || usage; TAG="$1"; shift ;;
+  esac
+done
+[[ -n "${TAG}" ]] || usage
+
+cd "$(git rev-parse --show-toplevel)"
+
+if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+  echo "Error: tag ${TAG} already exists locally." >&2
+  exit 1
+fi
+
+if [[ -z "${UPSTREAM_BRANCH}" ]]; then
+  UPSTREAM_BRANCH="$(git symbolic-ref --quiet --short HEAD || true)"
+  [[ -n "${UPSTREAM_BRANCH}" ]] \
+    || { echo "Error: detached HEAD; pass --branch <name>." >&2; exit 1; }
+fi
+
+# Discover the upstream remote by URL (see UPSTREAM_URL_REGEX).
+UPSTREAM_REMOTES=()
+while IFS= read -r line; do
+  UPSTREAM_REMOTES+=("$line")
+done < <(git remote -v | awk -v re="${UPSTREAM_URL_REGEX}" \
+  '$3 == "(fetch)" && $2 ~ re { print $1 }' | sort -u)
+
+case "${#UPSTREAM_REMOTES[@]}" in
+  0) echo "Error: no git remote points at lightningnetwork/lnd. Add one with" \
+          "'git remote add upstream" \
+          "https://github.com/lightningnetwork/lnd.git'." >&2
+     exit 1 ;;
+  1) UPSTREAM_REMOTE="${UPSTREAM_REMOTES[0]}" ;;
+  *) echo "Error: multiple remotes match lightningnetwork/lnd:" >&2
+     printf '  %s\n' "${UPSTREAM_REMOTES[@]}" >&2
+     exit 1 ;;
+esac
+
+# Fetch first so every later check runs against confirmed-current upstream
+# state. Without this, a stale local HEAD could pass the version-match check
+# while still being out of sync with what's on the release branch.
+echo "Fetching ${UPSTREAM_REMOTE} ${UPSTREAM_BRANCH}..."
+git fetch --quiet "${UPSTREAM_REMOTE}" "${UPSTREAM_BRANCH}"
+
+# Catch the race where another maintainer has already published this tag.
+if git ls-remote --exit-code --tags "${UPSTREAM_REMOTE}" \
+    "refs/tags/${TAG}" >/dev/null 2>&1; then
+  echo "Error: tag ${TAG} already exists on ${UPSTREAM_REMOTE}." >&2
+  exit 1
+fi
+
+# Compare against FETCH_HEAD rather than refs/remotes/<remote>/<branch>:
+# FETCH_HEAD is always written by `git fetch <remote> <branch>`, while the
+# remote-tracking ref depends on the user's refspec configuration.
+HEAD_SHA="$(git rev-parse HEAD)"
+UP_SHA="$(git rev-parse FETCH_HEAD)"
+if [[ "${HEAD_SHA}" != "${UP_SHA}" ]]; then
+  AHEAD="$(git rev-list --count FETCH_HEAD..HEAD)"
+  BEHIND="$(git rev-list --count HEAD..FETCH_HEAD)"
+  cat >&2 <<EOF
+
+Error: HEAD does not match ${UPSTREAM_REMOTE}/${UPSTREAM_BRANCH}.
+  HEAD:     ${HEAD_SHA}
+  Upstream: ${UP_SHA}
+  Ahead: ${AHEAD}, behind: ${BEHIND}.
+
+Push (or wait for) the version bump on ${UPSTREAM_BRANCH}, then re-run.
+EOF
+  exit 1
+fi
+
+# Parse version.go from HEAD (now confirmed in sync with upstream) so the
+# check reflects exactly what the tag will commit to. A single awk pass
+# extracts all four constants in the order they appear in the file. The
+# `|| :` keeps `set -e` from terminating the script if AppPreRelease is
+# absent from version.go and the final read hits EOF.
+{ read -r M && read -r m && read -r p && read -r pre || :; } < <(
+  git show "HEAD:${VERSION_FILE}" 2>/dev/null | awk '
+    /^[[:space:]]*AppMajor[[:space:]]+uint[[:space:]]*=/   { sub(/.*=[[:space:]]*/,""); sub(/[^0-9].*/,""); print }
+    /^[[:space:]]*AppMinor[[:space:]]+uint[[:space:]]*=/   { sub(/.*=[[:space:]]*/,""); sub(/[^0-9].*/,""); print }
+    /^[[:space:]]*AppPatch[[:space:]]+uint[[:space:]]*=/   { sub(/.*=[[:space:]]*/,""); sub(/[^0-9].*/,""); print }
+    /^[[:space:]]*AppPreRelease[[:space:]]*=/              { match($0,/"[^"]*"/); print substr($0,RSTART+1,RLENGTH-2) }
+  '
+)
+
+if [[ -z "${M}" || -z "${m}" || -z "${p}" ]]; then
+  echo "Error: failed to parse version constants from HEAD:${VERSION_FILE}." \
+       >&2
+  exit 1
+fi
+
+# Go treats `01` as an octal literal but %d prints it as decimal; force
+# base-10 here so we match build.Version()'s output.
+EXPECTED="v$((10#$M)).$((10#$m)).$((10#$p))"
+[[ -n "${pre}" ]] && EXPECTED="${EXPECTED}-${pre}"
+
+echo "Requested: ${TAG}"
+echo "Expected:  ${EXPECTED}  (from HEAD:${VERSION_FILE})"
+
+if [[ "${TAG}" != "${EXPECTED}" ]]; then
+  cat >&2 <<EOF
+
+Error: requested tag does not match HEAD:${VERSION_FILE}.
+  Requested: ${TAG}
+  Expected:  ${EXPECTED}
+
+Bump AppMajor/AppMinor/AppPatch/AppPreRelease and commit before tagging.
+EOF
+  exit 1
+fi
+
+echo "Creating signed tag ${TAG} at ${HEAD_SHA}."
+git tag -s -m "${TAG}" "${TAG}"
+echo "Done. Push with: git push ${UPSTREAM_REMOTE} ${TAG}"


### PR DESCRIPTION
## Summary

Adds `scripts/tag-release.sh`, a small wrapper around `git tag` that
refuses to create a release tag unless two invariants hold:

1. **The tag name matches `build/version.go` at HEAD.** The version
   constants are parsed straight from the committed blob (not the
   working tree), so an uncommitted edit cannot pass the check. This
   guards against the failure mode where a tag is applied to a commit
   whose embedded version string disagrees with the tag.

2. **HEAD is in sync with the upstream `lightningnetwork/lnd` release
   branch.** The script fetches just the target branch, then asserts
   `HEAD == <upstream>/<branch>`. A release tag must never point at a
   commit that has not yet been merged upstream.

The upstream remote is discovered by URL match
(`[:/]lightningnetwork/lnd(\.git)?$`) rather than by name, since
`origin` is conventionally the fork in a `gh repo fork` workflow.

The branch defaults to whichever one is currently checked out — which
matches the common flow of cutting tags from a release branch like
`v0.21.x-branch` — and can be overridden with `--branch`.

The script deliberately does **not**:

- push the tag (kept as an explicit human step),
- modify `build/version.go` (verify-only; the bump is its own commit),
- assume any particular remote name (URL-based discovery).

## Usage

```
./scripts/tag-release.sh v0.21.0-beta.rc3
./scripts/tag-release.sh v0.21.0-beta --branch v0.21.x-branch
```

## Test plan

- [x] Mismatched tag (`v0.21.0-beta.rc3` against the current
      `v0.20.99-beta` in master) → exits 1 with a clear "expected vs
      requested" diff.
- [x] `bash -n` syntax check passes.
- [x] Upstream remote discovered via URL on a setup where `origin` is
      the upstream and `fork` is the personal fork.
- [ ] End-to-end dry run on `v0.21.x-branch` before the next RC.