### PR TITLE
build: bump version to 0.20.2-beta.rc1

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -47,11 +47,11 @@ const (
 	AppMinor uint = 20
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 01
+	AppPatch uint = 02
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.
-	AppPreRelease = "beta"
+	AppPreRelease = "beta.rc1"
 )
 
 func init() {


### PR DESCRIPTION
## Change

Bump the lnd build patch version from `0.20.1-beta` to `0.20.2-beta.rc1` on the `v0.20.x-branch` release branch.

## Validation

- `go test ./build`