### PR TITLE
htlcswitch: adding temporary_channel_failure

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -21,6 +21,15 @@
 
 # Bug Fixes
 
+* [Fixed incorrect onion error](https://github.com/lightningnetwork/lnd/pull/6603)
+  returned when forwarding an HTLC to an offline peer. LND was returning
+  `unknown_next_peer` (which carries the permanent failure bit), causing
+  senders to permanently remove the channel from their routing graph and
+  lose routing revenue. The correct error per BOLT-4 is
+  `temporary_channel_failure` with a `channel_update` reflecting the
+  disabled channel, allowing senders to retry via a different path while
+  keeping the channel available for future routing once the peer reconnects.
+
 * Bitcoind outbound peer health checks [now use](https://github.com/lightningnetwork/lnd/pull/10686)
   `getnetworkinfo.connections_out` instead of `getpeerinfo`. The same PR also
   [clarifies](https://github.com/lightningnetwork/lnd/issues/10568) the ZMQ

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -2671,6 +2671,25 @@ func (s *Switch) failMailboxUpdate(outgoingScid,
 	return lnwire.NewTemporaryChannelFailure(update)
 }
 
+// temporaryChannelFailure constructs a temporary_channel_failure for the given
+// outgoing SCID. It attempts to include the latest channel update so the
+// sender can immediately update their routing graph. If no update is
+// available it falls back to FailTemporaryNodeFailure.
+func (s *Switch) temporaryChannelFailure(
+	scid lnwire.ShortChannelID) lnwire.FailureMessage {
+
+	update := s.failAliasUpdate(scid, false)
+	if update == nil {
+		var err error
+		update, err = s.cfg.FetchLastChannelUpdate(scid)
+		if err != nil {
+			return &lnwire.FailTemporaryNodeFailure{}
+		}
+	}
+
+	return lnwire.NewTemporaryChannelFailure(update)
+}
+
 // failAliasUpdate prepares a ChannelUpdate for a failed incoming or outgoing
 // HTLC on a channel where the option-scid-alias feature bit was negotiated. If
 // the associated channel is not one of these, this function will return nil
@@ -2886,8 +2905,9 @@ func (s *Switch) handlePacketAdd(packet *htlcPacket,
 		log.Debugf("unable to find link with "+
 			"destination %v", packet.outgoingChanID)
 
-		// If packet was forwarded from another channel link than we
-		// should notify this link that some error occurred.
+		// The link was not found in the forwarding index — it has been
+		// removed (e.g. channel closed). Signal to the sender that the
+		// next hop is unknown.
 		linkError := NewLinkError(
 			&lnwire.FailUnknownNextPeer{},
 		)
@@ -2909,11 +2929,12 @@ func (s *Switch) handlePacketAdd(packet *htlcPacket,
 	for _, link := range interfaceLinks {
 		var failure *LinkError
 
-		// We'll skip any links that aren't yet eligible for
-		// forwarding.
+		// We'll skip any links that aren't yet eligible for forwarding.
+		// Use temporary_channel_failure with latest channel update so the
+		// sender can update their routing graph.
 		if !link.EligibleToForward() {
 			failure = NewDetailedLinkError(
-				&lnwire.FailUnknownNextPeer{},
+				s.temporaryChannelFailure(link.ShortChanID()),
 				OutgoingFailureLinkNotEligible,
 			)
 		} else {

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -2682,7 +2682,7 @@ func (s *Switch) temporaryChannelFailure(
 	if update == nil {
 		var err error
 		update, err = s.cfg.FetchLastChannelUpdate(scid)
-		if err != nil {
+		if err != nil || update == nil {
 			return &lnwire.FailTemporaryNodeFailure{}
 		}
 	}

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -2143,7 +2143,7 @@ func TestSkipIneligibleLinksMultiHopForward(t *testing.T) {
 		// None of the channels is eligible.
 		{
 			name:          "not eligible",
-			expectedReply: lnwire.CodeUnknownNextPeer,
+			expectedReply: lnwire.CodeTemporaryChannelFailure,
 		},
 
 		// Channel one has a policy failure and the other channel isn't


### PR DESCRIPTION
This commit modifies the behaviour when a node can't forward an HTLC due to a temporary channel failure. Rather than return unknown_next_peer which instructs the sender to fully remove the channel from the graph temporary_channel_failure gives the sender the change to handle it more gracefully. We also return the latest channel update to the sender.

## Change Description
Description of change / link to associated issue.

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
