### PR TITLE
Remove RBF coop close staging feature bits

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -147,6 +147,22 @@
 
 ## Code Health
 
+* [Stopped signaling and
+  negotiating](https://github.com/lightningnetwork/lnd/pull/10891) the staging
+  feature bits for the RBF-based co-op close protocol (`rbf-coop-close-x`,
+  bits 160/161). The final feature bits (`rbf-coop-close`, bits 60/61) have
+  been signaled since `v0.20.0`, so the staging bits are no longer advertised
+  by `lnd` nor taken into account when deciding whether the RBF co-op close
+  protocol can be used. Peers that only advertise `rbf-coop-close-x` (`lnd`
+  `v0.19.x`) will fall back to the legacy co-op close flow; the bits are still
+  recognized on the wire, so no connection is rejected because of them. Note
+  that a co-op close that is already in flight with such a peer at the time of
+  the upgrade also falls back to the legacy flow on both ends, since the closer
+  is re-derived from the negotiated features when the peer reconnects. If the
+  RBF flow had already broadcast a closing transaction, that transaction can no
+  longer be fee-bumped through RBF and has to confirm at its current fee rate
+  or be bumped with a child transaction spending the local close output.
+
 ## Tooling and Documentation
 
 * [`dev.Dockerfile` now uses](https://github.com/lightningnetwork/lnd/pull/10903)
@@ -167,3 +183,4 @@
 * Erick Cestari
 * Jared Tobin
 * Nishant Bansal
+* Pins

--- a/feature/default_sets.go
+++ b/feature/default_sets.go
@@ -111,10 +111,6 @@ var defaultSetDesc = setDesc{
 	lnwire.ExperimentalAccountabilityOptional: {
 		SetNodeAnn: {}, // N
 	},
-	lnwire.RbfCoopCloseOptionalStaging: {
-		SetInit:    {}, // I
-		SetNodeAnn: {}, // N
-	},
 	lnwire.RbfCoopCloseOptional: {
 		SetInit:    {}, // I
 		SetNodeAnn: {}, // N

--- a/feature/manager.go
+++ b/feature/manager.go
@@ -224,8 +224,8 @@ func newManager(cfg Config, desc setDesc) (*Manager, error) {
 			raw.Unset(lnwire.ExperimentalAccountabilityRequired)
 		}
 		if cfg.NoRbfCoopClose {
-			raw.Unset(lnwire.RbfCoopCloseOptionalStaging)
 			raw.Unset(lnwire.RbfCoopCloseOptional)
+			raw.Unset(lnwire.RbfCoopCloseRequired)
 		}
 		if cfg.NoOnionMessages {
 			raw.Unset(lnwire.OnionMessagesOptional)

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -1135,8 +1135,7 @@ func (p *Brontide) rbfCoopCloseAllowed(chanType chanstate.ChannelType) bool {
 			p.LocalFeatures().HasFeature(bit)
 	}
 
-	featureNegotiated := bothHaveBit(lnwire.RbfCoopCloseOptional) ||
-		bothHaveBit(lnwire.RbfCoopCloseOptionalStaging)
+	featureNegotiated := bothHaveBit(lnwire.RbfCoopCloseOptional)
 
 	return featureNegotiated && !chanType.HasTapscriptRoot()
 }

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -2993,7 +2993,13 @@ func TestRbfCoopCloseAllowed(t *testing.T) {
 			name:     "both signal staging, plain channel",
 			peer:     newPeer(stagingBit, stagingBit),
 			chanType: chanstate.SingleFunderTweaklessBit,
-			allowed:  true,
+			allowed:  false,
+		},
+		{
+			name:     "local staging, remote final, plain channel",
+			peer:     newPeer(stagingBit, rbfBit),
+			chanType: chanstate.SingleFunderTweaklessBit,
+			allowed:  false,
 		},
 		{
 			name:     "both signal, simple taproot channel",
@@ -3004,12 +3010,6 @@ func TestRbfCoopCloseAllowed(t *testing.T) {
 		{
 			name:     "both signal, aux (overlay) channel",
 			peer:     newPeer(rbfBit, rbfBit),
-			chanType: overlayChan,
-			allowed:  false,
-		},
-		{
-			name:     "both signal staging, aux (overlay) channel",
-			peer:     newPeer(stagingBit, stagingBit),
 			chanType: overlayChan,
 			allowed:  false,
 		},


### PR DESCRIPTION
Fixes #9892 

Now that the final RBF-based co-op close feature bits (rbf-coop-close, bits 60/61) have been in production for a while, the staging feature bits (rbf-coop-close-x, bits 160/161) are no longer needed.