### PR TITLE
lnrpc+rpcserver: include short channel id in pending close channels

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -90,6 +90,12 @@
 
 ## RPC Updates
 
+* The `PendingChannels` response now [includes the short channel
+  id](https://github.com/lightningnetwork/lnd/pull/5575) of channels in the
+  `waiting_close_channels` and `pending_force_closing_channels` lists, so a
+  channel can be correlated with earlier `ListChannels` output without having
+  to match on the channel point.
+
 ## lncli Updates
 
 ## Breaking Changes

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -82,6 +82,12 @@
 
 ## RPC Updates
 
+* The `PendingChannels` response now [includes the short channel
+  id](https://github.com/lightningnetwork/lnd/pull/5575) of channels in the
+  `waiting_close_channels` and `pending_force_closing_channels` lists, so a
+  channel can be correlated with earlier `ListChannels` output without having
+  to match on the channel point.
+
 ## lncli Updates
 
 ## Breaking Changes

--- a/itest/lnd_onchain_test.go
+++ b/itest/lnd_onchain_test.go
@@ -411,6 +411,10 @@ func testAnchorThirdPartySpend(ht *lntest.HarnessTest) {
 		},
 	)
 
+	// Grab the short channel ID while the channel is still open so we can
+	// assert it's echoed back once the channel is pending close.
+	chanID := ht.GetChannelByChanPoint(alice, aliceChanPoint1).ChanId
+
 	// Send another UTXO if this is a neutrino backend. When sweeping
 	// anchors, there are two transactions created, `local_sweep_tx` for
 	// sweeping Alice's anchor on the local commitment, `remote_sweep_tx`
@@ -455,6 +459,11 @@ func testAnchorThirdPartySpend(ht *lntest.HarnessTest) {
 	pendingChannelsResp := alice.RPC.PendingChannels()
 	require.Equal(ht, testMemo,
 		pendingChannelsResp.WaitingCloseChannels[0].Channel.Memo)
+
+	// The short channel ID should also be returned while the channel is
+	// waiting close.
+	require.Equal(ht, chanID,
+		pendingChannelsResp.WaitingCloseChannels[0].ChanId)
 
 	// At this point, the channel is waiting close so we have the
 	// commitment transaction in the mempool. Alice's anchor, however,
@@ -538,6 +547,11 @@ func testAnchorThirdPartySpend(ht *lntest.HarnessTest) {
 	pendingChannelsResp = alice.RPC.PendingChannels()
 	require.Equal(ht, testMemo,
 		pendingChannelsResp.PendingForceClosingChannels[0].Channel.Memo)
+
+	// Same for the pending force close case, the short channel ID is
+	// carried over from the close summary.
+	require.Equal(ht, chanID,
+		pendingChannelsResp.PendingForceClosingChannels[0].ChanId)
 
 	// With the anchor output located, and the main commitment mined we'll
 	// instruct the wallet to send all coins in the wallet to a new address

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -18158,7 +18158,9 @@ type PendingChannelsResponse_WaitingCloseChannel struct {
 	// The block height at which the closing transaction was first confirmed.
 	// This will be zero if the closing transaction has not yet confirmed, or
 	// if this information is not available for older channels.
-	CloseHeight   uint32 `protobuf:"varint,7,opt,name=close_height,json=closeHeight,proto3" json:"close_height,omitempty"`
+	CloseHeight uint32 `protobuf:"varint,7,opt,name=close_height,json=closeHeight,proto3" json:"close_height,omitempty"`
+	// The unique channel ID for the channel.
+	ChanId        uint64 `protobuf:"varint,8,opt,name=chan_id,json=chanId,proto3" json:"chan_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -18238,6 +18240,13 @@ func (x *PendingChannelsResponse_WaitingCloseChannel) GetBlocksTilCloseConfirmed
 func (x *PendingChannelsResponse_WaitingCloseChannel) GetCloseHeight() uint32 {
 	if x != nil {
 		return x.CloseHeight
+	}
+	return 0
+}
+
+func (x *PendingChannelsResponse_WaitingCloseChannel) GetChanId() uint64 {
+	if x != nil {
+		return x.ChanId
 	}
 	return 0
 }
@@ -18407,8 +18416,10 @@ type PendingChannelsResponse_ForceClosedChannel struct {
 	RecoveredBalance int64                                                  `protobuf:"varint,6,opt,name=recovered_balance,json=recoveredBalance,proto3" json:"recovered_balance,omitempty"`
 	PendingHtlcs     []*PendingHTLC                                         `protobuf:"bytes,8,rep,name=pending_htlcs,json=pendingHtlcs,proto3" json:"pending_htlcs,omitempty"`
 	Anchor           PendingChannelsResponse_ForceClosedChannel_AnchorState `protobuf:"varint,9,opt,name=anchor,proto3,enum=lnrpc.PendingChannelsResponse_ForceClosedChannel_AnchorState" json:"anchor,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// The unique channel ID for the channel.
+	ChanId        uint64 `protobuf:"varint,10,opt,name=chan_id,json=chanId,proto3" json:"chan_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PendingChannelsResponse_ForceClosedChannel) Reset() {
@@ -18495,6 +18506,13 @@ func (x *PendingChannelsResponse_ForceClosedChannel) GetAnchor() PendingChannels
 		return x.Anchor
 	}
 	return PendingChannelsResponse_ForceClosedChannel_LIMBO
+}
+
+func (x *PendingChannelsResponse_ForceClosedChannel) GetChanId() uint64 {
+	if x != nil {
+		return x.ChanId
+	}
+	return 0
 }
 
 var File_lightning_proto protoreflect.FileDescriptor
@@ -19121,7 +19139,7 @@ const file_lightning_proto_rawDesc = "" +
 	"\x13blocks_til_maturity\x18\x05 \x01(\x05R\x11blocksTilMaturity\x12\x14\n" +
 	"\x05stage\x18\x06 \x01(\rR\x05stage\">\n" +
 	"\x16PendingChannelsRequest\x12$\n" +
-	"\x0einclude_raw_tx\x18\x01 \x01(\bR\fincludeRawTx\"\xe0\x15\n" +
+	"\x0einclude_raw_tx\x18\x01 \x01(\bR\fincludeRawTx\"\x9a\x16\n" +
 	"\x17PendingChannelsResponse\x12.\n" +
 	"\x13total_limbo_balance\x18\x01 \x01(\x03R\x11totalLimboBalance\x12e\n" +
 	"\x15pending_open_channels\x18\x02 \x03(\v21.lnrpc.PendingChannelsResponse.PendingOpenChannelR\x13pendingOpenChannels\x12j\n" +
@@ -19153,7 +19171,7 @@ const file_lightning_proto_rawDesc = "" +
 	"fee_per_kw\x18\x06 \x01(\x03R\bfeePerKw\x122\n" +
 	"\x15funding_expiry_blocks\x18\x03 \x01(\x05R\x13fundingExpiryBlocks\x12<\n" +
 	"\x1aconfirmations_until_active\x18\a \x01(\rR\x18confirmationsUntilActive\x12/\n" +
-	"\x13confirmation_height\x18\b \x01(\rR\x12confirmationHeightJ\x04\b\x02\x10\x03\x1a\xfa\x02\n" +
+	"\x13confirmation_height\x18\b \x01(\rR\x12confirmationHeightJ\x04\b\x02\x10\x03\x1a\x97\x03\n" +
 	"\x13WaitingCloseChannel\x12G\n" +
 	"\achannel\x18\x01 \x01(\v2-.lnrpc.PendingChannelsResponse.PendingChannelR\achannel\x12#\n" +
 	"\rlimbo_balance\x18\x02 \x01(\x03R\flimboBalance\x12L\n" +
@@ -19161,7 +19179,8 @@ const file_lightning_proto_rawDesc = "" +
 	"\fclosing_txid\x18\x04 \x01(\tR\vclosingTxid\x12$\n" +
 	"\x0eclosing_tx_hex\x18\x05 \x01(\tR\fclosingTxHex\x12;\n" +
 	"\x1ablocks_til_close_confirmed\x18\x06 \x01(\rR\x17blocksTilCloseConfirmed\x12!\n" +
-	"\fclose_height\x18\a \x01(\rR\vcloseHeight\x1a\xa3\x02\n" +
+	"\fclose_height\x18\a \x01(\rR\vcloseHeight\x12\x1b\n" +
+	"\achan_id\x18\b \x01(\x04B\x020\x01R\x06chanId\x1a\xa3\x02\n" +
 	"\vCommitments\x12\x1d\n" +
 	"\n" +
 	"local_txid\x18\x01 \x01(\tR\tlocalTxid\x12\x1f\n" +
@@ -19173,7 +19192,7 @@ const file_lightning_proto_rawDesc = "" +
 	"\x1dremote_pending_commit_fee_sat\x18\x06 \x01(\x04R\x19remotePendingCommitFeeSat\x1a{\n" +
 	"\rClosedChannel\x12G\n" +
 	"\achannel\x18\x01 \x01(\v2-.lnrpc.PendingChannelsResponse.PendingChannelR\achannel\x12!\n" +
-	"\fclosing_txid\x18\x02 \x01(\tR\vclosingTxid\x1a\xee\x03\n" +
+	"\fclosing_txid\x18\x02 \x01(\tR\vclosingTxid\x1a\x8b\x04\n" +
 	"\x12ForceClosedChannel\x12G\n" +
 	"\achannel\x18\x01 \x01(\v2-.lnrpc.PendingChannelsResponse.PendingChannelR\achannel\x12!\n" +
 	"\fclosing_txid\x18\x02 \x01(\tR\vclosingTxid\x12#\n" +
@@ -19182,7 +19201,9 @@ const file_lightning_proto_rawDesc = "" +
 	"\x13blocks_til_maturity\x18\x05 \x01(\x05R\x11blocksTilMaturity\x12+\n" +
 	"\x11recovered_balance\x18\x06 \x01(\x03R\x10recoveredBalance\x127\n" +
 	"\rpending_htlcs\x18\b \x03(\v2\x12.lnrpc.PendingHTLCR\fpendingHtlcs\x12U\n" +
-	"\x06anchor\x18\t \x01(\x0e2=.lnrpc.PendingChannelsResponse.ForceClosedChannel.AnchorStateR\x06anchor\"1\n" +
+	"\x06anchor\x18\t \x01(\x0e2=.lnrpc.PendingChannelsResponse.ForceClosedChannel.AnchorStateR\x06anchor\x12\x1b\n" +
+	"\achan_id\x18\n" +
+	" \x01(\x04B\x020\x01R\x06chanId\"1\n" +
 	"\vAnchorState\x12\t\n" +
 	"\x05LIMBO\x10\x00\x12\r\n" +
 	"\tRECOVERED\x10\x01\x12\b\n" +

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -18189,7 +18189,9 @@ type PendingChannelsResponse_WaitingCloseChannel struct {
 	// The block height at which the closing transaction was first confirmed.
 	// This will be zero if the closing transaction has not yet confirmed, or
 	// if this information is not available for older channels.
-	CloseHeight   uint32 `protobuf:"varint,7,opt,name=close_height,json=closeHeight,proto3" json:"close_height,omitempty"`
+	CloseHeight uint32 `protobuf:"varint,7,opt,name=close_height,json=closeHeight,proto3" json:"close_height,omitempty"`
+	// The unique channel ID for the channel.
+	ChanId        uint64 `protobuf:"varint,8,opt,name=chan_id,json=chanId,proto3" json:"chan_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -18269,6 +18271,13 @@ func (x *PendingChannelsResponse_WaitingCloseChannel) GetBlocksTilCloseConfirmed
 func (x *PendingChannelsResponse_WaitingCloseChannel) GetCloseHeight() uint32 {
 	if x != nil {
 		return x.CloseHeight
+	}
+	return 0
+}
+
+func (x *PendingChannelsResponse_WaitingCloseChannel) GetChanId() uint64 {
+	if x != nil {
+		return x.ChanId
 	}
 	return 0
 }
@@ -18438,8 +18447,10 @@ type PendingChannelsResponse_ForceClosedChannel struct {
 	RecoveredBalance int64                                                  `protobuf:"varint,6,opt,name=recovered_balance,json=recoveredBalance,proto3" json:"recovered_balance,omitempty"`
 	PendingHtlcs     []*PendingHTLC                                         `protobuf:"bytes,8,rep,name=pending_htlcs,json=pendingHtlcs,proto3" json:"pending_htlcs,omitempty"`
 	Anchor           PendingChannelsResponse_ForceClosedChannel_AnchorState `protobuf:"varint,9,opt,name=anchor,proto3,enum=lnrpc.PendingChannelsResponse_ForceClosedChannel_AnchorState" json:"anchor,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// The unique channel ID for the channel.
+	ChanId        uint64 `protobuf:"varint,10,opt,name=chan_id,json=chanId,proto3" json:"chan_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PendingChannelsResponse_ForceClosedChannel) Reset() {
@@ -18526,6 +18537,13 @@ func (x *PendingChannelsResponse_ForceClosedChannel) GetAnchor() PendingChannels
 		return x.Anchor
 	}
 	return PendingChannelsResponse_ForceClosedChannel_LIMBO
+}
+
+func (x *PendingChannelsResponse_ForceClosedChannel) GetChanId() uint64 {
+	if x != nil {
+		return x.ChanId
+	}
+	return 0
 }
 
 var File_lightning_proto protoreflect.FileDescriptor
@@ -19152,7 +19170,7 @@ const file_lightning_proto_rawDesc = "" +
 	"\x13blocks_til_maturity\x18\x05 \x01(\x05R\x11blocksTilMaturity\x12\x14\n" +
 	"\x05stage\x18\x06 \x01(\rR\x05stage\">\n" +
 	"\x16PendingChannelsRequest\x12$\n" +
-	"\x0einclude_raw_tx\x18\x01 \x01(\bR\fincludeRawTx\"\xe0\x15\n" +
+	"\x0einclude_raw_tx\x18\x01 \x01(\bR\fincludeRawTx\"\x9a\x16\n" +
 	"\x17PendingChannelsResponse\x12.\n" +
 	"\x13total_limbo_balance\x18\x01 \x01(\x03R\x11totalLimboBalance\x12e\n" +
 	"\x15pending_open_channels\x18\x02 \x03(\v21.lnrpc.PendingChannelsResponse.PendingOpenChannelR\x13pendingOpenChannels\x12j\n" +
@@ -19184,7 +19202,7 @@ const file_lightning_proto_rawDesc = "" +
 	"fee_per_kw\x18\x06 \x01(\x03R\bfeePerKw\x122\n" +
 	"\x15funding_expiry_blocks\x18\x03 \x01(\x05R\x13fundingExpiryBlocks\x12<\n" +
 	"\x1aconfirmations_until_active\x18\a \x01(\rR\x18confirmationsUntilActive\x12/\n" +
-	"\x13confirmation_height\x18\b \x01(\rR\x12confirmationHeightJ\x04\b\x02\x10\x03\x1a\xfa\x02\n" +
+	"\x13confirmation_height\x18\b \x01(\rR\x12confirmationHeightJ\x04\b\x02\x10\x03\x1a\x97\x03\n" +
 	"\x13WaitingCloseChannel\x12G\n" +
 	"\achannel\x18\x01 \x01(\v2-.lnrpc.PendingChannelsResponse.PendingChannelR\achannel\x12#\n" +
 	"\rlimbo_balance\x18\x02 \x01(\x03R\flimboBalance\x12L\n" +
@@ -19192,7 +19210,8 @@ const file_lightning_proto_rawDesc = "" +
 	"\fclosing_txid\x18\x04 \x01(\tR\vclosingTxid\x12$\n" +
 	"\x0eclosing_tx_hex\x18\x05 \x01(\tR\fclosingTxHex\x12;\n" +
 	"\x1ablocks_til_close_confirmed\x18\x06 \x01(\rR\x17blocksTilCloseConfirmed\x12!\n" +
-	"\fclose_height\x18\a \x01(\rR\vcloseHeight\x1a\xa3\x02\n" +
+	"\fclose_height\x18\a \x01(\rR\vcloseHeight\x12\x1b\n" +
+	"\achan_id\x18\b \x01(\x04B\x020\x01R\x06chanId\x1a\xa3\x02\n" +
 	"\vCommitments\x12\x1d\n" +
 	"\n" +
 	"local_txid\x18\x01 \x01(\tR\tlocalTxid\x12\x1f\n" +
@@ -19204,7 +19223,7 @@ const file_lightning_proto_rawDesc = "" +
 	"\x1dremote_pending_commit_fee_sat\x18\x06 \x01(\x04R\x19remotePendingCommitFeeSat\x1a{\n" +
 	"\rClosedChannel\x12G\n" +
 	"\achannel\x18\x01 \x01(\v2-.lnrpc.PendingChannelsResponse.PendingChannelR\achannel\x12!\n" +
-	"\fclosing_txid\x18\x02 \x01(\tR\vclosingTxid\x1a\xee\x03\n" +
+	"\fclosing_txid\x18\x02 \x01(\tR\vclosingTxid\x1a\x8b\x04\n" +
 	"\x12ForceClosedChannel\x12G\n" +
 	"\achannel\x18\x01 \x01(\v2-.lnrpc.PendingChannelsResponse.PendingChannelR\achannel\x12!\n" +
 	"\fclosing_txid\x18\x02 \x01(\tR\vclosingTxid\x12#\n" +
@@ -19213,7 +19232,9 @@ const file_lightning_proto_rawDesc = "" +
 	"\x13blocks_til_maturity\x18\x05 \x01(\x05R\x11blocksTilMaturity\x12+\n" +
 	"\x11recovered_balance\x18\x06 \x01(\x03R\x10recoveredBalance\x127\n" +
 	"\rpending_htlcs\x18\b \x03(\v2\x12.lnrpc.PendingHTLCR\fpendingHtlcs\x12U\n" +
-	"\x06anchor\x18\t \x01(\x0e2=.lnrpc.PendingChannelsResponse.ForceClosedChannel.AnchorStateR\x06anchor\"1\n" +
+	"\x06anchor\x18\t \x01(\x0e2=.lnrpc.PendingChannelsResponse.ForceClosedChannel.AnchorStateR\x06anchor\x12\x1b\n" +
+	"\achan_id\x18\n" +
+	" \x01(\x04B\x020\x01R\x06chanId\"1\n" +
 	"\vAnchorState\x12\t\n" +
 	"\x05LIMBO\x10\x00\x12\r\n" +
 	"\tRECOVERED\x10\x01\x12\b\n" +

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -2860,6 +2860,9 @@ message PendingChannelsResponse {
         if this information is not available for older channels.
         */
         uint32 close_height = 7;
+
+        // The unique channel ID for the channel.
+        uint64 chan_id = 8 [jstype = JS_STRING];
     }
 
     message Commitments {
@@ -2939,6 +2942,9 @@ message PendingChannelsResponse {
         }
 
         AnchorState anchor = 9;
+
+        // The unique channel ID for the channel.
+        uint64 chan_id = 10 [jstype = JS_STRING];
     }
 
     // The balance in satoshis encumbered in pending channels

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -2862,6 +2862,9 @@ message PendingChannelsResponse {
         if this information is not available for older channels.
         */
         uint32 close_height = 7;
+
+        // The unique channel ID for the channel.
+        uint64 chan_id = 8 [jstype = JS_STRING];
     }
 
     message Commitments {
@@ -2941,6 +2944,9 @@ message PendingChannelsResponse {
         }
 
         AnchorState anchor = 9;
+
+        // The unique channel ID for the channel.
+        uint64 chan_id = 10 [jstype = JS_STRING];
     }
 
     // The balance in satoshis encumbered in pending channels

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -3205,6 +3205,11 @@
         },
         "anchor": {
           "$ref": "#/definitions/ForceClosedChannelAnchorState"
+        },
+        "chan_id": {
+          "type": "string",
+          "format": "uint64",
+          "description": "The unique channel ID for the channel."
         }
       }
     },
@@ -3343,6 +3348,11 @@
           "type": "integer",
           "format": "int64",
           "description": "The block height at which the closing transaction was first confirmed.\nThis will be zero if the closing transaction has not yet confirmed, or\nif this information is not available for older channels."
+        },
+        "chan_id": {
+          "type": "string",
+          "format": "uint64",
+          "description": "The unique channel ID for the channel."
         }
       }
     },

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4233,6 +4233,7 @@ func (r *rpcServer) fetchPendingForceCloseChannels() (pendingForceClose,
 		}
 
 		closeTXID := pendingClose.ClosingTXID.String()
+		closeChanID := pendingClose.ShortChanID.ToUint64()
 
 		switch pendingClose.CloseType {
 
@@ -4253,6 +4254,7 @@ func (r *rpcServer) fetchPendingForceCloseChannels() (pendingForceClose,
 			forceClose := &lnrpc.PendingChannelsResponse_ForceClosedChannel{
 				Channel:     channel,
 				ClosingTxid: closeTXID,
+				ChanId:      closeChanID,
 			}
 
 			// Fetch reports from both nursery and resolvers. At the
@@ -4509,6 +4511,7 @@ func (r *rpcServer) fetchWaitingCloseChannels(
 			ClosingTxid:             closingTxid,
 			ClosingTxHex:            closingTxHex,
 			BlocksTilCloseConfirmed: blocksTilCloseConfirmed,
+			ChanId:      waitingClose.ShortChannelID.ToUint64(),
 			CloseHeight: waitingClose.CloseConfirmationHeight.
 				UnwrapOr(0),
 		}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4237,6 +4237,7 @@ func (r *rpcServer) fetchPendingForceCloseChannels() (pendingForceClose,
 		}
 
 		closeTXID := pendingClose.ClosingTXID.String()
+		closeChanID := pendingClose.ShortChanID.ToUint64()
 
 		switch pendingClose.CloseType {
 
@@ -4257,6 +4258,7 @@ func (r *rpcServer) fetchPendingForceCloseChannels() (pendingForceClose,
 			forceClose := &lnrpc.PendingChannelsResponse_ForceClosedChannel{
 				Channel:     channel,
 				ClosingTxid: closeTXID,
+				ChanId:      closeChanID,
 			}
 
 			// Fetch reports from both nursery and resolvers. At the
@@ -4506,6 +4508,8 @@ func (r *rpcServer) fetchWaitingCloseChannels(
 			},
 		)
 
+		waitingCloseChanID := waitingClose.ShortChannelID.ToUint64()
+
 		waitingCloseResp := &lnrpc.PendingChannelsResponse_WaitingCloseChannel{
 			Channel:                 channel,
 			LimboBalance:            channel.LocalBalance,
@@ -4513,6 +4517,7 @@ func (r *rpcServer) fetchWaitingCloseChannels(
 			ClosingTxid:             closingTxid,
 			ClosingTxHex:            closingTxHex,
 			BlocksTilCloseConfirmed: blocksTilCloseConfirmed,
+			ChanId:                  waitingCloseChanID,
 			CloseHeight: waitingClose.CloseConfirmationHeight.
 				UnwrapOr(0),
 		}


### PR DESCRIPTION
### Change Description

`PendingChannels` identifies channels only by their channel point, so correlating an entry with `ListChannels` output or forwarding history (both keyed on the short channel id) means matching on the outpoint by hand.

This adds `chan_id` to `WaitingCloseChannel` and `ForceClosedChannel`. Both already have the confirmed short channel id available server side — `ChannelCloseSummary.ShortChanID` for force closed channels and `OpenChannel.ShortChannelID` for waiting close ones — so it is just a matter of surfacing it.

Pending *open* channels are deliberately left out: the funding transaction has not confirmed yet, so there is no short channel id to report.

This picks up #8000, which had already been reviewed and green-lit but was closed because its staging branch got deleted (see https://github.com/lightningnetwork/lnd/pull/8000#issuecomment-1805164999). The proto field numbers and server-side wiring match that PR; I additionally added itest coverage.

Fixes #5575

### Steps to Test

The existing `testAnchorReservedValue` itest now captures the short channel id while the channel is open and asserts it is echoed back in both the waiting close and pending force close entries:

```
make itest icase=anchor_reserved_value
```

### Pull Request Checklist

- [x] Update `release-notes` file
- [x] Add tests
