### PR TITLE
build: bump master version to v0.21.99

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -44,7 +44,7 @@ const (
 	AppMajor uint = 0
 
 	// AppMinor defines the minor version of this binary.
-	AppMinor uint = 20
+	AppMinor uint = 21
 
 	// AppPatch defines the application patch for this binary.
 	AppPatch uint = 99

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -12,7 +12,10 @@ VERSION_FILE="build/version.go"
 
 # Match the canonical upstream URL across https / git@ / ssh:// forms, with or
 # without a `.git` suffix. We identify the remote by URL because `origin` is
-# conventionally the fork in a `gh repo fork` setup.
+# conventionally the fork in a `gh repo fork` setup. The URL is lower-cased
+# before matching (see below), so this pattern stays lower-case: GitHub treats
+# the org/repo as case-insensitive, and `origin` is often the mixed-case
+# `LightningNetwork/lnd`.
 UPSTREAM_URL_REGEX='[:/]lightningnetwork/lnd(\.git)?$'
 
 usage() {
@@ -59,7 +62,7 @@ UPSTREAM_REMOTES=()
 while IFS= read -r line; do
   UPSTREAM_REMOTES+=("$line")
 done < <(git remote -v | awk -v re="${UPSTREAM_URL_REGEX}" \
-  '$3 == "(fetch)" && $2 ~ re { print $1 }' | sort -u)
+  '$3 == "(fetch)" && tolower($2) ~ re { print $1 }' | sort -u)
 
 case "${#UPSTREAM_REMOTES[@]}" in
   0) echo "Error: no git remote points at lightningnetwork/lnd. Add one with" \


### PR DESCRIPTION
In this PR, we bump the master version to `v0.21.99`. Now that the `v0.21.0-beta` tag has been cut on `v0.21.x-branch`, master is beyond the last major release and will be a super set of anything in the v0.21.x series, so we reflect that in the version string with the `.99` patch placeholder we use for in-development master builds. The diff there is a single-line change to `AppMinor` in `build/version.go`, taking us from `0.20.99` to `0.21.99`.

While cutting the tag, we also hit a papercut in `scripts/tag-release.sh`: the upstream remote detection matched the URL case-sensitively, so a remote pointing at `LightningNetwork/lnd` (a common spelling for `origin`) wouldn't be recognized as `lightningnetwork/lnd`, and the script would bail out claiming no upstream remote existed even when one clearly did. GitHub treats the org/repo path as case-insensitive, so in the second commit we lower-case the URL with awk's `tolower()` before matching. This keeps the pattern itself lower-case and stays portable across the BSD awk on macOS and gawk in CI (unlike the gawk-only `IGNORECASE`).

See each commit message for a detailed description w.r.t the incremental changes.