### PR TITLE
contractcourt: fix HTLC success resolver phantom-input bug (#10840)

### DIFF
--- a/contractcourt/htlc_outgoing_contest_resolver_test.go
+++ b/contractcourt/htlc_outgoing_contest_resolver_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnmock"
 	"github.com/lightningnetwork/lnd/lntest/mock"
-	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/stretchr/testify/require"
@@ -76,7 +75,10 @@ func TestHtlcOutgoingResolverRemoteClaim(t *testing.T) {
 	ctx.resolve()
 
 	// The remote party sweeps the htlc. Notify our resolver of this event.
-	preimage := lntypes.Preimage{}
+	// The revealed preimage has to open this HTLC's payment hash, as that's
+	// the only thing that makes the spend a claim rather than some other
+	// spend of the output.
+	preimage := testResPreimage
 	spendTx := &wire.MsgTx{
 		TxIn: []*wire.TxIn{
 			{

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -277,6 +277,73 @@ func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash) error {
 	return h.Checkpoint(h, reports...)
 }
 
+// checkpointForeignSpend checkpoints an HTLC spend as failed when it occurred
+// outside the expected success path. Persisting the cleared
+// outputIncubating state prevents a restored resolver from offering a phantom
+// second-level output to the sweeper.
+func (h *htlcSuccessResolver) checkpointForeignSpend(
+	spendTxID chainhash.Hash) error {
+
+	h.log.Warnf("HTLC outpoint %v was spent by tx %v outside the "+
+		"expected success path", h.outpoint(), spendTxID)
+
+	err := h.ChainArbitratorConfig.PutFinalHtlcOutcome(
+		h.ChannelArbitratorConfig.ShortChanID, h.htlc.HtlcIndex, false,
+	)
+	if err != nil {
+		return err
+	}
+
+	// The final outcome is a separate durable write. If the resolver
+	// checkpoint below fails, only the live resolver state can be restored;
+	// retrying records the same failed outcome again.
+	report := &channeldb.ResolverReport{
+		OutPoint:        h.outpoint(),
+		Amount:          h.htlc.Amt.ToSatoshis(),
+		ResolverType:    channeldb.ResolverTypeIncomingHtlc,
+		ResolverOutcome: channeldb.ResolverOutcomeTimeout,
+		SpendTxID:       &spendTxID,
+	}
+
+	h.reportLock.Lock()
+	previousReport := h.currentReport
+	h.currentReport.RecoveredBalance = 0
+	h.currentReport.LimboBalance = 0
+	h.reportLock.Unlock()
+
+	// A foreign spend leaves no second-level success output to sweep.
+	previousIncubating := h.outputIncubating
+	h.outputIncubating = false
+
+	// Persist the terminal outcome while unresolved. If resolver removal
+	// does not complete during this run, a restart reloads the resolver and
+	// retries the terminal transition instead of skipping it as already
+	// resolved.
+	if err := h.Checkpoint(h, report); err != nil {
+		h.outputIncubating = previousIncubating
+
+		h.reportLock.Lock()
+		h.currentReport = previousReport
+		h.reportLock.Unlock()
+
+		return err
+	}
+
+	h.markResolved()
+	h.ChainArbitratorConfig.HtlcNotifier.NotifyFinalHtlcEvent(
+		models.CircuitKey{
+			ChanID: h.ShortChanID,
+			HtlcID: h.htlc.HtlcIndex,
+		},
+		channeldb.FinalHtlcInfo{
+			Settled:  false,
+			Offchain: false,
+		},
+	)
+
+	return nil
+}
+
 // Stop signals the resolver to cancel any current resolution processes, and
 // suspend.
 //

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -801,7 +801,8 @@ func (h *htlcSuccessResolver) sweepSuccessTx() error {
 }
 
 // sweepSuccessTxOutput attempts to sweep the output of the second level
-// success tx.
+// success tx. If the second-level success output cannot be found, Resolve will
+// checkpoint the foreign spend through the normal resolver-removal path.
 func (h *htlcSuccessResolver) sweepSuccessTxOutput() error {
 	h.log.Debugf("sweeping output %v from 2nd-level HTLC success tx",
 		h.htlcResolution.ClaimOutpoint)
@@ -816,6 +817,28 @@ func (h *htlcSuccessResolver) sweepSuccessTxOutput() error {
 	)
 	if err != nil {
 		return err
+	}
+	_, err = h.validatedSpendInput(commitSpend)
+	if err != nil {
+		return err
+	}
+	secondLevelOutpoint, matches, err := h.matchSecondLevelOutput(
+		commitSpend.SpendingTx, commitSpend.SpenderInputIndex,
+	)
+	if err != nil {
+		return err
+	}
+	if !matches {
+		// A resolver restored from a checkpoint written before
+		// commitment spend validation may have outputIncubating set
+		// without an expected second-level output.
+		//
+		// launchResolvers completes before the resolveContract
+		// goroutines start. If Launch marks the resolver resolved,
+		// resolveContract skips it and cannot remove it from the log.
+		// Return without a phantom sweep so Resolve can receive the
+		// historical spend and own checkpointing and cleanup.
+		return nil
 	}
 
 	// The HTLC success tx has a CSV lock that we must wait for, and if
@@ -840,16 +863,6 @@ func (h *htlcSuccessResolver) sweepSuccessTxOutput() error {
 			h, h.htlc.RHash[:], waitHeight)
 	}
 
-	// We'll use this input index to determine the second-level output
-	// index on the transaction, as the signatures requires the indexes to
-	// be the same. We don't look for the second-level output script
-	// directly, as there might be more than one HTLC output to the same
-	// pkScript.
-	op := &wire.OutPoint{
-		Hash:  *commitSpend.SpenderTxHash,
-		Index: commitSpend.SpenderInputIndex,
-	}
-
 	// Let the sweeper sweep the second-level output now that the
 	// CSV/CLTV locks have expired.
 	var witType input.StandardWitnessType
@@ -862,7 +875,7 @@ func (h *htlcSuccessResolver) sweepSuccessTxOutput() error {
 		witType = input.HtlcAcceptedSuccessSecondLevel
 	}
 	inp := h.makeSweepInput(
-		op, witType,
+		&secondLevelOutpoint, witType,
 		input.LeaseHtlcAcceptedSuccessSecondLevel,
 		&h.htlcResolution.SweepSignDesc,
 		h.htlcResolution.CsvDelay, uint32(commitSpend.SpendingHeight),
@@ -1048,8 +1061,8 @@ func (h *htlcSuccessResolver) Launch() error {
 	// second-level success tx or the output from the second-level success
 	// tx.
 	case h.isZeroFeeOutput():
-		// If the second-level success tx has already been swept, we
-		// can go ahead and sweep its output.
+		// If the second-level success tx has confirmed, offer the
+		// output to the sweeper.
 		if h.outputIncubating {
 			return h.sweepSuccessTxOutput()
 		}

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lightningnetwork/lnd/graph/db/models"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/labels"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnutils"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/sweep"
@@ -174,12 +175,64 @@ func (h *htlcSuccessResolver) resolveRemoteCommitOutput() error {
 	if err != nil {
 		return err
 	}
+	spendingInput, err := h.validatedSpendInput(sweepTxDetails)
+	if err != nil {
+		return err
+	}
+
+	signDesc := &h.htlcResolution.SweepSignDesc
+	if len(signDesc.WitnessScript) == 0 {
+		return fmt.Errorf("%w: missing success witness script",
+			errInvalidSuccessResolver)
+	}
+	if h.isTaproot() {
+		_, err := txscript.ParseControlBlock(signDesc.ControlBlock)
+		if err != nil {
+			return fmt.Errorf(
+				"%w: invalid success control block: %w",
+				errInvalidSuccessResolver, err,
+			)
+		}
+	}
+
+	spendTxID := sweepTxDetails.SpendingTx.TxHash()
+	witness := spendingInput.Witness
+	if !h.isPreimageSpend(witness) {
+		return h.checkpointForeignSpend(spendTxID)
+	}
+
+	var preimage lntypes.Preimage
+	copy(preimage[:], witness[localPreimageIndex])
+	if !preimage.Matches(h.htlc.RHash) {
+		return fmt.Errorf("%w: spend preimage does not match HTLC hash",
+			errInvalidSuccessResolver)
+	}
 
 	// TODO(yy): should also update the `RecoveredBalance` and
 	// `LimboBalance` like other paths?
 
 	// Checkpoint the resolver, and write the outcome to disk.
 	return h.checkpointClaim(sweepTxDetails.SpenderTxHash)
+}
+
+// isPreimageSpend returns true when the witness reveals the expected HTLC
+// success leaf and includes a correctly sized preimage.
+func (h *htlcSuccessResolver) isPreimageSpend(witness wire.TxWitness) bool {
+	if h.isTaproot() {
+		return h.isTaprootPreimageSpend(witness)
+	}
+
+	if !checkSizeAndIndex(
+		witness, expectedLocalWitnessSuccessSize, localPreimageIndex,
+	) {
+
+		return false
+	}
+
+	return bytes.Equal(
+		witness[len(witness)-1],
+		h.htlcResolution.SweepSignDesc.WitnessScript,
+	)
 }
 
 // isTaprootPreimageSpend returns true when the witness reveals the expected

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -212,7 +212,10 @@ func (h *htlcSuccessResolver) resolveRemoteCommitOutput() error {
 	// `LimboBalance` like other paths?
 
 	// Checkpoint the resolver, and write the outcome to disk.
-	return h.checkpointClaim(sweepTxDetails.SpenderTxHash)
+	return h.checkpointClaim(
+		h.htlcResolution.ClaimOutpoint,
+		&spendTxID,
+	)
 }
 
 // isPreimageSpend returns true when the witness reveals the expected HTLC
@@ -270,10 +273,12 @@ func (h *htlcSuccessResolver) isTaprootPreimageSpend(
 	)
 }
 
-// checkpointClaim checkpoints the success resolver with the reports it needs.
-// If this htlc was claimed two stages, it will write reports for both stages,
-// otherwise it will just write for the single htlc claim.
-func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash) error {
+// checkpointClaim checkpoints a successful HTLC claim. claimOutpoint is the
+// output recovered in the final stage, and spendTxID identifies the transaction
+// that spent it. A two-stage claim writes reports for both stages.
+func (h *htlcSuccessResolver) checkpointClaim(claimOutpoint wire.OutPoint,
+	spendTxID *chainhash.Hash) error {
+
 	// Mark the htlc as final settled.
 	err := h.ChainArbitratorConfig.PutFinalHtlcOutcome(
 		h.ChannelArbitratorConfig.ShortChanID, h.htlc.HtlcIndex, true,
@@ -298,11 +303,11 @@ func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash) error {
 	amt := btcutil.Amount(h.htlcResolution.SweepSignDesc.Output.Value)
 	reports := []*channeldb.ResolverReport{
 		{
-			OutPoint:        h.htlcResolution.ClaimOutpoint,
+			OutPoint:        claimOutpoint,
 			Amount:          amt,
 			ResolverType:    channeldb.ResolverTypeIncomingHtlc,
 			ResolverOutcome: channeldb.ResolverOutcomeClaimed,
-			SpendTxID:       spendTx,
+			SpendTxID:       spendTxID,
 		},
 	}
 
@@ -312,11 +317,10 @@ func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash) error {
 		// If the SignedSuccessTx is not nil, we are claiming the htlc
 		// in two stages, so we need to create a report for the first
 		// stage transaction as well.
-		spendTx := h.htlcResolution.SignedSuccessTx
-		spendTxID := spendTx.TxHash()
+		spendTxID := claimOutpoint.Hash
 
 		report := &channeldb.ResolverReport{
-			OutPoint:        spendTx.TxIn[0].PreviousOutPoint,
+			OutPoint:        h.outpoint(),
 			Amount:          h.htlc.Amt.ToSatoshis(),
 			ResolverType:    channeldb.ResolverTypeIncomingHtlc,
 			ResolverOutcome: channeldb.ResolverOutcomeFirstStage,
@@ -1015,7 +1019,7 @@ func (h *htlcSuccessResolver) resolveSuccessTxOutput(op wire.OutPoint) error {
 	h.currentReport.LimboBalance = 0
 	h.reportLock.Unlock()
 
-	return h.checkpointClaim(spend.SpenderTxHash)
+	return h.checkpointClaim(op, spend.SpenderTxHash)
 }
 
 // Launch creates an input based on the details of the incoming htlc resolution

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -2,6 +2,7 @@ package contractcourt
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -10,6 +11,7 @@ import (
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/chanstate"
 	"github.com/lightningnetwork/lnd/fn/v2"
@@ -20,6 +22,9 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/sweep"
 )
+
+// errInvalidSpendDetails identifies malformed notifier spend data.
+var errInvalidSpendDetails = errors.New("invalid spend details")
 
 // htlcSuccessResolver is a resolver that's capable of sweeping an incoming
 // HTLC output on-chain. If this is the remote party's commitment, we'll sweep
@@ -430,6 +435,40 @@ func (h *htlcSuccessResolver) isTaproot() bool {
 // channel.
 func (h *htlcSuccessResolver) isTaprootFinal() bool {
 	return h.chanType.IsTaprootFinal()
+}
+
+// validatedSpendInput returns the transaction input reported to spend this
+// resolver's HTLC outpoint after validating the notifier data.
+func (h *htlcSuccessResolver) validatedSpendInput(
+	spend *chainntnfs.SpendDetail) (*wire.TxIn, error) {
+
+	switch {
+	case spend == nil:
+		return nil, fmt.Errorf("%w: missing spend detail for %v",
+			errInvalidSpendDetails, h.outpoint())
+
+	case spend.SpendingTx == nil:
+		return nil, fmt.Errorf("%w: missing spending tx for %v",
+			errInvalidSpendDetails, h.outpoint())
+
+	case spend.SpenderInputIndex >= uint32(len(spend.SpendingTx.TxIn)):
+		return nil, fmt.Errorf("%w: spender input index %d out of "+
+			"range", errInvalidSpendDetails,
+			spend.SpenderInputIndex)
+	}
+
+	spendingInput := spend.SpendingTx.TxIn[spend.SpenderInputIndex]
+	if spendingInput == nil {
+		return nil, fmt.Errorf("%w: spender input %d is nil",
+			errInvalidSpendDetails, spend.SpenderInputIndex)
+	}
+	if spendingInput.PreviousOutPoint != h.outpoint() {
+		return nil, fmt.Errorf("%w: input %v, expected %v",
+			errInvalidSpendDetails, spendingInput.PreviousOutPoint,
+			h.outpoint())
+	}
+
+	return spendingInput, nil
 }
 
 // sweepRemoteCommitOutput creates a sweep request to sweep the HTLC output on

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -1,6 +1,7 @@
 package contractcourt
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -176,6 +177,41 @@ func (h *htlcSuccessResolver) resolveRemoteCommitOutput() error {
 
 	// Checkpoint the resolver, and write the outcome to disk.
 	return h.checkpointClaim(sweepTxDetails.SpenderTxHash)
+}
+
+// isTaprootPreimageSpend returns true when the witness reveals the expected
+// Taproot HTLC success leaf and includes a correctly sized preimage.
+func (h *htlcSuccessResolver) isTaprootPreimageSpend(
+	witness wire.TxWitness) bool {
+
+	// A BIP341 annex is an optional trailing witness element and is not
+	// part of the tapscript execution stack.
+	witness = input.StripTaprootAnnex(witness)
+	if !checkSizeAndIndex(
+		witness, localTaprootWitnessSuccessSize, localPreimageIndex,
+	) {
+
+		return false
+	}
+
+	tapScript := witness[len(witness)-2]
+	controlBlockBytes := witness[len(witness)-1]
+	controlBlock, err := txscript.ParseControlBlock(
+		controlBlockBytes,
+	)
+	expected, expectedErr := txscript.ParseControlBlock(
+		h.htlcResolution.SweepSignDesc.ControlBlock,
+	)
+	if err != nil || expectedErr != nil ||
+		controlBlock.LeafVersion != expected.LeafVersion {
+
+		return false
+	}
+
+	return bytes.Equal(
+		tapScript,
+		h.htlcResolution.SweepSignDesc.WitnessScript,
+	)
 }
 
 // checkpointClaim checkpoints the success resolver with the reports it needs.

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -957,8 +957,9 @@ func (h *htlcSuccessResolver) resolveLegacySuccessTx() error {
 	return h.resolveSuccessTxOutput(h.htlcResolution.ClaimOutpoint)
 }
 
-// resolveSuccessTx waits for the sweeping tx of the second-level success tx to
-// confirm and offers the output from the success tx to the sweeper.
+// resolveSuccessTx waits for the commitment HTLC spend. If it creates the
+// expected second-level success output, the resolver sweeps that output;
+// otherwise it checkpoints a foreign spend.
 func (h *htlcSuccessResolver) resolveSuccessTx() error {
 	h.log.Infof("waiting for 2nd-level HTLC success transaction to confirm")
 
@@ -973,22 +974,27 @@ func (h *htlcSuccessResolver) resolveSuccessTx() error {
 	if err != nil {
 		return err
 	}
+	_, err = h.validatedSpendInput(commitSpend)
+	if err != nil {
+		return err
+	}
+	secondLevelOutpoint, matches, err := h.matchSecondLevelOutput(
+		commitSpend.SpendingTx, commitSpend.SpenderInputIndex,
+	)
+	if err != nil {
+		return err
+	}
 
-	// We'll use this input index to determine the second-level output
-	// index on the transaction, as the signatures requires the indexes to
-	// be the same. We don't look for the second-level output script
-	// directly, as there might be more than one HTLC output to the same
-	// pkScript.
-	op := wire.OutPoint{
-		Hash:  *commitSpend.SpenderTxHash,
-		Index: commitSpend.SpenderInputIndex,
+	spendTxID := commitSpend.SpendingTx.TxHash()
+	if !matches {
+		return h.checkpointForeignSpend(spendTxID)
 	}
 
 	// If the 2nd-stage sweeping has already been started, we can
 	// fast-forward to start the resolving process for the stage two
 	// output.
 	if h.outputIncubating {
-		return h.resolveSuccessTxOutput(op)
+		return h.resolveSuccessTxOutput(secondLevelOutpoint)
 	}
 
 	// Now that the second-level transaction has confirmed, we checkpoint
@@ -999,15 +1005,14 @@ func (h *htlcSuccessResolver) resolveSuccessTx() error {
 		return err
 	}
 
-	h.log.Infof("2nd-level HTLC success tx=%v confirmed",
-		commitSpend.SpenderTxHash)
+	h.log.Infof("2nd-level HTLC success tx=%v confirmed", spendTxID)
 
 	// Send the sweep request for the output from the success tx.
 	if err := h.sweepSuccessTxOutput(); err != nil {
 		return err
 	}
 
-	return h.resolveSuccessTxOutput(op)
+	return h.resolveSuccessTxOutput(secondLevelOutpoint)
 }
 
 // resolveSuccessTxOutput waits for the spend of the output from the 2nd-level

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -27,6 +27,9 @@ import (
 // errInvalidSpendDetails identifies malformed notifier spend data.
 var errInvalidSpendDetails = errors.New("invalid spend details")
 
+// errInvalidSuccessResolver identifies malformed success resolver state.
+var errInvalidSuccessResolver = errors.New("invalid success resolver")
+
 // htlcSuccessResolver is a resolver that's capable of sweeping an incoming
 // HTLC output on-chain. If this is the remote party's commitment, we'll sweep
 // it directly from the commitment output *immediately*. If this is our
@@ -505,6 +508,60 @@ func (h *htlcSuccessResolver) validatedSpendInput(
 	}
 
 	return spendingInput, nil
+}
+
+// matchSecondLevelOutput checks whether the transaction spending the
+// commitment HTLC created the output expected by our sweep descriptor.
+//
+// The HTLC input uses SINGLE|ANYONECANPAY, so it commits to the transaction
+// output at the same index. A match returns that output's actual outpoint.
+func (h *htlcSuccessResolver) matchSecondLevelOutput(
+	spendingTx *wire.MsgTx,
+	outputIndex uint32) (wire.OutPoint, bool, error) {
+
+	var zeroOutpoint wire.OutPoint
+	if spendingTx == nil {
+		return zeroOutpoint, false, fmt.Errorf(
+			"%w: missing spending tx", errInvalidSpendDetails,
+		)
+	}
+
+	expected := h.htlcResolution.SweepSignDesc.Output
+	if expected == nil {
+		return zeroOutpoint, false, fmt.Errorf(
+			"%w: missing expected output for %v",
+			errInvalidSuccessResolver, h.outpoint(),
+		)
+	}
+
+	// The success output should be at the same index as the HTLC input
+	// being spent. If that output is missing, this cannot be our success
+	// tx.
+	if outputIndex >= uint32(len(spendingTx.TxOut)) {
+		return zeroOutpoint, false, nil
+	}
+
+	actual := spendingTx.TxOut[outputIndex]
+	if actual == nil {
+		return zeroOutpoint, false, fmt.Errorf(
+			"%w: output %d is nil", errInvalidSpendDetails,
+			outputIndex,
+		)
+	}
+
+	// The spender consumed the HTLC, but only an exact value/script match
+	// gives us a second-level success output that our sweep descriptor can
+	// spend.
+	if actual.Value != expected.Value ||
+		!bytes.Equal(actual.PkScript, expected.PkScript) {
+
+		return zeroOutpoint, false, nil
+	}
+
+	return wire.OutPoint{
+		Hash:  spendingTx.TxHash(),
+		Index: outputIndex,
+	}, true, nil
 }
 
 // sweepRemoteCommitOutput creates a sweep request to sweep the HTLC output on

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -325,6 +325,33 @@ func cloneTxOut(txOut *wire.TxOut) *wire.TxOut {
 	}
 }
 
+// newSuccessTestResolution creates a success resolution with distinct
+// commitment and second-level output descriptors.
+func newSuccessTestResolution(
+	commitOutpoint wire.OutPoint) lnwallet.IncomingHtlcResolution {
+
+	secondLevelOutput := cloneTxOut(testSignDesc.Output)
+	secondLevelOutput.PkScript = []byte{txscript.OP_TRUE}
+	sweepSignDesc := testSignDesc
+	sweepSignDesc.Output = secondLevelOutput
+
+	successTx := &wire.MsgTx{
+		TxIn:  []*wire.TxIn{{PreviousOutPoint: commitOutpoint}},
+		TxOut: []*wire.TxOut{cloneTxOut(secondLevelOutput)},
+	}
+
+	return lnwallet.IncomingHtlcResolution{
+		Preimage:        testResPreimage,
+		SignedSuccessTx: successTx,
+		SignDetails: &input.SignDetails{
+			SignDesc: testSignDesc,
+			PeerSig:  testSig,
+		},
+		ClaimOutpoint: wire.OutPoint{Hash: successTx.TxHash()},
+		SweepSignDesc: sweepSignDesc,
+	}
+}
+
 // newTaprootSuccessSpendFixture creates success and auxiliary leaves with the
 // same script and different leaf versions.
 func newTaprootSuccessSpendFixture(
@@ -396,6 +423,128 @@ func TestHtlcSuccessTaprootClassification(t *testing.T) {
 		dummyBytes, testResPreimage[:], fixture.successScript,
 		fixture.auxControl,
 	}))
+}
+
+// TestHtlcSuccessMatchSecondLevelOutput tests matching the success transaction
+// output against the sweep descriptor.
+func TestHtlcSuccessMatchSecondLevelOutput(t *testing.T) {
+	claim := wire.OutPoint{Index: 2}
+	newMatch := func() (*htlcSuccessResolver, *wire.MsgTx) {
+		resolution := newSuccessTestResolution(claim)
+		tx := &wire.MsgTx{
+			TxIn: []*wire.TxIn{
+				{PreviousOutPoint: wire.OutPoint{Index: 1}},
+				{PreviousOutPoint: claim},
+			},
+			TxOut: []*wire.TxOut{
+				cloneTxOut(
+					resolution.SignDetails.SignDesc.Output,
+				),
+				cloneTxOut(resolution.SweepSignDesc.Output),
+			},
+		}
+
+		return &htlcSuccessResolver{
+			htlcResolution: resolution,
+		}, tx
+	}
+
+	testCases := []struct {
+		name        string
+		prepare     func(*htlcSuccessResolver, *wire.MsgTx) *wire.MsgTx
+		matches     bool
+		expectedErr error
+	}{
+		{
+			name:    "match",
+			matches: true,
+		},
+		{
+			name: "commitment descriptor decoy",
+			prepare: func(resolver *htlcSuccessResolver,
+				tx *wire.MsgTx) *wire.MsgTx {
+
+				// This decoy proves the matcher uses the sweep
+				// descriptor, not the commitment descriptor.
+				resolution := &resolver.htlcResolution
+				signDetails := resolution.SignDetails
+				tx.TxOut[1] = cloneTxOut(
+					signDetails.SignDesc.Output,
+				)
+
+				return tx
+			},
+		},
+		{
+			name: "missing indexed output",
+			prepare: func(_ *htlcSuccessResolver,
+				tx *wire.MsgTx) *wire.MsgTx {
+
+				tx.TxOut = tx.TxOut[:1]
+
+				return tx
+			},
+		},
+		{
+			name: "missing expected output",
+			prepare: func(resolver *htlcSuccessResolver,
+				tx *wire.MsgTx) *wire.MsgTx {
+
+				resolution := &resolver.htlcResolution
+				resolution.SweepSignDesc.Output = nil
+
+				return tx
+			},
+			expectedErr: errInvalidSuccessResolver,
+		},
+		{
+			name: "nil indexed output",
+			prepare: func(_ *htlcSuccessResolver,
+				tx *wire.MsgTx) *wire.MsgTx {
+
+				tx.TxOut[1] = nil
+
+				return tx
+			},
+			expectedErr: errInvalidSpendDetails,
+		},
+		{
+			name: "nil transaction",
+			prepare: func(_ *htlcSuccessResolver,
+				_ *wire.MsgTx) *wire.MsgTx {
+
+				return nil
+			},
+			expectedErr: errInvalidSpendDetails,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			resolver, tx := newMatch()
+			if testCase.prepare != nil {
+				tx = testCase.prepare(resolver, tx)
+			}
+
+			outpoint, matches, err :=
+				resolver.matchSecondLevelOutput(tx, 1)
+			if testCase.expectedErr != nil {
+				require.ErrorIs(t, err, testCase.expectedErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, testCase.matches, matches)
+			if matches {
+				require.Equal(t, wire.OutPoint{
+					Hash:  tx.TxHash(),
+					Index: 1,
+				}, outpoint)
+			} else {
+				require.Zero(t, outpoint)
+			}
+		})
+	}
 }
 
 // TestHtlcSuccessSecondStageResolution tests successful sweep of a second

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -682,6 +682,159 @@ func TestHtlcSuccessSkipsForeignSuccessOutput(t *testing.T) {
 	}
 }
 
+// TestHtlcSuccessRejectsMalformedRestoredSpend tests validation before output
+// matching on the restored commitment-spend path.
+func TestHtlcSuccessRejectsMalformedRestoredSpend(t *testing.T) {
+	commitOutpoint := wire.OutPoint{Index: 2}
+	resolution := newSuccessTestResolution(commitOutpoint)
+	ctx := newHtlcResolverTestContext(t, func(htlc channeldb.HTLC,
+		cfg ResolverConfig) ContractResolver {
+
+		return newSuccessResolver(resolution, 0, htlc, 0, cfg)
+	})
+	ctx.checkpoint = func(_ ContractResolver,
+		_ ...*channeldb.ResolverReport) error {
+
+		t.Fatal("unexpected checkpoint")
+		return nil
+	}
+	ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
+		SpendingTx: &wire.MsgTx{},
+	}
+
+	resolver := requireSuccessResolver(t, ctx.resolver)
+	err := resolver.resolveSuccessTx()
+	require.ErrorIs(t, err, errInvalidSpendDetails)
+	require.False(t, resolver.IsResolved())
+	require.False(t, ctx.finalHtlcOutcomeStored)
+	require.Empty(t, ctx.htlcNotifier.finalHtlcEvents)
+}
+
+// TestHtlcSuccessForeignSpend tests checkpointing foreign commitment spends
+// before and after resolver restoration.
+func TestHtlcSuccessForeignSpend(t *testing.T) {
+	commitOutpoint := wire.OutPoint{Index: 2}
+	resolution := newSuccessTestResolution(commitOutpoint)
+	foreignTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{{PreviousOutPoint: commitOutpoint}},
+		TxOut: []*wire.TxOut{{
+			Value:    resolution.SweepSignDesc.Output.Value,
+			PkScript: []byte{txscript.OP_FALSE},
+		}},
+	}
+	foreignTxID := foreignTx.TxHash()
+	foreignSpend := newSpendDetail(commitOutpoint, foreignTx, 0)
+	foreignSpend.SpenderTxHash = nil
+	resolverType := channeldb.ResolverTypeIncomingHtlc
+	resolverOutcome := channeldb.ResolverOutcomeTimeout
+
+	testCases := []struct {
+		name    string
+		restart bool
+	}{
+		{
+			// A fresh resolver offers the commitment HTLC, but a
+			// foreign transaction confirms instead.
+			name: "fresh resolver",
+		},
+		{
+			// A restored resolver replays a historical spend.
+			// Launch avoids a phantom second-level sweep.
+			name:    "restored resolver",
+			restart: true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			defer timeout()()
+			ctx := newHtlcResolverTestContext(
+				t, func(htlc channeldb.HTLC,
+					cfg ResolverConfig) ContractResolver {
+
+					resolver := newSuccessResolver(
+						resolution, 0, htlc, 0, cfg,
+					)
+					if !testCase.restart {
+						return resolver
+					}
+
+					resolver.outputIncubating = true
+					var state bytes.Buffer
+					err := resolver.Encode(&state)
+					require.NoError(t, err)
+					decode := newSuccessResolverFromReader
+					restored, err := decode(&state, cfg)
+					require.NoError(t, err)
+					restored.Supplement(htlc)
+
+					return restored
+				},
+			)
+
+			var reports []*channeldb.ResolverReport
+			ctx.checkpoint = func(_ ContractResolver,
+				r ...*channeldb.ResolverReport) error {
+
+				reports = r
+				return nil
+			}
+
+			ctx.resolve()
+			resolver := requireSuccessResolver(t, ctx.resolver)
+			sweeper, ok := resolver.Sweeper.(*mockSweeper)
+			require.True(t, ok)
+			if !testCase.restart {
+				select {
+				case input := <-sweeper.sweptInputs:
+					require.Equal(
+						t, commitOutpoint,
+						input.OutPoint(),
+					)
+
+				case <-time.After(time.Second):
+					t.Fatal("expected input to be swept")
+				}
+			}
+			// Launch and Resolve each register after restart.
+			// Each receives its own historical-spend replay.
+			go func() {
+				ctx.notifier.SpendChan <- foreignSpend
+				if testCase.restart {
+					ctx.notifier.SpendChan <- foreignSpend
+				}
+			}()
+			ctx.waitForResult()
+
+			require.True(t, resolver.IsResolved())
+			require.False(t, resolver.outputIncubating)
+			require.Zero(t, resolver.currentReport.LimboBalance)
+			require.Zero(t, resolver.currentReport.RecoveredBalance)
+			require.True(t, ctx.finalHtlcOutcomeStored)
+			require.False(t, ctx.finalHtlcSettled)
+			require.Equal(t, []*channeldb.ResolverReport{{
+				OutPoint:        commitOutpoint,
+				Amount:          testHtlcAmt.ToSatoshis(),
+				ResolverType:    resolverType,
+				ResolverOutcome: resolverOutcome,
+				SpendTxID:       &foreignTxID,
+			}}, reports)
+			require.Equal(t, []finalHtlcEvent{{
+				key: testCircuitKey,
+				info: channeldb.FinalHtlcInfo{
+					Settled: false,
+				},
+			}}, ctx.htlcNotifier.finalHtlcEvents)
+
+			select {
+			case sweptInput := <-sweeper.sweptInputs:
+				t.Fatalf("unexpected phantom sweep: %v",
+					sweptInput.OutPoint())
+			default:
+			}
+		})
+	}
+}
+
 // TestHtlcSuccessForeignSpendCheckpointError tests rollback and retry after a
 // foreign-spend checkpoint failure.
 func TestHtlcSuccessForeignSpendCheckpointError(t *testing.T) {
@@ -1031,7 +1184,6 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 
 				ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
 					SpendingTx:        reSignedSuccessTx,
-					SpenderTxHash:     &reSignedHash,
 					SpenderInputIndex: 1,
 					SpendingHeight:    10,
 					SpentOutPoint:     &commitOutpoint,
@@ -1054,7 +1206,6 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 				if resumed {
 					ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
 						SpendingTx:        reSignedSuccessTx,
-						SpenderTxHash:     &reSignedHash,
 						SpenderInputIndex: 1,
 						SpendingHeight:    10,
 						SpentOutPoint:     &commitOutpoint,
@@ -1069,7 +1220,6 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 				// spend.
 				ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
 					SpendingTx:        reSignedSuccessTx,
-					SpenderTxHash:     &reSignedHash,
 					SpenderInputIndex: 1,
 					SpendingHeight:    10,
 					SpentOutPoint:     &commitOutpoint,

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -195,7 +195,13 @@ func TestHtlcSuccessSingleStage(t *testing.T) {
 	htlcOutpoint := wire.OutPoint{Index: 3}
 
 	sweepTx := &wire.MsgTx{
-		TxIn:  []*wire.TxIn{{}},
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: htlcOutpoint,
+			Witness: wire.TxWitness{
+				dummyBytes, testResPreimage[:],
+				testSignDesc.WitnessScript,
+			},
+		}},
 		TxOut: []*wire.TxOut{{}},
 	}
 
@@ -241,7 +247,8 @@ func TestHtlcSuccessSingleStage(t *testing.T) {
 			reports: []*channeldb.ResolverReport{
 				claim,
 			},
-			finalHtlcStored: true,
+			finalHtlcStored:  true,
+			finalHtlcSettled: true,
 		},
 	}
 
@@ -449,6 +456,76 @@ func TestHtlcSuccessTaprootClassification(t *testing.T) {
 		dummyBytes, testResPreimage[:], fixture.successScript,
 		fixture.auxControl,
 	}))
+}
+
+// TestHtlcSuccessSingleStageClassification tests direct HTLC spend paths.
+func TestHtlcSuccessSingleStageClassification(t *testing.T) {
+	fixture := newTaprootSuccessSpendFixture(t)
+
+	claimOutpoint := wire.OutPoint{Index: 3}
+	resolution := lnwallet.IncomingHtlcResolution{
+		Preimage:      testResPreimage,
+		SweepSignDesc: fixture.signDesc,
+		ClaimOutpoint: claimOutpoint,
+	}
+	auxSpendTx := &wire.MsgTx{TxIn: []*wire.TxIn{{
+		PreviousOutPoint: claimOutpoint,
+		Witness: wire.TxWitness{
+			dummyBytes, testResPreimage[:], fixture.successScript,
+			fixture.auxControl,
+		},
+	}}}
+	auxSpendTxID := auxSpendTx.TxHash()
+	testHtlcSuccess(t, resolution, []checkpoint{{
+		preCheckpoint: func(
+			ctx *htlcResolverTestContext, _ bool) error {
+
+			ctx.notifier.SpendChan <- newSpendDetail(
+				claimOutpoint, auxSpendTx, 0,
+			)
+
+			return nil
+		},
+		resolved: false,
+		reports: []*channeldb.ResolverReport{{
+			OutPoint:        claimOutpoint,
+			Amount:          testHtlcAmt.ToSatoshis(),
+			ResolverType:    channeldb.ResolverTypeIncomingHtlc,
+			ResolverOutcome: channeldb.ResolverOutcomeTimeout,
+			SpendTxID:       &auxSpendTxID,
+		}},
+		finalHtlcStored:      true,
+		checkpointsOnRestart: true,
+	}})
+
+	wrongPreimage := make([]byte, 32)
+	wrongPreimage[0] = 1
+	ctx := newHtlcResolverTestContext(t, func(htlc channeldb.HTLC,
+		cfg ResolverConfig) ContractResolver {
+
+		return newSuccessResolver(resolution, 0, htlc, 0, cfg)
+	})
+	ctx.checkpoint = func(_ ContractResolver,
+		_ ...*channeldb.ResolverReport) error {
+
+		t.Fatal("unexpected checkpoint")
+		return nil
+	}
+	wrongSpendTx := &wire.MsgTx{TxIn: []*wire.TxIn{{
+		PreviousOutPoint: claimOutpoint,
+		Witness: wire.TxWitness{
+			dummyBytes, wrongPreimage, fixture.successScript,
+			fixture.successControl,
+		},
+	}}}
+	ctx.notifier.SpendChan <- newSpendDetail(
+		claimOutpoint, wrongSpendTx, 0,
+	)
+	err := requireSuccessResolver(t, ctx.resolver).
+		resolveRemoteCommitOutput()
+	require.ErrorIs(t, err, errInvalidSuccessResolver)
+	require.False(t, ctx.finalHtlcOutcomeStored)
+	require.Empty(t, ctx.htlcNotifier.finalHtlcEvents)
 }
 
 // TestHtlcSuccessMatchSecondLevelOutput tests matching the success transaction
@@ -723,7 +800,8 @@ func TestHtlcSuccessSecondStageResolution(t *testing.T) {
 				secondStage,
 				firstStage,
 			},
-			finalHtlcStored: true,
+			finalHtlcStored:  true,
+			finalHtlcSettled: true,
 		},
 	}
 
@@ -942,11 +1020,27 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 				secondStage,
 				firstStage,
 			},
-			finalHtlcStored: true,
+			finalHtlcStored:  true,
+			finalHtlcSettled: true,
 		},
 	}
 
 	testHtlcSuccess(t, twoStageResolution, checkpoints)
+}
+
+// newSpendDetail creates notifier spend details for the selected transaction
+// input.
+func newSpendDetail(spent wire.OutPoint, tx *wire.MsgTx,
+	inputIndex uint32) *chainntnfs.SpendDetail {
+
+	txid := tx.TxHash()
+	return &chainntnfs.SpendDetail{
+		SpendingTx:        tx,
+		SpenderTxHash:     &txid,
+		SpenderInputIndex: inputIndex,
+		SpendingHeight:    10,
+		SpentOutPoint:     &spent,
+	}
 }
 
 // checkpoint holds expected data we expect the resolver to checkpoint itself
@@ -958,10 +1052,12 @@ type checkpoint struct {
 	preCheckpoint func(*htlcResolverTestContext, bool) error
 
 	// data we expect the resolver to be checkpointed with next.
-	incubating      bool
-	resolved        bool
-	reports         []*channeldb.ResolverReport
-	finalHtlcStored bool
+	incubating           bool
+	resolved             bool
+	reports              []*channeldb.ResolverReport
+	finalHtlcStored      bool
+	finalHtlcSettled     bool
+	checkpointsOnRestart bool
 }
 
 // testHtlcSuccess tests resolution of a success resolver. It takes a a list of
@@ -1008,8 +1104,13 @@ func testHtlcSuccess(t *testing.T, resolution lnwallet.IncomingHtlcResolution,
 			},
 		)
 
+		nextCheckpoint := i + 1
+		if checkpoints[i].checkpointsOnRestart {
+			nextCheckpoint = i
+		}
+
 		// Run from the given checkpoint, ensuring we'll hit the rest.
-		_ = runFromCheckpoint(t, ctx, checkpoints[i+1:])
+		_ = runFromCheckpoint(t, ctx, checkpoints[nextCheckpoint:])
 	}
 }
 
@@ -1073,6 +1174,10 @@ func runFromCheckpoint(t *testing.T, ctx *htlcResolverTestContext,
 		// Check that the final htlc outcome is stored.
 		if cp.finalHtlcStored != ctx.finalHtlcOutcomeStored {
 			t.Fatal("final htlc store expectation failed")
+		}
+		if cp.finalHtlcStored {
+			require.Equal(t, cp.finalHtlcSettled,
+				ctx.finalHtlcSettled)
 		}
 
 		// Finally encode the resolver, and store it for later use.

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/chainntnfs"
@@ -19,6 +21,7 @@ import (
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnmock"
 	"github.com/lightningnetwork/lnd/lntest/mock"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/stretchr/testify/require"
@@ -302,6 +305,97 @@ func TestHtlcSuccessValidatedSpendInput(t *testing.T) {
 			require.ErrorContains(t, err, testCase.errText)
 		})
 	}
+}
+
+type taprootSuccessSpendFixture struct {
+	signDesc       input.SignDescriptor
+	successScript  []byte
+	successControl []byte
+	timeoutScript  []byte
+	timeoutControl []byte
+	auxControl     []byte
+}
+
+// cloneTxOut returns a copy of a transaction output.
+func cloneTxOut(txOut *wire.TxOut) *wire.TxOut {
+	pkScript := append([]byte(nil), txOut.PkScript...)
+	return &wire.TxOut{
+		Value:    txOut.Value,
+		PkScript: pkScript,
+	}
+}
+
+// newTaprootSuccessSpendFixture creates success and auxiliary leaves with the
+// same script and different leaf versions.
+func newTaprootSuccessSpendFixture(
+	t *testing.T) *taprootSuccessSpendFixture {
+
+	t.Helper()
+	_, taprootKey := btcec.PrivKeyFromBytes([]byte{1})
+	successLeaf, err := input.SenderHTLCTapLeafSuccess(
+		taprootKey, testResHash[:],
+	)
+	require.NoError(t, err)
+
+	auxLeaf := txscript.NewTapLeaf(0xc2, successLeaf.Script)
+	tree, err := input.SenderHTLCScriptTaproot(
+		taprootKey, taprootKey, taprootKey, testResHash[:],
+		lntypes.Remote, fn.Some(auxLeaf),
+	)
+	require.NoError(t, err)
+	controlBytes := func(path input.ScriptPath) []byte {
+		control, err := tree.CtrlBlockForPath(path)
+		require.NoError(t, err)
+		serialized, err := control.ToBytes()
+		require.NoError(t, err)
+
+		return serialized
+	}
+	auxIndex := tree.TapScriptTree().LeafProofIndex[auxLeaf.TapHash()]
+	auxProof := tree.TapScriptTree().LeafMerkleProofs[auxIndex]
+	auxControl := auxProof.ToControlBlock(taprootKey)
+	auxControlBytes, err := auxControl.ToBytes()
+	require.NoError(t, err)
+
+	signDesc := testSignDesc
+	signDesc.Output = cloneTxOut(testSignDesc.Output)
+	signDesc.Output.PkScript = tree.PkScript()
+	signDesc.WitnessScript = successLeaf.Script
+	signDesc.ControlBlock = controlBytes(input.ScriptPathSuccess)
+
+	return &taprootSuccessSpendFixture{
+		signDesc:       signDesc,
+		successScript:  successLeaf.Script,
+		successControl: signDesc.ControlBlock,
+		timeoutScript:  tree.TimeoutTapLeaf.Script,
+		timeoutControl: controlBytes(input.ScriptPathTimeout),
+		auxControl:     auxControlBytes,
+	}
+}
+
+// TestHtlcSuccessTaprootClassification tests Taproot success leaf identity.
+func TestHtlcSuccessTaprootClassification(t *testing.T) {
+	fixture := newTaprootSuccessSpendFixture(t)
+	resolver := &htlcSuccessResolver{
+		htlcResolution: lnwallet.IncomingHtlcResolution{
+			SweepSignDesc: fixture.signDesc,
+		},
+	}
+	successWitness := wire.TxWitness{
+		dummyBytes, testResPreimage[:], fixture.successScript,
+		fixture.successControl,
+	}
+	require.True(t, resolver.isTaprootPreimageSpend(append(
+		successWitness, []byte{txscript.TaprootAnnexTag},
+	)))
+	require.False(t, resolver.isTaprootPreimageSpend(wire.TxWitness{
+		dummyBytes, dummyBytes, fixture.timeoutScript,
+		fixture.timeoutControl,
+	}))
+	require.False(t, resolver.isTaprootPreimageSpend(wire.TxWitness{
+		dummyBytes, testResPreimage[:], fixture.successScript,
+		fixture.auxControl,
+	}))
 }
 
 // TestHtlcSuccessSecondStageResolution tests successful sweep of a second

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -650,6 +650,38 @@ func TestHtlcSuccessMatchSecondLevelOutput(t *testing.T) {
 	}
 }
 
+// TestHtlcSuccessSkipsForeignSuccessOutput tests that Launch does not offer a
+// phantom second-level output after a foreign commitment spend.
+func TestHtlcSuccessSkipsForeignSuccessOutput(t *testing.T) {
+	commitOutpoint := wire.OutPoint{Index: 2}
+	resolution := newSuccessTestResolution(commitOutpoint)
+	ctx := newHtlcResolverTestContext(t, func(htlc channeldb.HTLC,
+		cfg ResolverConfig) ContractResolver {
+
+		return newSuccessResolver(resolution, 0, htlc, 0, cfg)
+	})
+	resolver := requireSuccessResolver(t, ctx.resolver)
+	foreignTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{{PreviousOutPoint: commitOutpoint}},
+		TxOut: []*wire.TxOut{{
+			Value:    resolution.SweepSignDesc.Output.Value,
+			PkScript: []byte{txscript.OP_FALSE},
+		}},
+	}
+	ctx.notifier.SpendChan <- newSpendDetail(
+		commitOutpoint, foreignTx, 0,
+	)
+
+	require.NoError(t, resolver.sweepSuccessTxOutput())
+	sweeper, ok := resolver.Sweeper.(*mockSweeper)
+	require.True(t, ok)
+	select {
+	case sweptInput := <-sweeper.sweptInputs:
+		t.Fatalf("unexpected phantom sweep: %v", sweptInput.OutPoint())
+	default:
+	}
+}
+
 // TestHtlcSuccessForeignSpendCheckpointError tests rollback and retry after a
 // foreign-spend checkpoint failure.
 func TestHtlcSuccessForeignSpendCheckpointError(t *testing.T) {
@@ -887,6 +919,10 @@ func TestHtlcSuccessCheckpointClaim(t *testing.T) {
 func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 	commitOutpoint := wire.OutPoint{Index: 2}
 	htlcOutpoint := wire.OutPoint{Index: 3}
+	secondLevelOutput := cloneTxOut(testSignDesc.Output)
+	secondLevelOutput.PkScript = []byte{txscript.OP_TRUE}
+	sweepSignDesc := testSignDesc
+	sweepSignDesc.Output = secondLevelOutput
 
 	successTx := &wire.MsgTx{
 		TxIn: []*wire.TxIn{
@@ -894,12 +930,7 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 				PreviousOutPoint: commitOutpoint,
 			},
 		},
-		TxOut: []*wire.TxOut{
-			{
-				Value:    123,
-				PkScript: []byte{0xff, 0xff},
-			},
-		},
+		TxOut: []*wire.TxOut{cloneTxOut(secondLevelOutput)},
 	}
 
 	reSignedSuccessTx := &wire.MsgTx{
@@ -950,7 +981,7 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 			PeerSig:  testSig,
 		},
 		ClaimOutpoint: htlcOutpoint,
-		SweepSignDesc: testSignDesc,
+		SweepSignDesc: sweepSignDesc,
 	}
 
 	firstStage := &channeldb.ResolverReport{

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -2,6 +2,7 @@ package contractcourt
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -27,7 +28,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testHtlcAmt = lnwire.MilliSatoshi(200000)
+var (
+	testHtlcAmt     = lnwire.MilliSatoshi(200000)
+	testShortChanID = lnwire.NewShortChanIDFromInt(99)
+	testCircuitKey  = models.CircuitKey{
+		ChanID: testShortChanID,
+		HtlcID: 7,
+	}
+)
 
 type htlcResolverTestContext struct {
 	resolver ContractResolver
@@ -36,10 +44,12 @@ type htlcResolverTestContext struct {
 		_ ...*channeldb.ResolverReport) error
 
 	notifier           *mock.ChainNotifier
+	htlcNotifier       *mockHTLCNotifier
 	resolverResultChan chan resolveResult
 	resolutionChan     chan ResolutionMsg
 
 	finalHtlcOutcomeStored bool
+	finalHtlcSettled       bool
 
 	t *testing.T
 }
@@ -63,17 +73,18 @@ func newHtlcResolverTestContext(t *testing.T,
 		ConfChan:  make(chan *chainntnfs.TxConfirmation, 1),
 	}
 
+	htlcNotifier := &mockHTLCNotifier{}
 	testCtx := &htlcResolverTestContext{
 		checkpoint:     nil,
 		notifier:       notifier,
+		htlcNotifier:   htlcNotifier,
 		resolutionChan: make(chan ResolutionMsg, 1),
 		t:              t,
 	}
 
-	htlcNotifier := &mockHTLCNotifier{}
-
 	witnessBeacon := newMockWitnessBeacon()
 	chainCfg := ChannelArbitratorConfig{
+		ShortChanID: testShortChanID,
 		ChainArbitratorConfig: ChainArbitratorConfig{
 			Notifier:   notifier,
 			PreimageDB: witnessBeacon,
@@ -99,10 +110,13 @@ func newHtlcResolverTestContext(t *testing.T,
 				testCtx.resolutionChan <- msgs[0]
 				return nil
 			},
-			PutFinalHtlcOutcome: func(chanId lnwire.ShortChannelID,
-				htlcId uint64, settled bool) error {
+			PutFinalHtlcOutcome: func(chanID lnwire.ShortChannelID,
+				htlcID uint64, settled bool) error {
 
+				require.Equal(t, testCircuitKey.ChanID, chanID)
+				require.Equal(t, testCircuitKey.HtlcID, htlcID)
 				testCtx.finalHtlcOutcomeStored = true
+				testCtx.finalHtlcSettled = settled
 
 				return nil
 			},
@@ -135,6 +149,7 @@ func newHtlcResolverTestContext(t *testing.T,
 	}
 
 	htlc := channeldb.HTLC{
+		HtlcIndex: testCircuitKey.HtlcID,
 		RHash:     testResHash,
 		OnionBlob: lnmock.MockOnion(),
 		Amt:       testHtlcAmt,
@@ -352,6 +367,17 @@ func newSuccessTestResolution(
 	}
 }
 
+// requireSuccessResolver returns the concrete success resolver used by a test.
+func requireSuccessResolver(t *testing.T,
+	resolver ContractResolver) *htlcSuccessResolver {
+
+	t.Helper()
+	successResolver, ok := resolver.(*htlcSuccessResolver)
+	require.True(t, ok)
+
+	return successResolver
+}
+
 // newTaprootSuccessSpendFixture creates success and auxiliary leaves with the
 // same script and different leaf versions.
 func newTaprootSuccessSpendFixture(
@@ -545,6 +571,80 @@ func TestHtlcSuccessMatchSecondLevelOutput(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestHtlcSuccessForeignSpendCheckpointError tests rollback and retry after a
+// foreign-spend checkpoint failure.
+func TestHtlcSuccessForeignSpendCheckpointError(t *testing.T) {
+	t.Parallel()
+
+	commitOutpoint := wire.OutPoint{Index: 4}
+	resolution := newSuccessTestResolution(commitOutpoint)
+	var resolverCfg ResolverConfig
+	ctx := newHtlcResolverTestContext(t, func(htlc channeldb.HTLC,
+		cfg ResolverConfig) ContractResolver {
+
+		resolverCfg = cfg
+		return newSuccessResolver(resolution, 0, htlc, 0, cfg)
+	})
+	resolver := requireSuccessResolver(t, ctx.resolver)
+	resolver.outputIncubating = true
+	resolver.currentReport.RecoveredBalance = 1
+	previousReport := resolver.currentReport
+
+	errCheckpoint := errors.New("checkpoint failed")
+	checkpointCalls := 0
+	ctx.checkpoint = func(_ ContractResolver,
+		reports ...*channeldb.ResolverReport) error {
+
+		checkpointCalls++
+		require.False(t, resolver.IsResolved())
+		require.False(t, resolver.outputIncubating)
+		require.Zero(t, resolver.currentReport.LimboBalance)
+		require.Zero(t, resolver.currentReport.RecoveredBalance)
+		require.Len(t, reports, 1)
+		require.Equal(t, channeldb.ResolverOutcomeTimeout,
+			reports[0].ResolverOutcome)
+		if checkpointCalls == 1 {
+			return errCheckpoint
+		}
+
+		var state bytes.Buffer
+		require.NoError(t, resolver.Encode(&state))
+		restored, err := newSuccessResolverFromReader(
+			&state, resolverCfg,
+		)
+		require.NoError(t, err)
+		require.False(t, restored.IsResolved())
+
+		return nil
+	}
+
+	foreignTx := &wire.MsgTx{
+		TxIn:  []*wire.TxIn{{PreviousOutPoint: commitOutpoint}},
+		TxOut: []*wire.TxOut{{PkScript: []byte{txscript.OP_FALSE}}},
+	}
+	spendTxID := foreignTx.TxHash()
+
+	err := resolver.checkpointForeignSpend(spendTxID)
+	require.ErrorIs(t, err, errCheckpoint)
+	require.False(t, resolver.IsResolved())
+	require.True(t, resolver.outputIncubating)
+	require.Equal(t, previousReport, resolver.currentReport)
+	require.Empty(t, ctx.htlcNotifier.finalHtlcEvents)
+
+	require.NoError(t, resolver.checkpointForeignSpend(spendTxID))
+	require.Equal(t, 2, checkpointCalls)
+	require.True(t, resolver.IsResolved())
+	require.False(t, resolver.outputIncubating)
+	require.Zero(t, resolver.currentReport.LimboBalance)
+	require.Zero(t, resolver.currentReport.RecoveredBalance)
+	require.Equal(t, []finalHtlcEvent{{
+		key: testCircuitKey,
+		info: channeldb.FinalHtlcInfo{
+			Settled: false,
+		},
+	}}, ctx.htlcNotifier.finalHtlcEvents)
 }
 
 // TestHtlcSuccessSecondStageResolution tests successful sweep of a second

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -232,6 +232,78 @@ func TestHtlcSuccessSingleStage(t *testing.T) {
 	)
 }
 
+// TestHtlcSuccessValidatedSpendInput tests extraction and validation of the
+// notified HTLC input.
+func TestHtlcSuccessValidatedSpendInput(t *testing.T) {
+	claim := wire.OutPoint{Index: 2}
+	resolver := &htlcSuccessResolver{
+		htlcResolution: lnwallet.IncomingHtlcResolution{
+			ClaimOutpoint: claim,
+		},
+	}
+	spendInput := &wire.TxIn{PreviousOutPoint: claim}
+	validSpend := &chainntnfs.SpendDetail{
+		SpendingTx: &wire.MsgTx{
+			TxIn: []*wire.TxIn{{}, spendInput},
+		},
+		SpenderInputIndex: 1,
+	}
+
+	input, err := resolver.validatedSpendInput(validSpend)
+	require.NoError(t, err)
+	require.Same(t, spendInput, input)
+
+	testCases := []struct {
+		name    string
+		spend   *chainntnfs.SpendDetail
+		errText string
+	}{
+		{
+			name:    "missing spend detail",
+			errText: "missing spend detail",
+		},
+		{
+			name:    "missing spending tx",
+			spend:   &chainntnfs.SpendDetail{},
+			errText: "missing spending tx",
+		},
+		{
+			name: "input index out of range",
+			spend: &chainntnfs.SpendDetail{
+				SpendingTx:        &wire.MsgTx{},
+				SpenderInputIndex: 1,
+			},
+			errText: "spender input index",
+		},
+		{
+			name: "nil spender input",
+			spend: &chainntnfs.SpendDetail{
+				SpendingTx: &wire.MsgTx{
+					TxIn: []*wire.TxIn{nil},
+				},
+			},
+			errText: "spender input 0 is nil",
+		},
+		{
+			name: "unexpected input outpoint",
+			spend: &chainntnfs.SpendDetail{
+				SpendingTx: &wire.MsgTx{
+					TxIn: []*wire.TxIn{{}},
+				},
+			},
+			errText: "input",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := resolver.validatedSpendInput(testCase.spend)
+			require.ErrorIs(t, err, errInvalidSpendDetails)
+			require.ErrorContains(t, err, testCase.errText)
+		})
+	}
+}
+
 // TestHtlcSuccessSecondStageResolution tests successful sweep of a second
 // stage htlc claim, going through the Nursery.
 func TestHtlcSuccessSecondStageResolution(t *testing.T) {

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -724,11 +724,24 @@ func TestHtlcSuccessForeignSpendCheckpointError(t *testing.T) {
 	}}, ctx.htlcNotifier.finalHtlcEvents)
 }
 
-// TestHtlcSuccessSecondStageResolution tests successful sweep of a second
-// stage htlc claim, going through the Nursery.
+// TestHtlcSuccessSecondStageResolution tests the legacy pre-anchor path, where
+// a successful second-stage HTLC claim goes through the Nursery.
 func TestHtlcSuccessSecondStageResolution(t *testing.T) {
 	commitOutpoint := wire.OutPoint{Index: 2}
-	htlcOutpoint := wire.OutPoint{Index: 3}
+	signedSuccessTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: commitOutpoint,
+		}},
+		TxOut: []*wire.TxOut{{
+			Value:    111,
+			PkScript: []byte{0xaa, 0xaa},
+		}},
+	}
+	successTx := signedSuccessTx.TxHash()
+	htlcOutpoint := wire.OutPoint{
+		Hash:  successTx,
+		Index: 3,
+	}
 
 	sweepTx := &wire.MsgTx{
 		TxIn:  []*wire.TxIn{{}},
@@ -739,25 +752,12 @@ func TestHtlcSuccessSecondStageResolution(t *testing.T) {
 	// twoStageResolution is a resolution for htlc on our own commitment
 	// which is spent from the signed success tx.
 	twoStageResolution := lnwallet.IncomingHtlcResolution{
-		Preimage: [32]byte{},
-		SignedSuccessTx: &wire.MsgTx{
-			TxIn: []*wire.TxIn{
-				{
-					PreviousOutPoint: commitOutpoint,
-				},
-			},
-			TxOut: []*wire.TxOut{
-				{
-					Value:    111,
-					PkScript: []byte{0xaa, 0xaa},
-				},
-			},
-		},
-		ClaimOutpoint: htlcOutpoint,
-		SweepSignDesc: testSignDesc,
+		Preimage:        [32]byte{},
+		SignedSuccessTx: signedSuccessTx,
+		ClaimOutpoint:   htlcOutpoint,
+		SweepSignDesc:   testSignDesc,
 	}
 
-	successTx := twoStageResolution.SignedSuccessTx.TxHash()
 	firstStage := &channeldb.ResolverReport{
 		OutPoint:        commitOutpoint,
 		Amount:          testHtlcAmt.ToSatoshis(),
@@ -810,6 +810,75 @@ func TestHtlcSuccessSecondStageResolution(t *testing.T) {
 	)
 }
 
+// TestHtlcSuccessCheckpointClaim tests that a re-signed success transaction is
+// recorded with the outpoint and transaction that actually confirmed.
+func TestHtlcSuccessCheckpointClaim(t *testing.T) {
+	commitOutpoint := wire.OutPoint{Index: 2}
+	resolution := lnwallet.IncomingHtlcResolution{
+		SignedSuccessTx: &wire.MsgTx{
+			TxIn: []*wire.TxIn{{
+				PreviousOutPoint: commitOutpoint,
+			}},
+			TxOut: []*wire.TxOut{{}},
+		},
+		ClaimOutpoint: wire.OutPoint{Index: 3},
+		SweepSignDesc: testSignDesc,
+	}
+
+	ctx := newHtlcResolverTestContext(
+		t, func(htlc channeldb.HTLC,
+			cfg ResolverConfig) ContractResolver {
+
+			return newSuccessResolver(resolution, 0, htlc, 0, cfg)
+		},
+	)
+	resolver := requireSuccessResolver(t, ctx.resolver)
+
+	secondLevelOutpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{1},
+		Index: 4,
+	}
+	spendTxID := chainhash.Hash{2}
+	var reports []*channeldb.ResolverReport
+	ctx.checkpoint = func(gotResolver ContractResolver,
+		gotReports ...*channeldb.ResolverReport) error {
+
+		require.Same(t, resolver, gotResolver)
+		reports = gotReports
+		return nil
+	}
+
+	require.NoError(t, resolver.checkpointClaim(
+		secondLevelOutpoint, &spendTxID,
+	))
+	require.True(t, resolver.IsResolved())
+	require.True(t, ctx.finalHtlcOutcomeStored)
+	require.Equal(t, []*channeldb.ResolverReport{
+		{
+			OutPoint: secondLevelOutpoint,
+			Amount: btcutil.Amount(
+				testSignDesc.Output.Value,
+			),
+			ResolverType:    channeldb.ResolverTypeIncomingHtlc,
+			ResolverOutcome: channeldb.ResolverOutcomeClaimed,
+			SpendTxID:       &spendTxID,
+		},
+		{
+			OutPoint:        commitOutpoint,
+			Amount:          testHtlcAmt.ToSatoshis(),
+			ResolverType:    channeldb.ResolverTypeIncomingHtlc,
+			ResolverOutcome: channeldb.ResolverOutcomeFirstStage,
+			SpendTxID:       &secondLevelOutpoint.Hash,
+		},
+	}, reports)
+	require.Equal(t, []finalHtlcEvent{{
+		key: testCircuitKey,
+		info: channeldb.FinalHtlcInfo{
+			Settled: true,
+		},
+	}}, ctx.htlcNotifier.finalHtlcEvents)
+}
+
 // TestHtlcSuccessSecondStageResolutionSweeper test that a resolver with
 // non-nil SignDetails will offer the second-level transaction to the sweeper
 // for re-signing.
@@ -858,18 +927,14 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 			successTx.TxOut[0],
 		},
 	}
-	reSignedHash := successTx.TxHash()
+	reSignedHash := reSignedSuccessTx.TxHash()
+	secondLevelOutpoint := wire.OutPoint{
+		Hash:  reSignedHash,
+		Index: 1,
+	}
 
 	sweepTx := &wire.MsgTx{
-		TxIn: []*wire.TxIn{
-
-			{
-				PreviousOutPoint: wire.OutPoint{
-					Hash:  reSignedHash,
-					Index: 1,
-				},
-			},
-		},
+		TxIn:  []*wire.TxIn{{PreviousOutPoint: secondLevelOutpoint}},
 		TxOut: []*wire.TxOut{{}},
 	}
 	sweepHash := sweepTx.TxHash()
@@ -897,7 +962,7 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 	}
 
 	secondStage := &channeldb.ResolverReport{
-		OutPoint:        htlcOutpoint,
+		OutPoint:        secondLevelOutpoint,
 		Amount:          btcutil.Amount(testSignDesc.Output.Value),
 		ResolverType:    channeldb.ResolverTypeIncomingHtlc,
 		ResolverOutcome: channeldb.ResolverOutcomeClaimed,
@@ -1223,6 +1288,19 @@ func runFromCheckpoint(t *testing.T, ctx *htlcResolverTestContext,
 
 	// Wait for the resolver to fully complete.
 	ctx.waitForResult()
+	if len(expectedCheckpoints) != 0 {
+		lastCheckpoint := len(expectedCheckpoints) - 1
+		finalCheckpoint := expectedCheckpoints[lastCheckpoint]
+		if finalCheckpoint.finalHtlcStored {
+			expectedSettled := finalCheckpoint.finalHtlcSettled
+			require.Equal(t, []finalHtlcEvent{{
+				key: testCircuitKey,
+				info: channeldb.FinalHtlcInfo{
+					Settled: expectedSettled,
+				},
+			}}, ctx.htlcNotifier.finalHtlcEvents)
+		}
+	}
 
 	return checkpointedState
 }

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -203,7 +203,9 @@ func (h *htlcTimeoutResolver) claimCleanUp(
 	// If this is a taproot channel, and there's only a single witness
 	// element, then we're actually on the losing side of a breach
 	// attempt...
-	case h.isTaproot() && len(spendingInput.Witness) == 1:
+	case h.isTaproot() &&
+		len(input.StripTaprootAnnex(spendingInput.Witness)) == 1:
+
 		return fmt.Errorf("breach attempt failed")
 
 	// Otherwise, they'll be spending directly from our commitment output.
@@ -344,6 +346,15 @@ func isPreimageSpend(isTaproot bool, spend *chainntnfs.SpendDetail,
 	spenderIndex := spend.SpenderInputIndex
 	spendingInput := spend.SpendingTx.TxIn[spenderIndex]
 	spendingWitness := spendingInput.Witness
+
+	// A taproot spender may append a BIP341 annex to any of the script
+	// paths enumerated below. The annex isn't part of the spend path, so we
+	// drop it before matching the stack against the shapes we know. Every
+	// index checked below is counted from the front of the stack, so
+	// removing a trailing element leaves them all in place.
+	if isTaproot {
+		spendingWitness = input.StripTaprootAnnex(spendingWitness)
+	}
 
 	switch {
 	// If this is a taproot remote commitment, then we can detect the type

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -2,6 +2,7 @@ package contractcourt
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -21,6 +22,8 @@ import (
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/sweep"
 )
+
+var errPreimageMismatch = errors.New("revealed preimage does not match HTLC")
 
 // htlcTimeoutResolver is a ContractResolver that's capable of resolving an
 // outgoing HTLC. The HTLC may be on our commitment transaction, or on the
@@ -225,6 +228,16 @@ func (h *htlcTimeoutResolver) claimCleanUp(
 	if err != nil {
 		return fmt.Errorf("unable to create pre-image from witness: %w",
 			err)
+	}
+
+	// The classifier above only asserts that the element at the preimage
+	// index is the right length, so confirm it actually opens this HTLC
+	// before we treat it as a claim. Otherwise a witness that merely has
+	// the shape of a success spend would poison the preimage cache and
+	// settle the incoming link with a preimage that isn't ours.
+	if !preimage.Matches(h.htlc.RHash) {
+		return fmt.Errorf("%w: preimage %v, htlc hash %v",
+			errPreimageMismatch, preimage, h.htlc.RHash)
 	}
 
 	log.Infof("%T(%v): extracting preimage=%v from on-chain "+

--- a/contractcourt/htlc_timeout_resolver_test.go
+++ b/contractcourt/htlc_timeout_resolver_test.go
@@ -94,7 +94,7 @@ type htlcTimeoutTestCase struct {
 }
 
 func genHtlcTimeoutTestCases() []htlcTimeoutTestCase {
-	fakePreimageBytes := bytes.Repeat([]byte{1}, lntypes.HashSize)
+	fakePreimageBytes := testResPreimage[:]
 
 	var (
 		htlcOutpoint wire.OutPoint
@@ -269,7 +269,7 @@ func genHtlcTimeoutTestCases() []htlcTimeoutTestCase {
 }
 
 func testHtlcTimeoutResolver(t *testing.T, testCase htlcTimeoutTestCase) {
-	fakePreimageBytes := bytes.Repeat([]byte{1}, lntypes.HashSize)
+	fakePreimageBytes := testResPreimage[:]
 	var fakePreimage lntypes.Preimage
 
 	fakeSignDesc := &input.SignDescriptor{
@@ -354,8 +354,12 @@ func testHtlcTimeoutResolver(t *testing.T, testCase htlcTimeoutTestCase) {
 		contractResolverKit: *newContractResolverKit(
 			cfg,
 		),
+		// The hash has to correspond to the preimage the spending
+		// witnesses reveal, since a claim is only accepted when the
+		// revealed preimage actually opens this HTLC.
 		htlc: channeldb.HTLC{
-			Amt: testHtlcAmt,
+			Amt:   testHtlcAmt,
+			RHash: testResHash,
 		},
 	}
 	resolver.initLogger("timeoutResolver")
@@ -792,7 +796,7 @@ func TestHtlcTimeoutSingleStageRemoteSpend(t *testing.T) {
 		TxOut: []*wire.TxOut{{}},
 	}
 
-	fakePreimageBytes := bytes.Repeat([]byte{1}, lntypes.HashSize)
+	fakePreimageBytes := testResPreimage[:]
 	var fakePreimage lntypes.Preimage
 	copy(fakePreimage[:], fakePreimageBytes)
 
@@ -920,7 +924,7 @@ func TestHtlcTimeoutSecondStageRemoteSpend(t *testing.T) {
 		TxOut: []*wire.TxOut{},
 	}
 
-	fakePreimageBytes := bytes.Repeat([]byte{1}, lntypes.HashSize)
+	fakePreimageBytes := testResPreimage[:]
 	var fakePreimage lntypes.Preimage
 	copy(fakePreimage[:], fakePreimageBytes)
 
@@ -1292,7 +1296,7 @@ func TestHtlcTimeoutSecondStageSweeperRemoteSpend(t *testing.T) {
 		TxOut: []*wire.TxOut{{}},
 	}
 
-	fakePreimageBytes := bytes.Repeat([]byte{1}, lntypes.HashSize)
+	fakePreimageBytes := testResPreimage[:]
 	var fakePreimage lntypes.Preimage
 	copy(fakePreimage[:], fakePreimageBytes)
 
@@ -1680,5 +1684,53 @@ func TestClaimCleanUpTaprootBreachAnnex(t *testing.T) {
 
 	err := resolver.claimCleanUp(spend)
 	require.ErrorContains(t, err, "breach attempt failed")
+	require.False(t, resolver.IsResolved())
+}
+
+// TestClaimCleanUpPreimageMismatch tests that a witness which merely has the
+// shape of a success spend cannot inject a foreign preimage. The classifier
+// only asserts the element at the preimage index is 32 bytes, so claimCleanUp
+// has to confirm the preimage actually opens this HTLC.
+func TestClaimCleanUpPreimageMismatch(t *testing.T) {
+	t.Parallel()
+
+	var preimage lntypes.Preimage
+	copy(preimage[:], preimageBytes)
+
+	// Build a resolver whose HTLC is locked to an entirely different
+	// payment hash than the one the spending witness reveals.
+	var otherHash lntypes.Hash
+	copy(otherHash[:], bytes.Repeat([]byte{9}, lntypes.HashSize))
+
+	resolver := &htlcTimeoutResolver{
+		htlcResolution: lnwallet.OutgoingHtlcResolution{
+			SweepSignDesc: input.SignDescriptor{
+				Output: &wire.TxOut{},
+			},
+		},
+		htlc: channeldb.HTLC{RHash: otherHash},
+	}
+
+	// A remote-commitment success spend on a legacy channel, carrying a
+	// well-formed preimage for some other payment.
+	spendingTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{{
+			Witness: wire.TxWitness{
+				dummyBytes, dummyBytes, dummyBytes,
+				preimageBytes, dummyBytes,
+			},
+		}},
+	}
+	spend := &chainntnfs.SpendDetail{SpendingTx: spendingTx}
+
+	// The witness passes the shape check, so this is exactly the input
+	// claimCleanUp would be handed in practice.
+	require.True(t, isPreimageSpend(false, spend, false))
+
+	err := resolver.claimCleanUp(spend)
+	require.ErrorIs(t, err, errPreimageMismatch)
+
+	// Nothing should have been resolved off the back of a foreign
+	// preimage.
 	require.False(t, resolver.IsResolved())
 }

--- a/contractcourt/htlc_timeout_resolver_test.go
+++ b/contractcourt/htlc_timeout_resolver_test.go
@@ -1505,11 +1505,16 @@ func TestCheckSizeAndIndex(t *testing.T) {
 func TestIsPreimageSpend(t *testing.T) {
 	t.Parallel()
 
+	// annexBytes is a minimal but valid BIP341 annex: a single element
+	// leading with the 0x50 tag.
+	annexBytes := []byte{txscript.TaprootAnnexTag}
+
 	testCases := []struct {
 		name        string
 		witness     wire.TxWitness
 		isTaproot   bool
 		localCommit bool
+		expected    bool
 	}{
 		{
 			// Test a preimage spend on the remote commitment for
@@ -1521,6 +1526,20 @@ func TestIsPreimageSpend(t *testing.T) {
 			},
 			isTaproot:   true,
 			localCommit: false,
+			expected:    true,
+		},
+		{
+			// The same spend with an annex appended. The spender
+			// chooses whether to include one, so it must not
+			// change how we classify the spend.
+			name: "tap preimage spend on remote with annex",
+			witness: wire.TxWitness{
+				dummyBytes, dummyBytes, preimageBytes,
+				dummyBytes, dummyBytes, annexBytes,
+			},
+			isTaproot:   true,
+			localCommit: false,
+			expected:    true,
 		},
 		{
 			// Test a preimage spend on the local commitment for
@@ -1532,6 +1551,26 @@ func TestIsPreimageSpend(t *testing.T) {
 			},
 			isTaproot:   true,
 			localCommit: true,
+			expected:    true,
+		},
+		{
+			name: "tap preimage spend on local with annex",
+			witness: wire.TxWitness{
+				dummyBytes, preimageBytes,
+				dummyBytes, dummyBytes, annexBytes,
+			},
+			isTaproot:   true,
+			localCommit: true,
+			expected:    true,
+		},
+		{
+			// An annex must not turn a key spend into something
+			// that looks like a preimage spend.
+			name:        "tap key spend with annex",
+			witness:     wire.TxWitness{dummyBytes, annexBytes},
+			isTaproot:   true,
+			localCommit: true,
+			expected:    false,
 		},
 		{
 			// Test a preimage spend on the remote commitment for
@@ -1543,6 +1582,7 @@ func TestIsPreimageSpend(t *testing.T) {
 			},
 			isTaproot:   false,
 			localCommit: false,
+			expected:    true,
 		},
 		{
 			// Test a preimage spend on the local commitment for
@@ -1553,6 +1593,20 @@ func TestIsPreimageSpend(t *testing.T) {
 			},
 			isTaproot:   false,
 			localCommit: true,
+			expected:    true,
+		},
+		{
+			// The annex is a taproot concept only. On a legacy
+			// spend the final element is the witness script, so a
+			// script that happens to lead with 0x50 must be left
+			// on the stack.
+			name: "legacy witness script leading with annex tag",
+			witness: wire.TxWitness{
+				dummyBytes, preimageBytes, annexBytes,
+			},
+			isTaproot:   false,
+			localCommit: true,
+			expected:    true,
 		},
 	}
 
@@ -1577,7 +1631,54 @@ func TestIsPreimageSpend(t *testing.T) {
 			result := isPreimageSpend(
 				tc.isTaproot, spend, tc.localCommit,
 			)
-			require.True(t, result)
+			require.Equal(t, tc.expected, result)
 		})
 	}
+}
+
+// TestClaimCleanUpTaprootBreachAnnex tests that an annex on a taproot key
+// spend doesn't hide the fact that we're on the losing side of a breach. The
+// key spend path is a lone signature, so the annex has to come off before the
+// stack is counted.
+func TestClaimCleanUpTaprootBreachAnnex(t *testing.T) {
+	t.Parallel()
+
+	// A v1 witness program, so the resolver treats this as taproot.
+	taprootPkScript := append(
+		[]byte{txscript.OP_1, 0x20},
+		bytes.Repeat([]byte{1}, lntypes.HashSize)...,
+	)
+
+	// A local commitment, so claimCleanUp reaches the breach check rather
+	// than the remote sweep cases above it.
+	resolver := &htlcTimeoutResolver{
+		htlcResolution: lnwallet.OutgoingHtlcResolution{
+			SweepSignDesc: input.SignDescriptor{
+				Output: &wire.TxOut{PkScript: taprootPkScript},
+			},
+			SignedTimeoutTx: &wire.MsgTx{
+				TxIn: []*wire.TxIn{{}},
+			},
+		},
+		htlc: channeldb.HTLC{RHash: testResHash},
+	}
+
+	// A key spend carrying an annex. The annex is preimage sized, so
+	// without stripping it would be read as the preimage.
+	spendingTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{{
+			Witness: wire.TxWitness{
+				dummyBytes,
+				append(
+					[]byte{txscript.TaprootAnnexTag},
+					bytes.Repeat([]byte{7}, 31)...,
+				),
+			},
+		}},
+	}
+	spend := &chainntnfs.SpendDetail{SpendingTx: spendingTx}
+
+	err := resolver.claimCleanUp(spend)
+	require.ErrorContains(t, err, "breach attempt failed")
+	require.False(t, resolver.IsResolved())
 }

--- a/contractcourt/mock_htlcnotifier_test.go
+++ b/contractcourt/mock_htlcnotifier_test.go
@@ -7,9 +7,20 @@ import (
 
 type mockHTLCNotifier struct {
 	HtlcNotifier
+
+	finalHtlcEvents []finalHtlcEvent
+}
+
+type finalHtlcEvent struct {
+	key  models.CircuitKey
+	info channeldb.FinalHtlcInfo
 }
 
 func (m *mockHTLCNotifier) NotifyFinalHtlcEvent(key models.CircuitKey,
 	info channeldb.FinalHtlcInfo) {
 
+	m.finalHtlcEvents = append(m.finalHtlcEvents, finalHtlcEvent{
+		key:  key,
+		info: info,
+	})
 }

--- a/docs/release-notes/release-notes-0.20.4.md
+++ b/docs/release-notes/release-notes-0.20.4.md
@@ -35,6 +35,10 @@
   overflowing offset and limit combinations without reaching a slice-bounds
   panic.
 
+* [Fixed an issue](https://github.com/lightningnetwork/lnd/pull/10869) where an
+  incoming HTLC resolver could treat a foreign commitment spend as its own
+  success transaction and offer a phantom input to the sweeper.
+
 # New Features
 
 ## Functional Enhancements

--- a/docs/release-notes/release-notes-0.21.3.md
+++ b/docs/release-notes/release-notes-0.21.3.md
@@ -35,6 +35,10 @@
   overflowing offset and limit combinations without reaching a slice-bounds
   panic.
 
+* [Fixed an issue](https://github.com/lightningnetwork/lnd/pull/10869) where an
+  incoming HTLC resolver could treat a foreign commitment spend as its own
+  success transaction and offer a phantom input to the sweeper.
+
 # New Features
 
 ## Functional Enhancements

--- a/input/script_utils.go
+++ b/input/script_utils.go
@@ -429,6 +429,25 @@ func SenderHtlcSpendRevoke(signer Signer, signDesc *SignDescriptor,
 	return SenderHtlcSpendRevokeWithKey(signer, signDesc, revokeKey, sweepTx)
 }
 
+// StripTaprootAnnex removes the BIP341 annex from a Taproot witness stack if
+// one is present, returning the stack as the script interpreter sees it. The
+// caller must only use this for a Taproot spend because earlier witness
+// versions treat the final element as the witness script.
+func StripTaprootAnnex(witness wire.TxWitness) wire.TxWitness {
+	if len(witness) < 2 {
+		return witness
+	}
+
+	lastElement := witness[len(witness)-1]
+	if len(lastElement) == 0 ||
+		lastElement[0] != txscript.TaprootAnnexTag {
+
+		return witness
+	}
+
+	return witness[:len(witness)-1]
+}
+
 // IsHtlcSpendRevoke is used to determine if the passed spend is spending a
 // HTLC output using the revocation key.
 func IsHtlcSpendRevoke(txIn *wire.TxIn, signDesc *SignDescriptor) (

--- a/input/script_utils.go
+++ b/input/script_utils.go
@@ -454,10 +454,11 @@ func IsHtlcSpendRevoke(txIn *wire.TxIn, signDesc *SignDescriptor) (
 	bool, error) {
 
 	// For taproot channels, the revocation path only has a single witness,
-	// as that's the key spend path.
+	// as that's the key spend path. A spender is free to append an annex,
+	// so we normalize the stack before counting its elements.
 	isTaproot := txscript.IsPayToTaproot(signDesc.Output.PkScript)
 	if isTaproot {
-		return len(txIn.Witness) == 1, nil
+		return len(StripTaprootAnnex(txIn.Witness)) == 1, nil
 	}
 
 	revokeKey, err := deriveRevokePubKey(signDesc)

--- a/input/script_utils_test.go
+++ b/input/script_utils_test.go
@@ -2375,3 +2375,68 @@ func TestTaprootHtlcScriptGeneration(t *testing.T) {
 		"receiver success leaf should be identical across variants",
 	)
 }
+
+// TestStripTaprootAnnex tests the exact BIP341 annex predicate.
+func TestStripTaprootAnnex(t *testing.T) {
+	t.Parallel()
+
+	stack := wire.TxWitness{{txscript.OP_TRUE}}
+	testCases := []struct {
+		name     string
+		witness  wire.TxWitness
+		expected wire.TxWitness
+	}{
+		{
+			name: "single byte",
+			witness: append(
+				stack, []byte{txscript.TaprootAnnexTag},
+			),
+			expected: stack,
+		},
+		{
+			name: "payload",
+			witness: append(
+				stack, []byte{txscript.TaprootAnnexTag, 1},
+			),
+			expected: stack,
+		},
+		{
+			name:     "single element",
+			witness:  wire.TxWitness{{txscript.TaprootAnnexTag}},
+			expected: wire.TxWitness{{txscript.TaprootAnnexTag}},
+		},
+		{
+			name:     "empty",
+			witness:  append(stack, nil),
+			expected: append(stack, nil),
+		},
+		{
+			name: "non annex",
+			witness: append(
+				stack, []byte{txscript.OP_TRUE},
+			),
+			expected: append(stack, []byte{txscript.OP_TRUE}),
+		},
+		{
+			name: "strips one annex",
+			witness: append(
+				stack, []byte{txscript.TaprootAnnexTag},
+				[]byte{txscript.TaprootAnnexTag},
+			),
+			expected: append(
+				stack, []byte{txscript.TaprootAnnexTag},
+			),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(
+				t, testCase.expected,
+				StripTaprootAnnex(testCase.witness),
+			)
+		})
+	}
+}

--- a/input/script_utils_test.go
+++ b/input/script_utils_test.go
@@ -2440,3 +2440,64 @@ func TestStripTaprootAnnex(t *testing.T) {
 		})
 	}
 }
+
+// TestIsHtlcSpendRevokeTaprootAnnex tests that a taproot revocation spend is
+// still recognized when the spender appends an annex to the key spend witness.
+func TestIsHtlcSpendRevokeTaprootAnnex(t *testing.T) {
+	t.Parallel()
+
+	taprootPkScript := append(
+		[]byte{txscript.OP_1, 0x20}, bytes.Repeat([]byte{1}, 32)...,
+	)
+	signDesc := &SignDescriptor{
+		Output: &wire.TxOut{PkScript: taprootPkScript},
+	}
+
+	dummySigBytes := bytes.Repeat([]byte{2}, 64)
+
+	testCases := []struct {
+		name     string
+		witness  wire.TxWitness
+		expected bool
+	}{
+		{
+			name:     "key spend",
+			witness:  wire.TxWitness{dummySigBytes},
+			expected: true,
+		},
+		{
+			name: "key spend with annex",
+			witness: wire.TxWitness{
+				dummySigBytes,
+				{txscript.TaprootAnnexTag},
+			},
+			expected: true,
+		},
+		{
+			name: "script path spend",
+			witness: wire.TxWitness{
+				dummySigBytes, {txscript.OP_TRUE},
+			},
+			expected: false,
+		},
+		{
+			name: "script path spend with annex",
+			witness: wire.TxWitness{
+				dummySigBytes, {txscript.OP_TRUE},
+				{txscript.TaprootAnnexTag},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			txIn := &wire.TxIn{Witness: tc.witness}
+			isRevoke, err := IsHtlcSpendRevoke(txIn, signDesc)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, isRevoke)
+		})
+	}
+}


### PR DESCRIPTION
Part of #10840.

## Summary

- validate that a commitment HTLC spend creates the exact second-level success output before offering it to the sweeper
- classify legacy and taproot direct spends by witness path, including BIP341 annex-bearing success spends
- checkpoint foreign spends as terminal timeout outcomes without leaving phantom inputs, balances, or notifications
- reject malformed notifier or resolver spend details and verify terminal notifications use the expected circuit key

Ordered incoming HTLC expiry follow-up: #10990.

Delayed missing-input batch isolation is implemented in #10842.

## Testing

- `go test ./contractcourt`
- `go test -race ./contractcourt`
- `go vet ./contractcourt`
- `make lint-source`
- `git diff d7d2aad11d612022c70c776b01a003f989b61c60..HEAD --check`