### PR TITLE
lnd+htlcswitch: keep on-chain intercepts held until the htlc expires

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -34,6 +34,16 @@
   the close transaction is actually broadcast, and
   `WaitingCloseChannel.ClosingTx` is never empty.
 
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/issues/10892) where
+  HTLCs offered to the interceptor through the on-chain resolution flow were
+  evicted from the held set on the first new block, because their auto-fail
+  height was never set. A settle sent by the interceptor after that point
+  failed with `fwd not found` and the preimage never reached the witness
+  beacon, so the HTLC could be lost to the remote's timeout claim. On-chain
+  intercepts are now kept available to the interceptor until the htlc expires
+  on-chain, and the auto-fail sweep no longer evicts forwards that have no
+  deadline set.
+
 # New Features
 
 ## Functional Enhancements
@@ -89,3 +99,4 @@
 
 * Boris Nagaev
 * Erick Cestari
+* Kevin Piotrkowski

--- a/htlcswitch/held_htlc_set.go
+++ b/htlcswitch/held_htlc_set.go
@@ -41,7 +41,11 @@ func (h *heldHtlcSet) popAll(cb func(InterceptedForward)) {
 // equal or less then the specified pop height and removes them from the set.
 func (h *heldHtlcSet) popAutoFails(height uint32, cb func(InterceptedForward)) {
 	for key, fwd := range h.set {
-		if uint32(fwd.Packet().AutoFailHeight) > height {
+		// A zero or negative auto-fail height means no deadline was
+		// set for this forward. Never auto-fail it, otherwise it would
+		// be evicted on the first block after being held.
+		autoFailHeight := fwd.Packet().AutoFailHeight
+		if autoFailHeight <= 0 || uint32(autoFailHeight) > height {
 			continue
 		}
 

--- a/htlcswitch/held_htlc_set_test.go
+++ b/htlcswitch/held_htlc_set_test.go
@@ -124,3 +124,51 @@ func TestHeldHtlcSetAutoFails(t *testing.T) {
 		},
 	)
 }
+
+// TestHeldHtlcSetAutoFailNoDeadline asserts that the auto-fail sweep only
+// pops forwards whose auto-fail height has been reached, and never pops
+// forwards without an auto-fail deadline (such as on-chain intercepts, which
+// cannot be failed back and must remain available to the interceptor until
+// they expire).
+func TestHeldHtlcSetAutoFailNoDeadline(t *testing.T) {
+	set := newHeldHtlcSet()
+
+	keyNoDeadline := models.CircuitKey{
+		ChanID: lnwire.NewShortChanIDFromInt(1),
+		HtlcID: 1,
+	}
+	keyWithDeadline := models.CircuitKey{
+		ChanID: lnwire.NewShortChanIDFromInt(1),
+		HtlcID: 2,
+	}
+
+	// A forward without an auto-fail height, as held by the on-chain
+	// interception flow.
+	require.NoError(t, set.push(keyNoDeadline, &interceptedForward{
+		htlc:   &lnwire.UpdateAddHTLC{},
+		packet: &htlcPacket{},
+	}))
+
+	require.NoError(t, set.push(keyWithDeadline, &interceptedForward{
+		htlc:           &lnwire.UpdateAddHTLC{},
+		packet:         &htlcPacket{},
+		autoFailHeight: 100,
+	}))
+
+	// Before the deadline, nothing should be popped.
+	set.popAutoFails(99, func(_ InterceptedForward) {
+		require.Fail(t, "unexpected fwd")
+	})
+	require.True(t, set.exists(keyNoDeadline))
+	require.True(t, set.exists(keyWithDeadline))
+
+	// At the deadline, only the forward with the deadline should be
+	// popped.
+	var popped int
+	set.popAutoFails(100, func(_ InterceptedForward) {
+		popped++
+	})
+	require.Equal(t, 1, popped)
+	require.True(t, set.exists(keyNoDeadline))
+	require.False(t, set.exists(keyWithDeadline))
+}

--- a/witness_beacon.go
+++ b/witness_beacon.go
@@ -106,6 +106,14 @@ func (p *preimageBeacon) SubscribeUpdates(
 		OutgoingAmount:       payload.FwdInfo.AmountToForward,
 		InOnionCustomRecords: payload.CustomRecords(),
 		InWireCustomRecords:  htlc.CustomRecords,
+
+		// An on-chain intercept cannot be failed back, only settled.
+		// Keep it available to the interceptor until the htlc expires
+		// on-chain, after which a settle can no longer win the race
+		// against the remote's timeout claim. Leaving this unset would
+		// cause the held forward to be evicted on the next block by
+		// the auto-fail sweep.
+		AutoFailHeight: int32(htlc.RefundTimeout),
 	}
 	copy(packet.OnionBlob[:], nextHopOnionBlob)
 


### PR DESCRIPTION
## Change Description

**Bug**: HTLCs offered to the interceptor through the on-chain resolution flow (`witness_beacon.go`) are created without an `AutoFailHeight`, and the auto-fail sweep in `htlcswitch` treats the zero value as a deadline that has already passed. 

**Consequence**: therefore, every on-chain intercept is  evicted from the held set on the first new block after being offered. Any later `Settle` from the interceptor fails with `fwd not found`, the preimage never reaches the witness
beacon, and the **htlc is eventually claimed by the counterparty via the timeout path even though the interceptor held the preimage**.

This PR fixes the witness beacon so that now sets `AutoFailHeight` to the htlc's on-chain expiry (`RefundTimeout`), (past it a settle can no longer reliably win the race against the remote's timeout claim).

This PR also changes the default behavior of the auto-fail sweep to skips held forwards with a non-positive `AutoFailHeight` instead of treating them as already expired. On-chain intercepts cannot be failed back anyway
  (`FailWithCode` returns `ErrCannotFail`), but the sweep deleted them from the held set regardless.

Fixes https://github.com/lightningnetwork/lnd/issues/10892

## Steps to Test

Regression test triggering the bug (fails on master, passes with this
change):

```
go test ./htlcswitch/ -run TestHeldHtlcSetAutoFailNoDeadline
```

End-to-end on regtest (recipe from the issue):

1. Three nodes A -> B -> C; B runs with `requireinterceptor=true` and an interceptor client connected.
2. Pay an invoice from A to C and have the interceptor hold the intercepted HTLC at B.
3. Force-close the A–B channel and let the close confirm; the contest resolver re-offers the HTLC to the interceptor through the on-chain flow.
4. Mine a block. On master, B logs `Cannot fail packet: cannot fail in the on-chain flow` and the held entry is evicted; with this change the forward stays held.
5. Send `Settle` with the correct preimage from the interceptor. On master it fails with `fwd not found`; with this change the preimage reaches the witness beacon and B claims the HTLC on-chain.

