### PR TITLE
multi: fix stale address accumulation when using externalhosts

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -55,6 +55,23 @@
   the reported network statistics such as total network capacity, channel
   count and max out degree.
 
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/issues/10952) where a
+  node using `externalhosts` accumulated a dead clearnet address in its node
+  announcement every time its IP changed while it was down. The configured
+  hosts are now resolved on startup and, together with `externalip` and any
+  NAT-discovered IPs, determine which clearnet addresses we advertise, so the
+  IPs a host used to resolve to are no longer carried over. Onion and I2P
+  addresses are always carried over, and nothing is pruned if a host fails to
+  resolve. Note that a node with `externalip` set previously dropped its
+  persisted onion and I2P addresses at startup and now retains them; an
+  operator who has since removed a Tor or I2P service can clear a leftover
+  address with `lncli peers updatenodeannouncement --address_remove=`. Each host
+  is resolved to a single address, so a host backed by several rotating A
+  records may see its advertised IP change between restarts. Likewise, a
+  clearnet address added with `updatenodeannouncement --address_add` is dropped
+  on restart when `externalhosts` (or `externalip`) is set; onion and I2P
+  additions are kept.
+
 # New Features
 
 ## Functional Enhancements
@@ -129,6 +146,11 @@
 
 ## Code Health
 
+* The `netann.HostAnnouncerConfig` field `AdvertisedIPs` (a set of advertised
+  IP strings) has been replaced by `InitialAddrs`, a map from host to the
+  address it resolved to at startup. Out-of-tree consumers constructing this
+  config must update accordingly.
+
 ## Tooling and Documentation
 
 * [`dev.Dockerfile` now uses](https://github.com/lightningnetwork/lnd/pull/10903)
@@ -144,6 +166,7 @@
 
 # Contributors (Alphabetical Order)
 
+* Abdulkbk
 * bitromortac
 * Boris Nagaev
 * Erick Cestari

--- a/netann/host_ann.go
+++ b/netann/host_ann.go
@@ -1,6 +1,7 @@
 package netann
 
 import (
+	"maps"
 	"net"
 	"sync"
 
@@ -21,10 +22,25 @@ type HostAnnouncerConfig struct {
 	// addresses.
 	LookupHost func(string) (net.Addr, error)
 
-	// AdvertisedIPs is the set of IPs that we've already announced with
-	// our current NodeAnnouncement1. This set will be constructed to avoid
-	// unnecessary node NodeAnnouncement1 updates.
-	AdvertisedIPs map[string]struct{}
+	// InitialAddrs maps each host to the address it resolved to when the
+	// backing node started up, and which it therefore already advertises.
+	// Seeding the announcer with this lets it recognise a later IP change
+	// as a change rather than as a brand new address, so that the address
+	// the host used to point at is removed instead of accumulating
+	// alongside the new one. Hosts that failed to resolve at startup are
+	// absent.
+	//
+	// Two invariants must hold, or the affected host silently reverts to
+	// accumulating stale addresses across restarts with no error:
+	//
+	//   - Each key must be byte-identical to its Hosts entry, since the
+	//     watcher looks these up by the exact strings in Hosts.
+	//   - Each value must share the String() normalization that LookupHost
+	//     produces, since a change is detected by comparing the two.
+	//
+	// The simplest way to satisfy both is to derive the keys, values and
+	// Hosts from a single source resolved with the same LookupHost.
+	InitialAddrs map[string]net.Addr
 
 	// AnnounceNewIPs announces a new set of IP addresses for the backing
 	// Lightning node. The first set of addresses is the new set of
@@ -84,7 +100,13 @@ func (h *HostAnnouncer) Stop() error {
 func (h *HostAnnouncer) hostWatcher() {
 	defer h.wg.Done()
 
-	ipMapping := make(map[string]net.Addr)
+	// Start from the addresses our hosts resolved to when the node started
+	// up. Without this we'd treat the first resolution after a restart as a
+	// brand new address and simply append it, letting the IPs the host used
+	// to point at pile up in our node announcement across restarts.
+	ipMapping := make(map[string]net.Addr, len(h.cfg.InitialAddrs))
+	maps.Copy(ipMapping, h.cfg.InitialAddrs)
+
 	refreshHosts := func() {
 		// We'll now run through each of our hosts to check if they had
 		// their backing IPs changed. If so, we'll want to re-announce
@@ -106,21 +128,10 @@ func (h *HostAnnouncer) hostWatcher() {
 				continue
 			}
 
-			// Update the IP mapping now, as if this is the first
-			// time then we don't need to send a new announcement.
 			ipMapping[host] = newAddr
 
-			// If this IP has already been announced, then we'll
-			// skip it to avoid triggering an unnecessary node
-			// announcement update.
-			_, ipAnnounced := h.cfg.AdvertisedIPs[newAddr.String()]
-			if ipAnnounced {
-				continue
-			}
-
-			// If we've reached this point, then the old address
-			// was found, and the new address we just looked up
-			// differs from the old one.
+			// If we've reached this point, then the address this
+			// host resolves to differs from the one we last saw.
 			log.Debugf("IP change detected! %v: %v -> %v", host,
 				oldAddr, newAddr)
 

--- a/netann/host_ann.go
+++ b/netann/host_ann.go
@@ -111,8 +111,7 @@ func (h *HostAnnouncer) hostWatcher() {
 		// We'll now run through each of our hosts to check if they had
 		// their backing IPs changed. If so, we'll want to re-announce
 		// them.
-		var addrsToUpdate []net.Addr
-		addrsToRemove := make(map[string]struct{})
+		var addrsToUpdate, staleCandidates []net.Addr
 		for _, host := range h.cfg.Hosts {
 			newAddr, err := h.cfg.LookupHost(host)
 			if err != nil {
@@ -136,9 +135,11 @@ func (h *HostAnnouncer) hostWatcher() {
 				oldAddr, newAddr)
 
 			// If we had already advertised an addr for this host,
-			// then we'll need to remove that old stale address.
+			// then the address may now be stale.
 			if oldAddr != nil {
-				addrsToRemove[oldAddr.String()] = struct{}{}
+				staleCandidates = append(
+					staleCandidates, oldAddr,
+				)
 			}
 
 			addrsToUpdate = append(addrsToUpdate, newAddr)
@@ -150,6 +151,27 @@ func (h *HostAnnouncer) hostWatcher() {
 			log.Debugf("No IP changes detected for hosts: %v",
 				h.cfg.Hosts)
 			return
+		}
+
+		// A host moving off an address doesn't make that address stale
+		// if another host still resolves to it, so we only remove the
+		// ones nothing points at any more. ipMapping is fully updated
+		// for this round by now, so it tells us what each host
+		// currently resolves to. A host we failed to resolve keeps its
+		// last known entry here, which means a transient DNS failure
+		// can't cost us an address either.
+		stillMapped := make(map[string]struct{}, len(ipMapping))
+		for _, addr := range ipMapping {
+			stillMapped[addr.String()] = struct{}{}
+		}
+
+		addrsToRemove := make(map[string]struct{}, len(staleCandidates))
+		for _, addr := range staleCandidates {
+			if _, ok := stillMapped[addr.String()]; ok {
+				continue
+			}
+
+			addrsToRemove[addr.String()] = struct{}{}
 		}
 
 		// Now that we know the set of IPs we need to update, we'll do

--- a/netann/host_ann_test.go
+++ b/netann/host_ann_test.go
@@ -2,12 +2,27 @@ package netann
 
 import (
 	"net"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/ticker"
+	"github.com/lightningnetwork/lnd/tor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
+
+const testHost = "test.com:9735"
+
+var (
+	addr1 = &net.TCPAddr{IP: net.ParseIP("1.1.1.1"), Port: 9735}
+	addr2 = &net.TCPAddr{IP: net.ParseIP("2.2.2.2"), Port: 9735}
+
+	onionAddr = &tor.OnionAddr{
+		OnionService: "abcdefghijklmnop.onion",
+		Port:         9735,
+	}
 )
 
 // TestHostAnnouncerUpdates tests that the HostAnnouncer will properly announce
@@ -36,8 +51,8 @@ func TestHostAnnouncerUpdates(t *testing.T) {
 	}
 
 	testCases := []struct {
-		preAdvertisedIPs map[string]struct{}
-		startingAddrs    []net.Addr
+		initialAddrs  map[string]net.Addr
+		startingAddrs []net.Addr
 
 		preTickHosts  map[string]net.Addr
 		postTickHosts map[string]net.Addr
@@ -141,13 +156,15 @@ func TestHostAnnouncerUpdates(t *testing.T) {
 			},
 		},
 
-		// Two addresses, one has already been advertised on start up,
-		// so we only expect one of them to be announced again. After
-		// the tick we don't expect an update trigger since nothing.
-		// changed.
+		// Two addresses, one of which already resolved to the same IP
+		// on start up and is therefore already advertised, so we only
+		// expect the other one to be announced. After the tick we don't
+		// expect an update trigger since nothing changed.
 		{
-			preAdvertisedIPs: map[string]struct{}{
-				"1.1.1.1:0": {},
+			initialAddrs: map[string]net.Addr{
+				"test.com": &net.TCPAddr{
+					IP: net.ParseIP("1.1.1.1"),
+				},
 			},
 			startingAddrs: []net.Addr{
 				&net.TCPAddr{
@@ -179,7 +196,7 @@ func TestHostAnnouncerUpdates(t *testing.T) {
 		annReqs := make(chan annReq)
 		hostAnncer := NewHostAnnouncer(HostAnnouncerConfig{
 			Hosts:         hosts,
-			AdvertisedIPs: testCase.preAdvertisedIPs,
+			InitialAddrs:  testCase.initialAddrs,
 			RefreshTicker: ticker,
 			LookupHost: func(str string) (net.Addr, error) {
 				return <-hostResps, nil
@@ -272,4 +289,166 @@ func TestHostAnnouncerUpdates(t *testing.T) {
 			t.Fatalf("unable to stop announcer: %v", err)
 		}
 	}
+}
+
+// annHarness drives a HostAnnouncer against a single host, applying the
+// announcements it makes to nodeAnn the same way the server does, so that tests
+// can assert on the address set we'd end up advertising.
+type annHarness struct {
+	t *testing.T
+
+	nodeAnn *lnwire.NodeAnnouncement1
+	ticker  *ticker.Force
+
+	mu      sync.Mutex
+	curAddr net.Addr
+
+	resolved  chan struct{}
+	announced chan struct{}
+}
+
+// newAnnHarness starts an announcer for a single host which currently resolves
+// to curAddr, with nodeAnn as the announcement restored from disk and
+// initialAddrs as the addresses the host resolved to at startup.
+func newAnnHarness(t *testing.T, nodeAnn *lnwire.NodeAnnouncement1,
+	initialAddrs map[string]net.Addr, curAddr net.Addr) *annHarness {
+
+	h := &annHarness{
+		t:         t,
+		nodeAnn:   nodeAnn,
+		ticker:    ticker.NewForce(time.Hour),
+		curAddr:   curAddr,
+		resolved:  make(chan struct{}, 10),
+		announced: make(chan struct{}, 10),
+	}
+
+	annCer := NewHostAnnouncer(HostAnnouncerConfig{
+		Hosts:         []string{testHost},
+		RefreshTicker: h.ticker,
+		InitialAddrs:  initialAddrs,
+		LookupHost: func(string) (net.Addr, error) {
+			h.mu.Lock()
+			defer h.mu.Unlock()
+			defer func() { h.resolved <- struct{}{} }()
+
+			return h.curAddr, nil
+		},
+		AnnounceNewIPs: func(newAddrs []net.Addr,
+			oldAddrs map[string]struct{}) error {
+
+			err := IPAnnouncer(func(mods ...NodeAnnModifier) (
+				lnwire.NodeAnnouncement1, error) {
+
+				for _, mod := range mods {
+					mod(h.nodeAnn)
+				}
+
+				return *h.nodeAnn, nil
+			})(newAddrs, oldAddrs)
+
+			h.announced <- struct{}{}
+
+			return err
+		},
+	})
+	require.NoError(t, annCer.Start())
+	t.Cleanup(func() {
+		require.NoError(t, annCer.Stop())
+	})
+
+	// Wait for the announcer's initial resolution so that the host's IP can
+	// only change once it has taken stock of the current one.
+	h.waitResolved()
+
+	return h
+}
+
+// resolveTo points the host at addr and forces a refresh, blocking until the
+// announcer has resolved the host again.
+func (h *annHarness) resolveTo(addr net.Addr) {
+	h.t.Helper()
+
+	h.mu.Lock()
+	h.curAddr = addr
+	h.mu.Unlock()
+
+	h.ticker.Force <- time.Now()
+	h.waitResolved()
+}
+
+// waitResolved blocks until the announcer resolves the host.
+func (h *annHarness) waitResolved() {
+	h.t.Helper()
+
+	select {
+	case <-h.resolved:
+	case <-time.After(time.Second):
+		h.t.Fatal("host was never resolved")
+	}
+}
+
+// assertAddrs waits for any in-flight announcement to be applied, then asserts
+// on the addresses we'd advertise.
+func (h *annHarness) assertAddrs(addrs ...net.Addr) {
+	h.t.Helper()
+
+	select {
+	case <-h.announced:
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	require.Equal(h.t, addrs, h.nodeAnn.Addresses)
+}
+
+// TestHostAnnouncerRestart tests that after a restart the announcer replaces
+// the address its host used to resolve to, rather than announcing the newly
+// resolved address alongside it. Without this, every restart that follows an
+// IP change would leave another dead IP behind in our node announcement.
+func TestHostAnnouncerRestart(t *testing.T) {
+	t.Parallel()
+
+	// Our node announcement was restored from disk, and still advertises
+	// the address our host resolved to when we last ran, alongside an onion
+	// address.
+	nodeAnn := &lnwire.NodeAnnouncement1{
+		Addresses: []net.Addr{addr1, onionAddr},
+	}
+	initialAddrs := map[string]net.Addr{testHost: addr1}
+
+	h := newAnnHarness(t, nodeAnn, initialAddrs, addr1)
+
+	// Nothing has changed yet, so we should still advertise what we started
+	// with.
+	h.assertAddrs(addr1, onionAddr)
+
+	// Our ISP now hands us a new IP, which our host resolves to.
+	h.resolveTo(addr2)
+
+	// The address the host used to resolve to is no longer reachable, so it
+	// should be replaced rather than added to. Our onion address is
+	// unrelated to the host and must survive.
+	h.assertAddrs(onionAddr, addr2)
+}
+
+// TestHostAnnouncerAddrFlipBack tests that we correctly track our host's
+// address when it changes back to one we advertised earlier in this run.
+func TestHostAnnouncerAddrFlipBack(t *testing.T) {
+	t.Parallel()
+
+	nodeAnn := &lnwire.NodeAnnouncement1{
+		Addresses: []net.Addr{addr1},
+	}
+	initialAddrs := map[string]net.Addr{testHost: addr1}
+
+	h := newAnnHarness(t, nodeAnn, initialAddrs, addr1)
+
+	// The host's address changes, which should swap out the old one.
+	h.resolveTo(addr2)
+	h.assertAddrs(addr2)
+
+	// It now flips back to the address we started with. We should end up
+	// advertising that address and nothing else, rather than holding on to
+	// the address that is no longer reachable.
+	h.resolveTo(addr1)
+	h.assertAddrs(addr1)
 }

--- a/netann/host_ann_test.go
+++ b/netann/host_ann_test.go
@@ -156,6 +156,45 @@ func TestHostAnnouncerUpdates(t *testing.T) {
 			},
 		},
 
+		// Both hosts resolve to the same IP and only one of them then
+		// changes. The address they used to share must stay advertised,
+		// since the host that didn't change still resolves to it.
+		{
+			preTickHosts: map[string]net.Addr{
+				"test.com": &net.TCPAddr{
+					IP: net.ParseIP("1.1.1.1"),
+				},
+				"example.com": &net.TCPAddr{
+					IP: net.ParseIP("1.1.1.1"),
+				},
+			},
+			startingAddrs: []net.Addr{
+				&net.TCPAddr{
+					IP: net.ParseIP("1.1.1.1"),
+				},
+				&net.TCPAddr{
+					IP: net.ParseIP("1.1.1.1"),
+				},
+			},
+
+			postTickHosts: map[string]net.Addr{
+				"test.com": &net.TCPAddr{
+					IP: net.ParseIP("2.2.2.2"),
+				},
+				"example.com": &net.TCPAddr{
+					IP: net.ParseIP("1.1.1.1"),
+				},
+			},
+
+			updateTriggered: true,
+			newAddrs: []net.Addr{
+				&net.TCPAddr{
+					IP: net.ParseIP("2.2.2.2"),
+				},
+			},
+			removedAddrs: map[string]struct{}{},
+		},
+
 		// Two addresses, one of which already resolved to the same IP
 		// on start up and is therefore already advertised, so we only
 		// expect the other one to be announced. After the tick we don't

--- a/server.go
+++ b/server.go
@@ -1970,21 +1970,11 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 	}
 
 	if len(cfg.ExternalHosts) != 0 {
-		advertisedIPs := make(map[string]struct{})
-		for _, addr := range s.currentNodeAnn.Addresses {
-			advertisedIPs[addr.String()] = struct{}{}
-		}
-
 		s.hostAnn = netann.NewHostAnnouncer(netann.HostAnnouncerConfig{
 			Hosts:         cfg.ExternalHosts,
 			RefreshTicker: ticker.New(defaultHostSampleInterval),
-			LookupHost: func(host string) (net.Addr, error) {
-				return lncfg.ParseAddressString(
-					host, strconv.Itoa(defaultPeerPort),
-					cfg.net.ResolveTCPAddr,
-				)
-			},
-			AdvertisedIPs: advertisedIPs,
+			LookupHost:    lookupHost,
+			InitialAddrs:  hostAddrs,
 			AnnounceNewIPs: netann.IPAnnouncer(
 				func(modifier ...netann.NodeAnnModifier) (
 					lnwire.NodeAnnouncement1, error) {

--- a/server.go
+++ b/server.go
@@ -11,6 +11,7 @@ import (
 	"math/big"
 	prand "math/rand"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -644,6 +645,68 @@ func withoutV2Onion(addrs []net.Addr) []net.Addr {
 	return filtered
 }
 
+// hostLookup returns a closure that resolves a hostname to the address we'd
+// advertise for it, applying the default peer port if the host doesn't carry
+// one.
+func hostLookup(netCfg tor.Net) func(string) (net.Addr, error) {
+	return func(host string) (net.Addr, error) {
+		return lncfg.ParseAddressString(
+			host, strconv.Itoa(defaultPeerPort),
+			netCfg.ResolveTCPAddr,
+		)
+	}
+}
+
+// resolveExternalHosts resolves each configured externalhosts entry to the
+// address it currently points at. The second return value reports whether every
+// host resolved. A failed lookup leaves us unable to tell which of our
+// persisted clearnet addresses are stale results for that host, so callers must
+// not prune any addresses unless all hosts resolved.
+//
+// Each host is resolved to a single address, matching the single-address model
+// the externalhosts subsystem has always used. A host with several rotating A
+// records may therefore resolve to a different sibling IP from one run to the
+// next, so pruning can flap its advertised address across restarts. Advertising
+// every record of a multi-address host would require resolving them all, which
+// is left for a follow-up.
+func resolveExternalHosts(hosts []string,
+	lookup func(string) (net.Addr, error)) (map[string]net.Addr, bool) {
+
+	addrs := make(map[string]net.Addr, len(hosts))
+	allResolved := true
+	for _, host := range hosts {
+		addr, err := lookup(host)
+		if err != nil {
+			srvrLog.Warnf("Unable to resolve IP for host %v: %v",
+				host, err)
+
+			allResolved = false
+
+			continue
+		}
+
+		addrs[host] = addr
+	}
+
+	return addrs, allResolved
+}
+
+// dedupAddrs removes duplicate addresses, preserving the original order.
+func dedupAddrs(addrs []net.Addr) []net.Addr {
+	seen := make(map[string]struct{}, len(addrs))
+	deduped := make([]net.Addr, 0, len(addrs))
+	for _, addr := range addrs {
+		if _, ok := seen[addr.String()]; ok {
+			continue
+		}
+
+		seen[addr.String()] = struct{}{}
+		deduped = append(deduped, addr)
+	}
+
+	return deduped
+}
+
 // noiseDial is a factory function which creates a connmgr compliant dialing
 // function by returning a closure which includes the server's identity key.
 func noiseDial(idKey keychain.SingleKeyECDH,
@@ -994,9 +1057,19 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 		}
 	}
 
+	// Resolve any configured externalhosts up front so that the initial
+	// node announcement and the HostAnnouncer below both start from the
+	// same view of DNS.
+	lookupHost := hostLookup(cfg.net)
+	hostAddrs, allHostsResolved := resolveExternalHosts(
+		cfg.ExternalHosts, lookupHost,
+	)
+
 	nodePubKey := route.NewVertex(nodeKeyDesc.PubKey)
 	// Set the self node which represents our node in the graph.
-	err = s.setSelfNode(ctx, nodePubKey, listenAddrs)
+	err = s.setSelfNode(
+		ctx, nodePubKey, listenAddrs, hostAddrs, allHostsResolved,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -3577,15 +3650,7 @@ func (s *server) genNodeAnnouncement(features *lnwire.RawFeatureVector,
 
 	// The modifiers may have added duplicate addresses, so we need to
 	// de-duplicate them here.
-	uniqueAddrs := map[string]struct{}{}
-	dedupedAddrs := make([]net.Addr, 0)
-	for _, addr := range newNodeAnn.Addresses {
-		if _, ok := uniqueAddrs[addr.String()]; !ok {
-			uniqueAddrs[addr.String()] = struct{}{}
-			dedupedAddrs = append(dedupedAddrs, addr)
-		}
-	}
-	newNodeAnn.Addresses = dedupedAddrs
+	newNodeAnn.Addresses = dedupAddrs(newNodeAnn.Addresses)
 
 	// Sign a new update after applying all of the passed modifiers.
 	err := netann.SignNodeAnnouncement(
@@ -5711,13 +5776,88 @@ func calculateNodeAnnouncementTimestamp(persistedTime,
 	return currentTime
 }
 
+// reconcileNodeAddrs returns the set of addresses we should advertise for this
+// run. configAddrs are the addresses backed by the current configuration
+// (externalip, NAT-discovered IPs and the freshly resolved externalhosts),
+// while persisted are the addresses left over from our previous run. The
+// config addresses are always advertised; pruneStale only decides what happens
+// to the persisted ones.
+//
+// If pruneStale is set, we drop every persisted clearnet address the config no
+// longer backs. This is what stops old DNS results for an externalhosts entry
+// from piling up across restarts. Persisted addresses we cannot re-derive from
+// the config, such as onion or I2P addresses, are always carried over.
+//
+// If pruneStale is not set we have no trustworthy view of which persisted
+// addresses are stale, so we keep all of them rather than risk dropping an
+// address we're still reachable on.
+func reconcileNodeAddrs(configAddrs, persisted []net.Addr,
+	pruneStale bool) []net.Addr {
+
+	// Never carry a legacy Tor v2 address into a new announcement.
+	persisted = withoutV2Onion(persisted)
+
+	configured := make(map[string]struct{}, len(configAddrs))
+	for _, addr := range configAddrs {
+		configured[addr.String()] = struct{}{}
+	}
+
+	addrs := make([]net.Addr, 0, len(configAddrs)+len(persisted))
+	addrs = append(addrs, configAddrs...)
+
+	for _, addr := range persisted {
+		// A clearnet address that the config no longer backs is stale,
+		// but only the config can tell us that.
+		_, isClearnet := addr.(*net.TCPAddr)
+		_, backed := configured[addr.String()]
+		if pruneStale && isClearnet && !backed {
+			// Surface the drop so an operator isn't left guessing
+			// why an address vanished.
+			srvrLog.Warnf("Removing clearnet address %v from our "+
+				"node announcement: no longer backed by "+
+				"externalip, externalhosts or NAT", addr)
+
+			continue
+		}
+
+		addrs = append(addrs, addr)
+	}
+
+	return dedupAddrs(addrs)
+}
+
+// shouldPruneStale reports whether we should drop the persisted clearnet
+// addresses that our config no longer backs. configAddrs are the addresses the
+// config produced this run (externalip, NAT-discovered IPs and the freshly
+// resolved externalhosts).
+//
+// We only prune when the config actually produced a clearnet address this run:
+// otherwise we'd have nothing to replace the persisted ones with and would
+// strip our only reachable address. We also require that every configured host
+// resolved, since a failed lookup leaves us unable to tell which persisted
+// clearnet addresses are its stale results.
+func shouldPruneStale(configAddrs []net.Addr, allHostsResolved bool) bool {
+	if !allHostsResolved {
+		return false
+	}
+
+	for _, addr := range configAddrs {
+		if _, ok := addr.(*net.TCPAddr); ok {
+			return true
+		}
+	}
+
+	return false
+}
+
 // setSelfNode configures and sets the server's self node. It sets the node
 // announcement, signs it, and updates the source node in the graph. When
 // determining values such as color and alias, the method prioritizes values
 // set in the config, then values previously persisted on disk, and finally
 // falls back to the defaults.
 func (s *server) setSelfNode(ctx context.Context, nodePub route.Vertex,
-	listenAddrs []net.Addr) error {
+	listenAddrs []net.Addr, hostAddrs map[string]net.Addr,
+	allHostsResolved bool) error {
 
 	// If we were requested to automatically configure port forwarding,
 	// we'll use the ports that the server will be listening on.
@@ -5750,7 +5890,7 @@ func (s *server) setSelfNode(ctx context.Context, nodePub route.Vertex,
 		}
 	}
 
-	// Normalize the external IP strings to net.Addr.
+	// Normalize the externalip and any NAT-forwarded IPs to net.Addr.
 	addrs, err := lncfg.NormalizeAddresses(
 		externalIPStrings, strconv.Itoa(defaultPeerPort),
 		s.cfg.net.ResolveTCPAddr,
@@ -5758,6 +5898,38 @@ func (s *server) setSelfNode(ctx context.Context, nodePub route.Vertex,
 	if err != nil {
 		return fmt.Errorf("unable to normalize addresses: %w", err)
 	}
+
+	// The externalhosts entries back our clearnet addresses just like
+	// externalip does, but we resolved them once already at startup, the
+	// same resolution that seeds the HostAnnouncer. Feed those resolved
+	// addresses in directly rather than resolving a second time, so the
+	// set we advertise can't drift from the one the announcer was seeded
+	// with. Sort them so an unchanged set yields the same announcement
+	// across restarts rather than a new order each time we range the map.
+	hostResolved := make([]net.Addr, 0, len(hostAddrs))
+	for _, addr := range hostAddrs {
+		hostResolved = append(hostResolved, addr)
+	}
+	sort.Slice(hostResolved, func(i, j int) bool {
+		return hostResolved[i].String() < hostResolved[j].String()
+	})
+	addrs = append(addrs, hostResolved...)
+
+	// A host we couldn't resolve leaves us unable to tell which of our
+	// persisted clearnet addresses are stale results for it, so we hold on
+	// to all of them rather than risk dropping our only reachable address
+	// over a transient DNS failure. Peers dial the IPs we advertise, not
+	// the host, so a failed lookup says nothing about reachability.
+	//
+	// This is all-or-nothing: the persisted addresses are a flat list with
+	// no record of which host each came from, so one failed lookup
+	// suppresses pruning for every host this run. That host is also absent
+	// from the HostAnnouncer's InitialAddrs, so when it resolves later its
+	// address is appended without the stale one being removed, and a host
+	// that reliably fails at boot keeps accumulating until a boot where
+	// every host resolves. Pruning per host would need a persisted
+	// host-to-address mapping, which we deliberately avoid.
+	pruneStale := shouldPruneStale(addrs, allHostsResolved)
 
 	// Parse the color from config. We will update this later if the config
 	// color is not changed from default (#3399FF) and we have a value in
@@ -5799,13 +5971,12 @@ func (s *server) setSelfNode(ctx context.Context, nodePub route.Vertex,
 			})
 		}
 
-		// If the `externalip` is not specified in the config, it means
-		// `addrs` will be empty, we'll use the source node's addresses.
-		// Filter out any persisted Tor v2 onion entries so an upgraded
-		// node never re-signs or re-broadcasts a legacy v2 address.
-		if len(s.cfg.ExternalIPs) == 0 {
-			addrs = withoutV2Onion(srcNode.Addresses)
-		}
+		// Merge the addresses backed by our config with the ones we
+		// persisted last run, dropping any persisted clearnet address
+		// the config no longer backs.
+		addrs = reconcileNodeAddrs(
+			addrs, srcNode.Addresses, pruneStale,
+		)
 
 	case errors.Is(err, graphdb.ErrSourceNodeNotSet):
 		// If an alias is not specified in the config, we'll use the

--- a/server_test.go
+++ b/server_test.go
@@ -238,3 +238,175 @@ func TestWithoutV2Onion(t *testing.T) {
 	// fetchNodeAdvertisedAddrs treat this as "no advertised address".
 	require.Empty(t, withoutV2Onion([]net.Addr{v2, v2}))
 }
+
+// TestReconcileNodeAddrs tests that on startup we only keep the persisted
+// clearnet addresses that our config still backs, so that the IPs an
+// externalhosts entry used to resolve to don't accumulate across restarts.
+func TestReconcileNodeAddrs(t *testing.T) {
+	t.Parallel()
+
+	var (
+		// staleIP and stalerIP are addresses our host resolved to on
+		// previous runs, and currentIP the one it resolves to now.
+		stalerIP = &net.TCPAddr{
+			IP: net.ParseIP("1.1.1.1"), Port: 9735,
+		}
+		staleIP = &net.TCPAddr{
+			IP: net.ParseIP("2.2.2.2"), Port: 9735,
+		}
+		currentIP = &net.TCPAddr{
+			IP: net.ParseIP("3.3.3.3"), Port: 9735,
+		}
+
+		onion = &tor.OnionAddr{
+			OnionService: "4acth47i6kxnvkewtm6q7ib2s3ufpo5sqbsn" +
+				"zjpbi7utijcltosqemad.onion",
+			Port: 9735,
+		}
+		v2Onion = &tor.OnionAddr{
+			OnionService: "3g2upl4pq6kufc4m.onion",
+			Port:         9735,
+		}
+	)
+
+	tests := []struct {
+		name        string
+		configAddrs []net.Addr
+		persisted   []net.Addr
+		pruneStale  bool
+		expected    []net.Addr
+	}{
+		{
+			// The IPs our host used to resolve to are no longer
+			// reachable and must not be carried over, while our
+			// onion address must be.
+			name:        "stale clearnet addrs dropped",
+			configAddrs: []net.Addr{currentIP},
+			persisted:   []net.Addr{stalerIP, staleIP, onion},
+			pruneStale:  true,
+			expected:    []net.Addr{currentIP, onion},
+		},
+		{
+			// Without a trustworthy view of our addresses we can't
+			// tell which persisted ones are stale, so we keep them
+			// all rather than risk dropping the only address we're
+			// reachable on.
+			name:        "nothing pruned without a trusted config",
+			configAddrs: []net.Addr{currentIP},
+			persisted:   []net.Addr{staleIP, onion},
+			pruneStale:  false,
+			expected:    []net.Addr{currentIP, staleIP, onion},
+		},
+		{
+			// With no address source configured we fall back to
+			// whatever we advertised last run.
+			name:        "no config addrs keeps persisted",
+			configAddrs: nil,
+			persisted:   []net.Addr{staleIP, onion},
+			pruneStale:  false,
+			expected:    []net.Addr{staleIP, onion},
+		},
+		{
+			// A persisted address our config still backs is kept,
+			// and isn't duplicated.
+			name:        "persisted addr still backed by config",
+			configAddrs: []net.Addr{currentIP},
+			persisted:   []net.Addr{currentIP, onion},
+			pruneStale:  true,
+			expected:    []net.Addr{currentIP, onion},
+		},
+		{
+			// A legacy v2 onion is never carried into a new
+			// announcement, regardless of pruning.
+			name:        "v2 onion always dropped",
+			configAddrs: []net.Addr{currentIP},
+			persisted:   []net.Addr{v2Onion, onion},
+			pruneStale:  false,
+			expected:    []net.Addr{currentIP, onion},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			addrs := reconcileNodeAddrs(
+				test.configAddrs, test.persisted,
+				test.pruneStale,
+			)
+			require.Equal(t, test.expected, addrs)
+		})
+	}
+}
+
+// TestShouldPruneStale tests that we only prune persisted clearnet addresses
+// when the config produced a clearnet address to replace them with and every
+// configured host resolved, so that neither an onion-only config nor a single
+// failed host lookup can strip our persisted addresses.
+func TestShouldPruneStale(t *testing.T) {
+	t.Parallel()
+
+	var (
+		clearnet = &net.TCPAddr{
+			IP: net.ParseIP("1.1.1.1"), Port: 9735,
+		}
+		onion = &tor.OnionAddr{
+			OnionService: "4acth47i6kxnvkewtm6q7ib2s3ufpo5sqbsn" +
+				"zjpbi7utijcltosqemad.onion",
+			Port: 9735,
+		}
+	)
+
+	tests := []struct {
+		name             string
+		configAddrs      []net.Addr
+		allHostsResolved bool
+		expected         bool
+	}{
+		{
+			// The config backs a clearnet address and every host
+			// resolved, so we can safely prune.
+			name:             "clearnet config, all resolved",
+			configAddrs:      []net.Addr{clearnet},
+			allHostsResolved: true,
+			expected:         true,
+		},
+		{
+			// A host failed to resolve, so we can't tell which
+			// persisted addresses are its stale results.
+			name:             "clearnet config, a host failed",
+			configAddrs:      []net.Addr{clearnet},
+			allHostsResolved: false,
+			expected:         false,
+		},
+		{
+			// The config produced no clearnet address, so pruning
+			// would leave us with none.
+			name:             "onion-only config",
+			configAddrs:      []net.Addr{onion},
+			allHostsResolved: true,
+			expected:         false,
+		},
+		{
+			// With no address source configured there's nothing to
+			// prune against.
+			name:             "no config addrs",
+			configAddrs:      nil,
+			allHostsResolved: true,
+			expected:         false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(
+				t, test.expected,
+				shouldPruneStale(
+					test.configAddrs, test.allHostsResolved,
+				),
+			)
+		})
+	}
+}


### PR DESCRIPTION
## Change Description
Fixes #10952.

`externalhosts` entries are now resolved during startup and, together with `externalip` and any NAT-discovered IPs, determine which clearnet addresses we advertise. A persisted clearnet address that none of these sources back is dropped, onion and I2P addresses are always carried over. Nothing is pruned unless every configured host is resolved, so a transient DNS failure can't strip the only address we're reachable on.

## Steps to Test
Steps for reviewers to follow to test the change.
```bash
go test -v -run TestReconcileNodeAddrs  

go test -v -run TestHostAnnouncerRestart ./netann 

go test -v -run TestHostAnnouncerAddrFlipBack ./netann
```

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.
