### PR TITLE
onionmessage: bound per-peer rate limiter registry 

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -55,6 +55,17 @@
   the reported network statistics such as total network capacity, channel
   count and max out degree.
 
+* [Bounded the per-peer onion message rate limiter
+  registry](https://github.com/lightningnetwork/lnd/pull/10981) so it no
+  longer grows without limit. The registry kept a token bucket per peer and
+  never removed entries, so with the channel-presence gate disabled via
+  `--onion-msg-relay-all` a peer reconnecting under many identities could
+  grow the map until the node ran out of memory. Buckets that have refilled
+  to their full burst, and therefore carry no rate-limiting state, are now
+  evicted once the registry grows past a high-water mark, while buckets that
+  still owe tokens are retained so the per-peer limit remains a ceiling
+  across reconnects.
+
 # New Features
 
 ## Functional Enhancements

--- a/onionmessage/ratelimit.go
+++ b/onionmessage/ratelimit.go
@@ -115,31 +115,44 @@ func NewGlobalLimiter(kbps uint64, burstBytes uint64) RateLimiter {
 	}
 }
 
+// defaultMaxRetainedPeers is the high-water mark for the number of per-peer
+// buckets retained in the registry. When creating a new bucket pushes the
+// count above this threshold, AllowN triggers a sweep that evicts every
+// bucket which has refilled to its full burst (see evictFullBuckets). It is
+// set well above the number of buckets a typical node accumulates, so the
+// sweep only runs when the registry grows unusually large, for example when
+// the channel-presence gate is disabled via --onion-msg-relay-all.
+const defaultMaxRetainedPeers = 10_000
+
 // PeerRateLimiter is a registry of per-peer onion message token buckets,
 // keyed by the peer's compressed public key. Tokens are bytes: callers pass
 // the on-the-wire size of each message to AllowN and the per-peer bucket is
 // debited accordingly. Buckets are created lazily on the first call to
-// AllowN for a given peer and retained for the lifetime of the process.
+// AllowN for a given peer and retained across disconnects.
 // When the configured rate or burst is zero the registry operates in
 // disabled mode and AllowN is a no-op.
 //
-// Retention across disconnect is load-bearing. Without it, a peer could
-// drain its burst, disconnect, reconnect, and get a fresh full-burst
-// bucket on every cycle, effectively promoting the global limiter into
-// its per-peer rate and using the shared budget as a personal allowance
-// until the global bucket trips. By keeping the bucket, a drained peer
-// stays drained until its bucket naturally refills regardless of how
-// often it cycles the connection, and the per-peer rate becomes a real
-// ceiling rather than a per-connection ceiling.
+// Buckets are retained across disconnects so that the per-peer rate is a
+// ceiling on the peer rather than on each connection. If buckets were
+// dropped on disconnect, a peer could drain its burst, reconnect, and
+// receive a fresh full-burst bucket on every cycle. Keeping the bucket
+// means a peer that has spent its budget stays limited until the bucket
+// refills, regardless of how often it reconnects.
 //
-// The memory cost of retention is bounded by the number of channel
-// peers that have ever sent an onion message: the ingress call site
-// gates AllowN on the peer having at least one open channel before
-// touching this registry, so random connecting strangers never allocate
-// a bucket. At a realistic few hundred to few thousand channel partners
-// and ~200 bytes per entry (rate.Limiter plus SyncMap overhead), the
-// registry stays comfortably sub-megabyte for the lifetime of the
-// process.
+// Retention is bounded by eviction rather than by connection state. In the
+// default configuration the channel-presence gate at the ingress call site
+// keeps peers without a channel out of the registry, so it only holds
+// buckets for channel peers. When that gate is disabled via
+// --onion-msg-relay-all, any connecting pubkey that sends an onion message
+// allocates a bucket, so the registry could otherwise grow with each new
+// identity. To keep it bounded in that case, AllowN evicts buckets that
+// have refilled to their full burst once the registry grows past maxPeers.
+// A full bucket holds the same tokens as a freshly-created one, so
+// recreating it lazily on the peer's next message preserves the limiter's
+// behaviour; a bucket that still owes tokens is not full and is retained.
+// This keeps the registry sized to peers with a currently-draining bucket
+// rather than to every identity that has ever sent a message. See
+// evictFullBuckets.
 //
 // The underlying bucket registry is an lnutils.SyncMap rather than a plain
 // map guarded by a mutex. Per-peer keys are stable for the lifetime of the
@@ -148,9 +161,18 @@ func NewGlobalLimiter(kbps uint64, burstBytes uint64) RateLimiter {
 // every hot-path AllowN call behind a single mutex even though rate.Limiter
 // is already safe for concurrent use.
 type PeerRateLimiter struct {
-	rate     rate.Limit
-	burst    int
-	peers    lnutils.SyncMap[[33]byte, *rate.Limiter]
+	rate  rate.Limit
+	burst int
+	peers lnutils.SyncMap[[33]byte, *rate.Limiter]
+
+	// maxPeers is the registry high-water mark that triggers a sweep of
+	// full buckets. It is a field rather than a package constant so tests
+	// can drive the sweep without allocating tens of thousands of
+	// entries; production always sets it to defaultMaxRetainedPeers.
+	maxPeers int64
+
+	numPeers atomic.Int64
+	sweeping atomic.Bool
 	dropped  atomic.Uint64
 	firstLog atomic.Bool
 }
@@ -170,7 +192,7 @@ func (p *PeerRateLimiter) FirstDropClaim() bool {
 // disables limiting; in that case AllowN always returns true and no
 // per-peer state is retained.
 func NewPeerRateLimiter(kbps uint64, burstBytes uint64) *PeerRateLimiter {
-	p := &PeerRateLimiter{}
+	p := &PeerRateLimiter{maxPeers: defaultMaxRetainedPeers}
 	if kbps > 0 && burstBytes > 0 {
 		p.rate = rate.Limit(kbpsToBytesPerSecond(kbps))
 		p.burst = int(burstBytes)
@@ -195,12 +217,33 @@ func (p *PeerRateLimiter) AllowN(peer [33]byte, n int) bool {
 
 	lim, ok := p.peers.Load(peer)
 	if !ok {
-		// Allocate a fresh limiter and race for ownership via
-		// LoadOrStore: if a concurrent caller inserted one first,
-		// we discard ours and use theirs so that every peer ends
-		// up with a single authoritative bucket.
+		// Debit the fresh limiter before publishing it, so it is
+		// never observable at full burst. Publishing first would let
+		// a sweep reclaim it while still full and discard the debit,
+		// leaving the peer a fresh full bucket on every message.
 		newLim := rate.NewLimiter(p.rate, p.burst)
-		lim, _ = p.peers.LoadOrStore(peer, newLim)
+		allowed := newLim.AllowN(time.Now(), n)
+
+		var loaded bool
+		lim, loaded = p.peers.LoadOrStore(peer, newLim)
+		if !loaded {
+			if !allowed {
+				p.dropped.Add(1)
+			}
+
+			// Account for the new entry. Once the registry crosses
+			// its high-water mark, reclaim buckets that have
+			// refilled to full to keep the map bounded.
+			if p.numPeers.Add(1) > p.maxPeers {
+				p.evictFullBuckets()
+			}
+
+			return allowed
+		}
+
+		// A concurrent caller published a bucket for this peer first.
+		// Discard ours, debit included, and charge theirs below so
+		// that every peer ends up with a single authoritative bucket.
 	}
 
 	if lim.AllowN(time.Now(), n) {
@@ -209,6 +252,44 @@ func (p *PeerRateLimiter) AllowN(peer [33]byte, n int) bool {
 	p.dropped.Add(1)
 
 	return false
+}
+
+// evictFullBuckets removes every per-peer bucket that has refilled to its
+// configured burst. A full bucket holds the same tokens as a
+// freshly-constructed one, so evicting it and lazily recreating it on the
+// peer's next message preserves the limiter's behaviour. A bucket that still
+// owes tokens is not full and is retained, so eviction does not reset a
+// peer's outstanding debt. This keeps the registry sized to peers whose
+// bucket is currently draining rather than to every identity that has ever
+// sent a message.
+//
+// A CompareAndSwap guard ensures at most one sweep runs at a time; callers
+// that cross the high-water mark while a sweep is in flight skip it and let
+// the running sweep do the work.
+func (p *PeerRateLimiter) evictFullBuckets() {
+	if !p.sweeping.CompareAndSwap(false, true) {
+		return
+	}
+	defer p.sweeping.Store(false)
+
+	full := float64(p.burst)
+	p.peers.Range(func(peer [33]byte, lim *rate.Limiter) bool {
+		if lim.TokensAt(time.Now()) < full {
+			return true
+		}
+
+		// Delete unconditionally so numPeers stays in sync with the
+		// map. A concurrent AllowN may debit this bucket between the
+		// check above and the delete; if so the peer's next message
+		// recreates a fresh one. That is a bounded, one-message reset
+		// of a bucket that had just refilled to full anyway, so it does
+		// not weaken the sustained per-peer rate.
+		if _, removed := p.peers.LoadAndDelete(peer); removed {
+			p.numPeers.Add(-1)
+		}
+
+		return true
+	})
 }
 
 // Dropped returns the total number of onion messages this registry has

--- a/onionmessage/ratelimit_test.go
+++ b/onionmessage/ratelimit_test.go
@@ -4,8 +4,10 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
 )
 
 // msgBytes is the byte count used as the per-Allow token charge across the
@@ -128,6 +130,45 @@ func TestPeerRateLimiterIsolation(t *testing.T) {
 	require.Equal(t, uint64(2), p.Dropped())
 }
 
+// TestPeerRateLimiterConcurrentFirstMessages sends a fresh peer's first
+// messages from many goroutines at once, so that they race to create that
+// peer's bucket, and asserts exactly one burst gets through. Every caller but
+// one ends up discarding the bucket it built; if the message that caller was
+// charging were discarded with it, the peer would be allowed more than its
+// burst. It is the accounting counterpart to the sweep tests: those cover a
+// bucket being reclaimed, this covers a bucket being superseded at birth.
+func TestPeerRateLimiterConcurrentFirstMessages(t *testing.T) {
+	t.Parallel()
+
+	// Room for exactly burstMessages, at a rate too slow to refill within
+	// the test, so the allowed count is decided purely by the accounting.
+	const (
+		burstMessages = 4
+		workers       = 32
+	)
+	p := NewPeerRateLimiter(1, burstMessages*msgBytes)
+
+	var peer [33]byte
+	peer[0] = 0x02
+
+	var (
+		allowed atomic.Uint64
+		wg      sync.WaitGroup
+	)
+	for range workers {
+		wg.Go(func() {
+			if p.AllowN(peer, msgBytes) {
+				allowed.Add(1)
+			}
+		})
+	}
+	wg.Wait()
+
+	require.Equal(t, uint64(burstMessages), allowed.Load(),
+		"racing first messages must each be charged exactly once")
+	require.Equal(t, uint64(workers-burstMessages), p.Dropped())
+}
+
 // TestCountingLimiterFirstDropClaimOnce verifies that FirstDropClaim on a
 // countingLimiter returns true exactly once and false on every subsequent
 // call, across concurrent goroutines, so that the first-drop info log is
@@ -241,4 +282,256 @@ func TestPeerRateLimiterConcurrentAllowN(t *testing.T) {
 // accounting it cares about.
 func peerMapLen(p *PeerRateLimiter) int {
 	return p.peers.Len()
+}
+
+// TestPeerRateLimiterEvictsOnlyFullBuckets verifies the core invariant of
+// the sweep: a bucket that has refilled to its full burst is evicted, while
+// a bucket that still owes tokens (is currently draining) is retained. The
+// latter is what preserves the anti-reset property across disconnects.
+func TestPeerRateLimiterEvictsOnlyFullBuckets(t *testing.T) {
+	t.Parallel()
+
+	p := NewPeerRateLimiter(1, msgBytes)
+
+	var fullPeer, drainedPeer [33]byte
+	fullPeer[0] = 0x01
+	drainedPeer[0] = 0x02
+
+	// A freshly constructed limiter starts at full burst.
+	p.peers.Store(fullPeer, rate.NewLimiter(p.rate, p.burst))
+
+	// Drain the second bucket completely so it owes its entire burst.
+	// With a per-peer rate of 1 Kbps it will not refill within the test.
+	drained := rate.NewLimiter(p.rate, p.burst)
+	require.True(t, drained.AllowN(time.Now(), p.burst))
+	p.peers.Store(drainedPeer, drained)
+	p.numPeers.Store(2)
+
+	p.evictFullBuckets()
+
+	// The full bucket is gone; the draining bucket is kept.
+	_, ok := p.peers.Load(fullPeer)
+	require.False(t, ok, "full bucket should be evicted")
+	_, ok = p.peers.Load(drainedPeer)
+	require.True(t, ok, "draining bucket must be retained")
+
+	require.Equal(t, 1, peerMapLen(p))
+	require.Equal(t, int64(1), p.numPeers.Load())
+}
+
+// TestPeerRateLimiterDebitsBeforeSweep asserts that a peer whose insertion
+// crosses the registry high-water mark still carries the cost of the message
+// that triggered the sweep. The sweep reclaims buckets sitting at full burst,
+// so a bucket that has not been debited by the time the sweep inspects it is
+// evicted right away and the debit lands on a limiter no longer in the
+// registry. The peer's next message would then allocate another full bucket,
+// handing it an unmetered burst per message for as long as the registry stays
+// at its high-water mark.
+func TestPeerRateLimiterDebitsBeforeSweep(t *testing.T) {
+	t.Parallel()
+
+	// A burst of exactly one message, at a rate far too slow to refill
+	// within the test: the peer's second message must be rejected.
+	p := NewPeerRateLimiter(1, msgBytes)
+	p.maxPeers = 1
+
+	// Pin the registry at its high-water mark with a fully drained bucket.
+	// It is never full, so no sweep can reclaim it, and every subsequent
+	// insertion therefore crosses the mark and triggers a sweep.
+	var pinned, peer [33]byte
+	pinned[0] = 0x01
+	peer[0] = 0x02
+
+	drained := rate.NewLimiter(p.rate, p.burst)
+	require.True(t, drained.AllowN(time.Now(), p.burst))
+	p.peers.Store(pinned, drained)
+	p.numPeers.Store(1)
+
+	// The first message allocates the peer's bucket and crosses the mark,
+	// triggering a sweep.
+	require.True(t, p.AllowN(peer, msgBytes))
+
+	// That bucket must have survived the sweep it triggered, still holding
+	// the debit for the message just allowed.
+	_, ok := p.peers.Load(peer)
+	require.True(t, ok, "debited bucket was evicted by the sweep it "+
+		"triggered")
+
+	// With its whole burst spent, the peer's next message must be rejected
+	// rather than served from a freshly recreated bucket.
+	require.False(t, p.AllowN(peer, msgBytes),
+		"peer received a fresh full burst after the sweep")
+	require.Equal(t, uint64(1), p.Dropped())
+}
+
+// TestPeerRateLimiterBurstNotResetBySweep gives each of many fresh peers a
+// two-message run while sweepers race the callers, and asserts every peer gets
+// exactly one message through. A bucket is only evictable while it sits at
+// full burst, so if AllowN publishes a bucket before debiting it, a sweep
+// landing in that window reclaims the bucket and drops the debit. The peer's
+// second message then misses the registry, allocates another full bucket and
+// is allowed, so winning that race repeatedly ratchets into unmetered
+// throughput rather than costing a single message.
+func TestPeerRateLimiterBurstNotResetBySweep(t *testing.T) {
+	t.Parallel()
+
+	// One message of burst, refilling at 125 B/s: over the lifetime of
+	// this test no bucket can legitimately refill enough for a second
+	// message, so each peer may be allowed exactly once.
+	p := NewPeerRateLimiter(1, msgBytes)
+
+	const (
+		peers    = 100_000
+		workers  = 8
+		sweepers = 4
+	)
+
+	var (
+		allowed atomic.Uint64
+		callers sync.WaitGroup
+		sweep   sync.WaitGroup
+		stop    = make(chan struct{})
+	)
+
+	// Sweepers are driven directly rather than through the high-water mark
+	// so that the window is exercised on every insertion.
+	for range sweepers {
+		sweep.Go(func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				p.evictFullBuckets()
+			}
+		})
+	}
+
+	for w := range workers {
+		callers.Go(func() {
+			for i := w; i < peers; i += workers {
+				var key [33]byte
+				key[0] = byte(i)
+				key[1] = byte(i >> 8)
+				key[2] = byte(i >> 16)
+
+				// The first message must pass and the second
+				// must not: the burst is a single message.
+				for range 2 {
+					if p.AllowN(key, msgBytes) {
+						allowed.Add(1)
+					}
+				}
+			}
+		})
+	}
+
+	callers.Wait()
+	close(stop)
+	sweep.Wait()
+
+	require.Equal(t, uint64(peers), allowed.Load(),
+		"a peer was allowed more than its burst; a sweep reclaimed a "+
+			"bucket before it was debited")
+}
+
+// TestPeerRateLimiterSweepAccountingUnderRace runs evictFullBuckets
+// concurrently with AllowN on a shared key set and asserts that, once quiesced,
+// numPeers still matches the registry size. It guards against a sweep leaving
+// the counter drifted above the map, which would eventually pin numPeers over
+// maxPeers and force an O(N) sweep on every new peer.
+func TestPeerRateLimiterSweepAccountingUnderRace(t *testing.T) {
+	t.Parallel()
+
+	// A single-message burst with a high rate snaps each bucket between
+	// full and empty: buckets read full most of the time (the sweep's
+	// check passes) but a debit landing mid-sweep drops one clearly below
+	// full. That is the interleaving that can desync numPeers.
+	p := NewPeerRateLimiter(1_000_000, msgBytes)
+
+	// Fewer keys than workers concentrates goroutines on the same key, and
+	// a low high-water mark keeps AllowN triggering sweeps that evict and
+	// recreate buckets.
+	const numKeys = 8
+	p.maxPeers = 4
+
+	keys := make([][33]byte, numKeys)
+	for i := range keys {
+		keys[i][0] = byte(i)
+	}
+
+	const (
+		workers = 16
+		rounds  = 4000
+		sweeps  = 3
+	)
+
+	var wg sync.WaitGroup
+
+	// Worker goroutines hammer AllowN across the shared key set.
+	for w := range workers {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			for r := range rounds {
+				p.AllowN(keys[(seed+r)%numKeys], msgBytes)
+			}
+		}(w)
+	}
+
+	// Dedicated sweeper goroutines race the workers.
+	for range sweeps {
+		wg.Go(func() {
+			for range rounds {
+				p.evictFullBuckets()
+			}
+		})
+	}
+
+	wg.Wait()
+
+	// At quiescence every map entry must be counted exactly once.
+	require.Equal(t, int64(peerMapLen(p)), p.numPeers.Load(),
+		"numPeers drifted from the registry size under concurrent "+
+			"sweeps")
+}
+
+// TestPeerRateLimiterBoundedUnderIdentityChurn exercises the sweep under a
+// large number of distinct pubkeys that each send a single small onion
+// message, as can happen when the channel gate is disabled via
+// --onion-msg-relay-all. Without eviction the registry would grow one entry
+// per identity; with it, the map stays bounded because each near-full bucket
+// refills and is reclaimed on a subsequent sweep.
+func TestPeerRateLimiterBoundedUnderIdentityChurn(t *testing.T) {
+	t.Parallel()
+
+	// A high per-peer rate means the tiny per-message debit refills
+	// essentially instantly, so buckets from earlier identities read as
+	// full by the time a later insertion triggers a sweep.
+	p := NewPeerRateLimiter(1_000_000, msgBytes)
+
+	// Lower the high-water mark so the test drives the sweep without
+	// allocating tens of thousands of entries.
+	p.maxPeers = 64
+
+	const identities = 100_000
+	for i := 0; i < identities; i++ {
+		var key [33]byte
+		key[0] = byte(i)
+		key[1] = byte(i >> 8)
+		key[2] = byte(i >> 16)
+
+		// One minimal onion message from a fresh identity.
+		require.True(t, p.AllowN(key, 1))
+	}
+
+	// After 100k distinct identities, the registry must remain bounded near
+	// the high-water mark rather than retaining an entry per identity. A
+	// small multiple of the threshold covers the entries created since the
+	// most recent sweep.
+	require.LessOrEqual(
+		t, int64(peerMapLen(p)), 2*p.maxPeers,
+		"registry grew unbounded under identity churn",
+	)
 }


### PR DESCRIPTION
The `PeerRateLimiter` kept a token bucket per peer and never removed any
entry. With the channel-presence gate disabled via` --onion-msg-relay-all`
any connecting pubkey that sends an onion message allocates a bucket,
and buckets are retained across disconnects, so a peer reconnecting
under a stream of fresh identities could grow the map without bound and
exhaust memory.

Bound the registry by evicting buckets that have refilled to their full
burst once it grows past a high-water mark. A full bucket holds the same
tokens as a freshly-created one, so recreating it lazily on the peer's
next message preserves the limiter's behaviour, while a bucket that
still owes tokens is retained and the per-peer rate stays a ceiling
across reconnects.

Since only a full bucket is evictable, `AllowN` debits a newly created
bucket before publishing it. Otherwise the sweep that its own insertion
triggers reclaims it while still full and discards the debit, handing
the peer a fresh burst on every message.