### PR TITLE
docs: move switchrpc release notes from v0.21 to v0.22

### DIFF
--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -151,17 +151,6 @@
   non-wumbo channel size (~0.168 BTC), with wumbo channels always requiring
   6 confirmations.
   
-* Introduced a new `AttemptStore` interface within `htlcswitch`, and expanded
-  its `kvdb` implementation, `networkResultStore`. A [new `InitAttempt` method](https://github.com/lightningnetwork/lnd/pull/10049),
-  which serves as a "durable write of intent" or "write-ahead log" to checkpoint
-  an attempt in a new `PENDING` state prior to dispatch, now provides the
-  foundational durable storage required for external tracking of the HTLC
-  attempt lifecycle. This is a preparatory step that enables a future
-  idempotent `switchrpc.SendOnion` RPC, which will offer "at most once"
-  processing of htlc dispatch requests for remote clients. Care was taken to
-  avoid modifications to the existing flows for dispatching local payments,
-  preserving the existing battle-tested logic.
-
 * [Added support for production (final) simple taproot
   channels](https://github.com/lightningnetwork/lnd/pull/9985) using the
   finalized taproot channel scripts with feature bits 80/81. Production taproot
@@ -211,86 +200,6 @@
   for the adversary model, the layers, the defaults, and operator
   recipes.
   
-* Added a new [switchrpc RPC sub-system](https://github.com/lightningnetwork/lnd/pull/9489)
-  with `SendOnion`, `BuildOnion`, and `TrackOnion` endpoints. This allows the
-  daemon to offload path-finding, onion construction and payment life-cycle
-  management to an external entity and instead accept onion payments for direct
-  delivery to the network. The new gRPC server should be used with caution. It
-  is currently only safe to allow a *single* entity (either the local router or
-  *one* external router) to dispatch attempts via the Switch at any given time.
-  Running multiple controllers concurrently will lead to undefined behavior and
-  potential loss of funds. The compilation of the server is hidden behind the
-  non-default `switchrpc` build tag.
-
-* The `SendOnion` RPC is now fully [idempotent](
-  https://github.com/lightningnetwork/lnd/pull/10473), providing a critical
-  reliability improvement for external payment orchestrators (such as a remote
-  `ChannelRouter`). Callers can now safely retry a `SendOnion` request after a
-  network timeout or ambiguous error without risking a duplicate payment. If a
-  request with the same `attempt_id` has already been processed, the RPC will
-  now return a `DUPLICATE_HTLC` error, serving as a definitive acknowledgment
-  that the dispatch was received. This allows clients to build more resilient
-  payment-sending logic.
-
-* The `switchrpc.TrackOnion` RPC has been
-  [overhauled](https://github.com/lightningnetwork/lnd/pull/10472) to provide a
-  more robust and type-safe error handling mechanism. The `TrackOnionResponse`
-  message now uses a top-level `oneof` to enforce a compile-time guarantee that
-  a response contains either a `preimage` (for success) or structured
-  `FailureDetails` (for a payment failure). This replaces the previous
-  string-based error reporting. Application-level payment failures are now
-  clearly separated from RPC-level failures (e.g., attempt not found), which are
-  communicated via standard gRPC status codes. This is a **breaking change** for
-  any clients of the `TrackOnion` RPC.
-
-* The `switchrpc.SendOnion` RPC has been
-  [overhauled](https://github.com/lightningnetwork/lnd/pull/10545) to provide a
-  more robust, client-friendly, and forward-compatible API. The
-  `SendOnionResponse` is now an empty message; a gRPC status of `OK` indicates
-  successful dispatch. Application-level dispatch failures carry structured
-  `SendOnionFailureDetails` in the gRPC status details, classifying each failure
-  as either `DefiniteFailure` (safe to fail the attempt) or `IndefiniteFailure`
-  (client MUST retry). This is a **breaking change** for any clients of the
-  `SendOnion` RPC.
-  
-* To support scenarios where an external entity, such as a remote router,
-  manages the payment lifecycle via the Switch RPC server, the node must
-  preserve the history of HTLC attempts across restarts. This [behavior](https://github.com/lightningnetwork/lnd/pull/10178) is now
-  conditional on how the lnd binary is built. When compiled with the `switchrpc`
-  build tag, the local `routing.ChannelRouter`'s automatic cleanup of the
-  dispatcher's (Switch) attempt store on startup is disabled. This shifts the
-  responsibility of state cleanup to the external controller, which is expected
-  to use an RPC interface (e.g., switchrpc) to manage the lifecycle of attempts.
-  Tying this behavior to a build tag, rather than a runtime flag, makes the
-  binary's purpose explicit and prevents potential misconfigurations.
-
-* Add [`DisableRemoteRouter` rpc](https://github.com/lightningnetwork/lnd/pull/10178)
-  to `switchrpc` which marks the database as no longer being used by a remote
-  router. This is useful for migrating from a remote router setup back to the
-  default embedded router. The external controller should first clean its
-  results from the attempt store via `DeleteAttempts` (#10602); this RPC will
-  fail if there are any remaining attempt entries.
-
-* The `ChannelRouter` now supports a [configurable attempt reconciliation
-  hook](https://github.com/lightningnetwork/lnd/pull/10621) that runs for each
-  in-flight HTLC attempt during startup, before result collection begins. This
-  enables write-first crash recovery for deployments where the router and switch
-  run in separate processes (e.g. a remote `ChannelRouter` dispatching via
-  `switchrpc.SendOnion`). The callback lets the caller confirm dispatch status by
-  idempotently re-submitting each attempt, resolving the ambiguity that arises
-  when a crash occurs between persisting an attempt and receiving the switch's
-  acknowledgement. The default is a no-op, so existing single-process lnd
-  deployments are unaffected.
-
-* Added a new [`switchrpc.DeleteAttempts`](https://github.com/lightningnetwork/lnd/pull/10602)
-  RPC that allows an external router to clean up terminal (settled or failed)
-  attempt records from the `AttemptStore`. The RPC accepts a batch of attempt
-  IDs and returns per-ID results indicating whether each was deleted, already
-  deleted, still pending (in-flight), or not found. Deleting a terminal attempt
-  record removes the duplicate protection established by InitAttempt, allowing a
-  subsequent SendOnion call with the same attempt ID to succeed. Clients should
-  only delete attempt IDs they have fully finalized and will never reuse.
-
 ## RPC Additions
 
 * [Added `DeleteForwardingHistory`
@@ -367,10 +276,6 @@
   request now accepts an `include_log` flag. By default, only the configuration
   map is returned. When `include_log` is set to `true`, the log file content is
   also included in the response.
-
-* [Add `source_pub_key` to `Route` proto message](https://github.com/lightningnetwork/lnd/pull/9153)
-  so that routes can be constructed and unmarshalled from the perspective of
-  different nodes. Defaults to the node's own public key.
 
 ## lncli Updates
 

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -48,6 +48,96 @@
   the source-end counterpart to `AdditionalEdge`, which extends the graph at
   the destination end via route hints.
 
+* Introduced a new `AttemptStore` interface within `htlcswitch`, and expanded
+  its `kvdb` implementation, `networkResultStore`. A [new `InitAttempt` method](https://github.com/lightningnetwork/lnd/pull/10049),
+  which serves as a "durable write of intent" or "write-ahead log" to checkpoint
+  an attempt in a new `PENDING` state prior to dispatch, now provides the
+  foundational durable storage required for external tracking of the HTLC
+  attempt lifecycle. This is a preparatory step that enables the new
+  idempotent `switchrpc.SendOnion` RPC, which offers "at most once"
+  processing of htlc dispatch requests for remote clients. Care was taken to
+  avoid modifications to the existing flows for dispatching local payments,
+  preserving the existing battle-tested logic.
+
+* Added a new [switchrpc RPC sub-system](https://github.com/lightningnetwork/lnd/pull/9489)
+  with `SendOnion`, `BuildOnion`, and `TrackOnion` endpoints. This allows the
+  daemon to offload path-finding, onion construction and payment life-cycle
+  management to an external entity and instead accept onion payments for direct
+  delivery to the network. The new gRPC server should be used with caution. It
+  is currently only safe to allow a *single* entity (either the local router or
+  *one* external router) to dispatch attempts via the Switch at any given time.
+  Running multiple controllers concurrently will lead to undefined behavior and
+  potential loss of funds. The compilation of the server is hidden behind the
+  non-default `switchrpc` build tag.
+
+* The `SendOnion` RPC is now fully [idempotent](https://github.com/lightningnetwork/lnd/pull/10473), providing a critical
+  reliability improvement for external payment orchestrators (such as a remote
+  `ChannelRouter`). Callers can now safely retry a `SendOnion` request after a
+  network timeout or ambiguous error without risking a duplicate payment. If a
+  request with the same `attempt_id` has already been processed, the RPC will
+  now return a `DUPLICATE_HTLC` error, serving as a definitive acknowledgment
+  that the dispatch was received. This allows clients to build more resilient
+  payment-sending logic.
+
+* The `switchrpc.TrackOnion` RPC has been
+  [overhauled](https://github.com/lightningnetwork/lnd/pull/10472) to provide a
+  more robust and type-safe error handling mechanism. The `TrackOnionResponse`
+  message now uses a top-level `oneof` to enforce a compile-time guarantee that
+  a response contains either a `preimage` (for success) or structured
+  `FailureDetails` (for a payment failure). This replaces the previous
+  string-based error reporting. Application-level payment failures are now
+  clearly separated from RPC-level failures (e.g., attempt not found), which are
+  communicated via standard gRPC status codes. This is a **breaking change** for
+  any clients of the `TrackOnion` RPC.
+
+* The `switchrpc.SendOnion` RPC has been
+  [overhauled](https://github.com/lightningnetwork/lnd/pull/10545) to provide a
+  more robust, client-friendly, and forward-compatible API. The
+  `SendOnionResponse` is now an empty message; a gRPC status of `OK` indicates
+  successful dispatch. Application-level dispatch failures carry structured
+  `SendOnionFailureDetails` in the gRPC status details, classifying each failure
+  as either `DefiniteFailure` (safe to fail the attempt) or `IndefiniteFailure`
+  (client MUST retry). This is a **breaking change** for any clients of the
+  `SendOnion` RPC.
+
+* To support scenarios where an external entity, such as a remote router,
+  manages the payment lifecycle via the Switch RPC server, the node must
+  preserve the history of HTLC attempts across restarts. This [behavior](https://github.com/lightningnetwork/lnd/pull/10178) is now
+  conditional on how the lnd binary is built. When compiled with the `switchrpc`
+  build tag, the local `routing.ChannelRouter`'s automatic cleanup of the
+  dispatcher's (Switch) attempt store on startup is disabled. This shifts the
+  responsibility of state cleanup to the external controller, which is expected
+  to use an RPC interface (e.g., switchrpc) to manage the lifecycle of attempts.
+  Tying this behavior to a build tag, rather than a runtime flag, makes the
+  binary's purpose explicit and prevents potential misconfigurations.
+
+* Added [`DisableRemoteRouter` rpc](https://github.com/lightningnetwork/lnd/pull/10178)
+  to `switchrpc` which marks the database as no longer being used by a remote
+  router. This is useful for migrating from a remote router setup back to the
+  default embedded router. The external controller should first clean its
+  results from the attempt store via `DeleteAttempts` (#10602); this RPC will
+  fail if there are any remaining attempt entries.
+
+* The `ChannelRouter` now supports a [configurable attempt reconciliation
+  hook](https://github.com/lightningnetwork/lnd/pull/10621) that runs for each
+  in-flight HTLC attempt during startup, before result collection begins. This
+  enables write-first crash recovery for deployments where the router and switch
+  run in separate processes (e.g. a remote `ChannelRouter` dispatching via
+  `switchrpc.SendOnion`). The callback lets the caller confirm dispatch status by
+  idempotently re-submitting each attempt, resolving the ambiguity that arises
+  when a crash occurs between persisting an attempt and receiving the switch's
+  acknowledgement. The default is a no-op, so existing single-process lnd
+  deployments are unaffected.
+
+* Added a new [`switchrpc.DeleteAttempts`](https://github.com/lightningnetwork/lnd/pull/10602)
+  RPC that allows an external router to clean up terminal (settled or failed)
+  attempt records from the `AttemptStore`. The RPC accepts a batch of attempt
+  IDs and returns per-ID results indicating whether each was deleted, already
+  deleted, still pending (in-flight), or not found. Deleting a terminal attempt
+  record removes the duplicate protection established by InitAttempt, allowing a
+  subsequent SendOnion call with the same attempt ID to succeed. Clients should
+  only delete attempt IDs they have fully finalized and will never reuse.
+
 ## RPC Additions
 
 * The `routerrpc.EstimateRouteFee` RPC now supports [restricting fee estimates
@@ -67,6 +157,10 @@
 ## Functional Updates
 
 ## RPC Updates
+
+* [Add `source_pub_key` to `Route` proto message](https://github.com/lightningnetwork/lnd/pull/9153)
+  so that routes can be constructed and unmarshalled from the perspective of
+  different nodes. Defaults to the node's own public key.
 
 ## lncli Updates
 


### PR DESCRIPTION
## Change Description
v0.21 has already shipped, so the release notes added throughout the payment-service PR sequence while v0.21 was the development target now belong in v0.22. The RouteOrigin entry already moved with PR #10764; this brings the rest alongside it: the switchrpc sub-system and its idempotency and error-handling reworks, the AttemptStore interface, configurable attempt reconciliation, DeleteAttempts, DisableRemoteRouter, and the source_pub_key field on the Route proto.
