### PR TITLE
kvdb/sqlbase: relax bulk migration isolation

### DIFF
--- a/kvdb/sqlbase/migration_bulk_postgres.go
+++ b/kvdb/sqlbase/migration_bulk_postgres.go
@@ -88,8 +88,13 @@ func (p *postgresDB) BeginBulk(ctx context.Context) (MigrationBulkKVTx, error) {
 		return nil, err
 	}
 
+	// A bulk migration can touch millions of rows in a single transaction.
+	// PostgreSQL retains predicate locks until a serializable transaction
+	// ends, which can make its predicate lock table consume excessive memory.
+	// Read committed is sufficient because the migration owns the empty
+	// destination database while loading it.
 	tx, err := conn.BeginTx(ctx, &sql.TxOptions{
-		Isolation: sql.LevelSerializable,
+		Isolation: sql.LevelReadCommitted,
 	})
 	if err != nil {
 		locker.Unlock()


### PR DESCRIPTION
## Change Description

Use PostgreSQL's read committed isolation level for the KVDB bulk migration
write transaction.

Serializable isolation retains predicate locks for the lifetime of the
transaction. Because a bulk migration can touch millions of rows in one
transaction, the predicate lock table can consume excessive memory. Read
committed is sufficient here because the migration owns the empty destination
database while loading it.

The read-only verification transaction remains repeatable read so it continues
to observe a stable snapshot.

## Steps to Test

```bash
cd kvdb
go test -tags=kvdb_postgres ./postgres -run 'TestMigrationBulk' -count=1
```

## Pull Request Checklist

### Testing

- [ ] Your PR passes all CI checks.
- [x] Existing bulk migration tests pass.

### Code Style and Documentation

- [x] The change obeys the code documentation and commenting guidelines, and
  lines wrap at 80 columns.
- [x] Commits follow the ideal Git commit structure.
- [x] No new logging statements or RPC commands are introduced.
- [x] No release note is needed (`no_changelog`).
