### PR TITLE
gomod: update `kvdb` and `btcwallet`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/lightningnetwork/lnd/healthcheck v1.2.6
 	github.com/lightningnetwork/lnd/kvdb v1.5.1
 	github.com/lightningnetwork/lnd/queue v1.2.0
-	github.com/lightningnetwork/lnd/sqldb v1.0.11
+	github.com/lightningnetwork/lnd/sqldb v1.0.13
 	github.com/lightningnetwork/lnd/ticker v1.1.1
 	github.com/lightningnetwork/lnd/tlv v1.3.2
 	github.com/lightningnetwork/lnd/tor v1.1.6

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/lightningnetwork/lnd/clock v1.1.1
 	github.com/lightningnetwork/lnd/fn/v2 v2.0.9
 	github.com/lightningnetwork/lnd/healthcheck v1.2.6
-	github.com/lightningnetwork/lnd/kvdb v1.5.0
+	github.com/lightningnetwork/lnd/kvdb v1.5.1
 	github.com/lightningnetwork/lnd/queue v1.2.0
 	github.com/lightningnetwork/lnd/sqldb v1.0.11
 	github.com/lightningnetwork/lnd/ticker v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/btcsuite/btclog v1.0.0
 	github.com/btcsuite/btclog/v2 v2.0.1-0.20250728225537-6090e87c6c5b
-	github.com/btcsuite/btcwallet v0.16.17-0.20260213031108-70a94ea39e9c
+	github.com/btcsuite/btcwallet v0.16.18
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.3.5
 	github.com/btcsuite/btcwallet/wallet/txrules v1.2.2
 	github.com/btcsuite/btcwallet/walletdb v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/btcsuite/btclog v1.0.0/go.mod h1:w7xnGOhwT3lmrS4H3b/D1XAXxvh+tbhUm8xe
 github.com/btcsuite/btclog/v2 v2.0.1-0.20250728225537-6090e87c6c5b h1:MQ+Q6sDy37V1wP1Yu79A5KqJutolqUGwA99UZWQDWZM=
 github.com/btcsuite/btclog/v2 v2.0.1-0.20250728225537-6090e87c6c5b/go.mod h1:XItGUfVOxotJL8kkuk2Hj3EVow5KCugXl3wWfQ6K0AE=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
-github.com/btcsuite/btcwallet v0.16.17-0.20260213031108-70a94ea39e9c h1:XJN7vcvFiclslw5Zixe9t4YRprTpADcQlBf2IN3nbW8=
-github.com/btcsuite/btcwallet v0.16.17-0.20260213031108-70a94ea39e9c/go.mod h1:4TTru0cgIPbCZpY4aRfAVwX87zrQw4GXM8MH6+A5xZw=
+github.com/btcsuite/btcwallet v0.16.18 h1:6h0kMxij4igPu35jOPAWZbn22ceOC4me4L3jj8Za6Zk=
+github.com/btcsuite/btcwallet v0.16.18/go.mod h1:4TTru0cgIPbCZpY4aRfAVwX87zrQw4GXM8MH6+A5xZw=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.5 h1:Rr0njWI3r341nhSPesKQ2JF+ugDSzdPoeckS75SeDZk=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.5/go.mod h1:+tXJ3Ym0nlQc/iHSwW1qzjmPs3ev+UVWMbGgfV1OZqU=
 github.com/btcsuite/btcwallet/wallet/txrules v1.2.2 h1:YEO+Lx1ZJJAtdRrjuhXjWrYsmAk26wLTlNzxt2q0lhk=

--- a/go.sum
+++ b/go.sum
@@ -321,8 +321,8 @@ github.com/lightningnetwork/lnd/fn/v2 v2.0.9 h1:ZytG4ltPac/sCyg1EJDn10RGzPIDJeye
 github.com/lightningnetwork/lnd/fn/v2 v2.0.9/go.mod h1:aPUJHJ31S+Lgoo8I5SxDIjnmeCifqujaiTXKZqpav3w=
 github.com/lightningnetwork/lnd/healthcheck v1.2.6 h1:1sWhqr93GdkWy4+6U7JxBfcyZIE78MhIHTJZfPx7qqI=
 github.com/lightningnetwork/lnd/healthcheck v1.2.6/go.mod h1:Mu02um4CWY/zdTOvFje7WJgJcHyX2zq/FG3MhOAiGaQ=
-github.com/lightningnetwork/lnd/kvdb v1.5.0 h1:Mglu7tGUdpFv8mDQTBIS2S8kwAz66MXlqUYUeaZ2+YQ=
-github.com/lightningnetwork/lnd/kvdb v1.5.0/go.mod h1:SxUoxWaMpyErZ2GM7maz661NQqwS8J/PUUQv6fnhzOI=
+github.com/lightningnetwork/lnd/kvdb v1.5.1 h1:OG5cDbqggxiCFKAJbSPw0PfQovi+0odCZAAU5r5b+ho=
+github.com/lightningnetwork/lnd/kvdb v1.5.1/go.mod h1:5lubXYoXHDBWBYKmC+2we7qgkjjz0cEZ/5QSQkxQSec=
 github.com/lightningnetwork/lnd/queue v1.2.0 h1:sSrn+u84OLuOT/F+xGxgg8VfknXeIZEAFQoMH6BL60s=
 github.com/lightningnetwork/lnd/queue v1.2.0/go.mod h1:qLNP0L3B7piRGvDyhAyJKic4xTt+Mw4D7mWrQeuAwxY=
 github.com/lightningnetwork/lnd/ticker v1.1.1 h1:J/b6N2hibFtC7JLV77ULQp++QLtCwT6ijJlbdiZFbSM=


### PR DESCRIPTION
Fixes and update the `kvdb` version to include the latest grpc bump,
- #10861 


We intentionally keep the local replace for now:
```go
replace github.com/lightningnetwork/lnd/sqldb => ./sqldb
```


That means lnd itself continues to build against the in-tree sqldb package on the release branch, so there is no behavioral change for the release build.

The important part is downstream module resolution. Go does not propagate replace directives from dependencies, so downstream consumers of lnd only see the `require github.com/lightningnetwork/lnd/sqldb` ... version. Before this bump, they could resolve an older tagged sqldb version that did not contain the current release-branch sqlc types and migrations, causing build failures.

The new `sqldb/v1.0.13` tag was created from the `v0.21` release-branch commit that contains the same sqldb code lnd currently uses via the local replace. So downstream consumers now fetch a tagged sqldb module matching the release branch, while lnd can keep the `replace` until we remove it in a follow-up cleanup.