### PR TITLE
channeldb: recover missing db version key

### DIFF
--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -43,6 +43,14 @@ import (
 
 const (
 	dbName = "channel.db"
+
+	// missingDBVersionRecoveryVersion is the latest mandatory DB
+	// version before the init ordering regression that could create a
+	// DB without writing the DB version key. Affected DBs are therefore
+	// already at least this version, so recovery starts here to run the
+	// v0.21 waiting proof migration without replaying older migrations
+	// against a modern DB.
+	missingDBVersionRecoveryVersion = 33
 )
 
 var (
@@ -1869,16 +1877,43 @@ func (c *ChannelStateDB) DeleteChannelOpeningState(outPoint []byte) error {
 // applies migration functions to the current database and recovers the
 // previous state of db if at least one error/panic appeared during migration.
 func (d *DB) syncVersions(versions []mandatoryVersion) error {
+	latestVersion := getLatestDBVersion(versions)
+
 	meta, err := d.FetchMeta()
 	if err != nil {
-		if err == ErrMetaNotFound {
+		switch {
+		case errors.Is(err, ErrMetaNotFound):
 			meta = &Meta{}
-		} else {
+
+		case errors.Is(err, ErrDBVersionNotFound):
+			recoveryVersion := uint32(
+				missingDBVersionRecoveryVersion,
+			)
+
+			// Missing DB version recovery is only valid for DBs
+			// created after the init ordering regression. Older DBs
+			// wrote the DB version before init returned, so a
+			// missing version key on a sub-33 DB is not a valid
+			// state to infer from.
+			if latestVersion < recoveryVersion {
+				return fmt.Errorf("unable to recover missing "+
+					"DB version key: latest_version=%v "+
+					"recovery_version=%v", latestVersion,
+					recoveryVersion)
+			}
+
+			log.Warnf("DB version key missing, recovering from "+
+				"db_version=%v", recoveryVersion)
+
+			meta = &Meta{
+				DbVersionNumber: recoveryVersion,
+			}
+
+		default:
 			return err
 		}
 	}
 
-	latestVersion := getLatestDBVersion(versions)
 	log.Infof("Checking for schema update: latest_version=%v, "+
 		"db_version=%v", latestVersion, meta.DbVersionNumber)
 

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -502,21 +502,36 @@ func initChannelDB(db kvdb.Backend) error {
 			return err
 		}
 
+		meta := &Meta{}
+		metaErr := FetchMeta(meta, tx)
+
 		for _, tlb := range dbTopLevelBuckets {
 			if _, err := tx.CreateTopLevelBucket(tlb); err != nil {
 				return err
 			}
 		}
 
-		meta := &Meta{}
-		// Check if DB is already initialized.
-		err := FetchMeta(meta, tx)
-		if err == nil {
+		switch {
+		// Metadata with a DB version already exists. Required
+		// top-level buckets were created above, so init is complete.
+		case metaErr == nil:
+			return nil
+
+		// There is no metadata bucket at all, so this is a fresh DB.
+		// Initialize the DB version after creating the required
+		// top-level buckets.
+		case errors.Is(metaErr, ErrMetaNotFound):
+			meta.DbVersionNumber = getLatestDBVersion(dbVersions)
+			return putMeta(meta, tx)
+
+		// The DB already has a metadata bucket but no version key.
+		// Leave recovery to the migration path, which can infer a
+		// safe starting version before writing the version key.
+		case errors.Is(metaErr, ErrDBVersionNotFound):
 			return nil
 		}
 
-		meta.DbVersionNumber = getLatestDBVersion(dbVersions)
-		return putMeta(meta, tx)
+		return metaErr
 	}, func() {})
 	if err != nil {
 		return fmt.Errorf("unable to create new channeldb: %w", err)

--- a/channeldb/error.go
+++ b/channeldb/error.go
@@ -42,6 +42,10 @@ var (
 	// created.
 	ErrMetaNotFound = fmt.Errorf("unable to locate meta information")
 
+	// ErrDBVersionNotFound is returned when the meta bucket exists, but
+	// the DB version key hasn't been written.
+	ErrDBVersionNotFound = fmt.Errorf("unable to locate db version")
+
 	// ErrNoClosedChannels is returned when a node is queries for all the
 	// channels it has closed, but it hasn't yet closed any channels.
 	ErrNoClosedChannels = fmt.Errorf("no channel have been closed yet")

--- a/channeldb/meta.go
+++ b/channeldb/meta.go
@@ -46,7 +46,7 @@ type Meta struct {
 
 // FetchMeta fetches the metadata from boltdb and returns filled meta structure.
 func (d *DB) FetchMeta() (*Meta, error) {
-	var meta *Meta
+	meta := &Meta{}
 
 	err := kvdb.View(d, func(tx kvdb.RTx) error {
 		return FetchMeta(meta, tx)
@@ -70,10 +70,10 @@ func FetchMeta(meta *Meta, tx kvdb.RTx) error {
 
 	data := metaBucket.Get(dbVersionKey)
 	if data == nil {
-		meta.DbVersionNumber = getLatestDBVersion(dbVersions)
-	} else {
-		meta.DbVersionNumber = byteOrder.Uint32(data)
+		return ErrDBVersionNotFound
 	}
+
+	meta.DbVersionNumber = byteOrder.Uint32(data)
 
 	return nil
 }

--- a/channeldb/meta_test.go
+++ b/channeldb/meta_test.go
@@ -603,6 +603,88 @@ func TestFetchMeta(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, LatestDBVersion(), meta.DbVersionNumber)
+
+	err = db.View(func(tx walletdb.ReadTx) error {
+		metaBucket := tx.ReadBucket(metaBucket)
+		require.NotNil(t, metaBucket)
+
+		versionBytes := metaBucket.Get(dbVersionKey)
+		require.Len(t, versionBytes, 4)
+		require.Equal(
+			t, LatestDBVersion(), byteOrder.Uint32(versionBytes),
+		)
+
+		return nil
+	}, func() {})
+	require.NoError(t, err)
+}
+
+// TestFetchMetaMissingDBVersion asserts that metadata with no DB version key is
+// reported as incomplete metadata.
+func TestFetchMetaMissingDBVersion(t *testing.T) {
+	t.Parallel()
+
+	backend, cleanup, err := kvdb.GetTestBackend(t.TempDir(), "cdb")
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	err = kvdb.Update(backend, func(tx kvdb.RwTx) error {
+		_, err := tx.CreateTopLevelBucket(metaBucket)
+
+		return err
+	}, func() {})
+	require.NoError(t, err)
+
+	db := &DB{
+		Backend: backend,
+	}
+
+	_, err = db.FetchMeta()
+	require.ErrorIs(t, err, ErrDBVersionNotFound)
+
+	err = kvdb.View(backend, func(tx kvdb.RTx) error {
+		meta := &Meta{}
+		err := FetchMeta(meta, tx)
+		require.ErrorIs(t, err, ErrDBVersionNotFound)
+
+		return nil
+	}, func() {})
+	require.NoError(t, err)
+}
+
+// TestInitChannelDBCreatesMissingTopLevelBuckets asserts that initialized DBs
+// with missing top-level buckets are repaired during initialization.
+func TestInitChannelDBCreatesMissingTopLevelBuckets(t *testing.T) {
+	t.Parallel()
+
+	backend, cleanup, err := kvdb.GetTestBackend(t.TempDir(), "cdb")
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	err = kvdb.Update(backend, func(tx kvdb.RwTx) error {
+		meta := &Meta{
+			DbVersionNumber: LatestDBVersion(),
+		}
+
+		return putMeta(meta, tx)
+	}, func() {})
+	require.NoError(t, err)
+
+	err = kvdb.View(backend, func(tx kvdb.RTx) error {
+		require.Nil(t, tx.ReadBucket(historicalChannelBucket))
+
+		return nil
+	}, func() {})
+	require.NoError(t, err)
+
+	require.NoError(t, initChannelDB(backend))
+
+	err = kvdb.View(backend, func(tx kvdb.RTx) error {
+		require.NotNil(t, tx.ReadBucket(historicalChannelBucket))
+
+		return nil
+	}, func() {})
+	require.NoError(t, err)
 }
 
 // TestMarkerAndTombstone tests that markers like a tombstone can be added to a

--- a/channeldb/meta_test.go
+++ b/channeldb/meta_test.go
@@ -2,12 +2,14 @@ package channeldb
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/stretchr/testify/require"
 )
 
@@ -685,6 +687,135 @@ func TestInitChannelDBCreatesMissingTopLevelBuckets(t *testing.T) {
 		return nil
 	}, func() {})
 	require.NoError(t, err)
+}
+
+// TestMissingDBVersionRunsWaitingProofMigration asserts that a DB initialized
+// without a version key is recovered from the last v0.20 mandatory version so
+// migration 35 can migrate legacy waiting proof records.
+func TestMissingDBVersionRunsWaitingProofMigration(t *testing.T) {
+	t.Parallel()
+
+	backend, cleanup, err := kvdb.GetTestBackend(t.TempDir(), "cdb")
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	const scid = 101
+	ann := &lnwire.AnnounceSignatures1{
+		ChannelID:        lnwire.ChannelID{1, 2, 3},
+		ShortChannelID:   lnwire.NewShortChanIDFromInt(scid),
+		NodeSignature:    wireSig,
+		BitcoinSignature: wireSig,
+		ExtraOpaqueData:  []byte{4, 5, 6},
+	}
+
+	legacyKey, legacyValue := encodeLegacyWaitingProof(t, true, ann)
+
+	err = kvdb.Update(backend, func(tx kvdb.RwTx) error {
+		_, err := tx.CreateTopLevelBucket(metaBucket)
+		if err != nil {
+			return err
+		}
+
+		bucket, err := tx.CreateTopLevelBucket(waitingProofsBucketKey)
+		if err != nil {
+			return err
+		}
+
+		return bucket.Put(legacyKey[:], legacyValue)
+	}, func() {})
+	require.NoError(t, err)
+
+	db, err := CreateWithBackend(backend)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	err = db.View(func(tx kvdb.RTx) error {
+		metaBucket := tx.ReadBucket(metaBucket)
+		require.NotNil(t, metaBucket)
+
+		versionBytes := metaBucket.Get(dbVersionKey)
+		require.Len(t, versionBytes, 4)
+		require.Equal(
+			t, LatestDBVersion(), byteOrder.Uint32(versionBytes),
+		)
+
+		bucket := tx.ReadBucket(waitingProofsBucketKey)
+		require.NotNil(t, bucket)
+		require.Nil(t, bucket.Get(legacyKey[:]))
+
+		proof := NewWaitingProof(true, ann)
+		typedKey := proof.Key()
+		require.NotNil(t, bucket.Get(typedKey[:]))
+
+		return nil
+	}, func() {})
+	require.NoError(t, err)
+
+	store, err := NewWaitingProofStore(db)
+	require.NoError(t, err)
+
+	proof := NewWaitingProof(true, ann)
+	migratedProof, err := store.Get(proof.Key())
+	require.NoError(t, err)
+	require.Equal(t, proof.Key(), migratedProof.Key())
+}
+
+// TestMissingDBVersionRecoveryRequiresBaseline asserts that a missing version
+// key cannot be recovered if the target version list does not include the
+// recovery baseline.
+func TestMissingDBVersionRecoveryRequiresBaseline(t *testing.T) {
+	t.Parallel()
+
+	backend, cleanup, err := kvdb.GetTestBackend(t.TempDir(), "cdb")
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	err = kvdb.Update(backend, func(tx kvdb.RwTx) error {
+		_, err := tx.CreateTopLevelBucket(metaBucket)
+
+		return err
+	}, func() {})
+	require.NoError(t, err)
+
+	db := &DB{
+		Backend: backend,
+	}
+
+	versions := []mandatoryVersion{
+		{
+			number:    0,
+			migration: nil,
+		},
+		{
+			number:    1,
+			migration: nil,
+		},
+	}
+
+	err = db.syncVersions(versions)
+	require.ErrorContains(t, err, "unable to recover missing DB version")
+}
+
+// encodeLegacyWaitingProof encodes a waiting proof using the pre-migration
+// format.
+func encodeLegacyWaitingProof(t *testing.T, isRemote bool,
+	ann *lnwire.AnnounceSignatures1) ([9]byte, []byte) {
+
+	t.Helper()
+
+	var key [9]byte
+	binary.BigEndian.PutUint64(key[:8], ann.ShortChannelID.ToUint64())
+	if isRemote {
+		key[8] = 1
+	}
+
+	var value bytes.Buffer
+	require.NoError(t, binary.Write(&value, byteOrder, isRemote))
+	require.NoError(t, ann.Encode(&value, 0))
+
+	return key, value.Bytes()
 }
 
 // TestMarkerAndTombstone tests that markers like a tombstone can be added to a

--- a/channeldb/migration35/migration.go
+++ b/channeldb/migration35/migration.go
@@ -143,6 +143,20 @@ func MigrateWaitingProofStore(tx kvdb.RwTx) error {
 			return nil
 		}
 
+		switch len(k) {
+		case len(legacyWaitingProofKey{}):
+			// Legacy records continue below and are migrated.
+
+		case len(waitingProofKey{}):
+			// The record already uses the typed key format. This
+			// makes the migration safe to re-run during missing
+			// version key recovery.
+			return nil
+
+		default:
+			return fmt.Errorf("unexpected waiting proof key %x", k)
+		}
+
 		proof, err := decodeLegacyWaitingProof(v)
 		if err != nil {
 			return fmt.Errorf("decode waiting proof for key %x: %w",

--- a/channeldb/migration35/migration_test.go
+++ b/channeldb/migration35/migration_test.go
@@ -162,6 +162,80 @@ func makeKeyMismatchSetup() (func(tx kvdb.RwTx) error,
 	return before, after
 }
 
+// makeMixedLegacyAndTypedSetup creates pre- and post-migration callbacks for a
+// bucket that already contains a typed waiting proof.
+func makeMixedLegacyAndTypedSetup() (func(tx kvdb.RwTx) error,
+	func(tx kvdb.RwTx) error) {
+
+	legacyProof := &waitingProof{
+		announceSignatures: newAnnSig(20, 5),
+		isRemote:           false,
+	}
+	typedProof := &waitingProof{
+		announceSignatures: newAnnSig(21, 6),
+		isRemote:           true,
+	}
+
+	legacyKey := legacyProof.LegacyKey()
+	migratedKey := legacyProof.Key()
+	typedKey := typedProof.Key()
+	typedValue, err := encodeUpdatedWaitingProof(typedProof)
+	if err != nil {
+		panic(err)
+	}
+
+	before := func(tx kvdb.RwTx) error {
+		bucket, err := tx.CreateTopLevelBucket(waitingProofsBucketKey)
+		if err != nil {
+			return err
+		}
+
+		err = bucket.Put(legacyKey[:], encodeLegacyProof(legacyProof))
+		if err != nil {
+			return err
+		}
+
+		return bucket.Put(typedKey[:], typedValue)
+	}
+
+	after := func(tx kvdb.RwTx) error {
+		bucket := tx.ReadWriteBucket(waitingProofsBucketKey)
+		if bucket == nil {
+			return fmt.Errorf("waiting proofs bucket not found")
+		}
+
+		if bucket.Get(legacyKey[:]) != nil {
+			return fmt.Errorf("legacy key %x still exists",
+				legacyKey)
+		}
+
+		migratedValue := bucket.Get(migratedKey[:])
+		if migratedValue == nil {
+			return fmt.Errorf("migrated key %x not found",
+				migratedKey)
+		}
+
+		expectedMigratedValue, err := encodeUpdatedWaitingProof(
+			legacyProof,
+		)
+		if err != nil {
+			return err
+		}
+
+		if !bytes.Equal(migratedValue, expectedMigratedValue) {
+			return fmt.Errorf("unexpected migrated value")
+		}
+
+		if !bytes.Equal(bucket.Get(typedKey[:]), typedValue) {
+			return fmt.Errorf("typed proof was modified")
+		}
+
+		return nil
+	}
+
+	return before, after
+}
+
 // TestMigrateWaitingProofStore verifies the waiting proof migration behavior.
 func TestMigrateWaitingProofStore(t *testing.T) {
 	t.Parallel()
@@ -182,6 +256,11 @@ func TestMigrateWaitingProofStore(t *testing.T) {
 			name:       "key mismatch fails",
 			setup:      makeKeyMismatchSetup,
 			shouldFail: true,
+		},
+		{
+			name:       "mixed legacy and typed proofs",
+			setup:      makeMixedLegacyAndTypedSetup,
+			shouldFail: false,
 		},
 	}
 

--- a/docs/release-notes/release-notes-0.21.2.md
+++ b/docs/release-notes/release-notes-0.21.2.md
@@ -36,6 +36,13 @@
   combination. This also affects callers replaying an affected historical
   route returned by `ListPayments` or `TrackPayment`.
 
+* [Fixed a channeldb migration
+  bug](https://github.com/lightningnetwork/lnd/pull/10985) where databases
+  initialized without a persisted `metadata/dbp` version key could skip later
+  mandatory migrations. This recovers such databases from the last known
+  v0.20-era mandatory version so the v0.21 waiting proof migration runs
+  without replaying older migrations against an already-initialized database.
+
 # New Features
 
 ## Functional Enhancements


### PR DESCRIPTION
## Change Description

Fixes a channeldb initialization/migration edge case where a DB can have a `metadata` bucket but no persisted `metadata/dbp` version key.

This state can be created by fresh nodes initialized after PR #9653 changed `initChannelDB` to create top-level buckets before checking metadata. That PR fixed a real bug where initialized DBs could be missing newer top-level buckets, so this PR keeps that behavior. The bug is that `FetchMeta` treats a present `metadata` bucket with a missing `dbp` key as the latest schema version. During an upgrade, that can make `syncVersions` skip mandatory migrations.

For a v0.20-created DB upgraded to v0.21, this can leave legacy `waitingproofs` records unmigrated. v0.21 then decodes a legacy remote waiting proof's leading `isRemote=0x01` byte as `WaitingProofTypeV2` and can fail during startup with:

```text
invalid public key: unsupported format: 3d
```

This PR:

- adds strict metadata reads that distinguish `metadata` missing, `metadata/dbp` missing, and `metadata/dbp` present;
- keeps `initChannelDB` creating required top-level buckets for already-initialized DBs, preserving the PR #9653 fix;
- writes `metadata/dbp` for genuinely fresh DBs;
- treats existing missing-`dbp` DBs as a recovery case in `syncVersions`, starting from mandatory version 33 instead of latest or 0;
- makes migration 35 skip already-typed waiting proof records so it is safe to run in missing-version recovery;
- adds tests for fresh DB metadata persistence, missing top-level bucket repair, missing-version waiting proof recovery, and repeatable waiting proof migration.

## Why recover from version 33?

A missing `metadata/dbp` key is not the same as DB version 0. The affected DBs were initialized by v0.20-era code, so replaying migrations 0 through 33 against them would be unsafe. Version 33 is the last mandatory DB version before the v0.20.x releases that could create a DB without writing the version key. Recovering from 33 lets v0.21 run migration 35, which is the migration needed for legacy waiting proofs, without replaying older migrations against an already-modern DB.

## Reproduction

The temporary reproduction snippets and exact commands are in this gist:

https://gist.github.com/ellemouton/4482a4d0bc7fd5a129c8bc17c6a30a70

The gist demonstrates:

1. `v0.20.1-beta` fresh channeldb init creates `metadata` but leaves `metadata/dbp` missing.
2. `v0.21.1-beta` opens a missing-`dbp` DB containing legacy waiting proofs, skips migration 35, and reproduces `invalid public key: unsupported format: 3d`.
3. This branch opens the exact same DB, writes `metadata/dbp`, runs migration 35, removes legacy waiting proof keys, writes typed V1 keys, and lets `NewWaitingProofStore` succeed.
4. A synthetic test manually writes a real Bolt `channel.db` with `metadata/dbp` missing and legacy 9-byte waiting proof records, verifies it fails with the same `3d` error before recovery, then verifies the fixed code writes `dbp` and rewrites the records to typed 10-byte keys.

## Testing

```bash
go test ./channeldb ./channeldb/migration35 -count=1
```

Additional local repro commands are documented in the gist above.

## Additional edge cases checked

The gist also includes a follow-up edge-case test file covering:

- missing `metadata/dbp` with no `waitingproofs` bucket: recovery writes `dbp` and does not create the bucket unnecessarily;
- missing `metadata/dbp` with already-typed V1 waiting proofs: recovery writes `dbp`, migration 35 skips the typed record, and `NewWaitingProofStore` succeeds;
- explicit `metadata/dbp=33` with legacy waiting proofs: normal migration selection runs migration 35 and startup succeeds;
- explicit `metadata/dbp=LatestDBVersion()` with legacy waiting proofs: this still crashes, which is outside the missing-version bug and would imply legacy waiting proofs were inserted/restored after the DB was already marked current.

