### PR TITLE
multi: write `connect --perm` address into the peer's LinkNode record

### DIFF
--- a/channeldb/nodes.go
+++ b/channeldb/nodes.go
@@ -225,6 +225,57 @@ func (l *LinkNodeDB) CreateLinkNodes(tx kvdb.RwTx,
 	return createNodes(tx)
 }
 
+// AddAddressForPeer ensures a LinkNode exists for the given pubkey and
+// records addr as one of its known addresses. If no LinkNode currently
+// exists for the peer, a new one is created with the given network. If a
+// LinkNode already exists, addr is appended to its address list (deduped
+// by string comparison); the network of the existing entry is preserved.
+// The returned bool is true when the address was newly added (the stored
+// set grew), false when it was already present.
+//
+// Used by `lncli connect --perm` to remember a peer's address across
+// restarts even when no channel exists with the peer yet.
+func (l *LinkNodeDB) AddAddressForPeer(net wire.BitcoinNet,
+	pub *btcec.PublicKey, addr net.Addr) (bool, error) {
+
+	var added bool
+	err := kvdb.Update(l.backend, func(tx kvdb.RwTx) error {
+		nodeMetaBucket, err := tx.CreateTopLevelBucket(nodeInfoBucket)
+		if err != nil {
+			return err
+		}
+
+		existing, err := fetchLinkNode(tx, pub)
+		switch {
+		case err == nil:
+			// LinkNode already exists — union in the new address
+			// (dedup by string).
+			for _, a := range existing.Addresses {
+				if a.String() == addr.String() {
+					added = false
+					return nil
+				}
+			}
+			existing.Addresses = append(existing.Addresses, addr)
+			added = true
+			return putLinkNode(nodeMetaBucket, existing)
+
+		case errors.Is(err, ErrNodeNotFound),
+			errors.Is(err, ErrLinkNodesNotFound):
+			// No LinkNode yet — create a fresh one.
+			ln := NewLinkNode(l, net, pub, addr)
+			added = true
+			return putLinkNode(nodeMetaBucket, ln)
+
+		default:
+			return err
+		}
+	}, func() {
+		added = false
+	})
+	return added, err
+}
+
 // DeleteLinkNode removes the link node with the given identity from the
 // database.
 func (l *LinkNodeDB) DeleteLinkNode(identity *btcec.PublicKey) error {

--- a/cmd/commands/commands.go
+++ b/cmd/commands/commands.go
@@ -1633,11 +1633,19 @@ func parseChannelPoint(ctx *cli.Context) (*lnrpc.ChannelPoint, error) {
 var listPeersCommand = cli.Command{
 	Name:     "listpeers",
 	Category: "Peers",
-	Usage:    "List all active, currently connected peers.",
+	Usage: "List currently connected peers, and optionally also " +
+		"offline peers that lnd is auto-reconnecting to.",
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "list_errors",
 			Usage: "list a full set of most recent errors for the peer",
+		},
+		cli.BoolFlag{
+			Name: "include_offline_persistent_peers",
+			Usage: "also list peers that lnd is auto-reconnecting " +
+				"to but is not currently connected to — " +
+				"either via a stored LinkNode record or " +
+				"because of an open channel",
 		},
 	},
 	Action: actionDecorator(listPeers),
@@ -1652,6 +1660,9 @@ func listPeers(ctx *cli.Context) error {
 	// specifically requests a full error set, then we will provide it.
 	req := &lnrpc.ListPeersRequest{
 		LatestError: !ctx.IsSet("list_errors"),
+		IncludeOfflinePersistentPeers: ctx.Bool(
+			"include_offline_persistent_peers",
+		),
 	}
 	resp, err := client.ListPeers(ctxc, req)
 	if err != nil {

--- a/cmd/commands/commands.go
+++ b/cmd/commands/commands.go
@@ -927,8 +927,15 @@ var connectCommand = cli.Command{
 		cli.BoolFlag{
 			Name: "perm",
 			Usage: "If set, the daemon will attempt to persistently " +
-				"connect to the target peer.\n" +
-				"           If not, the call will be synchronous.",
+				"connect to the target peer and record the " +
+				"address on disk so lnd reconnects after a " +
+				"restart. If not, the call is synchronous and " +
+				"only affects the current session. Known " +
+				"limitation: --perm-only records for peers we " +
+				"have never opened a channel with are pruned " +
+				"at daemon startup, so --perm on such a peer " +
+				"does not currently survive a restart; --perm " +
+				"for channel peers (open or historical) does.",
 		},
 		cli.DurationFlag{
 			Name: "timeout",

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -72,12 +72,25 @@
   the chain backend via bitcoind's `submitpackage`, allowing a zero-fee v3/TRUC
   parent to be accepted together with a fee-paying CPFP child.
 
+* [`ListPeers` gains address-source
+  detail](https://github.com/lightningnetwork/lnd/pull/10973). Each `Peer`
+  now carries `remembered_addresses` (addresses lnd has stored for the peer),
+  `gossip_addresses` (from the peer's current `NodeAnnouncement`),
+  `is_persistent` (true if lnd is auto-reconnecting to the peer), and
+  `reconnect_pending` (true if a retry is in flight). A new
+  `ListPeersRequest.include_offline_persistent_peers` flag opts into
+  surfacing peers in the reconnect set we are not currently connected to.
+
 ## lncli Additions
 
 * The `estimateroutefee` command now supports [restricting fee estimates to
   specific first-hop outgoing
   channels](https://github.com/lightningnetwork/lnd/pull/10501) via the new
   `--outgoing_chan_id` flag.
+
+* `lncli listpeers` gains
+  [`--include_offline_persistent_peers`](https://github.com/lightningnetwork/lnd/pull/10973)
+  (see the `ListPeers` RPC entry above).
 
 * A new
   [`wallet submitpackage`](https://github.com/lightningnetwork/lnd/pull/10900)
@@ -148,3 +161,4 @@
 * Boris Nagaev
 * Erick Cestari
 * Jared Tobin
+* ZZiigguurraatt

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -59,6 +59,27 @@
 
 ## Functional Enhancements
 
+* [`lncli connect --perm` now writes the requested address to the
+  peer's LinkNode
+  record](https://github.com/lightningnetwork/lnd/pull/XXXX). For peers
+  that also have (or have had) an open channel, this means a `--perm`-
+  supplied address is remembered across lnd restarts alongside the
+  address captured at first channel open, and is visible in
+  `ListPeers.remembered_addresses`. Channel-driven reconnect behaviour
+  is otherwise unchanged.
+
+  Known limitations: (1) `PruneLinkNodes` still runs at startup and
+  deletes LinkNode entries for peers with no open channels, so `--perm`
+  on a peer we have never opened a channel with does **not** currently
+  survive a restart — this may be addressed as a follow-up once the
+  migration to native SQL is complete. (2) `--perm` is add-only:
+  repeated calls accumulate addresses in the LinkNode, and there is no
+  supported way yet to remove an individual stored address without
+  disconnecting the peer — a separate follow-up will add manual
+  removal. Contributes to
+  [#10870](https://github.com/lightningnetwork/lnd/issues/10870) and
+  [#10871](https://github.com/lightningnetwork/lnd/issues/10871).
+
 ## RPC Additions
 
 * The `routerrpc.EstimateRouteFee` RPC now supports [restricting fee estimates

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -155,6 +155,14 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testListPeersAddressFields,
 	},
 	{
+		Name:     "perm adds remembered address",
+		TestFunc: testPermAddsRememberedAddress,
+	},
+	{
+		Name:     "perm non-channel peer lost on restart",
+		TestFunc: testPermNonChannelPeerLostOnRestart,
+	},
+	{
 		Name:     "addpeer config",
 		TestFunc: testAddPeerConfig,
 	},

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -151,6 +151,10 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testReconnectAfterIPChange,
 	},
 	{
+		Name:     "listpeers address fields",
+		TestFunc: testListPeersAddressFields,
+	},
+	{
 		Name:     "addpeer config",
 		TestFunc: testAddPeerConfig,
 	},

--- a/itest/lnd_network_test.go
+++ b/itest/lnd_network_test.go
@@ -414,3 +414,138 @@ func testListPeersAddressFields(ht *lntest.HarnessTest) {
 	require.NoError(ht, restartBob())
 }
 
+// testPermAddsRememberedAddress verifies that `lncli connect --perm`
+// records the requested address in the LinkNode store, so it shows up in
+// the peer's remembered_addresses list and (for peers with an open
+// channel) survives lnd restarts alongside the channel-open capture.
+//
+// This test exercises the "already connected + --perm" code path — the
+// active connection is left untouched; the only observable effect is
+// that remembered_addresses grows.
+//
+// Limitation: for peers with no open channel, --perm-added LinkNode
+// entries are pruned at startup by PruneLinkNodes, so a fresh-restart
+// reconnect on a non-channel peer is NOT covered here.
+func testPermAddsRememberedAddress(ht *lntest.HarnessTest) {
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNode("Bob", nil)
+	bobInfo := bob.RPC.GetInfo()
+
+	// Establish a channel so Bob gets a LinkNode from the channel-open
+	// path (this is what makes --perm-added addresses survive restart
+	// through PruneLinkNodes).
+	ht.ConnectNodes(alice, bob)
+	ht.OpenChannel(alice, bob, lntest.OpenChannelParams{Amt: 100_000})
+
+	bobPeer := func() *lnrpc.Peer {
+		resp := alice.RPC.ListPeersReq(&lnrpc.ListPeersRequest{})
+		for _, p := range resp.Peers {
+			if p.PubKey == bobInfo.IdentityPubkey {
+				return p
+			}
+		}
+		return nil
+	}
+
+	// Sanity: Bob's real P2P address should already be in
+	// remembered_addresses via the channel-open LinkNode capture.
+	require.NoError(ht, wait.NoError(func() error {
+		p := bobPeer()
+		if p == nil {
+			return fmt.Errorf("bob not yet in listpeers")
+		}
+		for _, a := range p.RememberedAddresses {
+			if a == bob.Cfg.P2PAddr() {
+				return nil
+			}
+		}
+		return fmt.Errorf("expected %s in remembered_addresses, "+
+			"got %v", bob.Cfg.P2PAddr(), p.RememberedAddresses)
+	}, defaultTimeout))
+
+	// --perm connect to a new (unreachable) address for Bob. Alice is
+	// already connected via the channel path, so this exercises the
+	// "already connected + --perm" branch: LinkNode gets the new
+	// address, no new active dial is required.
+	extraAddr := "127.0.0.1:1"
+	alice.RPC.ConnectPeer(&lnrpc.ConnectPeerRequest{
+		Addr: &lnrpc.LightningAddress{
+			Pubkey: bobInfo.IdentityPubkey,
+			Host:   extraAddr,
+		},
+		Perm: true,
+	})
+
+	// remembered_addresses should now include both.
+	require.NoError(ht, wait.NoError(func() error {
+		p := bobPeer()
+		if p == nil {
+			return fmt.Errorf("bob not in listpeers")
+		}
+		haveOrig, haveExtra := false, false
+		for _, a := range p.RememberedAddresses {
+			switch a {
+			case bob.Cfg.P2PAddr():
+				haveOrig = true
+			case extraAddr:
+				haveExtra = true
+			}
+		}
+		if !haveOrig || !haveExtra {
+			return fmt.Errorf("expected both %s and %s in "+
+				"remembered_addresses, got %v",
+				bob.Cfg.P2PAddr(), extraAddr,
+				p.RememberedAddresses)
+		}
+		return nil
+	}, defaultTimeout))
+
+	// Repeating the same --perm call with an address that is already
+	// stored is a no-op: the RPC should error out (consistent with the
+	// plain-`connect` behaviour when the request has nothing to do).
+	err := alice.RPC.ConnectPeerAssertErr(&lnrpc.ConnectPeerRequest{
+		Addr: &lnrpc.LightningAddress{
+			Pubkey: bobInfo.IdentityPubkey,
+			Host:   extraAddr,
+		},
+		Perm: true,
+	})
+	require.Error(ht, err,
+		"a redundant --perm to an already-stored address should "+
+			"error")
+}
+
+// testPermNonChannelPeerLostOnRestart pins down a known limitation of
+// the LinkNode-backed --perm persistence: for peers we have never opened
+// a channel with, PruneLinkNodes at startup deletes the LinkNode entry,
+// so the peer is NOT reconnected to after a restart.
+//
+// If PruneLinkNodes is ever taught to spare user-persistent entries,
+// this test should be flipped to assert AssertConnected instead and
+// renamed accordingly.
+func testPermNonChannelPeerLostOnRestart(ht *lntest.HarnessTest) {
+	alice := ht.NewNode("Alice", nil)
+	bob := ht.NewNode("Bob", nil)
+	bobInfo := bob.RPC.GetInfo()
+
+	ht.ConnectNodesPerm(alice, bob)
+	ht.AssertConnected(alice, bob)
+
+	ht.RestartNode(alice)
+
+	// After restart, PruneLinkNodes will have deleted Bob's LinkNode
+	// (no channel exists), so Bob should NOT be in Alice's persistent
+	// reconnect set — even with include_offline_persistent_peers set,
+	// Bob must not appear.
+	listResp := alice.RPC.ListPeersReq(&lnrpc.ListPeersRequest{
+		IncludeOfflinePersistentPeers: true,
+	})
+	for _, p := range listResp.Peers {
+		require.NotEqual(ht, bobInfo.IdentityPubkey, p.PubKey,
+			"bob should not be in the persistent set — his "+
+				"LinkNode was pruned at startup")
+	}
+}
+
+
+

--- a/itest/lnd_network_test.go
+++ b/itest/lnd_network_test.go
@@ -333,3 +333,84 @@ func testDisconnectingTargetPeer(ht *lntest.HarnessTest) {
 	// Check existing connection.
 	ht.AssertConnected(alice, bob)
 }
+
+// testListPeersAddressFields verifies the address-source fields that
+// ListPeers exposes on the Peer message: is_persistent, remembered_addresses
+// (from the LinkNode record), gossip_addresses (from NodeAnnouncement),
+// reconnect_pending, and the include_offline_persistent_peers request flag.
+func testListPeersAddressFields(ht *lntest.HarnessTest) {
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNode("Bob", nil)
+	bobInfo := bob.RPC.GetInfo()
+
+	// Opening a channel writes a LinkNode record for the peer (this is
+	// what remembered_addresses reads from), and puts the peer in the
+	// persistent-reconnect set.
+	ht.ConnectNodes(alice, bob)
+	ht.OpenChannel(alice, bob, lntest.OpenChannelParams{Amt: 100_000})
+
+	// Helper: pull Bob's entry out of Alice's ListPeers response.
+	bobPeer := func(req *lnrpc.ListPeersRequest) *lnrpc.Peer {
+		resp := alice.RPC.ListPeersReq(req)
+		for _, p := range resp.Peers {
+			if p.PubKey == bobInfo.IdentityPubkey {
+				return p
+			}
+		}
+		return nil
+	}
+
+	// While connected, the new fields should be populated.
+	require.NoError(ht, wait.NoError(func() error {
+		p := bobPeer(&lnrpc.ListPeersRequest{})
+		if p == nil {
+			return fmt.Errorf("bob not yet in listpeers")
+		}
+		if !p.IsPersistent {
+			return fmt.Errorf("is_persistent should be true for " +
+				"a channel peer")
+		}
+		if len(p.RememberedAddresses) == 0 {
+			return fmt.Errorf("remembered_addresses should be " +
+				"populated for a channel peer")
+		}
+		if p.ReconnectPending {
+			return fmt.Errorf("reconnect_pending should be " +
+				"false while connected")
+		}
+		return nil
+	}, defaultTimeout))
+
+	// Stop Bob so Alice's connection to him drops.
+	restartBob := ht.SuspendNode(bob)
+
+	// Without include_offline_persistent_peers, Bob should not appear
+	// in the response once his connection is gone.
+	require.NoError(ht, wait.NoError(func() error {
+		p := bobPeer(&lnrpc.ListPeersRequest{})
+		if p != nil {
+			return fmt.Errorf("bob still visible without " +
+				"include_offline_persistent_peers")
+		}
+		return nil
+	}, defaultTimeout))
+
+	// With include_offline_persistent_peers, Bob should appear as an
+	// offline persistent entry: address empty, remembered_addresses
+	// populated, is_persistent true.
+	p := bobPeer(&lnrpc.ListPeersRequest{
+		IncludeOfflinePersistentPeers: true,
+	})
+	require.NotNil(ht, p,
+		"bob should appear when include_offline_persistent_peers=true")
+	require.Empty(ht, p.Address,
+		"offline entry should have empty address")
+	require.True(ht, p.IsPersistent,
+		"offline channel peer should still be is_persistent")
+	require.NotEmpty(ht, p.RememberedAddresses,
+		"offline channel peer should still expose remembered_addresses")
+
+	// Bring Bob back online so the test doesn't leave a hung retry.
+	require.NoError(ht, restartBob())
+}
+

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -4166,7 +4166,14 @@ type ConnectPeerRequest struct {
 	// Lightning address of the peer to connect to.
 	Addr *LightningAddress `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
 	// If set, the daemon will attempt to persistently connect to the target
-	// peer. Otherwise, the call will be synchronous.
+	// peer and record the address in the peer's LinkNode entry so lnd
+	// reconnects to it after a restart. Otherwise, the call will be
+	// synchronous and only affects the current session.
+	//
+	// Known limitation: LinkNode entries for peers with no open channel are
+	// pruned at daemon startup, so `perm` on a peer we have never opened a
+	// channel with does not currently survive a restart. `perm` for peers
+	// we do share a channel with (open or historical) does persist.
 	Perm bool `protobuf:"varint,2,opt,name=perm,proto3" json:"perm,omitempty"`
 	// The connection timeout value (in seconds) for this request. It won't affect
 	// other requests.
@@ -5694,7 +5701,7 @@ type Peer struct {
 	// channel-driven persistent entry exists).
 	IsPersistent bool `protobuf:"varint,16,opt,name=is_persistent,json=isPersistent,proto3" json:"is_persistent,omitempty"`
 	// Addresses lnd has stored for the peer via its LinkNode record
-	// (captured at first channel open). Empty if no LinkNode entry exists
+	// (channel open or `connect --perm`). Empty if no LinkNode entry exists
 	// for the peer. Note: this list is reported verbatim from storage,
 	// including any v2 .onion entries lnd will not dial (v2 was deprecated
 	// by the Tor project in 2021). v2 entries are preserved on disk so

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -5650,7 +5650,10 @@ type Peer struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The identity pubkey of the peer
 	PubKey string `protobuf:"bytes,1,opt,name=pub_key,json=pubKey,proto3" json:"pub_key,omitempty"`
-	// Network address of the peer; eg `127.0.0.1:10011`
+	// Network address of the currently active connection to the peer; e.g.
+	// `127.0.0.1:10011`. Empty when the entry represents a persistent peer
+	// that is not currently connected (only present in the response when
+	// the request sets `include_offline_persistent_peers`).
 	Address string `protobuf:"bytes,3,opt,name=address,proto3" json:"address,omitempty"`
 	// Bytes of data transmitted to this peer
 	BytesSent uint64 `protobuf:"varint,4,opt,name=bytes_sent,json=bytesSent,proto3" json:"bytes_sent,omitempty"`
@@ -5686,8 +5689,28 @@ type Peer struct {
 	LastFlapNs int64 `protobuf:"varint,14,opt,name=last_flap_ns,json=lastFlapNs,proto3" json:"last_flap_ns,omitempty"`
 	// The last ping payload the peer has sent to us.
 	LastPingPayload []byte `protobuf:"bytes,15,opt,name=last_ping_payload,json=lastPingPayload,proto3" json:"last_ping_payload,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// True if lnd is maintaining a persistent reconnect attempt for this
+	// peer. Equivalent to (len(remembered_addresses) > 0 or an active
+	// channel-driven persistent entry exists).
+	IsPersistent bool `protobuf:"varint,16,opt,name=is_persistent,json=isPersistent,proto3" json:"is_persistent,omitempty"`
+	// Addresses lnd has stored for the peer via its LinkNode record
+	// (captured at first channel open). Empty if no LinkNode entry exists
+	// for the peer. Note: this list is reported verbatim from storage,
+	// including any v2 .onion entries lnd will not dial (v2 was deprecated
+	// by the Tor project in 2021). v2 entries are preserved on disk so
+	// that signed NodeAnnouncements still verify; a v2 appearing here is
+	// a stale-storage signal, not an indication that lnd is attempting to
+	// reach that address.
+	RememberedAddresses []string `protobuf:"bytes,17,rep,name=remembered_addresses,json=rememberedAddresses,proto3" json:"remembered_addresses,omitempty"`
+	// Addresses currently advertised by this peer in the gossip network's
+	// NodeAnnouncement. Empty when no NodeAnnouncement is known.
+	GossipAddresses []string `protobuf:"bytes,18,rep,name=gossip_addresses,json=gossipAddresses,proto3" json:"gossip_addresses,omitempty"`
+	// True if lnd currently has an in-flight reconnect attempt for this
+	// peer. Mainly informative for entries returned when the request sets
+	// `include_offline_persistent_peers`.
+	ReconnectPending bool `protobuf:"varint,19,opt,name=reconnect_pending,json=reconnectPending,proto3" json:"reconnect_pending,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *Peer) Reset() {
@@ -5818,6 +5841,34 @@ func (x *Peer) GetLastPingPayload() []byte {
 	return nil
 }
 
+func (x *Peer) GetIsPersistent() bool {
+	if x != nil {
+		return x.IsPersistent
+	}
+	return false
+}
+
+func (x *Peer) GetRememberedAddresses() []string {
+	if x != nil {
+		return x.RememberedAddresses
+	}
+	return nil
+}
+
+func (x *Peer) GetGossipAddresses() []string {
+	if x != nil {
+		return x.GossipAddresses
+	}
+	return nil
+}
+
+func (x *Peer) GetReconnectPending() bool {
+	if x != nil {
+		return x.ReconnectPending
+	}
+	return false
+}
+
 type TimestampedError struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The unix timestamp in seconds when the error occurred.
@@ -5877,9 +5928,16 @@ type ListPeersRequest struct {
 	// If true, only the last error that our peer sent us will be returned with
 	// the peer's information, rather than the full set of historic errors we have
 	// stored.
-	LatestError   bool `protobuf:"varint,1,opt,name=latest_error,json=latestError,proto3" json:"latest_error,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	LatestError bool `protobuf:"varint,1,opt,name=latest_error,json=latestError,proto3" json:"latest_error,omitempty"`
+	// If true, the response also includes peers that the daemon is keeping in
+	// the auto-reconnect set but is not currently connected to. A peer is in
+	// this set if lnd has a stored record for it (a LinkNode entry from a
+	// prior channel open or `connect --perm`) or an open channel. Per-
+	// connection fields (address, bytes_sent, ping_time, etc.) are empty/zero
+	// for these entries.
+	IncludeOfflinePersistentPeers bool `protobuf:"varint,2,opt,name=include_offline_persistent_peers,json=includeOfflinePersistentPeers,proto3" json:"include_offline_persistent_peers,omitempty"`
+	unknownFields                 protoimpl.UnknownFields
+	sizeCache                     protoimpl.SizeCache
 }
 
 func (x *ListPeersRequest) Reset() {
@@ -5915,6 +5973,13 @@ func (*ListPeersRequest) Descriptor() ([]byte, []int) {
 func (x *ListPeersRequest) GetLatestError() bool {
 	if x != nil {
 		return x.LatestError
+	}
+	return false
+}
+
+func (x *ListPeersRequest) GetIncludeOfflinePersistentPeers() bool {
+	if x != nil {
+		return x.IncludeOfflinePersistentPeers
 	}
 	return false
 }
@@ -18852,7 +18917,7 @@ const file_lightning_proto_rawDesc = "" +
 	"\x10funding_canceled\x18\x05 \x01(\bR\x0ffundingCanceled\x12\x1c\n" +
 	"\tabandoned\x18\x06 \x01(\bR\tabandoned\"P\n" +
 	"\x16ClosedChannelsResponse\x126\n" +
-	"\bchannels\x18\x01 \x03(\v2\x1a.lnrpc.ChannelCloseSummaryR\bchannels\"\x8b\x05\n" +
+	"\bchannels\x18\x01 \x03(\v2\x1a.lnrpc.ChannelCloseSummaryR\bchannels\"\xbb\x06\n" +
 	"\x04Peer\x12\x17\n" +
 	"\apub_key\x18\x01 \x01(\tR\x06pubKey\x12\x18\n" +
 	"\aaddress\x18\x03 \x01(\tR\aaddress\x12\x1d\n" +
@@ -18872,7 +18937,11 @@ const file_lightning_proto_rawDesc = "" +
 	"flap_count\x18\r \x01(\x05R\tflapCount\x12 \n" +
 	"\flast_flap_ns\x18\x0e \x01(\x03R\n" +
 	"lastFlapNs\x12*\n" +
-	"\x11last_ping_payload\x18\x0f \x01(\fR\x0flastPingPayload\x1aK\n" +
+	"\x11last_ping_payload\x18\x0f \x01(\fR\x0flastPingPayload\x12#\n" +
+	"\ris_persistent\x18\x10 \x01(\bR\fisPersistent\x121\n" +
+	"\x14remembered_addresses\x18\x11 \x03(\tR\x13rememberedAddresses\x12)\n" +
+	"\x10gossip_addresses\x18\x12 \x03(\tR\x0fgossipAddresses\x12+\n" +
+	"\x11reconnect_pending\x18\x13 \x01(\bR\x10reconnectPending\x1aK\n" +
 	"\rFeaturesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\rR\x03key\x12$\n" +
 	"\x05value\x18\x02 \x01(\v2\x0e.lnrpc.FeatureR\x05value:\x028\x01\"P\n" +
@@ -18883,9 +18952,10 @@ const file_lightning_proto_rawDesc = "" +
 	"\vPINNED_SYNC\x10\x03\"F\n" +
 	"\x10TimestampedError\x12\x1c\n" +
 	"\ttimestamp\x18\x01 \x01(\x04R\ttimestamp\x12\x14\n" +
-	"\x05error\x18\x02 \x01(\tR\x05error\"5\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error\"~\n" +
 	"\x10ListPeersRequest\x12!\n" +
-	"\flatest_error\x18\x01 \x01(\bR\vlatestError\"6\n" +
+	"\flatest_error\x18\x01 \x01(\bR\vlatestError\x12G\n" +
+	" include_offline_persistent_peers\x18\x02 \x01(\bR\x1dincludeOfflinePersistentPeers\"6\n" +
 	"\x11ListPeersResponse\x12!\n" +
 	"\x05peers\x18\x01 \x03(\v2\v.lnrpc.PeerR\x05peers\"\x17\n" +
 	"\x15PeerEventSubscription\"\x84\x01\n" +

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -1795,7 +1795,12 @@ message Peer {
     // The identity pubkey of the peer
     string pub_key = 1;
 
-    // Network address of the peer; eg `127.0.0.1:10011`
+    /*
+    Network address of the currently active connection to the peer; e.g.
+    `127.0.0.1:10011`. Empty when the entry represents a persistent peer
+    that is not currently connected (only present in the response when
+    the request sets `include_offline_persistent_peers`).
+    */
     string address = 3;
 
     // Bytes of data transmitted to this peer
@@ -1873,6 +1878,38 @@ message Peer {
     The last ping payload the peer has sent to us.
     */
     bytes last_ping_payload = 15;
+
+    /*
+    True if lnd is maintaining a persistent reconnect attempt for this
+    peer. Equivalent to (len(remembered_addresses) > 0 or an active
+    channel-driven persistent entry exists).
+    */
+    bool is_persistent = 16;
+
+    /*
+    Addresses lnd has stored for the peer via its LinkNode record
+    (captured at first channel open). Empty if no LinkNode entry exists
+    for the peer. Note: this list is reported verbatim from storage,
+    including any v2 .onion entries lnd will not dial (v2 was deprecated
+    by the Tor project in 2021). v2 entries are preserved on disk so
+    that signed NodeAnnouncements still verify; a v2 appearing here is
+    a stale-storage signal, not an indication that lnd is attempting to
+    reach that address.
+    */
+    repeated string remembered_addresses = 17;
+
+    /*
+    Addresses currently advertised by this peer in the gossip network's
+    NodeAnnouncement. Empty when no NodeAnnouncement is known.
+    */
+    repeated string gossip_addresses = 18;
+
+    /*
+    True if lnd currently has an in-flight reconnect attempt for this
+    peer. Mainly informative for entries returned when the request sets
+    `include_offline_persistent_peers`.
+    */
+    bool reconnect_pending = 19;
 }
 
 message TimestampedError {
@@ -1890,6 +1927,16 @@ message ListPeersRequest {
     stored.
     */
     bool latest_error = 1;
+
+    /*
+    If true, the response also includes peers that the daemon is keeping in
+    the auto-reconnect set but is not currently connected to. A peer is in
+    this set if lnd has a stored record for it (a LinkNode entry from a
+    prior channel open or `connect --perm`) or an open channel. Per-
+    connection fields (address, bytes_sent, ping_time, etc.) are empty/zero
+    for these entries.
+    */
+    bool include_offline_persistent_peers = 2;
 }
 message ListPeersResponse {
     // The list of currently connected peers

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -1258,7 +1258,14 @@ message ConnectPeerRequest {
 
     /*
     If set, the daemon will attempt to persistently connect to the target
-    peer. Otherwise, the call will be synchronous.
+    peer and record the address in the peer's LinkNode entry so lnd
+    reconnects to it after a restart. Otherwise, the call will be
+    synchronous and only affects the current session.
+
+    Known limitation: LinkNode entries for peers with no open channel are
+    pruned at daemon startup, so `perm` on a peer we have never opened a
+    channel with does not currently survive a restart. `perm` for peers
+    we do share a channel with (open or historical) does persist.
     */
     bool perm = 2;
 
@@ -1888,7 +1895,7 @@ message Peer {
 
     /*
     Addresses lnd has stored for the peer via its LinkNode record
-    (captured at first channel open). Empty if no LinkNode entry exists
+    (channel open or `connect --perm`). Empty if no LinkNode entry exists
     for the peer. Note: this list is reported verbatim from storage,
     including any v2 .onion entries lnd will not dial (v2 was deprecated
     by the Tor project in 2021). v2 entries are preserved on disk so

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -2442,6 +2442,13 @@
             "in": "query",
             "required": false,
             "type": "boolean"
+          },
+          {
+            "name": "include_offline_persistent_peers",
+            "description": "If true, the response also includes peers that the daemon is keeping in\nthe auto-reconnect set but is not currently connected to. A peer is in\nthis set if lnd has a stored record for it (a LinkNode entry from a\nprior channel open or `connect --perm`) or an open channel. Per-\nconnection fields (address, bytes_sent, ping_time, etc.) are empty/zero\nfor these entries.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "tags": [
@@ -6919,7 +6926,7 @@
         },
         "address": {
           "type": "string",
-          "title": "Network address of the peer; eg `127.0.0.1:10011`"
+          "description": "Network address of the currently active connection to the peer; e.g.\n`127.0.0.1:10011`. Empty when the entry represents a persistent peer\nthat is not currently connected (only present in the response when\nthe request sets `include_offline_persistent_peers`)."
         },
         "bytes_sent": {
           "type": "string",
@@ -6983,6 +6990,28 @@
           "type": "string",
           "format": "byte",
           "description": "The last ping payload the peer has sent to us."
+        },
+        "is_persistent": {
+          "type": "boolean",
+          "description": "True if lnd is maintaining a persistent reconnect attempt for this\npeer. Equivalent to (len(remembered_addresses) \u003e 0 or an active\nchannel-driven persistent entry exists)."
+        },
+        "remembered_addresses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Addresses lnd has stored for the peer via its LinkNode record\n(captured at first channel open). Empty if no LinkNode entry exists\nfor the peer. Note: this list is reported verbatim from storage,\nincluding any v2 .onion entries lnd will not dial (v2 was deprecated\nby the Tor project in 2021). v2 entries are preserved on disk so\nthat signed NodeAnnouncements still verify; a v2 appearing here is\na stale-storage signal, not an indication that lnd is attempting to\nreach that address."
+        },
+        "gossip_addresses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Addresses currently advertised by this peer in the gossip network's\nNodeAnnouncement. Empty when no NodeAnnouncement is known."
+        },
+        "reconnect_pending": {
+          "type": "boolean",
+          "description": "True if lnd currently has an in-flight reconnect attempt for this\npeer. Mainly informative for entries returned when the request sets\n`include_offline_persistent_peers`."
         }
       }
     },

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -4830,7 +4830,7 @@
         },
         "perm": {
           "type": "boolean",
-          "description": "If set, the daemon will attempt to persistently connect to the target\npeer. Otherwise, the call will be synchronous."
+          "description": "If set, the daemon will attempt to persistently connect to the target\npeer and record the address in the peer's LinkNode entry so lnd\nreconnects to it after a restart. Otherwise, the call will be\nsynchronous and only affects the current session.\n\nKnown limitation: LinkNode entries for peers with no open channel are\npruned at daemon startup, so `perm` on a peer we have never opened a\nchannel with does not currently survive a restart. `perm` for peers\nwe do share a channel with (open or historical) does persist."
         },
         "timeout": {
           "type": "string",
@@ -7000,7 +7000,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Addresses lnd has stored for the peer via its LinkNode record\n(captured at first channel open). Empty if no LinkNode entry exists\nfor the peer. Note: this list is reported verbatim from storage,\nincluding any v2 .onion entries lnd will not dial (v2 was deprecated\nby the Tor project in 2021). v2 entries are preserved on disk so\nthat signed NodeAnnouncements still verify; a v2 appearing here is\na stale-storage signal, not an indication that lnd is attempting to\nreach that address."
+          "description": "Addresses lnd has stored for the peer via its LinkNode record\n(channel open or `connect --perm`). Empty if no LinkNode entry exists\nfor the peer. Note: this list is reported verbatim from storage,\nincluding any v2 .onion entries lnd will not dial (v2 was deprecated\nby the Tor project in 2021). v2 entries are preserved on disk so\nthat signed NodeAnnouncements still verify; a v2 appearing here is\na stale-storage signal, not an indication that lnd is attempting to\nreach that address."
         },
         "gossip_addresses": {
           "type": "array",

--- a/lntest/rpc/lnd.go
+++ b/lntest/rpc/lnd.go
@@ -49,6 +49,19 @@ func (h *HarnessRPC) ListPeers() *lnrpc.ListPeersResponse {
 	return resp
 }
 
+// ListPeersReq calls ListPeers with a fully formed request.
+func (h *HarnessRPC) ListPeersReq(
+	req *lnrpc.ListPeersRequest) *lnrpc.ListPeersResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.LN.ListPeers(ctxt, req)
+	h.NoError(err, "ListPeers")
+
+	return resp
+}
+
 // DisconnectPeer calls the DisconnectPeer RPC on a given node with a specified
 // public key string and asserts there's no error.
 func (h *HarnessRPC) DisconnectPeer(

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3570,6 +3570,51 @@ func (r *rpcServer) ListPeers(ctx context.Context,
 		Peers: make([]*lnrpc.Peer, 0, len(serverPeers)),
 	}
 
+	// Pre-fetch the LinkNode store into a pubkey-keyed map so the
+	// per-peer loop becomes a constant lookup rather than a per-peer DB
+	// hit.
+	linkNodes, err := r.server.linkNodeDB.FetchAllLinkNodes()
+	if err != nil && !errors.Is(err, channeldb.ErrLinkNodesNotFound) {
+		return nil, fmt.Errorf("unable to fetch link nodes: %w", err)
+	}
+	rememberedAddrsByPub := make(map[string][]net.Addr, len(linkNodes))
+	for _, ln := range linkNodes {
+		key := string(ln.IdentityPub.SerializeCompressed())
+		rememberedAddrsByPub[key] = ln.Addresses
+	}
+
+	// Snapshot the in-memory persistent set so we can also emit
+	// disconnected entries if the caller opted in.
+	persistentSet := r.server.PersistentReconnectSet()
+
+	// Track which pubkeys we have already emitted so we don't duplicate
+	// when appending offline entries.
+	connectedPubs := make(map[string]struct{}, len(serverPeers))
+
+	// Helper: []net.Addr → []string.
+	toStrs := func(addrs []net.Addr) []string {
+		out := make([]string, 0, len(addrs))
+		for _, a := range addrs {
+			out = append(out, a.String())
+		}
+		return out
+	}
+
+	// Helper: gossip addresses for a pubkey, ignoring v2 onion entries.
+	// Returns an empty slice for any error (e.g. peer not in graph) since
+	// missing gossip data is normal.
+	gossipAddrsFor := func(pubBytes []byte) []string {
+		vertex, vErr := route.NewVertexFromBytes(pubBytes)
+		if vErr != nil {
+			return nil
+		}
+		node, gErr := r.server.v1Graph.FetchNode(ctx, vertex)
+		if gErr != nil {
+			return nil
+		}
+		return toStrs(withoutV2Onion(node.Addresses))
+	}
+
 	for _, serverPeer := range serverPeers {
 		var (
 			satSent int64
@@ -3690,10 +3735,46 @@ func (r *rpcServer) ListPeers(ctx context.Context,
 			}
 		}
 
+		// Enrich with the new persistent / multi-source address
+		// fields.
+		pubStr := string(nodePub[:])
+		connectedPubs[pubStr] = struct{}{}
+
+		rpcPeer.RememberedAddresses = toStrs(
+			rememberedAddrsByPub[pubStr],
+		)
+		rpcPeer.GossipAddresses = gossipAddrsFor(nodePub[:])
+		_, inPersistentSet := persistentSet[pubStr]
+		rpcPeer.IsPersistent = inPersistentSet ||
+			len(rpcPeer.RememberedAddresses) > 0
+		// We're connected, so reconnect_pending stays at its zero
+		// default.
+
 		resp.Peers = append(resp.Peers, rpcPeer)
 	}
 
-	rpcsLog.Debugf("[listpeers] yielded %v peers", serverPeers)
+	// Optionally append entries for persistent peers we're not currently
+	// connected to.
+	if in.IncludeOfflinePersistentPeers {
+		for pubStr, pending := range persistentSet {
+			if _, ok := connectedPubs[pubStr]; ok {
+				continue
+			}
+
+			pubBytes := []byte(pubStr)
+			resp.Peers = append(resp.Peers, &lnrpc.Peer{
+				PubKey: hex.EncodeToString(pubBytes),
+				RememberedAddresses: toStrs(
+					rememberedAddrsByPub[pubStr],
+				),
+				GossipAddresses:  gossipAddrsFor(pubBytes),
+				IsPersistent:     true,
+				ReconnectPending: pending,
+			})
+		}
+	}
+
+	rpcsLog.Debugf("[listpeers] yielded %d peers", len(resp.Peers))
 
 	return resp, nil
 }

--- a/server.go
+++ b/server.go
@@ -5154,6 +5154,23 @@ func (s *server) removePeerUnsafe(ctx context.Context, p *peer.Brontide) {
 	}()
 }
 
+// PersistentReconnectSet returns a snapshot of the pubkeys currently in the
+// persistent reconnect set, mapped to whether a reconnect attempt is in
+// flight. Keys are the raw 33-byte compressed pubkey as a Go string (matching
+// the keying convention used by s.persistentPeers).
+//
+// NOTE: This function is safe for concurrent access.
+func (s *server) PersistentReconnectSet() map[string]bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make(map[string]bool, len(s.persistentPeers))
+	for k := range s.persistentPeers {
+		out[k] = len(s.persistentConnReqs[k]) > 0
+	}
+	return out
+}
+
 // ConnectToPeer requests that the server connect to a Lightning Network peer
 // at the specified address. This function will *block* until either a
 // connection is established, or the initial handshake process fails.

--- a/server.go
+++ b/server.go
@@ -5187,22 +5187,20 @@ func (s *server) ConnectToPeer(addr *lnwire.NetAddress,
 	// lock to be released, and subsequently reacquired.
 	s.mu.Lock()
 
-	// Ensure we're not already connected to this peer.
+	// Check whether we're already connected to this peer.
 	peer, err := s.findPeerByPubStr(targetPub)
+	alreadyConnected := err == nil
 
-	// When there's no error it means we already have a connection with this
-	// peer. If this is a dev environment with the `--unsafeconnect` flag
-	// set, we will ignore the existing connection and continue.
-	if err == nil && !s.cfg.Dev.GetUnsafeConnect() {
+	// A non-perm connect to an already-connected peer is a redundant
+	// dial: error out (unless dev --unsafeconnect is set, in which case
+	// we fall through and open a second connection).
+	if alreadyConnected && !perm && !s.cfg.Dev.GetUnsafeConnect() {
 		s.mu.Unlock()
 		return &errPeerAlreadyConnected{peer: peer}
 	}
 
-	// Peer was not found, continue to pursue connection with peer.
-
 	// If there's already a pending connection request for this pubkey,
-	// then we ignore this request to ensure we don't create a redundant
-	// connection.
+	// then we log a warning but continue.
 	if reqs, ok := s.persistentConnReqs[targetPub]; ok {
 		srvrLog.Warnf("Already have %d persistent connection "+
 			"requests for %v, connecting anyway.", len(reqs), addr)
@@ -5213,25 +5211,60 @@ func (s *server) ConnectToPeer(addr *lnwire.NetAddress,
 	// persistent connection to the peer.
 	srvrLog.Debugf("Connecting to %v", addr)
 	if perm {
-		connReq := &connmgr.ConnReq{
-			Addr:      addr,
-			Permanent: true,
-		}
-
-		// Since the user requested a permanent connection, we'll set
-		// the entry to true which will tell the server to continue
-		// reconnecting even if the number of channels with this peer is
-		// zero.
+		// Since the user requested a permanent connection, mark the
+		// peer as user-perm so the server keeps reconnecting even if
+		// the number of channels with this peer is zero.
 		s.persistentPeers[targetPub] = true
 		if _, ok := s.persistentPeersBackoff[targetPub]; !ok {
 			s.persistentPeersBackoff[targetPub] = s.cfg.MinBackoff
 		}
-		s.persistentConnReqs[targetPub] = append(
-			s.persistentConnReqs[targetPub], connReq,
-		)
+
+		// Only create a new conn req if we're not already connected
+		// (or if the dev `--unsafeconnect` flag is on). When we're
+		// already connected, the request's sole effect is to persist
+		// the address to the LinkNode store below.
+		var connReq *connmgr.ConnReq
+		if !alreadyConnected || s.cfg.Dev.GetUnsafeConnect() {
+			connReq = &connmgr.ConnReq{
+				Addr:      addr,
+				Permanent: true,
+			}
+			s.persistentConnReqs[targetPub] = append(
+				s.persistentConnReqs[targetPub], connReq,
+			)
+		}
 		s.mu.Unlock()
 
-		go s.connMgr.Connect(connReq)
+		// Persist the address to the LinkNode store so lnd
+		// reconnects to it after a restart, even without an open
+		// channel.
+		added, err := s.linkNodeDB.AddAddressForPeer(
+			s.cfg.ActiveNetParams.Net,
+			addr.IdentityKey, addr.Address,
+		)
+		if err != nil {
+			srvrLog.Errorf("Unable to persist permanent peer "+
+				"%x address %v: %v",
+				addr.IdentityKey.SerializeCompressed(),
+				addr.Address, err)
+		} else if added {
+			srvrLog.Infof("Stored permanent peer %x address %v "+
+				"for reconnection across restarts",
+				addr.IdentityKey.SerializeCompressed(),
+				addr.Address)
+		}
+
+		// If we were already connected on entry and this call did
+		// not add anything to the LinkNode store, then nothing
+		// happened — surface that to the caller as an error, the
+		// same way plain `connect` errors when it has nothing to do.
+		if alreadyConnected && !added {
+			return &errPeerAlreadyConnected{peer: peer}
+		}
+
+		if connReq != nil {
+			go s.connMgr.Connect(connReq)
+		}
 
 		return nil
 	}


### PR DESCRIPTION
`lncli connect --perm` marks a peer as persistent in memory, but before this commit the requested address was not written to any on-disk store. On restart lnd had no record that the user had ever asked for the peer, so the persistent-reconnect intent was lost.

This commit routes `--perm` through the existing LinkNode store via a new `channeldb.LinkNodeDB.AddAddressForPeer` helper. The helper creates a fresh LinkNode if none exists for the peer, or appends the address to an existing one (deduped by string). The Go-side wiring is minimal — the existing `establishPersistentConnections` startup path already reads LinkNodes and reconnects to each entry, so no new startup logic is required.

`ConnectToPeer(perm=true)` now:

  * writes the address to the LinkNode store, and
  * for peers we are already connected to, marks them as user-persistent in the in-memory set without erroring or opening a duplicate connection (previously `--perm` against an already-connected peer always returned `errPeerAlreadyConnected`). It still errors when the call has nothing to do — i.e. the peer is already connected *and* the address is already stored in the LinkNode entry — matching the plain-`connect` behaviour of erroring on a no-op request.

The `remembered_addresses` field on the `Peer` proto message now notes `--perm` alongside "first channel open" as a source.

Scope / known limitation
------------------------

This is a partial fix for #10870. `PruneLinkNodes` still runs at startup and deletes LinkNode entries for peers with no open channels, so a `--perm` on a peer we have never opened a channel with is still lost across restart. The dominant use case — remembering an address for a peer we do have a channel with (e.g. because the peer stopped announcing that address) — is now covered.

Lifting the non-channel-peer limitation may be addressed as a follow-up once the migration to native SQL is complete.

The current semantic is add-only: repeated `--perm` calls with different addresses accumulate in the LinkNode, and there is no supported way to remove a stored address without disconnecting the peer. A separate follow-up commit will add a way to remove individual stored addresses manually.

itests:

  * `perm adds remembered address` opens a channel between two nodes, then `--perm`s a second (unreachable) address for the peer and asserts that both the original and the new address appear in the peer's `remembered_addresses` list.
  * `perm non-channel peer lost on restart` pins down the limitation above: two nodes, no channel, `--perm` connect, restart, assert the peer no longer appears in the persistent reconnect set (queried via `include_offline_persistent_peers=true`). If PruneLinkNodes is ever taught to spare user-persistent entries, this test should be flipped.

Depends on #10973 (ListPeers extension) for the `remembered_addresses` and `include_offline_persistent_peers` surfaces used by the itests.

Contributes to #10870.
Contributes to #10871.
