### PR TITLE
sweep: don't ratchet starting fee rate on non-fee failures

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -55,6 +55,12 @@
   the reported network statistics such as total network capacity, channel
   count and max out degree.
 
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/10898) in the
+  sweeper whereby an input's starting fee rate was ratcheted upward on
+  failures that carry no fee-rate signal (e.g. a lack of spendable wallet
+  UTXOs). Repeated spurious ratcheting could push the rate past the input's
+  budget, after which the sweep was silently stranded.
+
 # New Features
 
 ## Functional Enhancements

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -271,6 +271,15 @@ type BumpResult struct {
 	// FeeRate is the fee rate used for the new tx.
 	FeeRate chainfee.SatPerKWeight
 
+	// NextStartingFeeRate, when set, is the fee rate the sweeper should
+	// use as the starting rate for the next attempt to sweep this input
+	// set. It is only meaningful on failure-class events (TxFailed,
+	// TxUnknownSpend). fn.None signals that the input's existing
+	// starting fee rate must be preserved, and is used for any failure
+	// that carries no fee-rate signal - any error classifyRetryError
+	// maps to policyPreserve.
+	NextStartingFeeRate fn.Option[chainfee.SatPerKWeight]
+
 	// Fee is the fee paid by the new tx.
 	Fee btcutil.Amount
 
@@ -769,13 +778,24 @@ func (t *TxPublisher) broadcast(record *monitorRecord) (*BumpResult, error) {
 		event = TxFailed
 	}
 
+	feeRate := record.feeFunction.FeeRate()
 	result := &BumpResult{
 		Event:     event,
 		Tx:        record.tx,
 		Fee:       record.fee,
-		FeeRate:   record.feeFunction.FeeRate(),
+		FeeRate:   feeRate,
 		Err:       err,
 		requestID: record.requestID,
+	}
+
+	// On a wallet-publish failure, carry the attempted fee rate as the
+	// next starting fee rate so the sweeper resumes from where we left
+	// off rather than the input's original starting rate. A spend
+	// conflict (lnwallet.ErrDoubleSpend) is the exception: it carries
+	// no fee signal at all, and the conflicting spend will be picked up
+	// by the spend monitor, so the input's existing rate is preserved.
+	if event == TxFailed && !errors.Is(err, lnwallet.ErrDoubleSpend) {
+		result.NextStartingFeeRate = fn.Some(feeRate)
 	}
 
 	return result, nil
@@ -1090,6 +1110,54 @@ func (t *TxPublisher) handleTxConfirmed(r *monitorRecord) {
 	t.handleResult(result)
 }
 
+// retryPolicy describes how a failed sweep attempt affects the starting
+// fee rate used when the sweeper retries the involved inputs.
+type retryPolicy uint8
+
+const (
+	// policyPreserve keeps the input's existing starting fee rate. This
+	// is the default policy: an error that carries no positive fee-rate
+	// signal must never become a fee signal, otherwise repeated non-fee
+	// failures ratchet the rate past what an input's intrinsic budget
+	// can afford and permanently strand it.
+	policyPreserve retryPolicy = iota
+
+	// policyRatchet advances the fee function one step and carries the
+	// result as the starting fee rate for the next sweep attempt.
+	policyRatchet
+)
+
+// classifyRetryError maps the error from a failed sweep attempt to the
+// policy governing the starting fee rate of the next attempt. The mapping
+// is a positive allowlist: only errors that explicitly signal an
+// insufficient fee rate select policyRatchet. Everything else - resource
+// failures (ErrNotEnoughInputs, ErrNotEnoughBudget), structural failures
+// (ErrTxNoOutput, ErrZeroFeeRateDelta), spend conflicts
+// (lnwallet.ErrDoubleSpend) and unclassified errors - selects
+// policyPreserve.
+func classifyRetryError(err error) retryPolicy {
+	switch {
+	// The fee function has walked through its entire position window
+	// without a confirmation, meaning the deadline has effectively
+	// passed, so the retry should resume from the rate the function has
+	// reached rather than the input's original starting rate.
+	case errors.Is(err, ErrMaxPosition):
+		return policyRatchet
+
+	// These errors positively report that the fees paid are too low,
+	// either against the mempool's floor or the RBF requirements.
+	case errors.Is(err, chain.ErrInsufficientFee),
+		errors.Is(err, lnwallet.ErrMempoolFee),
+		errors.Is(err, chain.ErrMinRelayFeeNotMet),
+		errors.Is(err, chain.ErrMempoolMinFeeNotMet):
+
+		return policyRatchet
+
+	default:
+		return policyPreserve
+	}
+}
+
 // handleInitialTxError takes the error from `initializeTx` and decides the
 // bump event. It will construct a BumpResult and handles it.
 func (t *TxPublisher) handleInitialTxError(r *monitorRecord, err error) {
@@ -1101,41 +1169,21 @@ func (t *TxPublisher) handleInitialTxError(r *monitorRecord, err error) {
 
 	// We now decide what type of event to send.
 	switch {
-	// When the error is due to a dust output, we'll send a TxFailed so
-	// these inputs can be retried with a different group in the next
-	// block.
-	case errors.Is(err, ErrTxNoOutput):
-		result.Event = TxFailed
-
-	// When the error is due to zero fee rate delta, we'll send a TxFailed
-	// so these inputs can be retried in the next block.
-	case errors.Is(err, ErrZeroFeeRateDelta):
-		result.Event = TxFailed
-
-	// When the error is due to budget being used up, we'll send a TxFailed
-	// so these inputs can be retried with a different group in the next
-	// block.
-	case errors.Is(err, ErrMaxPosition):
-		fallthrough
-
-	// If the tx doesn't not have enough budget, or if the inputs amounts
-	// are not sufficient to cover the budget, we will return a TxFailed
-	// event so the sweeper can handle it by re-clustering the utxos.
-	case errors.Is(err, ErrNotEnoughInputs),
+	// These failures are retryable: we'll send a TxFailed so the
+	// sweeper can re-cluster the inputs and retry in the next block.
+	//
+	// - ErrTxNoOutput: the tx would only have a dust output.
+	// - ErrZeroFeeRateDelta: the fee function has no room to move.
+	// - ErrMaxPosition: the fee function has been exhausted.
+	// - ErrNotEnoughInputs/ErrNotEnoughBudget: the wallet inputs or
+	//   the budget cannot cover the intended fees.
+	case errors.Is(err, ErrTxNoOutput),
+		errors.Is(err, ErrZeroFeeRateDelta),
+		errors.Is(err, ErrMaxPosition),
+		errors.Is(err, ErrNotEnoughInputs),
 		errors.Is(err, ErrNotEnoughBudget):
 
 		result.Event = TxFailed
-
-		// Calculate the starting fee rate to be used when retry
-		// sweeping these inputs.
-		feeRate, err := t.calculateRetryFeeRate(r)
-		if err != nil {
-			result.Event = TxFatal
-			result.Err = err
-		}
-
-		// Attach the new fee rate.
-		result.FeeRate = feeRate
 
 	// When there are missing inputs, we'll create a TxUnknownSpend bump
 	// result here so the rest of the inputs can be retried.
@@ -1151,6 +1199,22 @@ func (t *TxPublisher) handleInitialTxError(r *monitorRecord, err error) {
 	// one only.
 	default:
 		result.Event = TxFatal
+	}
+
+	// For a retryable failure, consult the retry policy to decide the
+	// starting fee rate of the next attempt. Only fee-related failures
+	// ratchet the rate; all others leave NextStartingFeeRate as None so
+	// the sweeper preserves the input's existing starting rate.
+	if result.Event == TxFailed &&
+		classifyRetryError(err) == policyRatchet {
+
+		feeRate, ferr := t.calculateRetryFeeRate(r)
+		if ferr != nil {
+			result.Event = TxFatal
+			result.Err = ferr
+		} else {
+			result.NextStartingFeeRate = fn.Some(feeRate)
+		}
 	}
 
 	t.handleResult(result)
@@ -1282,17 +1346,19 @@ func (t *TxPublisher) createUnknownSpentBumpResult(
 		SpentInputs: r.spentInputs,
 	}
 
-	// Calculate the next fee rate for the retry.
+	// Calculate the next fee rate for the retry and attach it as the
+	// next starting fee rate for the sweeper.
 	feeRate, err := t.calculateRetryFeeRate(r)
 	if err != nil {
 		// Overwrite the event and error so the sweeper will
 		// remove this input.
 		result.Event = TxFatal
 		result.Err = err
+
+		return result
 	}
 
-	// Attach the new fee rate to be used for the next sweeping attempt.
-	result.FeeRate = feeRate
+	result.NextStartingFeeRate = fn.Some(feeRate)
 
 	return result
 }
@@ -1851,48 +1917,53 @@ func (t *TxPublisher) handleReplacementTxError(r *monitorRecord,
 	// been spent by another tx and confirmed. In this case we will handle
 	// it by returning a TxUnknownSpend bump result.
 	if errors.Is(err, ErrInputMissing) {
-		log.Warnf("Fail to fee bump tx %v: %v", oldTx.TxHash(), err)
+		log.Warnf("Failed to fee bump tx %v: %v", oldTx.TxHash(), err)
 		bumpResult := t.handleMissingInputs(r)
 
 		return fn.Some(*bumpResult)
 	}
 
-	// Return a failed event to retry the sweep.
-	event := TxFailed
-
-	// Calculate the next fee rate for the retry.
-	feeRate, ferr := t.calculateRetryFeeRate(r)
-	if ferr != nil {
-		// If there's an error with the fee calculation, we need to
-		// abort the sweep.
-		event = TxFatal
-	}
-
-	// If the error is not fee related, we will return a `TxFailed` event so
-	// this input can be retried.
-	result := fn.Some(BumpResult{
-		Event:     event,
+	// For all other failures we return a TxFailed event so the sweeper
+	// can re-cluster the inputs and retry in the next block. The retry
+	// policy decides the starting fee rate of that attempt: only errors
+	// that positively signal an insufficient fee ratchet the rate, all
+	// others leave NextStartingFeeRate as None so the sweeper preserves
+	// the input's existing starting rate.
+	bumpResult := BumpResult{
+		Event:     TxFailed,
 		Tx:        oldTx,
 		Err:       err,
 		requestID: r.requestID,
-		FeeRate:   feeRate,
-	})
+	}
 
-	// If the tx doesn't not have enough budget, or if the inputs amounts
-	// are not sufficient to cover the budget, we will return a result so
-	// the sweeper can handle it by re-clustering the utxos.
+	if classifyRetryError(err) == policyRatchet {
+		feeRate, ferr := t.calculateRetryFeeRate(r)
+		if ferr != nil {
+			// If there's an error with the fee calculation, we
+			// need to abort the sweep. Attribute the fatal
+			// transition to ferr so operators see the actual
+			// cause, matching the sibling paths in
+			// handleInitialTxError and
+			// createUnknownSpentBumpResult.
+			bumpResult.Event = TxFatal
+			bumpResult.Err = ferr
+		} else {
+			bumpResult.NextStartingFeeRate = fn.Some(feeRate)
+		}
+	}
+
+	// Running out of wallet inputs or budget is expected during normal
+	// operation, so log those at warning level and everything else as
+	// an error, then let the sweeper retry the whole process.
 	if errors.Is(err, ErrNotEnoughBudget) ||
 		errors.Is(err, ErrNotEnoughInputs) {
 
-		log.Warnf("Fail to fee bump tx %v: %v", oldTx.TxHash(), err)
-		return result
+		log.Warnf("Failed to fee bump tx %v: %v", oldTx.TxHash(), err)
+	} else {
+		log.Errorf("Failed to bump tx %v: %v", oldTx.TxHash(), err)
 	}
 
-	// Otherwise, an unexpected error occurred, we will log an error and let
-	// the sweeper retry the whole process.
-	log.Errorf("Failed to bump tx %v: %v", oldTx.TxHash(), err)
-
-	return result
+	return fn.Some(bumpResult)
 }
 
 // calculateRetryFeeRate calculates a new fee rate to be used as the starting

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -766,11 +766,33 @@ func TestTxPublisherBroadcast(t *testing.T) {
 			},
 			expectedErr: nil,
 			expectedResult: &BumpResult{
+				Event:               TxFailed,
+				Tx:                  tx,
+				Fee:                 fee,
+				FeeRate:             feerate,
+				NextStartingFeeRate: fn.Some(feerate),
+				Err:                 errDummy,
+				requestID:           requestID,
+			},
+		},
+		{
+			// When the publish fails with a spend conflict, no
+			// next starting fee rate is carried: the conflict
+			// gives no fee signal, so the input's existing
+			// starting rate must be preserved.
+			name: "fail to publish with double spend",
+			setupMock: func() {
+				m.wallet.On("PublishTransaction",
+					tx, mock.Anything).Return(
+					lnwallet.ErrDoubleSpend).Once()
+			},
+			expectedErr: nil,
+			expectedResult: &BumpResult{
 				Event:     TxFailed,
 				Tx:        tx,
 				Fee:       fee,
 				FeeRate:   feerate,
-				Err:       errDummy,
+				Err:       lnwallet.ErrDoubleSpend,
 				requestID: requestID,
 			},
 		},
@@ -1130,7 +1152,13 @@ func TestCreateAndPublishFail(t *testing.T) {
 	// Create a test feerate and return it from the mock fee function.
 	feerate := chainfee.SatPerKWeight(1000)
 	m.feeFunc.On("FeeRate").Return(feerate)
-	m.feeFunc.On("Increment").Return(true, nil).Once()
+
+	// Note: we deliberately do not expect Increment() to be called for
+	// ErrNotEnoughBudget. Ratcheting the starting fee rate on a non-fee
+	// failure mode would only strand inputs whose intrinsic budget can't
+	// accommodate a higher rate; classifyRetryError maps it to
+	// policyPreserve, so handleReplacementTxError (and the matching path
+	// in handleInitialTxError) skips the fee-function increment.
 
 	// Create a testing monitor record.
 	req := createTestBumpRequest()
@@ -1162,6 +1190,11 @@ func TestCreateAndPublishFail(t *testing.T) {
 	require.Equal(t, TxFailed, result.Event)
 	require.ErrorIs(t, result.Err, ErrNotEnoughBudget)
 	require.Equal(t, requestID, result.requestID)
+
+	// The result must NOT carry a next starting fee rate;
+	// ErrNotEnoughBudget is not a fee-related failure and ratcheting
+	// would be wrong.
+	require.True(t, result.NextStartingFeeRate.IsNone())
 
 	// Increase the budget and call it again. This time we will mock an
 	// error to be returned from CheckMempoolAcceptance.
@@ -1794,8 +1827,9 @@ func TestProcessRecordsSpent(t *testing.T) {
 		require.Equal(t, TxUnknownSpend, result.Event)
 		require.Equal(t, tx, result.Tx)
 
-		// We expect the fee rate to be updated.
-		require.Equal(t, feerate, result.FeeRate)
+		// We expect the next starting fee rate to be carried for the
+		// sweeper's retry.
+		require.Equal(t, fn.Some(feerate), result.NextStartingFeeRate)
 
 		// No error should be set.
 		require.ErrorIs(t, result.Err, ErrUnknownSpent)
@@ -1981,6 +2015,306 @@ func TestHandleInitialBroadcastFail(t *testing.T) {
 	// Validate the record was removed.
 	require.Equal(t, 0, tp.records.Len())
 	require.Equal(t, 0, tp.subscriberChans.Len())
+}
+
+// TestHandleInitialTxErrorNoRatchetOnNonFeeFailure asserts that
+// handleInitialTxError does not call the fee function's Increment method
+// when the failure carries no fee-rate signal - the resource failures
+// (ErrNotEnoughInputs, ErrNotEnoughBudget) as well as the structural ones
+// (ErrTxNoOutput, ErrZeroFeeRateDelta). Ratcheting the rate on each such
+// retry would only strand inputs whose intrinsic budget cannot accommodate
+// the increased starting rate.
+func TestHandleInitialTxErrorNoRatchetOnNonFeeFailure(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"ErrNotEnoughInputs", ErrNotEnoughInputs},
+		{"ErrNotEnoughBudget", ErrNotEnoughBudget},
+		{"ErrTxNoOutput", ErrTxNoOutput},
+		{"ErrZeroFeeRateDelta", ErrZeroFeeRateDelta},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tp, _ := createTestPublisher(t)
+
+			// We intentionally do not stub Increment() on the
+			// mock fee function: if the code under test calls
+			// it on a resource failure, testify will panic and
+			// the test will fail loudly.
+
+			inp := createTestInput(1000, input.WitnessKeyHash)
+			req := &BumpRequest{
+				DeliveryAddress: changePkScript,
+				Inputs:          []input.Input{&inp},
+				Budget:          btcutil.Amount(1000),
+				MaxFeeRate:      chainfee.SatPerKWeight(10000),
+				DeadlineHeight:  10,
+			}
+
+			rec := &monitorRecord{
+				requestID: 1,
+				req:       req,
+			}
+
+			// Subscribe so we can observe the bump result.
+			subChan := make(chan *BumpResult, 1)
+			tp.subscriberChans.Store(uint64(1), subChan)
+
+			tp.handleInitialTxError(rec, tc.err)
+
+			select {
+			case result := <-subChan:
+				require.Equal(t, TxFailed, result.Event)
+				require.ErrorIs(t, result.Err, tc.err)
+				require.True(
+					t,
+					result.NextStartingFeeRate.IsNone(),
+					"NextStartingFeeRate must be None "+
+						"for non-fee failures",
+				)
+			case <-time.After(time.Second):
+				t.Fatal("timeout waiting for result")
+			}
+		})
+	}
+}
+
+// TestHandleInitialTxErrorRatchetsOnErrMaxPosition asserts that an
+// ErrMaxPosition failure carries a Some next starting fee rate for the
+// sweeper. It uses a real LinearFeeFunction walked to its max position,
+// which pins the actual invariant: once the fee function is exhausted, its
+// internal Increment keeps returning ErrMaxPosition, calculateRetryFeeRate
+// swallows that error rather than escalating to TxFatal, and the retry
+// resumes pinned at the ending (max) fee rate.
+func TestHandleInitialTxErrorRatchetsOnErrMaxPosition(t *testing.T) {
+	t.Parallel()
+
+	tp, _ := createTestPublisher(t)
+
+	// Build a real linear fee function. The explicit starting fee rate
+	// means the estimator is never consulted.
+	startRate := chainfee.SatPerKWeight(1000)
+	maxRate := chainfee.SatPerKWeight(10000)
+	estimator := &chainfee.MockEstimator{}
+	defer estimator.AssertExpectations(t)
+
+	f, err := NewLinearFeeFunction(
+		maxRate, 3, estimator, fn.Some(startRate),
+	)
+	require.NoError(t, err)
+
+	// Walk the fee function to its max position: with a conf target of
+	// 3 the width is 2, so two increments reach the ending rate and any
+	// further increment returns ErrMaxPosition.
+	for {
+		_, err := f.Increment()
+		if err != nil {
+			require.ErrorIs(t, err, ErrMaxPosition)
+			break
+		}
+	}
+	require.Equal(t, maxRate, f.FeeRate())
+
+	inp := createTestInput(1000, input.WitnessKeyHash)
+	req := &BumpRequest{
+		DeliveryAddress: changePkScript,
+		Inputs:          []input.Input{&inp},
+		Budget:          btcutil.Amount(1000),
+		MaxFeeRate:      maxRate,
+		DeadlineHeight:  10,
+	}
+
+	rec := &monitorRecord{
+		requestID:   1,
+		req:         req,
+		feeFunction: f,
+	}
+
+	// Subscribe so we can observe the bump result.
+	subChan := make(chan *BumpResult, 1)
+	tp.subscriberChans.Store(uint64(1), subChan)
+
+	tp.handleInitialTxError(rec, ErrMaxPosition)
+
+	select {
+	case result := <-subChan:
+		require.Equal(t, TxFailed, result.Event)
+		require.ErrorIs(t, result.Err, ErrMaxPosition)
+		require.Equal(
+			t, fn.Some(maxRate), result.NextStartingFeeRate,
+			"ErrMaxPosition must carry the max fee rate as the "+
+				"next starting rate",
+		)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
+// TestClassifyRetryError asserts the explicit mapping from named errors to
+// retry policies. The mapping is a positive allowlist: only errors that
+// carry a fee signal may ratchet the starting fee rate, and any error not
+// named in the classifier must fall through to policyPreserve.
+func TestClassifyRetryError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		err    error
+		policy retryPolicy
+	}{
+		// Fee-related failures ratchet.
+		{
+			name:   "ErrMaxPosition",
+			err:    ErrMaxPosition,
+			policy: policyRatchet,
+		},
+		{
+			name:   "ErrInsufficientFee",
+			err:    chain.ErrInsufficientFee,
+			policy: policyRatchet,
+		},
+		{
+			name:   "ErrMempoolFee",
+			err:    lnwallet.ErrMempoolFee,
+			policy: policyRatchet,
+		},
+		{
+			name:   "ErrMinRelayFeeNotMet",
+			err:    chain.ErrMinRelayFeeNotMet,
+			policy: policyRatchet,
+		},
+		{
+			name:   "ErrMempoolMinFeeNotMet",
+			err:    chain.ErrMempoolMinFeeNotMet,
+			policy: policyRatchet,
+		},
+
+		// Resource failures preserve.
+		{
+			name:   "ErrNotEnoughInputs",
+			err:    ErrNotEnoughInputs,
+			policy: policyPreserve,
+		},
+		{
+			name:   "ErrNotEnoughBudget",
+			err:    ErrNotEnoughBudget,
+			policy: policyPreserve,
+		},
+
+		// Structural failures preserve.
+		{
+			name:   "ErrTxNoOutput",
+			err:    ErrTxNoOutput,
+			policy: policyPreserve,
+		},
+		{
+			name:   "ErrZeroFeeRateDelta",
+			err:    ErrZeroFeeRateDelta,
+			policy: policyPreserve,
+		},
+
+		// A spend conflict carries no fee signal - the conflicting
+		// spend is handled via spend detection instead.
+		{
+			name:   "ErrDoubleSpend",
+			err:    lnwallet.ErrDoubleSpend,
+			policy: policyPreserve,
+		},
+
+		// Unclassified errors must never become a fee signal.
+		{
+			name:   "unknown error",
+			err:    errDummy,
+			policy: policyPreserve,
+		},
+
+		// Wrapped errors classify by their sentinel.
+		{
+			name:   "wrapped ErrMaxPosition",
+			err:    fmt.Errorf("create tx: %w", ErrMaxPosition),
+			policy: policyRatchet,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.policy, classifyRetryError(tc.err))
+		})
+	}
+}
+
+// TestHandleReplacementTxErrorRetryPolicy asserts that
+// handleReplacementTxError applies the retry policy: an error with no fee
+// signal produces a TxFailed result with no next starting fee rate, while
+// a fee-related error ratchets the fee function and carries the new rate.
+func TestHandleReplacementTxErrorRetryPolicy(t *testing.T) {
+	t.Parallel()
+
+	oldTx := &wire.MsgTx{LockTime: 1}
+
+	t.Run("unknown error preserves rate", func(t *testing.T) {
+		t.Parallel()
+
+		tp, m := createTestPublisher(t)
+
+		// We intentionally do not stub Increment: if the code under
+		// test ratchets on an unclassified error, testify will panic
+		// and the test will fail loudly.
+		rec := &monitorRecord{
+			requestID:   1,
+			req:         createTestBumpRequest(),
+			feeFunction: m.feeFunc,
+			tx:          oldTx,
+		}
+
+		resultOpt := tp.handleReplacementTxError(rec, oldTx, errDummy)
+		require.True(t, resultOpt.IsSome())
+
+		result := resultOpt.UnsafeFromSome()
+		require.Equal(t, TxFailed, result.Event)
+		require.ErrorIs(t, result.Err, errDummy)
+		require.True(
+			t, result.NextStartingFeeRate.IsNone(),
+			"an unclassified error must not become a fee signal",
+		)
+	})
+
+	t.Run("fee error ratchets rate", func(t *testing.T) {
+		t.Parallel()
+
+		tp, m := createTestPublisher(t)
+
+		retryRate := chainfee.SatPerKWeight(5000)
+		m.feeFunc.On("Increment").Return(true, nil).Once()
+		m.feeFunc.On("FeeRate").Return(retryRate)
+
+		rec := &monitorRecord{
+			requestID:   1,
+			req:         createTestBumpRequest(),
+			feeFunction: m.feeFunc,
+			tx:          oldTx,
+		}
+
+		resultOpt := tp.handleReplacementTxError(
+			rec, oldTx, chain.ErrMinRelayFeeNotMet,
+		)
+		require.True(t, resultOpt.IsSome())
+
+		result := resultOpt.UnsafeFromSome()
+		require.Equal(t, TxFailed, result.Event)
+		require.ErrorIs(t, result.Err, chain.ErrMinRelayFeeNotMet)
+		require.Equal(
+			t, fn.Some(retryRate), result.NextStartingFeeRate,
+		)
+	})
 }
 
 // TestHasInputsSpent checks the expected outpoint:tx map is returned.

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -964,8 +964,12 @@ func (s *UtxoSweeper) markInputsPublished(tr *TxRecord, set InputSet) error {
 }
 
 // markInputsPublishFailed marks the list of inputs as failed to be published.
+// If nextStartingFeeRate is Some, it is recorded as the input's new starting
+// fee rate for the next attempt; if None, the input's existing StartingFeeRate
+// is preserved. None is delivered by any failure path that carries no
+// fee-rate signal - any error classifyRetryError maps to policyPreserve.
 func (s *UtxoSweeper) markInputsPublishFailed(set InputSet,
-	feeRate chainfee.SatPerKWeight) {
+	nextStartingFeeRate fn.Option[chainfee.SatPerKWeight]) {
 
 	// Reschedule sweep.
 	for _, inp := range set.Inputs() {
@@ -994,6 +998,23 @@ func (s *UtxoSweeper) markInputsPublishFailed(set InputSet,
 		// Update the input's state.
 		pi.state = PublishFailed
 
+		// Only ratchet the starting fee rate when the BumpResult
+		// carries one. Any failure path with no fee-rate signal
+		// (resource failures, dust outputs, zero fee-rate delta,
+		// etc.) delivers fn.None; preserving the input's existing
+		// starting rate in that case avoids stranding inputs whose
+		// intrinsic budget can't accommodate a higher rate and
+		// avoids resetting the rate to a meaningless value on
+		// non-fee failures.
+		if nextStartingFeeRate.IsNone() {
+			log.Debugf("Input(%v): preserving starting fee rate "+
+				"%v across non-fee failure", op,
+				pi.params.StartingFeeRate)
+
+			continue
+		}
+
+		feeRate := nextStartingFeeRate.UnsafeFromSome()
 		log.Debugf("Input(%v): updating params: starting fee rate "+
 			"[%v -> %v]", op, pi.params.StartingFeeRate,
 			feeRate)
@@ -1719,7 +1740,7 @@ func (s *UtxoSweeper) handleBumpEventTxFailed(resp *bumpResp) {
 	// the inputs specified by the set.
 	//
 	// TODO(yy): should we also remove the failed tx from db?
-	s.markInputsPublishFailed(resp.set, resp.result.FeeRate)
+	s.markInputsPublishFailed(resp.set, resp.result.NextStartingFeeRate)
 }
 
 // handleBumpEventTxReplaced handles the case where the sweeping tx has been
@@ -1970,7 +1991,7 @@ func (s *UtxoSweeper) handleUnknownSpendTx(inp *SweeperInput, tx *wire.MsgTx) {
 func (s *UtxoSweeper) handleBumpEventTxUnknownSpend(r *bumpResp) {
 	// Mark the inputs as publish failed, which means they will be retried
 	// later.
-	s.markInputsPublishFailed(r.set, r.result.FeeRate)
+	s.markInputsPublishFailed(r.set, r.result.NextStartingFeeRate)
 
 	// Get all the inputs that are not spent in the current sweeping tx.
 	spentInputs := r.result.SpentInputs

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
 )
 
 var (
@@ -237,7 +238,7 @@ func TestMarkInputsPublishFailed(t *testing.T) {
 	// Mark the test inputs. We expect the non-exist input and the
 	// inputInit to be skipped, and the final input to be marked as
 	// published.
-	s.markInputsPublishFailed(set, feeRate)
+	s.markInputsPublishFailed(set, fn.Some(feeRate))
 
 	// We expect unchanged number of pending inputs.
 	require.Len(s.inputs, 7)
@@ -280,6 +281,106 @@ func TestMarkInputsPublishFailed(t *testing.T) {
 
 	// Assert mocked statements are executed as expected.
 	mockStore.AssertExpectations(t)
+}
+
+// TestMarkInputsPublishFailedPreservesRateOnNone asserts that when
+// markInputsPublishFailed is invoked with fn.None, the input's existing
+// StartingFeeRate is preserved instead of being overwritten. This is the
+// sweeper-side contract that resource-failure callers (handleInitialTxError
+// and handleReplacementTxError for ErrNotEnoughInputs / ErrNotEnoughBudget)
+// rely on: those failures carry no fee-rate signal, so ratcheting the
+// starting rate upward on each retry would be incorrect.
+func TestMarkInputsPublishFailedPreservesRateOnNone(t *testing.T) {
+	t.Parallel()
+
+	mockStore := NewMockSweeperStore()
+	s := New(&UtxoSweeperConfig{Store: mockStore})
+
+	// Stage an input in PendingPublish with an existing starting fee
+	// rate. The rate we set here must not be touched by the call below.
+	existingRate := chainfee.SatPerKWeight(2500)
+	inp := createMockInput(t, s, PendingPublish)
+	s.inputs[inp.OutPoint()].params.StartingFeeRate =
+		fn.Some(existingRate)
+
+	set := &MockInputSet{}
+	defer set.AssertExpectations(t)
+	set.On("Inputs").Return([]input.Input{inp})
+
+	// Mark the input as publish-failed with fn.None, signalling a
+	// non-fee failure (e.g. ErrNotEnoughInputs).
+	s.markInputsPublishFailed(set, fn.None[chainfee.SatPerKWeight]())
+
+	// The input must still be in PublishFailed (state transition is
+	// independent of the rate signal) but its StartingFeeRate must
+	// remain the value we set above, not Some(0).
+	pi := s.inputs[inp.OutPoint()]
+	require.Equal(t, PublishFailed, pi.state)
+	require.True(t, pi.params.StartingFeeRate.IsSome())
+	require.Equal(t, existingRate,
+		pi.params.StartingFeeRate.UnsafeFromSome())
+
+	mockStore.AssertExpectations(t)
+}
+
+// TestMarkInputsPublishFailedRapid property-tests the fee-rate transition
+// performed by markInputsPublishFailed: over randomly generated prior and
+// next starting fee rates, the input always moves to PublishFailed, fn.None
+// preserves the exact prior StartingFeeRate, and fn.Some overwrites it with
+// the carried value.
+func TestMarkInputsPublishFailedRapid(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		s := New(&UtxoSweeperConfig{})
+
+		// Generate the input's prior optional starting fee rate.
+		prior := fn.None[chainfee.SatPerKWeight]()
+		if rapid.Bool().Draw(rt, "priorSet") {
+			prior = fn.Some(chainfee.SatPerKWeight(
+				rapid.Uint64Range(1, 1_000_000).
+					Draw(rt, "priorRate"),
+			))
+		}
+
+		// Generate the next starting fee rate carried by the bump
+		// result.
+		next := fn.None[chainfee.SatPerKWeight]()
+		if rapid.Bool().Draw(rt, "nextSet") {
+			next = fn.Some(chainfee.SatPerKWeight(
+				rapid.Uint64Range(1, 1_000_000).
+					Draw(rt, "nextRate"),
+			))
+		}
+
+		// Stage the input in one of the two states from which the
+		// publish-failed transition is valid.
+		state := PendingPublish
+		if rapid.Bool().Draw(rt, "published") {
+			state = Published
+		}
+
+		inp := createMockInput(t, s, state)
+		s.inputs[inp.OutPoint()].params.StartingFeeRate = prior
+
+		set := &MockInputSet{}
+		defer set.AssertExpectations(t)
+		set.On("Inputs").Return([]input.Input{inp})
+
+		s.markInputsPublishFailed(set, next)
+
+		// The state transition is independent of the rate signal.
+		pi := s.inputs[inp.OutPoint()]
+		require.Equal(rt, PublishFailed, pi.state)
+
+		// None preserves the exact prior value, Some performs the
+		// explicit update.
+		expected := prior
+		if next.IsSome() {
+			expected = next
+		}
+		require.Equal(rt, expected, pi.params.StartingFeeRate)
+	})
 }
 
 // TestMarkInputsSwept checks that given a list of inputs with different


### PR DESCRIPTION
Supplementary to #10897 (and replaces #10816).

The sweeper responds to a failed sweep attempt by ratcheting the input's fee rate for the next one. For fee-related failures this is the right response, but the same machinery also fires on resource failures, e.g. ErrNotEnoughInputs or ErrNotEnoughBudget. These failures carry no fee rate signal, so ratcheting the fee rate can't resolve them.

Each spurious ratchet raises the bar the input's budget must clear, and once the starting rate exceeds an input's budget, the aggregator filters it out of every future input set and the sweep is silently stranded. This PR skips the ratchet for failures with no fee dimension, preserving the input's existing starting fee rate across retries.

The TxUnknownSpend path also attaches a retry fee rate. It's deliberately left untouched here, since an unknown spend can reflect a genuine fee race with a counterparty; with #10897, that residual ratchet can no longer strand small-budget inputs.