### PR TITLE
itest: tolerate deferred HTLC timeout sweeps

### DIFF
--- a/itest/lnd_multi-hop_force_close_test.go
+++ b/itest/lnd_multi-hop_force_close_test.go
@@ -552,10 +552,22 @@ func runLocalClaimOutgoingHTLC(ht *lntest.HarnessTest,
 	ht.AssertNumPendingSweeps(bob, 2)
 	ht.AssertNumPendingSweeps(carol, 1)
 
-	// Bob's sweeper should sweep his outgoing HTLC immediately since it's
-	// expired. His to_local output cannot be swept due to the CSV lock.
-	// Carol's anchor sweep should be failed due to output being dust.
-	ht.AssertNumTxsInMempool(1)
+	// Bob's HTLC timeout input is mature, but it may be offered after the
+	// sweeper has processed the block that made it mature. If so, mine an
+	// empty block to trigger the next sweep round without confirming any
+	// txns that may be broadcast concurrently.
+	assertMaybeDeferredSweep := func() {
+		mempool := ht.GetRawMempool()
+		if len(mempool) == 0 {
+			ht.MineEmptyBlocks(1)
+			ht.AssertNumTxsInMempool(1)
+
+			return
+		}
+
+		require.Len(ht, mempool, 1)
+	}
+	assertMaybeDeferredSweep()
 
 	// Mine a block to confirm Bob's outgoing HTLC sweeping tx.
 	ht.MineBlocksAndAssertNumTxes(1, 1)
@@ -611,7 +623,7 @@ func runLocalClaimOutgoingHTLC(ht *lntest.HarnessTest,
 
 		// Bob's sweeper should now broadcast his second layer sweep
 		// due to the CSV on the HTLC timeout output.
-		ht.AssertNumTxsInMempool(1)
+		assertMaybeDeferredSweep()
 
 		// Next, we'll mine a final block that should confirm the
 		// sweeping transactions left.


### PR DESCRIPTION
## Change Description

The local-claim outgoing HTLC itest assumed Bob's mature timeout sweep is in the mempool immediately after the force-close block is processed. In practice, the resolver can offer the mature input after the sweeper has already processed that block, so publication can wait for the next blockbeat.

This PR updates the itest to accept both valid scheduler outcomes. If the sweep is not in the mempool yet, the test mines an empty block to trigger the next sweep round, then confirms the sweep. No production sweeper or resolver behavior changes are included.

## Steps to Test

- `GOWORK=off make fmt`
- `git diff --check 2a4aab892a8aa48ebdf103726562080f029b7884..HEAD`
- `GOWORK=off make itest backend=bitcoind dbbackend=postgres nativesql=1 icase=multihop-local_claim_outgoing_htlc_simple_taproot_zero_conf`
- `GOWORK=off make lint`

## Pull Request Checklist

### Testing

- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation

- [x] The change is not insubstantial.
- [x] The change obeys the Code Documentation and Commenting guidelines, and lines wrap at 80.
- [x] Commits follow the Ideal Git Commit Structure.
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x] No release note is included because this is an itest-only flake fix.
