### PR TITLE
feat(config): support custom signet block time

### DIFF
--- a/config.go
+++ b/config.go
@@ -1316,6 +1316,12 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 		numNets++
 		cfg.ActiveNetParams = chainreg.BitcoinSigNetParams
 
+		err := validateSigNetBackendOptions(cfg.Bitcoin)
+		if err != nil {
+			return nil, mkErr("error validating bitcoin "+
+				"params: %v", err)
+		}
+
 		// Let the user overwrite the default signet parameters.
 		// The challenge defines the actual signet network to
 		// join and the seed nodes are needed for network
@@ -1349,6 +1355,20 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 		chainParams := chaincfg.CustomSignetParams(
 			sigNetChallenge, sigNetSeeds,
 		)
+		if cfg.Bitcoin.SigNetBlockTime != 0 {
+			if cfg.Bitcoin.SigNetChallenge == "" {
+				return nil, mkErr("signet block time " +
+					"requires custom signet challenge")
+			}
+
+			err := applySigNetBlockTime(
+				&chainParams, cfg.Bitcoin.SigNetBlockTime,
+			)
+			if err != nil {
+				return nil, mkErr("invalid signet block "+
+					"time: %v", err)
+			}
+		}
 		cfg.ActiveNetParams.Params = &chainParams
 	}
 	if numNets > 1 {
@@ -2499,6 +2519,69 @@ func configToFlatMap(cfg Config) (map[string]string,
 	printConfig(reflect.ValueOf(cfg), "")
 
 	return result, deprecated, nil
+}
+
+// validateSigNetBackendOptions validates custom signet options against the
+// selected chain backend.
+func validateSigNetBackendOptions(cfg *lncfg.Chain) error {
+	if cfg == nil {
+		return fmt.Errorf("bitcoin config cannot be nil")
+	}
+
+	if !cfg.SigNet {
+		return nil
+	}
+
+	switch cfg.Node {
+	case bitcoindBackendName:
+		switch {
+		case cfg.SigNetChallenge != "":
+			return fmt.Errorf("bitcoin.signetchallenge must not " +
+				"be set with bitcoin.node=bitcoind; " +
+				"configure custom signet consensus options " +
+				"on bitcoind instead")
+
+		case cfg.SigNetBlockTime != 0:
+			return fmt.Errorf("bitcoin.signetblocktime must not " +
+				"be set with bitcoin.node=bitcoind; " +
+				"configure custom signet consensus options " +
+				"on bitcoind instead")
+		}
+
+	case btcdBackendName:
+		if cfg.SigNetBlockTime != 0 {
+			return fmt.Errorf("bitcoin.signetblocktime is not " +
+				"supported with bitcoin.node=btcd; btcd does " +
+				"not currently support custom signet block " +
+				"intervals")
+		}
+	}
+
+	return nil
+}
+
+// applySigNetBlockTime updates the expected block interval used by custom
+// signet header validation. This is needed for custom signets whose backing
+// bitcoind nodes were started with -signetblocktime.
+func applySigNetBlockTime(params *chaincfg.Params,
+	blockTime time.Duration) error {
+
+	if params == nil {
+		return fmt.Errorf("params cannot be nil")
+	}
+
+	if blockTime < time.Second {
+		return fmt.Errorf("must be at least one second")
+	}
+
+	if blockTime > params.TargetTimespan {
+		return fmt.Errorf("must not exceed target timespan %v",
+			params.TargetTimespan)
+	}
+
+	params.TargetTimePerBlock = blockTime
+
+	return nil
 }
 
 // logWarningsForDeprecation logs a warning if a deprecated config option is

--- a/config.go
+++ b/config.go
@@ -1380,6 +1380,12 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 		numNets++
 		cfg.ActiveNetParams = chainreg.BitcoinSigNetParams
 
+		err := validateSigNetBackendOptions(cfg.Bitcoin)
+		if err != nil {
+			return nil, mkErr("error validating bitcoin "+
+				"params: %v", err)
+		}
+
 		// Let the user overwrite the default signet parameters.
 		// The challenge defines the actual signet network to
 		// join and the seed nodes are needed for network
@@ -1413,6 +1419,20 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 		chainParams := chaincfg.CustomSignetParams(
 			sigNetChallenge, sigNetSeeds,
 		)
+		if cfg.Bitcoin.SigNetBlockTime != 0 {
+			if cfg.Bitcoin.SigNetChallenge == "" {
+				return nil, mkErr("signet block time " +
+					"requires custom signet challenge")
+			}
+
+			err := applySigNetBlockTime(
+				&chainParams, cfg.Bitcoin.SigNetBlockTime,
+			)
+			if err != nil {
+				return nil, mkErr("invalid signet block "+
+					"time: %v", err)
+			}
+		}
 		cfg.ActiveNetParams.Params = &chainParams
 	}
 	if numNets > 1 {
@@ -2574,6 +2594,69 @@ func configToFlatMap(cfg Config) (map[string]string,
 	printConfig(reflect.ValueOf(cfg), "")
 
 	return result, deprecated, nil
+}
+
+// validateSigNetBackendOptions validates custom signet options against the
+// selected chain backend.
+func validateSigNetBackendOptions(cfg *lncfg.Chain) error {
+	if cfg == nil {
+		return fmt.Errorf("bitcoin config cannot be nil")
+	}
+
+	if !cfg.SigNet {
+		return nil
+	}
+
+	switch cfg.Node {
+	case bitcoindBackendName:
+		switch {
+		case cfg.SigNetChallenge != "":
+			return fmt.Errorf("bitcoin.signetchallenge must not " +
+				"be set with bitcoin.node=bitcoind; " +
+				"configure custom signet consensus options " +
+				"on bitcoind instead")
+
+		case cfg.SigNetBlockTime != 0:
+			return fmt.Errorf("bitcoin.signetblocktime must not " +
+				"be set with bitcoin.node=bitcoind; " +
+				"configure custom signet consensus options " +
+				"on bitcoind instead")
+		}
+
+	case btcdBackendName:
+		if cfg.SigNetBlockTime != 0 {
+			return fmt.Errorf("bitcoin.signetblocktime is not " +
+				"supported with bitcoin.node=btcd; btcd does " +
+				"not currently support custom signet block " +
+				"intervals")
+		}
+	}
+
+	return nil
+}
+
+// applySigNetBlockTime updates the expected block interval used by custom
+// signet header validation. This is needed for custom signets whose backing
+// bitcoind nodes were started with -signetblocktime.
+func applySigNetBlockTime(params *chaincfg.Params,
+	blockTime time.Duration) error {
+
+	if params == nil {
+		return fmt.Errorf("params cannot be nil")
+	}
+
+	if blockTime < time.Second {
+		return fmt.Errorf("must be at least one second")
+	}
+
+	if blockTime > params.TargetTimespan {
+		return fmt.Errorf("must not exceed target timespan %v",
+			params.TargetTimespan)
+	}
+
+	params.TargetTimePerBlock = blockTime
+
+	return nil
 }
 
 // logWarningsForDeprecation logs a warning if a deprecated config option is

--- a/config_test.go
+++ b/config_test.go
@@ -3,16 +3,49 @@ package lnd
 import (
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
+	flags "github.com/jessevdk/go-flags"
+	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/chainreg"
 	"github.com/lightningnetwork/lnd/routing"
+	"github.com/lightningnetwork/lnd/signal"
 	"github.com/stretchr/testify/require"
 )
+
+// testSigNetChallengeHex is OP_TRUE encoded as Bitcoin Script hex.
+const testSigNetChallengeHex = "51"
 
 var (
 	testPassword     = "testpassword"
 	redactedPassword = "[redacted]"
 )
+
+// testSigNetChallenge is OP_TRUE encoded as Bitcoin Script bytes.
+var testSigNetChallenge = []byte{txscript.OP_TRUE}
+
+// validateTestConfig runs ValidateConfig with isolated test logging and closes
+// the log rotator that ValidateConfig starts on successful validation.
+func validateTestConfig(t *testing.T, cfg Config) (*Config, error) {
+	t.Helper()
+
+	cfg.SubLogMgr = build.NewSubLoggerManager()
+
+	fileParser := flags.NewParser(&cfg, flags.Default)
+	flagParser := flags.NewParser(&cfg, flags.Default)
+	cleanCfg, err := ValidateConfig(
+		cfg, signal.Interceptor{}, fileParser, flagParser,
+	)
+	if err != nil {
+		return cleanCfg, err
+	}
+
+	require.NoError(t, cleanCfg.LogRotator.Close())
+
+	return cleanCfg, nil
+}
 
 // TestConfigToFlatMap tests that the configToFlatMap function works as
 // expected on the default configuration.
@@ -112,6 +145,216 @@ func TestSupplyEnvValue(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			result := supplyEnvValue(test.input)
 			require.Equal(t, test.expected, result)
+		})
+	}
+}
+
+// TestApplySigNetBlockTime tests that custom signet block times update the
+// target block interval used for header difficulty validation.
+func TestApplySigNetBlockTime(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid block time", func(t *testing.T) {
+		t.Parallel()
+
+		params := chaincfg.CustomSignetParams(
+			chaincfg.DefaultSignetChallenge,
+			chaincfg.DefaultSignetDNSSeeds,
+		)
+		require.NoError(
+			t, applySigNetBlockTime(&params, 30*time.Second),
+		)
+
+		require.Equal(t, 30*time.Second, params.TargetTimePerBlock)
+		require.Equal(t, 14*24*time.Hour, params.TargetTimespan)
+		require.Equal(
+			t, int64(40320),
+			int64(params.TargetTimespan/params.TargetTimePerBlock),
+		)
+		require.False(t, params.ReduceMinDifficulty)
+	})
+
+	t.Run("nil params", func(t *testing.T) {
+		t.Parallel()
+
+		err := applySigNetBlockTime(nil, 30*time.Second)
+		require.ErrorContains(t, err, "params cannot be nil")
+	})
+
+	t.Run("sub-second block time", func(t *testing.T) {
+		t.Parallel()
+
+		params := chaincfg.CustomSignetParams(
+			chaincfg.DefaultSignetChallenge,
+			chaincfg.DefaultSignetDNSSeeds,
+		)
+		err := applySigNetBlockTime(&params, time.Millisecond)
+		require.ErrorContains(t, err, "at least one second")
+	})
+
+	t.Run("block time exceeds target timespan", func(t *testing.T) {
+		t.Parallel()
+
+		params := chaincfg.CustomSignetParams(
+			chaincfg.DefaultSignetChallenge,
+			chaincfg.DefaultSignetDNSSeeds,
+		)
+		blockTime := params.TargetTimespan + time.Second
+		err := applySigNetBlockTime(&params, blockTime)
+		require.ErrorContains(t, err, "must not exceed target timespan")
+	})
+}
+
+// TestValidateConfigSigNetBlockTime tests that custom signet block times are
+// only applied as an optional addition to a custom signet challenge.
+func TestValidateConfigSigNetBlockTime(t *testing.T) {
+	tests := []struct {
+		name        string
+		challenge   string
+		blockTime   time.Duration
+		expectError string
+		expectTime  time.Duration
+	}{
+		{
+			name:       "default signet",
+			expectTime: chaincfg.SigNetParams.TargetTimePerBlock,
+		},
+		{
+			name:       "custom challenge only",
+			challenge:  testSigNetChallengeHex,
+			expectTime: chaincfg.SigNetParams.TargetTimePerBlock,
+		},
+		{
+			name:       "custom challenge with block time",
+			challenge:  testSigNetChallengeHex,
+			blockTime:  30 * time.Second,
+			expectTime: 30 * time.Second,
+		},
+		{
+			name:        "block time without custom challenge",
+			blockTime:   30 * time.Second,
+			expectError: "requires custom signet challenge",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.LndDir = t.TempDir()
+			cfg.Bitcoin.Node = neutrinoBackendName
+			cfg.Bitcoin.SigNet = true
+			cfg.Bitcoin.SigNetChallenge = tc.challenge
+			cfg.Bitcoin.SigNetBlockTime = tc.blockTime
+
+			cleanCfg, err := validateTestConfig(t, cfg)
+
+			if tc.expectError != "" {
+				require.ErrorContains(t, err, tc.expectError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(
+				t, tc.expectTime,
+				cleanCfg.ActiveNetParams.Params.
+					TargetTimePerBlock,
+			)
+		})
+	}
+}
+
+// TestValidateConfigSigNetBackendOptions tests that custom signet options are
+// only accepted for backends that can use them.
+func TestValidateConfigSigNetBackendOptions(t *testing.T) {
+	err := validateSigNetBackendOptions(nil)
+	require.ErrorContains(t, err, "bitcoin config cannot be nil")
+
+	tests := []struct {
+		name        string
+		node        string
+		challenge   string
+		blockTime   time.Duration
+		expectError string
+		expectNet   chaincfg.Params
+	}{
+		{
+			name:      "bitcoind default signet",
+			node:      bitcoindBackendName,
+			expectNet: chaincfg.SigNetParams,
+		},
+		{
+			name:      "bitcoind custom challenge",
+			node:      bitcoindBackendName,
+			challenge: testSigNetChallengeHex,
+			expectError: "bitcoin.signetchallenge must not be " +
+				"set with bitcoin.node=bitcoind",
+		},
+		{
+			name:      "bitcoind custom challenge and block time",
+			node:      bitcoindBackendName,
+			challenge: testSigNetChallengeHex,
+			blockTime: 30 * time.Second,
+			expectError: "bitcoin.signetchallenge must not be " +
+				"set with bitcoin.node=bitcoind",
+		},
+		{
+			name:      "bitcoind custom block time",
+			node:      bitcoindBackendName,
+			blockTime: 30 * time.Second,
+			expectError: "bitcoin.signetblocktime must not be " +
+				"set with bitcoin.node=bitcoind",
+		},
+		{
+			name:      "btcd custom challenge",
+			node:      btcdBackendName,
+			challenge: testSigNetChallengeHex,
+			expectNet: chaincfg.CustomSignetParams(
+				testSigNetChallenge,
+				chaincfg.DefaultSignetDNSSeeds,
+			),
+		},
+		{
+			name:      "btcd custom block time",
+			node:      btcdBackendName,
+			challenge: testSigNetChallengeHex,
+			blockTime: 30 * time.Second,
+			expectError: "bitcoin.signetblocktime is not " +
+				"supported with bitcoin.node=btcd",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.LndDir = t.TempDir()
+			cfg.Bitcoin.Node = tc.node
+			cfg.Bitcoin.SigNet = true
+			cfg.Bitcoin.SigNetChallenge = tc.challenge
+			cfg.Bitcoin.SigNetBlockTime = tc.blockTime
+			cfg.BtcdMode.RPCUser = "user"
+			cfg.BtcdMode.RPCPass = "pass"
+			cfg.BitcoindMode.RPCUser = "user"
+			cfg.BitcoindMode.RPCPass = "pass"
+			cfg.BitcoindMode.RPCPolling = true
+
+			cleanCfg, err := validateTestConfig(t, cfg)
+
+			if tc.expectError != "" {
+				require.ErrorContains(t, err, tc.expectError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.node, cleanCfg.Bitcoin.Node)
+			require.Equal(
+				t, tc.expectNet.Net,
+				cleanCfg.ActiveNetParams.Params.Net,
+			)
+			require.Equal(
+				t, tc.expectNet.TargetTimePerBlock,
+				cleanCfg.ActiveNetParams.Params.
+					TargetTimePerBlock,
+			)
 		})
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -3,19 +3,52 @@ package lnd
 import (
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	flags "github.com/jessevdk/go-flags"
+	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/chainreg"
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/routing"
+	"github.com/lightningnetwork/lnd/signal"
 	"github.com/lightningnetwork/lnd/tor"
 	"github.com/stretchr/testify/require"
 )
+
+// testSigNetChallengeHex is OP_TRUE encoded as Bitcoin Script hex.
+const testSigNetChallengeHex = "51"
 
 var (
 	testPassword     = "testpassword"
 	redactedPassword = "[redacted]"
 )
+
+// testSigNetChallenge is OP_TRUE encoded as Bitcoin Script bytes.
+var testSigNetChallenge = []byte{txscript.OP_TRUE}
+
+// validateTestConfig runs ValidateConfig with isolated test logging and closes
+// the log rotator that ValidateConfig starts on successful validation.
+func validateTestConfig(t *testing.T, cfg Config) (*Config, error) {
+	t.Helper()
+
+	cfg.SubLogMgr = build.NewSubLoggerManager()
+
+	fileParser := flags.NewParser(&cfg, flags.Default)
+	flagParser := flags.NewParser(&cfg, flags.Default)
+	cleanCfg, err := ValidateConfig(
+		cfg, signal.Interceptor{}, fileParser, flagParser,
+	)
+	if err != nil {
+		return cleanCfg, err
+	}
+
+	require.NoError(t, cleanCfg.LogRotator.Close())
+
+	return cleanCfg, nil
+}
 
 // TestConfigToFlatMap tests that the configToFlatMap function works as
 // expected on the default configuration.
@@ -164,6 +197,216 @@ func TestNormalizeRemoteSignerListenAddrs(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, addrs, 1)
 			require.Equal(t, test.expected, addrs[0].String())
+		})
+	}
+}
+
+// TestApplySigNetBlockTime tests that custom signet block times update the
+// target block interval used for header difficulty validation.
+func TestApplySigNetBlockTime(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid block time", func(t *testing.T) {
+		t.Parallel()
+
+		params := chaincfg.CustomSignetParams(
+			chaincfg.DefaultSignetChallenge,
+			chaincfg.DefaultSignetDNSSeeds,
+		)
+		require.NoError(
+			t, applySigNetBlockTime(&params, 30*time.Second),
+		)
+
+		require.Equal(t, 30*time.Second, params.TargetTimePerBlock)
+		require.Equal(t, 14*24*time.Hour, params.TargetTimespan)
+		require.Equal(
+			t, int64(40320),
+			int64(params.TargetTimespan/params.TargetTimePerBlock),
+		)
+		require.False(t, params.ReduceMinDifficulty)
+	})
+
+	t.Run("nil params", func(t *testing.T) {
+		t.Parallel()
+
+		err := applySigNetBlockTime(nil, 30*time.Second)
+		require.ErrorContains(t, err, "params cannot be nil")
+	})
+
+	t.Run("sub-second block time", func(t *testing.T) {
+		t.Parallel()
+
+		params := chaincfg.CustomSignetParams(
+			chaincfg.DefaultSignetChallenge,
+			chaincfg.DefaultSignetDNSSeeds,
+		)
+		err := applySigNetBlockTime(&params, time.Millisecond)
+		require.ErrorContains(t, err, "at least one second")
+	})
+
+	t.Run("block time exceeds target timespan", func(t *testing.T) {
+		t.Parallel()
+
+		params := chaincfg.CustomSignetParams(
+			chaincfg.DefaultSignetChallenge,
+			chaincfg.DefaultSignetDNSSeeds,
+		)
+		blockTime := params.TargetTimespan + time.Second
+		err := applySigNetBlockTime(&params, blockTime)
+		require.ErrorContains(t, err, "must not exceed target timespan")
+	})
+}
+
+// TestValidateConfigSigNetBlockTime tests that custom signet block times are
+// only applied as an optional addition to a custom signet challenge.
+func TestValidateConfigSigNetBlockTime(t *testing.T) {
+	tests := []struct {
+		name        string
+		challenge   string
+		blockTime   time.Duration
+		expectError string
+		expectTime  time.Duration
+	}{
+		{
+			name:       "default signet",
+			expectTime: chaincfg.SigNetParams.TargetTimePerBlock,
+		},
+		{
+			name:       "custom challenge only",
+			challenge:  testSigNetChallengeHex,
+			expectTime: chaincfg.SigNetParams.TargetTimePerBlock,
+		},
+		{
+			name:       "custom challenge with block time",
+			challenge:  testSigNetChallengeHex,
+			blockTime:  30 * time.Second,
+			expectTime: 30 * time.Second,
+		},
+		{
+			name:        "block time without custom challenge",
+			blockTime:   30 * time.Second,
+			expectError: "requires custom signet challenge",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.LndDir = t.TempDir()
+			cfg.Bitcoin.Node = neutrinoBackendName
+			cfg.Bitcoin.SigNet = true
+			cfg.Bitcoin.SigNetChallenge = tc.challenge
+			cfg.Bitcoin.SigNetBlockTime = tc.blockTime
+
+			cleanCfg, err := validateTestConfig(t, cfg)
+
+			if tc.expectError != "" {
+				require.ErrorContains(t, err, tc.expectError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(
+				t, tc.expectTime,
+				cleanCfg.ActiveNetParams.Params.
+					TargetTimePerBlock,
+			)
+		})
+	}
+}
+
+// TestValidateConfigSigNetBackendOptions tests that custom signet options are
+// only accepted for backends that can use them.
+func TestValidateConfigSigNetBackendOptions(t *testing.T) {
+	err := validateSigNetBackendOptions(nil)
+	require.ErrorContains(t, err, "bitcoin config cannot be nil")
+
+	tests := []struct {
+		name        string
+		node        string
+		challenge   string
+		blockTime   time.Duration
+		expectError string
+		expectNet   chaincfg.Params
+	}{
+		{
+			name:      "bitcoind default signet",
+			node:      bitcoindBackendName,
+			expectNet: chaincfg.SigNetParams,
+		},
+		{
+			name:      "bitcoind custom challenge",
+			node:      bitcoindBackendName,
+			challenge: testSigNetChallengeHex,
+			expectError: "bitcoin.signetchallenge must not be " +
+				"set with bitcoin.node=bitcoind",
+		},
+		{
+			name:      "bitcoind custom challenge and block time",
+			node:      bitcoindBackendName,
+			challenge: testSigNetChallengeHex,
+			blockTime: 30 * time.Second,
+			expectError: "bitcoin.signetchallenge must not be " +
+				"set with bitcoin.node=bitcoind",
+		},
+		{
+			name:      "bitcoind custom block time",
+			node:      bitcoindBackendName,
+			blockTime: 30 * time.Second,
+			expectError: "bitcoin.signetblocktime must not be " +
+				"set with bitcoin.node=bitcoind",
+		},
+		{
+			name:      "btcd custom challenge",
+			node:      btcdBackendName,
+			challenge: testSigNetChallengeHex,
+			expectNet: chaincfg.CustomSignetParams(
+				testSigNetChallenge,
+				chaincfg.DefaultSignetDNSSeeds,
+			),
+		},
+		{
+			name:      "btcd custom block time",
+			node:      btcdBackendName,
+			challenge: testSigNetChallengeHex,
+			blockTime: 30 * time.Second,
+			expectError: "bitcoin.signetblocktime is not " +
+				"supported with bitcoin.node=btcd",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.LndDir = t.TempDir()
+			cfg.Bitcoin.Node = tc.node
+			cfg.Bitcoin.SigNet = true
+			cfg.Bitcoin.SigNetChallenge = tc.challenge
+			cfg.Bitcoin.SigNetBlockTime = tc.blockTime
+			cfg.BtcdMode.RPCUser = "user"
+			cfg.BtcdMode.RPCPass = "pass"
+			cfg.BitcoindMode.RPCUser = "user"
+			cfg.BitcoindMode.RPCPass = "pass"
+			cfg.BitcoindMode.RPCPolling = true
+
+			cleanCfg, err := validateTestConfig(t, cfg)
+
+			if tc.expectError != "" {
+				require.ErrorContains(t, err, tc.expectError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.node, cleanCfg.Bitcoin.Node)
+			require.Equal(
+				t, tc.expectNet.Net,
+				cleanCfg.ActiveNetParams.Params.Net,
+			)
+			require.Equal(
+				t, tc.expectNet.TargetTimePerBlock,
+				cleanCfg.ActiveNetParams.Params.
+					TargetTimePerBlock,
+			)
 		})
 	}
 }

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -38,6 +38,12 @@
 
 ## Functional Enhancements
 
+* A new [`bitcoin.signetblocktime`
+  config option](https://github.com/lightningnetwork/lnd/pull/10864) allows
+  neutrino-backed custom signet nodes to override the expected block interval
+  used for header validation, matching Bitcoin Core's `-signetblocktime`
+  setting.
+
 ## RPC Additions
 
 * The `routerrpc.EstimateRouteFee` RPC now supports [restricting fee estimates
@@ -89,3 +95,4 @@
 
 * Boris Nagaev
 * Erick Cestari
+* Tee8z

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -51,6 +51,12 @@
 
 ## Functional Enhancements
 
+* A new [`bitcoin.signetblocktime`
+  config option](https://github.com/lightningnetwork/lnd/pull/10864) allows
+  neutrino-backed custom signet nodes to override the expected block interval
+  used for header validation, matching Bitcoin Core's `-signetblocktime`
+  setting.
+
 ## RPC Additions
 
 * The `routerrpc.EstimateRouteFee` RPC now supports [restricting fee estimates
@@ -178,3 +184,4 @@
 * Erick Cestari
 * Jared Tobin
 * Nishant Bansal
+* Tee8z

--- a/lncfg/chain.go
+++ b/lncfg/chain.go
@@ -2,6 +2,7 @@ package lncfg
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/lightningnetwork/lnd/lnwire"
 )
@@ -15,14 +16,15 @@ type Chain struct {
 
 	Node string `long:"node" description:"The blockchain interface to use." choice:"btcd" choice:"bitcoind" choice:"neutrino" choice:"nochainbackend"`
 
-	MainNet         bool     `long:"mainnet" description:"Use the main network"`
-	TestNet3        bool     `long:"testnet" description:"Use the test network"`
-	TestNet4        bool     `long:"testnet4" description:"Use the testnet4 test network"`
-	SimNet          bool     `long:"simnet" description:"Use the simulation test network"`
-	RegTest         bool     `long:"regtest" description:"Use the regression test network"`
-	SigNet          bool     `long:"signet" description:"Use the signet test network"`
-	SigNetChallenge string   `long:"signetchallenge" description:"Connect to a custom signet network defined by this challenge instead of using the global default signet test network -- Can be specified multiple times"`
-	SigNetSeedNode  []string `long:"signetseednode" description:"Specify a seed node for the signet network instead of using the global default signet network seed nodes"`
+	MainNet         bool          `long:"mainnet" description:"Use the main network"`
+	TestNet3        bool          `long:"testnet" description:"Use the test network"`
+	TestNet4        bool          `long:"testnet4" description:"Use the testnet4 test network"`
+	SimNet          bool          `long:"simnet" description:"Use the simulation test network"`
+	RegTest         bool          `long:"regtest" description:"Use the regression test network"`
+	SigNet          bool          `long:"signet" description:"Use the signet test network"`
+	SigNetChallenge string        `long:"signetchallenge" description:"Connect to a custom signet network defined by this challenge instead of using the global default signet test network -- Can be specified multiple times. Do not set this with the bitcoind backend -- configure the custom signet on bitcoind instead."`
+	SigNetBlockTime time.Duration `long:"signetblocktime" description:"Override the expected block interval for a custom signet network. This must match the signet node's signetblocktime setting and is only supported with the neutrino backend."`
+	SigNetSeedNode  []string      `long:"signetseednode" description:"Specify a seed node for the signet network instead of using the global default signet network seed nodes"`
 
 	DefaultNumChanConfs int                 `long:"defaultchanconfs" description:"The default number of confirmations a channel must have before it's considered open. If this is not set, we will scale the value according to the channel size."`
 	DefaultRemoteDelay  int                 `long:"defaultremotedelay" description:"The default number of blocks we will require our channel counterparty to wait before accessing its funds in case of unilateral close. If this is not set, we will scale the value according to the channel size."`

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -668,8 +668,18 @@
 ; bitcoin.signet=false
 
 ; Connect to a custom signet network defined by this challenge instead of using
-; the global default signet test network -- Can be specified multiple times
+; the global default signet test network -- Can be specified multiple times.
+;
+; NOTE: Do not set this when bitcoin.node=bitcoind. For bitcoind-backed custom
+; signets, configure signetchallenge on bitcoind instead.
 ; bitcoin.signetchallenge=
+
+; Override the expected block interval for a custom signet network. This must
+; match the signet node's signetblocktime setting and is only supported with
+; bitcoin.node=neutrino. Do not set this when bitcoin.node=bitcoind; configure
+; signetblocktime on bitcoind instead. This is not currently supported with
+; bitcoin.node=btcd.
+; bitcoin.signetblocktime=
 
 ; Specify a seed node for the signet network instead of using the global default
 ; signet network seed nodes


### PR DESCRIPTION
## Change Description

Adds support for configuring the expected block interval for custom signet
networks via `bitcoin.signetblocktime`.

This allows `lnd` to validate headers correctly when connected to a custom
signet whose backing `bitcoind` nodes were started with `-signetblocktime`.
The configured value is applied to the custom signet chain params and is
validated to be at least one second and no greater than the target timespan.

This simplifies running `lnd` nodes on custom signet networks such as
Mutinynet.

## Steps to Test

1. Run the new unit test:

   ```bash
   go test . -run TestApplySigNetBlockTime -count=1
   ```

2. Optionally test manually with a Mutinynet Bitcoin Core backend configured
   with 30-second custom signet blocks and compact filter support:

   ```ini
   chain=signet
   signetblocktime=30
   signetchallenge=512102f7561d208dd9ae99bf497273e16f389bdbd6c4742ddb8e6b216e64fa2928ad8f51ae

   blockfilterindex=1
   peerblockfilters=1
   server=1
   txindex=1
   ```

3. Start `lnd` with matching Mutinynet signet settings and neutrino pointed at
   that Bitcoin Core node:

   ```ini
   [Bitcoin]
   bitcoin.node=neutrino
   bitcoin.signet=true
   bitcoin.defaultchanconfs=1
   bitcoin.signetchallenge=512102f7561d208dd9ae99bf497273e16f389bdbd6c4742ddb8e6b216e64fa2928ad8f51ae
   bitcoin.signetblocktime=30s

   [neutrino]
   neutrino.connect=127.0.0.1:29333
   neutrino.maxpeers=1
   neutrino.persistfilters=true
   ```

   If testing through a local port-forward, forward the Bitcoin Core P2P port
   to `127.0.0.1:29333`. If public P2P is reachable, set
   `neutrino.connect` directly to that host instead.

4. Verify that `lnd` starts and syncs headers for that custom signet.

5. Verify invalid values fail config validation:

   ```bash
   lnd --bitcoin.signet --bitcoin.signetblocktime=500ms
   ```

   This should fail with an `invalid signet block time` error.

## Pull Request Checklist

### Testing

- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions. N/A,
      this is a new feature.

### Code Style and Documentation

- [x] The change is not
      [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only).
      Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the
      [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting)
      guidelines, and lines wrap at 80.
- [x] Commits follow the
      [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging
      level. N/A, no logging statements added.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc
      in the proto file. N/A, no lncli commands added.
- [x] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes),
      or `[skip ci]` in the commit message for small changes.

