### PR TITLE
paymentsdb: normalize orphaned blinded total

### DIFF
--- a/docs/release-notes/release-notes-0.21.2.md
+++ b/docs/release-notes/release-notes-0.21.2.md
@@ -29,6 +29,13 @@
 * [Fixes a bug](https://github.com/lightningnetwork/lnd/pull/10962) that
   could allow the RBF closer to be used with incompatible aux channels.
 
+* [Fixes a payment migration failure](https://github.com/lightningnetwork/lnd/pull/10982)
+  caused by historical routes containing a blinded total amount without
+  encrypted recipient data. The migration now normalizes the orphaned total,
+  and `SendToRouteV2` rejects new routes with the same invalid field
+  combination. This also affects callers replaying an affected historical
+  route returned by `ListPayments` or `TrackPayment`.
+
 # New Features
 
 ## Functional Enhancements

--- a/lnrpc/routerrpc/router_backend.go
+++ b/lnrpc/routerrpc/router_backend.go
@@ -783,6 +783,13 @@ func UnmarshallHopWithPubkey(rpcHop *lnrpc.Hop, pubkey route.Vertex) (*route.Hop
 			"blinding point is provided")
 	}
 
+	// TotalAmtMsat is only defined for blinded payments, so it requires
+	// the encrypted recipient data that identifies this as a blinded hop.
+	if rpcHop.TotalAmtMsat != 0 && len(rpcHop.EncryptedData) == 0 {
+		return nil, errors.New("encrypted data should be present if " +
+			"blinded total amount is provided")
+	}
+
 	return hop, nil
 }
 
@@ -832,6 +839,17 @@ func (r *RouterBackend) UnmarshallRoute(rpcroute *lnrpc.Route) (
 
 	hops := make([]*route.Hop, len(rpcroute.Hops))
 	for i, hop := range rpcroute.Hops {
+		// TotalAmtMsat is the sender-declared target for the blinded
+		// HTLC set. The final node checks that every part declares the
+		// same total and withholds fulfillment until the received parts
+		// reach that amount. Since only the final node performs
+		// this set-level check, BOLT 4 only permits the field in its
+		// payload.
+		if hop.TotalAmtMsat != 0 && i != len(rpcroute.Hops)-1 {
+			return nil, errors.New("blinded total amount can " +
+				"only be provided for the final hop")
+		}
+
 		routeHop, err := r.UnmarshallHop(hop, prevNodePubKey)
 		if err != nil {
 			return nil, err

--- a/lnrpc/routerrpc/router_backend_test.go
+++ b/lnrpc/routerrpc/router_backend_test.go
@@ -33,6 +33,110 @@ var (
 	node2 = route.Vertex{11}
 )
 
+// TestUnmarshallHopBlindedFieldsRequireEncryptedData verifies that callers
+// cannot submit partial blinded-hop data through SendToRouteV2.
+func TestUnmarshallHopBlindedFieldsRequireEncryptedData(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		hop     *lnrpc.Hop
+		errText string
+	}{
+		{
+			name: "total amount without encrypted data",
+			hop: &lnrpc.Hop{
+				TotalAmtMsat: 1000,
+			},
+			errText: "encrypted data should be present",
+		},
+		{
+			name: "total amount with encrypted data",
+			hop: &lnrpc.Hop{
+				TotalAmtMsat:  1000,
+				EncryptedData: []byte{1},
+			},
+		},
+		{
+			name: "ordinary hop",
+			hop:  &lnrpc.Hop{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := UnmarshallHopWithPubkey(test.hop, node1)
+			if test.errText != "" {
+				require.ErrorContains(t, err, test.errText)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestUnmarshallRouteBlindedTotalAmountFinalHop verifies that the blinded
+// total amount is only accepted on the final hop of a caller-provided route.
+func TestUnmarshallRouteBlindedTotalAmountFinalHop(t *testing.T) {
+	t.Parallel()
+
+	blindedHop := func() *lnrpc.Hop {
+		return &lnrpc.Hop{
+			PubKey:        destKey,
+			EncryptedData: []byte{1},
+			TotalAmtMsat:  1000,
+		}
+	}
+	regularHop := func() *lnrpc.Hop {
+		return &lnrpc.Hop{
+			PubKey: destKey,
+		}
+	}
+
+	tests := []struct {
+		name    string
+		hops    []*lnrpc.Hop
+		errText string
+	}{
+		{
+			name: "intermediate hop",
+			hops: []*lnrpc.Hop{
+				blindedHop(), regularHop(),
+			},
+			errText: "blinded total amount can only be provided " +
+				"for the final hop",
+		},
+		{
+			name: "final hop",
+			hops: []*lnrpc.Hop{
+				regularHop(), blindedHop(),
+			},
+		},
+	}
+
+	backend := &RouterBackend{
+		SelfNode: sourceKey,
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := backend.UnmarshallRoute(&lnrpc.Route{
+				Hops: test.hops,
+			})
+			if test.errText != "" {
+				require.ErrorContains(t, err, test.errText)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
 // TestQueryRoutes asserts that query routes rpc parameters are properly parsed
 // and passed onto path finding.
 func TestQueryRoutes(t *testing.T) {

--- a/payments/db/migration1/migration_validation.go
+++ b/payments/db/migration1/migration_validation.go
@@ -394,9 +394,24 @@ func normalizePaymentForCompare(payment *MPPayment) {
 		}
 
 		for j := range htlc.Route.Hops {
-			if len(htlc.Route.Hops[j].CustomRecords) == 0 {
-				htlc.Route.Hops[j].CustomRecords =
+			hop := htlc.Route.Hops[j]
+			if len(hop.CustomRecords) == 0 {
+				hop.CustomRecords =
 					record.CustomSet{}
+			}
+
+			// The migration treats nil and empty encrypted data as
+			// absent, so it omits the blinded child row. SQL reads
+			// the hop back with nil encrypted data and a zero
+			// total. Apply the same transformation to the KV
+			// copy before comparing the payments. A blinding point
+			// without data is rejected during migration, so it
+			// cannot reach this comparison.
+			if len(hop.EncryptedData) == 0 &&
+				hop.BlindingPoint == nil {
+
+				hop.EncryptedData = nil
+				hop.TotalAmtMsat = 0
 			}
 
 			// LegacyPayload was a hint used by the KV store to
@@ -406,7 +421,7 @@ func normalizePaymentForCompare(payment *MPPayment) {
 			// all — each field is stored natively in its own
 			// column — so this flag has no meaning there and is
 			// never persisted.
-			htlc.Route.Hops[j].LegacyPayload = false
+			hop.LegacyPayload = false
 		}
 	}
 }

--- a/payments/db/migration1/sql_migration.go
+++ b/payments/db/migration1/sql_migration.go
@@ -734,8 +734,12 @@ func migrateHTLCAttempt(ctx context.Context, paymentID int64,
 	// Insert route hops.
 	for hopIndex := range htlc.Route.Hops {
 		hop := htlc.Route.Hops[hopIndex]
+
+		// Use the parent hash for diagnostics. For AMP payments this
+		// is the set ID, which identifies the payment containing the
+		// shard.
 		err = migrateRouteHop(
-			ctx, attemptIndex, hopIndex, hop,
+			ctx, parentPaymentHash, attemptIndex, hopIndex, hop,
 			sqlDB, stats,
 		)
 		if err != nil {
@@ -807,8 +811,8 @@ func migrateHTLCAttempt(ctx context.Context, paymentID int64,
 
 // migrateRouteHop migrates a single route hop.
 func migrateRouteHop(ctx context.Context,
-	attemptID int64, hopIndex int, hop *Hop, sqlDB SQLQueries,
-	stats *MigrationStats) error {
+	parentPaymentHash lntypes.Hash, attemptIndex int64, hopIndex int,
+	hop *Hop, sqlDB SQLQueries, stats *MigrationStats) error {
 
 	// Convert channel ID to string representation of uint64.
 	// The SCID is stored as a decimal string to match the converter
@@ -817,7 +821,7 @@ func migrateRouteHop(ctx context.Context,
 
 	// Insert route hop.
 	hopID, err := sqlDB.InsertRouteHop(ctx, sqlc.InsertRouteHopParams{
-		HtlcAttemptIndex: attemptID,
+		HtlcAttemptIndex: attemptIndex,
 		HopIndex:         int32(hopIndex),
 		PubKey:           hop.PubKeyBytes[:],
 		Scid:             scidStr,
@@ -829,10 +833,35 @@ func migrateRouteHop(ctx context.Context,
 		return fmt.Errorf("insert hop: %w", err)
 	}
 
-	// Check for blinded route data (route blinding).
-	if len(hop.EncryptedData) > 0 || hop.BlindingPoint != nil ||
-		hop.TotalAmtMsat != 0 {
+	// Non-empty encrypted recipient data identifies a blinded hop.
+	// The RPC boundary has required encrypted data with a blinding point
+	// since these fields were introduced. Internally built blinded routes
+	// also always contain both. Unlike an orphaned total, a point without
+	// encrypted data is not a supported legacy encoding. Report it as
+	// malformed instead of silently discarding it. Keep this rejection in
+	// sync with normalizePaymentForCompare, which only normalizes hops
+	// without a blinding point.
+	hasEncryptedData := len(hop.EncryptedData) > 0
+	if !hasEncryptedData && hop.BlindingPoint != nil {
+		return fmt.Errorf("invalid blinded hop: payment_hash=%x, "+
+			"attempt_index=%d, hop=%d: blinding point requires "+
+			"encrypted recipient data", parentPaymentHash[:8],
+			attemptIndex, hopIndex)
+	}
 
+	// SendToRouteV2 historically allowed a blinded total amount without
+	// blinded hop data. Omit such an orphaned total rather than creating a
+	// blinded-hop row.
+	if !hasEncryptedData && hop.TotalAmtMsat != 0 {
+		log.Warnf("Ignoring orphaned blinded total amount: "+
+			"payment_hash=%x, attempt_index=%d, hop=%d, "+
+			"total_amt_msat=%d", parentPaymentHash[:8],
+			attemptIndex, hopIndex, hop.TotalAmtMsat)
+	}
+
+	// The blinding point and total amount are only associated fields. Use
+	// the length so nil and empty encrypted data are handled consistently.
+	if hasEncryptedData {
 		var blindingPoint []byte
 		if hop.BlindingPoint != nil {
 			blindingPoint = hop.BlindingPoint.SerializeCompressed()

--- a/payments/db/migration1/sql_migration_test.go
+++ b/payments/db/migration1/sql_migration_test.go
@@ -940,6 +940,147 @@ func TestMigratePaymentWithBlindedRoute(t *testing.T) {
 	assertPaymentDataMatches(t, ctx, kvDB, sqlStore, paymentHash)
 }
 
+// TestMigrateOrphanedBlindedTotalAmount tests that a blinded total amount
+// without encrypted recipient data is normalized during migration.
+func TestMigrateOrphanedBlindedTotalAmount(t *testing.T) {
+	t.Parallel()
+
+	runTest := func(t *testing.T, hashString string,
+		encryptedData []byte) {
+
+		t.Helper()
+
+		ctx := context.Background()
+		kvDB := setupTestKVDB(t)
+
+		var paymentHash [32]byte
+		copy(paymentHash[:], []byte(hashString))
+
+		err := kvdb.Update(kvDB, func(tx kvdb.RwTx) error {
+			paymentsBucket, err := tx.CreateTopLevelBucket(
+				paymentsRootBucket,
+			)
+			if err != nil {
+				return err
+			}
+
+			indexBucket, err := tx.CreateTopLevelBucket(
+				paymentsIndexBucket,
+			)
+			if err != nil {
+				return err
+			}
+
+			return createTestPayment(
+				t, paymentsBucket, indexBucket,
+				paymentTestConfig{
+					hash:           paymentHash,
+					seqNum:         1,
+					value:          120000,
+					creationTime:   time.Unix(1, 0),
+					paymentRequest: hashString,
+					attemptID:      1,
+					numHops:        1,
+					baseChannelID:  400000,
+					baseTimeLock:   800000,
+					hopConfigurator: func(hop *Hop, _ int,
+						_ bool) {
+
+						hop.EncryptedData = encryptedData
+						hop.TotalAmtMsat = 119400
+					},
+				},
+			)
+		}, func() {})
+		require.NoError(t, err)
+
+		sqlStore := setupTestSQLDB(t)
+		err = runPaymentsMigration(ctx, kvDB, sqlStore)
+		require.NoError(t, err)
+
+		var hash lntypes.Hash
+		copy(hash[:], paymentHash[:])
+		payment, err := sqlStore.FetchPayment(ctx, hash)
+		require.NoError(t, err)
+		require.Zero(
+			t, payment.HTLCs[0].Route.Hops[0].TotalAmtMsat,
+		)
+
+		assertPaymentDataMatches(t, ctx, kvDB, sqlStore, paymentHash)
+	}
+
+	t.Run("nil encrypted data", func(t *testing.T) {
+		runTest(t, "orphaned_total_nil", nil)
+	})
+	t.Run("empty encrypted data", func(t *testing.T) {
+		runTest(t, "orphaned_total_empty", []byte{})
+	})
+}
+
+// TestMigrateBlindingPointWithoutEncryptedData tests that migration reports a
+// malformed blinded hop with enough context to locate the affected attempt.
+func TestMigrateBlindingPointWithoutEncryptedData(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	kvDB := setupTestKVDB(t)
+
+	var paymentHash [32]byte
+	copy(paymentHash[:], []byte("blinding_point_without_data"))
+	var attemptHash lntypes.Hash
+	copy(attemptHash[:], []byte("individual_amp_htlc_hash"))
+
+	err := kvdb.Update(kvDB, func(tx kvdb.RwTx) error {
+		paymentsBucket, err := tx.CreateTopLevelBucket(
+			paymentsRootBucket,
+		)
+		if err != nil {
+			return err
+		}
+
+		indexBucket, err := tx.CreateTopLevelBucket(
+			paymentsIndexBucket,
+		)
+		if err != nil {
+			return err
+		}
+
+		return createTestPayment(
+			t, paymentsBucket, indexBucket, paymentTestConfig{
+				hash:           paymentHash,
+				attemptHash:    &attemptHash,
+				seqNum:         1,
+				value:          120000,
+				creationTime:   time.Unix(1, 0),
+				paymentRequest: "blinding-point-without-data",
+				attemptID:      1,
+				numHops:        1,
+				baseChannelID:  400000,
+				baseTimeLock:   800000,
+				hopConfigurator: func(hop *Hop, _ int, _ bool) {
+					blindingKey, err := btcec.NewPrivateKey()
+					require.NoError(t, err)
+
+					hop.BlindingPoint = blindingKey.PubKey()
+				},
+			},
+		)
+	}, func() {})
+	require.NoError(t, err)
+
+	sqlStore := setupTestSQLDB(t)
+	err = runPaymentsMigration(ctx, kvDB, sqlStore)
+	require.ErrorContains(t, err, "blinding point requires encrypted "+
+		"recipient data")
+	require.ErrorContains(t, err, "attempt_index=1, hop=0")
+	require.ErrorContains(t, err, fmt.Sprintf(
+		"payment_hash=%x", paymentHash[:8],
+	))
+	require.NotContains(t, err.Error(), fmt.Sprintf(
+		"payment_hash=%x", attemptHash[:8],
+	))
+}
+
 // TestMigratePaymentWithMetadata tests migration of a payment with hop
 // metadata.
 func TestMigratePaymentWithMetadata(t *testing.T) {
@@ -1934,6 +2075,7 @@ func assertPaymentDataMatches(t *testing.T, ctx context.Context,
 // features.
 type paymentTestConfig struct {
 	hash              [32]byte
+	attemptHash       *lntypes.Hash
 	seqNum            uint64
 	value             lnwire.MilliSatoshi
 	creationTime      time.Time
@@ -2128,6 +2270,11 @@ func createTestPayment(t *testing.T, paymentsBucket, indexBucket kvdb.RwBucket,
 	}
 
 	// Create and serialize attempt info.
+	attemptHash := (*lntypes.Hash)(&cfg.hash)
+	if cfg.attemptHash != nil {
+		attemptHash = cfg.attemptHash
+	}
+
 	attemptInfo := &HTLCAttemptInfo{
 		AttemptID:  cfg.attemptID,
 		sessionKey: sessionKeyBytes,
@@ -2139,7 +2286,7 @@ func createTestPayment(t *testing.T, paymentsBucket, indexBucket kvdb.RwBucket,
 			FirstHopWireCustomRecords: cfg.attemptCustomRecs,
 		},
 		AttemptTime: cfg.creationTime.Add(time.Minute),
-		Hash:        (*lntypes.Hash)(&cfg.hash),
+		Hash:        attemptHash,
 	}
 
 	if err = writeHTLCAttempt(


### PR DESCRIPTION
## Change Description

Fix a KV-to-SQL payment migration failure for historical routes containing a
non-zero blinded `total_amt_msat` without encrypted recipient data.

`SendToRouteV2` historically copied the blinded total amount independently of
the encrypted data. LND did not classify such a hop as blinded at runtime, but
the migration treated the total amount as proof of a blinded hop and attempted
to insert a row with a NULL `encrypted_data` value. This violated the existing
SQL NOT NULL constraint and prevented LND from starting.

This PR:

- requires encrypted recipient data when `SendToRouteV2` supplies either a
  blinding point or blinded total amount;
- omits the orphaned total when migrating the historically accepted total-only
  representation;
- rejects malformed blinding-point-only migration records with payment,
  attempt and hop context;
- applies the same normalization during KV/SQL migration validation;
- emits a `PYDB` warning identifying the affected payment, attempt, hop and
  discarded total amount;
- keeps the strict SQL schema unchanged.

## Steps to Test

```bash
make unit-debug log="stdlog trace" \
  pkg=lnrpc/routerrpc \
  case=TestUnmarshallHopBlindedFieldsRequireEncryptedData \
  timeout=10s nocache=1

go test -v -tags="dev test_db_sqlite stdlog trace" \
  ./payments/db/migration1 \
  -run '^(TestMigrateOrphanedBlindedTotalAmount|TestMigrateBlindingPointWithoutEncryptedData)$' \
  -count=1 -timeout=10s

make unit pkg=lnrpc/routerrpc timeout=5m nocache=1

go test -tags=test_db_sqlite ./payments/db/migration1 \
  -count=1 -timeout=5m
```

## Pull Request Checklist

### Testing

- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative error paths are included.
- [x] The bug fix contains a regression test triggering the historical case.

### Code Style and Documentation

- [x] The change follows the documentation, commenting and 80-column rules.
- [x] Commits follow the ideal Git commit structure.
- [x] New logging uses the `PYDB` subsystem at warning level.
- [x] A change description is included in the v0.21.2 release notes.
