### PR TITLE
lncli: add nodeinfo command

### DIFF
--- a/cmd/commands/cmd_nodeinfo.go
+++ b/cmd/commands/cmd_nodeinfo.go
@@ -1,0 +1,200 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/urfave/cli"
+	"google.golang.org/grpc"
+)
+
+var nodeInfoCommand = cli.Command{
+	Name:     "nodeinfo",
+	Category: "Info",
+	Usage:    "Display a human-readable summary of the local node.",
+	Description: `
+nodeinfo prints a combined view of the running lnd node: identity,
+on-chain wallet balance, and Lightning channel balances — all in one
+place without having to call getinfo, walletbalance, and channelbalance
+separately.
+
+Use --json to get machine-readable output instead of formatted text.`,
+	Flags: []cli.Flag{
+		cli.BoolFlag{
+			Name:  "json",
+			Usage: "print raw JSON instead of formatted text",
+		},
+	},
+	Action: actionDecorator(nodeInfo),
+}
+
+// nodeInfoClient is the subset of lnrpc.LightningClient that nodeinfo needs.
+// Using a narrow interface keeps the command testable without mocking all 167
+// methods of the full LightningClient.
+type nodeInfoClient interface {
+	GetInfo(ctx context.Context, in *lnrpc.GetInfoRequest, opts ...grpc.CallOption) (*lnrpc.GetInfoResponse, error)
+	WalletBalance(ctx context.Context, in *lnrpc.WalletBalanceRequest, opts ...grpc.CallOption) (*lnrpc.WalletBalanceResponse, error)
+	ChannelBalance(ctx context.Context, in *lnrpc.ChannelBalanceRequest, opts ...grpc.CallOption) (*lnrpc.ChannelBalanceResponse, error)
+}
+
+func nodeInfo(ctx *cli.Context) error {
+	ctxc := getContext()
+	client, cleanUp := getClient(ctx)
+	defer cleanUp()
+	return nodeInfoFromClient(ctxc, ctx.Bool("json"), client)
+}
+
+// nodeInfoFromClient is the testable core: it fires the three RPCs, then
+// either prints formatted text or JSON depending on jsonOutput.
+func nodeInfoFromClient(ctxc context.Context, jsonOutput bool, client nodeInfoClient) error {
+	type infoRes struct {
+		v   *lnrpc.GetInfoResponse
+		err error
+	}
+	type walletRes struct {
+		v   *lnrpc.WalletBalanceResponse
+		err error
+	}
+	type chanRes struct {
+		v   *lnrpc.ChannelBalanceResponse
+		err error
+	}
+
+	infoCh := make(chan infoRes, 1)
+	walletCh := make(chan walletRes, 1)
+	chanCh := make(chan chanRes, 1)
+
+	go func() {
+		v, err := client.GetInfo(ctxc, &lnrpc.GetInfoRequest{})
+		infoCh <- infoRes{v, err}
+	}()
+	go func() {
+		v, err := client.WalletBalance(ctxc, &lnrpc.WalletBalanceRequest{})
+		walletCh <- walletRes{v, err}
+	}()
+	go func() {
+		v, err := client.ChannelBalance(ctxc, &lnrpc.ChannelBalanceRequest{})
+		chanCh <- chanRes{v, err}
+	}()
+
+	ir := <-infoCh
+	if ir.err != nil {
+		return ir.err
+	}
+	wr := <-walletCh
+	if wr.err != nil {
+		return wr.err
+	}
+	cr := <-chanCh
+	if cr.err != nil {
+		return cr.err
+	}
+
+	if jsonOutput {
+		printJSON(struct {
+			Info    *lnrpc.GetInfoResponse        `json:"info"`
+			Wallet  *lnrpc.WalletBalanceResponse  `json:"wallet"`
+			Channel *lnrpc.ChannelBalanceResponse `json:"channel"`
+		}{ir.v, wr.v, cr.v})
+		return nil
+	}
+
+	return printNodeInfo(ir.v, wr.v, cr.v)
+}
+
+func printNodeInfo(
+	info *lnrpc.GetInfoResponse,
+	wallet *lnrpc.WalletBalanceResponse,
+	channel *lnrpc.ChannelBalanceResponse,
+) error {
+
+	// ── Identity ──────────────────────────────────────────────────────────────
+	alias := info.Alias
+	if alias == "" {
+		alias = "(no alias)"
+	}
+	network := ""
+	if len(info.Chains) > 0 {
+		network = fmt.Sprintf("%s/%s", info.Chains[0].Chain, info.Chains[0].Network)
+	}
+	syncStatus := "synced"
+	if !info.SyncedToChain {
+		syncStatus = "NOT synced"
+	}
+
+	fmt.Printf("%-12s %s\n", "Node", info.IdentityPubkey)
+	fmt.Printf("%-12s %s  %s\n", "Alias", alias, info.Color)
+	fmt.Printf("%-12s %s   block %-7d  %s\n", "Network", network, info.BlockHeight, syncStatus)
+	for _, uri := range info.Uris {
+		fmt.Printf("%-12s %s\n", "URI", uri)
+	}
+
+	// ── On-chain balance ──────────────────────────────────────────────────────
+	fmt.Println()
+	fmt.Println("On-chain")
+	fmt.Printf("  %-14s %s\n", "Confirmed", commaSats(wallet.ConfirmedBalance))
+	if wallet.UnconfirmedBalance != 0 {
+		fmt.Printf("  %-14s %s\n", "Unconfirmed", commaSats(wallet.UnconfirmedBalance))
+	}
+
+	// ── Lightning channels ────────────────────────────────────────────────────
+	localSat := int64(channel.GetLocalBalance().GetSat())
+	remoteSat := int64(channel.GetRemoteBalance().GetSat())
+	pendingLocalSat := int64(channel.GetPendingOpenLocalBalance().GetSat())
+	pendingRemoteSat := int64(channel.GetPendingOpenRemoteBalance().GetSat())
+	totalSat := localSat + remoteSat
+
+	fmt.Println()
+	fmt.Println("Channels")
+	fmt.Printf("  %-14s active %-4d  inactive %-4d  pending %d\n",
+		"Count",
+		info.NumActiveChannels,
+		info.NumInactiveChannels,
+		info.NumPendingChannels,
+	)
+
+	if totalSat > 0 {
+		pct := int(localSat * 100 / totalSat)
+		fmt.Printf("  %-14s %s\n", "Capacity", commaSats(totalSat))
+		fmt.Printf("  %-14s %s  (%d%% local)\n", "Balance", commaSats(localSat), pct)
+		fmt.Printf("  %-14s %s\n", "Remote", commaSats(remoteSat))
+	}
+	if pendingLocalSat > 0 || pendingRemoteSat > 0 {
+		fmt.Printf("  %-14s local %s  remote %s\n",
+			"Pending open",
+			commaSats(pendingLocalSat),
+			commaSats(pendingRemoteSat),
+		)
+	}
+
+	// ── Peers ─────────────────────────────────────────────────────────────────
+	fmt.Println()
+	fmt.Printf("%-12s %d\n", "Peers", info.NumPeers)
+
+	return nil
+}
+
+// commaSats formats a satoshi amount with thousands separators,
+// e.g. "1,234,567 sats".
+func commaSats(sats int64) string {
+	neg := sats < 0
+	if neg {
+		sats = -sats
+	}
+
+	s := fmt.Sprintf("%d", sats)
+	out := make([]byte, 0, len(s)+len(s)/3+1)
+	for i, c := range s {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			out = append(out, ',')
+		}
+		out = append(out, byte(c))
+	}
+
+	result := string(out) + " sats"
+	if neg {
+		result = "-" + result
+	}
+	return result
+}

--- a/cmd/commands/cmd_nodeinfo_test.go
+++ b/cmd/commands/cmd_nodeinfo_test.go
@@ -1,0 +1,285 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// mockNodeInfoClient implements nodeInfoClient with scripted responses.
+type mockNodeInfoClient struct {
+	infoResp   *lnrpc.GetInfoResponse
+	infoErr    error
+	walletResp *lnrpc.WalletBalanceResponse
+	walletErr  error
+	chanResp   *lnrpc.ChannelBalanceResponse
+	chanErr    error
+}
+
+var _ nodeInfoClient = (*mockNodeInfoClient)(nil)
+
+func (m *mockNodeInfoClient) GetInfo(_ context.Context, _ *lnrpc.GetInfoRequest, _ ...grpc.CallOption) (*lnrpc.GetInfoResponse, error) {
+	return m.infoResp, m.infoErr
+}
+
+func (m *mockNodeInfoClient) WalletBalance(_ context.Context, _ *lnrpc.WalletBalanceRequest, _ ...grpc.CallOption) (*lnrpc.WalletBalanceResponse, error) {
+	return m.walletResp, m.walletErr
+}
+
+func (m *mockNodeInfoClient) ChannelBalance(_ context.Context, _ *lnrpc.ChannelBalanceRequest, _ ...grpc.CallOption) (*lnrpc.ChannelBalanceResponse, error) {
+	return m.chanResp, m.chanErr
+}
+
+// captureStdout runs f and returns everything it wrote to os.Stdout.
+func captureStdout(t *testing.T, f func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	old := os.Stdout
+	os.Stdout = w
+
+	f()
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	return buf.String()
+}
+
+// makeFullClient returns a mock with all three responses populated.
+func makeFullClient() *mockNodeInfoClient {
+	return &mockNodeInfoClient{
+		infoResp: &lnrpc.GetInfoResponse{
+			IdentityPubkey:      "03aabbccdd",
+			Alias:               "alice",
+			Color:               "#ff0000",
+			BlockHeight:         800_000,
+			SyncedToChain:       true,
+			NumActiveChannels:   2,
+			NumInactiveChannels: 1,
+			NumPendingChannels:  0,
+			NumPeers:            3,
+			Chains: []*lnrpc.Chain{
+				{Chain: "bitcoin", Network: "mainnet"},
+			},
+			Uris: []string{"03aabbccdd@1.2.3.4:9735"},
+		},
+		walletResp: &lnrpc.WalletBalanceResponse{
+			ConfirmedBalance:   5_000_000,
+			UnconfirmedBalance: 0,
+		},
+		chanResp: &lnrpc.ChannelBalanceResponse{
+			LocalBalance:  &lnrpc.Amount{Sat: 1_000_000},
+			RemoteBalance: &lnrpc.Amount{Sat: 500_000},
+		},
+	}
+}
+
+// ── commaSats ────────────────────────────────────────────────────────────────
+
+func TestCommaSats(t *testing.T) {
+	tests := []struct {
+		sats int64
+		want string
+	}{
+		{0, "0 sats"},
+		{1, "1 sats"},
+		{999, "999 sats"},
+		{1_000, "1,000 sats"},
+		{1_234, "1,234 sats"},
+		{999_999, "999,999 sats"},
+		{1_000_000, "1,000,000 sats"},
+		{1_234_567, "1,234,567 sats"},
+		{21_000_000_00000000, "2,100,000,000,000,000 sats"},
+		{-1_000, "-1,000 sats"},
+		{-1_234_567, "-1,234,567 sats"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.want, func(t *testing.T) {
+			require.Equal(t, tc.want, commaSats(tc.sats))
+		})
+	}
+}
+
+// ── nodeInfoFromClient: RPC error propagation ─────────────────────────────────
+
+func TestNodeInfoGetInfoError(t *testing.T) {
+	errBoom := errors.New("connection refused")
+	client := makeFullClient()
+	client.infoErr = errBoom
+
+	err := nodeInfoFromClient(context.Background(), false, client)
+	require.ErrorIs(t, err, errBoom)
+}
+
+func TestNodeInfoWalletBalanceError(t *testing.T) {
+	errBoom := errors.New("wallet locked")
+	client := makeFullClient()
+	client.walletErr = errBoom
+
+	err := nodeInfoFromClient(context.Background(), false, client)
+	require.ErrorIs(t, err, errBoom)
+}
+
+func TestNodeInfoChannelBalanceError(t *testing.T) {
+	errBoom := errors.New("db unavailable")
+	client := makeFullClient()
+	client.chanErr = errBoom
+
+	err := nodeInfoFromClient(context.Background(), false, client)
+	require.ErrorIs(t, err, errBoom)
+}
+
+// ── printNodeInfo: formatted output ──────────────────────────────────────────
+
+func TestPrintNodeInfoIdentity(t *testing.T) {
+	client := makeFullClient()
+	out := captureStdout(t, func() {
+		require.NoError(t, nodeInfoFromClient(context.Background(), false, client))
+	})
+
+	require.Contains(t, out, "03aabbccdd")
+	require.Contains(t, out, "alice")
+	require.Contains(t, out, "#ff0000")
+	require.Contains(t, out, "bitcoin/mainnet")
+	require.Contains(t, out, "800000")
+	require.Contains(t, out, "synced")
+	require.Contains(t, out, "03aabbccdd@1.2.3.4:9735")
+}
+
+func TestPrintNodeInfoOnChainBalance(t *testing.T) {
+	client := makeFullClient()
+	out := captureStdout(t, func() {
+		require.NoError(t, nodeInfoFromClient(context.Background(), false, client))
+	})
+
+	require.Contains(t, out, "5,000,000 sats")
+	// No unconfirmed balance — line should not appear.
+	require.NotContains(t, out, "Unconfirmed")
+}
+
+func TestPrintNodeInfoUnconfirmedBalance(t *testing.T) {
+	client := makeFullClient()
+	client.walletResp.UnconfirmedBalance = 250_000
+
+	out := captureStdout(t, func() {
+		require.NoError(t, nodeInfoFromClient(context.Background(), false, client))
+	})
+
+	require.Contains(t, out, "250,000 sats")
+	require.Contains(t, out, "Unconfirmed")
+}
+
+func TestPrintNodeInfoChannels(t *testing.T) {
+	client := makeFullClient()
+	out := captureStdout(t, func() {
+		require.NoError(t, nodeInfoFromClient(context.Background(), false, client))
+	})
+
+	require.Contains(t, out, "active 2")
+	require.Contains(t, out, "inactive 1")
+	// Capacity = local + remote = 1,500,000.
+	require.Contains(t, out, "1,500,000 sats")
+	// Local is 1,000,000 / 1,500,000 = 66%.
+	require.Contains(t, out, "66% local")
+	require.Contains(t, out, "Peers")
+	require.Contains(t, out, "3")
+}
+
+func TestPrintNodeInfoNoChannels(t *testing.T) {
+	client := makeFullClient()
+	client.chanResp = &lnrpc.ChannelBalanceResponse{}
+	client.infoResp.NumActiveChannels = 0
+	client.infoResp.NumInactiveChannels = 0
+
+	out := captureStdout(t, func() {
+		require.NoError(t, nodeInfoFromClient(context.Background(), false, client))
+	})
+
+	// With zero total capacity, balance/capacity lines must not appear.
+	require.NotContains(t, out, "Capacity")
+	require.NotContains(t, out, "Balance")
+	require.Contains(t, out, "active 0")
+}
+
+func TestPrintNodeInfoPendingChannels(t *testing.T) {
+	client := makeFullClient()
+	client.chanResp.PendingOpenLocalBalance = &lnrpc.Amount{Sat: 400_000}
+	client.chanResp.PendingOpenRemoteBalance = &lnrpc.Amount{Sat: 600_000}
+	client.infoResp.NumPendingChannels = 1
+
+	out := captureStdout(t, func() {
+		require.NoError(t, nodeInfoFromClient(context.Background(), false, client))
+	})
+
+	require.Contains(t, out, "Pending open")
+	require.Contains(t, out, "400,000 sats")
+	require.Contains(t, out, "600,000 sats")
+}
+
+func TestPrintNodeInfoNoAlias(t *testing.T) {
+	client := makeFullClient()
+	client.infoResp.Alias = ""
+
+	out := captureStdout(t, func() {
+		require.NoError(t, nodeInfoFromClient(context.Background(), false, client))
+	})
+
+	require.Contains(t, out, "(no alias)")
+}
+
+func TestPrintNodeInfoNotSynced(t *testing.T) {
+	client := makeFullClient()
+	client.infoResp.SyncedToChain = false
+
+	out := captureStdout(t, func() {
+		require.NoError(t, nodeInfoFromClient(context.Background(), false, client))
+	})
+
+	require.Contains(t, out, "NOT synced")
+}
+
+func TestPrintNodeInfoNoURIs(t *testing.T) {
+	client := makeFullClient()
+	client.infoResp.Uris = nil
+
+	out := captureStdout(t, func() {
+		require.NoError(t, nodeInfoFromClient(context.Background(), false, client))
+	})
+
+	require.NotContains(t, out, "URI")
+}
+
+// ── JSON output ───────────────────────────────────────────────────────────────
+
+func TestNodeInfoJSONOutput(t *testing.T) {
+	client := makeFullClient()
+	out := captureStdout(t, func() {
+		require.NoError(t, nodeInfoFromClient(context.Background(), true, client))
+	})
+
+	// Top-level keys from the merged struct.
+	require.Contains(t, out, `"info"`)
+	require.Contains(t, out, `"wallet"`)
+	require.Contains(t, out, `"channel"`)
+	// Spot-check a field from each sub-response.
+	require.Contains(t, out, `"identity_pubkey"`)
+	require.Contains(t, out, `"confirmed_balance"`)
+	require.Contains(t, out, `"local_balance"`)
+	// Must be valid JSON: no formatted text.
+	require.True(t, strings.HasPrefix(strings.TrimSpace(out), "{"))
+}

--- a/cmd/commands/main.go
+++ b/cmd/commands/main.go
@@ -467,6 +467,7 @@ func Main() {
 		walletBalanceCommand,
 		ChannelBalanceCommand,
 		getInfoCommand,
+		nodeInfoCommand,
 		getDebugInfoCommand,
 		encryptDebugPackageCommand,
 		decryptDebugPackageCommand,


### PR DESCRIPTION
## Summary

- Adds `lncli nodeinfo`, a new command that prints a human-readable summary of the local node by combining `GetInfo`, `WalletBalance`, and `ChannelBalance` into a single call
- The three RPCs are fired concurrently to minimise round-trip latency
- `--json` flag emits a merged JSON object (`info` / `wallet` / `channel` keys) for scripting

**Example output:**
\`\`\`
Node         03a189ac5fa02917f998...
Alias        alice  #3399ff
Network      bitcoin/mainnet   block 800000   synced
URI          03a189...@1.2.3.4:9735

On-chain
  Confirmed      5,000,000 sats

Channels
  Count          active 2     inactive 0     pending 0
  Capacity       1,500,000 sats
  Balance        1,000,000 sats  (66% local)
  Remote         500,000 sats

Peers        3
\`\`\`

## Implementation notes

- A narrow `nodeInfoClient` interface (3 methods) is extracted from `lnrpc.LightningClient` so the command can be unit-tested without mocking all 167 methods of the full interface
- `nodeInfoFromClient` is the testable core; `nodeInfo` is the thin CLI glue that calls `getClient` and delegates
- `commaSats` is a stdlib-only thousands-separator formatter (no external dependency)
- Command is registered adjacent to `getInfoCommand` in `main.go`

## Test plan

- [x] `TestCommaSats` — 11 table-driven cases covering zero, boundaries, max BTC supply, negatives
- [x] `TestNodeInfoGetInfoError` / `WalletBalanceError` / `ChannelBalanceError` — error propagation from each concurrent RPC goroutine
- [x] `TestPrintNodeInfoIdentity` — pubkey, alias, color, network, block height, URI in output
- [x] `TestPrintNodeInfoOnChainBalance` — confirmed balance present; unconfirmed line absent when zero
- [x] `TestPrintNodeInfoUnconfirmedBalance` — unconfirmed line appears when non-zero
- [x] `TestPrintNodeInfoChannels` — active/inactive counts, capacity math, local percentage
- [x] `TestPrintNodeInfoNoChannels` — capacity/balance lines suppressed when no open channels
- [x] `TestPrintNodeInfoPendingChannels` — pending-open line present when pending balances set
- [x] `TestPrintNodeInfoNoAlias` — `(no alias)` fallback
- [x] `TestPrintNodeInfoNotSynced` — `NOT synced` status string
- [x] `TestPrintNodeInfoNoURIs` — URI section absent when node has no URIs
- [x] `TestNodeInfoJSONOutput` — top-level keys, valid JSON shape, field names from each sub-response

\`\`\`
go test -run "TestCommaSats|TestNodeInfo|TestPrintNodeInfo" ./cmd/commands/
ok  github.com/lightningnetwork/lnd/cmd/commands  0.060s
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)