### PR TITLE
mod: drop queue + kvdb replaces, require tagged versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,8 +38,8 @@ require (
 	github.com/lightningnetwork/lnd/clock v1.1.1
 	github.com/lightningnetwork/lnd/fn/v2 v2.0.9
 	github.com/lightningnetwork/lnd/healthcheck v1.2.6
-	github.com/lightningnetwork/lnd/kvdb v1.4.16
-	github.com/lightningnetwork/lnd/queue v1.1.1
+	github.com/lightningnetwork/lnd/kvdb v1.5.0
+	github.com/lightningnetwork/lnd/queue v1.2.0
 	github.com/lightningnetwork/lnd/sqldb v1.0.11
 	github.com/lightningnetwork/lnd/ticker v1.1.1
 	github.com/lightningnetwork/lnd/tlv v1.3.2
@@ -197,14 +197,8 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
-// TODO(gijs): remove once new queue package is released.
-replace github.com/lightningnetwork/lnd/queue => ./queue
-
 // TODO(elle): remove once the gossip V2 sqldb changes have been made.
 replace github.com/lightningnetwork/lnd/sqldb => ./sqldb
-
-// TODO: remove once kvdb with pgx/v5 is released.
-replace github.com/lightningnetwork/lnd/kvdb => ./kvdb
 
 // This replace is for https://github.com/advisories/GHSA-25xm-hr59-7c27
 replace github.com/ulikunitz/xz => github.com/ulikunitz/xz v0.5.11

--- a/go.sum
+++ b/go.sum
@@ -321,6 +321,10 @@ github.com/lightningnetwork/lnd/fn/v2 v2.0.9 h1:ZytG4ltPac/sCyg1EJDn10RGzPIDJeye
 github.com/lightningnetwork/lnd/fn/v2 v2.0.9/go.mod h1:aPUJHJ31S+Lgoo8I5SxDIjnmeCifqujaiTXKZqpav3w=
 github.com/lightningnetwork/lnd/healthcheck v1.2.6 h1:1sWhqr93GdkWy4+6U7JxBfcyZIE78MhIHTJZfPx7qqI=
 github.com/lightningnetwork/lnd/healthcheck v1.2.6/go.mod h1:Mu02um4CWY/zdTOvFje7WJgJcHyX2zq/FG3MhOAiGaQ=
+github.com/lightningnetwork/lnd/kvdb v1.5.0 h1:Mglu7tGUdpFv8mDQTBIS2S8kwAz66MXlqUYUeaZ2+YQ=
+github.com/lightningnetwork/lnd/kvdb v1.5.0/go.mod h1:SxUoxWaMpyErZ2GM7maz661NQqwS8J/PUUQv6fnhzOI=
+github.com/lightningnetwork/lnd/queue v1.2.0 h1:sSrn+u84OLuOT/F+xGxgg8VfknXeIZEAFQoMH6BL60s=
+github.com/lightningnetwork/lnd/queue v1.2.0/go.mod h1:qLNP0L3B7piRGvDyhAyJKic4xTt+Mw4D7mWrQeuAwxY=
 github.com/lightningnetwork/lnd/ticker v1.1.1 h1:J/b6N2hibFtC7JLV77ULQp++QLtCwT6ijJlbdiZFbSM=
 github.com/lightningnetwork/lnd/ticker v1.1.1/go.mod h1:waPTRAAcwtu7Ji3+3k+u/xH5GHovTsCoSVpho0KDvdA=
 github.com/lightningnetwork/lnd/tlv v1.3.2 h1:MO4FCk7F4k5xPMqVZF6Nb/kOpxlwPrUQpYjmyKny5s0=


### PR DESCRIPTION
In this PR, we knock out most of the replace directive cleanup tracked in
#10854. Now that we've cut `queue/v1.2.0` and `kvdb/v1.5.0`, we can drop the
two in-tree replace directives that pointed the root module at `./queue` and
`./kvdb`, and require the tagged releases instead.

`queue/v1.2.0` is the `BackpressureQueue[T]` work (the "new queue package" the
TODO was waiting on), and `kvdb/v1.5.0` completes the pgx/v4 -> pgx/v5
migration. Both tags point at the same commit where each module last changed
on master, so what we build doesn't change: we're just consuming the modules
as proper tagged deps now instead of via the local replace.

We're leaving the `sqldb` replace in place. That one's still gated on the
gossip V2 sqldb changes landing before we can cut its tag, so it stays as-is
for now (still tracked in #10854).

## Backport

The queue half of this is being backported to v0.21 via #10847 (the rc3
bump). kvdb is master-only: 0.21 stays on `kvdb v1.4.16`/pgx-v4, so the
pgx/v5 migration doesn't ride into the release.

## Remaining from #10854

- [x] Cut `kvdb/v1.5.0` (pgx/v5)
- [x] Cut `queue/v1.2.0` (`BackpressureQueue[T]`)
- [x] Drop the queue + kvdb replace directives, bump requires
- [ ] Cut the next `sqldb` tag once the gossip V2 work lands, then drop the last replace