### PR TITLE
htlcswitch+invoices: tighten final-hop CLTV validation

### DIFF
--- a/config.go
+++ b/config.go
@@ -264,6 +264,58 @@ const (
 	defaultNoDisconnectOnPongFailure = false
 )
 
+// validateMaxOutgoingCltvExpiry validates the configured maximum outgoing CLTV
+// expiry against the node's default time lock delta.
+func validateMaxOutgoingCltvExpiry(maxCltvExpiry, timeLockDelta uint32) error {
+	if maxCltvExpiry < timeLockDelta {
+		return fmt.Errorf(
+			"max-cltv-expiry must be at least %v", timeLockDelta,
+		)
+	}
+
+	if maxCltvExpiry > MaxTimeLockDelta {
+		return fmt.Errorf(
+			"max-cltv-expiry must be at most %v", MaxTimeLockDelta,
+		)
+	}
+
+	return nil
+}
+
+// validateCltvDeltaBounds validates a CLTV delta against LND's absolute
+// supported bounds.
+func validateCltvDeltaBounds(delta uint32) error {
+	if delta < minTimeLockDelta {
+		return fmt.Errorf("time lock delta of %v is too small, "+
+			"minimum supported is %v", delta, minTimeLockDelta)
+	}
+
+	if delta > MaxTimeLockDelta {
+		return fmt.Errorf("time lock delta of %v is too big, "+
+			"maximum supported is %v", delta, MaxTimeLockDelta)
+	}
+
+	return nil
+}
+
+// validateChannelPolicyTimeLockDelta validates an advertised channel policy
+// time lock delta against the node's supported forwarding bounds.
+func validateChannelPolicyTimeLockDelta(timeLockDelta,
+	maxOutgoingCltvExpiry uint32) error {
+
+	if err := validateCltvDeltaBounds(timeLockDelta); err != nil {
+		return err
+	}
+
+	if timeLockDelta > maxOutgoingCltvExpiry {
+		return fmt.Errorf("time lock delta of %v exceeds "+
+			"max-cltv-expiry of %v", timeLockDelta,
+			maxOutgoingCltvExpiry)
+	}
+
+	return nil
+}
+
 var (
 	// DefaultLndDir is the default directory where lnd tries to find its
 	// configuration file and store its data. This is a directory in the
@@ -1196,6 +1248,12 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 		return nil, mkErr("invalid max commit fee rate anchors: %v, "+
 			"must be at least 1 sat/vByte",
 			cfg.MaxCommitFeeRateAnchors)
+	}
+
+	if err := validateMaxOutgoingCltvExpiry(
+		cfg.MaxOutgoingCltvExpiry, cfg.Bitcoin.TimeLockDelta,
+	); err != nil {
+		return nil, mkErr("%v", err)
 	}
 
 	// Validate the Tor config parameters.

--- a/config_test.go
+++ b/config_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/lightningnetwork/lnd/chainreg"
+	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/routing"
 	"github.com/stretchr/testify/require"
 )
@@ -170,4 +171,64 @@ func TestValidateConfigTrickleDelay(t *testing.T) {
 			)
 		})
 	}
+}
+
+// TestValidateMaxOutgoingCltvExpiry asserts that max-cltv-expiry accepts
+// values within its supported bounds and rejects values outside them.
+func TestValidateMaxOutgoingCltvExpiry(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig()
+
+	require.NoError(
+		t, validateMaxOutgoingCltvExpiry(
+			htlcswitch.DefaultMaxOutgoingCltvExpiry,
+			cfg.Bitcoin.TimeLockDelta,
+		),
+	)
+	require.NoError(t, validateMaxOutgoingCltvExpiry(
+		MaxTimeLockDelta, MaxTimeLockDelta,
+	))
+
+	err := validateMaxOutgoingCltvExpiry(
+		cfg.Bitcoin.TimeLockDelta-1,
+		cfg.Bitcoin.TimeLockDelta,
+	)
+	require.ErrorContains(t, err, "max-cltv-expiry must be at least")
+
+	err = validateMaxOutgoingCltvExpiry(
+		MaxTimeLockDelta+1, cfg.Bitcoin.TimeLockDelta,
+	)
+	require.ErrorContains(t, err, "max-cltv-expiry must be at most")
+}
+
+// TestValidateChannelPolicyTimeLockDelta asserts that advertised channel
+// policy CLTV deltas stay within the node's supported forwarding bounds.
+func TestValidateChannelPolicyTimeLockDelta(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig()
+
+	require.NoError(t, validateChannelPolicyTimeLockDelta(
+		cfg.Bitcoin.TimeLockDelta, cfg.MaxOutgoingCltvExpiry,
+	))
+	require.NoError(t, validateChannelPolicyTimeLockDelta(
+		cfg.MaxOutgoingCltvExpiry, cfg.MaxOutgoingCltvExpiry,
+	))
+
+	err := validateChannelPolicyTimeLockDelta(
+		minTimeLockDelta-1, cfg.MaxOutgoingCltvExpiry,
+	)
+	require.ErrorContains(t, err, "time lock delta of")
+	require.ErrorContains(t, err, "is too small")
+
+	err = validateChannelPolicyTimeLockDelta(
+		MaxTimeLockDelta+1, MaxTimeLockDelta,
+	)
+	require.ErrorContains(t, err, "is too big")
+
+	err = validateChannelPolicyTimeLockDelta(
+		cfg.MaxOutgoingCltvExpiry+1, cfg.MaxOutgoingCltvExpiry,
+	)
+	require.ErrorContains(t, err, "exceeds max-cltv-expiry")
 }

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -75,6 +75,11 @@ type ChainArbitratorConfig struct {
 	// htlcs. This value can be lower than the incoming broadcast delta.
 	OutgoingBroadcastDelta uint32
 
+	// CustomHtlcChecker optionally identifies HTLCs that should bypass the
+	// standard final-hop amount check because their amount validation is
+	// handled by auxiliary channel logic.
+	CustomHtlcChecker fn.Option[CustomHtlcChecker]
+
 	// NewSweepAddr is a function that returns a new address under control
 	// by the wallet. We'll use this to sweep any no-delay outputs as a
 	// result of unilateral channel closes.

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1432,7 +1432,7 @@ func (c *ChannelArbitrator) sweepAnchors(anchors *lnwallet.AnchorResolutions,
 //     HTLCs,  or,
 //   - half of the least CLTV from incoming HTLCs if the preimage is available.
 //
-// We use half of the CTLV value to ensure that we have enough time to sweep
+// We use half of the CLTV value to ensure that we have enough time to sweep
 // the second-level HTLCs.
 //
 // It also finds the total value that are time-sensitive, which is the sum of

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -213,7 +213,7 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 			"expected_expiry=%v, height=%v, max=%v), resolving as "+
 			"failed", h, h.htlcResolution.ClaimOutpoint,
 			h.htlc.Amt, payload.FwdInfo.AmountToForward,
-			h.htlcExpiry, payload.FwdInfo.OutgoingCTLV,
+			h.htlcExpiry, payload.FwdInfo.OutgoingCLTV,
 			currentHeight, invoices.MaxFinalCltvDelta)
 		h.markResolved()
 

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -79,6 +79,31 @@ func (h *htlcIncomingContestResolver) processFinalHtlcFail() error {
 	return nil
 }
 
+// invalidFinalHtlc returns true if the HTLC is an exit-hop HTLC that fails
+// final-hop validation.
+func (h *htlcIncomingContestResolver) invalidFinalHtlc(
+	payload *hop.Payload, height uint32) bool {
+
+	if payload.FwdInfo.NextHop != hop.Exit {
+		return false
+	}
+
+	// Custom HTLCs still enforce final CLTV correctness, but leave amount
+	// validation to auxiliary channel logic.
+	validateAmount := !fn.MapOptionZ(
+		h.CustomHtlcChecker,
+		func(checker CustomHtlcChecker) bool {
+			return checker.IsCustomHTLC(h.htlc.CustomRecords)
+		},
+	)
+
+	return hop.ValidateFinalHtlc(
+		h.htlc.Amt, h.htlcExpiry, height,
+		invoices.MaxFinalCltvDelta, payload.FwdInfo,
+		validateAmount,
+	) != hop.FinalHtlcValid
+}
+
 // Launch will call the inner resolver's launch method if the preimage can be
 // found, otherwise it's a no-op.
 func (h *htlcIncomingContestResolver) Launch() error {
@@ -102,7 +127,7 @@ func (h *htlcIncomingContestResolver) Launch() error {
 		return nil
 	}
 
-	h.log.Debugf("found preimage for htlc=%x,  transforming into success "+
+	h.log.Debugf("found preimage for htlc=%x, transforming into success "+
 		"resolver and launching it", h.htlc.RHash)
 
 	// Once we've applied the preimage, we'll launch the inner resolver to
@@ -177,6 +202,32 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 
 	log.Debugf("%T(%v): Resolving incoming HTLC(expiry=%v, height=%v)", h,
 		h.htlcResolution.ClaimOutpoint, h.htlcExpiry, currentHeight)
+
+	// If this final-hop HTLC does not match the expected final-hop details,
+	// keep the on-chain path aligned with link-level handling by recording
+	// a failed final outcome and leaving timeout resolution to the remote
+	// party.
+	if h.invalidFinalHtlc(payload, uint32(currentHeight)) {
+		log.Infof("%T(%v): final-hop HTLC did not match expected "+
+			"details (amt=%v, expected_amt=%v, expiry=%v, "+
+			"expected_expiry=%v, height=%v, max=%v), resolving as "+
+			"failed", h, h.htlcResolution.ClaimOutpoint,
+			h.htlc.Amt, payload.FwdInfo.AmountToForward,
+			h.htlcExpiry, payload.FwdInfo.OutgoingCTLV,
+			currentHeight, invoices.MaxFinalCltvDelta)
+		h.markResolved()
+
+		if err := h.processFinalHtlcFail(); err != nil {
+			return nil, err
+		}
+
+		report := h.report().resolverReport(
+			nil, channeldb.ResolverTypeIncomingHtlc,
+			channeldb.ResolverOutcomeAbandoned,
+		)
+
+		return nil, h.Checkpoint(h, report)
+	}
 
 	// We'll first check if this HTLC has been timed out, if so, we can
 	// return now and mark ourselves as resolved. If we're past the point of
@@ -616,11 +667,21 @@ var _ htlcContractResolver = (*htlcIncomingContestResolver)(nil)
 // NOTE: Since we have two places to query the preimage, we need to check both
 // the preimage db and the invoice db to look up the preimage.
 func (h *htlcIncomingContestResolver) findAndapplyPreimage() (bool, error) {
+	// Decode the hop payload up front; both the known-preimage path and the
+	// registry lookup below rely on the decoded final-hop details.
+	payload, _, err := h.decodePayload()
+
 	// Query to see if we already know the preimage.
 	preimage, ok := h.PreimageDB.LookupPreimage(h.htlc.RHash)
 
 	// If the preimage is known, we'll apply it.
 	if ok {
+		if err == nil &&
+			h.invalidFinalHtlc(payload, h.broadcastHeight) {
+
+			return false, nil
+		}
+
 		if err := h.applyPreimage(preimage); err != nil {
 			return false, err
 		}
@@ -629,8 +690,7 @@ func (h *htlcIncomingContestResolver) findAndapplyPreimage() (bool, error) {
 		return true, nil
 	}
 
-	// First try to parse the payload.
-	payload, _, err := h.decodePayload()
+	// Without a preimage we need a valid payload to look up the invoice.
 	if err != nil {
 		h.log.Errorf("Cannot decode payload of htlc %v", h.HtlcPoint())
 
@@ -640,8 +700,14 @@ func (h *htlcIncomingContestResolver) findAndapplyPreimage() (bool, error) {
 	}
 
 	// Exit early if this is not the exit hop, which means we are not the
-	// payment receiver and don't have preimage.
+	// payment receiver and don't have the preimage.
 	if payload.FwdInfo.NextHop != hop.Exit {
+		return false, nil
+	}
+
+	// If this final-hop HTLC does not match the expected final-hop details,
+	// let Resolve record the failed final outcome.
+	if h.invalidFinalHtlc(payload, h.broadcastHeight) {
 		return false, nil
 	}
 

--- a/contractcourt/htlc_incoming_contest_resolver_test.go
+++ b/contractcourt/htlc_incoming_contest_resolver_test.go
@@ -9,6 +9,7 @@ import (
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/graph/db/models"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/input"
@@ -260,8 +261,95 @@ func TestHtlcIncomingResolverExitCancelHodl(t *testing.T) {
 	ctx.waitForResult(false)
 }
 
+// TestHtlcIncomingResolverInvalidFinalHtlc asserts that an exit-hop HTLC with
+// final-hop details outside the expected range resolves without querying the
+// invoice registry for a preimage.
+func TestHtlcIncomingResolverInvalidFinalHtlc(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		cachePreimage bool
+		mutate        func(*incomingResolverTestContext)
+	}{{
+		name: "expiry too far",
+		mutate: func(ctx *incomingResolverTestContext) {
+			ctx.resolver.htlcExpiry = testInitialBlockHeight +
+				invoices.MaxFinalCltvDelta + 1
+		},
+	}, {
+		name:          "cached preimage expiry too far",
+		cachePreimage: true,
+		mutate: func(ctx *incomingResolverTestContext) {
+			ctx.resolver.htlcExpiry = testInitialBlockHeight +
+				invoices.MaxFinalCltvDelta + 1
+		},
+	}, {
+		name: "amount too low",
+		mutate: func(ctx *incomingResolverTestContext) {
+			ctx.onionProcessor.forwardAmount = testHtlcAmount + 1
+		},
+	}, {
+		name: "final cltv too low",
+		mutate: func(ctx *incomingResolverTestContext) {
+			ctx.onionProcessor.outgoingCltv = testHtlcExpiry + 1
+		},
+	}}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			defer timeout()()
+
+			ctx := newIncomingResolverTestContext(t, true)
+			if testCase.cachePreimage {
+				ctx.witnessBeacon.lookupPreimage[testResHash] =
+					testResPreimage
+			}
+
+			testCase.mutate(ctx)
+			resolution := invoices.NewSettleResolution(
+				testResPreimage, testResCircuitKey,
+				testAcceptHeight, invoices.ResultSettled,
+			)
+			ctx.registry.notifyResolution = resolution
+
+			ctx.resolve()
+			ctx.waitForResult(false)
+
+			require.EqualValues(
+				t, 0, ctx.registry.notifyCalls.Load(),
+			)
+		})
+	}
+}
+
+// TestHtlcIncomingResolverCustomHtlc asserts that a custom HTLC bypasses the
+// standard final-hop amount check in contract court, matching the link flow.
+func TestHtlcIncomingResolverCustomHtlc(t *testing.T) {
+	t.Parallel()
+	defer timeout()()
+
+	ctx := newIncomingResolverTestContext(t, true)
+	ctx.resolver.CustomHtlcChecker = fn.Some[CustomHtlcChecker](
+		mockCustomHtlcChecker{},
+	)
+	ctx.onionProcessor.forwardAmount = testHtlcAmount + 1
+	ctx.registry.notifyResolution = invoices.NewSettleResolution(
+		testResPreimage, testResCircuitKey, testAcceptHeight,
+		invoices.ResultSettled,
+	)
+
+	ctx.resolve()
+	ctx.waitForResult(true)
+
+	require.NotZero(t, ctx.registry.notifyCalls.Load())
+}
+
 type mockHopIterator struct {
-	isExit bool
+	isExit        bool
+	forwardAmount int
+	outgoingCltv  uint32
 	hop.Iterator
 }
 
@@ -271,11 +359,21 @@ func (h *mockHopIterator) HopPayload() (*hop.Payload, hop.RouteRole, error) {
 		nextAddress = [8]byte{0x01}
 	}
 
+	forwardAmount := h.forwardAmount
+	if forwardAmount == 0 {
+		forwardAmount = 100
+	}
+
+	outgoingCltv := h.outgoingCltv
+	if outgoingCltv == 0 {
+		outgoingCltv = 40
+	}
+
 	return hop.NewLegacyPayload(&sphinx.HopData{
 		Realm:         [1]byte{},
 		NextAddress:   nextAddress,
-		ForwardAmount: 100,
-		OutgoingCltv:  40,
+		ForwardAmount: uint64(forwardAmount),
+		OutgoingCltv:  outgoingCltv,
 		ExtraBytes:    [12]byte{},
 	}), hop.RouteRoleCleartext, nil
 }
@@ -286,6 +384,8 @@ func (h *mockHopIterator) EncodeNextHop(w io.Writer) error {
 
 type mockOnionProcessor struct {
 	isExit           bool
+	forwardAmount    int
+	outgoingCltv     uint32
 	offeredOnionBlob []byte
 }
 
@@ -298,7 +398,17 @@ func (o *mockOnionProcessor) ReconstructHopIterator(r io.Reader, rHash []byte,
 	}
 	o.offeredOnionBlob = data
 
-	return &mockHopIterator{isExit: o.isExit}, nil
+	return &mockHopIterator{
+		isExit:        o.isExit,
+		forwardAmount: o.forwardAmount,
+		outgoingCltv:  o.outgoingCltv,
+	}, nil
+}
+
+type mockCustomHtlcChecker struct{}
+
+func (m mockCustomHtlcChecker) IsCustomHTLC(lnwire.CustomRecords) bool {
+	return true
 }
 
 type incomingResolverTestContext struct {

--- a/contractcourt/interfaces.go
+++ b/contractcourt/interfaces.go
@@ -37,6 +37,15 @@ type Registry interface {
 	HodlUnsubscribeAll(subscriber chan<- interface{})
 }
 
+// CustomHtlcChecker identifies HTLCs whose final-hop amount validation is
+// handled by auxiliary channel logic instead of the standard onion amount
+// field.
+type CustomHtlcChecker interface {
+	// IsCustomHTLC returns true if the HTLC carries custom records that
+	// make it subject to auxiliary HTLC handling.
+	IsCustomHTLC(htlcRecords lnwire.CustomRecords) bool
+}
+
 // OnionProcessor is an interface used to decode onion blobs.
 type OnionProcessor interface {
 	// ReconstructHopIterator attempts to decode a valid sphinx packet from

--- a/contractcourt/mock_registry_test.go
+++ b/contractcourt/mock_registry_test.go
@@ -2,6 +2,7 @@ package contractcourt
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/lightningnetwork/lnd/graph/db/models"
 	"github.com/lightningnetwork/lnd/invoices"
@@ -21,6 +22,7 @@ type mockRegistry struct {
 	notifyChan       chan notifyExitHopData
 	notifyErr        error
 	notifyResolution invoices.HtlcResolution
+	notifyCalls      atomic.Int32
 }
 
 func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
@@ -28,6 +30,8 @@ func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
 	circuitKey models.CircuitKey, hodlChan chan<- interface{},
 	wireCustomRecords lnwire.CustomRecords,
 	payload invoices.Payload) (invoices.HtlcResolution, error) {
+
+	r.notifyCalls.Add(1)
 
 	// Exit early if the notification channel is nil.
 	if hodlChan == nil {

--- a/docs/release-notes/release-notes-0.21.1.md
+++ b/docs/release-notes/release-notes-0.21.1.md
@@ -47,6 +47,17 @@
 
 ## Functional Updates
 
+* lnd now [validates the CLTV expiry of HTLCs at the final
+hop](https://github.com/lightningnetwork/lnd/pull/10927). A final HTLC whose
+CLTV expiry falls outside the node's receive policy is failed back, bringing
+the final hop in line with the CLTV delta limits already enforced on the
+forwarding path. 
+As part of this change, the channel policy `TimeLockDelta` is
+now validated against LND's supported forwarding bounds: any node that
+previously set a per-channel `TimeLockDelta` greater than `2016` (the maximum
+default value) will now have its `UpdateChannelPolicy` request
+rejected, and must lower the value accordingly below the specified maximum.
+
 ## RPC Updates
 
 ## lncli Updates

--- a/graph/db/models/channel.go
+++ b/graph/db/models/channel.go
@@ -123,7 +123,7 @@ type ForwardingPolicy struct {
 	// create the time-lock value for the forwarded outgoing HTLC. The
 	// following constraint MUST hold for an HTLC to be forwarded:
 	//
-	//  * incomingHtlc.timeLock - timeLockDelta = fwdInfo.OutgoingCTLV
+	//  * incomingHtlc.timeLock - timeLockDelta = fwdInfo.OutgoingCLTV
 	//
 	// where fwdInfo is the forwarding information extracted from the
 	// per-hop payload of the incoming HTLC's onion packet.

--- a/htlcswitch/hop/forwarding_info.go
+++ b/htlcswitch/hop/forwarding_info.go
@@ -20,9 +20,9 @@ type ForwardingInfo struct {
 	// node should forward to the next hop.
 	AmountToForward lnwire.MilliSatoshi
 
-	// OutgoingCTLV is the specified value of the CTLV timelock to be used
+	// OutgoingCLTV is the specified value of the CLTV timelock to be used
 	// in the outgoing HTLC.
-	OutgoingCTLV uint32
+	OutgoingCLTV uint32
 
 	// NextBlinding is an optional blinding point to be passed to the next
 	// node in UpdateAddHtlc. This field is set if the htlc is part of a
@@ -71,7 +71,7 @@ func ValidateFinalHtlc(amt lnwire.MilliSatoshi, expiry, heightNow,
 
 	// The HTLC expiry is below the final CLTV requested by the onion
 	// payload.
-	case expiry < fwdInfo.OutgoingCTLV:
+	case expiry < fwdInfo.OutgoingCLTV:
 		return FinalHtlcInvalidCltv
 
 	// The HTLC expiry is outside the supported final-hop CLTV range.

--- a/htlcswitch/hop/forwarding_info.go
+++ b/htlcswitch/hop/forwarding_info.go
@@ -34,3 +34,52 @@ type ForwardingInfo struct {
 	// correct context.
 	PathID *chainhash.Hash
 }
+
+// FinalHtlcValidationResult describes the result of checking a final-hop
+// HTLC against the onion payload and supported final-hop CLTV range.
+type FinalHtlcValidationResult uint8
+
+const (
+	// FinalHtlcValid indicates that the HTLC matches the final-hop payload
+	// and supported final-hop CLTV range.
+	FinalHtlcValid FinalHtlcValidationResult = iota
+
+	// FinalHtlcInvalidAmount indicates that the HTLC amount is below the
+	// final amount requested by the onion payload.
+	FinalHtlcInvalidAmount
+
+	// FinalHtlcInvalidCltv indicates that the HTLC expiry is below the
+	// final CLTV requested by the onion payload.
+	FinalHtlcInvalidCltv
+
+	// FinalHtlcExpiryTooFar indicates that the HTLC expiry is outside the
+	// supported final-hop CLTV range.
+	FinalHtlcExpiryTooFar
+)
+
+// ValidateFinalHtlc checks final-hop HTLC amount and CLTV details before
+// invoice resolution.
+func ValidateFinalHtlc(amt lnwire.MilliSatoshi, expiry, heightNow,
+	maxFinalCltvDelta uint32, fwdInfo ForwardingInfo,
+	validateAmount bool) FinalHtlcValidationResult {
+
+	switch {
+	// The HTLC amount is below the final amount requested by the
+	// onion payload.
+	case validateAmount && amt < fwdInfo.AmountToForward:
+		return FinalHtlcInvalidAmount
+
+	// The HTLC expiry is below the final CLTV requested by the onion
+	// payload.
+	case expiry < fwdInfo.OutgoingCTLV:
+		return FinalHtlcInvalidCltv
+
+	// The HTLC expiry is outside the supported final-hop CLTV range.
+	case expiry > heightNow && expiry-heightNow > maxFinalCltvDelta:
+
+		return FinalHtlcExpiryTooFar
+
+	default:
+		return FinalHtlcValid
+	}
+}

--- a/htlcswitch/hop/forwarding_info_test.go
+++ b/htlcswitch/hop/forwarding_info_test.go
@@ -20,7 +20,7 @@ func TestValidateFinalHtlc(t *testing.T) {
 
 	fwdInfo := ForwardingInfo{
 		AmountToForward: amount,
-		OutgoingCTLV:    expiry,
+		OutgoingCLTV:    expiry,
 		NextHop:         Exit,
 	}
 
@@ -114,7 +114,7 @@ func TestValidateFinalHtlc(t *testing.T) {
 		maxCltvDelta: maxCltvDelta,
 		fwdInfo: ForwardingInfo{
 			AmountToForward: amount,
-			OutgoingCTLV:    expiry + maxCltvDelta + 2,
+			OutgoingCLTV:    expiry + maxCltvDelta + 2,
 			NextHop:         Exit,
 		},
 		validateAmount: true,

--- a/htlcswitch/hop/forwarding_info_test.go
+++ b/htlcswitch/hop/forwarding_info_test.go
@@ -1,0 +1,137 @@
+package hop
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateFinalHtlc exercises the final-hop HTLC validation helper.
+func TestValidateFinalHtlc(t *testing.T) {
+	t.Parallel()
+
+	const (
+		amount       = lnwire.MilliSatoshi(1000)
+		expiry       = uint32(150)
+		height       = uint32(100)
+		maxCltvDelta = uint32(50)
+	)
+
+	fwdInfo := ForwardingInfo{
+		AmountToForward: amount,
+		OutgoingCTLV:    expiry,
+		NextHop:         Exit,
+	}
+
+	testCases := []struct {
+		name           string
+		amount         lnwire.MilliSatoshi
+		expiry         uint32
+		height         uint32
+		maxCltvDelta   uint32
+		fwdInfo        ForwardingInfo
+		validateAmount bool
+		expected       FinalHtlcValidationResult
+	}{{
+		name:           "valid",
+		amount:         amount,
+		expiry:         expiry,
+		height:         height + 1,
+		maxCltvDelta:   maxCltvDelta,
+		fwdInfo:        fwdInfo,
+		validateAmount: true,
+		expected:       FinalHtlcValid,
+	}, {
+		name:           "amount too low",
+		amount:         amount - 1,
+		expiry:         expiry,
+		height:         height,
+		maxCltvDelta:   maxCltvDelta,
+		fwdInfo:        fwdInfo,
+		validateAmount: true,
+		expected:       FinalHtlcInvalidAmount,
+	}, {
+		name:           "amount check disabled",
+		amount:         amount - 1,
+		expiry:         expiry,
+		height:         height,
+		maxCltvDelta:   maxCltvDelta,
+		fwdInfo:        fwdInfo,
+		validateAmount: false,
+		expected:       FinalHtlcValid,
+	}, {
+		name:           "final cltv too low",
+		amount:         amount,
+		expiry:         expiry - 1,
+		height:         height,
+		maxCltvDelta:   maxCltvDelta,
+		fwdInfo:        fwdInfo,
+		validateAmount: true,
+		expected:       FinalHtlcInvalidCltv,
+	}, {
+		name:           "expiry too far",
+		amount:         amount,
+		expiry:         expiry + 1,
+		height:         height,
+		maxCltvDelta:   maxCltvDelta,
+		fwdInfo:        fwdInfo,
+		validateAmount: true,
+		expected:       FinalHtlcExpiryTooFar,
+	}, {
+		name:           "expiry at maximum",
+		amount:         amount,
+		expiry:         expiry,
+		height:         height,
+		maxCltvDelta:   maxCltvDelta,
+		fwdInfo:        fwdInfo,
+		validateAmount: true,
+		expected:       FinalHtlcValid,
+	}, {
+		name:           "height above expiry",
+		amount:         amount,
+		expiry:         expiry,
+		height:         expiry + 1,
+		maxCltvDelta:   maxCltvDelta,
+		fwdInfo:        fwdInfo,
+		validateAmount: true,
+		expected:       FinalHtlcValid,
+	}, {
+		name:           "amount failure takes precedence",
+		amount:         amount - 1,
+		expiry:         expiry - 1,
+		height:         height,
+		maxCltvDelta:   maxCltvDelta,
+		fwdInfo:        fwdInfo,
+		validateAmount: true,
+		expected:       FinalHtlcInvalidAmount,
+	}, {
+		name: "cltv failure takes precedence over " +
+			"expiry too far",
+		amount:       amount,
+		expiry:       expiry + maxCltvDelta + 1,
+		height:       height,
+		maxCltvDelta: maxCltvDelta,
+		fwdInfo: ForwardingInfo{
+			AmountToForward: amount,
+			OutgoingCTLV:    expiry + maxCltvDelta + 2,
+			NextHop:         Exit,
+		},
+		validateAmount: true,
+		expected:       FinalHtlcInvalidCltv,
+	}}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := ValidateFinalHtlc(
+				testCase.amount, testCase.expiry,
+				testCase.height, testCase.maxCltvDelta,
+				testCase.fwdInfo, testCase.validateAmount,
+			)
+
+			require.Equal(t, testCase.expected, result)
+		})
+	}
+}

--- a/htlcswitch/hop/fuzz_test.go
+++ b/htlcswitch/hop/fuzz_test.go
@@ -88,7 +88,7 @@ func FuzzOnionPacket(f *testing.F) {
 func hopFromPayload(p *Payload) (*route.Hop, uint64) {
 	return &route.Hop{
 		AmtToForward:     p.FwdInfo.AmountToForward,
-		OutgoingTimeLock: p.FwdInfo.OutgoingCTLV,
+		OutgoingTimeLock: p.FwdInfo.OutgoingCLTV,
 		MPP:              p.MPP,
 		AMP:              p.AMP,
 		Metadata:         p.metadata,

--- a/htlcswitch/hop/iterator.go
+++ b/htlcswitch/hop/iterator.go
@@ -327,7 +327,7 @@ func deriveBlindedRouteForwardingInfo(r *sphinxHopIterator,
 	payload.FwdInfo = ForwardingInfo{
 		NextHop:         nextSCID.Val,
 		AmountToForward: fwdAmt,
-		OutgoingCTLV: r.blindingKit.IncomingCltv - uint32(
+		OutgoingCLTV: r.blindingKit.IncomingCltv - uint32(
 			relayInfo.Val.CltvExpiryDelta,
 		),
 		// Remap from blinding override type to blinding point type.

--- a/htlcswitch/hop/iterator_test.go
+++ b/htlcswitch/hop/iterator_test.go
@@ -35,7 +35,7 @@ func TestSphinxHopIteratorForwardingInstructions(t *testing.T) {
 	expectedFwdInfo := ForwardingInfo{
 		NextHop:         lnwire.NewShortChanIDFromInt(nextAddrInt),
 		AmountToForward: lnwire.MilliSatoshi(hopData.ForwardAmount),
-		OutgoingCTLV:    hopData.OutgoingCltv,
+		OutgoingCLTV:    hopData.OutgoingCltv,
 	}
 
 	// For our TLV payload, we'll serialize the hop into into a TLV stream

--- a/htlcswitch/hop/payload.go
+++ b/htlcswitch/hop/payload.go
@@ -128,7 +128,7 @@ func NewLegacyPayload(f *sphinx.HopData) *Payload {
 		FwdInfo: ForwardingInfo{
 			NextHop:         lnwire.NewShortChanIDFromInt(nextHop),
 			AmountToForward: lnwire.MilliSatoshi(f.ForwardAmount),
-			OutgoingCTLV:    f.OutgoingCltv,
+			OutgoingCLTV:    f.OutgoingCltv,
 		},
 		customRecords: make(record.CustomSet),
 	}
@@ -203,7 +203,7 @@ func ParseTLVPayload(r io.Reader) (*Payload, map[tlv.Type][]byte, error) {
 		FwdInfo: ForwardingInfo{
 			NextHop:         lnwire.NewShortChanIDFromInt(cid),
 			AmountToForward: lnwire.MilliSatoshi(amt),
-			OutgoingCTLV:    cltv,
+			OutgoingCLTV:    cltv,
 		},
 		MPP:           mpp,
 		AMP:           amp,

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -2549,13 +2549,17 @@ func (l *channelLink) CheckHtlcForward(payHash [32]byte, incomingHtlcAmt,
 
 	// Finally, we'll ensure that the time-lock on the outgoing HTLC meets
 	// the following constraint: the incoming time-lock minus our time-lock
-	// delta should equal the outgoing time lock. Otherwise, whether the
+	// delta should equal the outgoing time lock. Otherwise, either the
 	// sender messed up, or an intermediate node tampered with the HTLC.
 	timeDelta := policy.TimeLockDelta
-	if incomingTimeout < outgoingTimeout+timeDelta {
+	var incomingDelta uint32
+	if incomingTimeout >= outgoingTimeout {
+		incomingDelta = incomingTimeout - outgoingTimeout
+	}
+	if incomingTimeout < outgoingTimeout || incomingDelta < timeDelta {
 		l.log.Warnf("incoming htlc(%x) has incorrect time-lock value: "+
 			"expected at least %v block delta, got %v block delta",
-			payHash[:], timeDelta, incomingTimeout-outgoingTimeout)
+			payHash[:], timeDelta, incomingDelta)
 
 		// Grab the latest routing policy so the sending node is up to
 		// date with our current policy.
@@ -2566,6 +2570,17 @@ func (l *channelLink) CheckHtlcForward(payHash [32]byte, incomingHtlcAmt,
 		}
 		failure := l.createFailureWithUpdate(false, originalScid, cb)
 		return NewLinkError(failure)
+	}
+
+	// Check that the incoming to outgoing time-lock delta is within the
+	// configured CLTV range.
+	if incomingDelta > l.cfg.MaxOutgoingCltvExpiry {
+		l.log.Warnf("incoming htlc(%x) has a time-lock delta "+
+			"outside the configured CLTV range: got %v, "+
+			"but maximum is %v",
+			payHash[:], incomingDelta, l.cfg.MaxOutgoingCltvExpiry)
+
+		return NewLinkError(&lnwire.FailExpiryTooFar{})
 	}
 
 	return nil
@@ -3163,7 +3178,7 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg) {
 				obfuscator, false,
 			)
 
-			l.log.Error("rejected htlc that uses use as an " +
+			l.log.Error("rejected htlc that uses us as an " +
 				"introduction point when we do not support " +
 				"route blinding")
 
@@ -3436,11 +3451,16 @@ func (l *channelLink) processExitHop(add lnwire.UpdateAddHTLC,
 		},
 	)
 
+	switch hop.ValidateFinalHtlc(
+		add.Amount, add.Expiry, heightNow,
+		invoices.MaxFinalCltvDelta,
+		fwdInfo, !isCustomHTLC,
+	) {
 	// As we're the exit hop, we'll double check the hop-payload included in
 	// the HTLC to ensure that it was crafted correctly by the sender and
 	// is compatible with the HTLC we were extended. If an external
 	// validator is active we might bypass the amount check.
-	if !isCustomHTLC && add.Amount < fwdInfo.AmountToForward {
+	case hop.FinalHtlcInvalidAmount:
 		l.log.Errorf("onion payload of incoming htlc(%x) has "+
 			"incompatible value: expected <=%v, got %v",
 			add.PaymentHash, add.Amount, fwdInfo.AmountToForward)
@@ -3451,11 +3471,10 @@ func (l *channelLink) processExitHop(add lnwire.UpdateAddHTLC,
 		l.sendHTLCError(add, sourceRef, failure, obfuscator, true)
 
 		return nil
-	}
 
 	// We'll also ensure that our time-lock value has been computed
 	// correctly.
-	if add.Expiry < fwdInfo.OutgoingCTLV {
+	case hop.FinalHtlcInvalidCltv:
 		l.log.Errorf("onion payload of incoming htlc(%x) has "+
 			"incompatible time-lock: expected <=%v, got %v",
 			add.PaymentHash, add.Expiry, fwdInfo.OutgoingCTLV)
@@ -3464,6 +3483,22 @@ func (l *channelLink) processExitHop(add lnwire.UpdateAddHTLC,
 			lnwire.NewFinalIncorrectCltvExpiry(add.Expiry),
 		)
 
+		l.sendHTLCError(add, sourceRef, failure, obfuscator, true)
+
+		return nil
+
+	// Check that the incoming HTLC expiry is within the supported final-hop
+	// CLTV range.
+	case hop.FinalHtlcExpiryTooFar:
+		l.log.Warnf("incoming htlc(%x) has a final-hop CLTV delta "+
+			"outside the supported range: got %v, but maximum "+
+			"is %v",
+			add.PaymentHash, add.Expiry-heightNow,
+			invoices.MaxFinalCltvDelta)
+
+		failure := NewLinkError(
+			lnwire.NewFailIncorrectDetails(add.Amount, heightNow),
+		)
 		l.sendHTLCError(add, sourceRef, failure, obfuscator, true)
 
 		return nil
@@ -3577,8 +3612,8 @@ func (l *channelLink) forwardBatch(replay bool, packets ...*htlcPacket) {
 	}
 }
 
-// sendHTLCError functions cancels HTLC and send cancel message back to the
-// peer from which HTLC was received.
+// sendHTLCError cancels the HTLC and sends a cancel message back to the peer
+// from which the HTLC was received.
 func (l *channelLink) sendHTLCError(add lnwire.UpdateAddHTLC,
 	sourceRef channeldb.AddRef, failure *LinkError,
 	e hop.ErrorEncrypter, isReceive bool) {
@@ -3591,7 +3626,7 @@ func (l *channelLink) sendHTLCError(add lnwire.UpdateAddHTLC,
 
 	err = l.channel.FailHTLC(add.ID, reason, &sourceRef, nil, nil)
 	if err != nil {
-		l.log.Errorf("unable cancel htlc: %v", err)
+		l.log.Errorf("unable to cancel htlc: %v", err)
 		return
 	}
 
@@ -4289,7 +4324,7 @@ func (l *channelLink) processRemoteCommitSig(ctx context.Context,
 	// want to ensure we release that memory back to the runtime.
 	l.uncommittedPreimages = nil
 
-	// We just received a new updates to our local commitment chain,
+	// We just received new updates to our local commitment chain,
 	// validate this new commitment, closing the link if invalid.
 	auxSigBlob, err := msg.CustomRecords.Serialize()
 	if err != nil {
@@ -4617,7 +4652,7 @@ func (l *channelLink) processLocalUpdateFulfillHTLC(ctx context.Context,
 	}
 
 	// An HTLC we forward to the switch has just settled somewhere upstream.
-	// Therefore we settle the HTLC within the our local state machine.
+	// Therefore we settle the HTLC within our local state machine.
 	inKey := pkt.inKey()
 	err := l.channel.SettleHTLC(
 		htlc.PaymentPreimage, pkt.incomingHTLCID, pkt.sourceRef,
@@ -4684,7 +4719,7 @@ func (l *channelLink) processLocalUpdateFailHTLC(ctx context.Context,
 	}
 
 	// An HTLC cancellation has been triggered somewhere upstream, we'll
-	// remove then HTLC from our local state machine.
+	// remove the HTLC from our local state machine.
 	inKey := pkt.inKey()
 	err := l.channel.FailHTLC(
 		pkt.incomingHTLCID, htlc.Reason, pkt.sourceRef, pkt.destRef,

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -3232,7 +3232,7 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg) {
 				// Otherwise, it was already processed, we can
 				// can collect it and continue.
 				outgoingAdd := &lnwire.UpdateAddHTLC{
-					Expiry:        fwdInfo.OutgoingCTLV,
+					Expiry:        fwdInfo.OutgoingCLTV,
 					Amount:        fwdInfo.AmountToForward,
 					PaymentHash:   add.PaymentHash,
 					BlindingPoint: fwdInfo.NextBlinding,
@@ -3271,7 +3271,7 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg) {
 					htlc:                 outgoingAdd,
 					obfuscator:           obfuscator,
 					incomingTimeout:      add.Expiry,
-					outgoingTimeout:      fwdInfo.OutgoingCTLV,
+					outgoingTimeout:      fwdInfo.OutgoingCLTV,
 					inOnionCustomRecords: pld.CustomRecords(),
 					inboundFee:           inboundFee,
 					inWireCustomRecords:  add.CustomRecords.Copy(),
@@ -3290,7 +3290,7 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg) {
 			// create the outgoing HTLC using the parameters as
 			// specified in the forwarding info.
 			addMsg := &lnwire.UpdateAddHTLC{
-				Expiry:        fwdInfo.OutgoingCTLV,
+				Expiry:        fwdInfo.OutgoingCLTV,
 				Amount:        fwdInfo.AmountToForward,
 				PaymentHash:   add.PaymentHash,
 				BlindingPoint: fwdInfo.NextBlinding,
@@ -3348,7 +3348,7 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg) {
 					htlc:                 addMsg,
 					obfuscator:           obfuscator,
 					incomingTimeout:      add.Expiry,
-					outgoingTimeout:      fwdInfo.OutgoingCTLV,
+					outgoingTimeout:      fwdInfo.OutgoingCLTV,
 					inOnionCustomRecords: pld.CustomRecords(),
 					inboundFee:           inboundFee,
 					inWireCustomRecords:  add.CustomRecords.Copy(),
@@ -3477,7 +3477,7 @@ func (l *channelLink) processExitHop(add lnwire.UpdateAddHTLC,
 	case hop.FinalHtlcInvalidCltv:
 		l.log.Errorf("onion payload of incoming htlc(%x) has "+
 			"incompatible time-lock: expected <=%v, got %v",
-			add.PaymentHash, add.Expiry, fwdInfo.OutgoingCTLV)
+			add.PaymentHash, add.Expiry, fwdInfo.OutgoingCLTV)
 
 		failure := NewLinkError(
 			lnwire.NewFinalIncorrectCltvExpiry(add.Expiry),

--- a/htlcswitch/link_isolated_test.go
+++ b/htlcswitch/link_isolated_test.go
@@ -237,9 +237,35 @@ func (l *linkTestContext) sendSettleBobToAlice(htlcID uint64,
 	l.aliceLink.HandleChannelUpdate(settle)
 }
 
-// receiveSettleAliceToBob waits for Alice to send a HTLC settle message to
-// Bob, then hands this to Bob.
+// receiveFailAliceToBob waits for Alice to fail an HTLC to Bob.
 func (l *linkTestContext) receiveFailAliceToBob() {
+	l.t.Helper()
+
+	l.receiveFailAliceToBobMsg()
+}
+
+// receiveFailAliceToBobWithCode waits for Alice to fail an HTLC to Bob and
+// verifies that the failure code matches the expectation.
+func (l *linkTestContext) receiveFailAliceToBobWithCode(
+	code lnwire.FailCode) {
+
+	l.t.Helper()
+
+	failMsg := l.receiveFailAliceToBobMsg()
+	failure, err := newMockDeobfuscator().DecryptError(failMsg.Reason)
+	if err != nil {
+		l.t.Fatalf("unable to decrypt failure: %v", err)
+	}
+
+	if failure.WireMessage().Code() != code {
+		l.t.Fatalf("expected %v but got %v",
+			code, failure.WireMessage().Code())
+	}
+}
+
+// receiveFailAliceToBobMsg waits for Alice to send a fail HTLC message to Bob,
+// applies it to Bob, and returns the message.
+func (l *linkTestContext) receiveFailAliceToBobMsg() *lnwire.UpdateFailHTLC {
 	l.t.Helper()
 
 	var msg lnwire.Message
@@ -258,6 +284,8 @@ func (l *linkTestContext) receiveFailAliceToBob() {
 	if err != nil {
 		l.t.Fatalf("unable to apply received fail htlc: %v", err)
 	}
+
+	return failMsg
 }
 
 // assertNoMsgFromAlice asserts that Alice hasn't sent a message. Before

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -779,13 +779,13 @@ func testChannelLinkInboundFee(t *testing.T, //nolint:thelper
 				NextHop: n.carolChannelLink.
 					ShortChanID(),
 				AmountToForward: 1_000_000,
-				OutgoingCTLV:    106,
+				OutgoingCLTV:    106,
 			},
 		},
 		{
 			FwdInfo: hop.ForwardingInfo{
 				AmountToForward: 1_000_000,
-				OutgoingCTLV:    106,
+				OutgoingCLTV:    106,
 			},
 		},
 	}
@@ -973,7 +973,7 @@ func TestExitNodeHTLCTimelockExceedsPayload(t *testing.T) {
 	// The proper value of the outgoing CLTV should be the policy set by
 	// the receiving node, instead we set it to be a value less than the
 	// incoming HTLC timelock.
-	hops[0].FwdInfo.OutgoingCTLV = htlcExpiry - 1
+	hops[0].FwdInfo.OutgoingCLTV = htlcExpiry - 1
 	firstHop := n.firstBobChannelLink.ShortChanID()
 	_, err = makePayment(
 		n.aliceServer, n.bobServer, firstHop, hops, amount, htlcAmt,
@@ -1011,7 +1011,7 @@ func TestExitNodeTimelockPayloadExceedsHTLC(t *testing.T) {
 	// The proper value of the outgoing CLTV should be the policy set by
 	// the receiving node, instead we set it to be a value greater than the
 	// incoming HTLC timelock.
-	hops[0].FwdInfo.OutgoingCTLV = htlcExpiry + 1
+	hops[0].FwdInfo.OutgoingCLTV = htlcExpiry + 1
 	firstHop := n.firstBobChannelLink.ShortChanID()
 	_, err = makePayment(
 		n.aliceServer, n.bobServer, firstHop, hops, amount, htlcAmt,

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -6321,14 +6321,48 @@ func TestCheckHtlcForward(t *testing.T) {
 
 	})
 
-	t.Run("cltv expiry too far in the future", func(t *testing.T) {
-		// Check that expiry isn't too far in the future.
+	t.Run("cltv expiry outside supported range", func(t *testing.T) {
+		// Check that expiry stays within the supported range.
 		result := link.CheckHtlcForward(
 			hash, 1500, 1000, 10200, 10100, models.InboundFee{}, 0,
 			lnwire.ShortChannelID{}, nil,
 		)
+		_, ok := result.WireMessage().(*lnwire.FailExpiryTooFar)
+		if !ok {
+			t.Fatalf("expected FailExpiryTooFar failure code")
+		}
+	})
+
+	t.Run("incoming cltv delta outside range", func(t *testing.T) {
+		result := link.CheckHtlcForward(
+			hash, 1500, 1000, 150+DefaultMaxOutgoingCltvExpiry+1,
+			150, models.InboundFee{}, 0, lnwire.ShortChannelID{},
+			nil,
+		)
 		if _, ok := result.WireMessage().(*lnwire.FailExpiryTooFar); !ok {
 			t.Fatalf("expected FailExpiryTooFar failure code")
+		}
+	})
+
+	t.Run("incoming cltv delta at maximum", func(t *testing.T) {
+		result := link.CheckHtlcForward(
+			hash, 1500, 1000, 150+DefaultMaxOutgoingCltvExpiry,
+			150, models.InboundFee{}, 0, lnwire.ShortChannelID{},
+			nil,
+		)
+		require.Nil(t, result)
+	})
+
+	t.Run("incoming cltv below outgoing cltv", func(t *testing.T) {
+		result := link.CheckHtlcForward(
+			hash, 1500, 1000, 190, 200, models.InboundFee{}, 0,
+			lnwire.ShortChannelID{}, nil,
+		)
+		_, ok := result.WireMessage().(*lnwire.FailIncorrectCltvExpiry)
+		if !ok {
+			t.Fatalf(
+				"expected FailIncorrectCltvExpiry failure code",
+			)
 		}
 	})
 
@@ -6661,6 +6695,121 @@ func TestChannelLinkHoldInvoiceRestart(t *testing.T) {
 		t.Fatalf("did not expect message %T", msg)
 	default:
 	}
+}
+
+// TestChannelLinkExitHopExpiryTooFar asserts that an exit hop fails an
+// incoming HTLC if its expiry is outside the supported range.
+func TestChannelLinkExitHopExpiryTooFar(t *testing.T) {
+	t.Parallel()
+
+	const chanAmt = btcutil.SatoshiPerBitcoin * 5
+	harness, err := newSingleLinkTestHarness(t, chanAmt, 0)
+	require.NoError(t, err, "unable to create link")
+
+	if err := harness.start(); err != nil {
+		t.Fatalf("unable to start test harness: %v", err)
+	}
+	t.Cleanup(harness.aliceLink.Stop)
+
+	coreLink, ok := harness.aliceLink.(*channelLink)
+	require.True(t, ok)
+
+	registry, ok := coreLink.cfg.Registry.(*mockInvoiceRegistry)
+	require.True(t, ok)
+
+	alicePeer, ok := coreLink.cfg.Peer.(*mockPeer)
+	require.True(t, ok)
+	aliceMsgs := alicePeer.sentMsgs
+
+	registry.settleChan = make(chan lntypes.Hash)
+
+	htlc, invoice := generateHtlcAndInvoice(t, 0)
+	htlc.Expiry = testStartingHeight +
+		invpkg.MaxFinalCltvDelta + 1
+
+	err = registry.AddInvoice(t.Context(), *invoice, htlc.PaymentHash)
+	require.NoError(t, err, "unable to add invoice to registry")
+
+	ctx := linkTestContext{
+		t:           t,
+		aliceSwitch: harness.aliceSwitch,
+		aliceLink:   harness.aliceLink,
+		aliceMsgs:   aliceMsgs,
+		bobChannel:  harness.bobChannel,
+	}
+
+	ctx.sendHtlcBobToAlice(htlc)
+	ctx.sendCommitSigBobToAlice(1)
+	ctx.receiveRevAndAckAliceToBob()
+	ctx.receiveCommitSigAliceToBob(1)
+	ctx.sendRevAndAckBobToAlice()
+	ctx.receiveFailAliceToBobWithCode(
+		lnwire.CodeIncorrectOrUnknownPaymentDetails,
+	)
+	ctx.receiveCommitSigAliceToBob(0)
+
+	select {
+	case <-registry.settleChan:
+		t.Fatal("exit hop notification received")
+	case <-time.After(time.Second):
+	}
+}
+
+// TestChannelLinkExitHopExpiryAtMaximum asserts that an exit hop accepts an
+// incoming HTLC if its expiry is exactly at the maximum.
+func TestChannelLinkExitHopExpiryAtMaximum(t *testing.T) {
+	t.Parallel()
+
+	const chanAmt = btcutil.SatoshiPerBitcoin * 5
+	harness, err := newSingleLinkTestHarness(t, chanAmt, 0)
+	require.NoError(t, err, "unable to create link")
+
+	if err := harness.start(); err != nil {
+		t.Fatalf("unable to start test harness: %v", err)
+	}
+	t.Cleanup(harness.aliceLink.Stop)
+
+	coreLink, ok := harness.aliceLink.(*channelLink)
+	require.True(t, ok)
+
+	registry, ok := coreLink.cfg.Registry.(*mockInvoiceRegistry)
+	require.True(t, ok)
+
+	alicePeer, ok := coreLink.cfg.Peer.(*mockPeer)
+	require.True(t, ok)
+	aliceMsgs := alicePeer.sentMsgs
+
+	registry.settleChan = make(chan lntypes.Hash)
+
+	htlc, invoice := generateHtlcAndInvoice(t, 0)
+	htlc.Expiry = testStartingHeight +
+		invpkg.MaxFinalCltvDelta
+
+	err = registry.AddInvoice(t.Context(), *invoice, htlc.PaymentHash)
+	require.NoError(t, err, "unable to add invoice to registry")
+
+	ctx := linkTestContext{
+		t:           t,
+		aliceSwitch: harness.aliceSwitch,
+		aliceLink:   harness.aliceLink,
+		aliceMsgs:   aliceMsgs,
+		bobChannel:  harness.bobChannel,
+	}
+
+	ctx.sendHtlcBobToAlice(htlc)
+	ctx.sendCommitSigBobToAlice(1)
+	ctx.receiveRevAndAckAliceToBob()
+	ctx.receiveCommitSigAliceToBob(1)
+	ctx.sendRevAndAckBobToAlice()
+
+	select {
+	case <-registry.settleChan:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected exit hop notification")
+	}
+
+	ctx.receiveSettleAliceToBob()
+	ctx.receiveCommitSigAliceToBob(0)
 }
 
 // TestChannelLinkRevocationWindowRegular asserts that htlcs paying to a regular

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -375,7 +375,8 @@ func encodeFwdInfo(w io.Writer, f *hop.ForwardingInfo) error {
 		return err
 	}
 
-	if err := binary.Write(w, binary.BigEndian, f.OutgoingCTLV); err != nil {
+	err := binary.Write(w, binary.BigEndian, f.OutgoingCLTV)
+	if err != nil {
 		return err
 	}
 
@@ -514,7 +515,7 @@ func (p *mockIteratorDecoder) DecodeHopIterator(r io.Reader, rHash []byte,
 			Realm:         [1]byte{}, // hop.BitcoinNetwork
 			NextAddress:   nextHopBytes,
 			ForwardAmount: uint64(f.AmountToForward),
-			OutgoingCltv:  f.OutgoingCTLV,
+			OutgoingCltv:  f.OutgoingCLTV,
 		})
 	}
 
@@ -569,7 +570,8 @@ func decodeFwdInfo(r io.Reader, f *hop.ForwardingInfo) error {
 		return err
 	}
 
-	if err := binary.Read(r, binary.BigEndian, &f.OutgoingCTLV); err != nil {
+	err := binary.Read(r, binary.BigEndian, &f.OutgoingCLTV)
+	if err != nil {
 		return err
 	}
 

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -3597,7 +3597,7 @@ func getThreeHopEvents(channels *clusterChannels, htlcID uint64,
 	bobInfo := HtlcInfo{
 		IncomingTimeLock: htlc.Expiry,
 		IncomingAmt:      htlc.Amount,
-		OutgoingTimeLock: hops[1].FwdInfo.OutgoingCTLV,
+		OutgoingTimeLock: hops[1].FwdInfo.OutgoingCLTV,
 		OutgoingAmt:      hops[1].FwdInfo.AmountToForward,
 	}
 

--- a/invoices/invoices.go
+++ b/invoices/invoices.go
@@ -3,6 +3,7 @@ package invoices
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -22,6 +23,11 @@ const (
 	// TODO(halseth): determine the max length payment request when field
 	// lengths are final.
 	MaxPaymentRequestSize = 4096
+
+	// MaxFinalCltvDelta is the upper bound for final CLTV deltas used by
+	// invoice creation and final-hop HTLC validation. It matches
+	// routing.MaxCLTVDelta.
+	MaxFinalCltvDelta = math.MaxUint16
 )
 
 var (

--- a/lnrpc/invoicesrpc/addinvoice.go
+++ b/lnrpc/invoicesrpc/addinvoice.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"math"
 	mathRand "math/rand"
 	"sort"
 	"time"
@@ -406,10 +405,12 @@ func AddInvoice(ctx context.Context, cfg *AddInvoiceConfig,
 		options = append(options, zpay32.Description(invoice.Memo))
 	}
 
-	if invoice.CltvExpiry > routing.MaxCLTVDelta {
+	// Final-hop invoices are limited to the same CLTV bound used by the
+	// link and contractcourt validation.
+	if invoice.CltvExpiry > invoices.MaxFinalCltvDelta {
 		return nil, nil, fmt.Errorf("CLTV delta of %v is too large, "+
 			"max accepted is: %v", invoice.CltvExpiry,
-			math.MaxUint16)
+			invoices.MaxFinalCltvDelta)
 	}
 
 	// We'll use our current default CLTV value unless one was specified as

--- a/lnrpc/invoicesrpc/addinvoice_test.go
+++ b/lnrpc/invoicesrpc/addinvoice_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/graph/db/models"
+	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/zpay32"
@@ -26,6 +27,24 @@ var (
 	_       = pubKeyY.SetByteSlice(pubkeyBytes)
 	pubkey  = btcec.NewPublicKey(new(btcec.FieldVal).SetInt(4), pubKeyY)
 )
+
+// TestAddInvoiceRejectsCltvAboveMaxIncoming asserts that invoice creation
+// rejects final CLTV deltas above the supported maximum.
+func TestAddInvoiceRejectsCltvAboveMaxIncoming(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := AddInvoice(
+		t.Context(), &AddInvoiceConfig{}, &AddInvoiceData{
+			CltvExpiry: invoices.MaxFinalCltvDelta + 1,
+		},
+	)
+	require.ErrorContains(
+		t, err, fmt.Sprintf(
+			"max accepted is: %v",
+			invoices.MaxFinalCltvDelta,
+		),
+	)
+}
 
 type hopHintsConfigMock struct {
 	t *testing.T

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -7500,14 +7500,10 @@ func (r *rpcServer) UpdateChannelPolicy(ctx context.Context,
 
 	// We'll also ensure that the user isn't setting a CLTV delta that
 	// won't give outgoing HTLCs enough time to fully resolve if needed.
-	if req.TimeLockDelta < minTimeLockDelta {
-		return nil, fmt.Errorf("time lock delta of %v is too small, "+
-			"minimum supported is %v", req.TimeLockDelta,
-			minTimeLockDelta)
-	} else if req.TimeLockDelta > uint32(MaxTimeLockDelta) {
-		return nil, fmt.Errorf("time lock delta of %v is too big, "+
-			"maximum supported is %v", req.TimeLockDelta,
-			MaxTimeLockDelta)
+	if err := validateChannelPolicyTimeLockDelta(
+		req.TimeLockDelta, r.cfg.MaxOutgoingCltvExpiry,
+	); err != nil {
+		return nil, err
 	}
 
 	// By default, positive inbound fees are rejected.

--- a/server.go
+++ b/server.go
@@ -1363,6 +1363,11 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 		ChainHash:              *s.cfg.ActiveNetParams.GenesisHash,
 		IncomingBroadcastDelta: lncfg.DefaultIncomingBroadcastDelta,
 		OutgoingBroadcastDelta: lncfg.DefaultOutgoingBroadcastDelta,
+		CustomHtlcChecker: fn.MapOption(
+			func(t htlcswitch.AuxTrafficShaper) contractcourt.CustomHtlcChecker {
+				return t
+			},
+		)(s.implCfg.TrafficShaper),
 		NewSweepAddr: func() ([]byte, error) {
 			addr, err := newSweepPkScriptGen(
 				cc.Wallet, netParams,

--- a/witness_beacon.go
+++ b/witness_beacon.go
@@ -102,7 +102,7 @@ func (p *preimageBeacon) SubscribeUpdates(
 			HtlcID: htlc.HtlcIndex,
 		},
 		OutgoingChanID:       payload.FwdInfo.NextHop,
-		OutgoingExpiry:       payload.FwdInfo.OutgoingCTLV,
+		OutgoingExpiry:       payload.FwdInfo.OutgoingCLTV,
 		OutgoingAmount:       payload.FwdInfo.AmountToForward,
 		InOnionCustomRecords: payload.CustomRecords(),
 		InWireCustomRecords:  htlc.CustomRecords,


### PR DESCRIPTION
## Change Description

This PR tightens validation of the CLTV expiry on HTLCs at the final hop and
makes the related policy bounds explicit and validated at config time.

Final-hop CLTV handling is currently permissive: an HTLC can specify a final
CLTV expiry far beyond any reasonable receive policy, and the values that bound
this behaviour aren't checked when set. Accepting an excessively large final
CLTV delta is undesirable — a single HTLC can tie up channel liquidity for a
very long time (a slow-jamming / liquidity-lockup concern), and there is no
legitimate reason for a final hop to require an expiry that far out. We already
cap CLTV deltas on the forwarding path; this brings the final hop in line and
catches misconfiguration early.

## Changes

- **htlcswitch + invoices:** validate the final-hop CLTV expiry. A final HTLC
  whose expiry falls outside the node's receive policy is failed back with
  `incorrect_or_unknown_payment_details`, consistent with how other final-hop
  policy mismatches are handled and without leaking receive-side policy to the
  sender. The maximum final CLTV delta is bounded and tied to the maximum
  already permitted at invoice creation, so the accept and create paths agree.

- **config:** validate the CLTV expiry policy bounds, rejecting out-of-range
  values instead of silently accepting them.

- **contractcourt:** apply the same final-HTLC validation before the invoice
  lookup, so an out-of-policy final HTLC is handled consistently.

## Compatibility

The CLTV policy bounds are now validated. A config value or `UpdateChannelPolicy`
request that sets an out-of-range value previously accepted silently will now be
rejected with a clear error. Nodes using sane values are unaffected.