### PR TITLE
Remove deprecated fee rate option --sat_per_byte

### DIFF
--- a/cmd/commands/cmd_open_channel.go
+++ b/cmd/commands/cmd_open_channel.go
@@ -180,11 +180,6 @@ var openChannelCommand = cli.Command{
 				"used for fee estimation",
 		},
 		cli.Int64Flag{
-			Name:   "sat_per_byte",
-			Usage:  "Deprecated, use sat_per_vbyte instead.",
-			Hidden: true,
-		},
-		cli.Int64Flag{
 			Name: "sat_per_vbyte",
 			Usage: "(optional) a manual fee expressed in " +
 				"sat/vbyte that should be used when crafting " +
@@ -319,19 +314,10 @@ func openChannel(ctx *cli.Context) error {
 		return nil
 	}
 
-	// Check that only the field sat_per_vbyte or the deprecated field
-	// sat_per_byte is used.
-	feeRateFlag, err := checkNotBothSet(
-		ctx, "sat_per_vbyte", "sat_per_byte",
-	)
-	if err != nil {
-		return err
-	}
-
 	minConfs := int32(ctx.Uint64("min_confs"))
 	req := &lnrpc.OpenChannelRequest{
 		TargetConf:                 int32(ctx.Int64("conf_target")),
-		SatPerVbyte:                ctx.Uint64(feeRateFlag),
+		SatPerVbyte:                ctx.Uint64("sat_per_vbyte"),
 		MinHtlcMsat:                ctx.Int64("min_htlc_msat"),
 		RemoteCsvDelay:             uint32(ctx.Uint64("remote_csv_delay")),
 		MinConfs:                   minConfs,
@@ -1080,7 +1066,7 @@ func checkPsbtFlags(req *lnrpc.OpenChannelRequest) error {
 		return fmt.Errorf("specifying minimum confirmations for PSBT " +
 			"funding is not supported")
 	}
-	if req.TargetConf != 0 || req.SatPerByte != 0 || req.SatPerVbyte != 0 { // nolint:staticcheck
+	if req.TargetConf != 0 || req.SatPerVbyte != 0 {
 		return fmt.Errorf("setting fee estimation parameters not " +
 			"supported for PSBT funding")
 	}

--- a/cmd/commands/commands.go
+++ b/cmd/commands/commands.go
@@ -498,11 +498,6 @@ var sendCoinsCommand = cli.Command{
 				"used for fee estimation",
 		},
 		cli.Int64Flag{
-			Name:   "sat_per_byte",
-			Usage:  "Deprecated, use sat_per_vbyte instead.",
-			Hidden: true,
-		},
-		cli.Int64Flag{
 			Name: "sat_per_vbyte",
 			Usage: "(optional) a manual fee expressed in " +
 				"sat/vbyte that should be used when crafting " +
@@ -555,18 +550,9 @@ func sendCoins(ctx *cli.Context) error {
 		return nil
 	}
 
-	// Check that only the field sat_per_vbyte or the deprecated field
-	// sat_per_byte is used.
-	feeRateFlag, err := checkNotBothSet(
-		ctx, "sat_per_vbyte", "sat_per_byte",
-	)
-	if err != nil {
-		return err
-	}
-
-	// Only fee rate flag or conf_target should be set, not both.
+	// Check that only one of sat_per_vbyte or conf_target is set, not both.
 	if _, err := checkNotBothSet(
-		ctx, feeRateFlag, "conf_target",
+		ctx, "sat_per_vbyte", "conf_target",
 	); err != nil {
 		return err
 	}
@@ -675,7 +661,7 @@ func sendCoins(ctx *cli.Context) error {
 		Addr:                  addr,
 		Amount:                amt,
 		TargetConf:            int32(ctx.Int64("conf_target")),
-		SatPerVbyte:           ctx.Uint64(feeRateFlag),
+		SatPerVbyte:           ctx.Uint64("sat_per_vbyte"),
 		SendAll:               ctx.Bool("sweepall"),
 		Label:                 ctx.String(txLabelFlag.Name),
 		MinConfs:              minConfs,
@@ -836,11 +822,6 @@ var sendManyCommand = cli.Command{
 				"confirm in, will be used for fee estimation",
 		},
 		cli.Int64Flag{
-			Name:   "sat_per_byte",
-			Usage:  "Deprecated, use sat_per_vbyte instead.",
-			Hidden: true,
-		},
-		cli.Int64Flag{
 			Name: "sat_per_vbyte",
 			Usage: "(optional) a manual fee expressed in " +
 				"sat/vbyte that should be used when crafting " +
@@ -868,18 +849,9 @@ func sendMany(ctx *cli.Context) error {
 		return err
 	}
 
-	// Check that only the field sat_per_vbyte or the deprecated field
-	// sat_per_byte is used.
-	feeRateFlag, err := checkNotBothSet(
-		ctx, "sat_per_vbyte", "sat_per_byte",
-	)
-	if err != nil {
-		return err
-	}
-
-	// Only fee rate flag or conf_target should be set, not both.
+	// Check that only one of sat_per_vbyte or conf_target is set, not both.
 	if _, err := checkNotBothSet(
-		ctx, feeRateFlag, "conf_target",
+		ctx, "sat_per_vbyte", "conf_target",
 	); err != nil {
 		return err
 	}
@@ -896,7 +868,7 @@ func sendMany(ctx *cli.Context) error {
 	txid, err := client.SendMany(ctxc, &lnrpc.SendManyRequest{
 		AddrToAmount:          amountToAddr,
 		TargetConf:            int32(ctx.Int64("conf_target")),
-		SatPerVbyte:           ctx.Uint64(feeRateFlag),
+		SatPerVbyte:           ctx.Uint64("sat_per_vbyte"),
 		Label:                 ctx.String(txLabelFlag.Name),
 		MinConfs:              minConfs,
 		SpendUnconfirmed:      minConfs == 0,
@@ -1087,11 +1059,6 @@ var closeChannelCommand = cli.Command{
 				"lnd config will be used.",
 		},
 		cli.Int64Flag{
-			Name:   "sat_per_byte",
-			Usage:  "Deprecated, use sat_per_vbyte instead.",
-			Hidden: true,
-		},
-		cli.Int64Flag{
 			Name: "sat_per_vbyte",
 			Usage: "(optional) a manual fee expressed in " +
 				"sat/vbyte that should be used when crafting " +
@@ -1128,15 +1095,6 @@ func closeChannel(ctx *cli.Context) error {
 		return nil
 	}
 
-	// Check that only the field sat_per_vbyte or the deprecated field
-	// sat_per_byte is used.
-	feeRateFlag, err := checkNotBothSet(
-		ctx, "sat_per_vbyte", "sat_per_byte",
-	)
-	if err != nil {
-		return err
-	}
-
 	channelPoint, err := parseChannelPoint(ctx)
 	if err != nil {
 		return err
@@ -1147,7 +1105,7 @@ func closeChannel(ctx *cli.Context) error {
 		ChannelPoint:    channelPoint,
 		Force:           ctx.Bool("force"),
 		TargetConf:      int32(ctx.Int64("conf_target")),
-		SatPerVbyte:     ctx.Uint64(feeRateFlag),
+		SatPerVbyte:     ctx.Uint64("sat_per_vbyte"),
 		DeliveryAddress: ctx.String("delivery_addr"),
 		MaxFeePerVbyte:  ctx.Uint64("max_fee_rate"),
 		// This makes sure that a coop close will also be executed if
@@ -1291,11 +1249,6 @@ var closeAllChannelsCommand = cli.Command{
 				"used for fee estimation",
 		},
 		cli.Int64Flag{
-			Name:   "sat_per_byte",
-			Usage:  "Deprecated, use sat_per_vbyte instead.",
-			Hidden: true,
-		},
-		cli.Int64Flag{
 			Name: "sat_per_vbyte",
 			Usage: "(optional) a manual fee expressed in " +
 				"sat/vbyte that should be used when crafting " +
@@ -1314,15 +1267,6 @@ func closeAllChannels(ctx *cli.Context) error {
 	ctxc := getContext()
 	client, cleanUp := getClient(ctx)
 	defer cleanUp()
-
-	// Check that only the field sat_per_vbyte or the deprecated field
-	// sat_per_byte is used.
-	feeRateFlag, err := checkNotBothSet(
-		ctx, "sat_per_vbyte", "sat_per_byte",
-	)
-	if err != nil {
-		return err
-	}
 
 	prompt := "Do you really want to close ALL channels? (yes/no): "
 	if !ctx.Bool("skip_confirmation") && !promptForConfirmation(prompt) {
@@ -1457,7 +1401,7 @@ func closeAllChannels(ctx *cli.Context) error {
 				},
 				Force:       !channel.GetActive(),
 				TargetConf:  int32(ctx.Int64("conf_target")),
-				SatPerVbyte: ctx.Uint64(feeRateFlag),
+				SatPerVbyte: ctx.Uint64("sat_per_vbyte"),
 			}
 
 			txidChan := make(chan string, 1)

--- a/cmd/commands/walletrpc_active.go
+++ b/cmd/commands/walletrpc_active.go
@@ -276,11 +276,6 @@ var bumpFeeCommand = cli.Command{
 	can be specified and LND will query its fee estimator for the current
 	fee rate for the given target.`,
 		},
-		cli.Uint64Flag{
-			Name:   "sat_per_byte",
-			Usage:  "Deprecated, use sat_per_vbyte instead.",
-			Hidden: true,
-		},
 		cli.BoolFlag{
 			Name:   "force",
 			Usage:  "Deprecated, use immediate instead.",
@@ -395,11 +390,6 @@ var bumpCloseFeeCommand = cli.Command{
 	can be specified and LND will query its fee estimator for the current
 	fee rate for the given target.`,
 		},
-		cli.Uint64Flag{
-			Name:   "sat_per_byte",
-			Usage:  "Deprecated, use sat_per_vbyte instead.",
-			Hidden: true,
-		},
 		cli.BoolFlag{
 			Name:   "force",
 			Usage:  "Deprecated, use immediate instead.",
@@ -462,11 +452,6 @@ var bumpForceCloseFeeCommand = cli.Command{
 	reached, ALL the budget will be spent as fees.`,
 		},
 		cli.Uint64Flag{
-			Name:   "sat_per_byte",
-			Usage:  "Deprecated, use sat_per_vbyte instead.",
-			Hidden: true,
-		},
-		cli.Uint64Flag{
 			Name: "sat_per_vbyte",
 			Usage: `
 	The starting fee rate, expressed in sat/vbyte. This value will be used
@@ -515,11 +500,6 @@ func bumpForceCloseFee(ctx *cli.Context) error {
 	rpcChannelPoint, err := parseChanPoint(channelPoint)
 	if err != nil {
 		return err
-	}
-
-	// `sat_per_byte` was deprecated we only use sats/vbyte now.
-	if ctx.IsSet("sat_per_byte") {
-		return fmt.Errorf("deprecated, use sat_per_vbyte instead")
 	}
 
 	// Retrieve pending sweeps.

--- a/cmd/commands/walletrpc_active.go
+++ b/cmd/commands/walletrpc_active.go
@@ -278,11 +278,6 @@ var bumpFeeCommand = cli.Command{
 	can be specified and LND will query its fee estimator for the current
 	fee rate for the given target.`,
 		},
-		cli.Uint64Flag{
-			Name:   "sat_per_byte",
-			Usage:  "Deprecated, use sat_per_vbyte instead.",
-			Hidden: true,
-		},
 		cli.BoolFlag{
 			Name:   "force",
 			Usage:  "Deprecated, use immediate instead.",
@@ -397,11 +392,6 @@ var bumpCloseFeeCommand = cli.Command{
 	can be specified and LND will query its fee estimator for the current
 	fee rate for the given target.`,
 		},
-		cli.Uint64Flag{
-			Name:   "sat_per_byte",
-			Usage:  "Deprecated, use sat_per_vbyte instead.",
-			Hidden: true,
-		},
 		cli.BoolFlag{
 			Name:   "force",
 			Usage:  "Deprecated, use immediate instead.",
@@ -464,11 +454,6 @@ var bumpForceCloseFeeCommand = cli.Command{
 	reached, ALL the budget will be spent as fees.`,
 		},
 		cli.Uint64Flag{
-			Name:   "sat_per_byte",
-			Usage:  "Deprecated, use sat_per_vbyte instead.",
-			Hidden: true,
-		},
-		cli.Uint64Flag{
 			Name: "sat_per_vbyte",
 			Usage: `
 	The starting fee rate, expressed in sat/vbyte. This value will be used
@@ -517,11 +502,6 @@ func bumpForceCloseFee(ctx *cli.Context) error {
 	rpcChannelPoint, err := parseChanPoint(channelPoint)
 	if err != nil {
 		return err
-	}
-
-	// `sat_per_byte` was deprecated we only use sats/vbyte now.
-	if ctx.IsSet("sat_per_byte") {
-		return fmt.Errorf("deprecated, use sat_per_vbyte instead")
 	}
 
 	// Retrieve pending sweeps.

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -94,6 +94,22 @@
 
 ## Breaking Changes
 
+* The deprecated fee rate option `--sat_per_byte` was removed
+[PR#10889](https://github.com/lightningnetwork/lnd/pull/10889)
+
+  The following RPCs were impacted:
+
+  | RPC Method | Messages | Removed Option | 
+  |----------------------|----------------|-------------|
+  | [`lnrpc.CloseChannel`](https://lightning.engineering/api-docs/api/lnd/lightning/close-channel/) | [`lnrpc.CloseChannelRequest`](https://lightning.engineering/api-docs/api/lnd/lightning/close-channel/#lnrpcclosechannelrequest) | sat_per_byte |
+  | [`lnrpc.OpenChannelSync`](https://lightning.engineering/api-docs/api/lnd/lightning/open-channel-sync/) | [`lnrpc.OpenChannelRequest`](https://lightning.engineering/api-docs/api/lnd/lightning/open-channel-sync/#lnrpcopenchannelrequest) | sat_per_byte | 
+  | [`lnrpc.OpenChannel`](https://lightning.engineering/api-docs/api/lnd/lightning/open-channel/) | [`lnrpc.OpenChannelRequest`](https://lightning.engineering/api-docs/api/lnd/lightning/open-channel/#lnrpcopenchannelrequest) | sat_per_byte |
+  | [`lnrpc.SendCoins`](https://lightning.engineering/api-docs/api/lnd/lightning/send-coins/) | [`lnrpc.SendCoinsRequest`](https://lightning.engineering/api-docs/api/lnd/lightning/send-coins/#lnrpcsendcoinsrequest) | sat_per_byte |
+  | [`lnrpc.SendMany`](https://lightning.engineering/api-docs/api/lnd/lightning/send-many/) | [`lnrpc.SendManyRequest`](https://lightning.engineering/api-docs/api/lnd/lightning/send-many/#lnrpcsendmanyrequest) | sat_per_byte |
+  | [`walletrpc.BumpFee`](https://lightning.engineering/api-docs/api/lnd/wallet-kit/bump-fee/) | [`walletrpc.BumpFeeRequest`](https://lightning.engineering/api-docs/api/lnd/wallet-kit/bump-fee/#walletrpcbumpfeerequest) | sat_per_byte |
+
+* [PR#10889](https://github.com/lightningnetwork/lnd/pull/10889) also removed the `--sat_per_byte` lncli flag from `openchannel`, `sendcoins`, `sendmany`, `closechannel`, `closeallchannels`, `bumpfee`, and `bumpforceclosefee`.
+
 ## Performance Improvements
 
 ## Deprecations
@@ -148,3 +164,4 @@
 * Boris Nagaev
 * Erick Cestari
 * Jared Tobin
+* Pins

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -86,6 +86,22 @@
 
 ## Breaking Changes
 
+* The deprecated fee rate option `--sat_per_byte` was removed
+[PR#10889](https://github.com/lightningnetwork/lnd/pull/10889)
+
+  The following RPCs were impacted:
+
+  | RPC Method | Messages | Removed Option | 
+  |----------------------|----------------|-------------|
+  | [`lnrpc.CloseChannel`](https://lightning.engineering/api-docs/api/lnd/lightning/close-channel/) | [`lnrpc.CloseChannelRequest`](https://lightning.engineering/api-docs/api/lnd/lightning/close-channel/#lnrpcclosechannelrequest) | sat_per_byte |
+  | [`lnrpc.OpenChannelSync`](https://lightning.engineering/api-docs/api/lnd/lightning/open-channel-sync/) | [`lnrpc.OpenChannelRequest`](https://lightning.engineering/api-docs/api/lnd/lightning/open-channel-sync/#lnrpcopenchannelrequest) | sat_per_byte | 
+  | [`lnrpc.OpenChannel`](https://lightning.engineering/api-docs/api/lnd/lightning/open-channel/) | [`lnrpc.OpenChannelRequest`](https://lightning.engineering/api-docs/api/lnd/lightning/open-channel/#lnrpcopenchannelrequest) | sat_per_byte |
+  | [`lnrpc.SendCoins`](https://lightning.engineering/api-docs/api/lnd/lightning/send-coins/) | [`lnrpc.SendCoinsRequest`](https://lightning.engineering/api-docs/api/lnd/lightning/send-coins/#lnrpcsendcoinsrequest) | sat_per_byte |
+  | [`lnrpc.SendMany`](https://lightning.engineering/api-docs/api/lnd/lightning/send-many/) | [`lnrpc.SendManyRequest`](https://lightning.engineering/api-docs/api/lnd/lightning/send-many/#lnrpcsendmanyrequest) | sat_per_byte |
+  | [`walletrpc.BumpFee`](https://lightning.engineering/api-docs/api/lnd/wallet-kit/bump-fee/) | [`walletrpc.BumpFeeRequest`](https://lightning.engineering/api-docs/api/lnd/wallet-kit/bump-fee/#walletrpcbumpfeerequest) | sat_per_byte |
+
+* [PR#10889](https://github.com/lightningnetwork/lnd/pull/10889) also removed the `--sat_per_byte` lncli flag from `openchannel`, `sendcoins`, `sendmany`, `closechannel`, `closeallchannels`, `bumpfee`, and `bumpforceclosefee`.
+
 ## Performance Improvements
 
 ## Deprecations
@@ -167,3 +183,4 @@
 * Erick Cestari
 * Jared Tobin
 * Nishant Bansal
+* Pins

--- a/itest/lnd_wallet_import_test.go
+++ b/itest/lnd_wallet_import_test.go
@@ -567,9 +567,9 @@ func runWalletImportAccountScenario(ht *lntest.HarnessTest,
 	// balance updates accordingly.
 	alice := ht.NewNodeWithCoins("Alice", nil)
 	req := &lnrpc.SendCoinsRequest{
-		Addr:       externalAddr,
-		Amount:     utxoAmt,
-		SatPerByte: 1,
+		Addr:        externalAddr,
+		Amount:      utxoAmt,
+		SatPerVbyte: 1,
 	}
 	alice.RPC.SendCoins(req)
 
@@ -600,9 +600,9 @@ func runWalletImportAccountScenario(ht *lntest.HarnessTest,
 	// Send coins to Carol's address and confirm them, making sure the
 	// balance updates accordingly.
 	req = &lnrpc.SendCoinsRequest{
-		Addr:       externalAddr,
-		Amount:     utxoAmt,
-		SatPerByte: 1,
+		Addr:        externalAddr,
+		Amount:      utxoAmt,
+		SatPerVbyte: 1,
 	}
 	alice.RPC.SendCoins(req)
 
@@ -739,9 +739,9 @@ func testWalletImportPubKeyScenario(ht *lntest.HarnessTest,
 		// Send coins to Carol's address and confirm them, making sure
 		// the balance updates accordingly.
 		req := &lnrpc.SendCoinsRequest{
-			Addr:       carolAddrResp.Address,
-			Amount:     utxoAmt,
-			SatPerByte: 1,
+			Addr:        carolAddrResp.Address,
+			Amount:      utxoAmt,
+			SatPerVbyte: 1,
 		}
 		alice.RPC.SendCoins(req)
 

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -3321,8 +3321,7 @@ type EstimateFeeResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The total fee in satoshis.
 	FeeSat int64 `protobuf:"varint,1,opt,name=fee_sat,json=feeSat,proto3" json:"fee_sat,omitempty"`
-	// Deprecated, use sat_per_vbyte.
-	// The fee rate in satoshi/vbyte.
+	// Removed, use sat_per_vbyte.
 	//
 	// Deprecated: Marked as deprecated in lightning.proto.
 	FeerateSatPerByte int64 `protobuf:"varint,2,opt,name=feerate_sat_per_byte,json=feerateSatPerByte,proto3" json:"feerate_sat_per_byte,omitempty"`
@@ -3403,9 +3402,7 @@ type SendManyRequest struct {
 	// A manual fee rate set in sat/vbyte that should be used when crafting the
 	// transaction.
 	SatPerVbyte uint64 `protobuf:"varint,4,opt,name=sat_per_vbyte,json=satPerVbyte,proto3" json:"sat_per_vbyte,omitempty"`
-	// Deprecated, use sat_per_vbyte.
-	// A manual fee rate set in sat/vbyte that should be used when crafting the
-	// transaction.
+	// Removed, use sat_per_vbyte.
 	//
 	// Deprecated: Marked as deprecated in lightning.proto.
 	SatPerByte int64 `protobuf:"varint,5,opt,name=sat_per_byte,json=satPerByte,proto3" json:"sat_per_byte,omitempty"`
@@ -3566,9 +3563,7 @@ type SendCoinsRequest struct {
 	// A manual fee rate set in sat/vbyte that should be used when crafting the
 	// transaction.
 	SatPerVbyte uint64 `protobuf:"varint,4,opt,name=sat_per_vbyte,json=satPerVbyte,proto3" json:"sat_per_vbyte,omitempty"`
-	// Deprecated, use sat_per_vbyte.
-	// A manual fee rate set in sat/vbyte that should be used when crafting the
-	// transaction.
+	// Removed, use sat_per_vbyte.
 	//
 	// Deprecated: Marked as deprecated in lightning.proto.
 	SatPerByte int64 `protobuf:"varint,5,opt,name=sat_per_byte,json=satPerByte,proto3" json:"sat_per_byte,omitempty"`
@@ -6798,9 +6793,7 @@ type CloseChannelRequest struct {
 	// The target number of blocks that the closure transaction should be
 	// confirmed by.
 	TargetConf int32 `protobuf:"varint,3,opt,name=target_conf,json=targetConf,proto3" json:"target_conf,omitempty"`
-	// Deprecated, use sat_per_vbyte.
-	// A manual fee rate set in sat/vbyte that should be used when crafting the
-	// closure transaction.
+	// Removed, use sat_per_vbyte.
 	//
 	// Deprecated: Marked as deprecated in lightning.proto.
 	SatPerByte int64 `protobuf:"varint,4,opt,name=sat_per_byte,json=satPerByte,proto3" json:"sat_per_byte,omitempty"`
@@ -7610,9 +7603,7 @@ type OpenChannelRequest struct {
 	// The target number of blocks that the funding transaction should be
 	// confirmed by.
 	TargetConf int32 `protobuf:"varint,6,opt,name=target_conf,json=targetConf,proto3" json:"target_conf,omitempty"`
-	// Deprecated, use sat_per_vbyte.
-	// A manual fee rate set in sat/vbyte that should be used when crafting the
-	// funding transaction.
+	// Removed, use sat_per_vbyte.
 	//
 	// Deprecated: Marked as deprecated in lightning.proto.
 	SatPerByte int64 `protobuf:"varint,7,opt,name=sat_per_byte,json=satPerByte,proto3" json:"sat_per_byte,omitempty"`

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -3321,8 +3321,7 @@ type EstimateFeeResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The total fee in satoshis.
 	FeeSat int64 `protobuf:"varint,1,opt,name=fee_sat,json=feeSat,proto3" json:"fee_sat,omitempty"`
-	// Deprecated, use sat_per_vbyte.
-	// The fee rate in satoshi/vbyte.
+	// Removed, use sat_per_vbyte.
 	//
 	// Deprecated: Marked as deprecated in lightning.proto.
 	FeerateSatPerByte int64 `protobuf:"varint,2,opt,name=feerate_sat_per_byte,json=feerateSatPerByte,proto3" json:"feerate_sat_per_byte,omitempty"`
@@ -3403,9 +3402,7 @@ type SendManyRequest struct {
 	// A manual fee rate set in sat/vbyte that should be used when crafting the
 	// transaction.
 	SatPerVbyte uint64 `protobuf:"varint,4,opt,name=sat_per_vbyte,json=satPerVbyte,proto3" json:"sat_per_vbyte,omitempty"`
-	// Deprecated, use sat_per_vbyte.
-	// A manual fee rate set in sat/vbyte that should be used when crafting the
-	// transaction.
+	// Removed, use sat_per_vbyte.
 	//
 	// Deprecated: Marked as deprecated in lightning.proto.
 	SatPerByte int64 `protobuf:"varint,5,opt,name=sat_per_byte,json=satPerByte,proto3" json:"sat_per_byte,omitempty"`
@@ -3566,9 +3563,7 @@ type SendCoinsRequest struct {
 	// A manual fee rate set in sat/vbyte that should be used when crafting the
 	// transaction.
 	SatPerVbyte uint64 `protobuf:"varint,4,opt,name=sat_per_vbyte,json=satPerVbyte,proto3" json:"sat_per_vbyte,omitempty"`
-	// Deprecated, use sat_per_vbyte.
-	// A manual fee rate set in sat/vbyte that should be used when crafting the
-	// transaction.
+	// Removed, use sat_per_vbyte.
 	//
 	// Deprecated: Marked as deprecated in lightning.proto.
 	SatPerByte int64 `protobuf:"varint,5,opt,name=sat_per_byte,json=satPerByte,proto3" json:"sat_per_byte,omitempty"`
@@ -6798,9 +6793,7 @@ type CloseChannelRequest struct {
 	// The target number of blocks that the closure transaction should be
 	// confirmed by.
 	TargetConf int32 `protobuf:"varint,3,opt,name=target_conf,json=targetConf,proto3" json:"target_conf,omitempty"`
-	// Deprecated, use sat_per_vbyte.
-	// A manual fee rate set in sat/vbyte that should be used when crafting the
-	// closure transaction.
+	// Removed, use sat_per_vbyte.
 	//
 	// Deprecated: Marked as deprecated in lightning.proto.
 	SatPerByte int64 `protobuf:"varint,4,opt,name=sat_per_byte,json=satPerByte,proto3" json:"sat_per_byte,omitempty"`
@@ -7611,9 +7604,7 @@ type OpenChannelRequest struct {
 	// The target number of blocks that the funding transaction should be
 	// confirmed by.
 	TargetConf int32 `protobuf:"varint,6,opt,name=target_conf,json=targetConf,proto3" json:"target_conf,omitempty"`
-	// Deprecated, use sat_per_vbyte.
-	// A manual fee rate set in sat/vbyte that should be used when crafting the
-	// funding transaction.
+	// Removed, use sat_per_vbyte.
 	//
 	// Deprecated: Marked as deprecated in lightning.proto.
 	SatPerByte int64 `protobuf:"varint,7,opt,name=sat_per_byte,json=satPerByte,proto3" json:"sat_per_byte,omitempty"`

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -1075,8 +1075,7 @@ message EstimateFeeResponse {
     // The total fee in satoshis.
     int64 fee_sat = 1;
 
-    // Deprecated, use sat_per_vbyte.
-    // The fee rate in satoshi/vbyte.
+    // Removed, use sat_per_vbyte.
     int64 feerate_sat_per_byte = 2 [deprecated = true];
 
     // The fee rate in satoshi/vbyte.
@@ -1098,9 +1097,7 @@ message SendManyRequest {
     // transaction.
     uint64 sat_per_vbyte = 4;
 
-    // Deprecated, use sat_per_vbyte.
-    // A manual fee rate set in sat/vbyte that should be used when crafting the
-    // transaction.
+    // Removed, use sat_per_vbyte.
     int64 sat_per_byte = 5 [deprecated = true];
 
     // An optional label for the transaction, limited to 500 characters.
@@ -1136,9 +1133,7 @@ message SendCoinsRequest {
     // transaction.
     uint64 sat_per_vbyte = 4;
 
-    // Deprecated, use sat_per_vbyte.
-    // A manual fee rate set in sat/vbyte that should be used when crafting the
-    // transaction.
+    // Removed, use sat_per_vbyte.
     int64 sat_per_byte = 5 [deprecated = true];
 
     /*
@@ -2090,9 +2085,7 @@ message CloseChannelRequest {
     // confirmed by.
     int32 target_conf = 3;
 
-    // Deprecated, use sat_per_vbyte.
-    // A manual fee rate set in sat/vbyte that should be used when crafting the
-    // closure transaction.
+    // Removed, use sat_per_vbyte.
     int64 sat_per_byte = 4 [deprecated = true];
 
     /*
@@ -2345,9 +2338,7 @@ message OpenChannelRequest {
     // confirmed by.
     int32 target_conf = 6;
 
-    // Deprecated, use sat_per_vbyte.
-    // A manual fee rate set in sat/vbyte that should be used when crafting the
-    // funding transaction.
+    // Removed, use sat_per_vbyte.
     int64 sat_per_byte = 7 [deprecated = true];
 
     // Whether this channel should be private, not announced to the greater

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -1075,8 +1075,7 @@ message EstimateFeeResponse {
     // The total fee in satoshis.
     int64 fee_sat = 1;
 
-    // Deprecated, use sat_per_vbyte.
-    // The fee rate in satoshi/vbyte.
+    // Removed, use sat_per_vbyte.
     int64 feerate_sat_per_byte = 2 [deprecated = true];
 
     // The fee rate in satoshi/vbyte.
@@ -1098,9 +1097,7 @@ message SendManyRequest {
     // transaction.
     uint64 sat_per_vbyte = 4;
 
-    // Deprecated, use sat_per_vbyte.
-    // A manual fee rate set in sat/vbyte that should be used when crafting the
-    // transaction.
+    // Removed, use sat_per_vbyte.
     int64 sat_per_byte = 5 [deprecated = true];
 
     // An optional label for the transaction, limited to 500 characters.
@@ -1136,9 +1133,7 @@ message SendCoinsRequest {
     // transaction.
     uint64 sat_per_vbyte = 4;
 
-    // Deprecated, use sat_per_vbyte.
-    // A manual fee rate set in sat/vbyte that should be used when crafting the
-    // transaction.
+    // Removed, use sat_per_vbyte.
     int64 sat_per_byte = 5 [deprecated = true];
 
     /*
@@ -2090,9 +2085,7 @@ message CloseChannelRequest {
     // confirmed by.
     int32 target_conf = 3;
 
-    // Deprecated, use sat_per_vbyte.
-    // A manual fee rate set in sat/vbyte that should be used when crafting the
-    // closure transaction.
+    // Removed, use sat_per_vbyte.
     int64 sat_per_byte = 4 [deprecated = true];
 
     /*
@@ -2346,9 +2339,7 @@ message OpenChannelRequest {
     // confirmed by.
     int32 target_conf = 6;
 
-    // Deprecated, use sat_per_vbyte.
-    // A manual fee rate set in sat/vbyte that should be used when crafting the
-    // funding transaction.
+    // Removed, use sat_per_vbyte.
     int64 sat_per_byte = 7 [deprecated = true];
 
     // Whether this channel should be private, not announced to the greater

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -738,7 +738,7 @@
           },
           {
             "name": "sat_per_byte",
-            "description": "Deprecated, use sat_per_vbyte.\nA manual fee rate set in sat/vbyte that should be used when crafting the\nclosure transaction.",
+            "description": "Removed, use sat_per_vbyte.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -4950,7 +4950,7 @@
         "feerate_sat_per_byte": {
           "type": "string",
           "format": "int64",
-          "description": "Deprecated, use sat_per_vbyte.\nThe fee rate in satoshi/vbyte."
+          "description": "Removed, use sat_per_vbyte."
         },
         "sat_per_vbyte": {
           "type": "string",
@@ -6558,7 +6558,7 @@
         "sat_per_byte": {
           "type": "string",
           "format": "int64",
-          "description": "Deprecated, use sat_per_vbyte.\nA manual fee rate set in sat/vbyte that should be used when crafting the\nfunding transaction."
+          "description": "Removed, use sat_per_vbyte."
         },
         "private": {
           "type": "boolean",
@@ -7513,7 +7513,7 @@
         "sat_per_byte": {
           "type": "string",
           "format": "int64",
-          "description": "Deprecated, use sat_per_vbyte.\nA manual fee rate set in sat/vbyte that should be used when crafting the\ntransaction."
+          "description": "Removed, use sat_per_vbyte."
         },
         "send_all": {
           "type": "boolean",
@@ -7608,7 +7608,7 @@
         "sat_per_byte": {
           "type": "string",
           "format": "int64",
-          "description": "Deprecated, use sat_per_vbyte.\nA manual fee rate set in sat/vbyte that should be used when crafting the\ntransaction."
+          "description": "Removed, use sat_per_vbyte."
         },
         "label": {
           "type": "string",

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -738,7 +738,7 @@
           },
           {
             "name": "sat_per_byte",
-            "description": "Deprecated, use sat_per_vbyte.\nA manual fee rate set in sat/vbyte that should be used when crafting the\nclosure transaction.",
+            "description": "Removed, use sat_per_vbyte.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -4950,7 +4950,7 @@
         "feerate_sat_per_byte": {
           "type": "string",
           "format": "int64",
-          "description": "Deprecated, use sat_per_vbyte.\nThe fee rate in satoshi/vbyte."
+          "description": "Removed, use sat_per_vbyte."
         },
         "sat_per_vbyte": {
           "type": "string",
@@ -6558,7 +6558,7 @@
         "sat_per_byte": {
           "type": "string",
           "format": "int64",
-          "description": "Deprecated, use sat_per_vbyte.\nA manual fee rate set in sat/vbyte that should be used when crafting the\nfunding transaction."
+          "description": "Removed, use sat_per_vbyte."
         },
         "private": {
           "type": "boolean",
@@ -7527,7 +7527,7 @@
         "sat_per_byte": {
           "type": "string",
           "format": "int64",
-          "description": "Deprecated, use sat_per_vbyte.\nA manual fee rate set in sat/vbyte that should be used when crafting the\ntransaction."
+          "description": "Removed, use sat_per_vbyte."
         },
         "send_all": {
           "type": "boolean",
@@ -7622,7 +7622,7 @@
         "sat_per_byte": {
           "type": "string",
           "format": "int64",
-          "description": "Deprecated, use sat_per_vbyte.\nA manual fee rate set in sat/vbyte that should be used when crafting the\ntransaction."
+          "description": "Removed, use sat_per_vbyte."
         },
         "label": {
           "type": "string",

--- a/lnrpc/rpc_utils.go
+++ b/lnrpc/rpc_utils.go
@@ -3,7 +3,6 @@ package lnrpc
 import (
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"sort"
 
 	"github.com/btcsuite/btcd/chainhash/v2"
@@ -55,6 +54,12 @@ var (
 	RESTJsonUnmarshalOpts = &protojson.UnmarshalOptions{
 		AllowPartial: false,
 	}
+
+	// ErrSatPerByteRemoved is returned when a request still sets the
+	// deprecated sat_per_byte field. The field was deprecated in v0.13.0
+	// in favor of sat_per_vbyte and is no longer honored.
+	ErrSatPerByteRemoved = errors.New("sat_per_byte is no longer " +
+		"supported, use sat_per_vbyte instead")
 )
 
 // RPCTransaction returns a rpc transaction.
@@ -227,28 +232,13 @@ func GetChannelOutPoint(chanPoint *ChannelPoint) (*OutPoint, error) {
 	}, nil
 }
 
-// CalculateFeeRate uses either satPerByte or satPerVByte, but not both, from a
-// request to calculate the fee rate. It provides compatibility for the
-// deprecated field, satPerByte. Once the field is safe to be removed, the
-// check can then be deleted.
-func CalculateFeeRate(satPerByte, satPerVByte uint64, targetConf uint32,
+// CalculateFeeRate uses satPerVByte from a request to calculate the fee rate.
+func CalculateFeeRate(satPerVByte uint64, targetConf uint32,
 	estimator chainfee.Estimator) (chainfee.SatPerKWeight, error) {
 
 	var feeRate chainfee.SatPerKWeight
 
-	// We only allow using either the deprecated field or the new field.
-	if satPerByte != 0 && satPerVByte != 0 {
-		return feeRate, fmt.Errorf("either SatPerByte or " +
-			"SatPerVByte should be set, but not both")
-	}
-
-	// Default to satPerVByte, and overwrite it if satPerByte is set.
 	satPerKw := chainfee.SatPerKVByte(satPerVByte * 1000).FeePerKWeight()
-	if satPerByte != 0 {
-		satPerKw = chainfee.SatPerKVByte(
-			satPerByte * 1000,
-		).FeePerKWeight()
-	}
 
 	// Based on the passed fee related parameters, we'll determine an
 	// appropriate fee rate for this transaction.

--- a/lnrpc/walletrpc/walletkit.pb.go
+++ b/lnrpc/walletrpc/walletkit.pb.go
@@ -2937,10 +2937,7 @@ type PendingSweep struct {
 	WitnessType WitnessType `protobuf:"varint,2,opt,name=witness_type,json=witnessType,proto3,enum=walletrpc.WitnessType" json:"witness_type,omitempty"`
 	// The value of the output we're attempting to sweep.
 	AmountSat uint32 `protobuf:"varint,3,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
-	// Deprecated, use sat_per_vbyte.
-	// The fee rate we'll use to sweep the output, expressed in sat/vbyte. The fee
-	// rate is only determined once a sweeping transaction for the output is
-	// created, so it's possible for this to be 0 before this.
+	// Removed, use sat_per_vbyte.
 	//
 	// Deprecated: Marked as deprecated in walletrpc/walletkit.proto.
 	SatPerByte uint32 `protobuf:"varint,4,opt,name=sat_per_byte,json=satPerByte,proto3" json:"sat_per_byte,omitempty"`
@@ -3218,9 +3215,7 @@ type BumpFeeRequest struct {
 	// Optional. The conf target the underlying fee estimator will use to
 	// estimate the starting fee rate for the fee function.
 	TargetConf uint32 `protobuf:"varint,2,opt,name=target_conf,json=targetConf,proto3" json:"target_conf,omitempty"`
-	// Deprecated, use sat_per_vbyte.
-	// The fee rate, expressed in sat/vbyte, that should be used to spend the input
-	// with.
+	// Removed, use sat_per_vbyte.
 	//
 	// Deprecated: Marked as deprecated in walletrpc/walletkit.proto.
 	SatPerByte uint32 `protobuf:"varint,3,opt,name=sat_per_byte,json=satPerByte,proto3" json:"sat_per_byte,omitempty"`

--- a/lnrpc/walletrpc/walletkit.pb.go
+++ b/lnrpc/walletrpc/walletkit.pb.go
@@ -3061,10 +3061,7 @@ type PendingSweep struct {
 	WitnessType WitnessType `protobuf:"varint,2,opt,name=witness_type,json=witnessType,proto3,enum=walletrpc.WitnessType" json:"witness_type,omitempty"`
 	// The value of the output we're attempting to sweep.
 	AmountSat uint32 `protobuf:"varint,3,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
-	// Deprecated, use sat_per_vbyte.
-	// The fee rate we'll use to sweep the output, expressed in sat/vbyte. The fee
-	// rate is only determined once a sweeping transaction for the output is
-	// created, so it's possible for this to be 0 before this.
+	// Removed, use sat_per_vbyte.
 	//
 	// Deprecated: Marked as deprecated in walletrpc/walletkit.proto.
 	SatPerByte uint32 `protobuf:"varint,4,opt,name=sat_per_byte,json=satPerByte,proto3" json:"sat_per_byte,omitempty"`
@@ -3342,9 +3339,7 @@ type BumpFeeRequest struct {
 	// Optional. The conf target the underlying fee estimator will use to
 	// estimate the starting fee rate for the fee function.
 	TargetConf uint32 `protobuf:"varint,2,opt,name=target_conf,json=targetConf,proto3" json:"target_conf,omitempty"`
-	// Deprecated, use sat_per_vbyte.
-	// The fee rate, expressed in sat/vbyte, that should be used to spend the input
-	// with.
+	// Removed, use sat_per_vbyte.
 	//
 	// Deprecated: Marked as deprecated in walletrpc/walletkit.proto.
 	SatPerByte uint32 `protobuf:"varint,3,opt,name=sat_per_byte,json=satPerByte,proto3" json:"sat_per_byte,omitempty"`

--- a/lnrpc/walletrpc/walletkit.proto
+++ b/lnrpc/walletrpc/walletkit.proto
@@ -1216,12 +1216,7 @@ message PendingSweep {
     // The value of the output we're attempting to sweep.
     uint32 amount_sat = 3;
 
-    /*
-    Deprecated, use sat_per_vbyte.
-    The fee rate we'll use to sweep the output, expressed in sat/vbyte. The fee
-    rate is only determined once a sweeping transaction for the output is
-    created, so it's possible for this to be 0 before this.
-    */
+    // Removed, use sat_per_vbyte.
     uint32 sat_per_byte = 4 [deprecated = true];
 
     // The number of broadcast attempts we've made to sweep the output.
@@ -1304,11 +1299,7 @@ message BumpFeeRequest {
     // estimate the starting fee rate for the fee function.
     uint32 target_conf = 2;
 
-    /*
-    Deprecated, use sat_per_vbyte.
-    The fee rate, expressed in sat/vbyte, that should be used to spend the input
-    with.
-    */
+    // Removed, use sat_per_vbyte.
     uint32 sat_per_byte = 3 [deprecated = true];
 
     /*

--- a/lnrpc/walletrpc/walletkit.proto
+++ b/lnrpc/walletrpc/walletkit.proto
@@ -1307,12 +1307,7 @@ message PendingSweep {
     // The value of the output we're attempting to sweep.
     uint32 amount_sat = 3;
 
-    /*
-    Deprecated, use sat_per_vbyte.
-    The fee rate we'll use to sweep the output, expressed in sat/vbyte. The fee
-    rate is only determined once a sweeping transaction for the output is
-    created, so it's possible for this to be 0 before this.
-    */
+    // Removed, use sat_per_vbyte.
     uint32 sat_per_byte = 4 [deprecated = true];
 
     // The number of broadcast attempts we've made to sweep the output.
@@ -1395,11 +1390,7 @@ message BumpFeeRequest {
     // estimate the starting fee rate for the fee function.
     uint32 target_conf = 2;
 
-    /*
-    Deprecated, use sat_per_vbyte.
-    The fee rate, expressed in sat/vbyte, that should be used to spend the input
-    with.
-    */
+    // Removed, use sat_per_vbyte.
     uint32 sat_per_byte = 3 [deprecated = true];
 
     /*

--- a/lnrpc/walletrpc/walletkit.swagger.json
+++ b/lnrpc/walletrpc/walletkit.swagger.json
@@ -1462,7 +1462,7 @@
         "sat_per_byte": {
           "type": "integer",
           "format": "int64",
-          "description": "Deprecated, use sat_per_vbyte.\nThe fee rate, expressed in sat/vbyte, that should be used to spend the input\nwith."
+          "description": "Removed, use sat_per_vbyte."
         },
         "force": {
           "type": "boolean",
@@ -1977,7 +1977,7 @@
         "sat_per_byte": {
           "type": "integer",
           "format": "int64",
-          "description": "Deprecated, use sat_per_vbyte.\nThe fee rate we'll use to sweep the output, expressed in sat/vbyte. The fee\nrate is only determined once a sweeping transaction for the output is\ncreated, so it's possible for this to be 0 before this."
+          "description": "Removed, use sat_per_vbyte."
         },
         "broadcast_attempts": {
           "type": "integer",

--- a/lnrpc/walletrpc/walletkit.swagger.json
+++ b/lnrpc/walletrpc/walletkit.swagger.json
@@ -1496,7 +1496,7 @@
         "sat_per_byte": {
           "type": "integer",
           "format": "int64",
-          "description": "Deprecated, use sat_per_vbyte.\nThe fee rate, expressed in sat/vbyte, that should be used to spend the input\nwith."
+          "description": "Removed, use sat_per_vbyte."
         },
         "force": {
           "type": "boolean",
@@ -2011,7 +2011,7 @@
         "sat_per_byte": {
           "type": "integer",
           "format": "int64",
-          "description": "Deprecated, use sat_per_vbyte.\nThe fee rate we'll use to sweep the output, expressed in sat/vbyte. The fee\nrate is only determined once a sweeping transaction for the output is\ncreated, so it's possible for this to be 0 before this."
+          "description": "Removed, use sat_per_vbyte."
         },
         "broadcast_attempts": {
           "type": "integer",

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -48,6 +48,8 @@ import (
 	"github.com/lightningnetwork/lnd/macaroons"
 	"github.com/lightningnetwork/lnd/sweep"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 )
 
@@ -1055,19 +1057,12 @@ func validateBumpFeeRequest(in *BumpFeeRequest, estimator chainfee.Estimator) (
 	// Get the specified fee rate if set.
 	satPerKwOpt := fn.None[chainfee.SatPerKWeight]()
 
-	// We only allow using either the deprecated field or the new field.
-	switch {
-	case in.SatPerByte != 0 && in.SatPerVbyte != 0:
-		return satPerKwOpt, false, fmt.Errorf("either SatPerByte or " +
-			"SatPerVbyte should be set, but not both")
+	// The deprecated sat_per_byte field is no longer honored.
+	if in.SatPerByte != 0 {
+		return satPerKwOpt, false, lnrpc.ErrSatPerByteRemoved
+	}
 
-	case in.SatPerByte != 0:
-		satPerKw := chainfee.SatPerVByte(
-			in.SatPerByte,
-		).FeePerKWeight()
-		satPerKwOpt = fn.Some(satPerKw)
-
-	case in.SatPerVbyte != 0:
+	if in.SatPerVbyte != 0 {
 		satPerKw := chainfee.SatPerVByte(
 			in.SatPerVbyte,
 		).FeePerKWeight()
@@ -1242,6 +1237,14 @@ func (w *WalletKit) BumpFee(ctx context.Context,
 	// - the budget of this input was not enough to RBF the existing tx.
 	params, existing, err := w.prepareSweepParams(in, *op, currentHeight)
 	if err != nil {
+		// Surface the removal of the deprecated sat_per_byte field as
+		// InvalidArgument.
+		if errors.Is(err, lnrpc.ErrSatPerByteRemoved) {
+			return nil, status.Error(
+				codes.InvalidArgument, err.Error(),
+			)
+		}
+
 		return nil, err
 	}
 

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -49,6 +49,8 @@ import (
 	"github.com/lightningnetwork/lnd/macaroons"
 	"github.com/lightningnetwork/lnd/sweep"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 )
 
@@ -1060,19 +1062,12 @@ func validateBumpFeeRequest(in *BumpFeeRequest, estimator chainfee.Estimator) (
 	// Get the specified fee rate if set.
 	satPerKwOpt := fn.None[chainfee.SatPerKWeight]()
 
-	// We only allow using either the deprecated field or the new field.
-	switch {
-	case in.SatPerByte != 0 && in.SatPerVbyte != 0:
-		return satPerKwOpt, false, fmt.Errorf("either SatPerByte or " +
-			"SatPerVbyte should be set, but not both")
+	// The deprecated sat_per_byte field is no longer honored.
+	if in.SatPerByte != 0 {
+		return satPerKwOpt, false, lnrpc.ErrSatPerByteRemoved
+	}
 
-	case in.SatPerByte != 0:
-		satPerKw := chainfee.SatPerVByte(
-			in.SatPerByte,
-		).FeePerKWeight()
-		satPerKwOpt = fn.Some(satPerKw)
-
-	case in.SatPerVbyte != 0:
+	if in.SatPerVbyte != 0 {
 		satPerKw := chainfee.SatPerVByte(
 			in.SatPerVbyte,
 		).FeePerKWeight()
@@ -1247,6 +1242,14 @@ func (w *WalletKit) BumpFee(ctx context.Context,
 	// - the budget of this input was not enough to RBF the existing tx.
 	params, existing, err := w.prepareSweepParams(in, *op, currentHeight)
 	if err != nil {
+		// Surface the removal of the deprecated sat_per_byte field as
+		// InvalidArgument.
+		if errors.Is(err, lnrpc.ErrSatPerByteRemoved) {
+			return nil, status.Error(
+				codes.InvalidArgument, err.Error(),
+			)
+		}
+
 		return nil, err
 	}
 

--- a/lnrpc/walletrpc/walletkit_server_test.go
+++ b/lnrpc/walletrpc/walletkit_server_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lntest/mock"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
@@ -719,4 +720,29 @@ func TestFundPsbtCoinSelect(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestValidateBumpFeeRequestSatPerByte tests that validateBumpFeeRequest
+// rejects the deprecated sat_per_byte field while still accepting the same fee
+// rate expressed via sat_per_vbyte.
+func TestValidateBumpFeeRequestSatPerByte(t *testing.T) {
+	t.Parallel()
+
+	// A request that sets the deprecated sat_per_byte field must be
+	// rejected with ErrSatPerByteRemoved. The check happens before the fee
+	// estimator is used, so a nil estimator is fine here.
+	deprecated := &BumpFeeRequest{
+		SatPerByte: 1,
+	}
+	_, _, err := validateBumpFeeRequest(deprecated, nil)
+	require.ErrorIs(t, err, lnrpc.ErrSatPerByteRemoved)
+
+	// The same fee rate expressed via sat_per_vbyte is accepted and yields
+	// a starting fee rate.
+	valid := &BumpFeeRequest{
+		SatPerVbyte: 1,
+	}
+	feeRate, _, err := validateBumpFeeRequest(valid, nil)
+	require.NoError(t, err)
+	require.False(t, feeRate.IsNone())
 }

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1332,13 +1332,11 @@ func (r *rpcServer) EstimateFee(ctx context.Context,
 
 // maybeUseDefaultConf makes sure that when the user doesn't set either the fee
 // rate or conf target, the default conf target is used.
-func maybeUseDefaultConf(satPerByte int64, satPerVByte uint64,
-	targetConf uint32) uint32 {
-
+func maybeUseDefaultConf(satPerVByte uint64, targetConf uint32) uint32 {
 	// If the fee rate is set, there's no need to use the default conf
 	// target. In this case, we just return the targetConf from the
 	// request.
-	if satPerByte != 0 || satPerVByte != 0 {
+	if satPerVByte != 0 {
 		return targetConf
 	}
 
@@ -1360,16 +1358,19 @@ func maybeUseDefaultConf(satPerByte int64, satPerVByte uint64,
 func (r *rpcServer) SendCoins(ctx context.Context,
 	in *lnrpc.SendCoinsRequest) (*lnrpc.SendCoinsResponse, error) {
 
+	// The deprecated sat_per_byte field is no longer honored.
+	if in.SatPerByte != 0 {
+		return nil, status.Error(codes.InvalidArgument,
+			lnrpc.ErrSatPerByteRemoved.Error())
+	}
+
 	// Keep the old behavior prior to 0.18.0 - when the user doesn't set
 	// fee rate or conf target, the default conf target of 6 is used.
-	targetConf := maybeUseDefaultConf(
-		in.SatPerByte, in.SatPerVbyte, uint32(in.TargetConf),
-	)
+	targetConf := maybeUseDefaultConf(in.SatPerVbyte, uint32(in.TargetConf))
 
 	// Calculate an appropriate fee rate for this transaction.
 	feePerKw, err := lnrpc.CalculateFeeRate(
-		uint64(in.SatPerByte), in.SatPerVbyte, // nolint:staticcheck
-		targetConf, r.server.cc.FeeEstimator,
+		in.SatPerVbyte, targetConf, r.server.cc.FeeEstimator,
 	)
 	if err != nil {
 		return nil, err
@@ -1604,16 +1605,19 @@ func (r *rpcServer) SendCoins(ctx context.Context,
 func (r *rpcServer) SendMany(ctx context.Context,
 	in *lnrpc.SendManyRequest) (*lnrpc.SendManyResponse, error) {
 
+	// The deprecated sat_per_byte field is no longer honored.
+	if in.SatPerByte != 0 {
+		return nil, status.Error(codes.InvalidArgument,
+			lnrpc.ErrSatPerByteRemoved.Error())
+	}
+
 	// Keep the old behavior prior to 0.18.0 - when the user doesn't set
 	// fee rate or conf target, the default conf target of 6 is used.
-	targetConf := maybeUseDefaultConf(
-		in.SatPerByte, in.SatPerVbyte, uint32(in.TargetConf),
-	)
+	targetConf := maybeUseDefaultConf(in.SatPerVbyte, uint32(in.TargetConf))
 
 	// Calculate an appropriate fee rate for this transaction.
 	feePerKw, err := lnrpc.CalculateFeeRate(
-		uint64(in.SatPerByte), in.SatPerVbyte, // nolint:staticcheck
-		targetConf, r.server.cc.FeeEstimator,
+		in.SatPerVbyte, targetConf, r.server.cc.FeeEstimator,
 	)
 	if err != nil {
 		return nil, err
@@ -2054,7 +2058,7 @@ func newPsbtAssembler(req *lnrpc.OpenChannelRequest,
 	if len(psbtShim.PendingChanId) != 32 {
 		return nil, fmt.Errorf("pending chan ID not set")
 	}
-	if req.SatPerByte != 0 || req.SatPerVbyte != 0 || req.TargetConf != 0 { // nolint:staticcheck
+	if req.SatPerVbyte != 0 || req.TargetConf != 0 {
 		return nil, fmt.Errorf("specifying fee estimation parameters " +
 			"is not supported for PSBT funding")
 	}
@@ -2110,6 +2114,12 @@ func (r *rpcServer) parseOpenChannelReq(in *lnrpc.OpenChannelRequest,
 	rpcsLog.Debugf("[openchannel] request to NodeKey(%x) "+
 		"allocation(us=%v, them=%v)", in.NodePubkey,
 		in.LocalFundingAmount, in.PushSat)
+
+	// The deprecated sat_per_byte field is no longer honored.
+	if in.SatPerByte != 0 {
+		return nil, status.Error(codes.InvalidArgument,
+			lnrpc.ErrSatPerByteRemoved.Error())
+	}
 
 	localFundingAmt := btcutil.Amount(in.LocalFundingAmount)
 	remoteInitialBalance := btcutil.Amount(in.PushSat)
@@ -2283,14 +2293,11 @@ func (r *rpcServer) parseOpenChannelReq(in *lnrpc.OpenChannelRequest,
 
 	// NOTE: We also need to do the fee rate calculation for the psbt
 	// funding flow because the `batchfund` depends on it.
-	targetConf := maybeUseDefaultConf(
-		in.SatPerByte, in.SatPerVbyte, uint32(in.TargetConf),
-	)
+	targetConf := maybeUseDefaultConf(in.SatPerVbyte, uint32(in.TargetConf))
 
 	// Calculate an appropriate fee rate for this transaction.
 	feeRate, err := lnrpc.CalculateFeeRate(
-		uint64(in.SatPerByte), in.SatPerVbyte,
-		targetConf, r.server.cc.FeeEstimator,
+		in.SatPerVbyte, targetConf, r.server.cc.FeeEstimator,
 	)
 	if err != nil {
 		return nil, err
@@ -2748,11 +2755,15 @@ func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 		return fmt.Errorf("must specify channel point in close channel")
 	}
 
+	// The deprecated sat_per_byte field is no longer honored.
+	if in.SatPerByte != 0 {
+		return status.Error(codes.InvalidArgument,
+			lnrpc.ErrSatPerByteRemoved.Error())
+	}
+
 	// If force closing a channel, the fee set in the commitment transaction
 	// is used.
-	if in.Force && (in.SatPerByte != 0 || in.SatPerVbyte != 0 || // nolint:staticcheck
-		in.TargetConf != 0) {
-
+	if in.Force && (in.SatPerVbyte != 0 || in.TargetConf != 0) {
 		return fmt.Errorf("force closing a channel uses a pre-defined fee")
 	}
 
@@ -2927,15 +2938,14 @@ func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 		// doesn't set fee rate or conf target, the default conf target
 		// of 6 is used.
 		targetConf := maybeUseDefaultConf(
-			in.SatPerByte, in.SatPerVbyte, uint32(in.TargetConf),
+			in.SatPerVbyte, uint32(in.TargetConf),
 		)
 
 		// Based on the passed fee related parameters, we'll determine
 		// an appropriate fee rate for the cooperative closure
 		// transaction.
 		feeRate, err := lnrpc.CalculateFeeRate(
-			uint64(in.SatPerByte), in.SatPerVbyte, // nolint:staticcheck
-			targetConf, r.server.cc.FeeEstimator,
+			in.SatPerVbyte, targetConf, r.server.cc.FeeEstimator,
 		)
 		if err != nil {
 			return err

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1336,13 +1336,11 @@ func (r *rpcServer) EstimateFee(ctx context.Context,
 
 // maybeUseDefaultConf makes sure that when the user doesn't set either the fee
 // rate or conf target, the default conf target is used.
-func maybeUseDefaultConf(satPerByte int64, satPerVByte uint64,
-	targetConf uint32) uint32 {
-
+func maybeUseDefaultConf(satPerVByte uint64, targetConf uint32) uint32 {
 	// If the fee rate is set, there's no need to use the default conf
 	// target. In this case, we just return the targetConf from the
 	// request.
-	if satPerByte != 0 || satPerVByte != 0 {
+	if satPerVByte != 0 {
 		return targetConf
 	}
 
@@ -1364,16 +1362,19 @@ func maybeUseDefaultConf(satPerByte int64, satPerVByte uint64,
 func (r *rpcServer) SendCoins(ctx context.Context,
 	in *lnrpc.SendCoinsRequest) (*lnrpc.SendCoinsResponse, error) {
 
+	// The deprecated sat_per_byte field is no longer honored.
+	if in.SatPerByte != 0 {
+		return nil, status.Error(codes.InvalidArgument,
+			lnrpc.ErrSatPerByteRemoved.Error())
+	}
+
 	// Keep the old behavior prior to 0.18.0 - when the user doesn't set
 	// fee rate or conf target, the default conf target of 6 is used.
-	targetConf := maybeUseDefaultConf(
-		in.SatPerByte, in.SatPerVbyte, uint32(in.TargetConf),
-	)
+	targetConf := maybeUseDefaultConf(in.SatPerVbyte, uint32(in.TargetConf))
 
 	// Calculate an appropriate fee rate for this transaction.
 	feePerKw, err := lnrpc.CalculateFeeRate(
-		uint64(in.SatPerByte), in.SatPerVbyte, // nolint:staticcheck
-		targetConf, r.server.cc.FeeEstimator,
+		in.SatPerVbyte, targetConf, r.server.cc.FeeEstimator,
 	)
 	if err != nil {
 		return nil, err
@@ -1608,16 +1609,19 @@ func (r *rpcServer) SendCoins(ctx context.Context,
 func (r *rpcServer) SendMany(ctx context.Context,
 	in *lnrpc.SendManyRequest) (*lnrpc.SendManyResponse, error) {
 
+	// The deprecated sat_per_byte field is no longer honored.
+	if in.SatPerByte != 0 {
+		return nil, status.Error(codes.InvalidArgument,
+			lnrpc.ErrSatPerByteRemoved.Error())
+	}
+
 	// Keep the old behavior prior to 0.18.0 - when the user doesn't set
 	// fee rate or conf target, the default conf target of 6 is used.
-	targetConf := maybeUseDefaultConf(
-		in.SatPerByte, in.SatPerVbyte, uint32(in.TargetConf),
-	)
+	targetConf := maybeUseDefaultConf(in.SatPerVbyte, uint32(in.TargetConf))
 
 	// Calculate an appropriate fee rate for this transaction.
 	feePerKw, err := lnrpc.CalculateFeeRate(
-		uint64(in.SatPerByte), in.SatPerVbyte, // nolint:staticcheck
-		targetConf, r.server.cc.FeeEstimator,
+		in.SatPerVbyte, targetConf, r.server.cc.FeeEstimator,
 	)
 	if err != nil {
 		return nil, err
@@ -2058,7 +2062,7 @@ func newPsbtAssembler(req *lnrpc.OpenChannelRequest,
 	if len(psbtShim.PendingChanId) != 32 {
 		return nil, fmt.Errorf("pending chan ID not set")
 	}
-	if req.SatPerByte != 0 || req.SatPerVbyte != 0 || req.TargetConf != 0 { // nolint:staticcheck
+	if req.SatPerVbyte != 0 || req.TargetConf != 0 {
 		return nil, fmt.Errorf("specifying fee estimation parameters " +
 			"is not supported for PSBT funding")
 	}
@@ -2114,6 +2118,12 @@ func (r *rpcServer) parseOpenChannelReq(in *lnrpc.OpenChannelRequest,
 	rpcsLog.Debugf("[openchannel] request to NodeKey(%x) "+
 		"allocation(us=%v, them=%v)", in.NodePubkey,
 		in.LocalFundingAmount, in.PushSat)
+
+	// The deprecated sat_per_byte field is no longer honored.
+	if in.SatPerByte != 0 {
+		return nil, status.Error(codes.InvalidArgument,
+			lnrpc.ErrSatPerByteRemoved.Error())
+	}
 
 	localFundingAmt := btcutil.Amount(in.LocalFundingAmount)
 	remoteInitialBalance := btcutil.Amount(in.PushSat)
@@ -2287,14 +2297,11 @@ func (r *rpcServer) parseOpenChannelReq(in *lnrpc.OpenChannelRequest,
 
 	// NOTE: We also need to do the fee rate calculation for the psbt
 	// funding flow because the `batchfund` depends on it.
-	targetConf := maybeUseDefaultConf(
-		in.SatPerByte, in.SatPerVbyte, uint32(in.TargetConf),
-	)
+	targetConf := maybeUseDefaultConf(in.SatPerVbyte, uint32(in.TargetConf))
 
 	// Calculate an appropriate fee rate for this transaction.
 	feeRate, err := lnrpc.CalculateFeeRate(
-		uint64(in.SatPerByte), in.SatPerVbyte,
-		targetConf, r.server.cc.FeeEstimator,
+		in.SatPerVbyte, targetConf, r.server.cc.FeeEstimator,
 	)
 	if err != nil {
 		return nil, err
@@ -2752,11 +2759,15 @@ func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 		return fmt.Errorf("must specify channel point in close channel")
 	}
 
+	// The deprecated sat_per_byte field is no longer honored.
+	if in.SatPerByte != 0 {
+		return status.Error(codes.InvalidArgument,
+			lnrpc.ErrSatPerByteRemoved.Error())
+	}
+
 	// If force closing a channel, the fee set in the commitment transaction
 	// is used.
-	if in.Force && (in.SatPerByte != 0 || in.SatPerVbyte != 0 || // nolint:staticcheck
-		in.TargetConf != 0) {
-
+	if in.Force && (in.SatPerVbyte != 0 || in.TargetConf != 0) {
 		return fmt.Errorf("force closing a channel uses a pre-defined fee")
 	}
 
@@ -2931,15 +2942,14 @@ func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 		// doesn't set fee rate or conf target, the default conf target
 		// of 6 is used.
 		targetConf := maybeUseDefaultConf(
-			in.SatPerByte, in.SatPerVbyte, uint32(in.TargetConf),
+			in.SatPerVbyte, uint32(in.TargetConf),
 		)
 
 		// Based on the passed fee related parameters, we'll determine
 		// an appropriate fee rate for the cooperative closure
 		// transaction.
 		feeRate, err := lnrpc.CalculateFeeRate(
-			uint64(in.SatPerByte), in.SatPerVbyte, // nolint:staticcheck
-			targetConf, r.server.cc.FeeEstimator,
+			in.SatPerVbyte, targetConf, r.server.cc.FeeEstimator,
 		)
 		if err != nil {
 			return err

--- a/rpcserver_test.go
+++ b/rpcserver_test.go
@@ -123,3 +123,35 @@ func TestRpcCommitmentType(t *testing.T) {
 		})
 	}
 }
+
+// TestRejectDeprecatedSatPerByte ensures the RPCs that previously honored the
+// deprecated sat_per_byte field now reject requests that set it. The rejection
+// happens before any server state is accessed, so a zero-value rpcServer is
+// sufficient here.
+func TestRejectDeprecatedSatPerByte(t *testing.T) {
+	t.Parallel()
+
+	r := &rpcServer{}
+	ctx := t.Context()
+
+	_, err := r.SendCoins(ctx, &lnrpc.SendCoinsRequest{SatPerByte: 1})
+	require.ErrorContains(t, err, lnrpc.ErrSatPerByteRemoved.Error())
+
+	_, err = r.SendMany(ctx, &lnrpc.SendManyRequest{SatPerByte: 1})
+	require.ErrorContains(t, err, lnrpc.ErrSatPerByteRemoved.Error())
+
+	_, err = r.parseOpenChannelReq(
+		&lnrpc.OpenChannelRequest{SatPerByte: 1}, false,
+	)
+	require.ErrorContains(t, err, lnrpc.ErrSatPerByteRemoved.Error())
+
+	// CloseChannel checks that the server is started before validating the
+	// request, so it needs a minimally-started server. The deprecated field
+	// is still rejected before any close logic runs.
+	started := &rpcServer{server: &server{active: 1}}
+	err = started.CloseChannel(&lnrpc.CloseChannelRequest{
+		ChannelPoint: &lnrpc.ChannelPoint{},
+		SatPerByte:   1,
+	}, nil)
+	require.ErrorContains(t, err, lnrpc.ErrSatPerByteRemoved.Error())
+}

--- a/rpcserver_test.go
+++ b/rpcserver_test.go
@@ -153,3 +153,35 @@ func TestRpcCommitmentType(t *testing.T) {
 		})
 	}
 }
+
+// TestRejectDeprecatedSatPerByte ensures the RPCs that previously honored the
+// deprecated sat_per_byte field now reject requests that set it. The rejection
+// happens before any server state is accessed, so a zero-value rpcServer is
+// sufficient here.
+func TestRejectDeprecatedSatPerByte(t *testing.T) {
+	t.Parallel()
+
+	r := &rpcServer{}
+	ctx := t.Context()
+
+	_, err := r.SendCoins(ctx, &lnrpc.SendCoinsRequest{SatPerByte: 1})
+	require.ErrorContains(t, err, lnrpc.ErrSatPerByteRemoved.Error())
+
+	_, err = r.SendMany(ctx, &lnrpc.SendManyRequest{SatPerByte: 1})
+	require.ErrorContains(t, err, lnrpc.ErrSatPerByteRemoved.Error())
+
+	_, err = r.parseOpenChannelReq(
+		&lnrpc.OpenChannelRequest{SatPerByte: 1}, false,
+	)
+	require.ErrorContains(t, err, lnrpc.ErrSatPerByteRemoved.Error())
+
+	// CloseChannel checks that the server is started before validating the
+	// request, so it needs a minimally-started server. The deprecated field
+	// is still rejected before any close logic runs.
+	started := &rpcServer{server: &server{active: 1}}
+	err = started.CloseChannel(&lnrpc.CloseChannelRequest{
+		ChannelPoint: &lnrpc.ChannelPoint{},
+		SatPerByte:   1,
+	}, nil)
+	require.ErrorContains(t, err, lnrpc.ErrSatPerByteRemoved.Error())
+}


### PR DESCRIPTION
As defined at [release doc v0.21.0](https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/release-notes-0.21.0.md#deprecations) we now remove the option --sat_per_byte.

### Change Description
The sat_per_byte field was deprecated back in v0.13.0 in favor of sat_per_vbyte. This PR completes its removal: the deprecated field is no longer honored by the RPC server, the CLI, or the wallet RPC, and any request that still sets it is now explicitly rejected.

### Behavior change
Previously, sat_per_byte was still accepted and silently converted, with a guard preventing both fields from being set at once.

Now, if a request sets sat_per_byte the `ErrSatPerByteRemoved` is returned.