### PR TITLE
feature: allow custom feature bits already set by default

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -55,6 +55,12 @@
   the reported network statistics such as total network capacity, channel
   count and max out degree.
 
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/10888) where
+  configuring a `protocol.custom-init` or `protocol.custom-nodeann` feature bit
+  that lnd already advertises by default caused startup to fail with a
+  `feature bit: X already set` error. Such a duplicate now yields an identical
+  feature vector and is treated as a no-op.
+
 # New Features
 
 ## Functional Enhancements
@@ -148,3 +154,4 @@
 * Boris Nagaev
 * Erick Cestari
 * Jared Tobin
+* Lrifton92

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -47,6 +47,12 @@
   the reported network statistics such as total network capacity, channel
   count and max out degree.
 
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/10888) where
+  configuring a `protocol.custom-init` or `protocol.custom-nodeann` feature bit
+  that lnd already advertises by default caused startup to fail with a
+  `feature bit: X already set` error. Such a duplicate now yields an identical
+  feature vector and is treated as a no-op.
+
 # New Features
 
 ## Functional Enhancements
@@ -166,4 +172,8 @@
 * Boris Nagaev
 * Erick Cestari
 * Jared Tobin
+<<<<<<< HEAD
 * Nishant Bansal
+=======
+* Lrifton92
+>>>>>>> c870ccf4b (docs: add release note for #10888)

--- a/feature/manager.go
+++ b/feature/manager.go
@@ -239,9 +239,15 @@ func newManager(cfg Config, desc setDesc) (*Manager, error) {
 					set, set.Maximum())
 			}
 
+			// If the feature bit is already advertised in lnd's
+			// default feature vector, configuring it as a custom
+			// feature produces an identical vector. Treat this as a
+			// no-op rather than failing startup (see #10883).
+			// Genuine conflicts between the optional and required
+			// variants of a feature are still caught by SafeSet
+			// below.
 			if raw.IsSet(custom) {
-				return nil, fmt.Errorf("feature bit: %v "+
-					"already set", custom)
+				continue
 			}
 
 			if err := raw.SafeSet(custom); err != nil {

--- a/feature/manager_internal_test.go
+++ b/feature/manager_internal_test.go
@@ -289,3 +289,33 @@ func TestUpdateFeatureSets(t *testing.T) {
 		})
 	}
 }
+
+// TestManagerCustomFeatureAlreadyDefault asserts that configuring a custom
+// feature bit which lnd already advertises by default does not prevent the
+// feature manager from initializing. The resulting feature vector is identical,
+// so the duplicate must be treated as a no-op rather than a fatal error.
+//
+// See: https://github.com/lightningnetwork/lnd/issues/10883
+func TestManagerCustomFeatureAlreadyDefault(t *testing.T) {
+	t.Parallel()
+
+	// TLVOnionPayloadRequired is advertised by default in the Init set per
+	// testSetDesc, so configuring it as a custom feature for the same set
+	// duplicates an already-set bit. This previously failed startup with a
+	// "feature bit: ... already set" error.
+	cfg := Config{
+		CustomFeatures: map[Set][]lnwire.FeatureBit{
+			SetInit: {lnwire.TLVOnionPayloadRequired},
+		},
+	}
+
+	m, err := newManager(cfg, testSetDesc)
+	require.NoError(t, err)
+
+	// The required bit must still be advertised, and the duplicate must not
+	// have introduced its optional variant (which would form an invalid
+	// pairing). Check the exact bits via the raw vector.
+	rawInit := m.GetRaw(SetInit)
+	require.True(t, rawInit.IsSet(lnwire.TLVOnionPayloadRequired))
+	require.False(t, rawInit.IsSet(lnwire.TLVOnionPayloadOptional))
+}


### PR DESCRIPTION
### Change Description

Fixes #10883.

When a custom feature bit configured via `protocol.custom-init` or `protocol.custom-nodeann` is **already advertised** in lnd's default feature vector, `newManager` returned a fatal `feature bit: X already set` error and lnd failed to start:

```
unable to create server: feature bit: 39 already set
```

For example, bit `39` is `OnionMessagesOptional`, which lnd already advertises by default. A config such as:

```ini
[protocol]
protocol.custom-nodeann=39
protocol.custom-init=39
```

does not change the effective feature vector at all, yet it prevented startup.

### Fix

Re-advertising an already-set bit yields an identical feature vector, so it is harmless. This treats an already-set custom bit as a no-op (`continue`) instead of a fatal error. Genuine conflicts between the optional and required variants of a feature are still rejected by `SafeSet` immediately below, so the safety property is preserved.

```go
 if raw.IsSet(custom) {
-	return nil, fmt.Errorf("feature bit: %v "+
-		"already set", custom)
+	continue
 }
```

### Testing

Added `TestManagerCustomFeatureAlreadyDefault`, which configures a custom feature bit that is already set by default and asserts that:
- `newManager` no longer errors, and
- the resulting raw vector keeps the required bit set without introducing an invalid optional/required pairing.

```
$ go test ./feature/
ok  	github.com/lightningnetwork/lnd/feature
```

`gofmt`, `go vet ./feature/` clean. Tested on go1.26.4.

### Steps to Test

1. Start lnd with `protocol.custom-init=39` and `protocol.custom-nodeann=39` in `lnd.conf`.
2. Before this change lnd aborts with `feature bit: 39 already set`; after it, lnd starts normally and the feature vector is unchanged.

#### Pull Request Checklist

- [x] Change is reasonably small and self-contained.
- [x] Tests added/updated and passing.
- [ ] Release notes (added in a follow-up commit referencing this PR number).