### PR TITLE
build: bump version to v0.21.0-beta

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -51,7 +51,7 @@ const (
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.
-	AppPreRelease = "beta.rc3"
+	AppPreRelease = "beta"
 )
 
 func init() {


### PR DESCRIPTION
## Change

Bumps the release version from `v0.21.0-beta.rc3` to `v0.21.0-beta`.

## Verification

- `go test ./build`