### PR TITLE
multi: add `--forget_node` and `--forget_address` to `lncli disconnect`

### DIFF
--- a/channeldb/error.go
+++ b/channeldb/error.go
@@ -34,6 +34,18 @@ var (
 	// specific identity can't be found.
 	ErrNodeNotFound = fmt.Errorf("link node with target identity not found")
 
+	// ErrNodeAddressNotFound is returned when a LinkNode entry exists
+	// for the target peer, but the requested address is not among its
+	// stored addresses.
+	ErrNodeAddressNotFound = fmt.Errorf("address not stored for peer")
+
+	// ErrLastPeerAddress is returned by RemoveAddressForPeer when the
+	// caller has not opted in to deleting the LinkNode entry (via
+	// allowLast) and the requested address is the last stored address
+	// for the peer.
+	ErrLastPeerAddress = fmt.Errorf("refusing to remove last stored " +
+		"address for peer")
+
 	// ErrChannelNotFound is returned when we attempt to locate a channel
 	// for a specific chain, but it is not found.
 	ErrChannelNotFound = fmt.Errorf("channel not found")

--- a/channeldb/nodes.go
+++ b/channeldb/nodes.go
@@ -225,6 +225,62 @@ func (l *LinkNodeDB) CreateLinkNodes(tx kvdb.RwTx,
 	return createNodes(tx)
 }
 
+// RemoveAddressForPeer removes addr from the peer's stored LinkNode
+// address list.
+//
+// If the removal would leave the LinkNode with no addresses (i.e. addr
+// was the last stored address for the peer):
+//   - if allowLast is true, the LinkNode entry is deleted and
+//     deletedEntry is set to true.
+//   - if allowLast is false, ErrLastPeerAddress is returned and the
+//     LinkNode is left untouched.
+//
+// Returns ErrNodeNotFound if no LinkNode exists for the peer, and
+// ErrNodeAddressNotFound if the LinkNode exists but does not contain
+// addr.
+func (l *LinkNodeDB) RemoveAddressForPeer(pub *btcec.PublicKey,
+	addr net.Addr, allowLast bool) (deletedEntry bool, err error) {
+
+	err = kvdb.Update(l.backend, func(tx kvdb.RwTx) error {
+		nodeMetaBucket := tx.ReadWriteBucket(nodeInfoBucket)
+		if nodeMetaBucket == nil {
+			return ErrLinkNodesNotFound
+		}
+
+		existing, ferr := fetchLinkNode(tx, pub)
+		if ferr != nil {
+			return ferr
+		}
+
+		target := addr.String()
+		remaining := existing.Addresses[:0]
+		found := false
+		for _, a := range existing.Addresses {
+			if !found && a.String() == target {
+				found = true
+				continue
+			}
+			remaining = append(remaining, a)
+		}
+		if !found {
+			return ErrNodeAddressNotFound
+		}
+
+		if len(remaining) == 0 {
+			if !allowLast {
+				return ErrLastPeerAddress
+			}
+			deletedEntry = true
+			return deleteLinkNode(tx, pub)
+		}
+		existing.Addresses = remaining
+		return putLinkNode(nodeMetaBucket, existing)
+	}, func() {
+		deletedEntry = false
+	})
+	return deletedEntry, err
+}
+
 // DeleteLinkNode removes the link node with the given identity from the
 // database.
 func (l *LinkNodeDB) DeleteLinkNode(identity *btcec.PublicKey) error {

--- a/channeldb/nodes.go
+++ b/channeldb/nodes.go
@@ -243,6 +243,46 @@ func deleteLinkNode(tx kvdb.RwTx, identity *btcec.PublicKey) error {
 	return nodeMetaBucket.Delete(pubKey)
 }
 
+// AddAddressIfPeerKnown appends addr to the address list of the LinkNode entry
+// for identity, but only if an entry already exists. If no LinkNode is stored
+// for the peer this is a no-op and returns (false, nil). Duplicate addresses
+// are ignored (matched by String()). Returns true if the address was newly
+// stored.
+func (l *LinkNodeDB) AddAddressIfPeerKnown(identity *btcec.PublicKey,
+	addr net.Addr) (bool, error) {
+
+	var added bool
+	err := kvdb.Update(l.backend, func(tx kvdb.RwTx) error {
+		nodeMetaBucket := tx.ReadWriteBucket(nodeInfoBucket)
+		if nodeMetaBucket == nil {
+			return nil
+		}
+
+		node, err := fetchLinkNode(tx, identity)
+		if errors.Is(err, ErrNodeNotFound) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		for _, a := range node.Addresses {
+			if a.String() == addr.String() {
+				return nil
+			}
+		}
+
+		node.Addresses = append(node.Addresses, addr)
+		added = true
+
+		return putLinkNode(nodeMetaBucket, node)
+	}, func() {
+		added = false
+	})
+
+	return added, err
+}
+
 // FetchLinkNode attempts to lookup the data for a LinkNode based on a target
 // identity public key. If a particular LinkNode for the passed identity public
 // key cannot be found, then ErrNodeNotFound if returned.

--- a/chanrestore.go
+++ b/chanrestore.go
@@ -332,7 +332,7 @@ func (s *server) ConnectPeer(nodePub *btcec.PublicKey, addrs []net.Addr) error {
 	// Before we connect to the remote peer, we'll remove any connections
 	// to ensure the new connection is created after this new link/channel
 	// is known.
-	if err := s.DisconnectPeer(nodePub); err != nil {
+	if err := s.DisconnectPeer(nodePub, false, false); err != nil {
 		ltndLog.Infof("Peer(%x) is already connected, proceeding "+
 			"with chan restore", nodePub.SerializeCompressed())
 	}

--- a/cmd/commands/commands.go
+++ b/cmd/commands/commands.go
@@ -978,11 +978,88 @@ var disconnectCommand = cli.Command{
 	Usage: "Disconnect a remote lightning peer identified by " +
 		"public key.",
 	ArgsUsage: "<pubkey>",
+	Description: `
+	Disconnect a remote lightning peer identified by public key.
+
+	By default this only drops the active connection; the peer's stored
+	LinkNode entry (and any addresses in it) is left in place, so lnd
+	will still reconnect to the peer on the next restart via its
+	remembered addresses or the gossip graph.
+
+	With --forget_node lnd drops the active connection AND removes the
+	peer's stored LinkNode entry. The LinkNode delete is refused if open
+	channels still exist with the peer unless --force is also passed.
+	--forget_node removes all of the peer's stored addresses at once;
+	use --forget_address to remove just one.
+
+	No reconnect is attempted from our side in the current session
+	after --forget_node. Note that the remote peer may still re-dial us if
+	they have us in their own persistent set (typical when a channel
+	exists), in which case we'll accept the inbound connection. On the
+	next lnd restart, if the peer still has open channels, the
+	channel-driven persistence path will reconnect using
+	NodeAnnouncement addresses from the gossip graph.
+
+	For a peer with no open channels, --forget_node is a shortcut for
+	work that would happen on the next lnd restart anyway: at startup
+	lnd runs PruneLinkNodes, which deletes stored LinkNode entries for
+	peers with no open channels. --forget_node on such a peer just
+	performs that delete now, and additionally drops the live
+	connection. --force is not required in this case.
+
+	With --forget_address <host:port> a single stored address is removed
+	from the peer's LinkNode entry. The live connection is left alone
+	unless the removed address happens to be the one currently in use,
+	in which case the connection is dropped so lnd can re-dial via the
+	remaining stored/gossip addresses. If the removed address would be
+	the last stored address for the peer, behaviour depends on whether
+	there are open channels with the peer: when there are no open
+	channels the LinkNode entry is deleted automatically; when there
+	are open channels the request is refused unless --force is also
+	passed.
+
+	--forget_node and --forget_address are mutually exclusive. Passing
+	--force without either is an error.
+
+	Note: after --forget_address --force removes the last stored address
+	for a channel peer, the peer stays in the persistent-reconnect set
+	— the peer-termination watcher will fetch the peer's advertised
+	addresses from its NodeAnnouncement (via the gossip graph) and
+	reconnect using those. Use --forget_node instead if you want to
+	remove the last stored address AND stop reconnecting from our side
+	until lnd next restarts.
+	Even with --forget_address --force, a channel peer is only truly
+	orphaned when it also has no NodeAnnouncement.
+	`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name: "node_key",
 			Usage: "The hex-encoded compressed public key of the peer " +
 				"to disconnect from",
+		},
+		cli.BoolFlag{
+			Name: "forget_node",
+			Usage: "Also remove the peer's stored LinkNode entry so " +
+				"lnd will not auto-reconnect on the next " +
+				"restart. Refused if open channels exist unless " +
+				"'--force' is also set.",
+		},
+		cli.BoolFlag{
+			Name: "force",
+			Usage: "Only meaningful with '--forget_node' or " +
+				"'--forget_address'. With '--forget_node', " +
+				"bypasses the open-channel guard. With " +
+				"'--forget_address', allows removing the last " +
+				"stored address (which deletes the LinkNode " +
+				"entry itself).",
+		},
+		cli.StringFlag{
+			Name: "forget_address",
+			Usage: "Remove a single stored address from the peer's " +
+				"LinkNode entry (does not drop the live " +
+				"connection unless the removed address is the " +
+				"one currently in use). Mutually exclusive with " +
+				"'--forget_node'.",
 		},
 	},
 	Action: actionDecorator(disconnectPeer),
@@ -1004,7 +1081,10 @@ func disconnectPeer(ctx *cli.Context) error {
 	}
 
 	req := &lnrpc.DisconnectPeerRequest{
-		PubKey: pubKey,
+		PubKey:        pubKey,
+		ForgetNode:    ctx.Bool("forget_node"),
+		Force:         ctx.Bool("force"),
+		ForgetAddress: ctx.String("forget_address"),
 	}
 
 	lnid, err := client.DisconnectPeer(ctxc, req)

--- a/cmd/commands/commands.go
+++ b/cmd/commands/commands.go
@@ -1633,11 +1633,19 @@ func parseChannelPoint(ctx *cli.Context) (*lnrpc.ChannelPoint, error) {
 var listPeersCommand = cli.Command{
 	Name:     "listpeers",
 	Category: "Peers",
-	Usage:    "List all active, currently connected peers.",
+	Usage: "List currently connected peers, and optionally also " +
+		"offline peers that lnd is auto-reconnecting to.",
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "list_errors",
 			Usage: "list a full set of most recent errors for the peer",
+		},
+		cli.BoolFlag{
+			Name: "include_offline_persistent_peers",
+			Usage: "also list peers that lnd is auto-reconnecting " +
+				"to but is not currently connected to — " +
+				"either via a stored LinkNode record or " +
+				"because of an open channel",
 		},
 	},
 	Action: actionDecorator(listPeers),
@@ -1652,6 +1660,9 @@ func listPeers(ctx *cli.Context) error {
 	// specifically requests a full error set, then we will provide it.
 	req := &lnrpc.ListPeersRequest{
 		LatestError: !ctx.IsSet("list_errors"),
+		IncludeOfflinePersistentPeers: ctx.Bool(
+			"include_offline_persistent_peers",
+		),
 	}
 	resp, err := client.ListPeers(ctxc, req)
 	if err != nil {

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -101,6 +101,24 @@
 
 ## Functional Updates
 
+* [Peer addresses now auto-persist on
+  connect](https://github.com/lightningnetwork/lnd/pull/10975) for peers we
+  have an open channel with. When lnd completes an outbound connection to
+  a channel peer, it records the dialed address in the peer's `LinkNode`
+  entry if it isn't already listed. On restart lnd attempts this address
+  in addition to those from the peer's current `NodeAnnouncement`, so a
+  channel peer remains reachable across restarts even when the address we
+  last used to reach them isn't in their gossip entry — because they have
+  since removed it from their `NodeAnnouncement` but are still listening
+  on the same host and port, because they moved to a new host and/or port
+  and we learned the new address out-of-band faster than their
+  re-broadcast `NodeAnnouncement` could catch up, or because they never
+  advertised it in gossip in the first place. Only outbound connections
+  trigger this — for inbound TCP the peer's remote address is an
+  ephemeral source port rather than a dialable listener. Non-channel
+  peers are also skipped so casual connections do not grow the on-disk
+  address list.
+
 ## RPC Updates
 
 ## lncli Updates

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -81,6 +81,25 @@
   `ListPeersRequest.include_offline_persistent_peers` flag opts into
   surfacing peers in the reconnect set we are not currently connected to.
 
+* [`DisconnectPeer` gains `forget_node`, `force`, and `forget_address`
+  fields](https://github.com/lightningnetwork/lnd/pull/10976).
+  `forget_node=true` also removes the peer's stored LinkNode entry so no
+  auto-reconnect is attempted on the next lnd restart; refused if open
+  channels exist unless `force=true`. `forget_address="<host:port>"`
+  removes a single stored address for the peer without dropping the live
+  connection (unless the removed address is the currently-connected one,
+  in which case the connection is dropped so lnd can re-dial via remaining
+  stored/gossip addresses). If `forget_address` would remove the last
+  stored address for the peer, behaviour depends on whether open channels
+  exist: with no open channels the LinkNode entry is deleted
+  automatically; with open channels the request is refused unless
+  `force=true`. `forget_node` and `forget_address` are mutually exclusive;
+  `force` on its own is rejected. Note: after `force` removes the last
+  stored address for a channel peer, the peer-termination watcher falls
+  back to the peer's NodeAnnouncement addresses for reconnect, so a
+  channel peer is only truly orphaned when it also has no
+  NodeAnnouncement.
+
 ## lncli Additions
 
 * The `estimateroutefee` command now supports [restricting fee estimates to
@@ -91,6 +110,10 @@
 * `lncli listpeers` gains
   [`--include_offline_persistent_peers`](https://github.com/lightningnetwork/lnd/pull/10973)
   (see the `ListPeers` RPC entry above).
+
+* `lncli disconnect` gains
+  [`--forget_node`, `--force`, and `--forget_address`](https://github.com/lightningnetwork/lnd/pull/10976)
+  (see the `DisconnectPeer` RPC entry above).
 
 * A new
   [`wallet submitpackage`](https://github.com/lightningnetwork/lnd/pull/10900)

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -72,12 +72,25 @@
   the chain backend via bitcoind's `submitpackage`, allowing a zero-fee v3/TRUC
   parent to be accepted together with a fee-paying CPFP child.
 
+* [`ListPeers` gains address-source
+  detail](https://github.com/lightningnetwork/lnd/pull/10973). Each `Peer`
+  now carries `remembered_addresses` (addresses lnd has stored for the peer),
+  `gossip_addresses` (from the peer's current `NodeAnnouncement`),
+  `is_persistent` (true if lnd is auto-reconnecting to the peer), and
+  `reconnect_pending` (true if a retry is in flight). A new
+  `ListPeersRequest.include_offline_persistent_peers` flag opts into
+  surfacing peers in the reconnect set we are not currently connected to.
+
 ## lncli Additions
 
 * The `estimateroutefee` command now supports [restricting fee estimates to
   specific first-hop outgoing
   channels](https://github.com/lightningnetwork/lnd/pull/10501) via the new
   `--outgoing_chan_id` flag.
+
+* `lncli listpeers` gains
+  [`--include_offline_persistent_peers`](https://github.com/lightningnetwork/lnd/pull/10973)
+  (see the `ListPeers` RPC entry above).
 
 * A new
   [`wallet submitpackage`](https://github.com/lightningnetwork/lnd/pull/10900)
@@ -148,3 +161,4 @@
 * Boris Nagaev
 * Erick Cestari
 * Jared Tobin
+* ZZiigguurraatt

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -159,6 +159,10 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testAutoPersistChannelPeerAddress,
 	},
 	{
+		Name:     "disconnect forget",
+		TestFunc: testDisconnectForget,
+	},
+	{
 		Name:     "addpeer config",
 		TestFunc: testAddPeerConfig,
 	},

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -151,6 +151,10 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testReconnectAfterIPChange,
 	},
 	{
+		Name:     "listpeers address fields",
+		TestFunc: testListPeersAddressFields,
+	},
+	{
 		Name:     "addpeer config",
 		TestFunc: testAddPeerConfig,
 	},

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -155,6 +155,10 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testListPeersAddressFields,
 	},
 	{
+		Name:     "auto persist channel peer address",
+		TestFunc: testAutoPersistChannelPeerAddress,
+	},
+	{
 		Name:     "addpeer config",
 		TestFunc: testAddPeerConfig,
 	},

--- a/itest/lnd_network_test.go
+++ b/itest/lnd_network_test.go
@@ -523,3 +523,168 @@ func testAutoPersistChannelPeerAddress(ht *lntest.HarnessTest) {
 	}, defaultTimeout))
 }
 
+// testDisconnectForget covers the whole-peer `--forget_node` and
+// per-address `--forget_address` code paths on `lncli disconnect`:
+//
+//   * `--forget_node` without `--force` when open channels exist:
+//     LinkNode preserved (remembered_addresses still populated after
+//     reconnect).
+//   * `--forget_node --force` with open channels: LinkNode gone.
+//   * `--forget_address` for a specific stored address: address removed
+//     from remembered_addresses; live connection left intact when the
+//     removed address isn't the currently-connected one.
+//   * `--forget_address` for the last stored address without `--force`:
+//     rejected; LinkNode still intact.
+//   * `--force` without `--forget_node` or `--forget_address`: rejected.
+//   * `--forget_node` together with `--forget_address`: rejected.
+func testDisconnectForget(ht *lntest.HarnessTest) {
+	// Bob binds a second listener on portB in addition to his default
+	// portA. Alice will seed a second stored address for Bob by
+	// reconnecting on portB — the auto-persist behaviour introduced by
+	// the previous commit captures the address on that outbound.
+	portB := port.NextAvailablePort()
+	addrB := fmt.Sprintf("127.0.0.1:%d", portB)
+	bobArgs := []string{fmt.Sprintf("--listen=%s", addrB)}
+
+	// Alice runs with --nolisten so Bob's own reconnect logic cannot
+	// dial back and create an inbound peer entry that races with the
+	// test. Long backoff on Alice's side is defence-in-depth.
+	aliceArgs := []string{
+		"--nolisten",
+		"--minbackoff=1h",
+		"--maxbackoff=1h",
+	}
+	alice := ht.NewNodeWithCoins("Alice", aliceArgs)
+	bob := ht.NewNode("Bob", bobArgs)
+	bobInfo := bob.RPC.GetInfo()
+
+	addrA := bob.Cfg.P2PAddr()
+
+	ht.ConnectNodes(alice, bob)
+	ht.OpenChannel(alice, bob, lntest.OpenChannelParams{Amt: 100_000})
+
+	bobPeer := func() *lnrpc.Peer {
+		resp := alice.RPC.ListPeersReq(&lnrpc.ListPeersRequest{})
+		for _, p := range resp.Peers {
+			if p.PubKey == bobInfo.IdentityPubkey {
+				return p
+			}
+		}
+		return nil
+	}
+
+	// Sanity: initial state has Bob's portA in remembered_addresses.
+	require.NoError(ht, wait.NoError(func() error {
+		p := bobPeer()
+		if p == nil || len(p.RememberedAddresses) == 0 {
+			return fmt.Errorf("waiting for remembered_addresses")
+		}
+		return nil
+	}, defaultTimeout))
+
+	// --force without --forget_node or --forget_address is rejected.
+	err := alice.RPC.DisconnectPeerReqAssertErr(&lnrpc.DisconnectPeerRequest{
+		PubKey: bobInfo.IdentityPubkey,
+		Force:  true,
+	})
+	require.Error(ht, err)
+
+	// --forget_node together with --forget_address is rejected.
+	err = alice.RPC.DisconnectPeerReqAssertErr(&lnrpc.DisconnectPeerRequest{
+		PubKey:        bobInfo.IdentityPubkey,
+		ForgetNode:    true,
+		ForgetAddress: addrA,
+	})
+	require.Error(ht, err)
+
+	// Seed a second stored address by reconnecting Alice on Bob's
+	// alternate listener. Auto-persist will append portB to Bob's
+	// LinkNode entry.
+	ht.DisconnectNodes(alice, bob)
+	alice.RPC.ConnectPeer(&lnrpc.ConnectPeerRequest{
+		Addr: &lnrpc.LightningAddress{
+			Pubkey: bobInfo.IdentityPubkey,
+			Host:   addrB,
+		},
+	})
+	ht.AssertConnected(alice, bob)
+	require.NoError(ht, wait.NoError(func() error {
+		p := bobPeer()
+		if p == nil {
+			return fmt.Errorf("bob missing from listpeers")
+		}
+		if len(p.RememberedAddresses) < 2 {
+			return fmt.Errorf("waiting for both remembered "+
+				"addresses, got %v", p.RememberedAddresses)
+		}
+		return nil
+	}, defaultTimeout))
+
+	// Alice is now connected on portB, so portA is the non-current
+	// stored address. --forget_address portA removes it cleanly with
+	// no last-address warning, and the connection on portB stays.
+	resp := alice.RPC.DisconnectPeerReq(&lnrpc.DisconnectPeerRequest{
+		PubKey:        bobInfo.IdentityPubkey,
+		ForgetAddress: addrA,
+	})
+	require.NotContains(ht, resp.Status, "last stored address",
+		"non-last removal should not include last-address warning")
+	ht.AssertConnected(alice, bob)
+	require.NoError(ht, wait.NoError(func() error {
+		p := bobPeer()
+		if p == nil {
+			return fmt.Errorf("bob missing")
+		}
+		for _, a := range p.RememberedAddresses {
+			if a == addrA {
+				return fmt.Errorf("portA should be removed " +
+					"but still present")
+			}
+		}
+		return nil
+	}, defaultTimeout))
+
+	// --forget_address on the sole remaining address (portB) without
+	// --force: rejected; LinkNode remains.
+	p := bobPeer()
+	require.Len(ht, p.RememberedAddresses, 1,
+		"expected exactly one remembered address before "+
+			"last-address test")
+	lastAddr := p.RememberedAddresses[0]
+	err = alice.RPC.DisconnectPeerReqAssertErr(&lnrpc.DisconnectPeerRequest{
+		PubKey:        bobInfo.IdentityPubkey,
+		ForgetAddress: lastAddr,
+	})
+	require.Error(ht, err)
+	p = bobPeer()
+	require.Len(ht, p.RememberedAddresses, 1,
+		"LinkNode should be intact after refused --forget_address")
+
+	// --forget_node without --force with an open channel: LinkNode
+	// preserved.
+	alice.RPC.DisconnectPeerReq(&lnrpc.DisconnectPeerRequest{
+		PubKey:     bobInfo.IdentityPubkey,
+		ForgetNode: true,
+	})
+	ht.AssertPeerNotConnected(alice, bob)
+	ht.ConnectNodes(alice, bob)
+	ht.AssertConnected(alice, bob)
+	p = bobPeer()
+	require.NotEmpty(ht, p.RememberedAddresses,
+		"--forget_node without --force should preserve LinkNode "+
+			"when open channels exist")
+
+	// --forget_node --force with an open channel: LinkNode removed.
+	alice.RPC.DisconnectPeerReq(&lnrpc.DisconnectPeerRequest{
+		PubKey:     bobInfo.IdentityPubkey,
+		ForgetNode: true,
+		Force:      true,
+	})
+	ht.AssertPeerNotConnected(alice, bob)
+	ht.ConnectNodes(alice, bob)
+	ht.AssertConnected(alice, bob)
+	p = bobPeer()
+	require.Empty(ht, p.RememberedAddresses,
+		"--forget_node --force should remove LinkNode even with "+
+			"open channels")
+}

--- a/itest/lnd_network_test.go
+++ b/itest/lnd_network_test.go
@@ -414,3 +414,112 @@ func testListPeersAddressFields(ht *lntest.HarnessTest) {
 	require.NoError(ht, restartBob())
 }
 
+// testAutoPersistChannelPeerAddress verifies that when a peer we have an
+// open channel with connects on an address that isn't already in its
+// LinkNode entry, that address is appended to the entry so a future
+// restart can dial it. The scenario: open a channel between Alice and Bob
+// at port A, disconnect them, move Bob to port B, reconnect Alice to Bob
+// at port B, then assert that Alice's remembered_addresses for Bob now
+// contains both A and B.
+func testAutoPersistChannelPeerAddress(ht *lntest.HarnessTest) {
+	// Alice is set up with --nolisten so Bob physically cannot dial
+	// back to her at any point during the test. Combined with the
+	// long backoff on Alice's own persistent-reconnect logic, this
+	// guarantees the only peer connection to Bob we ever observe
+	// during the test is the outbound one we initiate explicitly.
+	aliceArgs := []string{
+		"--nolisten",
+		"--minbackoff=1h",
+		"--maxbackoff=1h",
+	}
+	alice := ht.NewNodeWithCoins("Alice", aliceArgs)
+	bob := ht.NewNode("Bob", nil)
+	bobInfo := bob.RPC.GetInfo()
+
+	portA := bob.Cfg.P2PPort
+	addrA := fmt.Sprintf("127.0.0.1:%d", portA)
+
+	// Open a channel — this seeds Alice's LinkNode entry for Bob with
+	// Bob's address at channel-open time, which is port A.
+	ht.ConnectNodes(alice, bob)
+	ht.OpenChannel(alice, bob, lntest.OpenChannelParams{Amt: 100_000})
+
+	// bobPeer pulls Bob's entry out of Alice's ListPeers response,
+	// including offline persistent entries so the assertion still works
+	// while Alice is disconnected from Bob.
+	bobPeer := func() *lnrpc.Peer {
+		resp := alice.RPC.ListPeersReq(&lnrpc.ListPeersRequest{
+			IncludeOfflinePersistentPeers: true,
+		})
+		for _, p := range resp.Peers {
+			if p.PubKey == bobInfo.IdentityPubkey {
+				return p
+			}
+		}
+		return nil
+	}
+
+	// Sanity: port A appears in remembered_addresses now.
+	require.NoError(ht, wait.NoError(func() error {
+		p := bobPeer()
+		if p == nil {
+			return fmt.Errorf("bob not yet in listpeers")
+		}
+		for _, a := range p.RememberedAddresses {
+			if a == addrA {
+				return nil
+			}
+		}
+		return fmt.Errorf("remembered_addresses %v missing %s",
+			p.RememberedAddresses, addrA)
+	}, defaultTimeout))
+
+	// Move Bob to port B.
+	portB := port.NextAvailablePort()
+	addrB := fmt.Sprintf("127.0.0.1:%d", portB)
+
+	ht.DisconnectNodes(alice, bob)
+	bob.Cfg.P2PPort = portB
+	ht.RestartNode(bob)
+
+	// Reconnect Alice to Bob explicitly at port B. This is a plain
+	// (non-perm) connect — the auto-persist behaviour is what we're
+	// exercising.
+	alice.RPC.ConnectPeer(&lnrpc.ConnectPeerRequest{
+		Addr: &lnrpc.LightningAddress{
+			Pubkey: bobInfo.IdentityPubkey,
+			Host:   addrB,
+		},
+	})
+	ht.AssertConnected(alice, bob)
+
+	// Alice's remembered_addresses for Bob should now list both A
+	// (from channel open) and B (auto-persisted on this connect).
+	require.NoError(ht, wait.NoError(func() error {
+		p := bobPeer()
+		if p == nil {
+			return fmt.Errorf("bob missing from listpeers")
+		}
+		haveA, haveB := false, false
+		for _, a := range p.RememberedAddresses {
+			switch a {
+			case addrA:
+				haveA = true
+			case addrB:
+				haveB = true
+			}
+		}
+		if !haveA {
+			return fmt.Errorf("remembered_addresses %v missing "+
+				"channel-open address %s",
+				p.RememberedAddresses, addrA)
+		}
+		if !haveB {
+			return fmt.Errorf("remembered_addresses %v missing "+
+				"auto-persisted address %s",
+				p.RememberedAddresses, addrB)
+		}
+		return nil
+	}, defaultTimeout))
+}
+

--- a/itest/lnd_network_test.go
+++ b/itest/lnd_network_test.go
@@ -333,3 +333,84 @@ func testDisconnectingTargetPeer(ht *lntest.HarnessTest) {
 	// Check existing connection.
 	ht.AssertConnected(alice, bob)
 }
+
+// testListPeersAddressFields verifies the address-source fields that
+// ListPeers exposes on the Peer message: is_persistent, remembered_addresses
+// (from the LinkNode record), gossip_addresses (from NodeAnnouncement),
+// reconnect_pending, and the include_offline_persistent_peers request flag.
+func testListPeersAddressFields(ht *lntest.HarnessTest) {
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	bob := ht.NewNode("Bob", nil)
+	bobInfo := bob.RPC.GetInfo()
+
+	// Opening a channel writes a LinkNode record for the peer (this is
+	// what remembered_addresses reads from), and puts the peer in the
+	// persistent-reconnect set.
+	ht.ConnectNodes(alice, bob)
+	ht.OpenChannel(alice, bob, lntest.OpenChannelParams{Amt: 100_000})
+
+	// Helper: pull Bob's entry out of Alice's ListPeers response.
+	bobPeer := func(req *lnrpc.ListPeersRequest) *lnrpc.Peer {
+		resp := alice.RPC.ListPeersReq(req)
+		for _, p := range resp.Peers {
+			if p.PubKey == bobInfo.IdentityPubkey {
+				return p
+			}
+		}
+		return nil
+	}
+
+	// While connected, the new fields should be populated.
+	require.NoError(ht, wait.NoError(func() error {
+		p := bobPeer(&lnrpc.ListPeersRequest{})
+		if p == nil {
+			return fmt.Errorf("bob not yet in listpeers")
+		}
+		if !p.IsPersistent {
+			return fmt.Errorf("is_persistent should be true for " +
+				"a channel peer")
+		}
+		if len(p.RememberedAddresses) == 0 {
+			return fmt.Errorf("remembered_addresses should be " +
+				"populated for a channel peer")
+		}
+		if p.ReconnectPending {
+			return fmt.Errorf("reconnect_pending should be " +
+				"false while connected")
+		}
+		return nil
+	}, defaultTimeout))
+
+	// Stop Bob so Alice's connection to him drops.
+	restartBob := ht.SuspendNode(bob)
+
+	// Without include_offline_persistent_peers, Bob should not appear
+	// in the response once his connection is gone.
+	require.NoError(ht, wait.NoError(func() error {
+		p := bobPeer(&lnrpc.ListPeersRequest{})
+		if p != nil {
+			return fmt.Errorf("bob still visible without " +
+				"include_offline_persistent_peers")
+		}
+		return nil
+	}, defaultTimeout))
+
+	// With include_offline_persistent_peers, Bob should appear as an
+	// offline persistent entry: address empty, remembered_addresses
+	// populated, is_persistent true.
+	p := bobPeer(&lnrpc.ListPeersRequest{
+		IncludeOfflinePersistentPeers: true,
+	})
+	require.NotNil(ht, p,
+		"bob should appear when include_offline_persistent_peers=true")
+	require.Empty(ht, p.Address,
+		"offline entry should have empty address")
+	require.True(ht, p.IsPersistent,
+		"offline channel peer should still be is_persistent")
+	require.NotEmpty(ht, p.RememberedAddresses,
+		"offline channel peer should still expose remembered_addresses")
+
+	// Bring Bob back online so the test doesn't leave a hung retry.
+	require.NoError(ht, restartBob())
+}
+

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -5650,7 +5650,10 @@ type Peer struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The identity pubkey of the peer
 	PubKey string `protobuf:"bytes,1,opt,name=pub_key,json=pubKey,proto3" json:"pub_key,omitempty"`
-	// Network address of the peer; eg `127.0.0.1:10011`
+	// Network address of the currently active connection to the peer; e.g.
+	// `127.0.0.1:10011`. Empty when the entry represents a persistent peer
+	// that is not currently connected (only present in the response when
+	// the request sets `include_offline_persistent_peers`).
 	Address string `protobuf:"bytes,3,opt,name=address,proto3" json:"address,omitempty"`
 	// Bytes of data transmitted to this peer
 	BytesSent uint64 `protobuf:"varint,4,opt,name=bytes_sent,json=bytesSent,proto3" json:"bytes_sent,omitempty"`
@@ -5686,8 +5689,28 @@ type Peer struct {
 	LastFlapNs int64 `protobuf:"varint,14,opt,name=last_flap_ns,json=lastFlapNs,proto3" json:"last_flap_ns,omitempty"`
 	// The last ping payload the peer has sent to us.
 	LastPingPayload []byte `protobuf:"bytes,15,opt,name=last_ping_payload,json=lastPingPayload,proto3" json:"last_ping_payload,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// True if lnd is maintaining a persistent reconnect attempt for this
+	// peer. Equivalent to (len(remembered_addresses) > 0 or an active
+	// channel-driven persistent entry exists).
+	IsPersistent bool `protobuf:"varint,16,opt,name=is_persistent,json=isPersistent,proto3" json:"is_persistent,omitempty"`
+	// Addresses lnd has stored for the peer via its LinkNode record
+	// (captured at first channel open). Empty if no LinkNode entry exists
+	// for the peer. Note: this list is reported verbatim from storage,
+	// including any v2 .onion entries lnd will not dial (v2 was deprecated
+	// by the Tor project in 2021). v2 entries are preserved on disk so
+	// that signed NodeAnnouncements still verify; a v2 appearing here is
+	// a stale-storage signal, not an indication that lnd is attempting to
+	// reach that address.
+	RememberedAddresses []string `protobuf:"bytes,17,rep,name=remembered_addresses,json=rememberedAddresses,proto3" json:"remembered_addresses,omitempty"`
+	// Addresses currently advertised by this peer in the gossip network's
+	// NodeAnnouncement. Empty when no NodeAnnouncement is known.
+	GossipAddresses []string `protobuf:"bytes,18,rep,name=gossip_addresses,json=gossipAddresses,proto3" json:"gossip_addresses,omitempty"`
+	// True if lnd currently has an in-flight reconnect attempt for this
+	// peer. Mainly informative for entries returned when the request sets
+	// `include_offline_persistent_peers`.
+	ReconnectPending bool `protobuf:"varint,19,opt,name=reconnect_pending,json=reconnectPending,proto3" json:"reconnect_pending,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *Peer) Reset() {
@@ -5818,6 +5841,34 @@ func (x *Peer) GetLastPingPayload() []byte {
 	return nil
 }
 
+func (x *Peer) GetIsPersistent() bool {
+	if x != nil {
+		return x.IsPersistent
+	}
+	return false
+}
+
+func (x *Peer) GetRememberedAddresses() []string {
+	if x != nil {
+		return x.RememberedAddresses
+	}
+	return nil
+}
+
+func (x *Peer) GetGossipAddresses() []string {
+	if x != nil {
+		return x.GossipAddresses
+	}
+	return nil
+}
+
+func (x *Peer) GetReconnectPending() bool {
+	if x != nil {
+		return x.ReconnectPending
+	}
+	return false
+}
+
 type TimestampedError struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The unix timestamp in seconds when the error occurred.
@@ -5877,9 +5928,16 @@ type ListPeersRequest struct {
 	// If true, only the last error that our peer sent us will be returned with
 	// the peer's information, rather than the full set of historic errors we have
 	// stored.
-	LatestError   bool `protobuf:"varint,1,opt,name=latest_error,json=latestError,proto3" json:"latest_error,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	LatestError bool `protobuf:"varint,1,opt,name=latest_error,json=latestError,proto3" json:"latest_error,omitempty"`
+	// If true, the response also includes peers that the daemon is keeping in
+	// the auto-reconnect set but is not currently connected to. A peer is in
+	// this set if lnd has a stored record for it (a LinkNode entry from a
+	// prior channel open or `connect --perm`) or an open channel. Per-
+	// connection fields (address, bytes_sent, ping_time, etc.) are empty/zero
+	// for these entries.
+	IncludeOfflinePersistentPeers bool `protobuf:"varint,2,opt,name=include_offline_persistent_peers,json=includeOfflinePersistentPeers,proto3" json:"include_offline_persistent_peers,omitempty"`
+	unknownFields                 protoimpl.UnknownFields
+	sizeCache                     protoimpl.SizeCache
 }
 
 func (x *ListPeersRequest) Reset() {
@@ -5915,6 +5973,13 @@ func (*ListPeersRequest) Descriptor() ([]byte, []int) {
 func (x *ListPeersRequest) GetLatestError() bool {
 	if x != nil {
 		return x.LatestError
+	}
+	return false
+}
+
+func (x *ListPeersRequest) GetIncludeOfflinePersistentPeers() bool {
+	if x != nil {
+		return x.IncludeOfflinePersistentPeers
 	}
 	return false
 }
@@ -18852,7 +18917,7 @@ const file_lightning_proto_rawDesc = "" +
 	"\x10funding_canceled\x18\x05 \x01(\bR\x0ffundingCanceled\x12\x1c\n" +
 	"\tabandoned\x18\x06 \x01(\bR\tabandoned\"P\n" +
 	"\x16ClosedChannelsResponse\x126\n" +
-	"\bchannels\x18\x01 \x03(\v2\x1a.lnrpc.ChannelCloseSummaryR\bchannels\"\x8b\x05\n" +
+	"\bchannels\x18\x01 \x03(\v2\x1a.lnrpc.ChannelCloseSummaryR\bchannels\"\xbb\x06\n" +
 	"\x04Peer\x12\x17\n" +
 	"\apub_key\x18\x01 \x01(\tR\x06pubKey\x12\x18\n" +
 	"\aaddress\x18\x03 \x01(\tR\aaddress\x12\x1d\n" +
@@ -18872,7 +18937,11 @@ const file_lightning_proto_rawDesc = "" +
 	"flap_count\x18\r \x01(\x05R\tflapCount\x12 \n" +
 	"\flast_flap_ns\x18\x0e \x01(\x03R\n" +
 	"lastFlapNs\x12*\n" +
-	"\x11last_ping_payload\x18\x0f \x01(\fR\x0flastPingPayload\x1aK\n" +
+	"\x11last_ping_payload\x18\x0f \x01(\fR\x0flastPingPayload\x12#\n" +
+	"\ris_persistent\x18\x10 \x01(\bR\fisPersistent\x121\n" +
+	"\x14remembered_addresses\x18\x11 \x03(\tR\x13rememberedAddresses\x12)\n" +
+	"\x10gossip_addresses\x18\x12 \x03(\tR\x0fgossipAddresses\x12+\n" +
+	"\x11reconnect_pending\x18\x13 \x01(\bR\x10reconnectPending\x1aK\n" +
 	"\rFeaturesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\rR\x03key\x12$\n" +
 	"\x05value\x18\x02 \x01(\v2\x0e.lnrpc.FeatureR\x05value:\x028\x01\"P\n" +
@@ -18883,9 +18952,10 @@ const file_lightning_proto_rawDesc = "" +
 	"\vPINNED_SYNC\x10\x03\"F\n" +
 	"\x10TimestampedError\x12\x1c\n" +
 	"\ttimestamp\x18\x01 \x01(\x04R\ttimestamp\x12\x14\n" +
-	"\x05error\x18\x02 \x01(\tR\x05error\"5\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error\"~\n" +
 	"\x10ListPeersRequest\x12!\n" +
-	"\flatest_error\x18\x01 \x01(\bR\vlatestError\"6\n" +
+	"\flatest_error\x18\x01 \x01(\bR\vlatestError\x12G\n" +
+	" include_offline_persistent_peers\x18\x02 \x01(\bR\x1dincludeOfflinePersistentPeers\"6\n" +
 	"\x11ListPeersResponse\x12!\n" +
 	"\x05peers\x18\x01 \x03(\v2\v.lnrpc.PeerR\x05peers\"\x17\n" +
 	"\x15PeerEventSubscription\"\x84\x01\n" +

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -5694,7 +5694,8 @@ type Peer struct {
 	// channel-driven persistent entry exists).
 	IsPersistent bool `protobuf:"varint,16,opt,name=is_persistent,json=isPersistent,proto3" json:"is_persistent,omitempty"`
 	// Addresses lnd has stored for the peer via its LinkNode record
-	// (captured at first channel open). Empty if no LinkNode entry exists
+	// (captured at channel open and on subsequent outbound connects to a
+	// channel peer). Empty if no LinkNode entry exists
 	// for the peer. Note: this list is reported verbatim from storage,
 	// including any v2 .onion entries lnd will not dial (v2 was deprecated
 	// by the Tor project in 2021). v2 entries are preserved on disk so

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -4274,7 +4274,53 @@ func (x *ConnectPeerResponse) GetStatus() string {
 type DisconnectPeerRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The pubkey of the node to disconnect from
-	PubKey        string `protobuf:"bytes,1,opt,name=pub_key,json=pubKey,proto3" json:"pub_key,omitempty"`
+	PubKey string `protobuf:"bytes,1,opt,name=pub_key,json=pubKey,proto3" json:"pub_key,omitempty"`
+	// If set, the peer's stored LinkNode entry is also removed and no automatic
+	// reconnect is attempted from our side in the current session. Mutually
+	// exclusive with `forget_address`.
+	//
+	// Note: the remote peer may still re-dial us if they have us in their own
+	// persistent set (typical when a channel exists), in which case we'll
+	// accept the inbound connection. On the next lnd restart, if the peer
+	// still has open channels, the channel-driven persistence path will
+	// reconnect using NodeAnnouncement addresses from the gossip graph.
+	//
+	// For a peer with no open channels, `forget_node` is a shortcut for work
+	// that would happen on the next lnd restart anyway: at startup lnd runs
+	// `PruneLinkNodes`, which deletes stored LinkNode entries for peers with
+	// no open channels. `forget_node` on such a peer just performs that
+	// delete now, and additionally drops the live connection. `force` is not
+	// required in this case.
+	ForgetNode bool `protobuf:"varint,2,opt,name=forget_node,json=forgetNode,proto3" json:"forget_node,omitempty"`
+	// Only meaningful with `forget_node` or `forget_address`.
+	// With `forget_node`, `force` bypasses the guard that refuses to
+	// delete the LinkNode entry when open channels still exist with the
+	// peer.
+	// With `forget_address`, `force` allows removing the last stored
+	// address when the peer still has open channels (removing the last
+	// stored address is otherwise allowed automatically when no channels
+	// exist).
+	// Setting `force` without either `forget_node` or `forget_address` is
+	// rejected.
+	Force bool `protobuf:"varint,3,opt,name=force,proto3" json:"force,omitempty"`
+	// Remove a single stored address from the peer's LinkNode entry. The live
+	// connection is left untouched unless the peer happens to be connected on
+	// this exact address, in which case the connection is dropped so lnd can
+	// re-dial via the remaining stored/gossip addresses. If the removal would
+	// leave the LinkNode with no addresses and the peer still has open
+	// channels, the request is refused unless `force` is also set; if no
+	// open channels exist, the LinkNode entry is deleted automatically.
+	// Mutually exclusive with `forget_node`.
+	//
+	// Note: after `forget_address` + `force` removes the last stored address
+	// for a channel peer, the peer stays in the persistent-reconnect set —
+	// the peer-termination watcher will fetch the peer's NodeAnnouncement
+	// addresses (via the gossip graph) and use those for reconnect. Use
+	// `forget_node` instead if you want to remove the last stored address
+	// AND stop reconnecting from our side until lnd next restarts. Even
+	// with `forget_address` + `force`, a channel peer is only truly
+	// orphaned when it also has no NodeAnnouncement.
+	ForgetAddress string `protobuf:"bytes,4,opt,name=forget_address,json=forgetAddress,proto3" json:"forget_address,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4312,6 +4358,27 @@ func (*DisconnectPeerRequest) Descriptor() ([]byte, []int) {
 func (x *DisconnectPeerRequest) GetPubKey() string {
 	if x != nil {
 		return x.PubKey
+	}
+	return ""
+}
+
+func (x *DisconnectPeerRequest) GetForgetNode() bool {
+	if x != nil {
+		return x.ForgetNode
+	}
+	return false
+}
+
+func (x *DisconnectPeerRequest) GetForce() bool {
+	if x != nil {
+		return x.Force
+	}
+	return false
+}
+
+func (x *DisconnectPeerRequest) GetForgetAddress() string {
+	if x != nil {
+		return x.ForgetAddress
 	}
 	return ""
 }
@@ -18787,9 +18854,13 @@ const file_lightning_proto_rawDesc = "" +
 	"\x04perm\x18\x02 \x01(\bR\x04perm\x12\x18\n" +
 	"\atimeout\x18\x03 \x01(\x04R\atimeout\"-\n" +
 	"\x13ConnectPeerResponse\x12\x16\n" +
-	"\x06status\x18\x01 \x01(\tR\x06status\"0\n" +
+	"\x06status\x18\x01 \x01(\tR\x06status\"\x8e\x01\n" +
 	"\x15DisconnectPeerRequest\x12\x17\n" +
-	"\apub_key\x18\x01 \x01(\tR\x06pubKey\"0\n" +
+	"\apub_key\x18\x01 \x01(\tR\x06pubKey\x12\x1f\n" +
+	"\vforget_node\x18\x02 \x01(\bR\n" +
+	"forgetNode\x12\x14\n" +
+	"\x05force\x18\x03 \x01(\bR\x05force\x12%\n" +
+	"\x0eforget_address\x18\x04 \x01(\tR\rforgetAddress\"0\n" +
 	"\x16DisconnectPeerResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\"\xa3\x02\n" +
 	"\x04HTLC\x12\x1a\n" +

--- a/lnrpc/lightning.pb.gw.go
+++ b/lnrpc/lightning.pb.gw.go
@@ -427,6 +427,10 @@ func local_request_Lightning_ConnectPeer_0(ctx context.Context, marshaler runtim
 
 }
 
+var (
+	filter_Lightning_DisconnectPeer_0 = &utilities.DoubleArray{Encoding: map[string]int{"pub_key": 0, "pubKey": 1}, Base: []int{1, 1, 2, 0, 0}, Check: []int{0, 1, 1, 2, 3}}
+)
+
 func request_Lightning_DisconnectPeer_0(ctx context.Context, marshaler runtime.Marshaler, client LightningClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq DisconnectPeerRequest
 	var metadata runtime.ServerMetadata
@@ -446,6 +450,13 @@ func request_Lightning_DisconnectPeer_0(ctx context.Context, marshaler runtime.M
 	protoReq.PubKey, err = runtime.String(val)
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "pub_key", err)
+	}
+
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_Lightning_DisconnectPeer_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	msg, err := client.DisconnectPeer(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
@@ -472,6 +483,13 @@ func local_request_Lightning_DisconnectPeer_0(ctx context.Context, marshaler run
 	protoReq.PubKey, err = runtime.String(val)
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "pub_key", err)
+	}
+
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_Lightning_DisconnectPeer_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	msg, err := server.DisconnectPeer(ctx, &protoReq)

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -1795,7 +1795,12 @@ message Peer {
     // The identity pubkey of the peer
     string pub_key = 1;
 
-    // Network address of the peer; eg `127.0.0.1:10011`
+    /*
+    Network address of the currently active connection to the peer; e.g.
+    `127.0.0.1:10011`. Empty when the entry represents a persistent peer
+    that is not currently connected (only present in the response when
+    the request sets `include_offline_persistent_peers`).
+    */
     string address = 3;
 
     // Bytes of data transmitted to this peer
@@ -1873,6 +1878,38 @@ message Peer {
     The last ping payload the peer has sent to us.
     */
     bytes last_ping_payload = 15;
+
+    /*
+    True if lnd is maintaining a persistent reconnect attempt for this
+    peer. Equivalent to (len(remembered_addresses) > 0 or an active
+    channel-driven persistent entry exists).
+    */
+    bool is_persistent = 16;
+
+    /*
+    Addresses lnd has stored for the peer via its LinkNode record
+    (captured at first channel open). Empty if no LinkNode entry exists
+    for the peer. Note: this list is reported verbatim from storage,
+    including any v2 .onion entries lnd will not dial (v2 was deprecated
+    by the Tor project in 2021). v2 entries are preserved on disk so
+    that signed NodeAnnouncements still verify; a v2 appearing here is
+    a stale-storage signal, not an indication that lnd is attempting to
+    reach that address.
+    */
+    repeated string remembered_addresses = 17;
+
+    /*
+    Addresses currently advertised by this peer in the gossip network's
+    NodeAnnouncement. Empty when no NodeAnnouncement is known.
+    */
+    repeated string gossip_addresses = 18;
+
+    /*
+    True if lnd currently has an in-flight reconnect attempt for this
+    peer. Mainly informative for entries returned when the request sets
+    `include_offline_persistent_peers`.
+    */
+    bool reconnect_pending = 19;
 }
 
 message TimestampedError {
@@ -1890,6 +1927,16 @@ message ListPeersRequest {
     stored.
     */
     bool latest_error = 1;
+
+    /*
+    If true, the response also includes peers that the daemon is keeping in
+    the auto-reconnect set but is not currently connected to. A peer is in
+    this set if lnd has a stored record for it (a LinkNode entry from a
+    prior channel open or `connect --perm`) or an open channel. Per-
+    connection fields (address, bytes_sent, ping_time, etc.) are empty/zero
+    for these entries.
+    */
+    bool include_offline_persistent_peers = 2;
 }
 message ListPeersResponse {
     // The list of currently connected peers

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -1888,7 +1888,8 @@ message Peer {
 
     /*
     Addresses lnd has stored for the peer via its LinkNode record
-    (captured at first channel open). Empty if no LinkNode entry exists
+    (captured at channel open and on subsequent outbound connects to a
+    channel peer). Empty if no LinkNode entry exists
     for the peer. Note: this list is reported verbatim from storage,
     including any v2 .onion entries lnd will not dial (v2 was deprecated
     by the Tor project in 2021). v2 entries are preserved on disk so

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -1276,6 +1276,61 @@ message ConnectPeerResponse {
 message DisconnectPeerRequest {
     // The pubkey of the node to disconnect from
     string pub_key = 1;
+
+    /*
+    If set, the peer's stored LinkNode entry is also removed and no automatic
+    reconnect is attempted from our side in the current session. Mutually
+    exclusive with `forget_address`.
+
+    Note: the remote peer may still re-dial us if they have us in their own
+    persistent set (typical when a channel exists), in which case we'll
+    accept the inbound connection. On the next lnd restart, if the peer
+    still has open channels, the channel-driven persistence path will
+    reconnect using NodeAnnouncement addresses from the gossip graph.
+
+    For a peer with no open channels, `forget_node` is a shortcut for work
+    that would happen on the next lnd restart anyway: at startup lnd runs
+    `PruneLinkNodes`, which deletes stored LinkNode entries for peers with
+    no open channels. `forget_node` on such a peer just performs that
+    delete now, and additionally drops the live connection. `force` is not
+    required in this case.
+    */
+    bool forget_node = 2;
+
+    /*
+    Only meaningful with `forget_node` or `forget_address`.
+      * With `forget_node`, `force` bypasses the guard that refuses to
+        delete the LinkNode entry when open channels still exist with the
+        peer.
+      * With `forget_address`, `force` allows removing the last stored
+        address when the peer still has open channels (removing the last
+        stored address is otherwise allowed automatically when no channels
+        exist).
+    Setting `force` without either `forget_node` or `forget_address` is
+    rejected.
+    */
+    bool force = 3;
+
+    /*
+    Remove a single stored address from the peer's LinkNode entry. The live
+    connection is left untouched unless the peer happens to be connected on
+    this exact address, in which case the connection is dropped so lnd can
+    re-dial via the remaining stored/gossip addresses. If the removal would
+    leave the LinkNode with no addresses and the peer still has open
+    channels, the request is refused unless `force` is also set; if no
+    open channels exist, the LinkNode entry is deleted automatically.
+    Mutually exclusive with `forget_node`.
+
+    Note: after `forget_address` + `force` removes the last stored address
+    for a channel peer, the peer stays in the persistent-reconnect set —
+    the peer-termination watcher will fetch the peer's NodeAnnouncement
+    addresses (via the gossip graph) and use those for reconnect. Use
+    `forget_node` instead if you want to remove the last stored address
+    AND stop reconnecting from our side until lnd next restarts. Even
+    with `forget_address` + `force`, a channel peer is only truly
+    orphaned when it also has no NodeAnnouncement.
+    */
+    string forget_address = 4;
 }
 message DisconnectPeerResponse {
     // The status of the disconnect operation.

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -2442,6 +2442,13 @@
             "in": "query",
             "required": false,
             "type": "boolean"
+          },
+          {
+            "name": "include_offline_persistent_peers",
+            "description": "If true, the response also includes peers that the daemon is keeping in\nthe auto-reconnect set but is not currently connected to. A peer is in\nthis set if lnd has a stored record for it (a LinkNode entry from a\nprior channel open or `connect --perm`) or an open channel. Per-\nconnection fields (address, bytes_sent, ping_time, etc.) are empty/zero\nfor these entries.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "tags": [
@@ -6919,7 +6926,7 @@
         },
         "address": {
           "type": "string",
-          "title": "Network address of the peer; eg `127.0.0.1:10011`"
+          "description": "Network address of the currently active connection to the peer; e.g.\n`127.0.0.1:10011`. Empty when the entry represents a persistent peer\nthat is not currently connected (only present in the response when\nthe request sets `include_offline_persistent_peers`)."
         },
         "bytes_sent": {
           "type": "string",
@@ -6983,6 +6990,28 @@
           "type": "string",
           "format": "byte",
           "description": "The last ping payload the peer has sent to us."
+        },
+        "is_persistent": {
+          "type": "boolean",
+          "description": "True if lnd is maintaining a persistent reconnect attempt for this\npeer. Equivalent to (len(remembered_addresses) \u003e 0 or an active\nchannel-driven persistent entry exists)."
+        },
+        "remembered_addresses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Addresses lnd has stored for the peer via its LinkNode record\n(captured at first channel open). Empty if no LinkNode entry exists\nfor the peer. Note: this list is reported verbatim from storage,\nincluding any v2 .onion entries lnd will not dial (v2 was deprecated\nby the Tor project in 2021). v2 entries are preserved on disk so\nthat signed NodeAnnouncements still verify; a v2 appearing here is\na stale-storage signal, not an indication that lnd is attempting to\nreach that address."
+        },
+        "gossip_addresses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Addresses currently advertised by this peer in the gossip network's\nNodeAnnouncement. Empty when no NodeAnnouncement is known."
+        },
+        "reconnect_pending": {
+          "type": "boolean",
+          "description": "True if lnd currently has an in-flight reconnect attempt for this\npeer. Mainly informative for entries returned when the request sets\n`include_offline_persistent_peers`."
         }
       }
     },

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -7000,7 +7000,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Addresses lnd has stored for the peer via its LinkNode record\n(captured at first channel open). Empty if no LinkNode entry exists\nfor the peer. Note: this list is reported verbatim from storage,\nincluding any v2 .onion entries lnd will not dial (v2 was deprecated\nby the Tor project in 2021). v2 entries are preserved on disk so\nthat signed NodeAnnouncements still verify; a v2 appearing here is\na stale-storage signal, not an indication that lnd is attempting to\nreach that address."
+          "description": "Addresses lnd has stored for the peer via its LinkNode record\n(captured at channel open and on subsequent outbound connects to a\nchannel peer). Empty if no LinkNode entry exists\nfor the peer. Note: this list is reported verbatim from storage,\nincluding any v2 .onion entries lnd will not dial (v2 was deprecated\nby the Tor project in 2021). v2 entries are preserved on disk so\nthat signed NodeAnnouncements still verify; a v2 appearing here is\na stale-storage signal, not an indication that lnd is attempting to\nreach that address."
         },
         "gossip_addresses": {
           "type": "array",

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -2544,6 +2544,27 @@
             "in": "path",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "forget_node",
+            "description": "If set, the peer's stored LinkNode entry is also removed and no automatic\nreconnect is attempted from our side in the current session. Mutually\nexclusive with `forget_address`.\n\nNote: the remote peer may still re-dial us if they have us in their own\npersistent set (typical when a channel exists), in which case we'll\naccept the inbound connection. On the next lnd restart, if the peer\nstill has open channels, the channel-driven persistence path will\nreconnect using NodeAnnouncement addresses from the gossip graph.\n\nFor a peer with no open channels, `forget_node` is a shortcut for work\nthat would happen on the next lnd restart anyway: at startup lnd runs\n`PruneLinkNodes`, which deletes stored LinkNode entries for peers with\nno open channels. `forget_node` on such a peer just performs that\ndelete now, and additionally drops the live connection. `force` is not\nrequired in this case.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "force",
+            "description": "Only meaningful with `forget_node` or `forget_address`.\nWith `forget_node`, `force` bypasses the guard that refuses to\ndelete the LinkNode entry when open channels still exist with the\npeer.\nWith `forget_address`, `force` allows removing the last stored\naddress when the peer still has open channels (removing the last\nstored address is otherwise allowed automatically when no channels\nexist).\nSetting `force` without either `forget_node` or `forget_address` is\nrejected.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "forget_address",
+            "description": "Remove a single stored address from the peer's LinkNode entry. The live\nconnection is left untouched unless the peer happens to be connected on\nthis exact address, in which case the connection is dropped so lnd can\nre-dial via the remaining stored/gossip addresses. If the removal would\nleave the LinkNode with no addresses and the peer still has open\nchannels, the request is refused unless `force` is also set; if no\nopen channels exist, the LinkNode entry is deleted automatically.\nMutually exclusive with `forget_node`.\n\nNote: after `forget_address` + `force` removes the last stored address\nfor a channel peer, the peer stays in the persistent-reconnect set —\nthe peer-termination watcher will fetch the peer's NodeAnnouncement\naddresses (via the gossip graph) and use those for reconnect. Use\n`forget_node` instead if you want to remove the last stored address\nAND stop reconnecting from our side until lnd next restarts. Even\nwith `forget_address` + `force`, a channel peer is only truly\norphaned when it also has no NodeAnnouncement.",
+            "in": "query",
+            "required": false,
+            "type": "string"
           }
         ],
         "tags": [

--- a/lntest/rpc/lnd.go
+++ b/lntest/rpc/lnd.go
@@ -78,6 +78,33 @@ func (h *HarnessRPC) DisconnectPeer(
 	return resp
 }
 
+// DisconnectPeerReq calls DisconnectPeer with a fully formed request,
+// allowing tests to exercise the forget / force / forget_address flags.
+func (h *HarnessRPC) DisconnectPeerReq(
+	req *lnrpc.DisconnectPeerRequest) *lnrpc.DisconnectPeerResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.LN.DisconnectPeer(ctxt, req)
+	h.NoError(err, "DisconnectPeer")
+
+	return resp
+}
+
+// DisconnectPeerReqAssertErr calls DisconnectPeer expecting a non-nil error.
+func (h *HarnessRPC) DisconnectPeerReqAssertErr(
+	req *lnrpc.DisconnectPeerRequest) error {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	_, err := h.LN.DisconnectPeer(ctxt, req)
+	require.Error(h, err, "expected an error from DisconnectPeer")
+
+	return err
+}
+
 // DeleteAllPayments makes a RPC call to the node's DeleteAllPayments and
 // asserts.
 func (h *HarnessRPC) DeleteAllPayments() {

--- a/lntest/rpc/lnd.go
+++ b/lntest/rpc/lnd.go
@@ -49,6 +49,19 @@ func (h *HarnessRPC) ListPeers() *lnrpc.ListPeersResponse {
 	return resp
 }
 
+// ListPeersReq calls ListPeers with a fully formed request.
+func (h *HarnessRPC) ListPeersReq(
+	req *lnrpc.ListPeersRequest) *lnrpc.ListPeersResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.LN.ListPeers(ctxt, req)
+	h.NoError(err, "ListPeers")
+
+	return resp
+}
+
 // DisconnectPeer calls the DisconnectPeer RPC on a given node with a specified
 // public key string and asserts there's no error.
 func (h *HarnessRPC) DisconnectPeer(

--- a/pilot.go
+++ b/pilot.go
@@ -251,7 +251,9 @@ func initAutoPilot(svr *server, cfg *lncfg.AutoPilot,
 
 			return false, nil
 		},
-		DisconnectPeer: svr.DisconnectPeer,
+		DisconnectPeer: func(pk *btcec.PublicKey) error {
+			return svr.DisconnectPeer(pk, false, false)
+		},
 	}
 
 	// Create and return the autopilot.ManagerCfg that administrates this

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1945,9 +1945,45 @@ func (r *rpcServer) DisconnectPeer(ctx context.Context,
 			pubKeyBytes, len(nodeChannels))
 	}
 
+	// Validate flag combinations before doing any work.
+	if in.Force && !in.ForgetNode && in.ForgetAddress == "" {
+		return nil, fmt.Errorf("force can only be set together " +
+			"with forget_node or forget_address")
+	}
+	if in.ForgetNode && in.ForgetAddress != "" {
+		return nil, fmt.Errorf("forget_node and forget_address " +
+			"are mutually exclusive")
+	}
+
+	// Per-address removal takes a distinct code path: it does not drop
+	// the live connection (unless the removed address is the currently
+	// connected one), and it returns a warning in the status if the
+	// LinkNode entry itself was deleted as a result.
+	if in.ForgetAddress != "" {
+		addr, addrErr := parseAddr(in.ForgetAddress, r.cfg.net)
+		if addrErr != nil {
+			return nil, fmt.Errorf("unable to parse "+
+				"forget_address: %w", addrErr)
+		}
+		deletedEntry, fErr := r.server.ForgetPeerAddress(
+			peerPubKey, addr, in.Force,
+		)
+		if fErr != nil {
+			return nil, fmt.Errorf("unable to forget peer "+
+				"address: %w", fErr)
+		}
+		status := fmt.Sprintf("forgot address %v for peer %x",
+			addr, pubKeyBytes)
+		if deletedEntry {
+			status = fmt.Sprintf("%s; this was the last stored "+
+				"address, LinkNode entry removed", status)
+		}
+		return &lnrpc.DisconnectPeerResponse{Status: status}, nil
+	}
+
 	// With all initial validation complete, we'll now request that the
 	// server disconnects from the peer.
-	err = r.server.DisconnectPeer(peerPubKey)
+	err = r.server.DisconnectPeer(peerPubKey, in.ForgetNode, in.Force)
 	if err != nil {
 		return nil, fmt.Errorf("unable to disconnect peer: %w", err)
 	}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3570,6 +3570,51 @@ func (r *rpcServer) ListPeers(ctx context.Context,
 		Peers: make([]*lnrpc.Peer, 0, len(serverPeers)),
 	}
 
+	// Pre-fetch the LinkNode store into a pubkey-keyed map so the
+	// per-peer loop becomes a constant lookup rather than a per-peer DB
+	// hit.
+	linkNodes, err := r.server.linkNodeDB.FetchAllLinkNodes()
+	if err != nil && !errors.Is(err, channeldb.ErrLinkNodesNotFound) {
+		return nil, fmt.Errorf("unable to fetch link nodes: %w", err)
+	}
+	rememberedAddrsByPub := make(map[string][]net.Addr, len(linkNodes))
+	for _, ln := range linkNodes {
+		key := string(ln.IdentityPub.SerializeCompressed())
+		rememberedAddrsByPub[key] = ln.Addresses
+	}
+
+	// Snapshot the in-memory persistent set so we can also emit
+	// disconnected entries if the caller opted in.
+	persistentSet := r.server.PersistentReconnectSet()
+
+	// Track which pubkeys we have already emitted so we don't duplicate
+	// when appending offline entries.
+	connectedPubs := make(map[string]struct{}, len(serverPeers))
+
+	// Helper: []net.Addr → []string.
+	toStrs := func(addrs []net.Addr) []string {
+		out := make([]string, 0, len(addrs))
+		for _, a := range addrs {
+			out = append(out, a.String())
+		}
+		return out
+	}
+
+	// Helper: gossip addresses for a pubkey, ignoring v2 onion entries.
+	// Returns an empty slice for any error (e.g. peer not in graph) since
+	// missing gossip data is normal.
+	gossipAddrsFor := func(pubBytes []byte) []string {
+		vertex, vErr := route.NewVertexFromBytes(pubBytes)
+		if vErr != nil {
+			return nil
+		}
+		node, gErr := r.server.v1Graph.FetchNode(ctx, vertex)
+		if gErr != nil {
+			return nil
+		}
+		return toStrs(withoutV2Onion(node.Addresses))
+	}
+
 	for _, serverPeer := range serverPeers {
 		var (
 			satSent int64
@@ -3690,10 +3735,46 @@ func (r *rpcServer) ListPeers(ctx context.Context,
 			}
 		}
 
+		// Enrich with the new persistent / multi-source address
+		// fields.
+		pubStr := string(nodePub[:])
+		connectedPubs[pubStr] = struct{}{}
+
+		rpcPeer.RememberedAddresses = toStrs(
+			rememberedAddrsByPub[pubStr],
+		)
+		rpcPeer.GossipAddresses = gossipAddrsFor(nodePub[:])
+		_, inPersistentSet := persistentSet[pubStr]
+		rpcPeer.IsPersistent = inPersistentSet ||
+			len(rpcPeer.RememberedAddresses) > 0
+		// We're connected, so reconnect_pending stays at its zero
+		// default.
+
 		resp.Peers = append(resp.Peers, rpcPeer)
 	}
 
-	rpcsLog.Debugf("[listpeers] yielded %v peers", serverPeers)
+	// Optionally append entries for persistent peers we're not currently
+	// connected to.
+	if in.IncludeOfflinePersistentPeers {
+		for pubStr, pending := range persistentSet {
+			if _, ok := connectedPubs[pubStr]; ok {
+				continue
+			}
+
+			pubBytes := []byte(pubStr)
+			resp.Peers = append(resp.Peers, &lnrpc.Peer{
+				PubKey: hex.EncodeToString(pubBytes),
+				RememberedAddresses: toStrs(
+					rememberedAddrsByPub[pubStr],
+				),
+				GossipAddresses:  gossipAddrsFor(pubBytes),
+				IsPersistent:     true,
+				ReconnectPending: pending,
+			})
+		}
+	}
+
+	rpcsLog.Debugf("[listpeers] yielded %d peers", len(resp.Peers))
 
 	return resp, nil
 }

--- a/server.go
+++ b/server.go
@@ -2877,7 +2877,7 @@ func (s *server) Stop() error {
 		// Disconnect from each active peers to ensure that
 		// peerTerminationWatchers signal completion to each peer.
 		for _, peer := range s.Peers() {
-			err := s.DisconnectPeer(peer.IdentityKey())
+			err := s.DisconnectPeer(peer.IdentityKey(), false, false)
 			if err != nil {
 				srvrLog.Warnf("could not disconnect peer: %v"+
 					"received error: %v", peer.IdentityKey(),
@@ -4465,7 +4465,7 @@ func (s *server) notifyFundingTimeoutPeerEvent(op wire.OutPoint,
 	if errors.Is(err, ErrNoMoreRestrictedAccessSlots) {
 		// If we encounter an error while attempting to disconnect the
 		// peer, log the error.
-		if dcErr := s.DisconnectPeer(remotePub); dcErr != nil {
+		if dcErr := s.DisconnectPeer(remotePub, false, false); dcErr != nil {
 			srvrLog.Errorf("Unable to disconnect peer: %v\n", err)
 		}
 	}
@@ -4634,7 +4634,9 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 		ChannelNotifier: s.channelNotifier,
 		HtlcNotifier:    s.htlcNotifier,
 		TowerClient:     towerClient,
-		DisconnectPeer:  s.DisconnectPeer,
+		DisconnectPeer: func(pk *btcec.PublicKey) error {
+			return s.DisconnectPeer(pk, false, false)
+		},
 		GenNodeAnnouncement: func(...netann.NodeAnnModifier) (
 			lnwire.NodeAnnouncement1, error) {
 
@@ -5328,10 +5330,14 @@ func (s *server) connectToPeer(addr *lnwire.NetAddress,
 }
 
 // DisconnectPeer sends the request to server to close the connection with peer
-// identified by public key.
+// identified by public key. If forgetNode is true, the peer's LinkNode entry
+// is also removed (whole-peer forget); when open channels still exist with
+// the peer, the LinkNode delete is refused unless force is also true.
 //
 // NOTE: This function is safe for concurrent access.
-func (s *server) DisconnectPeer(pubKey *btcec.PublicKey) error {
+func (s *server) DisconnectPeer(pubKey *btcec.PublicKey,
+	forgetNode, force bool) error {
+
 	pubBytes := pubKey.SerializeCompressed()
 	pubStr := string(pubBytes)
 
@@ -5346,9 +5352,38 @@ func (s *server) DisconnectPeer(pubKey *btcec.PublicKey) error {
 		return fmt.Errorf("peer %x is not connected", pubBytes)
 	}
 
-	srvrLog.Infof("Disconnecting from %v", peer)
+	srvrLog.Infof("Disconnecting from %v (forget_node=%v, force=%v)",
+		peer, forgetNode, force)
 
 	s.cancelConnReqs(pubStr, nil)
+
+	// If forgetNode was requested, drop the peer's LinkNode entry
+	// unless open channels still exist and force wasn't set.
+	if forgetNode {
+		nodeChannels, fcErr := s.chanStateDB.FetchOpenChannels(pubKey)
+		switch {
+		case fcErr != nil:
+			srvrLog.Errorf("Unable to check open channels for "+
+				"peer %x while forgetting: %v", pubBytes,
+				fcErr)
+
+		case len(nodeChannels) > 0 && !force:
+			srvrLog.Infof("Keeping LinkNode for peer %x: %d "+
+				"open channel(s) still exist; pass force=true "+
+				"to remove anyway", pubBytes,
+				len(nodeChannels))
+
+		default:
+			err := s.linkNodeDB.DeleteLinkNode(pubKey)
+			if err != nil &&
+				!errors.Is(err, channeldb.ErrLinkNodesNotFound) &&
+				!errors.Is(err, channeldb.ErrNodeNotFound) {
+
+				srvrLog.Errorf("Unable to remove LinkNode "+
+					"for peer %x: %v", pubBytes, err)
+			}
+		}
+	}
 
 	// If this peer was formerly a persistent connection, then we'll remove
 	// them from this map so we don't attempt to re-connect after we
@@ -5364,6 +5399,73 @@ func (s *server) DisconnectPeer(pubKey *btcec.PublicKey) error {
 	go peer.Disconnect(fmt.Errorf("server: DisconnectPeer called"))
 
 	return nil
+}
+
+// ForgetPeerAddress removes a single stored address from the peer's LinkNode
+// entry. If the removal would leave the LinkNode with no addresses:
+//   - if force is true, the entry is deleted.
+//   - if force is false and the peer has no open channels, the entry is
+//     deleted (removing the last stored address for a channel-less peer is
+//     considered safe).
+//   - if force is false and the peer still has open channels,
+//     ErrLastPeerAddress is returned and the store is left untouched.
+//
+// If the peer is currently connected on the address being removed, the live
+// connection is also dropped so lnd will re-dial through the remaining
+// address sources.
+//
+// deletedEntry is true when the whole LinkNode entry was removed as part of
+// this call.
+//
+// NOTE: This function is safe for concurrent access.
+func (s *server) ForgetPeerAddress(pubKey *btcec.PublicKey, addr net.Addr,
+	force bool) (deletedEntry bool, err error) {
+
+	// Removing the last stored address is safe when the peer has no
+	// open channels; require `force` otherwise so the operator doesn't
+	// accidentally orphan a live channel from its stored address.
+	allowLast := force
+	if !allowLast {
+		nodeChannels, fcErr := s.chanStateDB.FetchOpenChannels(pubKey)
+		if fcErr != nil {
+			return false, fmt.Errorf("unable to check open "+
+				"channels for peer: %w", fcErr)
+		}
+		allowLast = len(nodeChannels) == 0
+	}
+
+	deletedEntry, err = s.linkNodeDB.RemoveAddressForPeer(
+		pubKey, addr, allowLast,
+	)
+	if err != nil {
+		return false, err
+	}
+
+	pubBytes := pubKey.SerializeCompressed()
+	if deletedEntry {
+		srvrLog.Infof("Removed last stored address %v for peer %x; "+
+			"LinkNode entry deleted", addr, pubBytes)
+	} else {
+		srvrLog.Infof("Removed stored address %v for peer %x", addr,
+			pubBytes)
+	}
+
+	// If we are currently connected on the removed address, drop the
+	// connection so lnd can re-dial via the remaining stored/gossip
+	// addresses.
+	pubStr := string(pubBytes)
+	s.mu.Lock()
+	peer, findErr := s.findPeerByPubStr(pubStr)
+	s.mu.Unlock()
+	if findErr == nil && peer.Address().String() == addr.String() {
+		srvrLog.Infof("Dropping connection to peer %x on removed "+
+			"address %v", pubBytes, addr)
+		go peer.Disconnect(fmt.Errorf(
+			"server: ForgetPeerAddress removed current address",
+		))
+	}
+
+	return deletedEntry, nil
 }
 
 // OpenChannel sends a request to the server to open a channel to the specified

--- a/server.go
+++ b/server.go
@@ -4474,6 +4474,42 @@ func (s *server) notifyFundingTimeoutPeerEvent(op wire.OutPoint,
 	s.channelNotifier.NotifyFundingTimeout(op)
 }
 
+// maybePersistPeerAddress records addr in the LinkNode entry for pubKey when
+// the peer has an open channel with us. It is a no-op for non-channel peers,
+// for peers without an existing LinkNode entry, and for address types other
+// than TCP and onion. Errors are logged and swallowed — this is best-effort
+// bookkeeping and must not interfere with the connection.
+func (s *server) maybePersistPeerAddress(pubKey *btcec.PublicKey, addr net.Addr) {
+	switch addr.(type) {
+	case *net.TCPAddr, *tor.OnionAddr:
+	default:
+		return
+	}
+
+	channels, err := s.chanStateDB.FetchOpenChannels(pubKey)
+	if err != nil {
+		srvrLog.Errorf("Unable to fetch open channels for %x when "+
+			"considering address persistence: %v",
+			pubKey.SerializeCompressed(), err)
+		return
+	}
+	if len(channels) == 0 {
+		return
+	}
+
+	added, err := s.linkNodeDB.AddAddressIfPeerKnown(pubKey, addr)
+	if err != nil {
+		srvrLog.Errorf("Unable to record address %v for channel "+
+			"peer %x: %v", addr, pubKey.SerializeCompressed(), err)
+		return
+	}
+	if added {
+		srvrLog.Infof("Recorded address %v for channel peer %x for "+
+			"reconnection across restarts", addr,
+			pubKey.SerializeCompressed())
+	}
+}
+
 // peerConnected is a function that handles initialization a newly connected
 // peer by adding it to the server's global list of all active peers, and
 // starting all the goroutines the peer needs to function properly. The inbound
@@ -4658,6 +4694,19 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 	//  * also mark last-seen, do it one single transaction?
 
 	s.addPeer(p)
+
+	// For outbound connections to a channel peer, record the address we
+	// dialed in the peer's LinkNode entry if it isn't already listed.
+	// This lets us reconnect on that address after a restart if the
+	// peer's current NodeAnnouncement no longer lists it.
+	//
+	// We only do this for outbound connections. For inbound TCP,
+	// conn.RemoteAddr() is the peer's ephemeral source port rather than
+	// a listener we could dial back to, so persisting it would just
+	// inflate the address list with non-dialable entries.
+	if !inbound {
+		s.maybePersistPeerAddress(pubKey, addr)
+	}
 
 	// Once we have successfully added the peer to the server, we can
 	// delete the previous error buffer from the server's map of error

--- a/server.go
+++ b/server.go
@@ -5154,6 +5154,23 @@ func (s *server) removePeerUnsafe(ctx context.Context, p *peer.Brontide) {
 	}()
 }
 
+// PersistentReconnectSet returns a snapshot of the pubkeys currently in the
+// persistent reconnect set, mapped to whether a reconnect attempt is in
+// flight. Keys are the raw 33-byte compressed pubkey as a Go string (matching
+// the keying convention used by s.persistentPeers).
+//
+// NOTE: This function is safe for concurrent access.
+func (s *server) PersistentReconnectSet() map[string]bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make(map[string]bool, len(s.persistentPeers))
+	for k := range s.persistentPeers {
+		out[k] = len(s.persistentConnReqs[k]) > 0
+	}
+	return out
+}
+
 // ConnectToPeer requests that the server connect to a Lightning Network peer
 // at the specified address. This function will *block* until either a
 // connection is established, or the initial handshake process fails.


### PR DESCRIPTION
Extends `lncli disconnect` with two ways to prune a peer's stored
LinkNode state:

  * `--forget_node` for whole-peer removal.
  * `--forget_address` for surgical, per-address removal.

Both operations are gated by a shared `--force` flag when the requested
action would lose meaningful state:

  * `--forget_node` drops the live connection (base `disconnect` behavior)
    and additionally deletes the peer's LinkNode entry. The LinkNode
    delete is refused if open channels still exist with the peer unless
    `--force` is also set.
  * `--forget_address <host:port>` removes a single stored address from
    the peer's LinkNode entry. The live connection is left in place
    unless the removed address happens to be the currently-connected
    one, in which case the connection is dropped so lnd can re-dial via
    the remaining stored/gossip addresses. If the removed address would
    be the last one stored for the peer, behaviour depends on whether
    open channels exist: with no open channels the LinkNode entry is
    deleted automatically; with open channels the request is refused
    unless `--force` is also set. Note that after `--forget_address
    --force` removes the last stored address for a channel peer, the
    peer stays in the persistent-reconnect set — the peer-termination
    watcher falls back to the peer's NodeAnnouncement addresses for
    reconnect. `--forget_node` is the way to also stop reconnecting
    from our side (until lnd next restarts). Even with `--forget_address
    --force`, a channel peer is only truly orphaned when it also has
    no NodeAnnouncement.
  * `--force` on its own is rejected. `--forget_node` and `--forget_address`
    are mutually exclusive.

Response Status carries a warning when `--forget_address` triggers the
last-address LinkNode delete.

DB helper:

  * new `channeldb.LinkNodeDB.RemoveAddressForPeer(pub, addr, allowLast)`
    returning `(deletedEntry bool, err error)`.
  * new sentinel errors: `ErrNodeAddressNotFound` (address not stored
    for peer), `ErrLastPeerAddress` (refusing to remove last address
    without `allowLast`).

Server:

  * `DisconnectPeer` signature grows `forgetNode` and `force` parameters.
  * new `ForgetPeerAddress` method handles the per-address case,
    including the "disconnect if removed address is current" behaviour.
  * all internal callers of `DisconnectPeer` updated to pass
    `false, false`.

Proto: `DisconnectPeerRequest` gains `forget_node` (2), `force` (3), and
`forget_address` (4). `DisconnectPeerResponse.Status` reuses its
existing type.

itest: `disconnect forget` covers all branches — per-address removal,
last-address gating, `--forget_node` with and without `--force` against a
channel peer, and both error cases (`--force` alone; `--forget_node` +
`--forget_address`).

Depends on #10975 (which depends on #10973): the itest seeds a second
stored address by reconnecting Alice on Bob's alternate listener, which
#10975's auto-persist captures into LinkNode; it also reads the
`remembered_addresses` field added in #10973.

Contributes to #10871.

