### PR TITLE
sqldb: avoid materializing non-terminal payments

### DIFF
--- a/sqldb/sqlc/payments.sql.go
+++ b/sqldb/sqlc/payments.sql.go
@@ -392,27 +392,6 @@ func (q *Queries) FetchHtlcAttemptsForPayments(ctx context.Context, paymentIds [
 }
 
 const fetchNonTerminalPayments = `-- name: FetchNonTerminalPayments :many
-WITH non_terminal_ids AS (
-    SELECT p.id
-    FROM payments p
-    WHERE p.fail_reason IS NULL
-    AND NOT EXISTS (
-        SELECT 1 FROM payment_htlc_attempt_resolutions hr
-        JOIN payment_htlc_attempts ha
-            ON ha.attempt_index = hr.attempt_index
-        WHERE ha.payment_id = p.id
-        AND hr.resolution_type = 1
-    )
-
-    UNION
-
-    SELECT DISTINCT ha.payment_id AS id
-    FROM payment_htlc_attempts ha
-    WHERE NOT EXISTS (
-        SELECT 1 FROM payment_htlc_attempt_resolutions hr
-        WHERE hr.attempt_index = ha.attempt_index
-    )
-)
 SELECT
     p.id,
     p.amount_msat,
@@ -421,12 +400,33 @@ SELECT
     p.fail_reason,
     pi.intent_type,
     pi.intent_payload
-FROM non_terminal_ids n
-JOIN payments p
-    ON p.id = n.id
+FROM payments p
 LEFT JOIN payment_intents pi
     ON pi.payment_id = p.id
 WHERE p.id > $1
+AND (
+    (
+        p.fail_reason IS NULL
+        AND NOT EXISTS (
+            SELECT 1
+            FROM payment_htlc_attempts ha
+            JOIN payment_htlc_attempt_resolutions hr
+                ON hr.attempt_index = ha.attempt_index
+            WHERE ha.payment_id = p.id
+            AND hr.resolution_type = 1
+        )
+    )
+    OR EXISTS (
+        SELECT 1
+        FROM payment_htlc_attempts ha
+        WHERE ha.payment_id = p.id
+        AND NOT EXISTS (
+            SELECT 1
+            FROM payment_htlc_attempt_resolutions hr
+            WHERE hr.attempt_index = ha.attempt_index
+        )
+    )
+)
 ORDER BY p.id ASC
 LIMIT $2
 `

--- a/sqldb/sqlc/queries/payments.sql
+++ b/sqldb/sqlc/queries/payments.sql
@@ -129,27 +129,6 @@ ORDER BY p.id ASC;
 -- Fetch all non-terminal payments using pagination. A payment is
 -- non-terminal if it has an unresolved attempt, or if it has not been
 -- permanently failed and has no settled attempt yet.
-WITH non_terminal_ids AS (
-    SELECT p.id
-    FROM payments p
-    WHERE p.fail_reason IS NULL
-    AND NOT EXISTS (
-        SELECT 1 FROM payment_htlc_attempt_resolutions hr
-        JOIN payment_htlc_attempts ha
-            ON ha.attempt_index = hr.attempt_index
-        WHERE ha.payment_id = p.id
-        AND hr.resolution_type = 1
-    )
-
-    UNION
-
-    SELECT DISTINCT ha.payment_id AS id
-    FROM payment_htlc_attempts ha
-    WHERE NOT EXISTS (
-        SELECT 1 FROM payment_htlc_attempt_resolutions hr
-        WHERE hr.attempt_index = ha.attempt_index
-    )
-)
 SELECT
     p.id,
     p.amount_msat,
@@ -158,12 +137,33 @@ SELECT
     p.fail_reason,
     pi.intent_type,
     pi.intent_payload
-FROM non_terminal_ids n
-JOIN payments p
-    ON p.id = n.id
+FROM payments p
 LEFT JOIN payment_intents pi
     ON pi.payment_id = p.id
 WHERE p.id > $1
+AND (
+    (
+        p.fail_reason IS NULL
+        AND NOT EXISTS (
+            SELECT 1
+            FROM payment_htlc_attempts ha
+            JOIN payment_htlc_attempt_resolutions hr
+                ON hr.attempt_index = ha.attempt_index
+            WHERE ha.payment_id = p.id
+            AND hr.resolution_type = 1
+        )
+    )
+    OR EXISTS (
+        SELECT 1
+        FROM payment_htlc_attempts ha
+        WHERE ha.payment_id = p.id
+        AND NOT EXISTS (
+            SELECT 1
+            FROM payment_htlc_attempt_resolutions hr
+            WHERE hr.attempt_index = ha.attempt_index
+        )
+    )
+)
 ORDER BY p.id ASC
 LIMIT $2;
 


### PR DESCRIPTION
## Motivation

`FetchInFlightPayments` uses `FetchNonTerminalPayments` during SQL payment recovery, including router startup payment resume and `TrackPayments` subscription setup.

The current query first builds a `non_terminal_ids` CTE using `UNION`, then applies pagination outside the CTE:

```sql
FROM non_terminal_ids n
JOIN payments p ON p.id = n.id
WHERE p.id > $1
ORDER BY p.id ASC
LIMIT $2
```

On SQLite this can force materialization of the full candidate set before the outer `WHERE`/`ORDER BY`/`LIMIT` can be applied. On a node with a large payment history, `EXPLAIN QUERY PLAN` showed:

```text
MATERIALIZE non_terminal_ids
UNION USING TEMP B-TREE
SCAN ha
```

That means the query can effectively scan historical payment/attempt/resolution tables before returning a single page. In one observed DB, `payments WHERE fail_reason IS NULL` alone contained ~250k rows, causing startup recovery to spend a long time inside `FetchNonTerminalPayments`.

## What Changed

This rewrites `FetchNonTerminalPayments` to be payment-driven:

```sql
FROM payments p
WHERE p.id > $1
...
ORDER BY p.id ASC
LIMIT $2
```

The non-terminal checks are kept as correlated `EXISTS` / `NOT EXISTS` predicates on each candidate payment.

This lets SQLite use the primary-key payment cursor first and stop once the requested page is found, instead of materializing all non-terminal IDs up front.

The observed query plan for the rewritten shape is:

```text
SEARCH p USING INTEGER PRIMARY KEY (rowid>?)
CORRELATED SCALAR SUBQUERY
  SEARCH ha USING INDEX idx_htlc_payment_id_attempt_time (payment_id=?)
  SEARCH hr USING INTEGER PRIMARY KEY (rowid=?)
SEARCH pi USING INDEX sqlite_autoindex_payment_intents_1 (payment_id=?)
```

On the affected DB, the rewritten query returned the first page in ~0.4s.

## Semantics

The returned payment set is unchanged:

- payments that have not permanently failed and have no settled attempt
- payments with at least one unresolved HTLC attempt

The change only alters the selector shape so pagination can be applied before scanning historical attempts/resolutions.

## Testing

- Ran `make sqlc`
- Manually compared SQLite query plans on an affected payment DB
- Verified the rewritten query returns quickly on the affected DB
