### PR TITLE
[v0.21.x-branch] Backport #10838: build: bump Go toolchain to 1.26.3

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -52,8 +52,8 @@ runs:
         # The key is used to create and later look up the cache. It's made of
         # four parts:
         # - The base part is made from the OS name, Go version and a
-        #   job-specified key prefix. Example: `linux-go-1.25.5-unit-test-`.
-        #   It ensures that a job running on Linux with Go 1.25 only looks for
+        #   job-specified key prefix. Example: `linux-go-1.26.3-unit-test-`.
+        #   It ensures that a job running on Linux with Go 1.26 only looks for
         #   caches from the same environment.
         # - The unique part is the `hashFiles('**/go.sum')`, which calculates a
         #   hash (a fingerprint) of the go.sum file. 

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,109 @@
+name: Vulnerability scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run weekly to catch newly published vulnerabilities even when the code
+    # does not change.
+    - cron: "0 9 * * 1"
+  pull_request:
+    paths:
+      - ".github/workflows/govulncheck.yml"
+      - ".github/actions/setup-go/action.yml"
+      - "Makefile"
+      - "make/release_flags.mk"
+      - "**/*.go"
+      - "**/go.mod"
+      - "**/go.sum"
+  push:
+    branches:
+      - "master"
+    paths:
+      - ".github/workflows/govulncheck.yml"
+      - ".github/actions/setup-go/action.yml"
+      - "Makefile"
+      - "make/release_flags.mk"
+      - "**/*.go"
+      - "**/go.mod"
+      - "**/go.sum"
+  merge_group:
+    branches:
+      - "master"
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  # If you change this please also update GO_VERSION in Makefile (then run
+  # `make lint` to see where else it needs to be updated as well).
+  GO_VERSION: 1.26.3
+
+jobs:
+  govulncheck:
+    name: Scan release binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go ${{ env.GO_VERSION }}
+        uses: ./.github/actions/setup-go
+        with:
+          go-version: '${{ env.GO_VERSION }}'
+          key-prefix: govulncheck
+          use-build-cache: 'no'
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
+
+      - name: Build release binaries
+        run: make release-install
+
+      - name: Run govulncheck
+        run: |
+          set +e
+
+          gopath="$(go env GOPATH)"
+          final_exit_code=0
+          advisory_findings=0
+
+          for binary in lnd lncli; do
+            output="govulncheck-${binary}.txt"
+            "${gopath}/bin/govulncheck" \
+              -mode=binary \
+              "${gopath}/bin/${binary}" 2>&1 | tee "${output}"
+            exit_code=${PIPESTATUS[0]}
+
+            {
+              echo "### govulncheck ${binary}"
+              echo
+              echo '```'
+              sed -n '1,200p' "${output}"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+
+            if [ "$exit_code" -eq 3 ]; then
+              advisory_findings=1
+              continue
+            fi
+
+            if [ "$exit_code" -ne 0 ] && [ "$final_exit_code" -eq 0 ]; then
+              final_exit_code="$exit_code"
+            fi
+          done
+
+          if [ "$advisory_findings" -eq 1 ]; then
+            echo "::warning title=govulncheck findings::govulncheck found vulnerabilities; see the job summary for details."
+            {
+              echo
+              echo "> govulncheck exited with code 3 for one or more release binaries. This job is advisory while the existing vulnerability baseline is remediated."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          exit "$final_exit_code"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ env:
 
   # If you change this please also update GO_VERSION in Makefile (then run
   # `make lint` to see where else it needs to be updated as well).
-  GO_VERSION: 1.25.5
+  GO_VERSION: 1.26.3
 
 jobs:
   static-checks:
@@ -176,7 +176,7 @@ jobs:
           - name: amd64
             sys: darwin-amd64 freebsd-amd64 linux-amd64 netbsd-amd64 openbsd-amd64 windows-amd64
           - name: arm
-            sys: darwin-arm64 freebsd-arm linux-armv6 linux-armv7 linux-arm64 windows-arm
+            sys: darwin-arm64 freebsd-arm linux-armv6 linux-armv7 linux-arm64 windows-arm64
     steps:
       - name: Git checkout
         uses: actions/checkout@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ defaults:
 env:
   # If you change this please also update GO_VERSION in Makefile (then run
   # `make lint` to see where else it needs to be updated as well).
-  GO_VERSION: 1.25.5
+  GO_VERSION: 1.26.3
 
 jobs:
   ########################

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@ version: "2"
 run:
   # If you change this please also update GO_VERSION in Makefile (then run
   # `make lint` to see where else it needs to be updated as well).
-  go: "1.25.5"
+  go: "1.26.3"
 
   # Abort after 10 minutes.
   timeout: 10m

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # If you change this please also update GO_VERSION in Makefile (then run
 # `make lint` to see where else it needs to be updated as well).
-FROM golang:1.25.5-alpine as builder
+FROM golang:1.26.3-alpine as builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ACTIVE_GO_VERSION_MINOR := $(shell echo $(ACTIVE_GO_VERSION) | cut -d. -f2)
 # GO_VERSION is the Go version used for the release build, docker files, and
 # GitHub Actions. This is the reference version for the project. All other Go
 # versions are checked against this version.
-GO_VERSION = 1.25.5
+GO_VERSION = 1.26.3
 
 GOBUILD := $(GOCC) build -v
 GOINSTALL := $(GOCC) install -v

--- a/actor/go.mod
+++ b/actor/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/actor
 
-go 1.25.5
+go 1.25.10
 
 require (
 	github.com/btcsuite/btclog/v2 v2.0.1-0.20250602222548-9967d19bb084

--- a/cert/go.mod
+++ b/cert/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/cert
 
-go 1.25.5
+go 1.25.10
 
 require github.com/stretchr/testify v1.8.2
 

--- a/clock/go.mod
+++ b/clock/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/clock
 
-go 1.25.5
+go 1.25.10
 
 require github.com/stretchr/testify v1.8.2
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,6 +1,6 @@
 # If you change this please also update GO_VERSION in Makefile (then run
 # `make lint` to see where else it needs to be updated as well).
-FROM golang:1.25.5-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 

--- a/discovery/bootstrapper_test.go
+++ b/discovery/bootstrapper_test.go
@@ -49,7 +49,7 @@ func (s *stubChannelGraph) ForEachNode(ctx context.Context,
 // ForEachNodesChannels is a no-op stub; SampleNodeAddrs does not exercise
 // the channel iteration path.
 func (s *stubChannelGraph) ForEachNodesChannels(_ context.Context,
-	_ func(context.Context, autopilot.NodeID,
+	_ func(context.Context, autopilot.Node,
 		[]*autopilot.ChannelEdge) error, _ func()) error {
 
 	return nil

--- a/docker/btcd/Dockerfile
+++ b/docker/btcd/Dockerfile
@@ -1,6 +1,6 @@
 # If you change this please also update GO_VERSION in Makefile (then run
 # `make lint` to see where else it needs to be updated as well).
-FROM golang:1.25.5-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -93,7 +93,7 @@ following build dependencies are required:
 
 ### Installing Go
 
-`lnd` is written in Go, with a minimum version of `1.25.5` (or, in case this
+`lnd` is written in Go, with a minimum version of `1.25.10` (or, in case this
 document gets out of date, whatever the Go version in the main `go.mod` file
 requires). To install, run one of the following commands for your OS:
 
@@ -101,15 +101,15 @@ requires). To install, run one of the following commands for your OS:
   <summary>Linux (x86-64)</summary>
 
   ```
-  wget https://dl.google.com/go/go1.25.5.linux-amd64.tar.gz
-  echo "9e9b755d63b36acf30c12a9a3fc379243714c1c6d3dd72861da637f336ebb35b  go1.25.5.linux-amd64.tar.gz" | sha256sum --check
+  wget https://dl.google.com/go/go1.25.10.linux-amd64.tar.gz
+  echo "42d4f7a32316aa66591eca7e89867256057a4264451aca10570a715b3637ba70  go1.25.10.linux-amd64.tar.gz" | sha256sum --check
   ```
 
-  The command above should output `go1.25.5.linux-amd64.tar.gz: OK`. If it
+  The command above should output `go1.25.10.linux-amd64.tar.gz: OK`. If it
   doesn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
   this version of Go. If it matches, then proceed to install Go:
   ```
-  sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.25.5.linux-amd64.tar.gz
+  sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.25.10.linux-amd64.tar.gz
   export PATH=$PATH:/usr/local/go/bin
   ```
 </details>
@@ -118,15 +118,15 @@ requires). To install, run one of the following commands for your OS:
   <summary>Linux (ARMv6)</summary>
 
   ```
-  wget https://dl.google.com/go/go1.25.5.linux-armv6l.tar.gz
-  echo "0b27e3dec8d04899d6941586d2aa2721c3dee67c739c1fc1b528188f3f6e8ab5  go1.25.5.linux-armv6l.tar.gz" | sha256sum --check
+  wget https://dl.google.com/go/go1.25.10.linux-armv6l.tar.gz
+  echo "39f168f158e693887d3ad006168af1b1a3007b19c5993cae4d9d57f82f52aaf8  go1.25.10.linux-armv6l.tar.gz" | sha256sum --check
   ```
 
-  The command above should output `go1.25.5.linux-armv6l.tar.gz: OK`. If it
+  The command above should output `go1.25.10.linux-armv6l.tar.gz: OK`. If it
   isn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
   this version of Go. If it matches, then proceed to install Go:
   ```
-  sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.25.5.linux-armv6l.tar.gz
+  sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.25.10.linux-armv6l.tar.gz
   export PATH=$PATH:/usr/local/go/bin
   ```
 

--- a/fn/go.mod
+++ b/fn/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/fn/v2
 
-go 1.25.5
+go 1.25.10
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -221,9 +221,9 @@ replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 // allows us to specify that as an option.
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display
 
-// If you change this please also update docs/INSTALL.md and GO_VERSION in
-// Makefile (then run `make lint` to see where else it needs to be updated as
-// well).
-go 1.25.5
+// If you change this please also update docs/INSTALL.md and all other go.mod
+// files. The release build toolchain version is tracked separately by
+// GO_VERSION in Makefile.
+go 1.25.10
 
 retract v0.0.2

--- a/healthcheck/go.mod
+++ b/healthcheck/go.mod
@@ -24,4 +24,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.25.5
+go 1.25.10

--- a/kvdb/go.mod
+++ b/kvdb/go.mod
@@ -147,4 +147,4 @@ replace github.com/ulikunitz/xz => github.com/ulikunitz/xz v0.5.11
 // https://deps.dev/advisory/OSV/GO-2021-0053?from=%2Fgo%2Fgithub.com%252Fgogo%252Fprotobuf%2Fv1.3.1
 replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 
-go 1.25.5
+go 1.25.10

--- a/lnrpc/Dockerfile
+++ b/lnrpc/Dockerfile
@@ -1,6 +1,6 @@
 # If you change this please also update GO_VERSION in Makefile (then run
 # `make lint` to see where else it needs to be updated as well).
-FROM golang:1.25.5-bookworm
+FROM golang:1.26.3-bookworm
 
 RUN apt-get update && apt-get install -y \
   git \

--- a/lnrpc/gen_protos_docker.sh
+++ b/lnrpc/gen_protos_docker.sh
@@ -6,7 +6,7 @@ set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # golang docker image version used in this script.
-GO_IMAGE=docker.io/library/golang:1.25.5-alpine
+GO_IMAGE=docker.io/library/golang:1.26.3-alpine
 
 PROTOBUF_VERSION=$(docker run --rm -v $DIR/../:/lnd -w /lnd $GO_IMAGE \
 	go list -f '{{.Version}}' -m google.golang.org/protobuf)

--- a/make/builder.Dockerfile
+++ b/make/builder.Dockerfile
@@ -1,6 +1,6 @@
 # If you change this please also update GO_VERSION in Makefile (then run
 # `make lint` to see where else it needs to be updated as well).
-FROM golang:1.25.5-bookworm
+FROM golang:1.26.3-bookworm
 
 MAINTAINER Olaoluwa Osuntokun <laolu@lightning.engineering>
 

--- a/make/release_flags.mk
+++ b/make/release_flags.mk
@@ -26,7 +26,7 @@ netbsd-amd64 \
 openbsd-amd64 \
 windows-386 \
 windows-amd64 \
-windows-arm
+windows-arm64
 
 RELEASE_TAGS = autopilotrpc signrpc walletrpc chainrpc invoicesrpc watchtowerrpc neutrinorpc monitoring peersrpc kvdb_postgres kvdb_etcd kvdb_sqlite
 

--- a/queue/go.mod
+++ b/queue/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/queue
 
-go 1.25.5
+go 1.25.10
 
 require (
 	github.com/lightningnetwork/lnd/fn/v2 v2.0.8

--- a/sqldb/go.mod
+++ b/sqldb/go.mod
@@ -75,4 +75,4 @@ require (
 	modernc.org/token v1.1.0 // indirect
 )
 
-go 1.25.5
+go 1.25.10

--- a/sqldb/v2/go.mod
+++ b/sqldb/v2/go.mod
@@ -74,4 +74,4 @@ require (
 // did not yet make it into the upstream repository.
 replace github.com/golang-migrate/migrate/v4 => github.com/lightninglabs/migrate/v4 v4.18.2-9023d66a-fork-pr-2.0.20251211093704-71c1eef09789
 
-go 1.23.12
+go 1.25.10

--- a/ticker/go.mod
+++ b/ticker/go.mod
@@ -1,3 +1,3 @@
 module github.com/lightningnetwork/lnd/ticker
 
-go 1.25.5
+go 1.25.10

--- a/tlv/go.mod
+++ b/tlv/go.mod
@@ -22,4 +22,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.25.5
+go 1.25.10

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.5
+FROM golang:1.26.3
 
 RUN apt-get update && apt-get install -y git
 ENV GOCACHE=/tmp/build/.cache

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/tools
 
-go 1.25.5
+go 1.25.10
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0 // indirect

--- a/tools/linters/go.mod
+++ b/tools/linters/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/tools/linters
 
-go 1.25.5
+go 1.25.10
 
 require (
 	github.com/golangci/plugin-module-register v0.1.1

--- a/tor/go.mod
+++ b/tor/go.mod
@@ -23,4 +23,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.25.5
+go 1.25.10


### PR DESCRIPTION
Backport of #10838

---

This PR replaces #10566 with a narrower Go version update that separates the build toolchain from the module language/minimum Go version.

The build toolchain pins move from Go 1.25.5 to Go 1.26.3 across:

- Makefile and CI/release workflow Go version pins
- Docker image tags used for builds, release helpers, tools, and protobuf generation
- golangci-lint configured Go version

The module language/minimum Go version stays on the Go 1.25 line and is updated only to the latest patch release:

- all tracked go.mod files now use go 1.25.10
- install documentation and Go tarball checksums now reference Go 1.25.10

It also carries forward the compatibility fix discussed in #10566: Go 1.26 no longer supports the windows/arm port, so the release target and CI arm matrix now use windows-arm64 instead.

This PR also adds a dedicated govulncheck workflow that builds the release-style lnd binary and scans it in binary mode. The workflow runs weekly, can be started manually, and runs on PRs/pushes that touch Go dependency or Go build-version surfaces. This avoids making every ordinary PR fail because the external vulnerability database changed, while still catching newly published vulnerabilities on a schedule.

No functional lnd code changes are included.