### PR TITLE
sqldb: guard native-SQL migration path against silent downgrades

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -55,6 +55,15 @@
   the reported network statistics such as total network capacity, channel
   count and max out degree.
 
+* [Guarded the native-SQL store's migration path against silent
+  downgrades](https://github.com/lightningnetwork/lnd/pull/10964). If the
+  database's tracked migration version was ever higher than the versions
+  known to the running binary (e.g. an older `lnd` binary started against a
+  database already migrated forward by a newer release), every migration
+  would be silently skipped instead of erroring, letting `lnd` operate
+  against a schema it doesn't understand. `ApplyMigrations` now fails with
+  `ErrDBDowngrade` in that case.
+
 # New Features
 
 ## Functional Enhancements

--- a/sqldb/migrations.go
+++ b/sqldb/migrations.go
@@ -142,6 +142,14 @@ var (
 	// match the original record.
 	ErrMigrationMismatch = fmt.Errorf("migrated record does not match " +
 		"original record")
+
+	// ErrDBDowngrade is returned when the database's tracked migration
+	// version is higher than the highest version known to the running
+	// binary. This indicates the database was previously migrated
+	// forward by a newer lnd release, and the binary currently running
+	// is older than that release.
+	ErrDBDowngrade = fmt.Errorf("database version is newer than this " +
+		"binary supports, refusing to downgrade")
 )
 
 // MigrationConfig is a configuration struct that describes SQL migrations. Each
@@ -445,6 +453,29 @@ func ApplyMigrations(ctx context.Context, db *BaseDB,
 
 		log.Infof("No database version found, using schema version %d "+
 			"(dirty=%v) as base version", currentVersion, dirty)
+	}
+
+	// Guard against downgrades. If the database's tracked migration
+	// version is higher than anything this binary knows about, the
+	// database was already migrated forward by a newer lnd release and
+	// an older binary is now being run against it. Without this check,
+	// the loop below would treat every migration as "already applied"
+	// (since each migration's Version would be <= currentVersion) and
+	// silently skip all of them, letting lnd operate against a schema it
+	// doesn't understand and risking data corruption. We fail loudly
+	// instead.
+	//
+	// NOTE: highestKnownVersion equals len(migrations) because the
+	// version-ordering check above guarantees migrations are numbered
+	// contiguously starting at 1.
+	highestKnownVersion := len(migrations)
+	if currentVersion > highestKnownVersion {
+		return fmt.Errorf("%w: database is at migration version %d "+
+			"but this binary only knows about migrations up to "+
+			"version %d; this can happen if an older lnd binary "+
+			"is started against a database that was already "+
+			"migrated by a newer lnd release",
+			ErrDBDowngrade, currentVersion, highestKnownVersion)
 	}
 
 	// Due to an a migration issue in v0.19.0-rc1 we may be at version 2 and

--- a/sqldb/migrations_test.go
+++ b/sqldb/migrations_test.go
@@ -618,6 +618,127 @@ func TestMigrationSucceedsAfterDirtyStateMigrationFailure19RC1(t *testing.T) {
 	})
 }
 
+// TestApplyMigrationsRefusesDowngrade asserts that ApplyMigrations refuses to
+// proceed and returns ErrDBDowngrade when the database's tracked migration
+// version is higher than the highest version known to the migrations list
+// passed in. This simulates an operator starting an older lnd binary against
+// a database that was already migrated forward by a newer lnd release, which
+// must fail loudly instead of silently skipping every migration and running
+// against an unrecognized schema.
+func TestApplyMigrationsRefusesDowngrade(t *testing.T) {
+	ctxb := t.Context()
+
+	// A "newer" binary that knows about 3 migrations.
+	newerMigrations := []MigrationConfig{
+		{
+			Name:          "000001_invoices",
+			Version:       1,
+			SchemaVersion: 1,
+		},
+		{
+			Name:          "000002_amp_invoices",
+			Version:       2,
+			SchemaVersion: 2,
+		},
+		{
+			Name:          "000003_invoice_events",
+			Version:       3,
+			SchemaVersion: 3,
+		},
+	}
+
+	// An "older" binary that only knows about the first 2 migrations.
+	olderMigrations := newerMigrations[:2]
+
+	t.Run("SQLite", func(t *testing.T) {
+		dbFileName := filepath.Join(t.TempDir(), "tmp.db")
+
+		// The "newer" binary starts up first and migrates the
+		// database forward through all 3 versions it knows about.
+		dbNewer, err := NewSqliteStore(&SqliteConfig{
+			SkipMigrations: false,
+		}, dbFileName)
+		require.NoError(t, err)
+
+		require.NoError(
+			t, dbNewer.ApplyAllMigrations(ctxb, newerMigrations),
+		)
+
+		version, err := dbNewer.GetDatabaseVersion(ctxb)
+		require.NoError(t, err)
+		require.EqualValues(t, 3, version)
+		require.NoError(t, dbNewer.DB.Close())
+
+		// Now simulate a downgrade: an "older" binary that only
+		// knows about the first 2 migrations is started against the
+		// same, already-migrated database file.
+		dbOlder, err := NewSqliteStore(&SqliteConfig{
+			SkipMigrations: false,
+		}, dbFileName)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, dbOlder.DB.Close())
+		})
+
+		err = dbOlder.ApplyAllMigrations(ctxb, olderMigrations)
+		require.ErrorIs(t, err, ErrDBDowngrade)
+
+		// The tracked version must remain untouched; no migration or
+		// schema change should have been attempted.
+		version, err = dbOlder.GetDatabaseVersion(ctxb)
+		require.NoError(t, err)
+		require.EqualValues(t, 3, version)
+	})
+
+	t.Run("Postgres", func(t *testing.T) {
+		fixture := NewTestPgFixture(t, DefaultPostgresFixtureLifetime)
+		t.Cleanup(func() {
+			fixture.TearDown(t)
+		})
+
+		dbName := randomDBName(t)
+		_, err := fixture.db.ExecContext(
+			ctxb, "CREATE DATABASE "+dbName,
+		)
+		require.NoError(t, err)
+
+		cfg := fixture.GetConfig(dbName)
+		cfg.SkipMigrations = false
+
+		// The "newer" binary starts up first and migrates the
+		// database forward through all 3 versions it knows about.
+		dbNewer, err := NewPostgresStore(cfg)
+		require.NoError(t, err)
+
+		require.NoError(
+			t, dbNewer.ApplyAllMigrations(ctxb, newerMigrations),
+		)
+
+		version, err := dbNewer.GetDatabaseVersion(ctxb)
+		require.NoError(t, err)
+		require.EqualValues(t, 3, version)
+		require.NoError(t, dbNewer.DB.Close())
+
+		// Now simulate a downgrade: an "older" binary that only
+		// knows about the first 2 migrations is started against the
+		// same, already-migrated database.
+		dbOlder, err := NewPostgresStore(cfg)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, dbOlder.DB.Close())
+		})
+
+		err = dbOlder.ApplyAllMigrations(ctxb, olderMigrations)
+		require.ErrorIs(t, err, ErrDBDowngrade)
+
+		// The tracked version must remain untouched; no migration or
+		// schema change should have been attempted.
+		version, err = dbOlder.GetDatabaseVersion(ctxb)
+		require.NoError(t, err)
+		require.EqualValues(t, 3, version)
+	})
+}
+
 // TestMigrationConfigConsistency verifies that the migration configuration in
 // migrationConfig is consistent with the actual SQL schema files embedded in
 // the binary. This catches version collisions (e.g. two migrations claiming


### PR DESCRIPTION
### Change Description

Fixes #10781.

`sqldb.ApplyMigrations` reads the migration version tracked in the
`migration_tracker` table and skips every configured migration whose
`Version` is `<= currentVersion`. There is no check for the reverse case:
if `currentVersion` is *higher* than anything the running binary's
`migrationConfig` knows about, every migration is silently skipped and
`lnd` proceeds to operate against a schema it doesn't understand.

This can happen if a user upgrades to a newer `lnd` release (which
advances `migration_tracker` forward), then accidentally relaunches an
older binary against the same database. The older binary has no way of
knowing it's behind, and unlike `channeldb`'s kvdb meta store (which
already guards against this via `ErrDBReversion`), the native-SQL store
had no equivalent protection.

Note: `sqldb/v2/migrations.go` (an in-progress, not-yet-wired-in
package) already implements the same kind of guard for schema-level
downgrades (`ErrMigrationDowngrade`). This PR ports that idiom to the
currently-in-use `sqldb` package's `migration_tracker`-level version
check, which is what the linked issue is specifically about.

### Fix

Added `ErrDBDowngrade` and a check in `ApplyMigrations` that compares
`currentVersion` against the highest version the binary's
`migrationConfig` contains (`len(migrations)`, which is safe because the
function already validates that migration versions are numbered
contiguously from 1). If the database is ahead, `ApplyMigrations` now
fails loudly instead of silently skipping every migration.

### Scope note

The issue also proposed a second, complementary change: bumping
`channeldb`'s mandatory kvdb version with a no-op entry, so that even a
*pre-fix* binary refuses to start against a database a newer release
already touched (closing the gap for binaries that predate this PR).
I intentionally left that out of this PR — it affects every `lnd` node
on upgrade (not just native-SQL-store users) and "spends" a kvdb version
slot permanently, which felt like a call best left to a maintainer
rather than bundled unilaterally into a bug-fix PR. Happy to follow up
with that change if maintainers want it.

### Testing

- `go build ./...` and `go vet ./...` clean in the `sqldb` module.
- Added `TestApplyMigrationsRefusesDowngrade`: migrates a fresh database
  forward using a 3-entry migration list (simulating a "newer" binary),
  then reopens the same database file/instance and calls
  `ApplyAllMigrations` with only a 2-entry list (simulating an "older"
  binary). Asserts `ErrDBDowngrade` is returned and that the tracked
  migration version is left untouched. Covered for both SQLite and
  Postgres backends.
- Ran the full existing migration suite (`TestMigrations`,
  `TestCustomMigration`, `TestMigrationSucceedsAfterDirtyStateMigrationFailure19RC1`,
  `TestMigrationConfigConsistency`) plus the new test under `go test
  -race`. All SQLite-backed and non-DB cases pass. Postgres-backed cases
  in this suite require a local Docker daemon, which wasn't available in
  my dev environment (`docker info` confirms), so those specific
  subtests couldn't be locally exercised — this is a pre-existing
  environment limitation, not something introduced by this change, and
  CI should cover the Postgres path.
- `gofmt -l` clean; all added lines respect the repo's 80-column
  convention.

## Pull Request Checklist

### Testing

- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation

- [x] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only).
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [x] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes).

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.