### PR TITLE
lint: reactivate several disabled linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,7 +114,6 @@ linters:
     - testifylint
     - perfsprint
     - inamedparam
-    - copyloopvar
     - tagalign
     - protogetter
     - revive

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,15 +46,28 @@ linters:
     # Init functions are used by loggers throughout the codebase.
     - gochecknoinits
 
-    # Deprecated linters. See https://golangci-lint.run/usage/linters/.
-    - bodyclose
+    # contextcheck requires threading context.Context through many existing
+    # function signatures (including test harnesses), so we leave it off for
+    # now.
     - contextcheck
-    - nilerr
-    - noctx
-    - rowserrcheck
-    - sqlclosecheck
+
+    # tparallel requires adding t.Parallel() to a large number of existing
+    # subtests, which can surface shared-state races. Disabled until we can
+    # address it carefully.
     - tparallel
+
+    # unparam has a sizeable backlog of unused parameters to clean up before it
+    # can be enabled.
     - unparam
+
+    # nilerr is too noisy for our code base: most reports are intentional error
+    # swallowing (documented with comments) or false positives where a boolean
+    # check is mistaken for an error check.
+    - nilerr
+
+    # noctx would only flag a couple of interface methods and a test helper that
+    # have no context to thread through, so it adds little value for now.
+    - noctx
 
     # Disable whitespace linters as it has conflict rules against our
     # contribution guidelines.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,7 +55,6 @@ linters:
     - sqlclosecheck
     - tparallel
     - unparam
-    - wastedassign
 
     # Disable whitespace linters as it has conflict rules against our
     # contribution guidelines.

--- a/aliasmgr/aliasmgr_test.go
+++ b/aliasmgr/aliasmgr_test.go
@@ -259,7 +259,6 @@ func TestGetNextScid(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			nextScid := getNextScid(test.current)
 			require.Equal(t, test.expected, nextScid)

--- a/amp/derivation_test.go
+++ b/amp/derivation_test.go
@@ -43,7 +43,6 @@ var sharerTests = []sharerTest{
 // receiver, produce identical child hashes and preimages as the sender.
 func TestSharer(t *testing.T) {
 	for _, test := range sharerTests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/autopilot/betweenness_centrality_test.go
+++ b/autopilot/betweenness_centrality_test.go
@@ -40,7 +40,6 @@ func TestBetweennessCentralityEmptyGraph(t *testing.T) {
 	)
 
 	for _, chanGraph := range chanGraphs {
-		chanGraph := chanGraph
 		graph, err := chanGraph.genFunc(t)
 		require.NoError(t, err, "unable to create graph")
 
@@ -83,7 +82,6 @@ func TestBetweennessCentralityWithNonEmptyGraph(t *testing.T) {
 
 	for _, numWorkers := range workers {
 		for _, chanGraph := range chanGraphs {
-			chanGraph := chanGraph
 			numWorkers := numWorkers
 			graph, err := chanGraph.genFunc(t)
 			require.NoError(t, err, "unable to create graph")
@@ -110,7 +108,6 @@ func TestBetweennessCentralityWithNonEmptyGraph(t *testing.T) {
 				require.NoError(t1, err)
 
 				for _, expected := range tests {
-					expected := expected
 					centrality := metric.GetMetric(
 						expected.normalize,
 					)

--- a/autopilot/prefattach_test.go
+++ b/autopilot/prefattach_test.go
@@ -91,7 +91,6 @@ func TestPrefAttachmentSelectEmptyGraph(t *testing.T) {
 	}
 
 	for _, chanGraph := range chanGraphs {
-		chanGraph := chanGraph
 		graph, err := chanGraph.genFunc(t)
 		require.NoError(t, err, "unable to create graph")
 
@@ -128,7 +127,6 @@ func TestPrefAttachmentSelectTwoVertexes(t *testing.T) {
 	)
 
 	for _, chanGraph := range chanGraphs {
-		chanGraph := chanGraph
 		graph, err := chanGraph.genFunc(t)
 		require.NoError(t, err, "unable to create graph")
 
@@ -215,7 +213,6 @@ func TestPrefAttachmentSelectGreedyAllocation(t *testing.T) {
 	)
 
 	for _, chanGraph := range chanGraphs {
-		chanGraph := chanGraph
 		graph, err := chanGraph.genFunc(t)
 		require.NoError(t, err, "unable to create graph")
 
@@ -328,7 +325,6 @@ func TestPrefAttachmentSelectSkipNodes(t *testing.T) {
 	)
 
 	for _, chanGraph := range chanGraphs {
-		chanGraph := chanGraph
 		graph, err := chanGraph.genFunc(t)
 		require.NoError(t, err, "unable to create graph")
 

--- a/autopilot/top_centrality_test.go
+++ b/autopilot/top_centrality_test.go
@@ -83,7 +83,6 @@ func TestTopCentrality(t *testing.T) {
 	}
 
 	for _, chanGraph := range chanGraphs {
-		chanGraph := chanGraph
 
 		success := t.Run(chanGraph.name, func(t1 *testing.T) {
 			t1.Parallel()

--- a/build/log_test.go
+++ b/build/log_test.go
@@ -92,7 +92,6 @@ func TestParseAndSetDebugLevels(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			m := &mockSubLogger{
 				subLogLevels: make(map[string]string),

--- a/chainntnfs/mempool.go
+++ b/chainntnfs/mempool.go
@@ -298,8 +298,6 @@ func (m *MempoolNotifier) notifySpent(spentInputs inputsWithTx) {
 
 	// Iterate the spent inputs to notify the subscribers concurrently.
 	for op, tx := range spentInputs {
-		op, tx := op, tx
-
 		m.wg.Add(1)
 		go notifyAll(tx, op)
 	}

--- a/chainntnfs/txnotifier_test.go
+++ b/chainntnfs/txnotifier_test.go
@@ -172,7 +172,6 @@ func TestTxNotifierRegistrationValidation(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		success := t.Run(testCase.name, func(t *testing.T) {
 			hintCache := newMockHintCache()
 			n := chainntnfs.NewTxNotifier(

--- a/chainntnfs/txnotifier_test.go
+++ b/chainntnfs/txnotifier_test.go
@@ -1942,14 +1942,18 @@ func TestTxNotifierConfirmHintCache(t *testing.T) {
 	// the height hints should remain unchanged. This simulates blocks
 	// confirming while the historical dispatch is processing the
 	// registration.
-	hint, err := hintCache.QueryConfirmHint(ntfn1.HistoricalDispatch.ConfRequest)
+	_, err = hintCache.QueryConfirmHint(
+		ntfn1.HistoricalDispatch.ConfRequest,
+	)
 	if err != chainntnfs.ErrConfirmHintNotFound {
 		t.Fatalf("unexpected error when querying for height hint "+
 			"want: %v, got %v",
 			chainntnfs.ErrConfirmHintNotFound, err)
 	}
 
-	hint, err = hintCache.QueryConfirmHint(ntfn2.HistoricalDispatch.ConfRequest)
+	_, err = hintCache.QueryConfirmHint(
+		ntfn2.HistoricalDispatch.ConfRequest,
+	)
 	if err != chainntnfs.ErrConfirmHintNotFound {
 		t.Fatalf("unexpected error when querying for height hint "+
 			"want: %v, got %v",
@@ -1978,7 +1982,9 @@ func TestTxNotifierConfirmHintCache(t *testing.T) {
 	// Now that both notifications are waiting at tip for confirmations,
 	// they should have their height hints updated to the latest block
 	// height.
-	hint, err = hintCache.QueryConfirmHint(ntfn1.HistoricalDispatch.ConfRequest)
+	hint, err := hintCache.QueryConfirmHint(
+		ntfn1.HistoricalDispatch.ConfRequest,
+	)
 	require.NoError(t, err, "unable to query for hint")
 	if hint != tx1Height {
 		t.Fatalf("expected hint %d, got %d",

--- a/chanacceptor/acceptor_test.go
+++ b/chanacceptor/acceptor_test.go
@@ -134,8 +134,6 @@ func (c *channelAcceptorCtx) queryAndAssert(queries map[*lnwire.OpenChannel]*Cha
 	)
 
 	for request, expected := range queries {
-		request := request
-		expected := expected
 
 		go func() {
 			resp := c.acceptor.Accept(&ChannelAcceptRequest{

--- a/chanacceptor/merge_test.go
+++ b/chanacceptor/merge_test.go
@@ -182,7 +182,6 @@ func TestMergeResponse(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			resp, err := mergeResponse(test.current, test.new)

--- a/chanacceptor/rpcacceptor_test.go
+++ b/chanacceptor/rpcacceptor_test.go
@@ -118,7 +118,6 @@ func TestValidateAcceptorResponse(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			// Create an acceptor, everything can be nil because

--- a/chanbackup/backupfile_test.go
+++ b/chanbackup/backupfile_test.go
@@ -431,7 +431,6 @@ func TestCreateArchiveFile(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			defer os.RemoveAll(archiveDir)
 			if tc.setup != nil {

--- a/chanfitness/chanevent_test.go
+++ b/chanfitness/chanevent_test.go
@@ -388,7 +388,6 @@ func TestGetOnlinePeriod(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -545,7 +544,6 @@ func TestUptime(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			score := &peerLog{

--- a/chanfitness/chaneventstore_test.go
+++ b/chanfitness/chaneventstore_test.go
@@ -57,7 +57,6 @@ func TestStartStoreError(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			clock := clock.NewTestClock(testNow)

--- a/chanfitness/rate_limit_test.go
+++ b/chanfitness/rate_limit_test.go
@@ -39,7 +39,6 @@ func TestGetRateLimit(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -91,7 +90,6 @@ func TestCooldownFlapCount(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -566,7 +566,6 @@ func TestOptionalShutdown(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			fullDB, err := MakeTestDB(t)
@@ -1325,7 +1324,6 @@ func TestShutdownInfo(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -1513,7 +1511,6 @@ func TestCloseInitiator(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -1634,7 +1631,6 @@ func TestHasChanStatus(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			c := &OpenChannel{
@@ -1817,7 +1813,6 @@ func TestHTLCsExtraData(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()

--- a/channeldb/db_test.go
+++ b/channeldb/db_test.go
@@ -594,7 +594,6 @@ func TestFetchChannels(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/channeldb/height_hint.go
+++ b/channeldb/height_hint.go
@@ -91,7 +91,6 @@ func (c *HeightHintCache) CommitSpendHint(height uint32,
 		}
 
 		for _, spendRequest := range spendRequests {
-			spendRequest := spendRequest
 			spendHintKey, err := spendHintKey(&spendRequest)
 			if err != nil {
 				return err
@@ -161,7 +160,6 @@ func (c *HeightHintCache) PurgeSpendHint(
 		}
 
 		for _, spendRequest := range spendRequests {
-			spendRequest := spendRequest
 			spendHintKey, err := spendHintKey(&spendRequest)
 			if err != nil {
 				return err
@@ -198,7 +196,6 @@ func (c *HeightHintCache) CommitConfirmHint(height uint32,
 		}
 
 		for _, confRequest := range confRequests {
-			confRequest := confRequest
 			confHintKey, err := confHintKey(&confRequest)
 			if err != nil {
 				return err
@@ -269,7 +266,6 @@ func (c *HeightHintCache) PurgeConfirmHint(
 		}
 
 		for _, confRequest := range confRequests {
-			confRequest := confRequest
 			confHintKey, err := confHintKey(&confRequest)
 			if err != nil {
 				return err

--- a/channeldb/invoices.go
+++ b/channeldb/invoices.go
@@ -938,7 +938,6 @@ func (k *kvInvoiceUpdater) storeAddHtlcsUpdate() error {
 	// As we don't update the settle index above for AMP invoices, we'll do
 	// it here for each sub-AMP invoice that was settled.
 	for settledSetID := range k.settledSetIDs {
-		settledSetID := settledSetID
 		err := k.setSettleMetaFields(&settledSetID)
 		if err != nil {
 			return err
@@ -1862,7 +1861,6 @@ func ampStateEncoder(w io.Writer, val interface{}, buf *[8]byte) error {
 		// inner length prefix.
 		for setID, ampState := range *v {
 			setID := [32]byte(setID)
-			ampState := ampState
 
 			htlcState := uint8(ampState.State)
 			settleDate := ampState.SettleDate

--- a/channeldb/meta_test.go
+++ b/channeldb/meta_test.go
@@ -547,7 +547,7 @@ func TestApplyOptionalVersions(t *testing.T) {
 	require.Equal(t, 0, migrateCount, "expected no migration")
 
 	// Check the optional meta is not updated.
-	om, err := db.fetchOptionalMeta()
+	_, err = db.fetchOptionalMeta()
 	require.NoError(t, err, "error getting optional meta")
 
 	// Enable all optional migrations.
@@ -563,7 +563,7 @@ func TestApplyOptionalVersions(t *testing.T) {
 	)
 
 	// Fetch the updated optional meta.
-	om, err = db.fetchOptionalMeta()
+	om, err := db.fetchOptionalMeta()
 	require.NoError(t, err, "error getting optional meta")
 
 	// Verify that the optional meta is updated as expected.

--- a/channeldb/migration/create_tlb_test.go
+++ b/channeldb/migration/create_tlb_test.go
@@ -37,7 +37,6 @@ func TestCreateTLB(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			migtest.ApplyMigration(
 				t,

--- a/channeldb/migration12/migration_test.go
+++ b/channeldb/migration12/migration_test.go
@@ -192,7 +192,6 @@ func genAfterMigration(afterBytes []byte) func(kvdb.RwTx) error {
 // final struct, but verifies that the field is properly removed.
 func TestTLVInvoiceMigration(t *testing.T) {
 	for _, test := range migrationTests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			migtest.ApplyMigration(
 				t,

--- a/channeldb/migration16/migration_test.go
+++ b/channeldb/migration16/migration_test.go
@@ -105,7 +105,6 @@ func TestMigrateSequenceIndex(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			// Before the migration we have a payments bucket.

--- a/channeldb/migration23/migration_test.go
+++ b/channeldb/migration23/migration_test.go
@@ -155,7 +155,6 @@ func TestMigrateHtlcAttempts(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		migtest.ApplyMigration(
 			t,

--- a/channeldb/migration25/migration_test.go
+++ b/channeldb/migration25/migration_test.go
@@ -229,7 +229,6 @@ func TestMigrateInitialBalances(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			migtest.ApplyMigration(
 				t,

--- a/channeldb/migration26/migration_test.go
+++ b/channeldb/migration26/migration_test.go
@@ -85,7 +85,6 @@ func TestMigrateBalancesToTlvRecords(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		// Before running the test, set the balance fields based on the
 		// test params.

--- a/channeldb/migration27/migration_test.go
+++ b/channeldb/migration27/migration_test.go
@@ -97,7 +97,6 @@ func TestMigrateHistoricalBalances(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		// testChannel is used to test the balance fields are correctly
 		// set.

--- a/channeldb/migration30/iterator_test.go
+++ b/channeldb/migration30/iterator_test.go
@@ -123,7 +123,6 @@ func TestLocateChanBucket(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			err := testLocator(tc.locator)
 			require.Equal(t, tc.expectedErr, err)
@@ -283,7 +282,6 @@ func TestFindNextMigrateHeight(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			// Create a test channel.
 			c := createTestChannel(nil)
@@ -658,7 +656,6 @@ func TestLocalNextUpdateNum(t *testing.T) {
 		cdb, err := migtest.MakeDB(t)
 		require.NoError(t, err)
 
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup the test case.
 			c, height := tc.setup(cdb)

--- a/channeldb/migration30/migration_test.go
+++ b/channeldb/migration30/migration_test.go
@@ -78,7 +78,6 @@ func TestMigrateRevocationLog(t *testing.T) {
 	fmt.Printf("withAmtData is set to: %v\n", withAmtData)
 
 	for i, tc := range testCases {
-		tc := tc
 
 		// Construct a test case name that can be easily traced.
 		name := fmt.Sprintf("case_%d", i)
@@ -169,7 +168,6 @@ func TestValidateMigration(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		// Create a test db.
 		cdb, err := migtest.MakeDB(t)

--- a/channeldb/migration35/migration_test.go
+++ b/channeldb/migration35/migration_test.go
@@ -186,8 +186,6 @@ func TestMigrateWaitingProofStore(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/channeldb/reports_test.go
+++ b/channeldb/reports_test.go
@@ -46,7 +46,6 @@ func TestPersistReport(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			db, err := MakeTestDB(t)
@@ -193,7 +192,6 @@ func TestFetchChannelWriteBucket(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			db, err := MakeTestDB(t)

--- a/channeldb/revocation_log_test.go
+++ b/channeldb/revocation_log_test.go
@@ -341,7 +341,6 @@ func TestSerializeAndDeserializeRevLog(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -586,7 +585,6 @@ func TestPutRevocationLog(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		fullDB, err := MakeTestDB(t)
 		require.NoError(t, err)
@@ -686,7 +684,6 @@ func TestFetchRevocationLogCompatible(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		fullDB, err := MakeTestDB(t)
 		require.NoError(t, err)

--- a/channeldb/waitingproof_test.go
+++ b/channeldb/waitingproof_test.go
@@ -129,8 +129,6 @@ func TestWaitingProofV2RoundTrip(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/cmd/commands/commands.go
+++ b/cmd/commands/commands.go
@@ -769,7 +769,6 @@ func listUnspent(ctx *cli.Context) error {
 			cli.ShowCommandHelp(ctx, "listunspent")
 			return nil
 		}
-		args = args.Tail()
 	}
 
 	unconfirmedOnly := ctx.Bool("unconfirmed_only")

--- a/cmd/commands/walletrpc_active.go
+++ b/cmd/commands/walletrpc_active.go
@@ -2013,7 +2013,6 @@ func signMessageWithAddr(ctx *cli.Context) error {
 
 	case ctx.Args().Present():
 		msg = []byte(args.First())
-		args = args.Tail()
 
 	default:
 		return fmt.Errorf("msg argument missing")
@@ -2121,7 +2120,6 @@ func verifyMessageWithAddr(ctx *cli.Context) error {
 
 	case ctx.Args().Present():
 		msg = []byte(args.First())
-		args = args.Tail()
 
 	default:
 		return fmt.Errorf("msg argument missing")

--- a/config_onion_ratelimit_test.go
+++ b/config_onion_ratelimit_test.go
@@ -73,7 +73,6 @@ func TestValidateOnionMsgLimiter(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			err := validateOnionMsgLimiter(

--- a/contractcourt/breach_arbitrator.go
+++ b/contractcourt/breach_arbitrator.go
@@ -912,7 +912,6 @@ Loop:
 			}
 
 			for _, tx := range justiceTxs.spendSecondLevelHTLCs {
-				tx := tx
 
 				brarLog.Debugf("Broadcasting justice tx "+
 					"spending second-level HTLC output: %v",

--- a/contractcourt/briefcase.go
+++ b/contractcourt/briefcase.go
@@ -1582,7 +1582,6 @@ func encodeTaprootAuxData(w io.Writer, c *ContractResolutions) error {
 
 	htlcBlobs := newAuxHtlcBlobs()
 	for _, htlc := range c.HtlcResolutions.IncomingHTLCs {
-		htlc := htlc
 
 		htlcSignDesc := htlc.SweepSignDesc
 		ctrlBlock := htlcSignDesc.ControlBlock
@@ -1619,7 +1618,6 @@ func encodeTaprootAuxData(w io.Writer, c *ContractResolutions) error {
 		})
 	}
 	for _, htlc := range c.HtlcResolutions.OutgoingHTLCs {
-		htlc := htlc
 
 		htlcSignDesc := htlc.SweepSignDesc
 		ctrlBlock := htlcSignDesc.ControlBlock

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -1359,7 +1359,6 @@ func (c *ChainArbitrator) loadOpenChannels() error {
 	// ChannelArbitrator.
 	for _, channel := range openChannels {
 		chanPoint := channel.FundingOutpoint
-		channel := channel
 
 		// First, we'll create an active chainWatcher for this channel
 		// to ensure that we detect any relevant on chain events.

--- a/contractcourt/chain_watcher_coop_reorg_test.go
+++ b/contractcourt/chain_watcher_coop_reorg_test.go
@@ -132,7 +132,6 @@ func TestChainWatcherCoopCloseScaledConfirmationsWithReorg(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/contractcourt/chain_watcher_test.go
+++ b/contractcourt/chain_watcher_test.go
@@ -499,7 +499,6 @@ func TestChainWatcherDataLossProtect(t *testing.T) {
 		testName := fmt.Sprintf("num_updates=%v,broadcast_state_num=%v",
 			testCase.NumUpdates, testCase.BroadcastStateNum)
 
-		testCase := testCase
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
@@ -724,7 +723,6 @@ func TestChainWatcherLocalForceCloseDetect(t *testing.T) {
 			testCase.localOutputOnly,
 		)
 
-		testCase := testCase
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -615,7 +615,6 @@ func maybeAugmentTaprootResolvers(chanType channeldb.ChannelType,
 		//nolint:ll
 		htlcResolutions := contractResolutions.HtlcResolutions.OutgoingHTLCs
 		for _, htlcRes := range htlcResolutions {
-			htlcRes := htlcRes
 
 			if r.htlcResolution.ClaimOutpoint ==
 				htlcRes.ClaimOutpoint {
@@ -628,7 +627,6 @@ func maybeAugmentTaprootResolvers(chanType channeldb.ChannelType,
 		//nolint:ll
 		htlcResolutions := contractResolutions.HtlcResolutions.OutgoingHTLCs
 		for _, htlcRes := range htlcResolutions {
-			htlcRes := htlcRes
 
 			if r.htlcResolution.ClaimOutpoint ==
 				htlcRes.ClaimOutpoint {
@@ -641,7 +639,6 @@ func maybeAugmentTaprootResolvers(chanType channeldb.ChannelType,
 		//nolint:ll
 		htlcResolutions := contractResolutions.HtlcResolutions.IncomingHTLCs
 		for _, htlcRes := range htlcResolutions {
-			htlcRes := htlcRes
 
 			if r.htlcResolution.ClaimOutpoint ==
 				htlcRes.ClaimOutpoint {
@@ -653,7 +650,6 @@ func maybeAugmentTaprootResolvers(chanType channeldb.ChannelType,
 		//nolint:ll
 		htlcResolutions := contractResolutions.HtlcResolutions.IncomingHTLCs
 		for _, htlcRes := range htlcResolutions {
-			htlcRes := htlcRes
 
 			if r.htlcResolution.ClaimOutpoint ==
 				htlcRes.ClaimOutpoint {
@@ -724,7 +720,6 @@ func (c *ChannelArbitrator) relaunchResolvers(commitSet *CommitSet,
 	// order to ensure we have complete coverage.
 	htlcMap := make(map[wire.OutPoint]*channeldb.HTLC)
 	for _, htlc := range confirmedHTLCs {
-		htlc := htlc
 		outpoint := wire.OutPoint{
 			Hash:  commitHash,
 			Index: uint32(htlc.OutputIndex),
@@ -2450,7 +2445,6 @@ func (c *ChannelArbitrator) prepContractResolutions(
 		// claim the HTLC (second-level or directly), then add the pre
 		case HtlcClaimAction:
 			for _, htlc := range htlcs {
-				htlc := htlc
 
 				htlcOp := wire.OutPoint{
 					Hash:  commitHash,
@@ -2481,7 +2475,6 @@ func (c *ChannelArbitrator) prepContractResolutions(
 		// backwards.
 		case HtlcTimeoutAction:
 			for _, htlc := range htlcs {
-				htlc := htlc
 
 				htlcOp := wire.OutPoint{
 					Hash:  commitHash,
@@ -2518,7 +2511,6 @@ func (c *ChannelArbitrator) prepContractResolutions(
 		// learn of the pre-image, or let the remote party time out.
 		case HtlcIncomingWatchAction:
 			for _, htlc := range htlcs {
-				htlc := htlc
 
 				htlcOp := wire.OutPoint{
 					Hash:  commitHash,
@@ -2551,7 +2543,6 @@ func (c *ChannelArbitrator) prepContractResolutions(
 		// backwards), or just timeout.
 		case HtlcOutgoingWatchAction:
 			for _, htlc := range htlcs {
-				htlc := htlc
 
 				htlcOp := wire.OutPoint{
 					Hash:  commitHash,

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -1678,7 +1678,6 @@ func TestChannelArbitratorCommitFailure(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		test := test
 
 		log := &mockArbitratorLog{
 			state:      StateDefault,
@@ -1889,7 +1888,6 @@ func TestChannelArbitratorDanglingCommitForceClose(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		testName := fmt.Sprintf("testCase: htlcExpired=%v,"+
 			"remotePendingHTLC=%v,remotePendingCommitConf=%v",
 			testCase.htlcExpired, testCase.remotePendingHTLC,
@@ -2214,7 +2212,6 @@ func TestRemoteCloseInitiator(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -2479,7 +2476,6 @@ func TestFindCommitmentDeadlineAndValue(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			// Mock the method `FindOutgoingHTLCDeadline`.
 			tc.mockFindOutgoingHTLCDeadline()
@@ -3074,7 +3070,6 @@ func TestChannelArbitratorStartForceCloseFail(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/contractcourt/commit_sweep_resolver_test.go
+++ b/contractcourt/commit_sweep_resolver_test.go
@@ -348,7 +348,6 @@ func TestCommitSweepResolverDelay(t *testing.T) {
 	}}
 
 	for _, tc := range testCases {
-		tc := tc
 		ok := t.Run(tc.name, func(t *testing.T) {
 			testCommitSweepResolverDelay(t, tc.sweepErr)
 		})

--- a/contractcourt/htlc_timeout_resolver_test.go
+++ b/contractcourt/htlc_timeout_resolver_test.go
@@ -1488,7 +1488,6 @@ func TestCheckSizeAndIndex(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -1558,7 +1557,6 @@ func TestIsPreimageSpend(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		// Run the test.
 		t.Run(tc.name, func(t *testing.T) {

--- a/contractcourt/taproot_briefcase.go
+++ b/contractcourt/taproot_briefcase.go
@@ -167,7 +167,6 @@ func (r *resolverCtrlBlocks) Encode(w io.Writer) error {
 	}
 
 	for id, ctrlBlock := range *r {
-		ctrlBlock := ctrlBlock
 
 		if _, err := w.Write(id[:]); err != nil {
 			return err
@@ -486,7 +485,6 @@ func (h *htlcTapTweaks) Encode(w io.Writer) error {
 	}
 
 	for id, tweak := range *h {
-		tweak := tweak
 
 		if _, err := w.Write(id[:]); err != nil {
 			return err

--- a/contractcourt/utxonursery_test.go
+++ b/contractcourt/utxonursery_test.go
@@ -687,7 +687,6 @@ func TestRejectedCribTransaction(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -1386,8 +1385,6 @@ func TestPatchZeroHeightHint(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1457,7 +1457,6 @@ func (d *AuthenticatedGossiper) sendRemoteBatch(ctx context.Context,
 	}
 
 	for _, msgChunk := range annBatch {
-		msgChunk := msgChunk
 
 		// With the syncers taken care of, we'll merge the sender map
 		// with the set of syncers, so we don't send out duplicate

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -222,14 +222,12 @@ func (r *mockGraphSource) ForAllOutgoingChannels(_ context.Context,
 
 	chans := make(map[uint64]graphdb.ChannelEdge)
 	for _, info := range r.infos {
-		info := info
 
 		edgeInfo := chans[info.ChannelID]
 		edgeInfo.Info = &info
 		chans[info.ChannelID] = edgeInfo
 	}
 	for _, edges := range r.edges {
-		edges := edges
 
 		edge := chans[edges[0].ChannelID]
 		edge.Policy1 = &edges[0]

--- a/discovery/syncer_test.go
+++ b/discovery/syncer_test.go
@@ -2296,7 +2296,6 @@ func TestGossipSyncerSyncTransitions(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -2626,7 +2625,6 @@ func TestGossipSyncerStateHandlerErrors(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/feature/deps_test.go
+++ b/feature/deps_test.go
@@ -150,7 +150,6 @@ var depTests = []depTest{
 // dependencies.
 func TestValidateDeps(t *testing.T) {
 	for _, test := range depTests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testValidateDeps(t, test)
 		})

--- a/feature/manager_internal_test.go
+++ b/feature/manager_internal_test.go
@@ -65,7 +65,6 @@ var managerTests = []managerTest{
 // including that the proper features are removed in response to config changes.
 func TestManager(t *testing.T) {
 	for _, test := range managerTests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testManager(t, test)
 		})
@@ -260,7 +259,6 @@ func TestUpdateFeatureSets(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/funding/batch.go
+++ b/funding/batch.go
@@ -301,7 +301,6 @@ func (b *Batcher) BatchFund(ctx context.Context,
 
 		// Launch a goroutine that waits for the initial response on
 		// either the update or error chan.
-		channel := channel
 		eg.Go(func() error {
 			return b.waitForUpdate(channel, true)
 		})
@@ -415,7 +414,6 @@ func (b *Batcher) BatchFund(ctx context.Context,
 	for _, channel := range b.channels {
 		// Launch another goroutine that waits for the channel pending
 		// response on the update chan.
-		channel := channel
 		eg.Go(func() error {
 			return b.waitForUpdate(channel, false)
 		})

--- a/funding/batch_test.go
+++ b/funding/batch_test.go
@@ -343,7 +343,6 @@ func TestBatchFund(t *testing.T) {
 	}}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/funding/commitment_type_negotiation_test.go
+++ b/funding/commitment_type_negotiation_test.go
@@ -499,7 +499,6 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		ok := t.Run(testCase.name, func(t *testing.T) {
 			localFeatures := lnwire.NewFeatureVector(
 				testCase.localFeatures, lnwire.Features,

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -3609,7 +3609,6 @@ func TestFundingManagerInvalidChanReserve(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -4355,7 +4354,6 @@ func TestFundingManagerFundMax(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -4464,7 +4462,6 @@ func TestGetUpfrontShutdownScript(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			var mockPeer testNode
@@ -4742,7 +4739,6 @@ func TestFundingManagerUpfrontShutdown(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			testUpfrontFailure(t, test.pkscript, test.expectErr)

--- a/graph/builder_test.go
+++ b/graph/builder_test.go
@@ -2074,7 +2074,7 @@ func createTestGraphFromChannels(t *testing.T, useCache bool,
 			}
 		}
 
-		channelID++ //nolint:ineffassign
+		channelID++ //nolint:ineffassign,wastedassign
 	}
 
 	return &testGraphInstance{

--- a/graph/builder_test.go
+++ b/graph/builder_test.go
@@ -1106,8 +1106,6 @@ func TestIsZombieChannel(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
-
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -252,8 +252,6 @@ func TestVersionedDBs(t *testing.T) {
 
 	// Run all v1 tests.
 	for _, vt := range versionedTests {
-		vt := vt
-
 		t.Run(vt.name+"/v1", func(t *testing.T) {
 			vt.test(t, lnwire.GossipVersion1)
 		})
@@ -1954,7 +1952,6 @@ func TestGraphCacheTraversal(t *testing.T) {
 	// properly been reached.
 	numNodeChans := 0
 	for _, node := range nodeList {
-		node := node
 
 		err := graph.ForEachNodeDirectedChannel(
 			ctx, node.PubKeyBytes, func(d *DirectedChannel) error {
@@ -4142,7 +4139,6 @@ func TestStressTestChannelGraphAPI(t *testing.T) {
 	)
 
 	for i := 0; i < concurrencyLevel; i++ {
-		i := i
 
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			t.Parallel()
@@ -4347,7 +4343,6 @@ func TestFilterChannelRange(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/htlcswitch/hop/iterator_test.go
+++ b/htlcswitch/hop/iterator_test.go
@@ -139,7 +139,6 @@ func TestForwardingAmountCalc(t *testing.T) {
 	}
 
 	for _, testCase := range tests {
-		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()

--- a/htlcswitch/hop/payload_test.go
+++ b/htlcswitch/hop/payload_test.go
@@ -758,7 +758,6 @@ func TestValidateBlindedRouteData(t *testing.T) {
 	}
 
 	for _, testCase := range tests {
-		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			err := hop.ValidateBlindedRouteData(

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -922,7 +922,6 @@ func TestChannelLinkCancelFullCommitment(t *testing.T) {
 
 	// Now, settle all htlcs held by bob and clear the commitment of htlcs.
 	for _, preimage := range preimages {
-		preimage := preimage
 
 		// It's possible that the HTLCs have not been delivered to the
 		// invoice registry at this point, so we poll until we are able

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -441,7 +441,6 @@ func TestSwitchForwardMapping(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			testSwitchForwardMapping(
@@ -661,7 +660,6 @@ func TestSwitchSendHTLCMapping(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			testSwitchSendHtlcMapping(
@@ -1917,7 +1915,6 @@ func TestCircularForwards(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -2099,7 +2096,6 @@ func TestCheckCircularForward(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -2183,7 +2179,6 @@ func TestSkipIneligibleLinksMultiHopForward(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testSkipIneligibleLinksMultiHopForward(t, &test)
 		})
@@ -3371,7 +3366,6 @@ func TestHtlcNotifier(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			testHtcNotifier(
@@ -4864,7 +4858,6 @@ func TestSwitchForwardFailAlias(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			testSwitchForwardFailAlias(t, test.zeroConf)
@@ -5074,7 +5067,6 @@ func TestSwitchAliasFailAdd(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			testSwitchAliasFailAdd(
@@ -5263,7 +5255,6 @@ func TestSwitchHandlePacketForward(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			testSwitchHandlePacketForward(
@@ -5420,7 +5411,6 @@ func TestSwitchAliasInterceptFail(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			testSwitchAliasInterceptFail(t, test.zeroConf)

--- a/input/musig2_test.go
+++ b/input/musig2_test.go
@@ -178,7 +178,6 @@ func TestMuSig2CombineKeys(t *testing.T) {
 	}}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(tt *testing.T) {
 			tt.Parallel()
 

--- a/input/size_test.go
+++ b/input/size_test.go
@@ -1579,7 +1579,6 @@ var witnessSizeTests = []witnessSizeTest{
 // aren't under estimating or our transactions could get stuck.
 func TestWitnessSizes(t *testing.T) {
 	for _, test := range witnessSizeTests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			size := test.genWitness(t).SerializeSize()
 			if size != test.expSize {
@@ -1793,7 +1792,6 @@ var txSizeTests = []txSizeTest{
 // TestTxSizes asserts the correctness of our magic tx size constants.
 func TestTxSizes(t *testing.T) {
 	for _, test := range txSizeTests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			tx := test.genTx(t)
 

--- a/input/taproot_test.go
+++ b/input/taproot_test.go
@@ -388,8 +388,6 @@ func testTaprootSenderHtlcSpend(t *testing.T, auxLeaf AuxTapLeaf,
 	}
 
 	for i, testCase := range testCases {
-		i := i
-		testCase := testCase
 
 		spendTxCopy := spendTx.Copy()
 
@@ -883,8 +881,6 @@ func testTaprootReceiverHtlcSpend(t *testing.T, auxLeaf AuxTapLeaf,
 		},
 	}
 	for i, testCase := range testCases {
-		i := i
-		testCase := testCase
 		spendTxCopy := spendTx.Copy()
 
 		t.Run(testCase.name, func(t *testing.T) {
@@ -1225,8 +1221,6 @@ func testTaprootCommitScriptToSelf(t *testing.T, auxLeaf AuxTapLeaf,
 	}
 
 	for i, testCase := range testCases {
-		i := i
-		testCase := testCase
 		spendTxCopy := spendTx.Copy()
 
 		t.Run(testCase.name, func(t *testing.T) {
@@ -1439,8 +1433,6 @@ func testTaprootCommitScriptRemote(t *testing.T, auxLeaf AuxTapLeaf,
 	}
 
 	for i, testCase := range testCases {
-		i := i
-		testCase := testCase
 		spendTxCopy := spendTx.Copy()
 
 		t.Run(testCase.name, func(t *testing.T) {
@@ -1695,8 +1687,6 @@ func TestTaprootAnchorScript(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		i := i
-		testCase := testCase
 		spendTxCopy := spendTx.Copy()
 
 		t.Run(testCase.name, func(t *testing.T) {
@@ -1984,8 +1974,6 @@ func testTaprootSecondLevelHtlcScript(t *testing.T, auxLeaf AuxTapLeaf,
 	}
 
 	for i, testCase := range testCases {
-		i := i
-		testCase := testCase
 		spendTxCopy := spendTx.Copy()
 
 		t.Run(testCase.name, func(t *testing.T) {

--- a/internal/musig2v040/musig2_test.go
+++ b/internal/musig2v040/musig2_test.go
@@ -1048,7 +1048,6 @@ func testMultiPartySign(t *testing.T, taprootTweak []byte,
 	// signer.
 	var wg sync.WaitGroup
 	for i, signCtx := range signers {
-		signCtx := signCtx
 
 		wg.Add(1)
 		go func(idx int, signer *Session) {

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -196,7 +196,6 @@ func (i *InvoiceRegistry) scanInvoicesOnStart(ctx context.Context) error {
 
 	var pending []invoiceExpiry
 	for paymentHash, invoice := range pendingInvoices {
-		invoice := invoice
 		expiryRef := makeInvoiceExpiry(paymentHash, &invoice)
 		if expiryRef != nil {
 			pending = append(pending, expiryRef)
@@ -509,7 +508,6 @@ func (i *InvoiceRegistry) deliverBacklogEvents(ctx context.Context,
 	for _, addEvent := range addEvents {
 		// We re-bind the loop variable to ensure we don't hold onto
 		// the loop reference causing is to point to the same item.
-		addEvent := addEvent
 
 		select {
 		case client.ntfnQueue.ChanIn() <- &invoiceEvent{
@@ -523,7 +521,6 @@ func (i *InvoiceRegistry) deliverBacklogEvents(ctx context.Context,
 	for _, settleEvent := range settleEvents {
 		// We re-bind the loop variable to ensure we don't hold onto
 		// the loop reference causing is to point to the same item.
-		settleEvent := settleEvent
 
 		select {
 		case client.ntfnQueue.ChanIn() <- &invoiceEvent{

--- a/invoices/invoiceregistry_test.go
+++ b/invoices/invoiceregistry_test.go
@@ -159,7 +159,6 @@ func TestInvoiceRegistry(t *testing.T) {
 	}
 
 	for _, test := range testList {
-		test := test
 
 		t.Run(test.name+"_KV", func(t *testing.T) {
 			test.test(t, makeKeyValueDB)
@@ -1924,7 +1923,6 @@ func testSpontaneousAmpPayment(t *testing.T,
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testSpontaneousAmpPaymentImpl(
 				t, test.ampEnabled, test.failReconstruction,

--- a/invoices/invoices_test.go
+++ b/invoices/invoices_test.go
@@ -261,7 +261,6 @@ func TestInvoices(t *testing.T) {
 	}
 
 	for _, test := range testList {
-		test := test
 		t.Run(test.name+"_KV", func(t *testing.T) {
 			test.test(t, makeKeyValueDB)
 		})
@@ -340,7 +339,6 @@ func testInvoiceWorkflow(t *testing.T,
 	t.Parallel()
 
 	for _, test := range invWorkflowTests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			testInvoiceWorkflowImpl(t, test, makeDB)
@@ -2618,7 +2616,6 @@ func testUpdateHTLCPreimages(t *testing.T,
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			testUpdateHTLCPreimagesImpl(t, test, makeDB)

--- a/invoices/invoices_test.go
+++ b/invoices/invoices_test.go
@@ -2813,7 +2813,7 @@ func testDeleteCanceledInvoices(t *testing.T,
 
 		// Cancel every second invoice.
 		if i%2 == 0 {
-			invoice, err = db.UpdateInvoice(
+			_, err = db.UpdateInvoice(
 				ctxb, invpkg.InvoiceRefByHash(paymentHash), nil,
 				updateFunc,
 			)

--- a/invoices/kv_sql_migration_test.go
+++ b/invoices/kv_sql_migration_test.go
@@ -134,7 +134,6 @@ func TestMigrationWithChannelDB(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			var kvStore *channeldb.DB
 

--- a/invoices/update_invoice_test.go
+++ b/invoices/update_invoice_test.go
@@ -744,7 +744,6 @@ func TestUpdateHTLC(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testUpdateHTLC(t, test, testNow)
 		})

--- a/itest/lnd_channel_force_close_test.go
+++ b/itest/lnd_channel_force_close_test.go
@@ -997,7 +997,7 @@ func runChannelForceClosureTestRestart(ht *lntest.HarnessTest,
 	sweeps = ht.AssertNumPendingSweeps(alice, 2)
 	commitSweep, anchorSweep := sweeps[0], sweeps[1]
 	if commitSweep.AmountSat < anchorSweep.AmountSat {
-		commitSweep, anchorSweep = anchorSweep, commitSweep
+		commitSweep = anchorSweep
 	}
 
 	// Alice's sweeping transaction should now be broadcast. So we fetch the

--- a/itest/lnd_coop_close_rbf_test.go
+++ b/itest/lnd_coop_close_rbf_test.go
@@ -157,7 +157,6 @@ func testCoopCloseRbf(ht *lntest.HarnessTest) {
 	}
 
 	for _, chanType := range channelTypes {
-		chanType := chanType
 		ht.Run(chanType.name, func(t1 *testing.T) {
 			st := ht.Subtest(t1)
 			// Set the fee estimate to 1sat/vbyte. This ensures that

--- a/itest/lnd_coop_close_with_htlcs_test.go
+++ b/itest/lnd_coop_close_with_htlcs_test.go
@@ -72,7 +72,6 @@ func testCoopCloseWithHtlcs(ht *lntest.HarnessTest) {
 	testCases := createFlagCombos()
 
 	for _, testCase := range testCases {
-		testCase := testCase // Capture range variable.
 		ht.Run(testCase.testName, func(t *testing.T) {
 			tt := ht.Subtest(t)
 
@@ -94,7 +93,6 @@ func testCoopCloseWithHtlcsWithRestart(ht *lntest.HarnessTest) {
 	testCases := createFlagCombos()
 
 	for _, testCase := range testCases {
-		testCase := testCase // Capture range variable.
 		ht.Run(testCase.testName, func(t *testing.T) {
 			tt := ht.Subtest(t)
 

--- a/itest/lnd_etcd_failover_test.go
+++ b/itest/lnd_etcd_failover_test.go
@@ -47,7 +47,6 @@ func testEtcdFailover(ht *lntest.HarnessTest) {
 	}}
 
 	for _, test := range testCases {
-		test := test
 
 		success := ht.Run(test.name, func(t1 *testing.T) {
 			st := ht.Subtest(t1)

--- a/itest/lnd_forward_delete_test.go
+++ b/itest/lnd_forward_delete_test.go
@@ -43,7 +43,6 @@ func testDeleteForwardingHistory(ht *lntest.HarnessTest) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		success := ht.Run(tc.name, func(t *testing.T) {
 			st := ht.Subtest(t)
 			tc.test(st)

--- a/itest/lnd_macaroons_test.go
+++ b/itest/lnd_macaroons_test.go
@@ -391,7 +391,6 @@ func testMacaroonAuthentication(ht *lntest.HarnessTest) {
 	}}
 
 	for _, tc := range testCases {
-		tc := tc
 		ht.Run(tc.name, func(tt *testing.T) {
 			ctxt, cancel := context.WithTimeout(
 				ht.Context(), defaultTimeout,
@@ -607,7 +606,6 @@ func testBakeMacaroon(ht *lntest.HarnessTest) {
 	}}
 
 	for _, tc := range testCases {
-		tc := tc
 		ht.Run(tc.name, func(tt *testing.T) {
 			ctxt, cancel := context.WithTimeout(
 				ht.Context(), defaultTimeout,

--- a/itest/lnd_nonstd_sweep_test.go
+++ b/itest/lnd_nonstd_sweep_test.go
@@ -62,7 +62,6 @@ func testNonstdSweep(ht *lntest.HarnessTest) {
 	}
 
 	for _, test := range tests {
-		test := test
 		success := ht.Run(test.name, func(t *testing.T) {
 			st := ht.Subtest(t)
 

--- a/itest/lnd_psbt_test.go
+++ b/itest/lnd_psbt_test.go
@@ -1920,7 +1920,7 @@ func testPsbtChanFundingWithUnstableUtxos(ht *lntest.HarnessTest) {
 	// Consume the "channel pending" update. This waits until the funding
 	// transaction was fully compiled.
 	updateResp = ht.ReceiveOpenChannelUpdate(chanUpdates)
-	upd, ok = updateResp.Update.(*lnrpc.OpenStatusUpdate_ChanPending)
+	_, ok = updateResp.Update.(*lnrpc.OpenStatusUpdate_ChanPending)
 	require.True(ht, ok)
 
 	err = finalTx.Deserialize(bytes.NewReader(finalizeRes.RawFinalTx))

--- a/itest/lnd_rest_api_test.go
+++ b/itest/lnd_rest_api_test.go
@@ -221,14 +221,12 @@ func testRestAPI(ht *lntest.HarnessTest) {
 	alice := ht.NewNodeWithCoins("Alice", args)
 
 	for _, tc := range testCases {
-		tc := tc
 		ht.Run(tc.name, func(t *testing.T) {
 			tc.run(t, alice, bob)
 		})
 	}
 
 	for _, tc := range wsTestCases {
-		tc := tc
 		ht.Run(tc.name, func(t *testing.T) {
 			st := ht.Subtest(t)
 			tc.run(st)

--- a/itest/lnd_rpc_middleware_interceptor_test.go
+++ b/itest/lnd_rpc_middleware_interceptor_test.go
@@ -205,7 +205,6 @@ func middlewareRegistrationRestrictionTests(t *testing.T,
 	}}
 
 	for idx, tc := range testCases {
-		tc := tc
 
 		t.Run(fmt.Sprintf("%d", idx), func(tt *testing.T) {
 			invalidName := registerMiddleware(

--- a/itest/lnd_test.go
+++ b/itest/lnd_test.go
@@ -128,7 +128,6 @@ func TestLightningNetworkDaemon(t *testing.T) {
 
 	// Run the subset of the test cases selected in this tranche.
 	for idx, testCase := range testCases {
-		testCase := testCase
 		name := fmt.Sprintf("tranche%02d/%02d-of-%d/%s/%s",
 			trancheIndex, trancheOffset+uint(idx)+1,
 			len(allTestCases), harnessTest.ChainBackendName(),

--- a/itest/lnd_wallet_import_test.go
+++ b/itest/lnd_wallet_import_test.go
@@ -646,7 +646,6 @@ func testWalletImportPubKey(ht *lntest.HarnessTest) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		success := ht.Run(tc.name, func(tt *testing.T) {
 			testFunc := func(ht *lntest.HarnessTest) {
 				testWalletImportPubKeyScenario(

--- a/itest/lnd_zero_conf_test.go
+++ b/itest/lnd_zero_conf_test.go
@@ -281,7 +281,6 @@ func testOptionScidAlias(ht *lntest.HarnessTest) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		success := ht.Run(testCase.name, func(t *testing.T) {
 			st := ht.Subtest(t)
 			optionScidAliasScenario(

--- a/keychain/interface_test.go
+++ b/keychain/interface_test.go
@@ -345,7 +345,7 @@ func TestSecretKeyRingDerivation(t *testing.T) {
 
 				// If we attempt to query for this key, then we
 				// should get ErrCannotDerivePrivKey.
-				privKey, err = secretKeyRing.DerivePrivKey(
+				_, err = secretKeyRing.DerivePrivKey(
 					keyDesc,
 				)
 				if err != ErrCannotDerivePrivKey {

--- a/lnencrypt/crypto_test.go
+++ b/lnencrypt/crypto_test.go
@@ -66,9 +66,7 @@ func TestEncryptDecryptPayload(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, payloadCase := range payloadCases {
-		payloadCase := payloadCase
 		for _, enc := range []*Encrypter{keyRingEnc, privKeyEnc} {
-			enc := enc
 
 			// First, we'll encrypt the passed payload with our
 			// scheme.

--- a/lnrpc/devrpc/dev_server.go
+++ b/lnrpc/devrpc/dev_server.go
@@ -270,7 +270,6 @@ func (s *Server) ImportGraph(ctx context.Context,
 	}
 
 	for _, rpcEdge := range graph.Edges {
-		rpcEdge := rpcEdge
 
 		node1, err := parsePubKey(rpcEdge.Node1Pub)
 		if err != nil {

--- a/lnrpc/invoicesrpc/addinvoice_test.go
+++ b/lnrpc/invoicesrpc/addinvoice_test.go
@@ -448,7 +448,6 @@ var shouldIncludeChannelTestCases = []struct {
 
 func TestShouldIncludeChannel(t *testing.T) {
 	for _, tc := range shouldIncludeChannelTestCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -514,7 +513,6 @@ var sufficientHintsTestCases = []struct {
 
 func TestSufficientHints(t *testing.T) {
 	for _, tc := range sufficientHintsTestCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -881,7 +879,6 @@ func setupMockTwoChannels(h *hopHintsConfigMock) (lnwire.ChannelID,
 
 func TestPopulateHopHints(t *testing.T) {
 	for _, tc := range populateHopHintsTestCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/lnrpc/routerrpc/parse_duration_test.go
+++ b/lnrpc/routerrpc/parse_duration_test.go
@@ -128,7 +128,6 @@ func TestParseDuration(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/lnrpc/routerrpc/router_backend_test.go
+++ b/lnrpc/routerrpc/router_backend_test.go
@@ -337,7 +337,6 @@ func TestUnmarshalMPP(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testUnmarshalMPP(t, test)
 		})
@@ -447,7 +446,6 @@ func TestUnmarshalAMP(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testUnmarshalAMP(t, test)
 		})

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -2273,7 +2273,6 @@ func (w *WalletKit) handleChange(packet *psbt.Packet, changeIndex int32,
 func marshallLeases(locks []*base.ListLeasedOutputResult) []*UtxoLease {
 	rpcLocks := make([]*UtxoLease, len(locks))
 	for idx, lock := range locks {
-		lock := lock
 
 		rpcLocks[idx] = &UtxoLease{
 			Id:         lock.LockID[:],

--- a/lnrpc/walletrpc/walletkit_server_test.go
+++ b/lnrpc/walletrpc/walletkit_server_test.go
@@ -43,8 +43,6 @@ func TestWitnessTypeMapping(t *testing.T) {
 	for witnessType, witnessTypeProto := range allWitnessTypes {
 		// Redeclare to avoid loop variables being captured
 		// by func literal.
-		witnessType := witnessType
-		witnessTypeProto := witnessTypeProto
 
 		t.Run(witnessType.String(), func(tt *testing.T) {
 			tt.Parallel()
@@ -629,7 +627,6 @@ func TestFundPsbtCoinSelect(t *testing.T) {
 	}}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		privKey, err := btcec.NewPrivateKey()
 		require.NoError(t, err)

--- a/lnrpc/walletrpc/walletkit_util_test.go
+++ b/lnrpc/walletrpc/walletkit_util_test.go
@@ -55,7 +55,6 @@ func TestParseDerivationPath(t *testing.T) {
 	}}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(tt *testing.T) {
 			result, err := parseDerivationPath(tc.path)

--- a/lnutils/fs_test.go
+++ b/lnutils/fs_test.go
@@ -66,7 +66,6 @@ func TestCreateDir(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			dir := tc.setup()
 			defer os.RemoveAll(dir)

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -618,7 +618,6 @@ func (b *BtcWallet) ListAccounts(name string,
 			return nil, err
 		}
 		for _, account := range accounts.Accounts {
-			account := account
 			res = append(res, &account.AccountProperties)
 		}
 
@@ -631,7 +630,6 @@ func (b *BtcWallet) ListAccounts(name string,
 				return nil, err
 			}
 			for _, account := range accounts.Accounts {
-				account := account
 				res = append(res, &account.AccountProperties)
 			}
 		}
@@ -644,7 +642,6 @@ func (b *BtcWallet) ListAccounts(name string,
 			return nil, err
 		}
 		for _, account := range accounts.Accounts {
-			account := account
 			res = append(res, &account.AccountProperties)
 		}
 	}

--- a/lnwallet/btcwallet/psbt_test.go
+++ b/lnwallet/btcwallet/psbt_test.go
@@ -277,7 +277,6 @@ func TestSignPsbt(t *testing.T) {
 	}}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		// This is the private key we're going to sign with.
 		privKey, err := w.deriveKeyByBIP32Path(tc.inputType.keyPath())
@@ -465,7 +464,6 @@ func TestEstimateInputWeight(t *testing.T) {
 		input.WitnessHeaderSize
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(tt *testing.T) {
 			estimator := input.TxWeightEstimator{}
@@ -551,7 +549,6 @@ func TestBip32DerivationFromKeyDesc(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(tt *testing.T) {
 			d, trD, path := Bip32DerivationFromKeyDesc(
@@ -607,7 +604,6 @@ func TestBip32DerivationFromAddress(t *testing.T) {
 
 	w, _ := newTestWallet(t, netParams, seedBytes)
 	for _, tc := range testCases {
-		tc := tc
 
 		addr, err := w.NewAddress(
 			tc.addrType, false, lnwallet.DefaultAccountName,

--- a/lnwallet/btcwallet/signer_test.go
+++ b/lnwallet/btcwallet/signer_test.go
@@ -188,7 +188,6 @@ func TestBip32KeyDerivation(t *testing.T) {
 
 	// Let's go through the test cases now that we know our wallet is ready.
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			privKey, err := w.deriveKeyByBIP32Path(tc.path)
@@ -513,7 +512,6 @@ func TestMaybeTweakPrivKey(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			// Create a sign descriptor with the test tweaks.
 			signDesc := &input.SignDescriptor{

--- a/lnwallet/chainfee/estimator_test.go
+++ b/lnwallet/chainfee/estimator_test.go
@@ -261,7 +261,6 @@ func TestWebAPIFeeEstimator(t *testing.T) {
 	require.NoError(t, estimator.Start(), "unable to start fee estimator")
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			est, err := estimator.EstimateFeePerKW(tc.target)
 
@@ -361,7 +360,6 @@ func TestGetCachedFee(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			cachedFee, err := estimator.getCachedFee(tc.confTarget)

--- a/lnwallet/chainfee/filtermanager_test.go
+++ b/lnwallet/chainfee/filtermanager_test.go
@@ -35,7 +35,6 @@ func TestFeeFilterMedian(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			cb := func() ([]SatPerKWeight, error) {
 				return nil, nil

--- a/lnwallet/chancloser/chancloser_test.go
+++ b/lnwallet/chancloser/chancloser_test.go
@@ -123,7 +123,6 @@ func TestMaybeMatchScript(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -361,7 +360,6 @@ func TestMaxFeeClamp(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -398,7 +396,6 @@ func TestMaxFeeBailOut(t *testing.T) {
 	)
 
 	for _, isInitiator := range []bool{true, false} {
-		isInitiator := isInitiator
 
 		t.Run(fmt.Sprintf("initiator=%v", isInitiator), func(t *testing.T) {
 			t.Parallel()
@@ -494,7 +491,6 @@ func TestParseUpfrontShutdownAddress(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/lnwallet/chanfunding/coin_select_test.go
+++ b/lnwallet/chanfunding/coin_select_test.go
@@ -123,7 +123,6 @@ func TestCalculateFees(t *testing.T) {
 	fundingOutputEstimate.AddP2WSHOutput()
 
 	for _, test := range testCases {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			feeNoChange, feeWithChange, err := calculateFees(
 				test.utxos, feeRate, fundingOutputEstimate,
@@ -309,7 +308,6 @@ func TestCoinSelect(t *testing.T) {
 	fundingOutputEstimate.AddP2WSHOutput()
 
 	for _, test := range testCases {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -451,7 +449,6 @@ func TestCalculateChangeAmount(t *testing.T) {
 	}}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(tt *testing.T) {
 			changeAmt, needMore, err := CalculateChangeAmount(
 				tc.totalInputAmt, tc.requiredAmt,
@@ -644,7 +641,6 @@ func TestCoinSelectSubtractFees(t *testing.T) {
 	fundingOutputEstimate.AddP2WSHOutput()
 
 	for _, test := range testCases {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			feeRate := feeRate
@@ -893,7 +889,6 @@ func TestCoinSelectUpToAmount(t *testing.T) {
 	fundingOutputEstimate.AddP2WSHOutput()
 
 	for _, test := range testCases {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/lnwallet/chanfunding/psbt_assembler_test.go
+++ b/lnwallet/chanfunding/psbt_assembler_test.go
@@ -456,7 +456,6 @@ func TestPsbtVerify(t *testing.T) {
 
 	// Loop through all our test cases.
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			// Reset the state from a previous test and create a new
 			// pending PSBT that we can manipulate.
@@ -622,7 +621,6 @@ func TestPsbtFinalize(t *testing.T) {
 
 	// Loop through all our test cases.
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			// Reset the state from a previous test and create a new
 			// pending PSBT that we can manipulate.
@@ -739,7 +737,6 @@ func TestVerifyAllInputsSegWit(t *testing.T) {
 	}}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			r := strings.NewReader(tc.packet)

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -9059,8 +9059,7 @@ func NewAnchorResolution(chanState *channeldb.OpenChannel,
 		return nil, err
 	}
 	if chanState.ChanType.IsTaproot() && whoseCommit.IsRemote() {
-		//nolint:ineffassign
-		localAnchor, remoteAnchor = remoteAnchor, localAnchor
+		localAnchor = remoteAnchor
 	}
 
 	// TODO(roasbeef): remote anchor not needed above

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -603,8 +603,6 @@ func (lc *LightningChannel) extractPayDescs(feeRate chainfee.SatPerKWeight,
 		// persist state w.r.t to if forwarded or not, or can
 		// inadvertently trigger replays
 
-		htlc := htlc
-
 		auxLeaf := fn.FlatMapOption(
 			func(l CommitAuxLeaves) input.AuxTapLeaf {
 				leaves := l.OutgoingHtlcLeaves
@@ -1774,7 +1772,6 @@ func (lc *LightningChannel) restorePendingRemoteUpdates(
 		len(unsignedAckedUpdates))
 
 	for _, logUpdate := range unsignedAckedUpdates {
-		logUpdate := logUpdate
 
 		payDesc, err := lc.remoteLogUpdateToPayDesc(
 			&logUpdate, lc.updateLogs.Local, localCommitmentHeight,
@@ -1854,7 +1851,6 @@ func (lc *LightningChannel) restorePeerLocalUpdates(updates []channeldb.LogUpdat
 		len(updates))
 
 	for _, logUpdate := range updates {
-		logUpdate := logUpdate
 
 		payDesc, err := lc.localLogUpdateToPayDesc(
 			&logUpdate, lc.updateLogs.Remote,
@@ -1908,7 +1904,6 @@ func (lc *LightningChannel) restorePendingLocalUpdates(
 	// If we did have a dangling commit, then we'll examine which updates
 	// we included in that state and re-insert them into our update log.
 	for _, logUpdate := range pendingRemoteCommitDiff.LogUpdates {
-		logUpdate := logUpdate
 
 		payDesc, err := lc.logUpdateToPayDesc(
 			&logUpdate, lc.updateLogs.Remote, pendingHeight,
@@ -8189,7 +8184,6 @@ func extractHtlcResolutions(feePerKw chainfee.SatPerKWeight,
 	incomingResolutions := make([]IncomingHtlcResolution, 0, len(htlcs))
 	outgoingResolutions := make([]OutgoingHtlcResolution, 0, len(htlcs))
 	for _, htlc := range htlcs {
-		htlc := htlc
 
 		// We'll skip any HTLC's which were dust on the commitment
 		// transaction, as these don't have a corresponding output

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -1384,7 +1384,6 @@ func TestForceCloseDustOutput(t *testing.T) {
 
 	htlcAmount := lnwire.NewMSatFromSatoshis(500)
 
-	aliceAmount := aliceChannel.channelState.LocalCommitment.LocalBalance
 	bobAmount := bobChannel.channelState.LocalCommitment.LocalBalance
 
 	// Have Bobs' to-self output be below her dust limit and check
@@ -1409,8 +1408,7 @@ func TestForceCloseDustOutput(t *testing.T) {
 		t.Fatalf("Can't update the channel state: %v", err)
 	}
 
-	aliceAmount = aliceChannel.channelState.LocalCommitment.LocalBalance
-	bobAmount = bobChannel.channelState.LocalCommitment.RemoteBalance
+	aliceAmount := aliceChannel.channelState.LocalCommitment.LocalBalance
 
 	closeSummary, err := aliceChannel.ForceClose()
 	require.NoError(t, err, "unable to force close channel")
@@ -7105,7 +7103,6 @@ func TestChanReserve(t *testing.T) {
 	//	Bob:	5.0
 	htlcAmt := lnwire.NewMSatFromSatoshis(0.5 * btcutil.SatoshiPerBitcoin)
 	htlc, _ := createHTLC(aliceIndex, htlcAmt)
-	aliceIndex++
 	addAndReceiveHTLC(t, aliceChannel, bobChannel, htlc, nil)
 
 	// Force a state transition, making sure this HTLC is considered valid
@@ -7127,7 +7124,6 @@ func TestChanReserve(t *testing.T) {
 	//	Alice:	4.5
 	//	Bob:	5.0
 	htlc, _ = createHTLC(bobIndex, htlcAmt)
-	bobIndex++
 	_, err := bobChannel.AddHTLC(htlc, nil)
 	require.ErrorIs(t, err, ErrBelowChanReserve)
 
@@ -7140,7 +7136,6 @@ func TestChanReserve(t *testing.T) {
 	aliceChannel, bobChannel = setupChannels()
 
 	aliceIndex = 0
-	bobIndex = 0
 
 	// Now we'll add HTLC of 3.5 BTC to Alice's commitment, this should put
 	// Alice's balance at 1.5 BTC.
@@ -7161,7 +7156,6 @@ func TestChanReserve(t *testing.T) {
 	// balance dip below.
 	htlcAmt = lnwire.NewMSatFromSatoshis(1 * btcutil.SatoshiPerBitcoin)
 	htlc, _ = createHTLC(aliceIndex, htlcAmt)
-	aliceIndex++
 	_, err = aliceChannel.AddHTLC(htlc, nil)
 	require.ErrorIs(t, err, ErrBelowChanReserve)
 
@@ -7182,7 +7176,6 @@ func TestChanReserve(t *testing.T) {
 	//	Bob:	7.0
 	htlcAmt = lnwire.NewMSatFromSatoshis(2 * btcutil.SatoshiPerBitcoin)
 	htlc, preimage := createHTLC(aliceIndex, htlcAmt)
-	aliceIndex++
 	aliceHtlcIndex, err := aliceChannel.AddHTLC(htlc, nil)
 	require.NoError(t, err, "unable to add htlc")
 	bobHtlcIndex, err := bobChannel.ReceiveHTLC(htlc)
@@ -7218,7 +7211,6 @@ func TestChanReserve(t *testing.T) {
 	// the fee this is okay.
 	htlcAmt = lnwire.NewMSatFromSatoshis(1 * btcutil.SatoshiPerBitcoin)
 	htlc, _ = createHTLC(bobIndex, htlcAmt)
-	bobIndex++
 	addAndReceiveHTLC(t, bobChannel, aliceChannel, htlc, nil)
 
 	// Do a last state transition, which should succeed.
@@ -7622,7 +7614,7 @@ func TestChannelRestoreUpdateLogs(t *testing.T) {
 	// and remote commit chains are updated in an async fashion. Since the
 	// remote chain was updated with the latest state (since Bob sent the
 	// revocation earlier) we can keep advancing the remote commit chain.
-	aliceNewCommit, err = aliceChannel.SignNextCommitment(ctxb)
+	_, err = aliceChannel.SignNextCommitment(ctxb)
 	require.NoError(t, err, "unable to sign commitment")
 
 	// After Alice has signed this commitment, her local commitment will

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -387,7 +387,6 @@ func TestSimpleAddSettleWorkflow(t *testing.T) {
 	t.Parallel()
 
 	for _, tweakless := range []bool{true, false} {
-		tweakless := tweakless
 
 		t.Run(fmt.Sprintf("tweakless=%v", tweakless), func(t *testing.T) {
 			testAddSettleWorkflow(t, tweakless, 0, false)
@@ -8927,7 +8926,6 @@ func TestFetchParent(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			// Create a lightning channel with newly initialized
@@ -9274,7 +9272,6 @@ func TestEvaluateView(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			isInitiator := test.channelInitiator == lntypes.Local
@@ -10312,7 +10309,6 @@ func TestCreateBreachRetribution(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			tx := spendTx
 			if tc.noSpendTx {
@@ -10741,7 +10737,6 @@ func TestApplyCommitmentFee(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			//nolint:ll
 			balance, bufferAmt, commitFee, err := tc.channel.applyCommitFee(

--- a/lnwallet/confscale_test.go
+++ b/lnwallet/confscale_test.go
@@ -262,7 +262,6 @@ func TestScaleNumConfsKnownValues(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			result := ScaleNumConfs(tc.chanAmt, tc.pushAmt)
 

--- a/lnwallet/parameters_test.go
+++ b/lnwallet/parameters_test.go
@@ -38,7 +38,6 @@ func TestDefaultRoutingFeeLimitForAmount(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(fmt.Sprintf("%d sats", test.amount), func(t *testing.T) {
 			feeLimit := DefaultRoutingFeeLimitForAmount(test.amount)
@@ -85,7 +84,6 @@ func TestDustLimitForSize(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			dustlimit := DustLimitForSize(test.size)

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -3540,8 +3540,6 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 	// wallet state after each step.
 	for _, walletTest := range walletTests {
 
-		walletTest := walletTest
-
 		testName := fmt.Sprintf("%v/%v:%v", walletType, backEnd,
 			walletTest.name)
 		success := t.Run(testName, func(t *testing.T) {

--- a/lnwallet/transactions_test.go
+++ b/lnwallet/transactions_test.go
@@ -226,7 +226,6 @@ func TestCommitmentAndHTLCTransactions(t *testing.T) {
 	}
 
 	for _, set := range vectorSets {
-		set := set
 
 		var testCases []testCase
 
@@ -237,7 +236,6 @@ func TestCommitmentAndHTLCTransactions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, test := range testCases {
-			test := test
 			name := fmt.Sprintf("%s-%s", set.name, test.Name)
 
 			t.Run(name, func(t *testing.T) {
@@ -787,7 +785,6 @@ func TestCommitmentSpendValidation(t *testing.T) {
 	// but we also need to support older nodes that want to open channels
 	// with the legacy format, so we'll test spending in both scenarios.
 	for _, tweakless := range []bool{true, false} {
-		tweakless := tweakless
 		t.Run(fmt.Sprintf("tweak=%v", tweakless), func(t *testing.T) {
 			testSpendValidation(t, tweakless)
 		})

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -619,7 +619,6 @@ func (l *LightningWallet) ListUnspentWitnessFromDefaultAccount(
 func (l *LightningWallet) LockedOutpoints() []*wire.OutPoint {
 	outPoints := make([]*wire.OutPoint, 0, len(l.lockedOutPoints))
 	for outPoint := range l.lockedOutPoints {
-		outPoint := outPoint
 
 		outPoints = append(outPoints, &outPoint)
 	}

--- a/lnwire/accept_channel_test.go
+++ b/lnwire/accept_channel_test.go
@@ -29,7 +29,6 @@ func TestDecodeAcceptChannel(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			priv, err := btcec.NewPrivateKey()

--- a/lnwire/features_test.go
+++ b/lnwire/features_test.go
@@ -340,7 +340,6 @@ func TestFeatures(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			fv := NewFeatureVector(
 				toRawFV(test.exp), Features,
@@ -508,7 +507,6 @@ func TestValidateUpdate(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()

--- a/lnwire/local_nonces_test.go
+++ b/lnwire/local_nonces_test.go
@@ -78,7 +78,6 @@ func TestLocalNoncesDataEncodeDecodeValue(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -181,7 +180,6 @@ func TestLocalNoncesDataDecodeFailuresValue(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/lnwire/onion_error_test.go
+++ b/lnwire/onion_error_test.go
@@ -93,7 +93,6 @@ func TestEncodeDecodeTlv(t *testing.T) {
 	t.Parallel()
 
 	for _, testFailure := range onionFailures {
-		testFailure := testFailure
 		code := testFailure.Code().String()
 
 		t.Run(code, func(t *testing.T) {

--- a/lnwire/ping_test.go
+++ b/lnwire/ping_test.go
@@ -19,7 +19,6 @@ func TestPingDecodeAllowsNoReplyPongSizes(t *testing.T) {
 	testCases := []uint16{65532, 65535}
 
 	for _, numPongBytes := range testCases {
-		numPongBytes := numPongBytes
 		testName := strconv.FormatUint(uint64(numPongBytes), 10)
 
 		t.Run(testName, func(t *testing.T) {

--- a/lnwire/query_channel_range_test.go
+++ b/lnwire/query_channel_range_test.go
@@ -39,7 +39,6 @@ func TestQueryChannelRange(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/lnwire/query_short_chan_ids_test.go
+++ b/lnwire/query_short_chan_ids_test.go
@@ -50,7 +50,6 @@ var (
 // that contains duplicate or unsorted ids returns an ErrUnsortedSIDs failure.
 func TestQueryShortChanIDsUnsorted(t *testing.T) {
 	for _, test := range unsortedSidTests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			req := &QueryShortChanIDs{
 				EncodingType: test.encType,
@@ -96,7 +95,6 @@ func TestQueryShortChanIDsZero(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			req := &QueryShortChanIDs{
 				EncodingType: test.encoding,

--- a/lnwire/reply_channel_range_test.go
+++ b/lnwire/reply_channel_range_test.go
@@ -12,7 +12,6 @@ import (
 // that contains duplicate or unsorted ids returns an ErrUnsortedSIDs failure.
 func TestReplyChannelRangeUnsorted(t *testing.T) {
 	for _, test := range unsortedSidTests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			req := &ReplyChannelRange{
 				EncodingType: test.encType,
@@ -63,7 +62,6 @@ func TestReplyChannelRangeEmpty(t *testing.T) {
 	}
 
 	for _, test := range emptyChannelsTests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			req := ReplyChannelRange{
 				FirstBlockHeight: 1,
@@ -210,7 +208,6 @@ func TestReplyChannelRangeEncode(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -327,7 +324,6 @@ func TestReplyChannelRangeDecode(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/lnwire/signature_test.go
+++ b/lnwire/signature_test.go
@@ -273,7 +273,6 @@ func TestNewSigFromRawSignature(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := NewSigFromECDSARawSignature(tc.rawSig)
 			require.Equal(t, tc.expectedErr, err)

--- a/lnwire/writer_test.go
+++ b/lnwire/writer_test.go
@@ -457,7 +457,6 @@ func TestWriteTCPAddr(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			oldLen := buf.Len()
 
@@ -545,7 +544,6 @@ func TestWriteOnionAddr(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			oldLen := buf.Len()
 
@@ -618,7 +616,6 @@ func TestWriteNetAddrs(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			buf := new(bytes.Buffer)
 

--- a/netann/channel_update_test.go
+++ b/netann/channel_update_test.go
@@ -105,7 +105,6 @@ func TestUpdateDisableFlag(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range updateDisableTests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			// Create the initial update, the only fields we are
 			// concerned with in this test are the timestamp and the

--- a/onionmessage/ratelimit_test.go
+++ b/onionmessage/ratelimit_test.go
@@ -29,7 +29,6 @@ func TestGlobalLimiterDisabled(t *testing.T) {
 		{"both zero", 0, 0},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			lim := NewGlobalLimiter(tc.kbps, tc.burstBytes)
@@ -84,7 +83,6 @@ func TestPeerRateLimiterDisabled(t *testing.T) {
 		{"both zero", 0, 0},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			p := NewPeerRateLimiter(tc.kbps, tc.burstBytes)
@@ -217,7 +215,6 @@ func TestPeerRateLimiterConcurrentAllowN(t *testing.T) {
 	var wg sync.WaitGroup
 	var ops atomic.Uint64
 	for w := 0; w < workers; w++ {
-		w := w
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/payments/db/migration1/payment.go
+++ b/payments/db/migration1/payment.go
@@ -335,7 +335,6 @@ func (m *MPPayment) InFlightHTLCs() []HTLCAttempt {
 func (m *MPPayment) GetAttempt(id uint64) (*HTLCAttempt, error) {
 	// TODO(yy): iteration can be slow, make it into a tree or use BS.
 	for _, htlc := range m.HTLCs {
-		htlc := htlc
 		if htlc.AttemptID == id {
 			return &htlc, nil
 		}

--- a/payments/db/payment.go
+++ b/payments/db/payment.go
@@ -416,7 +416,6 @@ func (m *MPPayment) InFlightHTLCs() []HTLCAttempt {
 func (m *MPPayment) GetAttempt(id uint64) (*HTLCAttempt, error) {
 	// TODO(yy): iteration can be slow, make it into a tree or use BS.
 	for _, htlc := range m.HTLCs {
-		htlc := htlc
 		if htlc.AttemptID == id {
 			return &htlc, nil
 		}

--- a/payments/db/payment_status_test.go
+++ b/payments/db/payment_status_test.go
@@ -168,7 +168,6 @@ func TestDecidePaymentStatus(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -228,7 +227,6 @@ func TestPaymentStatusActions(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		i, tc := i, tc
 
 		ps := tc.status
 		name := fmt.Sprintf("test_%d_%s", i, ps.String())

--- a/payments/db/payment_test.go
+++ b/payments/db/payment_test.go
@@ -783,8 +783,6 @@ func TestPaymentRegistrable(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		i, tc := i, tc
-
 		p := &MPPayment{
 			Status: tc.status,
 			State: &MPPaymentState{
@@ -901,8 +899,6 @@ func TestPaymentSetState(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1034,8 +1030,6 @@ func TestNeedWaitAttempts(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		p := &MPPayment{
 			Info: &PaymentCreationInfo{
 				PaymentIdentifier: [32]byte{1, 2, 3},
@@ -1212,8 +1206,6 @@ func TestAllowMoreAttempts(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
-
 		p := &MPPayment{
 			Info: &PaymentCreationInfo{
 				PaymentIdentifier: [32]byte{1, 2, 3},

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -737,7 +737,6 @@ func TestChooseDeliveryScript(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			script, err := chooseDeliveryScript(
@@ -817,7 +816,6 @@ func TestCustomShutdownScript(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			// Open a channel.
@@ -985,7 +983,6 @@ func TestStaticRemoteDowngrade(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			params := createTestPeer(t)
@@ -1288,7 +1285,6 @@ func TestHandleNewPendingChannel(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		// Create a request for testing.
 		errChan := make(chan error, 1)
@@ -1373,7 +1369,6 @@ func TestHandleRemovePendingChannel(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		// Create a request for testing.
 		errChan := make(chan error, 1)

--- a/record/blinded_data_test.go
+++ b/record/blinded_data_test.go
@@ -79,7 +79,6 @@ func TestBlindedDataEncoding(t *testing.T) {
 	}
 
 	for _, testCase := range tests {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -143,7 +142,6 @@ func TestBlindedDataFinalHopEncoding(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -73,7 +73,6 @@ var recordEncDecTests = []recordEncDecTest{
 // the original record matches the decoded record.
 func TestRecordEncodeDecode(t *testing.T) {
 	for _, test := range recordEncDecTests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			r := test.encRecord()
 			r2 := test.decRecord()

--- a/routing/additional_edge_test.go
+++ b/routing/additional_edge_test.go
@@ -68,7 +68,6 @@ func TestIntermediatePayloadSize(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()

--- a/routing/bandwidth_test.go
+++ b/routing/bandwidth_test.go
@@ -102,7 +102,6 @@ func TestBandwidthManager(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			g := newMockGraph(t)

--- a/routing/blindedpath/blinded_path_test.go
+++ b/routing/blindedpath/blinded_path_test.go
@@ -161,7 +161,6 @@ func TestApplyBlindedPathPolicyBuffer(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -351,7 +350,6 @@ func TestPadBlindedHopInfo(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/routing/blinding_test.go
+++ b/routing/blinding_test.go
@@ -64,7 +64,6 @@ func TestBlindedPathValidation(t *testing.T) {
 	}
 
 	for _, testCase := range tests {
-		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()

--- a/routing/integrated_routing_test.go
+++ b/routing/integrated_routing_test.go
@@ -270,7 +270,6 @@ func TestBadFirstHopHint(t *testing.T) {
 // TestMppSend tests that a payment can be completed using multiple shards.
 func TestMppSend(t *testing.T) {
 	for _, testCase := range mppTestCases {
-		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			testMppSend(t, &testCase)

--- a/routing/localchans/manager_test.go
+++ b/routing/localchans/manager_test.go
@@ -359,7 +359,6 @@ func TestManager(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			currentPolicy = test.currentPolicy
 			channelSet = test.channelSet

--- a/routing/missioncontrol.go
+++ b/routing/missioncontrol.go
@@ -709,7 +709,6 @@ func (m *MissionControl) applyPaymentResult(
 	}
 
 	for pair, pairResult := range i.pairResults {
-		pairResult := pairResult
 
 		if pairResult.success {
 			m.log.Debugf("Reporting pair success to Mission "+

--- a/routing/missioncontrol_store_test.go
+++ b/routing/missioncontrol_store_test.go
@@ -276,7 +276,6 @@ func BenchmarkMissionControlStoreFlushing(b *testing.B) {
 	const testMaxRecords = 1000
 
 	for _, tc := range tests {
-		tc := tc
 		name := fmt.Sprintf("%v additional results", tc)
 		b.Run(name, func(b *testing.B) {
 			h := newMCStoreTestHarness(

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -899,7 +899,6 @@ func TestPathFinding(t *testing.T) {
 
 	// Run with graph cache enabled.
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run("cache=true/"+tc.name, func(tt *testing.T) {
 			tt.Parallel()
@@ -911,7 +910,6 @@ func TestPathFinding(t *testing.T) {
 	// And with the DB fallback to make sure everything works the same
 	// still.
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run("cache=false/"+tc.name, func(tt *testing.T) {
 			tt.Parallel()
@@ -1686,7 +1684,6 @@ func TestNewRoute(t *testing.T) {
 		}}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 
 		// Overwrite the final hop's features if the test requires a
 		// custom feature vector.
@@ -2804,7 +2801,6 @@ func runProbabilityRouting(t *testing.T, useCache bool) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			testProbabilityRouting(
@@ -3717,7 +3713,6 @@ func TestLastHopPayloadSize(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -797,8 +797,6 @@ func createTestGraphFromChannels(t *testing.T, useCache bool,
 				return nil, err
 			}
 		}
-
-		channelID++
 	}
 
 	return &testGraphInstance{

--- a/routing/payment_lifecycle.go
+++ b/routing/payment_lifecycle.go
@@ -1148,8 +1148,6 @@ func (p *paymentLifecycle) reloadInflightAttempts(
 	}
 
 	for _, a := range payment.InFlightHTLCs() {
-		a := a
-
 		log.Infof("Resuming HTLC attempt %v for payment %v",
 			a.AttemptID, p.identifier)
 

--- a/routing/payment_lifecycle_test.go
+++ b/routing/payment_lifecycle_test.go
@@ -574,7 +574,6 @@ func TestDecideNextStep(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		// Create a test paymentLifecycle.
 		p, _ := newTestPaymentLifecycle(t)

--- a/routing/payment_session_test.go
+++ b/routing/payment_session_test.go
@@ -55,7 +55,6 @@ func TestValidateCLTVLimit(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 
 		success := t.Run(testCase.name, func(t *testing.T) {
 			err := ValidateCLTVLimit(

--- a/routing/probability_apriori_test.go
+++ b/routing/probability_apriori_test.go
@@ -315,7 +315,6 @@ func TestCapacityCutoff(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/routing/probability_bimodal_test.go
+++ b/routing/probability_bimodal_test.go
@@ -239,7 +239,6 @@ func TestSuccessProbability(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -369,7 +368,6 @@ func TestIntegral(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -671,7 +669,6 @@ func TestComputeProbability(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -748,7 +745,6 @@ func TestLocalPairProbability(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/routing/route/route_test.go
+++ b/routing/route/route_test.go
@@ -255,7 +255,6 @@ func TestBlindedHops(t *testing.T) {
 	}
 
 	for _, testCase := range tests {
-		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
@@ -358,7 +357,6 @@ func TestPayloadSize(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()

--- a/routing/router.go
+++ b/routing/router.go
@@ -1476,7 +1476,6 @@ func (r *ChannelRouter) resumePayments() error {
 		// Get the hashes used for the outstanding HTLCs.
 		htlcs := make(map[uint64]lntypes.Hash)
 		for _, a := range payment.HTLCs {
-			a := a
 
 			// We check whether the individual attempts have their
 			// HTLC hash set, if not we'll fall back to the overall

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -1423,8 +1423,6 @@ func TestSendToRouteStructuredError(t *testing.T) {
 	}
 
 	for failIndex, errorType := range testCases {
-		failIndex := failIndex
-		errorType := errorType
 
 		t.Run(fmt.Sprintf("%T", errorType), func(t *testing.T) {
 			// We'll modify the SendToSwitch method so that it
@@ -2086,7 +2084,6 @@ func TestInboundOutbound(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 
 		t.Run(tc.name, func(tt *testing.T) {
 			testInboundOutboundFee(
@@ -2692,7 +2689,6 @@ func TestNewRouteRequest(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -165,6 +165,7 @@ func createTestCtxFromGraphInstanceAssumeValid(t *testing.T,
 			&mockTrafficShaper{},
 		),
 	})
+	require.NoError(t, err, "unable to create router")
 	require.NoError(t, router.Start(), "unable to start router")
 
 	ctx := &testCtx{

--- a/routing/unified_edges_test.go
+++ b/routing/unified_edges_test.go
@@ -224,7 +224,6 @@ func TestNodeEdgeUnifier(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -6016,7 +6016,6 @@ func (r *rpcServer) ListInvoices(ctx context.Context,
 		LastIndexOffset:  invoiceSlice.LastIndexOffset,
 	}
 	for i, invoice := range invoiceSlice.Invoices {
-		invoice := invoice
 		resp.Invoices[i], err = invoicesrpc.CreateRPCInvoice(
 			&invoice, r.cfg.ActiveNetParams.Params,
 		)
@@ -7027,7 +7026,6 @@ func (r *rpcServer) ListPayments(ctx context.Context,
 	}
 
 	for _, payment := range paymentsQuerySlice.Payments {
-		payment := payment
 
 		rpcPayment, err := r.routerBackend.MarshallPayment(payment)
 		if err != nil {

--- a/sweep/aggregator_test.go
+++ b/sweep/aggregator_test.go
@@ -370,7 +370,6 @@ func TestBudgetAggregatorCreateInputSets(t *testing.T) {
 
 	// Iterate over the test cases.
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup the mocks.

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -220,7 +220,6 @@ func TestBumpRequestMaxFeeRateAllowed(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			// Check the method under test.
@@ -503,7 +502,6 @@ func TestCreateAndCheckTx(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		r := &monitorRecord{
 			req:         tc.req,
@@ -674,7 +672,6 @@ func TestCreateRBFCompliantTx(t *testing.T) {
 
 	var requestCounter atomic.Uint64
 	for _, tc := range testCases {
-		tc := tc
 
 		rid := requestCounter.Add(1)
 
@@ -798,7 +795,6 @@ func TestTxPublisherBroadcast(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			tc.setupMock()
@@ -931,7 +927,6 @@ func TestRemoveResult(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			requestID := tc.setupRecord()

--- a/sweep/fee_function_test.go
+++ b/sweep/fee_function_test.go
@@ -258,7 +258,6 @@ func TestLinearFeeFunctionFeeRateAtPosition(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -747,7 +747,6 @@ func (s *UtxoSweeper) collector() {
 // those inputs will be removed from the wallet.
 func (s *UtxoSweeper) removeExclusiveGroup(group uint64, op wire.OutPoint) {
 	for outpoint, input := range s.inputs {
-		outpoint := outpoint
 
 		// Skip the input that caused the exclusive group to be removed.
 		if outpoint == op {

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -1043,7 +1043,6 @@ func TestMonitorFeeBumpResult(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup the testing result channel.

--- a/sweep/txgenerator_test.go
+++ b/sweep/txgenerator_test.go
@@ -134,7 +134,6 @@ func TestWeightEstimatorUnknownScript(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testUnknownScriptInner(
 				t, test.pkscript, test.expectFail,

--- a/sweep/walletsweep_test.go
+++ b/sweep/walletsweep_test.go
@@ -126,7 +126,6 @@ func TestFeeEstimateInfo(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup the mockers if specified.

--- a/tls_manager_test.go
+++ b/tls_manager_test.go
@@ -428,7 +428,6 @@ func TestGenerateCertPairWithPartialFiles(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/watchtower/blob/justice_kit_test.go
+++ b/watchtower/blob/justice_kit_test.go
@@ -326,7 +326,6 @@ func TestJusticeKitRemoteWitnessConstruction(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testJusticeKitRemoteWitnessConstruction(t, test)
 		})
@@ -485,7 +484,6 @@ func TestJusticeKitToLocalWitnessConstruction(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/watchtower/wtclient/backup_task_internal_test.go
+++ b/watchtower/wtclient/backup_task_internal_test.go
@@ -552,7 +552,6 @@ func TestBackupTask(t *testing.T) {
 	}
 
 	for _, test := range backupTaskTests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/watchtower/wtclient/client_test.go
+++ b/watchtower/wtclient/client_test.go
@@ -334,7 +334,6 @@ func (c *mockChannel) createRemoteCommitTx(t *testing.T) {
 			SignMethod:    input.TaprootScriptSpendSignMethod,
 			ControlBlock:  ctrlBytes,
 		}
-		outputIndex++
 	}
 
 	txid := commitTxn.TxHash()
@@ -357,7 +356,6 @@ func (c *mockChannel) createRemoteCommitTx(t *testing.T) {
 			Hash:  txid,
 			Index: uint32(outputIndex),
 		}
-		outputIndex++
 	}
 
 	commitKeyRing := &lnwallet.CommitmentKeyRing{

--- a/watchtower/wtclient/queue_test.go
+++ b/watchtower/wtclient/queue_test.go
@@ -61,7 +61,6 @@ func TestDiskOverflowQueue(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(tt *testing.T) {
 			tt.Parallel()

--- a/watchtower/wtdb/migration1/client_db_test.go
+++ b/watchtower/wtdb/migration1/client_db_test.go
@@ -94,7 +94,6 @@ func TestMigrateTowerToSessionIndex(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			// Before the migration we have a sessions bucket.

--- a/watchtower/wtdb/migration2/client_db_test.go
+++ b/watchtower/wtdb/migration2/client_db_test.go
@@ -69,7 +69,6 @@ func TestMigrateClientChannelDetails(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/watchtower/wtdb/migration3/client_db_test.go
+++ b/watchtower/wtdb/migration3/client_db_test.go
@@ -83,7 +83,6 @@ func TestMigrateChannelIDIndex(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/watchtower/wtdb/migration4/client_db_test.go
+++ b/watchtower/wtdb/migration4/client_db_test.go
@@ -226,7 +226,6 @@ func TestMigrateAckedUpdates(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/watchtower/wtdb/migration5/client_db_test.go
+++ b/watchtower/wtdb/migration5/client_db_test.go
@@ -95,7 +95,6 @@ func TestCompleteTowerToSessionIndex(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/watchtower/wtdb/migration6/client_db_test.go
+++ b/watchtower/wtdb/migration6/client_db_test.go
@@ -81,7 +81,6 @@ func TestMigrateSessionIDIndex(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/watchtower/wtdb/migration7/client_db_test.go
+++ b/watchtower/wtdb/migration7/client_db_test.go
@@ -112,7 +112,6 @@ func TestMigrateChannelToSessionIndex(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/zpay32/invoice_internal_test.go
+++ b/zpay32/invoice_internal_test.go
@@ -834,7 +834,6 @@ func TestParseTaggedFields(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc // pin
 		t.Run(tc.name, func(t *testing.T) {
 			var invoice Invoice
 			gotErr := parseTaggedFields(&invoice, tc.data, netParams)

--- a/zpay32/invoice_test.go
+++ b/zpay32/invoice_test.go
@@ -901,7 +901,6 @@ func TestDecodeEncode(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		test := test
 
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			t.Parallel()
@@ -1050,7 +1049,6 @@ func TestNewInvoice(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		test := test
 
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
This PR enables five previously-disabled linters and fixes the violations they surface. It also corrects a mislabeled section of `.golangci.yml` where a block of active linters was wrongly commented as "Deprecated linters".

Each linter is enabled in its own commit, with code fixes landing before the linter is switched on, so CI stays green at every commit. Code changes are also split into separate test-file and non-test-file commits.

Linters enabled:
- `copyloopvar`: redundant `x := x` loop-variable copies, unnecessary since Go 1.22 per-iteration scoping (161 files).
- `wastedassign`: dead stores assigned but never read (25 sites). This surfaced a real missing error check in `routing/router_test.go`, where err from New() was never asserted.
- `bodyclose`: unclosed HTTP response bodies (0 existing issues).
- `rowserrcheck`: unchecked sql.Rows.Err() (0 existing issues).
- `sqlclosecheck`: unclosed sql.Rows / sql.Stmt (0 existing issues).

Linters left disabled, now with accurate comments instead of the wrong "deprecated" label:
- `contextcheck`: requires threading `context.Context` through many existing signatures, including test harnesses.
- `tparallel`: requires adding `t.Parallel()` to many existing subtests, which can surface shared-state races.
- `unparam`: sizeable backlog of unused parameters to clean up first.
- `nilerr`: too noisy here; nearly all reports are intentional documented error-swallowing or false positives.
- `noctx`: only flags a couple of interface methods and a test helper with no context to thread through.

https://github.com/lightningnetwork/lnd/pull/10858#discussion_r3349220980