### PR TITLE
lnwire: enforce bolt 4 rules for onion message final-hop payloads

### DIFF
--- a/docs/release-notes/release-notes-0.21.2.md
+++ b/docs/release-notes/release-notes-0.21.2.md
@@ -1,0 +1,71 @@
+# Release Notes
+- [Bug Fixes](#bug-fixes)
+- [New Features](#new-features)
+    - [Functional Enhancements](#functional-enhancements)
+    - [RPC Additions](#rpc-additions)
+    - [lncli Additions](#lncli-additions)
+- [Improvements](#improvements)
+    - [Functional Updates](#functional-updates)
+    - [RPC Updates](#rpc-updates)
+    - [lncli Updates](#lncli-updates)
+    - [Breaking Changes](#breaking-changes)
+    - [Performance Improvements](#performance-improvements)
+    - [Deprecations](#deprecations)
+- [Technical and Architectural Updates](#technical-and-architectural-updates)
+    - [BOLT Spec Updates](#bolt-spec-updates)
+    - [Testing](#testing)
+    - [Database](#database)
+    - [Code Health](#code-health)
+    - [Robustness](#robustness)
+    - [Tooling and Documentation](#tooling-and-documentation)
+- [Contributors (Alphabetical Order)](#contributors-alphabetical-order)
+
+# Bug Fixes
+
+* [Fixed several bugs](https://github.com/lightningnetwork/lnd/pull/10948)
+  in onion message decoding where messages that should have been rejected
+  per BOLT 4 were instead accepted, or a valid TLV was dropped.
+
+# New Features
+
+## Functional Enhancements
+
+## RPC Additions
+
+## lncli Additions
+
+# Improvements
+
+## Functional Updates
+
+## RPC Updates
+
+## lncli Updates
+
+## Breaking Changes
+
+## Performance Improvements
+
+## Deprecations
+
+### ⚠️ **Warning:** Deprecated fields in `lnrpc.Hop` will be removed in release version **0.22**
+
+### ⚠️ **Warning:** The deprecated fee rate option `--sat_per_byte` will be removed in release version **0.22**
+
+# Technical and Architectural Updates
+
+## BOLT Spec Updates
+
+## Testing
+
+## Database
+
+## Code Health
+
+## Robustness
+
+## Tooling and Documentation
+
+# Contributors (Alphabetical Order)
+
+* bitromortac

--- a/lnwire/onion_msg_payload.go
+++ b/lnwire/onion_msg_payload.go
@@ -39,6 +39,12 @@ const (
 // correct range.
 var ErrNotFinalPayload = errors.New("final hop payloads type should be >= 64")
 
+// ErrUnknownEvenType is returned when an onion message payload contains an
+// unknown even TLV type. BOLT 4 requires the whole message to be ignored in
+// this case, because even types are "must understand".
+var ErrUnknownEvenType = errors.New("onion message payload contains unknown " +
+	"even tlv type")
+
 // OnionMessagePayload contains the contents of an onion message payload.
 type OnionMessagePayload struct {
 	// ReplyPath contains a blinded path that can be used to respond to an
@@ -174,11 +180,6 @@ func (o *OnionMessagePayload) Decode(r io.Reader) (map[tlv.Type][]byte, error) {
 	// recognized. We'll just directly read these out and allow higher
 	// application layers to deal with them.
 	for tlvType, tlvBytes := range tlvMap {
-		// Skip any tlvs that are not in our range.
-		if tlvType < finalHopPayloadStart {
-			continue
-		}
-
 		// Skip any tlvs that have been recognized in our decoding.
 		// DecodeWithParsedTypesP2P stores a nil entry for known types
 		// that it decoded into a dedicated field above, and the raw
@@ -189,7 +190,25 @@ func (o *OnionMessagePayload) Decode(r io.Reader) (map[tlv.Type][]byte, error) {
 			continue
 		}
 
-		// Add the payload to our message's final hop payloads.
+		// BOLT 4: if the onionmsg_tlv contains unknown even types, the
+		// whole message must be ignored, since even types are
+		// "must understand". This applies regardless of the type range,
+		// so we check it before skipping types outside the final hop
+		// range.
+		if tlvType%2 == 0 {
+			return tlvMap, fmt.Errorf("%w: %v", ErrUnknownEvenType,
+				tlvType)
+		}
+
+		// Skip any unknown odd tlvs outside the final hop payload
+		// range: they are not addressed to the final hop's application
+		// layer, and odd types are safe to ignore.
+		if tlvType < finalHopPayloadStart {
+			continue
+		}
+
+		// Add the unknown odd final hop payload to our message so that
+		// higher application layers can deal with it.
 		payload := &FinalHopTLV{
 			TLVType: tlvType,
 			Value:   tlvBytes,

--- a/lnwire/onion_msg_payload.go
+++ b/lnwire/onion_msg_payload.go
@@ -45,6 +45,12 @@ var ErrNotFinalPayload = errors.New("final hop payloads type should be >= 64")
 var ErrUnknownEvenType = errors.New("onion message payload contains unknown " +
 	"even tlv type")
 
+// ErrMultipleFinalHopPayloads is returned when an onion message payload for the
+// final hop contains more than one payload field (tlv type >= 64). BOLT 4
+// requires the message to be ignored in this case.
+var ErrMultipleFinalHopPayloads = errors.New("onion message payload contains " +
+	"more than one final hop payload field")
+
 // OnionMessagePayload contains the contents of an onion message payload.
 type OnionMessagePayload struct {
 	// ReplyPath contains a blinded path that can be used to respond to an
@@ -239,6 +245,14 @@ func (o *OnionMessagePayload) Decode(r io.Reader) (map[tlv.Type][]byte, error) {
 		o.FinalHopTLVs = append(
 			o.FinalHopTLVs, invoiceRequestPayload,
 		)
+	}
+
+	// BOLT 4: the final node must ignore an onion message whose
+	// onionmsg_tlv contains more than one payload field (tlv type >= 64).
+	// Every entry in FinalHopTLVs is in the final hop range by
+	// construction, so its length is the number of payload fields present.
+	if len(o.FinalHopTLVs) > 1 {
+		return tlvMap, ErrMultipleFinalHopPayloads
 	}
 
 	// Iteration through maps occurs in random order - sort final hop

--- a/lnwire/onion_msg_payload.go
+++ b/lnwire/onion_msg_payload.go
@@ -179,9 +179,13 @@ func (o *OnionMessagePayload) Decode(r io.Reader) (map[tlv.Type][]byte, error) {
 			continue
 		}
 
-		// Skip any tlvs that have been recognized in our decoding (a
-		// zero entry means that we recognized the entry).
-		if len(tlvBytes) == 0 {
+		// Skip any tlvs that have been recognized in our decoding.
+		// DecodeWithParsedTypesP2P stores a nil entry for known types
+		// that it decoded into a dedicated field above, and the raw
+		// bytes for unknown types. A nil check (rather than a length
+		// check) is required so that a valid unknown odd tlv with a
+		// zero-length value is not mistaken for a recognized type.
+		if tlvBytes == nil {
 			continue
 		}
 
@@ -199,7 +203,7 @@ func (o *OnionMessagePayload) Decode(r io.Reader) (map[tlv.Type][]byte, error) {
 	// If we read out an invoice, invoice error or invoice request tlv
 	// sub-namespace, add it to our set of final payloads. This value won't
 	// have been added in the loop above, because we recognized the TLV so
-	// len(tlvMap[invoiceType].tlvBytes) will be zero (thus, skipped above).
+	// tlvMap[invoiceType].tlvBytes will be nil (thus, skipped above).
 	if _, ok := tlvMap[InvoiceNamespaceType]; ok {
 		o.FinalHopTLVs = append(
 			o.FinalHopTLVs, invoicePayload,

--- a/lnwire/onion_msg_payload_test.go
+++ b/lnwire/onion_msg_payload_test.go
@@ -294,6 +294,28 @@ func TestOnionMessagePayloadRoundTrip(t *testing.T) {
 			decoded.FinalHopTLVs[0].Value,
 		)
 	})
+
+	t.Run("odd unknown zero-length final hop TLV", func(t *testing.T) {
+		t.Parallel()
+
+		// A valid unknown odd tlv with a zero-length value must be
+		// preserved rather than mistaken for a recognized type, which
+		// is why decode keys off a nil entry instead of an empty one.
+		original := &OnionMessagePayload{
+			FinalHopTLVs: []*FinalHopTLV{
+				{
+					TLVType: 65,
+					Value:   []byte{},
+				},
+			},
+		}
+
+		decoded := encodeAndDecode(t, original)
+
+		require.Len(t, decoded.FinalHopTLVs, 1)
+		require.Equal(t, tlv.Type(65), decoded.FinalHopTLVs[0].TLVType)
+		require.Empty(t, decoded.FinalHopTLVs[0].Value)
+	})
 }
 
 // TestFinalHopTLVValidate tests that FinalHopTLV.Validate correctly rejects

--- a/lnwire/onion_msg_payload_test.go
+++ b/lnwire/onion_msg_payload_test.go
@@ -316,6 +316,49 @@ func TestOnionMessagePayloadRoundTrip(t *testing.T) {
 		require.Equal(t, tlv.Type(65), decoded.FinalHopTLVs[0].TLVType)
 		require.Empty(t, decoded.FinalHopTLVs[0].Value)
 	})
+
+	t.Run("unknown even final hop type rejected", func(t *testing.T) {
+		t.Parallel()
+
+		// Type 70 is in the final hop range but is an unknown even
+		// type, so BOLT 4 requires the message to be ignored.
+		original := &OnionMessagePayload{
+			FinalHopTLVs: []*FinalHopTLV{
+				{
+					TLVType: 70,
+					Value:   []byte("must-understand"),
+				},
+			},
+		}
+
+		encoded, err := original.Encode()
+		require.NoError(t, err)
+
+		decoded := NewOnionMessagePayload()
+		_, err = decoded.Decode(bytes.NewReader(encoded))
+		require.ErrorIs(t, err, ErrUnknownEvenType)
+	})
+
+	t.Run("unknown even type below range rejected", func(t *testing.T) {
+		t.Parallel()
+
+		// An unknown even type outside the final hop range must also be
+		// rejected: the must-understand rule applies regardless of the
+		// tlv range. We build the stream directly because the encoder's
+		// FinalHopTLV.Validate would reject a sub-64 type.
+		val := []byte("data")
+		record := tlv.MakePrimitiveRecord(tlv.Type(6), &val)
+
+		stream, err := tlv.NewStream(record)
+		require.NoError(t, err)
+
+		var b bytes.Buffer
+		require.NoError(t, stream.Encode(&b))
+
+		decoded := NewOnionMessagePayload()
+		_, err = decoded.Decode(bytes.NewReader(b.Bytes()))
+		require.ErrorIs(t, err, ErrUnknownEvenType)
+	})
 }
 
 // TestFinalHopTLVValidate tests that FinalHopTLV.Validate correctly rejects

--- a/lnwire/onion_msg_payload_test.go
+++ b/lnwire/onion_msg_payload_test.go
@@ -203,9 +203,13 @@ func TestOnionMessagePayloadRoundTrip(t *testing.T) {
 		)
 	})
 
-	t.Run("multiple final hop TLVs", func(t *testing.T) {
+	t.Run("multiple final hop payloads rejected", func(t *testing.T) {
 		t.Parallel()
 
+		// BOLT 4 requires the final node to ignore an onion message
+		// that carries more than one final hop payload field, so decode
+		// must reject a payload bundling invoice_request, invoice, and
+		// invoice_error together.
 		original := &OnionMessagePayload{
 			FinalHopTLVs: []*FinalHopTLV{
 				{
@@ -223,24 +227,12 @@ func TestOnionMessagePayloadRoundTrip(t *testing.T) {
 			},
 		}
 
-		decoded := encodeAndDecode(t, original)
+		encoded, err := original.Encode()
+		require.NoError(t, err)
 
-		require.Nil(t, decoded.ReplyPath)
-		require.Len(t, decoded.FinalHopTLVs, 3)
-
-		// Decoded TLVs should be sorted by type.
-		require.Equal(
-			t, InvoiceRequestNamespaceType,
-			decoded.FinalHopTLVs[0].TLVType,
-		)
-		require.Equal(
-			t, InvoiceNamespaceType,
-			decoded.FinalHopTLVs[1].TLVType,
-		)
-		require.Equal(
-			t, InvoiceErrorNamespaceType,
-			decoded.FinalHopTLVs[2].TLVType,
-		)
+		decoded := NewOnionMessagePayload()
+		_, err = decoded.Decode(bytes.NewReader(encoded))
+		require.ErrorIs(t, err, ErrMultipleFinalHopPayloads)
 	})
 
 	t.Run("all fields populated", func(t *testing.T) {
@@ -479,15 +471,16 @@ func TestOnionMessagePayloadRoundTripQuickCheck(t *testing.T) {
 			).Draw(t, "encryptedData")
 		}
 
-		// Optionally include final hop TLVs. We use the three known
-		// even types (64, 66, 68) since unknown even types would cause
-		// decode to fail.
+		// Optionally include a final hop payload. We use the three
+		// known even types (64, 66, 68) since unknown even types would
+		// cause decode to fail. At most one payload field is drawn
+		// because BOLT 4 requires decode to reject more than one.
 		knownTypes := []tlv.Type{
 			InvoiceRequestNamespaceType,
 			InvoiceNamespaceType,
 			InvoiceErrorNamespaceType,
 		}
-		numFinalTLVs := rapid.IntRange(0, len(knownTypes)).Draw(
+		numFinalTLVs := rapid.IntRange(0, 1).Draw(
 			t, "numFinalTLVs",
 		)
 		for i := range numFinalTLVs {


### PR DESCRIPTION
While reviewing #10789 (h/t to @vctt94), three BOLT 4 compliance gaps in onion message decoding came up but were deferred as out of scope.

This PR forces that we only accept a single final hop payload type and that we correctly handle even/odd acceptance. We could in principle also refactor `OnionMessagePayload` to only carry a single final hop TLV, but that would need further consumer changes.