### PR TITLE
build: bump version to v0.21.1-beta

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -47,7 +47,7 @@ const (
 	AppMinor uint = 21
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 00
+	AppPatch uint = 01
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.


### PR DESCRIPTION
## Change

Bumps the lnd application patch version from `0.21.0-beta` to `0.21.1-beta` on the `v0.21.x-branch` release branch.
