### PR TITLE
walletrpc: fix custom lock rollback

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -55,6 +55,11 @@
   the reported network statistics such as total network capacity, channel
   count and max out degree.
 
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/10983) in
+  `FundPsbt` where a partial lease rollback used lnd's internal lock ID instead
+  of the caller's custom lock ID, leaving successfully leased inputs locked
+  until expiration.
+
 # New Features
 
 ## Functional Enhancements

--- a/lnrpc/walletrpc/psbt.go
+++ b/lnrpc/walletrpc/psbt.go
@@ -85,7 +85,7 @@ func lockInputs(w lnwallet.WalletController, outpoints []wire.OutPoint,
 			for i := 0; i < idx; i++ {
 				op := locks[i].Outpoint
 				if err := w.ReleaseOutput(
-					chanfunding.LndInternalLockID, op,
+					locks[i].LockID, op,
 				); err != nil {
 					log.Errorf("could not release the "+
 						"lock on %v: %v", op, err)

--- a/lnrpc/walletrpc/psbt_test.go
+++ b/lnrpc/walletrpc/psbt_test.go
@@ -1,0 +1,66 @@
+//go:build walletrpc
+// +build walletrpc
+
+package walletrpc
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+	"github.com/lightningnetwork/lnd/lntest/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type mockLockingWallet struct {
+	*mock.WalletController
+
+	leaseCount        int
+	releasedLockIDs   []wtxmgr.LockID
+	releasedOutpoints []wire.OutPoint
+}
+
+func (m *mockLockingWallet) LeaseOutput(wtxmgr.LockID, wire.OutPoint,
+	time.Duration) (time.Time, error) {
+
+	m.leaseCount++
+	if m.leaseCount == 2 {
+		return time.Time{}, errors.New("lease failed")
+	}
+
+	return time.Now(), nil
+}
+
+func (m *mockLockingWallet) ReleaseOutput(lockID wtxmgr.LockID,
+	outpoint wire.OutPoint) error {
+
+	m.releasedLockIDs = append(m.releasedLockIDs, lockID)
+	m.releasedOutpoints = append(m.releasedOutpoints, outpoint)
+
+	return nil
+}
+
+// TestLockInputsRollbackCustomLockID tests that a partial lease failure rolls
+// back previously leased outputs using the custom lock ID.
+func TestLockInputsRollbackCustomLockID(t *testing.T) {
+	t.Parallel()
+
+	wallet := &mockLockingWallet{
+		WalletController: &mock.WalletController{},
+	}
+	customLockID := wtxmgr.LockID{1, 2, 3}
+	outpoints := []wire.OutPoint{
+		{Index: 1},
+		{Index: 2},
+	}
+
+	locks, err := lockInputs(
+		wallet, outpoints, &customLockID, time.Minute,
+	)
+	require.ErrorContains(t, err, "could not lease a lock on UTXO")
+	require.Nil(t, locks)
+	require.Equal(t, []wtxmgr.LockID{customLockID}, wallet.releasedLockIDs)
+	require.Equal(t, outpoints[:1], wallet.releasedOutpoints)
+}


### PR DESCRIPTION
## Change Description

Fixes #10966.

When `FundPsbt` failed after leasing only part of its selected inputs, the
rollback always attempted to release those inputs with lnd's internal lock ID.
For callers using a custom lock ID, the wallet rejected that release and left
the inputs leased until expiration.

The rollback now uses the lock ID recorded for each successful lease. A focused
unit test covers a failure on the second lease and verifies that the first
output is released with the caller's custom lock ID.

## Steps to Test

```shell
go test -tags=walletrpc ./lnrpc/walletrpc
go vet -tags=walletrpc ./lnrpc/walletrpc
```
