### PR TITLE
chancloser: account for aux close outputs in initial coop close fee baseline

### DIFF
--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -113,6 +113,10 @@
   channel arbitrator suppresses the duplicate event that would otherwise be
   emitted from `MarkChannelClosed` at the final confirmation depth.
 
+* [Fixed coop close fee baseline for channels with auxiliary close outputs](https://github.com/lightningnetwork/lnd/pull/10969)
+  by including extra outputs in initial fee estimation, preventing underpriced
+  taproot/custom channel cooperative closes from failing mempool acceptance.
+
 # New Features
 
 - [Basic Support](https://github.com/lightningnetwork/lnd/pull/9868) for onion

--- a/docs/release-notes/release-notes-0.21.3.md
+++ b/docs/release-notes/release-notes-0.21.3.md
@@ -53,6 +53,10 @@
   transaction confirmed stayed in the `channelReadySent` opening state forever,
   never added to the graph and never announced. Only a restart recovered.
 
+* [Fixed coop close fee baseline for channels with auxiliary close outputs](https://github.com/lightningnetwork/lnd/pull/10969)
+  by including extra outputs in initial fee estimation, preventing underpriced
+  taproot/custom channel cooperative closes from failing mempool acceptance.
+
 # New Features
 
 ## Functional Enhancements

--- a/lnwallet/chancloser/aux_closer.go
+++ b/lnwallet/chancloser/aux_closer.go
@@ -21,12 +21,40 @@ type AuxCloseOutputs struct {
 	CustomSort lnwallet.CloseSortFunc
 }
 
+// AuxCloseOutputShape describes a single auxiliary close output in a
+// fee-independent way, capturing only the properties that contribute to the
+// weight of the co-op close transaction.
+type AuxCloseOutputShape struct {
+	// IsLocal is true if the output belongs to the local party.
+	IsLocal bool
+
+	// PkScriptSize is the size, in bytes, of the output's pkScript.
+	PkScriptSize int
+}
+
+// AuxCloseShape is the fee-independent shape of the auxiliary outputs that
+// will be added to the co-op close transaction: their number and pkScript
+// sizes. The values of the concrete outputs may still depend on the
+// negotiated close fee, but values don't contribute to transaction weight.
+type AuxCloseShape struct {
+	// Outputs describes each auxiliary close output.
+	Outputs []AuxCloseOutputShape
+}
+
 // AuxChanCloser is used to allow an external caller to modify the co-op close
 // transaction.
 type AuxChanCloser interface {
 	// ShutdownBlob returns the set of custom records that should be
 	// included in the shutdown message.
 	ShutdownBlob(req types.AuxShutdownReq) (fn.Option[lnwire.CustomRecords],
+		error)
+
+	// AuxCloseShape returns the fee-independent shape of the auxiliary
+	// outputs required to close the channel. The shape determines the
+	// transaction weight used for fee negotiation, so it MUST NOT depend
+	// on the close fee, while the values of the concrete outputs returned
+	// by AuxCloseOutputs may.
+	AuxCloseShape(desc types.AuxCloseShapeDesc) (fn.Option[AuxCloseShape],
 		error)
 
 	// AuxCloseOutputs returns the set of custom outputs that should be used

--- a/lnwallet/chancloser/chancloser.go
+++ b/lnwallet/chancloser/chancloser.go
@@ -254,9 +254,10 @@ type ChanCloser struct {
 }
 
 // calcCoopCloseFee computes an "ideal" absolute co-op close fee given the
-// delivery scripts of both parties and our ideal fee rate.
+// delivery scripts of both parties, any extra (e.g. auxiliary) close outputs
+// to include in the weight estimate, and our ideal fee rate.
 func calcCoopCloseFee(chanType channeldb.ChannelType,
-	localOutput, remoteOutput *wire.TxOut,
+	localOutput, remoteOutput *wire.TxOut, extraOutputs []*wire.TxOut,
 	idealFeeRate chainfee.SatPerKWeight) btcutil.Amount {
 
 	var weightEstimator input.TxWeightEstimator
@@ -277,6 +278,9 @@ func calcCoopCloseFee(chanType channeldb.ChannelType,
 	if remoteOutput != nil {
 		weightEstimator.AddTxOutput(remoteOutput)
 	}
+	for _, extraOutput := range extraOutputs {
+		weightEstimator.AddTxOutput(extraOutput)
+	}
 
 	totalWeight := weightEstimator.Weight()
 
@@ -296,7 +300,64 @@ func (d *SimpleCoopFeeEstimator) EstimateFee(chanType channeldb.ChannelType,
 	localTxOut, remoteTxOut *wire.TxOut,
 	idealFeeRate chainfee.SatPerKWeight) btcutil.Amount {
 
-	return calcCoopCloseFee(chanType, localTxOut, remoteTxOut, idealFeeRate)
+	return calcCoopCloseFee(
+		chanType, localTxOut, remoteTxOut, nil, idealFeeRate,
+	)
+}
+
+// estimateCloseFee computes a close fee for the given fee rate while taking
+// into account any optional auxiliary close outputs.
+func (c *ChanCloser) estimateCloseFee(localTxOut, remoteTxOut *wire.TxOut,
+	feeRate chainfee.SatPerKWeight) (btcutil.Amount, error) {
+
+	// Historical behavior uses the default channel type here and doesn't
+	// differentiate between channel feature variants.
+	var defaultChanType channeldb.ChannelType
+	fee := c.cfg.FeeEstimator.EstimateFee(
+		defaultChanType, localTxOut, remoteTxOut, feeRate,
+	)
+
+	if c.cfg.AuxCloser.IsNone() {
+		return fee, nil
+	}
+
+	// Aux output selection can depend on CloseFee. After we bump the fee,
+	// the aux closer can return a different output set (for example
+	// around dust thresholds). Run a second pass so the fee and output
+	// set are self-consistent, while keeping this bounded.
+	for range 2 {
+		auxOutputs, err := c.auxCloseOutputs(fee)
+		if err != nil {
+			return 0, err
+		}
+
+		var extraOutputs []*wire.TxOut
+		auxOutputs.WhenSome(func(outs AuxCloseOutputs) {
+			extraOutputs = make(
+				[]*wire.TxOut, 0, len(outs.ExtraCloseOutputs),
+			)
+			for _, closeOutput := range outs.ExtraCloseOutputs {
+				txOut := closeOutput.TxOut
+				extraOutputs = append(extraOutputs, &txOut)
+			}
+		})
+
+		if len(extraOutputs) == 0 {
+			return fee, nil
+		}
+
+		feeWithAuxOutputs := calcCoopCloseFee(
+			defaultChanType, localTxOut, remoteTxOut,
+			extraOutputs, feeRate,
+		)
+		if feeWithAuxOutputs <= fee {
+			return fee, nil
+		}
+
+		fee = feeWithAuxOutputs
+	}
+
+	return fee, nil
 }
 
 // NewChanCloser creates a new instance of the channel closure given the passed
@@ -327,8 +388,10 @@ func NewChanCloser(cfg ChanCloseCfg, deliveryScript DeliveryAddrWithKey,
 }
 
 // initFeeBaseline computes our ideal fee rate, and also the largest fee we'll
-// accept given information about the delivery script of the remote party.
-func (c *ChanCloser) initFeeBaseline() {
+// accept given information about the delivery script of the remote party. It
+// returns an error if the auxiliary close outputs cannot be enumerated to
+// include in the fee estimate.
+func (c *ChanCloser) initFeeBaseline() error {
 	// Depending on if a balance ends up being dust or not, we'll pass a
 	// nil TxOut into the EstimateFee call which can handle it.
 	var localTxOut, remoteTxOut *wire.TxOut
@@ -347,18 +410,25 @@ func (c *ChanCloser) initFeeBaseline() {
 
 	// Given the target fee-per-kw, we'll compute what our ideal _total_
 	// fee will be starting at for this fee negotiation.
-	c.idealFeeSat = c.cfg.FeeEstimator.EstimateFee(
-		0, localTxOut, remoteTxOut, c.idealFeeRate,
+	var err error
+	c.idealFeeSat, err = c.estimateCloseFee(
+		localTxOut, remoteTxOut, c.idealFeeRate,
 	)
+	if err != nil {
+		return err
+	}
 
 	// When we're the initiator, we'll want to also factor in the highest
 	// fee we want to pay. This'll either be 3x the ideal fee, or the
 	// specified explicit max fee.
 	c.maxFee = c.idealFeeSat * defaultMaxFeeMultiplier
 	if c.cfg.MaxFee > 0 {
-		c.maxFee = c.cfg.FeeEstimator.EstimateFee(
-			0, localTxOut, remoteTxOut, c.cfg.MaxFee,
+		c.maxFee, err = c.estimateCloseFee(
+			localTxOut, remoteTxOut, c.cfg.MaxFee,
 		)
+		if err != nil {
+			return err
+		}
 	}
 
 	// TODO(ziggie): Make sure the ideal fee is not higher than the max fee.
@@ -367,6 +437,8 @@ func (c *ChanCloser) initFeeBaseline() {
 	chancloserLog.Infof("Ideal fee for closure of ChannelPoint(%v) "+
 		"is: %v sat (max_fee=%v sat)", c.cfg.Channel.ChannelPoint(),
 		int64(c.idealFeeSat), int64(c.maxFee))
+
+	return nil
 }
 
 // initChanShutdown begins the shutdown process by un-registering the channel,
@@ -741,7 +813,10 @@ func (c *ChanCloser) BeginNegotiation() (fn.Option[lnwire.ClosingSigned],
 	case closeAwaitingFlush:
 		// Now that we know their desired delivery script, we can
 		// compute what our max/ideal fee will be.
-		c.initFeeBaseline()
+		err := c.initFeeBaseline()
+		if err != nil {
+			return noClosingSigned, err
+		}
 
 		// At this point, we can now start the fee negotiation state, by
 		// constructing and sending our initial signature for what we

--- a/lnwallet/chancloser/chancloser.go
+++ b/lnwallet/chancloser/chancloser.go
@@ -57,6 +57,11 @@ var (
 	// errNoShutdownNonce is returned when a shutdown message is received
 	// w/o a nonce for a taproot channel.
 	errNoShutdownNonce = fmt.Errorf("shutdown nonce not populated")
+
+	// ErrAuxShapeMismatch is returned when the concrete auxiliary close
+	// outputs don't match the shape that was declared for fee estimation.
+	ErrAuxShapeMismatch = fmt.Errorf("aux close outputs don't match " +
+		"declared shape")
 )
 
 // closeState represents all the possible states the channel closer state
@@ -257,12 +262,18 @@ type ChanCloser struct {
 	// auxOutputs are the optional additional outputs that might be added to
 	// the closing transaction.
 	auxOutputs fn.Option[AuxCloseOutputs]
+
+	// auxShape is the fee-independent shape of the auxiliary close
+	// outputs, as declared by the aux closer when the fee baseline was
+	// established. The concrete outputs are validated against it.
+	auxShape fn.Option[AuxCloseShape]
 }
 
 // calcCoopCloseFee computes an "ideal" absolute co-op close fee given the
-// delivery scripts of both parties and our ideal fee rate.
+// delivery scripts of both parties, any extra (e.g. auxiliary) close outputs
+// to include in the weight estimate, and our ideal fee rate.
 func calcCoopCloseFee(chanType channeldb.ChannelType,
-	localOutput, remoteOutput *wire.TxOut,
+	localOutput, remoteOutput *wire.TxOut, extraOutputs []*wire.TxOut,
 	idealFeeRate chainfee.SatPerKWeight) btcutil.Amount {
 
 	var weightEstimator input.TxWeightEstimator
@@ -283,6 +294,9 @@ func calcCoopCloseFee(chanType channeldb.ChannelType,
 	if remoteOutput != nil {
 		weightEstimator.AddTxOutput(remoteOutput)
 	}
+	for _, extraOutput := range extraOutputs {
+		weightEstimator.AddTxOutput(extraOutput)
+	}
 
 	totalWeight := weightEstimator.Weight()
 
@@ -296,13 +310,78 @@ type SimpleCoopFeeEstimator struct {
 }
 
 // EstimateFee estimates an _absolute_ fee for a co-op close transaction given
-// the local+remote tx outs (for the co-op close transaction), channel type,
-// and ideal fee rate.
+// the local+remote tx outs (for the co-op close transaction), any extra
+// outputs the close transaction will carry, channel type, and ideal fee rate.
 func (d *SimpleCoopFeeEstimator) EstimateFee(chanType channeldb.ChannelType,
-	localTxOut, remoteTxOut *wire.TxOut,
+	localTxOut, remoteTxOut *wire.TxOut, extraTxOuts []*wire.TxOut,
 	idealFeeRate chainfee.SatPerKWeight) btcutil.Amount {
 
-	return calcCoopCloseFee(chanType, localTxOut, remoteTxOut, idealFeeRate)
+	return calcCoopCloseFee(
+		chanType, localTxOut, remoteTxOut, extraTxOuts, idealFeeRate,
+	)
+}
+
+// auxShapeTxOuts synthesizes zero-value outputs matching the declared aux
+// close shape, for use in fee estimation. Only the pkScript sizes matter, as
+// output values don't contribute to transaction weight.
+func auxShapeTxOuts(shape fn.Option[AuxCloseShape]) []*wire.TxOut {
+	var txOuts []*wire.TxOut
+	shape.WhenSome(func(s AuxCloseShape) {
+		txOuts = make([]*wire.TxOut, 0, len(s.Outputs))
+		for _, out := range s.Outputs {
+			txOuts = append(txOuts, &wire.TxOut{
+				PkScript: make([]byte, out.PkScriptSize),
+			})
+		}
+	})
+
+	return txOuts
+}
+
+// validateAuxShape ensures the concrete auxiliary outputs match the shape
+// that was declared for fee estimation. A mismatch would invalidate the
+// negotiated fee, so we fail rather than sign off on a misestimated close
+// transaction.
+func validateAuxShape(shape fn.Option[AuxCloseShape],
+	auxOutputs fn.Option[AuxCloseOutputs]) error {
+
+	var declared []AuxCloseOutputShape
+	shape.WhenSome(func(s AuxCloseShape) {
+		declared = s.Outputs
+	})
+
+	var concrete []lnwallet.CloseOutput
+	auxOutputs.WhenSome(func(outs AuxCloseOutputs) {
+		concrete = outs.ExtraCloseOutputs
+	})
+
+	if len(declared) != len(concrete) {
+		return fmt.Errorf("%w: declared %v aux close outputs, got %v",
+			ErrAuxShapeMismatch, len(declared), len(concrete))
+	}
+
+	// Compare the two sets while being agnostic to ordering: count the
+	// declared outputs per kind, then match each concrete output against
+	// the remaining declared kinds.
+	kinds := make(map[AuxCloseOutputShape]int, len(declared))
+	for _, out := range declared {
+		kinds[out]++
+	}
+	for _, out := range concrete {
+		kind := AuxCloseOutputShape{
+			IsLocal:      out.IsLocal,
+			PkScriptSize: len(out.TxOut.PkScript),
+		}
+		if kinds[kind] == 0 {
+			return fmt.Errorf("%w: output (is_local=%v, "+
+				"pk_script_size=%v) wasn't declared",
+				ErrAuxShapeMismatch, kind.IsLocal,
+				kind.PkScriptSize)
+		}
+		kinds[kind]--
+	}
+
+	return nil
 }
 
 // NewChanCloser creates a new instance of the channel closure given the passed
@@ -333,8 +412,10 @@ func NewChanCloser(cfg ChanCloseCfg, deliveryScript DeliveryAddrWithKey,
 }
 
 // initFeeBaseline computes our ideal fee rate, and also the largest fee we'll
-// accept given information about the delivery script of the remote party.
-func (c *ChanCloser) initFeeBaseline() {
+// accept given information about the delivery script of the remote party. It
+// returns an error if the auxiliary close outputs cannot be enumerated to
+// include in the fee estimate.
+func (c *ChanCloser) initFeeBaseline() error {
 	// Depending on if a balance ends up being dust or not, we'll pass a
 	// nil TxOut into the EstimateFee call which can handle it.
 	var localTxOut, remoteTxOut *wire.TxOut
@@ -351,10 +432,20 @@ func (c *ChanCloser) initFeeBaseline() {
 		}
 	}
 
+	// Fetch the fee-independent shape of any auxiliary close outputs, and
+	// synthesize their weight contribution, so the fee we negotiate
+	// matches the final transaction that will carry them.
+	var err error
+	c.auxShape, err = c.auxCloseShape()
+	if err != nil {
+		return err
+	}
+	extraTxOuts := auxShapeTxOuts(c.auxShape)
+
 	// Given the target fee-per-kw, we'll compute what our ideal _total_
 	// fee will be starting at for this fee negotiation.
 	c.idealFeeSat = c.cfg.FeeEstimator.EstimateFee(
-		0, localTxOut, remoteTxOut, c.idealFeeRate,
+		0, localTxOut, remoteTxOut, extraTxOuts, c.idealFeeRate,
 	)
 
 	// When we're the initiator, we'll want to also factor in the highest
@@ -363,7 +454,7 @@ func (c *ChanCloser) initFeeBaseline() {
 	c.maxFee = c.idealFeeSat * defaultMaxFeeMultiplier
 	if c.cfg.MaxFee > 0 {
 		c.maxFee = c.cfg.FeeEstimator.EstimateFee(
-			0, localTxOut, remoteTxOut, c.cfg.MaxFee,
+			0, localTxOut, remoteTxOut, extraTxOuts, c.cfg.MaxFee,
 		)
 	}
 
@@ -373,6 +464,8 @@ func (c *ChanCloser) initFeeBaseline() {
 	chancloserLog.Infof("Ideal fee for closure of ChannelPoint(%v) "+
 		"is: %v sat (max_fee=%v sat)", c.cfg.Channel.ChannelPoint(),
 		int64(c.idealFeeSat), int64(c.maxFee))
+
+	return nil
 }
 
 // initChanShutdown begins the shutdown process by un-registering the channel,
@@ -752,7 +845,10 @@ func (c *ChanCloser) BeginNegotiation() (fn.Option[lnwire.ClosingSigned],
 	case closeAwaitingFlush:
 		// Now that we know their desired delivery script, we can
 		// compute what our max/ideal fee will be.
-		c.initFeeBaseline()
+		err := c.initFeeBaseline()
+		if err != nil {
+			return noClosingSigned, err
+		}
 
 		// At this point, we can now start the fee negotiation state, by
 		// constructing and sending our initial signature for what we
@@ -952,6 +1048,10 @@ func (c *ChanCloser) ReceiveClosingSigned( //nolint:funlen
 		if err != nil {
 			return noClosing, err
 		}
+		err = validateAuxShape(c.auxShape, c.auxOutputs)
+		if err != nil {
+			return noClosing, err
+		}
 		c.auxOutputs.WhenSome(func(outs AuxCloseOutputs) {
 			closeOpts = append(
 				closeOpts, lnwallet.WithExtraCloseOutputs(
@@ -1023,6 +1123,42 @@ func (c *ChanCloser) ReceiveClosingSigned( //nolint:funlen
 	}
 }
 
+// auxShutdownReq assembles the shutdown request that describes this channel
+// to the aux closer.
+func (c *ChanCloser) auxShutdownReq() types.AuxShutdownReq {
+	return types.AuxShutdownReq{
+		ChanPoint:   c.chanPoint,
+		ShortChanID: c.cfg.Channel.ShortChanID(),
+		InternalKey: c.localInternalKey,
+		Initiator:   c.cfg.Channel.IsInitiator(),
+		CommitBlob:  c.cfg.Channel.LocalCommitmentBlob(),
+		FundingBlob: c.cfg.Channel.FundingBlob(),
+	}
+}
+
+// auxCloseShape returns the fee-independent shape of any additional outputs
+// that will be added to the close transaction.
+func (c *ChanCloser) auxCloseShape() (fn.Option[AuxCloseShape], error) {
+	var closeShape fn.Option[AuxCloseShape]
+	err := fn.MapOptionZ(c.cfg.AuxCloser, func(aux AuxChanCloser) error {
+		shape, err := aux.AuxCloseShape(types.AuxCloseShapeDesc{
+			AuxShutdownReq: c.auxShutdownReq(),
+		})
+		if err != nil {
+			return err
+		}
+
+		closeShape = shape
+
+		return nil
+	})
+	if err != nil {
+		return closeShape, err
+	}
+
+	return closeShape, nil
+}
+
 // auxCloseOutputs returns any additional outputs that should be used when
 // closing the channel.
 func (c *ChanCloser) auxCloseOutputs(
@@ -1030,16 +1166,8 @@ func (c *ChanCloser) auxCloseOutputs(
 
 	var closeOuts fn.Option[AuxCloseOutputs]
 	err := fn.MapOptionZ(c.cfg.AuxCloser, func(aux AuxChanCloser) error {
-		req := types.AuxShutdownReq{
-			ChanPoint:   c.chanPoint,
-			ShortChanID: c.cfg.Channel.ShortChanID(),
-			InternalKey: c.localInternalKey,
-			Initiator:   c.cfg.Channel.IsInitiator(),
-			CommitBlob:  c.cfg.Channel.LocalCommitmentBlob(),
-			FundingBlob: c.cfg.Channel.FundingBlob(),
-		}
 		outs, err := aux.AuxCloseOutputs(types.AuxCloseDesc{
-			AuxShutdownReq:    req,
+			AuxShutdownReq:    c.auxShutdownReq(),
 			CloseFee:          closeFee,
 			CommitFee:         c.cfg.Channel.CommitFee(),
 			LocalCloseOutput:  c.localCloseOutput,
@@ -1084,6 +1212,9 @@ func (c *ChanCloser) proposeCloseSigned(fee btcutil.Amount) (
 	// for the closing purpose.
 	c.auxOutputs, err = c.auxCloseOutputs(fee)
 	if err != nil {
+		return nil, err
+	}
+	if err := validateAuxShape(c.auxShape, c.auxOutputs); err != nil {
 		return nil, err
 	}
 	c.auxOutputs.WhenSome(func(outs AuxCloseOutputs) {

--- a/lnwallet/chancloser/chancloser_test.go
+++ b/lnwallet/chancloser/chancloser_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnutils"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	wallettypes "github.com/lightningnetwork/lnd/lnwallet/types"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/stretchr/testify/require"
@@ -311,6 +312,38 @@ func (m *mockMusigSession) ClosingNonce() (*musig2.Nonces, error) {
 	}, nil
 }
 
+type mockAuxChanCloser struct {
+	extraScript []byte
+}
+
+func (m *mockAuxChanCloser) ShutdownBlob(
+	req wallettypes.AuxShutdownReq,
+) (fn.Option[lnwire.CustomRecords], error) {
+
+	return fn.None[lnwire.CustomRecords](), nil
+}
+
+func (m *mockAuxChanCloser) AuxCloseOutputs(
+	desc wallettypes.AuxCloseDesc) (fn.Option[AuxCloseOutputs], error) {
+
+	closeOutputs := []lnwallet.CloseOutput{{
+		TxOut: wire.TxOut{
+			PkScript: m.extraScript,
+			Value:    0,
+		},
+	}}
+
+	return fn.Some(AuxCloseOutputs{
+		ExtraCloseOutputs: closeOutputs,
+	}), nil
+}
+
+func (m *mockAuxChanCloser) FinalizeClose(desc wallettypes.AuxCloseDesc,
+	closeTx *wire.MsgTx) error {
+
+	return nil
+}
+
 type mockCoopFeeEstimator struct {
 	targetFee btcutil.Amount
 }
@@ -377,11 +410,75 @@ func TestMaxFeeClamp(t *testing.T) {
 
 			// We'll call initFeeBaseline early here since we need
 			// the populate these internal variables.
-			chanCloser.initFeeBaseline()
+			require.NoError(t, chanCloser.initFeeBaseline())
 
 			require.Equal(t, test.maxFee, chanCloser.maxFee)
 		})
 	}
+}
+
+// TestInitFeeBaselineWithAuxCloseOutputs tests that aux close outputs are
+// accounted for in the initial fee baseline calculation.
+func TestInitFeeBaselineWithAuxCloseOutputs(t *testing.T) {
+	t.Parallel()
+
+	localScript := bytes.Repeat([]byte{0x11}, 34)
+	remoteScript := bytes.Repeat([]byte{0x22}, 34)
+	extraScript := bytes.Repeat([]byte{0x33}, 34)
+
+	channel := &mockChannel{
+		initiator: true,
+	}
+
+	newCloser := func(auxCloser fn.Option[AuxChanCloser]) *ChanCloser {
+		closer := NewChanCloser(
+			ChanCloseCfg{
+				Channel:      channel,
+				FeeEstimator: &SimpleCoopFeeEstimator{},
+				AuxCloser:    auxCloser,
+			},
+			DeliveryAddrWithKey{
+				DeliveryAddress: localScript,
+			},
+			chainfee.FeePerKwFloor, 0, nil, lntypes.Local,
+		)
+		closer.remoteDeliveryScript = remoteScript
+
+		return closer
+	}
+
+	closerNoAux := newCloser(fn.None[AuxChanCloser]())
+	require.NoError(t, closerNoAux.initFeeBaseline())
+
+	closerWithAux := newCloser(fn.Some[AuxChanCloser](&mockAuxChanCloser{
+		extraScript: extraScript,
+	}))
+	require.NoError(t, closerWithAux.initFeeBaseline())
+
+	localOutput := &wire.TxOut{
+		PkScript: localScript,
+		Value:    0,
+	}
+	remoteOutput := &wire.TxOut{
+		PkScript: remoteScript,
+		Value:    0,
+	}
+	extraOutput := &wire.TxOut{
+		PkScript: extraScript,
+		Value:    0,
+	}
+
+	expectedFeeNoAux := calcCoopCloseFee(
+		0, localOutput, remoteOutput, nil, chainfee.FeePerKwFloor,
+	)
+	expectedFeeWithAux := calcCoopCloseFee(
+		0, localOutput, remoteOutput, []*wire.TxOut{extraOutput},
+		chainfee.FeePerKwFloor,
+	)
+
+	require.Equal(t, expectedFeeNoAux, closerNoAux.idealFeeSat)
+	require.Equal(t, expectedFeeWithAux, closerWithAux.idealFeeSat)
+	require.Greater(t, closerWithAux.idealFeeSat, closerNoAux.idealFeeSat)
 }
 
 // TestMaxFeeBailOut tests that once the negotiated fee rate rises above our
@@ -541,7 +638,7 @@ func TestTaprootFastClose(t *testing.T) {
 			},
 		}, DeliveryAddrWithKey{}, idealFee, 0, nil, lntypes.Local,
 	)
-	aliceCloser.initFeeBaseline()
+	require.NoError(t, aliceCloser.initFeeBaseline())
 
 	bobCloser := NewChanCloser(
 		ChanCloseCfg{
@@ -558,7 +655,7 @@ func TestTaprootFastClose(t *testing.T) {
 			},
 		}, DeliveryAddrWithKey{}, idealFee, 0, nil, lntypes.Remote,
 	)
-	bobCloser.initFeeBaseline()
+	require.NoError(t, bobCloser.initFeeBaseline())
 
 	// With our set up complete, we'll now initialize the shutdown
 	// procedure kicked off by Alice.

--- a/lnwallet/chancloser/chancloser_test.go
+++ b/lnwallet/chancloser/chancloser_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnutils"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	wallettypes "github.com/lightningnetwork/lnd/lnwallet/types"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/stretchr/testify/require"
@@ -311,12 +312,56 @@ func (m *mockMusigSession) ClosingNonce() (*musig2.Nonces, error) {
 	}, nil
 }
 
+type mockAuxChanCloser struct {
+	extraScript []byte
+}
+
+func (m *mockAuxChanCloser) ShutdownBlob(
+	req wallettypes.AuxShutdownReq,
+) (fn.Option[lnwire.CustomRecords], error) {
+
+	return fn.None[lnwire.CustomRecords](), nil
+}
+
+func (m *mockAuxChanCloser) AuxCloseShape(
+	desc wallettypes.AuxCloseShapeDesc) (fn.Option[AuxCloseShape], error) {
+
+	return fn.Some(AuxCloseShape{
+		Outputs: []AuxCloseOutputShape{{
+			IsLocal:      true,
+			PkScriptSize: len(m.extraScript),
+		}},
+	}), nil
+}
+
+func (m *mockAuxChanCloser) AuxCloseOutputs(
+	desc wallettypes.AuxCloseDesc) (fn.Option[AuxCloseOutputs], error) {
+
+	closeOutputs := []lnwallet.CloseOutput{{
+		TxOut: wire.TxOut{
+			PkScript: m.extraScript,
+			Value:    0,
+		},
+		IsLocal: true,
+	}}
+
+	return fn.Some(AuxCloseOutputs{
+		ExtraCloseOutputs: closeOutputs,
+	}), nil
+}
+
+func (m *mockAuxChanCloser) FinalizeClose(desc wallettypes.AuxCloseDesc,
+	closeTx *wire.MsgTx) error {
+
+	return nil
+}
+
 type mockCoopFeeEstimator struct {
 	targetFee btcutil.Amount
 }
 
 func (m *mockCoopFeeEstimator) EstimateFee(chanType channeldb.ChannelType,
-	localTxOut, remoteTxOut *wire.TxOut,
+	localTxOut, remoteTxOut *wire.TxOut, extraTxOuts []*wire.TxOut,
 	idealFeeRate chainfee.SatPerKWeight) btcutil.Amount {
 
 	return m.targetFee
@@ -377,9 +422,155 @@ func TestMaxFeeClamp(t *testing.T) {
 
 			// We'll call initFeeBaseline early here since we need
 			// the populate these internal variables.
-			chanCloser.initFeeBaseline()
+			require.NoError(t, chanCloser.initFeeBaseline())
 
 			require.Equal(t, test.maxFee, chanCloser.maxFee)
+		})
+	}
+}
+
+// TestInitFeeBaselineWithAuxCloseOutputs tests that aux close outputs are
+// accounted for in the initial fee baseline calculation.
+func TestInitFeeBaselineWithAuxCloseOutputs(t *testing.T) {
+	t.Parallel()
+
+	localScript := bytes.Repeat([]byte{0x11}, 34)
+	remoteScript := bytes.Repeat([]byte{0x22}, 34)
+	extraScript := bytes.Repeat([]byte{0x33}, 34)
+
+	channel := &mockChannel{
+		initiator: true,
+	}
+
+	newCloser := func(auxCloser fn.Option[AuxChanCloser]) *ChanCloser {
+		closer := NewChanCloser(
+			ChanCloseCfg{
+				Channel:      channel,
+				FeeEstimator: &SimpleCoopFeeEstimator{},
+				AuxCloser:    auxCloser,
+			},
+			DeliveryAddrWithKey{
+				DeliveryAddress: localScript,
+			},
+			chainfee.FeePerKwFloor, 0, nil, lntypes.Local,
+		)
+		closer.remoteDeliveryScript = remoteScript
+
+		return closer
+	}
+
+	closerNoAux := newCloser(fn.None[AuxChanCloser]())
+	require.NoError(t, closerNoAux.initFeeBaseline())
+
+	closerWithAux := newCloser(fn.Some[AuxChanCloser](&mockAuxChanCloser{
+		extraScript: extraScript,
+	}))
+	require.NoError(t, closerWithAux.initFeeBaseline())
+
+	localOutput := &wire.TxOut{
+		PkScript: localScript,
+		Value:    0,
+	}
+	remoteOutput := &wire.TxOut{
+		PkScript: remoteScript,
+		Value:    0,
+	}
+	extraOutput := &wire.TxOut{
+		PkScript: extraScript,
+		Value:    0,
+	}
+
+	expectedFeeNoAux := calcCoopCloseFee(
+		0, localOutput, remoteOutput, nil, chainfee.FeePerKwFloor,
+	)
+	expectedFeeWithAux := calcCoopCloseFee(
+		0, localOutput, remoteOutput, []*wire.TxOut{extraOutput},
+		chainfee.FeePerKwFloor,
+	)
+
+	require.Equal(t, expectedFeeNoAux, closerNoAux.idealFeeSat)
+	require.Equal(t, expectedFeeWithAux, closerWithAux.idealFeeSat)
+	require.Greater(t, closerWithAux.idealFeeSat, closerNoAux.idealFeeSat)
+}
+
+// TestValidateAuxShape tests that concrete aux close outputs are matched
+// against the shape declared for fee estimation, independent of ordering.
+func TestValidateAuxShape(t *testing.T) {
+	t.Parallel()
+
+	shape := func(outs ...AuxCloseOutputShape) fn.Option[AuxCloseShape] {
+		return fn.Some(AuxCloseShape{Outputs: outs})
+	}
+	outputs := func(outs ...lnwallet.CloseOutput) fn.Option[AuxCloseOutputs] { //nolint:ll
+		return fn.Some(AuxCloseOutputs{ExtraCloseOutputs: outs})
+	}
+	closeOut := func(isLocal bool, scriptSize int) lnwallet.CloseOutput {
+		return lnwallet.CloseOutput{
+			TxOut: wire.TxOut{
+				PkScript: make([]byte, scriptSize),
+			},
+			IsLocal: isLocal,
+		}
+	}
+
+	testCases := []struct {
+		name       string
+		shape      fn.Option[AuxCloseShape]
+		auxOutputs fn.Option[AuxCloseOutputs]
+		valid      bool
+	}{{
+		name:       "both absent",
+		shape:      fn.None[AuxCloseShape](),
+		auxOutputs: fn.None[AuxCloseOutputs](),
+		valid:      true,
+	}, {
+		name: "matching outputs in different order",
+		shape: shape(
+			AuxCloseOutputShape{IsLocal: true, PkScriptSize: 34},
+			AuxCloseOutputShape{IsLocal: false, PkScriptSize: 34},
+		),
+		auxOutputs: outputs(
+			closeOut(false, 34), closeOut(true, 34),
+		),
+		valid: true,
+	}, {
+		name:       "undeclared output",
+		shape:      fn.None[AuxCloseShape](),
+		auxOutputs: outputs(closeOut(true, 34)),
+		valid:      false,
+	}, {
+		name: "missing output",
+		shape: shape(
+			AuxCloseOutputShape{IsLocal: true, PkScriptSize: 34},
+		),
+		auxOutputs: fn.None[AuxCloseOutputs](),
+		valid:      false,
+	}, {
+		name: "script size mismatch",
+		shape: shape(
+			AuxCloseOutputShape{IsLocal: true, PkScriptSize: 34},
+		),
+		auxOutputs: outputs(closeOut(true, 35)),
+		valid:      false,
+	}, {
+		name: "ownership mismatch",
+		shape: shape(
+			AuxCloseOutputShape{IsLocal: true, PkScriptSize: 34},
+		),
+		auxOutputs: outputs(closeOut(false, 34)),
+		valid:      false,
+	}}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := validateAuxShape(
+				testCase.shape, testCase.auxOutputs,
+			)
+			if testCase.valid {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, ErrAuxShapeMismatch)
+			}
 		})
 	}
 }
@@ -541,7 +732,7 @@ func TestTaprootFastClose(t *testing.T) {
 			},
 		}, DeliveryAddrWithKey{}, idealFee, 0, nil, lntypes.Local,
 	)
-	aliceCloser.initFeeBaseline()
+	require.NoError(t, aliceCloser.initFeeBaseline())
 
 	bobCloser := NewChanCloser(
 		ChanCloseCfg{
@@ -558,7 +749,7 @@ func TestTaprootFastClose(t *testing.T) {
 			},
 		}, DeliveryAddrWithKey{}, idealFee, 0, nil, lntypes.Remote,
 	)
-	bobCloser.initFeeBaseline()
+	require.NoError(t, bobCloser.initFeeBaseline())
 
 	// With our set up complete, we'll now initialize the shutdown
 	// procedure kicked off by Alice.

--- a/lnwallet/chancloser/interface.go
+++ b/lnwallet/chancloser/interface.go
@@ -18,11 +18,13 @@ import (
 type CoopFeeEstimator interface {
 	// EstimateFee estimates an _absolute_ fee for a co-op close transaction
 	// given the local+remote tx outs (for the co-op close transaction),
+	// any extra (e.g. auxiliary) outputs the close transaction will carry,
 	// channel type, and ideal fee rate. If a passed TxOut is nil, then
 	// that indicates that an output is dust on the co-op close transaction
 	// _before_ fees are accounted for.
 	EstimateFee(chanType channeldb.ChannelType,
 		localTxOut, remoteTxOut *wire.TxOut,
+		extraTxOuts []*wire.TxOut,
 		idealFeeRate chainfee.SatPerKWeight) btcutil.Amount
 }
 

--- a/lnwallet/chancloser/mock.go
+++ b/lnwallet/chancloser/mock.go
@@ -89,10 +89,12 @@ type mockFeeEstimator struct {
 }
 
 func (m *mockFeeEstimator) EstimateFee(chanType channeldb.ChannelType,
-	localTxOut, remoteTxOut *wire.TxOut,
+	localTxOut, remoteTxOut *wire.TxOut, extraTxOuts []*wire.TxOut,
 	idealFeeRate chainfee.SatPerKWeight) btcutil.Amount {
 
-	args := m.Called(chanType, localTxOut, remoteTxOut, idealFeeRate)
+	args := m.Called(
+		chanType, localTxOut, remoteTxOut, extraTxOuts, idealFeeRate,
+	)
 	return args.Get(0).(btcutil.Amount)
 }
 

--- a/lnwallet/chancloser/rbf_coop_test.go
+++ b/lnwallet/chancloser/rbf_coop_test.go
@@ -416,7 +416,7 @@ func (r *rbfCloserTestHarness) expectFeeEstimate(absoluteFee btcutil.Amount,
 
 	r.feeEstimator.On(
 		"EstimateFee", mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything,
+		mock.Anything, mock.Anything,
 	).Return(absoluteFee, nil).Times(numTimes)
 }
 

--- a/lnwallet/chancloser/rbf_coop_transitions.go
+++ b/lnwallet/chancloser/rbf_coop_transitions.go
@@ -613,7 +613,7 @@ func (c *ChannelFlushing) ProcessEvent(event ProtocolEvent, env *Environment,
 		// we'd propose.
 		localTxOut, remoteTxOut := closeTerms.DeriveCloseTxOuts()
 		absoluteFee := env.FeeEstimator.EstimateFee(
-			env.ChanType, localTxOut, remoteTxOut,
+			env.ChanType, localTxOut, remoteTxOut, nil,
 			idealFeeRate.FeePerKWeight(),
 		)
 
@@ -1135,7 +1135,7 @@ func (l *LocalCloseStart) ProcessEvent(event ProtocolEvent, env *Environment,
 		// First, we'll figure out the absolute fee rate we should pay
 		localTxOut, remoteTxOut := l.DeriveCloseTxOuts()
 		absoluteFee := env.FeeEstimator.EstimateFee(
-			env.ChanType, localTxOut, remoteTxOut,
+			env.ChanType, localTxOut, remoteTxOut, nil,
 			msg.TargetFeeRate.FeePerKWeight(),
 		)
 

--- a/lnwallet/types/close_types.go
+++ b/lnwallet/types/close_types.go
@@ -51,6 +51,12 @@ type AuxShutdownReq struct {
 	FundingBlob fn.Option[tlv.Blob]
 }
 
+// AuxCloseShapeDesc describes a channel close for which the fee-independent
+// shape of the auxiliary close outputs is being queried.
+type AuxCloseShapeDesc struct {
+	AuxShutdownReq
+}
+
 // AuxCloseDesc is used to describe the channel close that is being performed.
 type AuxCloseDesc struct {
 	AuxShutdownReq

--- a/peer/musig_nonce_order_test.go
+++ b/peer/musig_nonce_order_test.go
@@ -108,7 +108,7 @@ func TestRemoteCloseStartTaprootIntegration(t *testing.T) {
 	feeEstimator := &mockCoopFeeEstimator{}
 	feeEstimator.On(
 		"EstimateFee", mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything,
 	).Return(btcutil.Amount(1000))
 
 	chanObserver := &mockChanObserver{}
@@ -246,9 +246,12 @@ type mockCoopFeeEstimator struct {
 
 func (m *mockCoopFeeEstimator) EstimateFee(
 	chanType channeldb.ChannelType, localTxOut, remoteTxOut *wire.TxOut,
+	extraTxOuts []*wire.TxOut,
 	idealFeeRate chainfee.SatPerKWeight) btcutil.Amount {
 
-	args := m.Called(chanType, localTxOut, remoteTxOut, idealFeeRate)
+	args := m.Called(
+		chanType, localTxOut, remoteTxOut, extraTxOuts, idealFeeRate,
+	)
 
 	amt, _ := args.Get(0).(btcutil.Amount)
 


### PR DESCRIPTION
> Reopens #10615, which was auto-closed by GitHub when my fork was deleted. Same commit, same diff.

### Problem

Custom channel coop closes can fail with: `unable to process close msg: insufficient fee`.

### Root cause

For taproot/custom channels, `ChanCloser` computed the initial coop close fee (`idealFeeSat`) from only local+remote outputs, but the final close tx can include auxiliary extra outputs.

That mismatch can underprice the first accepted close offer (notably in taproot fast-close), causing mempool rejection and peer disconnect.

### Fix

Extend coop close fee weight calculation to include optional extra outputs.