### PR TITLE
build: fix data race in RotatingLogWriter during startup

### DIFF
--- a/build/logrotator.go
+++ b/build/logrotator.go
@@ -2,10 +2,12 @@ package build
 
 import (
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/jrick/logrotate/rotator"
 	"github.com/klauspost/compress/zstd"
@@ -18,6 +20,13 @@ type RotatingLogWriter struct {
 	pipe *io.PipeWriter
 
 	rotator *rotator.Rotator
+
+	// wg tracks the rotator Run goroutine so that Close can wait for it
+	// to finish before closing the underlying rotator.
+	wg sync.WaitGroup
+
+	// mu protects the pipe field from concurrent access.
+	mu sync.RWMutex
 }
 
 // NewRotatingLogWriter creates a new file rotating log writer.
@@ -73,23 +82,31 @@ func (r *RotatingLogWriter) InitLogRotator(cfg *FileLoggerConfig,
 	// runtime (like running out of disk space or not being allowed to
 	// create a new logfile for whatever reason).
 	pr, pw := io.Pipe()
+
+	r.mu.Lock()
+	r.pipe = pw
+	r.mu.Unlock()
+	r.wg.Add(1)
 	go func() {
+		defer r.wg.Done()
 		err := r.rotator.Run(pr)
-		if err != nil {
+		if err != nil && !errors.Is(err, io.EOF) {
 			_, _ = fmt.Fprintf(os.Stderr,
 				"failed to run file rotator: %v\n", err)
 		}
 	}()
-
-	r.pipe = pw
 
 	return nil
 }
 
 // Write writes the byte slice to the log rotator, if present.
 func (r *RotatingLogWriter) Write(b []byte) (int, error) {
-	if r.rotator != nil {
-		return r.rotator.Write(b)
+	r.mu.RLock()
+	pipe := r.pipe
+	r.mu.RUnlock()
+
+	if pipe != nil {
+		return pipe.Write(b)
 	}
 
 	return len(b), nil
@@ -97,6 +114,18 @@ func (r *RotatingLogWriter) Write(b []byte) (int, error) {
 
 // Close closes the underlying log rotator if it has already been created.
 func (r *RotatingLogWriter) Close() error {
+	r.mu.Lock()
+	pipe := r.pipe
+	r.pipe = nil
+	r.mu.Unlock()
+
+	if pipe != nil {
+		if err := pipe.Close(); err != nil {
+			return err
+		}
+		r.wg.Wait()
+	}
+
 	if r.rotator != nil {
 		return r.rotator.Close()
 	}

--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -113,6 +113,12 @@
   channel arbitrator suppresses the duplicate event that would otherwise be
   emitted from `MarkChannelClosed` at the final confirmation depth.
 
+* [Fixed a data race in the `RotatingLogWriter`](https://github.com/lightningnetwork/lnd/pull/10886)
+  during startup. The `pipe` field was being read concurrently by `Write` while
+  being written by `InitLogRotator` and `Close`, which could trigger a race
+  condition. A `sync.RWMutex` is now used to synchronize access to the `pipe`
+  field, and `Close` sets `pipe` to `nil` under the lock to ensure idempotency.
+
 # New Features
 
 - [Basic Support](https://github.com/lightningnetwork/lnd/pull/9868) for onion


### PR DESCRIPTION
The` RotatingLogWriter.Write()` method called `rotator.Write()` directly while rotator.Run() executed concurrently in a background goroutine. Both accessed the **rotator's** internal size field without synchronization, triggering a data race detected by -race.

The fix writes to the **io.PipeWriter** instead of calling `rotator.Write()` directly. The pipe is designed for concurrent use and feeds data to Run() through its reader end. A `sync.RWMutex `is introduced to protect the pipe field from concurrent access between Write, `InitLogRotator`, and Close. Additionally, Close() now closes the pipe first (setting it to nil for idempotency), waits for the Run goroutine to finish via `sync.WaitGroup`, then closes the underlying rotator to ensure a clean shutdown.

Fixes #10867

## Steps to Test
1. Build lnd with race detector:
```bash
go build -race -o lnd-race ./cmd/lnd
```
2. Start **btcd** in **simnet** mode (minimal config)

3. Start **lnd** with race detector in **simnet** mode

4. Verify no data race warnings appear during startup

5. Run unit tests with race detector:
```bash
go test -race ./build/...
```

7. Run linter:
```bash
make lint
```
## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [X] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [X] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [X] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [X] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [X] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
