### PR TITLE
tor: skip onion cleanup before service creation

### DIFF
--- a/tor/controller.go
+++ b/tor/controller.go
@@ -171,26 +171,35 @@ func (c *Controller) Start() error {
 
 // Stop closes the connection between the controller and the Tor server.
 func (c *Controller) Stop() error {
+	if c.conn == nil {
+		return fmt.Errorf("no connection available to the tor server")
+	}
+
 	if !atomic.CompareAndSwapInt32(&c.stopped, 0, 1) {
 		return nil
 	}
 
 	log.Info("Stopping tor controller")
 
-	// Remove the onion service.
-	if err := c.DelOnion(c.activeServiceID); err != nil {
-		log.Errorf("DEL_ONION got error: %v", err)
-		return err
+	var delOnionErr error
+
+	// Remove the onion service if one was created successfully.
+	if c.activeServiceID != "" {
+		if err := c.DelOnion(c.activeServiceID); err != nil {
+			log.Errorf("DEL_ONION got error: %v", err)
+			delOnionErr = err
+		}
 	}
 
-	// Reset service ID.
-	c.activeServiceID = ""
-
-	if c.conn == nil {
-		return fmt.Errorf("no connection available to the tor server")
+	closeErr := c.conn.Close()
+	if delOnionErr == nil || closeErr == nil {
+		// Reset service ID. If DEL_ONION failed but the control
+		// connection closed successfully, the ephemeral service is
+		// removed by Tor along with the connection.
+		c.activeServiceID = ""
 	}
 
-	return c.conn.Close()
+	return errors.Join(delOnionErr, closeErr)
 }
 
 // Reconnect makes a new socket connection between the tor controller and

--- a/tor/controller_test.go
+++ b/tor/controller_test.go
@@ -1,12 +1,16 @@
 package tor
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/textproto"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -116,6 +120,26 @@ func (tp *testProxy) cleanUp() {
 	if err := tp.server.Close(); err != nil {
 		log.Errorf("closing proxy server got err: %v", err)
 	}
+}
+
+// closeErrorConn is an in-memory control connection that returns a configured
+// error from Close.
+type closeErrorConn struct {
+	responses *strings.Reader
+	commands  strings.Builder
+	closeErr  error
+}
+
+func (c *closeErrorConn) Read(p []byte) (int, error) {
+	return c.responses.Read(p)
+}
+
+func (c *closeErrorConn) Write(p []byte) (int, error) {
+	return c.commands.Write(p)
+}
+
+func (c *closeErrorConn) Close() error {
+	return c.closeErr
 }
 
 // createTestProxy creates a proxy server to listen on a random address,
@@ -300,6 +324,115 @@ func TestReconnectTCMustBeRunning(t *testing.T) {
 
 	// Reconnect should fail because the TC is stopped.
 	require.Equal(t, errTCStopped, c.Reconnect())
+}
+
+// TestStopWithoutConnectionDoesNotMarkStopped checks that Stop doesn't consume
+// the one-way stopped flag if no control connection is available.
+func TestStopWithoutConnectionDoesNotMarkStopped(t *testing.T) {
+	c := &Controller{}
+
+	err := c.Stop()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no connection available")
+	require.Zero(t, c.stopped)
+}
+
+// TestStopWithoutActiveService closes the control connection without issuing a
+// DEL_ONION command if ADD_ONION never completed successfully.
+func TestStopWithoutActiveService(t *testing.T) {
+	proxy := createTestProxy(t)
+	t.Cleanup(proxy.cleanUp)
+
+	c := &Controller{
+		conn: proxy.clientConn,
+	}
+
+	require.NoError(t, c.Stop())
+
+	assertControlConnClosed(t, proxy.serverConn)
+}
+
+// TestStopClosesConnectionOnDelOnionError checks that Stop closes the control
+// connection even if Tor rejects the DEL_ONION command.
+func TestStopClosesConnectionOnDelOnionError(t *testing.T) {
+	proxy := createTestProxy(t)
+	t.Cleanup(proxy.cleanUp)
+
+	const serviceID = "fakeID"
+	c := &Controller{
+		conn:            proxy.clientConn,
+		activeServiceID: serviceID,
+	}
+
+	serverErr := make(chan error, 1)
+	go func() {
+		reader := bufio.NewReader(proxy.serverConn)
+
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			serverErr <- err
+
+			return
+		}
+
+		_, writeErr := proxy.serverConn.Write([]byte(
+			"512 Bad arguments\r\n",
+		))
+
+		expectedCmd := fmt.Sprintf("DEL_ONION %s\r\n", serviceID)
+		if line != expectedCmd {
+			serverErr <- fmt.Errorf("expected %q, got %q",
+				expectedCmd, line)
+
+			return
+		}
+
+		serverErr <- writeErr
+	}()
+
+	err := c.Stop()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid arguments")
+	require.NoError(t, <-serverErr)
+	require.Empty(t, c.activeServiceID)
+
+	assertControlConnClosed(t, proxy.serverConn)
+}
+
+// TestStopReturnsDelOnionAndCloseErrors checks that Stop preserves both
+// cleanup failures and keeps the active service ID for diagnostics.
+func TestStopReturnsDelOnionAndCloseErrors(t *testing.T) {
+	const serviceID = "fakeID"
+
+	closeErr := errors.New("close failed")
+	conn := &closeErrorConn{
+		responses: strings.NewReader("512 Bad arguments\r\n"),
+		closeErr:  closeErr,
+	}
+	c := &Controller{
+		conn:            textproto.NewConn(conn),
+		activeServiceID: serviceID,
+	}
+
+	err := c.Stop()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid arguments")
+	require.ErrorIs(t, err, closeErr)
+	require.Equal(t, serviceID, c.activeServiceID)
+	require.Equal(t, "DEL_ONION fakeID\r\n", conn.commands.String())
+}
+
+// assertControlConnClosed asserts that the control connection was closed by
+// the peer instead of timing out while waiting for data.
+func assertControlConnClosed(t *testing.T, conn net.Conn) {
+	t.Helper()
+
+	buf := make([]byte, 1)
+	require.NoError(t, conn.SetReadDeadline(
+		time.Now().Add(50*time.Millisecond),
+	))
+	_, err := conn.Read(buf)
+	require.ErrorIs(t, err, io.EOF)
 }
 
 // TestReconnectSucceed tests a reconnection will succeed when the tor


### PR DESCRIPTION
## Change Description
Only send DEL_ONION if ADD_ONION completed successfully and the controller has an active service ID to remove.

This avoids masking the original ADD_ONION failure with a secondary empty DEL_ONION error during startup cleanup.

See the log attached in https://github.com/lightningnetwork/lnd/issues/10915
The log has misleading error messages:
```
[ERR] TORC: DEL_ONION got error: invalid arguments: unexpected code
[ERR] SRVR: Cleanup failed: invalid arguments: unexpected code
```

The code issue was fixed in https://github.com/lightningnetwork/lnd/pull/10907

This PR addresses is a follow-up to skip DelOnion is there is no service ID (nothing to delete yet).

## Steps to Test

```
cd tor
go test
```

I added a regression test which makes sure `.Stop()` works if a service is not created. The test would fail if `.Stop()` attempted to delete an empty service ID.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
