### PR TITLE
docs: remove release note for DNS fallback panic of 0.22.0

### DIFF
--- a/docs/release-notes/release-notes-0.21.1.md
+++ b/docs/release-notes/release-notes-0.21.1.md
@@ -29,6 +29,12 @@
   which could default new onion service creation to the retired v2
   `NEW:RSA1024` key type that modern Tor rejects with `513 Invalid key type`.
 
+* [Fixed a panic](https://github.com/lightningnetwork/lnd/pull/10914) in the
+  DNS fallback SRV lookup, which unconditionally type-asserted each DNS Answer
+  record to `*dns.SRV` and crashed the daemon when the response contained a
+  non-SRV record. Non-SRV records are now skipped, and an empty `LookupHost`
+  result for the shim no longer triggers an out-of-bounds index.
+
 # New Features
 
 ## Functional Enhancements

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -42,12 +42,6 @@
   regardless of peer connectivity. Uptime is now seeded from the peer's
   actual connection state.
 
-* [Fixed a panic](https://github.com/lightningnetwork/lnd/pull/10914) in the
-  DNS fallback SRV lookup, which unconditionally type-asserted each DNS Answer
-  record to `*dns.SRV` and crashed the daemon when the response contained a
-  non-SRV record. Non-SRV records are now skipped, and an empty `LookupHost`
-  result for the shim no longer triggers an out-of-bounds index.
-
 # New Features
 
 ## Functional Enhancements


### PR DESCRIPTION
Since we will backport #10914 to 0.21.1, the release notes for 0.22.0 are no longer needed.