### PR TITLE
routerrpc: document default timeout for EstimateRouteFee probes

### DIFF
--- a/lnrpc/routerrpc/router.pb.go
+++ b/lnrpc/routerrpc/router.pb.go
@@ -777,7 +777,8 @@ type RouteFeeRequest struct {
 	// timeout is reached. Note that the probing process itself can take longer
 	// than the timeout if the HTLC becomes delayed or stuck. Canceling the context
 	// of this call will not cancel the payment loop, the duration is only
-	// controlled by the timeout parameter.
+	// controlled by the timeout parameter. If the field is not set or is
+	// explicitly set to zero, the default value of 60 seconds will be applied.
 	Timeout uint32 `protobuf:"varint,4,opt,name=timeout,proto3" json:"timeout,omitempty"`
 	// The channel ids of the channels that are allowed for the first hop. If
 	// empty, any channel may be used. This field is applicable to both

--- a/lnrpc/routerrpc/router.proto
+++ b/lnrpc/routerrpc/router.proto
@@ -407,7 +407,8 @@ message RouteFeeRequest {
     timeout is reached. Note that the probing process itself can take longer
     than the timeout if the HTLC becomes delayed or stuck. Canceling the context
     of this call will not cancel the payment loop, the duration is only
-    controlled by the timeout parameter.
+    controlled by the timeout parameter. If the field is not set or is
+    explicitly set to zero, the default value of 60 seconds will be applied.
     */
     uint32 timeout = 4;
 

--- a/lnrpc/routerrpc/router.swagger.json
+++ b/lnrpc/routerrpc/router.swagger.json
@@ -1935,7 +1935,7 @@
         "timeout": {
           "type": "integer",
           "format": "int64",
-          "description": "A user preference of how long a probe payment should maximally be allowed to\ntake, denoted in seconds. The probing payment loop is aborted if this\ntimeout is reached. Note that the probing process itself can take longer\nthan the timeout if the HTLC becomes delayed or stuck. Canceling the context\nof this call will not cancel the payment loop, the duration is only\ncontrolled by the timeout parameter."
+          "description": "A user preference of how long a probe payment should maximally be allowed to\ntake, denoted in seconds. The probing payment loop is aborted if this\ntimeout is reached. Note that the probing process itself can take longer\nthan the timeout if the HTLC becomes delayed or stuck. Canceling the context\nof this call will not cancel the payment loop, the duration is only\ncontrolled by the timeout parameter. If the field is not set or is\nexplicitly set to zero, the default value of 60 seconds will be applied."
         },
         "outgoing_chan_ids": {
           "type": "array",


### PR DESCRIPTION
## Change Description
The RouteFeeRequest.timeout field did not document its behavior when unset or explicitly set to zero. This is easy to misread as "no timeout", i.e. an unbounded, uncancellable probe, especially given the adjacent note that canceling the context does not stop the payment loop.

In practice the probe path runs through SendPaymentV2, which replaces a zero timeout_seconds with DefaultPaymentTimeout (60 seconds) before dispatching the probe. A zero or unset timeout therefore falls back to the same 60 second default that SendPaymentRequest.timeout_seconds already documents.

Mirror that wording on RouteFeeRequest.timeout so the zero-value behavior is explicit, and update the generated gRPC stub and swagger description to match. Documentation only; no behavior change.

_In another review, Claude misunderstood the original description, interpreting it like zero timeout means unbound timeout, so I decided to add this to prevent such AI confusion in the future._


## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
