### PR TITLE
ci: require signer OTS proof for final releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,10 +81,11 @@ jobs:
 
             ## Verifying the Release Timestamp 
 
-            From this new version onwards, in addition time-stamping the _git tag_ with [OpenTimestamps](https://opentimestamps.org/), we'll also now timestamp the manifest file along with its signature. Two new files are now included along with the rest of our release artifacts: ` manifest-roasbeef-${{ env.RELEASE_VERSION }}.txt.asc.ots`.
+            From this new version onwards, in addition to time-stamping the _git tag_ with [OpenTimestamps](https://opentimestamps.org/), we'll also now timestamp the manifest file along with the `roasbeef` release signature. For final releases, and for release candidates when these optional artifacts are uploaded, timestamp proof files are included along with the rest of our release artifacts: `manifest-${{ env.RELEASE_VERSION }}.txt.ots` and `manifest-roasbeef-${{ env.RELEASE_VERSION }}.sig.ots`.
 
             Assuming you have the opentimestamps client installed locally, the timestamps can be verified with the following commands: 
             ```
+            ots verify manifest-${{ env.RELEASE_VERSION }}.txt.ots -f manifest-${{ env.RELEASE_VERSION }}.txt
             ots verify manifest-roasbeef-${{ env.RELEASE_VERSION }}.sig.ots -f manifest-roasbeef-${{ env.RELEASE_VERSION }}.sig
             ```
 

--- a/.github/workflows/verify-release.yaml
+++ b/.github/workflows/verify-release.yaml
@@ -17,6 +17,44 @@ jobs:
     name: Verify release signatures and binaries
     runs-on: ubuntu-latest
     steps:
+      - name: git checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version || github.sha }}
+
+      - name: Check final release OpenTimestamps asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version || github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${VERSION}" =~ \.rc[0-9]+$ ]]; then
+            echo "Release candidate ${VERSION}; skipping OpenTimestamps asset check."
+            exit 0
+          fi
+
+          REQUIRED_MANIFEST_OTS="manifest-${VERSION}.txt.ots"
+          REQUIRED_SIG="manifest-roasbeef-${VERSION}.sig"
+          REQUIRED_SIG_OTS="${REQUIRED_SIG}.ots"
+
+          ASSETS="$(gh release view "${VERSION}" \
+            --repo "${{ github.repository }}" \
+            --json assets \
+            --jq '.assets[].name')"
+
+          for asset in "${REQUIRED_MANIFEST_OTS}" "${REQUIRED_SIG}" "${REQUIRED_SIG_OTS}"; do
+            if ! grep -Fxq "${asset}" <<< "${ASSETS}"; then
+              echo "ERROR: Final release ${VERSION} is missing ${asset}."
+              exit 1
+            fi
+          done
+
+          echo "Found required release timestamp artifacts:"
+          echo "  ${REQUIRED_MANIFEST_OTS}"
+          echo "  ${REQUIRED_SIG}"
+          echo "  ${REQUIRED_SIG_OTS}"
+
       - name: Verify release
         env:
           VERSION: ${{ inputs.version || github.event.release.tag_name }}


### PR DESCRIPTION
## Change Description

Require final published releases to include OpenTimestamps-related artifacts
for the `roasbeef` manifest signature:

- the release manifest timestamp proof: `manifest-${VERSION}.txt.ots`
- the `roasbeef` manifest signature: `manifest-roasbeef-${VERSION}.sig`
- the `roasbeef` signature timestamp proof:
  `manifest-roasbeef-${VERSION}.sig.ots`

Release candidate tags ending in `.rcN` are skipped.

The release verification workflow keeps this as a small asset-presence gate
before running the existing Docker-based `/verify-install.sh ${VERSION}`
verification. The Docker verification remains responsible for validating the
release signatures themselves.

This also updates the generated release text to document the `roasbeef` OTS
proof filename and verification command.

## Steps to Test

- Ran `git diff --check`.
- Confirmed the release candidate skip path locally while the check was split
  out during review.
- Reviewed the final workflow diff for the exact required asset names.
