### PR TITLE
rpcserver: fix stats undercount in GetNetworkInfo

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -49,6 +49,12 @@
   exclude such inputs from sweeping even though their input set could
   comfortably pay its fees.
 
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/10963) in
+  `GetNetworkInfo` where encountering an already-seen channel skipped the
+  rest of that node's channels instead of just that channel, undercounting
+  the reported network statistics such as total network capacity, channel
+  count and max out degree.
+
 # New Features
 
 ## Functional Enhancements

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -6681,11 +6681,10 @@ func (r *rpcServer) GetNetworkInfo(ctx context.Context,
 			// channel encountered.
 			outDegree++
 
-			// If we've already seen this channel, then we'll
-			// return early to ensure that we don't double-count
-			// stats.
+			// If we've already seen this channel, skip it to
+			// ensure that we don't double-count stats.
 			if _, ok := seenChans[edge.ChannelID]; ok {
-				return nil
+				continue
 			}
 
 			// Compare the capacity of this channel against the


### PR DESCRIPTION
I was seeing dubious numbers from `getnetworkinfo` command which did not match at all to the graph from `describegraph`. 

Seems the issue is that it is returning early instead of continuing in the loop in `GetNetworkInfo` so it ended up under counting the stats.

**Finding the issue in the code was LLM-assisted**