### PR TITLE
github: add gateway code-review workflow

### DIFF
--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -1,0 +1,42 @@
+name: gateway
+
+# Opt-in code-review bot. Triggered by a `/gateway <command>` comment on a PR
+# (e.g. `/gateway review`); review/approve commands are gated to maintainers.
+# Comment-commands only — no pull_request triggers — so fork PRs (which receive
+# no secrets) never spawn failing runs.
+#
+# Thin shim: the public lightninglabs/gateway-action mints an App token and
+# checks out the private gateway runtime at execution time. The runtime stays
+# private; only this entry point is public.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  # The action mints an App installation token internally; the GITHUB_TOKEN
+  # handed to this shim is unused, so we minimise it.
+  contents: read
+
+jobs:
+  review:
+    # issue_comment fires for all issues; filter to PR comments only.
+    if: ${{ github.event.issue.pull_request != null }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GATEWAY_REVIEW_MODE: multi
+    steps:
+      - uses: lightninglabs/gateway-action@fa29e3132c8af9cdabd9cedca3b1b6ece56d0982 # v0.4.3
+        with:
+          event_name:      ${{ github.event_name }}
+          event_action:    ${{ github.event.action }}
+          repo:            ${{ github.repository }}
+          pr_number:       ${{ github.event.issue.number }}
+          actor:           ${{ github.event.sender.login }}
+          comment_body:    ${{ github.event.comment.body }}
+          comment_id:      ${{ github.event.comment.id }}
+          installation_id: 140960039
+          app_id:                  ${{ secrets.GATEWAY_APP_ID }}
+          private_key:             ${{ secrets.GATEWAY_PRIVATE_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -20,8 +20,11 @@ permissions:
 
 jobs:
   review:
-    # issue_comment fires for all issues; filter to PR comments only.
-    if: ${{ github.event.issue.pull_request != null }}
+    # issue_comment fires for all issues and every PR comment. Filter to PR
+    # comments that look like a /gateway command so unrelated comments don't
+    # spin up a no-op runner. `contains` (not `startsWith`) because the runtime
+    # accepts the command at column 0 of any line, including multi-line bodies.
+    if: ${{ github.event.issue.pull_request != null && contains(github.event.comment.body, '/gateway') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -29,6 +32,10 @@ jobs:
     steps:
       - uses: lightninglabs/gateway-action@fa29e3132c8af9cdabd9cedca3b1b6ece56d0982 # v0.4.3
         with:
+          # Pin the private runtime to an immutable commit (matches the action
+          # SHA-pin above) so runtime upgrades go through an lnd PR, not a moved
+          # tag. Without this, runtime_ref defaults to the v0.4.3 tag.
+          runtime_ref: bb11d9744cd6fe7fbeeb9de720fc8a74b5232a8e # gateway v0.4.3
           event_name:      ${{ github.event_name }}
           event_action:    ${{ github.event.action }}
           repo:            ${{ github.repository }}


### PR DESCRIPTION
Adds an opt-in code-review bot, **gateway**.

## What

- Triggered by a `/gateway <command>` comment on a PR (e.g. `/gateway review`). Review/approve commands are gated to maintainers (write access).
- Thin shim onto the public `lightninglabs/gateway-action` (SHA-pinned to v0.4.3); it mints an App token and checks out the gateway runtime at execution time. The review runtime stays private — only this entry point is public.

## Scope / safety

- **Comment-commands only** — no `pull_request` triggers — so fork PRs (which receive no secrets) never spawn failing runs.
- `permissions: contents: read` on the shim; the action mints its own scoped App installation token internally.
- Opt-in by design: nothing runs until someone comments `/gateway …`.