### PR TITLE
contractcourt: order incoming HTLC expiry handling

### DIFF
--- a/chainio/blockbeat.go
+++ b/chainio/blockbeat.go
@@ -2,6 +2,7 @@ package chainio
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightningnetwork/lnd/chainntnfs"
@@ -20,6 +21,13 @@ type Beat struct {
 	// log is the customized logger for the blockbeat which prints the
 	// block height.
 	log btclog.Logger
+}
+
+// processDeadlineBeat scopes a processing deadline to one root dispatch. It
+// embeds the original beat so nested dispatches carry the same deadline.
+type processDeadlineBeat struct {
+	Blockbeat
+	processDeadline time.Time
 }
 
 // Compile-time check to ensure Beat satisfies the Blockbeat interface.
@@ -51,4 +59,46 @@ func (b *Beat) Height() int32 {
 // NOTE: Part of the private blockbeat interface.
 func (b *Beat) logger() btclog.Logger {
 	return b.log
+}
+
+// withProcessBlockDeadline wraps a root Beat with a processing deadline.
+// Already scoped beats and non-Beat implementations are returned unchanged.
+func withProcessBlockDeadline(beat Blockbeat,
+	deadline time.Time) Blockbeat {
+
+	if _, ok := beat.(*processDeadlineBeat); ok {
+		return beat
+	}
+	if _, ok := beat.(*Beat); !ok {
+		return beat
+	}
+
+	return &processDeadlineBeat{
+		Blockbeat:       beat,
+		processDeadline: deadline,
+	}
+}
+
+// ProcessBlockDeadline returns the deadline assigned to the current root
+// dispatch.
+func ProcessBlockDeadline(beat Blockbeat) (time.Time, bool) {
+	b, ok := beat.(*processDeadlineBeat)
+	if !ok {
+		return time.Time{}, false
+	}
+
+	return b.processDeadline, true
+}
+
+// WithoutProcessBlockDeadline removes the current dispatch scope so reusing a
+// beat starts with a fresh processing budget.
+func WithoutProcessBlockDeadline(beat Blockbeat) Blockbeat {
+	for {
+		b, ok := beat.(*processDeadlineBeat)
+		if !ok {
+			return beat
+		}
+
+		beat = b.Blockbeat
+	}
 }

--- a/chainio/dispatcher.go
+++ b/chainio/dispatcher.go
@@ -337,6 +337,7 @@ func notifyAndWait(b Blockbeat, c Consumer, timeout time.Duration) error {
 
 	// Record the time it takes the consumer to process this block.
 	start := time.Now()
+	b = withProcessBlockDeadline(b, start.Add(timeout))
 
 	errChan := make(chan error, 1)
 	go func() {

--- a/chainio/dispatcher_test.go
+++ b/chainio/dispatcher_test.go
@@ -10,6 +10,73 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type deadlineConsumer struct {
+	name    string
+	process func(Blockbeat) error
+}
+
+func (d *deadlineConsumer) Name() string {
+	return d.name
+}
+
+func (d *deadlineConsumer) ProcessBlock(beat Blockbeat) error {
+	return d.process(beat)
+}
+
+// TestProcessBlockDeadlineDispatchScope verifies that nested dispatches share
+// their parent's deadline while a redispatch receives a fresh deadline.
+func TestProcessBlockDeadlineDispatchScope(t *testing.T) {
+	t.Parallel()
+
+	beat := NewBeat(chainntnfs.BlockEpoch{Height: 1})
+	var parentBeat Blockbeat
+	var parentDeadline, childDeadline time.Time
+
+	child := &deadlineConsumer{
+		name: "child",
+		process: func(beat Blockbeat) error {
+			var ok bool
+			childDeadline, ok = ProcessBlockDeadline(beat)
+			require.True(t, ok)
+
+			return nil
+		},
+	}
+	parent := &deadlineConsumer{
+		name: "parent",
+		process: func(beat Blockbeat) error {
+			parentBeat = beat
+			var ok bool
+			parentDeadline, ok = ProcessBlockDeadline(beat)
+			require.True(t, ok)
+
+			return notifyAndWait(beat, child, 2*time.Second)
+		},
+	}
+
+	require.NoError(t, notifyAndWait(beat, parent, time.Second))
+	require.Equal(t, parentDeadline, childDeadline)
+
+	redispatchBeat := WithoutProcessBlockDeadline(parentBeat)
+	_, ok := ProcessBlockDeadline(redispatchBeat)
+	require.False(t, ok)
+
+	var redispatchDeadline time.Time
+	redispatch := &deadlineConsumer{
+		name: "redispatch",
+		process: func(beat Blockbeat) error {
+			redispatchDeadline, ok = ProcessBlockDeadline(beat)
+			require.True(t, ok)
+
+			return nil
+		},
+	}
+	require.NoError(t, notifyAndWait(
+		redispatchBeat, redispatch, 2*time.Second,
+	))
+	require.True(t, redispatchDeadline.After(parentDeadline))
+}
+
 // TestNotifyAndWaitOnConsumerErr asserts when the consumer returns an error,
 // it's returned by notifyAndWait.
 func TestNotifyAndWaitOnConsumerErr(t *testing.T) {

--- a/contractcourt/briefcase.go
+++ b/contractcourt/briefcase.go
@@ -62,6 +62,10 @@ type ArbitratorLog interface {
 	// TODO(roasbeef): document on interface the errors expected to be
 	// returned
 
+	// UpdateResolverConfig updates the runtime dependencies copied into
+	// resolvers returned by FetchUnresolvedContracts.
+	UpdateResolverConfig(func(*ChannelArbitratorConfig))
+
 	// CurrentState returns the current state of the ChannelArbitrator. It
 	// takes an optional database transaction, which will be used if it is
 	// non-nil, otherwise the lookup will be done in its own transaction.
@@ -432,6 +436,14 @@ func newBoltArbitratorLog(db kvdb.Backend, cfg ChannelArbitratorConfig,
 // A compile time check to ensure boltArbitratorLog meets the ArbitratorLog
 // interface.
 var _ ArbitratorLog = (*boltArbitratorLog)(nil)
+
+// UpdateResolverConfig updates the runtime dependencies used when decoding
+// persisted resolvers.
+func (b *boltArbitratorLog) UpdateResolverConfig(
+	update func(*ChannelArbitratorConfig)) {
+
+	update(&b.cfg)
+}
 
 func fetchContractReadBucket(tx kvdb.RTx, scopeKey []byte) (kvdb.RBucket, error) {
 	scopeBucket := tx.ReadBucket(scopeKey)

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -1497,7 +1497,7 @@ func (c *ChainArbitrator) loadPendingCloseChannels() error {
 // process.
 func (c *ChainArbitrator) RedispatchBlockbeat(chanPoints []wire.OutPoint) {
 	// Get the current blockbeat.
-	beat := c.beat
+	beat := chainio.WithoutProcessBlockDeadline(c.beat)
 
 	// Prepare two sets of consumers.
 	channels := make([]chainio.Consumer, 0, len(chanPoints))

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1694,6 +1694,62 @@ func (c *ChannelArbitrator) cancelBlockbeatSubscription(
 	close(sub.quit)
 }
 
+// dispatchBlockbeatToSub sends one beat and waits for its acknowledgement.
+func (c *ChannelArbitrator) dispatchBlockbeatToSub(beat chainio.Blockbeat,
+	sub *blockbeatSubscription, deadline time.Time) error {
+
+	timeoutErr := func() error {
+		c.cancelBlockbeatSubscription(sub)
+
+		return fmt.Errorf("resolver blockbeat subscriber: %w",
+			chainio.ErrProcessBlockTimeout)
+	}
+
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return timeoutErr()
+	}
+
+	timer := time.NewTimer(remaining)
+	defer timer.Stop()
+
+	// A delivery-specific buffered ack prevents a late acknowledgement from
+	// satisfying a later beat after this dispatch times out.
+	update := blockbeatUpdate{
+		beat:    beat,
+		errChan: make(chan error, 1),
+	}
+
+	select {
+	case sub.blockbeatChan <- update:
+	case <-sub.quit:
+		return nil
+	case <-c.quit:
+		return nil
+	case <-timer.C:
+		return timeoutErr()
+	}
+
+	select {
+	case err := <-update.errChan:
+		return err
+
+	case <-sub.quit:
+		select {
+		case err := <-update.errChan:
+			return err
+		default:
+			return nil
+		}
+
+	case <-c.quit:
+		return nil
+
+	case <-timer.C:
+		return timeoutErr()
+	}
+}
+
 // advanceState is the main driver of our state machine. This method is an
 // iterative function which repeatedly attempts to advance the internal state
 // of the channel arbitrator. The state will be advanced until we reach a

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -43,6 +43,10 @@ const (
 	// channel arbitrator.
 	arbitratorBlockBufferSize = 20
 
+	// resolverBlockbeatTimeoutReserve leaves time to acknowledge the
+	// parent after resolver dispatch finishes.
+	resolverBlockbeatTimeoutReserve = time.Second
+
 	// AnchorOutputValue is the output value for the anchor output of an
 	// anchor channel.
 	// See BOLT 03 for more details:
@@ -1750,6 +1754,50 @@ func (c *ChannelArbitrator) dispatchBlockbeatToSub(beat chainio.Blockbeat,
 	}
 }
 
+// dispatchBlockbeatToSubscribers concurrently delivers a beat to the current
+// resolver subscriptions and waits for all acknowledgements.
+func (c *ChannelArbitrator) dispatchBlockbeatToSubscribers(
+	beat chainio.Blockbeat) error {
+
+	deadline, ok := chainio.ProcessBlockDeadline(beat)
+	if !ok {
+		deadline = time.Now().Add(chainio.DefaultProcessBlockTimeout)
+	}
+	deadline = deadline.Add(-resolverBlockbeatTimeoutReserve)
+
+	var subs []*blockbeatSubscription
+	c.blockbeatSubs.Range(func(
+		sub *blockbeatSubscription, _ struct{}) bool {
+
+		subs = append(subs, sub)
+		return true
+	})
+
+	errChan := make(chan error, len(subs))
+	var wg sync.WaitGroup
+	for _, sub := range subs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			err := c.dispatchBlockbeatToSub(beat, sub, deadline)
+			if err != nil {
+				errChan <- err
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errChan)
+
+	var dispatchErrs []error
+	for err := range errChan {
+		dispatchErrs = append(dispatchErrs, err)
+	}
+
+	return errors.Join(dispatchErrs...)
+}
+
 // advanceState is the main driver of our state machine. This method is an
 // iterative function which repeatedly attempts to advance the internal state
 // of the channel arbitrator. The state will be advanced until we reach a
@@ -3112,10 +3160,19 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32,
 
 // handleBlockbeat processes a newly received blockbeat by advancing the
 // arbitrator's internal state using the received block height.
-func (c *ChannelArbitrator) handleBlockbeat(beat chainio.Blockbeat) error {
-	// Notify we've processed the block.
-	defer c.NotifyBlockProcessed(beat, nil)
+func (c *ChannelArbitrator) handleBlockbeat(
+	beat chainio.Blockbeat) error {
 
+	err := c.processBlockbeat(beat)
+	c.NotifyBlockProcessed(beat, nil)
+
+	return err
+}
+
+// processBlockbeat advances this channel's state and dispatches the beat to
+// active resolver subscriptions. Resolver errors are logged locally, while
+// state-machine errors are returned to the channel attendant.
+func (c *ChannelArbitrator) processBlockbeat(beat chainio.Blockbeat) error {
 	// If the state is StateContractClosed, StateWaitingFullResolution, or
 	// StateFullyResolved, there's no need to read the close event channel
 	// since the arbitrator can only get to this state after processing a
@@ -3130,6 +3187,10 @@ func (c *ChannelArbitrator) handleBlockbeat(beat chainio.Blockbeat) error {
 		// already launched resolvers this will be NOOP as they track
 		// their own `launched` states.
 		c.launchResolvers()
+
+		if err := c.dispatchBlockbeatToSubscribers(beat); err != nil {
+			log.Errorf("Resolver blockbeat failed: %v", err)
+		}
 
 		return nil
 	}
@@ -3152,6 +3213,9 @@ func (c *ChannelArbitrator) handleBlockbeat(beat chainio.Blockbeat) error {
 
 	// Launch all active resolvers when a new blockbeat is received.
 	c.launchResolvers()
+	if err := c.dispatchBlockbeatToSubscribers(beat); err != nil {
+		log.Errorf("Resolver blockbeat failed: %v", err)
+	}
 
 	return nil
 }

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -176,6 +176,10 @@ type ChannelArbitratorConfig struct {
 	// spend his/her outgoing HTLC via the timeout path.
 	FindOutgoingHTLCDeadline func(htlc channeldb.HTLC) fn.Option[int32]
 
+	// subscribeBlockbeats lets resolvers subscribe to ordered blockbeats
+	// while they are waiting for block-based progress.
+	subscribeBlockbeats func() (*blockbeatSubscription, func())
+
 	ChainArbitratorConfig
 }
 
@@ -316,6 +320,27 @@ func (h HtlcSetKey) String() string {
 	}
 }
 
+// blockbeatUpdate carries a beat and a delivery-specific acknowledgement.
+type blockbeatUpdate struct {
+	beat    chainio.Blockbeat
+	errChan chan error
+}
+
+// ack reports the resolver result without blocking if delivery has ended.
+func (b blockbeatUpdate) ack(err error) {
+	select {
+	case b.errChan <- err:
+	default:
+	}
+}
+
+// blockbeatSubscription exists only while a resolver is ready to consume
+// ordered blockbeats.
+type blockbeatSubscription struct {
+	blockbeatChan chan blockbeatUpdate
+	quit          chan struct{}
+}
+
 // ChannelArbitrator is the on-chain arbitrator for a particular channel. The
 // struct will keep in sync with the current set of HTLCs on the commitment
 // transaction. The job of the attendant is to go on-chain to either settle or
@@ -366,6 +391,9 @@ type ChannelArbitrator struct {
 	// resolvers slice.
 	activeResolversLock sync.RWMutex
 
+	// blockbeatSubs tracks resolvers currently waiting for ordered beats.
+	blockbeatSubs lnutils.SyncMap[*blockbeatSubscription, struct{}]
+
 	// resolutionSignal is a channel that will be sent upon by contract
 	// resolvers once their contract has been fully resolved. With each
 	// send, we'll check to see if the contract is fully resolved.
@@ -411,6 +439,10 @@ func NewChannelArbitrator(cfg ChannelArbitratorConfig,
 		cfg:              cfg,
 		quit:             make(chan struct{}),
 	}
+	c.cfg.subscribeBlockbeats = c.subscribeBlockbeats
+	c.log.UpdateResolverConfig(func(cfg *ChannelArbitratorConfig) {
+		cfg.subscribeBlockbeats = c.subscribeBlockbeats
+	})
 
 	// Mount the block consumer.
 	c.BeatConsumer = chainio.NewBeatConsumer(c.quit, c.Name())
@@ -1634,6 +1666,32 @@ func (c *ChannelArbitrator) launchResolvers() {
 			return
 		}
 	}
+}
+
+// subscribeBlockbeats registers a resolver for ordered blockbeats.
+func (c *ChannelArbitrator) subscribeBlockbeats() (
+	*blockbeatSubscription, func()) {
+
+	sub := &blockbeatSubscription{
+		blockbeatChan: make(chan blockbeatUpdate),
+		quit:          make(chan struct{}),
+	}
+	c.blockbeatSubs.Store(sub, struct{}{})
+
+	return sub, func() {
+		c.cancelBlockbeatSubscription(sub)
+	}
+}
+
+// cancelBlockbeatSubscription removes a subscription and closes it once.
+func (c *ChannelArbitrator) cancelBlockbeatSubscription(
+	sub *blockbeatSubscription) {
+
+	if _, ok := c.blockbeatSubs.LoadAndDelete(sub); !ok {
+		return
+	}
+
+	close(sub.quit)
 }
 
 // advanceState is the main driver of our state machine. This method is an

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -46,6 +46,7 @@ type mockArbitratorLog struct {
 	failCommitState ArbitratorState
 	resolutions     *ContractResolutions
 	resolvers       map[ContractResolver]struct{}
+	resolverConfig  ChannelArbitratorConfig
 
 	commitSet *CommitSet
 
@@ -55,6 +56,12 @@ type mockArbitratorLog struct {
 // A compile time check to ensure mockArbitratorLog meets the ArbitratorLog
 // interface.
 var _ ArbitratorLog = (*mockArbitratorLog)(nil)
+
+func (b *mockArbitratorLog) UpdateResolverConfig(
+	update func(*ChannelArbitratorConfig)) {
+
+	update(&b.resolverConfig)
+}
 
 func (b *mockArbitratorLog) CurrentState(kvdb.RTx) (ArbitratorState, error) {
 	return b.state, nil
@@ -3164,6 +3171,52 @@ func assertResolverReport(t *testing.T, reports chan *channeldb.ResolverReport,
 
 	case <-time.After(defaultTimeout):
 		t.Fatalf("no reports present")
+	}
+}
+
+// TestBlockbeatSubscriptionCancel tests that subscription cancellation is
+// idempotent and removes the subscription before signaling its consumer.
+func TestBlockbeatSubscriptionCancel(t *testing.T) {
+	t.Parallel()
+
+	chanArb := &ChannelArbitrator{}
+	sub, cancel := chanArb.subscribeBlockbeats()
+	require.Equal(t, 1, chanArb.blockbeatSubs.Len())
+
+	cancel()
+	require.Zero(t, chanArb.blockbeatSubs.Len())
+	select {
+	case <-sub.quit:
+	default:
+		t.Fatal("expected subscription cancellation")
+	}
+
+	cancel()
+}
+
+// TestResolverConfigThroughArbitratorLog tests that runtime resolver config is
+// injected through decorated log implementations.
+func TestResolverConfigThroughArbitratorLog(t *testing.T) {
+	t.Parallel()
+
+	log := &mockArbitratorLog{}
+	decoratedLog := &testArbLog{ArbitratorLog: log}
+	chanArb := NewChannelArbitrator(
+		ChannelArbitratorConfig{}, map[HtlcSetKey]htlcSet{},
+		decoratedLog,
+	)
+
+	subscribe := log.resolverConfig.subscribeBlockbeats
+	require.NotNil(t, subscribe)
+	sub, cancel := subscribe()
+	require.Equal(t, 1, chanArb.blockbeatSubs.Len())
+
+	cancel()
+	require.Zero(t, chanArb.blockbeatSubs.Len())
+	select {
+	case <-sub.quit:
+	default:
+		t.Fatal("expected subscription cancellation")
 	}
 }
 

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -3220,6 +3220,69 @@ func TestResolverConfigThroughArbitratorLog(t *testing.T) {
 	}
 }
 
+// TestDispatchBlockbeatToSubSendTimeout tests that an unread subscription is
+// canceled instead of blocking channel arbitrator progress.
+func TestDispatchBlockbeatToSubSendTimeout(t *testing.T) {
+	t.Parallel()
+
+	chanArb := &ChannelArbitrator{quit: make(chan struct{})}
+	sub, _ := chanArb.subscribeBlockbeats()
+
+	err := chanArb.dispatchBlockbeatToSub(
+		newBeatFromHeight(1), sub, time.Now().Add(10*time.Millisecond),
+	)
+	require.ErrorIs(t, err, chainio.ErrProcessBlockTimeout)
+	require.Zero(t, chanArb.blockbeatSubs.Len())
+	select {
+	case <-sub.quit:
+	default:
+		t.Fatal("expected timed out subscription to be canceled")
+	}
+}
+
+// TestDispatchBlockbeatToSubAckTimeout tests that a late ack remains scoped to
+// its canceled delivery and cannot acknowledge a replacement subscription.
+func TestDispatchBlockbeatToSubAckTimeout(t *testing.T) {
+	t.Parallel()
+
+	chanArb := &ChannelArbitrator{quit: make(chan struct{})}
+	firstSub, _ := chanArb.subscribeBlockbeats()
+	firstResult := make(chan error, 1)
+	go func() {
+		firstResult <- chanArb.dispatchBlockbeatToSub(
+			newBeatFromHeight(1), firstSub,
+			time.Now().Add(50*time.Millisecond),
+		)
+	}()
+	firstUpdate := <-firstSub.blockbeatChan
+
+	err := <-firstResult
+	require.ErrorIs(t, err, chainio.ErrProcessBlockTimeout)
+	require.Zero(t, chanArb.blockbeatSubs.Len())
+
+	secondSub, _ := chanArb.subscribeBlockbeats()
+	secondResult := make(chan error, 1)
+	go func() {
+		secondResult <- chanArb.dispatchBlockbeatToSub(
+			newBeatFromHeight(2), secondSub,
+			time.Now().Add(time.Second),
+		)
+	}()
+	secondUpdate := <-secondSub.blockbeatChan
+
+	// A late acknowledgement for the canceled delivery must not complete
+	// the replacement dispatch.
+	firstUpdate.ack(nil)
+	select {
+	case err := <-secondResult:
+		t.Fatalf("late ack completed replacement dispatch: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	secondUpdate.ack(nil)
+	require.NoError(t, <-secondResult)
+}
+
 type mockChannel struct {
 	anchorResolutions *lnwallet.AnchorResolutions
 

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -3283,6 +3283,113 @@ func TestDispatchBlockbeatToSubAckTimeout(t *testing.T) {
 	require.NoError(t, <-secondResult)
 }
 
+// TestDispatchBlockbeatToSubscribersConcurrent tests concurrent delivery and
+// joined child errors.
+func TestDispatchBlockbeatToSubscribersConcurrent(t *testing.T) {
+	t.Parallel()
+
+	chanArb := &ChannelArbitrator{quit: make(chan struct{})}
+	firstSub, _ := chanArb.subscribeBlockbeats()
+	secondSub, _ := chanArb.subscribeBlockbeats()
+
+	result := make(chan error, 1)
+	go func() {
+		result <- chanArb.dispatchBlockbeatToSubscribers(
+			newBeatFromHeight(1),
+		)
+	}()
+
+	firstUpdate := <-firstSub.blockbeatChan
+	var secondUpdate blockbeatUpdate
+	select {
+	case secondUpdate = <-secondSub.blockbeatChan:
+	case <-time.After(time.Second):
+		t.Fatal("second subscriber was not dispatched concurrently")
+	}
+
+	firstErr := errors.New("first resolver failed")
+	secondErr := errors.New("second resolver failed")
+	firstUpdate.ack(firstErr)
+	secondUpdate.ack(secondErr)
+
+	err := <-result
+	require.ErrorIs(t, err, firstErr)
+	require.ErrorIs(t, err, secondErr)
+}
+
+// TestHandleBlockbeatIsolatesResolverError tests that a resolver dispatch error
+// does not fail the channel arbitrator's parent acknowledgement.
+func TestHandleBlockbeatIsolatesResolverError(t *testing.T) {
+	t.Parallel()
+
+	chanArb := &ChannelArbitrator{
+		state: StateContractClosed,
+		quit:  make(chan struct{}),
+	}
+	chanArb.BeatConsumer = chainio.NewBeatConsumer(
+		chanArb.quit, "blockbeat propagation test",
+	)
+
+	dispatchErr := errors.New("resolver dispatch failed")
+	sub, _ := chanArb.subscribeBlockbeats()
+	go func() {
+		update := <-sub.blockbeatChan
+		update.ack(dispatchErr)
+	}()
+
+	beat := newBeatFromHeight(1)
+	processResult := make(chan error, 1)
+	go func() {
+		processResult <- chanArb.ProcessBlock(beat)
+	}()
+
+	receivedBeat := <-chanArb.BlockbeatChan
+	err := chanArb.handleBlockbeat(receivedBeat)
+	require.NoError(t, err)
+	require.NoError(t, <-processResult)
+}
+
+// TestHandleBlockbeatIsolatesAdvanceStateError tests that a channel-local state
+// transition failure does not fail the parent blockbeat acknowledgement.
+func TestHandleBlockbeatIsolatesAdvanceStateError(t *testing.T) {
+	t.Parallel()
+
+	advanceErr := errors.New("invoice lookup failed")
+	log := &mockArbitratorLog{
+		state:     StateDefault,
+		newStates: make(chan ArbitratorState, 1),
+	}
+	ctx, err := createTestChannelArbitrator(
+		t, log, func(opts *testChanArbOpts) {
+			opts.arbCfg.Registry = &mockRegistry{
+				lookupErr: advanceErr,
+			}
+		},
+	)
+	require.NoError(t, err)
+	htlcs := htlcSet{
+		incomingHTLCs: map[uint64]channeldb.HTLC{
+			1: {
+				HtlcIndex:   1,
+				OutputIndex: 0,
+			},
+		},
+	}
+	ctx.chanArb.activeHTLCs[LocalHtlcSet] = htlcs
+	ctx.chanArb.unmergedSet[LocalHtlcSet] = htlcs
+
+	beat := newBeatFromHeight(1)
+	processResult := make(chan error, 1)
+	go func() {
+		processResult <- ctx.chanArb.ProcessBlock(beat)
+	}()
+
+	receivedBeat := <-ctx.chanArb.BlockbeatChan
+	err = ctx.chanArb.handleBlockbeat(receivedBeat)
+	require.ErrorIs(t, err, advanceErr)
+	require.NoError(t, <-processResult)
+}
+
 type mockChannel struct {
 	anchorResolutions *lnwallet.AnchorResolutions
 

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
@@ -37,6 +38,12 @@ type htlcIncomingContestResolver struct {
 	// htlcSuccessResolver is the inner resolver that may be utilized if we
 	// learn of the preimage.
 	*htlcSuccessResolver
+
+	// transitionMtx serializes launch-time preimage lookup with timeout.
+	transitionMtx sync.Mutex
+
+	// preimageMtx protects the inner resolution and canned witness update.
+	preimageMtx sync.Mutex
 }
 
 // newIncomingContestResolver instantiates a new incoming htlc contest resolver.
@@ -57,14 +64,14 @@ func newIncomingContestResolver(
 
 func (h *htlcIncomingContestResolver) processFinalHtlcFail() error {
 	// Mark the htlc as final failed.
-	err := h.ChainArbitratorConfig.PutFinalHtlcOutcome(
+	return h.ChainArbitratorConfig.PutFinalHtlcOutcome(
 		h.ChannelArbitratorConfig.ShortChanID, h.htlc.HtlcIndex, false,
 	)
-	if err != nil {
-		return err
-	}
+}
 
-	// Send notification.
+// notifyFinalHtlcFail notifies subscribers after the failed resolver state is
+// durably checkpointed.
+func (h *htlcIncomingContestResolver) notifyFinalHtlcFail() {
 	h.ChainArbitratorConfig.HtlcNotifier.NotifyFinalHtlcEvent(
 		models.CircuitKey{
 			ChanID: h.ShortChanID,
@@ -75,8 +82,6 @@ func (h *htlcIncomingContestResolver) processFinalHtlcFail() error {
 			Offchain: false,
 		},
 	)
-
-	return nil
 }
 
 // invalidFinalHtlc returns true if the HTLC is an exit-hop HTLC that fails
@@ -107,6 +112,13 @@ func (h *htlcIncomingContestResolver) invalidFinalHtlc(
 // Launch will call the inner resolver's launch method if the preimage can be
 // found, otherwise it's a no-op.
 func (h *htlcIncomingContestResolver) Launch() error {
+	h.transitionMtx.Lock()
+	defer h.transitionMtx.Unlock()
+	if h.IsResolved() {
+		h.log.Tracef("already resolved")
+		return nil
+	}
+
 	// NOTE: we don't mark this resolver as launched as the inner resolver
 	// will set it when it's launched.
 	if h.isLaunched() {
@@ -178,7 +190,13 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 			nil, channeldb.ResolverTypeIncomingHtlc,
 			channeldb.ResolverOutcomeAbandoned,
 		)
-		return nil, h.PutResolverReport(nil, resReport)
+		if err := h.PutResolverReport(nil, resReport); err != nil {
+			return nil, err
+		}
+
+		h.notifyFinalHtlcFail()
+
+		return nil, nil
 	}
 
 	// Register for block epochs. After registration, the current height
@@ -226,7 +244,13 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 			channeldb.ResolverOutcomeAbandoned,
 		)
 
-		return nil, h.Checkpoint(h, report)
+		if err := h.Checkpoint(h, report); err != nil {
+			return nil, err
+		}
+
+		h.notifyFinalHtlcFail()
+
+		return nil, nil
 	}
 
 	// We'll first check if this HTLC has been timed out, if so, we can
@@ -237,27 +261,7 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 	// preimage. Otherwise the resolver could potentially stay active
 	// indefinitely and the channel will never close properly.
 	if uint32(currentHeight) >= h.htlcExpiry {
-		// TODO(roasbeef): should also somehow check if outgoing is
-		// resolved or not
-		//  * may need to hook into the circuit map
-		//  * can't timeout before the outgoing has been
-
-		log.Infof("%T(%v): HTLC has timed out (expiry=%v, height=%v), "+
-			"abandoning", h, h.htlcResolution.ClaimOutpoint,
-			h.htlcExpiry, currentHeight)
-		h.markResolved()
-
-		if err := h.processFinalHtlcFail(); err != nil {
-			return nil, err
-		}
-
-		// Finally, get our report and checkpoint our resolver with a
-		// timeout outcome report.
-		report := h.report().resolverReport(
-			nil, channeldb.ResolverTypeIncomingHtlc,
-			channeldb.ResolverOutcomeTimeout,
-		)
-		return nil, h.Checkpoint(h, report)
+		return h.timeoutOrSuccessResolver(uint32(currentHeight))
 	}
 
 	// Define a closure to process htlc resolutions either directly or
@@ -286,8 +290,6 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 				h.htlcResolution.ClaimOutpoint,
 				h.htlcExpiry, currentHeight)
 
-			h.markResolved()
-
 			if err := h.processFinalHtlcFail(); err != nil {
 				return nil, err
 			}
@@ -298,7 +300,16 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 				nil, channeldb.ResolverTypeIncomingHtlc,
 				channeldb.ResolverOutcomeAbandoned,
 			)
-			return nil, h.Checkpoint(h, report)
+
+			h.markResolved()
+			if err := h.Checkpoint(h, report); err != nil {
+				h.resolved.Store(false)
+				return nil, err
+			}
+
+			h.notifyFinalHtlcFail()
+
+			return nil, nil
 
 		// Error if the resolution type is unknown, we are only
 		// expecting settles and fails.
@@ -444,23 +455,7 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 			// resolved and exit.
 			newHeight := uint32(newBlock.Height)
 			if newHeight >= h.htlcExpiry {
-				log.Infof("%T(%v): HTLC has timed out "+
-					"(expiry=%v, height=%v), abandoning", h,
-					h.htlcResolution.ClaimOutpoint,
-					h.htlcExpiry, currentHeight)
-
-				h.markResolved()
-
-				if err := h.processFinalHtlcFail(); err != nil {
-					return nil, err
-				}
-
-				report := h.report().resolverReport(
-					nil,
-					channeldb.ResolverTypeIncomingHtlc,
-					channeldb.ResolverOutcomeTimeout,
-				)
-				return nil, h.Checkpoint(h, report)
+				return h.timeoutOrSuccessResolver(newHeight)
 			}
 
 		case <-h.quit:
@@ -469,12 +464,62 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 	}
 }
 
+// timeoutOrSuccessResolver continues a success path selected by Launch before
+// recording the HTLC as timed out.
+func (h *htlcIncomingContestResolver) timeoutOrSuccessResolver(
+	currentHeight uint32) (ContractResolver, error) {
+
+	h.transitionMtx.Lock()
+	defer h.transitionMtx.Unlock()
+
+	if h.isLaunched() {
+		return h.htlcSuccessResolver, nil
+	}
+	// A raw best-height check can observe expiry before the ordered beat is
+	// dispatched. Perform the same final lookup as Launch before failing.
+	applied, err := h.findAndapplyPreimage()
+	if err != nil {
+		return nil, err
+	}
+	if applied {
+		return h.htlcSuccessResolver, nil
+	}
+
+	// TODO(roasbeef): For forwarded HTLCs, also check whether the outgoing
+	// circuit resolved before timing out the incoming side.
+	log.Infof("%T(%v): HTLC has timed out (expiry=%v, height=%v), "+
+		"abandoning", h, h.htlcResolution.ClaimOutpoint, h.htlcExpiry,
+		currentHeight)
+
+	if err := h.processFinalHtlcFail(); err != nil {
+		return nil, err
+	}
+
+	report := h.report().resolverReport(
+		nil, channeldb.ResolverTypeIncomingHtlc,
+		channeldb.ResolverOutcomeTimeout,
+	)
+
+	h.markResolved()
+	if err := h.Checkpoint(h, report); err != nil {
+		h.resolved.Store(false)
+		return nil, err
+	}
+
+	h.notifyFinalHtlcFail()
+
+	return nil, nil
+}
+
 // applyPreimage is a helper function that will populate our internal resolver
 // with the preimage we learn of. This should be called once the preimage is
 // revealed so the inner resolver can properly complete its duties. The error
 // return value indicates whether the preimage was properly applied.
 func (h *htlcIncomingContestResolver) applyPreimage(
 	preimage lntypes.Preimage) error {
+
+	h.preimageMtx.Lock()
+	defer h.preimageMtx.Unlock()
 
 	// Sanity check to see if this preimage matches our htlc. At this point
 	// it should never happen that it does not match.

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -199,23 +199,9 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 		return nil, nil
 	}
 
-	// Register for block epochs. After registration, the current height
-	// will be sent on the channel immediately.
-	blockEpochs, err := h.Notifier.RegisterBlockEpochNtfn(nil)
+	_, currentHeight, err := h.ChainIO.GetBestBlock()
 	if err != nil {
 		return nil, err
-	}
-	defer blockEpochs.Cancel()
-
-	var currentHeight int32
-	select {
-	case newBlock, ok := <-blockEpochs.Epochs:
-		if !ok {
-			return nil, errResolverShuttingDown
-		}
-		currentHeight = newBlock.Height
-	case <-h.quit:
-		return nil, errResolverShuttingDown
 	}
 
 	log.Debugf("%T(%v): Resolving incoming HTLC(expiry=%v, height=%v)", h,
@@ -431,6 +417,49 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 		witnessUpdates = preimageSubscription.WitnessUpdates
 	}
 
+	if h.subscribeBlockbeats == nil {
+		return nil, errors.New("blockbeat subscription unavailable")
+	}
+
+	subscribe := func() (*blockbeatSubscription, func(),
+		ContractResolver, error) {
+
+		blockbeatSub, cancel := h.subscribeBlockbeats()
+		// Register so a concurrent beat is either delivered here or
+		// reflected by GetBestBlock.
+		_, currentHeight, err = h.ChainIO.GetBestBlock()
+		if err != nil {
+			cancel()
+			return nil, nil, nil, err
+		}
+
+		if uint32(currentHeight) >= h.htlcExpiry {
+			nextResolver, err := h.timeoutOrSuccessResolver(
+				uint32(currentHeight),
+			)
+			if err != nil {
+				h.log.Errorf("Expiry failed: %v", err)
+				return blockbeatSub, cancel, nil, nil
+			}
+
+			cancel()
+
+			return nil, nil, nextResolver, nil
+		}
+
+		return blockbeatSub, cancel, nil, nil
+	}
+
+	blockbeatSub, cancelBlockbeats, nextResolver, err := subscribe()
+	if blockbeatSub == nil || err != nil {
+		return nextResolver, err
+	}
+	defer func() {
+		if cancelBlockbeats != nil {
+			cancelBlockbeats()
+		}
+	}()
+
 	for {
 		select {
 		case preimage := <-witnessUpdates:
@@ -456,17 +485,38 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 			htlcResolution := hodlItem.(invoices.HtlcResolution)
 			return processHtlcResolution(htlcResolution)
 
-		case newBlock, ok := <-blockEpochs.Epochs:
-			if !ok {
-				return nil, errResolverShuttingDown
-			}
-
+		case update := <-blockbeatSub.blockbeatChan:
 			// If this new height expires the HTLC, then this means
 			// we never found out the preimage, so we can mark
 			// resolved and exit.
-			newHeight := uint32(newBlock.Height)
+			currentHeight = update.beat.Height()
+			newHeight := uint32(currentHeight)
 			if newHeight >= h.htlcExpiry {
-				return h.timeoutOrSuccessResolver(newHeight)
+				nextResolver, err := h.timeoutOrSuccessResolver(
+					newHeight,
+				)
+				update.ack(err)
+				if err != nil {
+					h.log.Errorf("Expiry failed: %v", err)
+					continue
+				}
+
+				return nextResolver, nil
+			}
+			update.ack(nil)
+
+		case <-blockbeatSub.quit:
+			select {
+			case <-h.quit:
+				return nil, errResolverShuttingDown
+			default:
+			}
+
+			cancelBlockbeats()
+			blockbeatSub, cancelBlockbeats, nextResolver, err =
+				subscribe()
+			if blockbeatSub == nil || err != nil {
+				return nextResolver, err
 			}
 
 		case <-h.quit:

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -275,7 +275,18 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 		// If the htlc resolution was a settle, apply the
 		// preimage and return a success resolver.
 		case *invoices.HtlcSettleResolution:
-			err := h.applyPreimage(resolution.Preimage)
+			_, bestHeight, err := h.ChainIO.GetBestBlock()
+			if err != nil {
+				return nil, err
+			}
+			height := uint32(bestHeight)
+			if height >= h.htlcExpiry &&
+				resolution.Outcome == invoices.ResultSettled {
+
+				return h.timeoutOrSuccessResolver(height)
+			}
+
+			err = h.applyPreimage(resolution.Preimage)
 			if err != nil {
 				return nil, err
 			}
@@ -705,9 +716,8 @@ func (h *htlcIncomingContestResolver) decodePayload() (*hop.Payload,
 var _ htlcContractResolver = (*htlcIncomingContestResolver)(nil)
 
 // findAndapplyPreimage performs a non-blocking read to find the preimage for
-// the incoming HTLC. If found, it will be applied to the resolver. This method
-// is used for the resolver to decide whether it wants to transform into a
-// success resolver during launching.
+// the incoming HTLC. A fresh invoice settlement does not start after expiry,
+// while a preimage that was already known can still be claimed.
 //
 // NOTE: Since we have two places to query the preimage, we need to check both
 // the preimage db and the invoice db to look up the preimage.
@@ -756,6 +766,21 @@ func (h *htlcIncomingContestResolver) findAndapplyPreimage() (bool, error) {
 		return false, nil
 	}
 
+	_, bestHeight, err := h.ChainIO.GetBestBlock()
+	if err != nil {
+		return false, err
+	}
+
+	// Before absolute expiry, preserve the zero-height sentinel used by
+	// this on-chain recovery path. Passing the current height would apply
+	// the registry's admission-time CLTV safety margin to an HTLC that is
+	// already on chain. At expiry, pass the real height so a fresh invoice
+	// settlement cannot be created.
+	registryHeight := int32(0)
+	if uint32(bestHeight) >= h.htlcExpiry {
+		registryHeight = bestHeight
+	}
+
 	// Notify registry that we are potentially resolving as an exit hop
 	// on-chain. If this HTLC indeed pays to an existing invoice, the
 	// invoice registry will tell us what to do with the HTLC. This is
@@ -769,13 +794,13 @@ func (h *htlcIncomingContestResolver) findAndapplyPreimage() (bool, error) {
 	// immediately, we'll assume we don't know it yet and let the `Resolve`
 	// handle the waiting.
 	//
-	// NOTE: we use a nil subscriber here and a zero current height as we
-	// are only interested in the settle resolution.
+	// NOTE: we use a nil subscriber here as we are only interested in the
+	// settle resolution.
 	//
 	// TODO(yy): move this logic to link and let the preimage be accessed
 	// via the preimage beacon.
 	resolution, err := h.Registry.NotifyExitHopHtlc(
-		h.htlc.RHash, h.htlc.Amt, h.htlcExpiry, 0,
+		h.htlc.RHash, h.htlc.Amt, h.htlcExpiry, registryHeight,
 		circuitKey, nil, h.htlc.CustomRecords, payload,
 	)
 	if err != nil {
@@ -786,6 +811,14 @@ func (h *htlcIncomingContestResolver) findAndapplyPreimage() (bool, error) {
 
 	// Exit early if it's not a settle resolution.
 	if !ok {
+		return false, nil
+	}
+
+	// A fresh invoice settlement is too late once the HTLC expires. Other
+	// settle outcomes describe a preimage that was already persisted.
+	if uint32(bestHeight) >= h.htlcExpiry &&
+		res.Outcome == invoices.ResultSettled {
+
 		return false, nil
 	}
 

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -239,17 +239,6 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 		return nil, nil
 	}
 
-	// We'll first check if this HTLC has been timed out, if so, we can
-	// return now and mark ourselves as resolved. If we're past the point of
-	// expiry of the HTLC, then at this point the sender can sweep it, so
-	// we'll end our lifetime. Here we deliberately forego the chance that
-	// the sender doesn't sweep and we already have or will learn the
-	// preimage. Otherwise the resolver could potentially stay active
-	// indefinitely and the channel will never close properly.
-	if uint32(currentHeight) >= h.htlcExpiry {
-		return h.timeoutOrSuccessResolver(uint32(currentHeight))
-	}
-
 	// Define a closure to process htlc resolutions either directly or
 	// triggered by future notifications.
 	processHtlcResolution := func(e invoices.HtlcResolution) (
@@ -317,9 +306,28 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 	}
 
 	var (
-		hodlChan       <-chan interface{}
-		witnessUpdates <-chan lntypes.Preimage
+		hodlChan          <-chan interface{}
+		witnessUpdates    <-chan lntypes.Preimage
+		pendingResolution invoices.HtlcResolution
 	)
+	processPendingResolution := func() (ContractResolver, error) {
+		switch pendingResolution.(type) {
+		case *invoices.HtlcFailResolution:
+		default:
+			return processHtlcResolution(pendingResolution)
+		}
+
+		// A failed resolution can become stale while Launch retries the
+		// success path. Serialize the choice with Launch and prefer the
+		// already-launched success resolver.
+		h.transitionMtx.Lock()
+		defer h.transitionMtx.Unlock()
+		if h.isLaunched() {
+			return h.htlcSuccessResolver, nil
+		}
+
+		return processHtlcResolution(pendingResolution)
+	}
 	if payload.FwdInfo.NextHop == hop.Exit {
 		// Create a buffered hodl chan to prevent deadlock.
 		hodlQueue := queue.NewConcurrentQueue(10)
@@ -364,12 +372,26 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 			// was known to the registry, we can directly resolve
 			// the htlc.
 			if res.Outcome != invoices.ResultInvoiceNotFound {
-				return processHtlcResolution(resolution)
+				nextResolver, err := processHtlcResolution(
+					resolution,
+				)
+				if err == nil {
+					return nextResolver, nil
+				}
+
+				h.log.Errorf("HTLC resolution failed: %v", err)
+				pendingResolution = resolution
 			}
 
 		// If we settled the htlc, we can resolve it.
 		case *invoices.HtlcSettleResolution:
-			return processHtlcResolution(resolution)
+			nextResolver, err := processHtlcResolution(resolution)
+			if err == nil {
+				return nextResolver, nil
+			}
+
+			h.log.Errorf("HTLC resolution failed: %v", err)
+			pendingResolution = resolution
 
 		// If the resolution is nil, the htlc was neither settled nor
 		// failed so we cannot take action at present.
@@ -429,8 +451,12 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 		// reflected by GetBestBlock.
 		_, currentHeight, err = h.ChainIO.GetBestBlock()
 		if err != nil {
-			cancel()
-			return nil, nil, nil, err
+			h.log.Errorf("Height resync failed: %v", err)
+			return blockbeatSub, cancel, nil, nil
+		}
+
+		if pendingResolution != nil {
+			return blockbeatSub, cancel, nil, nil
 		}
 
 		if uint32(currentHeight) >= h.htlcExpiry {
@@ -483,9 +509,31 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 
 		case hodlItem := <-hodlChan:
 			htlcResolution := hodlItem.(invoices.HtlcResolution)
-			return processHtlcResolution(htlcResolution)
+			nextResolver, err := processHtlcResolution(
+				htlcResolution,
+			)
+			if err == nil {
+				return nextResolver, nil
+			}
+
+			h.log.Errorf("HTLC resolution failed: %v", err)
+			pendingResolution = htlcResolution
 
 		case update := <-blockbeatSub.blockbeatChan:
+			if pendingResolution != nil {
+				nextResolver, err := processPendingResolution()
+				update.ack(err)
+				if err != nil {
+					h.log.Errorf(
+						"Resolution failed: %v", err,
+					)
+
+					continue
+				}
+
+				return nextResolver, nil
+			}
+
 			// If this new height expires the HTLC, then this means
 			// we never found out the preimage, so we can mark
 			// resolved and exit.

--- a/contractcourt/htlc_incoming_contest_resolver_test.go
+++ b/contractcourt/htlc_incoming_contest_resolver_test.go
@@ -147,6 +147,131 @@ func TestHtlcIncomingResolverNotifiesAfterCheckpoint(t *testing.T) {
 	require.Len(t, ctx.htlcNotifier.finalHtlcEvents, 1)
 }
 
+// TestHtlcIncomingResolverRetriesExpiryError tests that a transient final
+// lookup error is retried on the next ordered blockbeat.
+func TestHtlcIncomingResolverRetriesExpiryError(t *testing.T) {
+	t.Parallel()
+	defer timeout()()
+
+	ctx := newIncomingResolverTestContext(t, true)
+	ctx.resolve()
+	sub := ctx.activeSub()
+	ctx.registry.notifyErr = io.ErrUnexpectedEOF
+	update := blockbeatUpdate{
+		beat:    newBeatFromHeight(testHtlcExpiry),
+		errChan: make(chan error, 1),
+	}
+	sub.blockbeatChan <- update
+	require.ErrorIs(t, <-update.errChan, io.ErrUnexpectedEOF)
+
+	ctx.registry.notifyErr = nil
+	ctx.notifyBlockbeat(testHtlcExpiry + 1)
+	ctx.waitForResult(false)
+}
+
+// TestHtlcIncomingResolverRetriesInitialExpiryError tests that an expiry
+// lookup failure after subscription is retried on the next blockbeat.
+func TestHtlcIncomingResolverRetriesInitialExpiryError(t *testing.T) {
+	t.Parallel()
+	defer timeout()()
+
+	ctx := newIncomingResolverTestContext(t, true)
+	require.NoError(t, ctx.resolver.Launch())
+	ctx.chainIO.setBestHeight(testHtlcExpiry)
+	ctx.registry.immediateErr = io.ErrUnexpectedEOF
+	ctx.registry.immediateErrAt = testHtlcExpiry
+	lookupAttempted := make(chan chan struct{})
+	ctx.registry.notifyHook = func() {
+		ctx.registry.notifyHook = nil
+		continueLookup := make(chan struct{})
+		lookupAttempted <- continueLookup
+		<-continueLookup
+	}
+	ctx.startResolve()
+	continueLookup := <-lookupAttempted
+
+	select {
+	case err := <-ctx.resolveErr:
+		t.Fatalf("resolver exited before retry: %v", err)
+	default:
+	}
+	ctx.chainIO.setBestHeight(testHtlcExpiry + 1)
+	update := blockbeatUpdate{
+		beat:    newBeatFromHeight(testHtlcExpiry + 1),
+		errChan: make(chan error, 1),
+	}
+	sub := ctx.activeSub()
+	go func() {
+		sub.blockbeatChan <- update
+	}()
+	close(continueLookup)
+	require.NoError(t, <-update.errChan)
+	ctx.waitForResult(false)
+}
+
+// TestHtlcIncomingResolverRetriesSettlementError tests that transient
+// immediate and hodl settlement errors remain subscribed for retry.
+func TestHtlcIncomingResolverRetriesSettlementError(t *testing.T) {
+	t.Parallel()
+
+	for _, immediate := range []bool{true, false} {
+		name := "hodl"
+		if immediate {
+			name = "immediate"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			defer timeout()()
+
+			ctx := newIncomingResolverTestContext(t, true)
+			ctx.finalHtlcOutcomeErr = io.ErrUnexpectedEOF
+			settle := invoices.NewSettleResolution(
+				testResPreimage, testResCircuitKey,
+				testAcceptHeight, invoices.ResultSettled,
+			)
+
+			if immediate {
+				ctx.registry.subscribedResult = settle
+				require.NoError(t, ctx.resolver.Launch())
+				ctx.chainIO.setBestHeight(testHtlcExpiry)
+				ctx.startResolve()
+			} else {
+				ctx.resolve()
+				notifyData := <-ctx.registry.notifyChan
+				ctx.activeSub()
+				ctx.chainIO.setBestHeight(testHtlcExpiry)
+				notifyData.hodlChan <- settle
+			}
+
+			<-ctx.finalHtlcOutcomeFailed
+			ctx.notifyBlockbeat(testHtlcExpiry + 1)
+			ctx.waitForResult(false)
+		})
+	}
+}
+
+// TestHtlcIncomingResolverPrefersLaunchedSuccess tests that a failed pending
+// resolution cannot override a success path launched before its retry.
+func TestHtlcIncomingResolverPrefersLaunchedSuccess(t *testing.T) {
+	t.Parallel()
+	defer timeout()()
+
+	ctx := newIncomingResolverTestContext(t, true)
+	ctx.finalHtlcOutcomeErr = io.ErrUnexpectedEOF
+	ctx.registry.subscribedResult = invoices.NewFailResolution(
+		testResCircuitKey, testAcceptHeight, invoices.ResultCanceled,
+	)
+	ctx.resolve()
+	<-ctx.finalHtlcOutcomeFailed
+
+	ctx.witnessBeacon.lookupPreimage[testResHash] = testResPreimage
+	require.NoError(t, ctx.resolver.Launch())
+	require.True(t, ctx.resolver.isLaunched())
+	ctx.notifyBlockbeat(testHtlcExpiry)
+	ctx.waitForResult(true)
+	require.False(t, ctx.finalHtlcOutcomeStored)
+}
+
 // TestHtlcIncomingResolverBlockbeatCancelResyncs tests that cancellation makes
 // the resolver resubscribe and process a height missed during dispatch.
 func TestHtlcIncomingResolverBlockbeatCancelResyncs(t *testing.T) {
@@ -712,6 +837,8 @@ type incomingResolverTestContext struct {
 	resolveErr             chan error
 	nextResolver           ContractResolver
 	finalHtlcOutcomeStored bool
+	finalHtlcOutcomeErr    error
+	finalHtlcOutcomeFailed chan struct{}
 	checkpointErr          error
 	t                      *testing.T
 }
@@ -745,6 +872,7 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 		t:              t,
 	}
 	c.blockbeatSubChan = make(chan *incomingResolverBlockbeatSub, 1)
+	c.finalHtlcOutcomeFailed = make(chan struct{}, 1)
 
 	chainCfg := ChannelArbitratorConfig{
 		ChainArbitratorConfig: ChainArbitratorConfig{
@@ -754,6 +882,14 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 			OnionProcessor: onionProcessor,
 			PutFinalHtlcOutcome: func(chanId lnwire.ShortChannelID,
 				htlcId uint64, settled bool) error {
+
+				if c.finalHtlcOutcomeErr != nil {
+					err := c.finalHtlcOutcomeErr
+					c.finalHtlcOutcomeErr = nil
+					c.finalHtlcOutcomeFailed <- struct{}{}
+
+					return err
+				}
 
 				c.finalHtlcOutcomeStored = true
 
@@ -824,7 +960,10 @@ type incomingResolverBlockbeatSub struct {
 
 func (i *incomingResolverTestContext) resolve() {
 	require.NoError(i.t, i.resolver.Launch())
+	i.startResolve()
+}
 
+func (i *incomingResolverTestContext) startResolve() {
 	i.resolveErr = make(chan error, 1)
 	go func() {
 		nextResolver, err := i.resolver.Resolve()

--- a/contractcourt/htlc_incoming_contest_resolver_test.go
+++ b/contractcourt/htlc_incoming_contest_resolver_test.go
@@ -3,8 +3,10 @@ package contractcourt
 import (
 	"bytes"
 	"io"
+	"sync"
 	"testing"
 
+	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/chainntnfs"
@@ -157,6 +159,146 @@ func TestHtlcIncomingResolverFwdExpiredPreimageKnown(t *testing.T) {
 	ctx.waitForResult(true)
 }
 
+// TestHtlcIncomingResolverExpiredSettlement tests the complete launch and
+// resolve lifecycle for fresh and replayed settlements at expiry.
+func TestHtlcIncomingResolverExpiredSettlement(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		outcome       invoices.SettleResolutionResult
+		expectSuccess bool
+	}{
+		{"settlement replay", invoices.ResultReplayToSettled, true},
+		{"fresh settlement", invoices.ResultSettled, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			defer timeout()()
+
+			ctx := newIncomingResolverTestContext(t, true)
+			ctx.resolver.htlcExpiry = testInitialBlockHeight
+			ctx.registry.notifyResolution =
+				invoices.NewSettleResolution(
+					testResPreimage, testResCircuitKey,
+					testAcceptHeight, tc.outcome,
+				)
+
+			ctx.resolve()
+			ctx.waitForResult(tc.expectSuccess)
+		})
+	}
+}
+
+// TestHtlcIncomingResolverLaunchAfterExpiry tests which preimage sources may
+// start the success path once the HTLC has expired.
+func TestHtlcIncomingResolverLaunchAfterExpiry(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                        string
+		isExit, known, expectLaunch bool
+		outcome                     invoices.SettleResolutionResult
+	}{
+		{"known preimage", false, true, true, 0},
+		{
+			"settlement replay", true, false, true,
+			invoices.ResultReplayToSettled,
+		},
+		{"fresh settlement", true, false, false,
+			invoices.ResultSettled},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			defer timeout()()
+
+			ctx := newIncomingResolverTestContext(t, tc.isExit)
+			ctx.resolver.htlcExpiry = testInitialBlockHeight
+			if tc.known {
+				ctx.witnessBeacon.lookupPreimage[testResHash] =
+					testResPreimage
+			} else {
+				ctx.registry.notifyResolution =
+					invoices.NewSettleResolution(
+						testResPreimage,
+						testResCircuitKey,
+						testAcceptHeight, tc.outcome,
+					)
+			}
+
+			require.NoError(t, ctx.resolver.Launch())
+			if tc.isExit {
+				require.Len(t, ctx.registry.immediateNotify, 1)
+				notify := ctx.registry.immediateNotify[0]
+				require.Equal(t, int32(testInitialBlockHeight),
+					notify.currentHeight)
+			}
+			require.Equal(
+				t, tc.expectLaunch, ctx.resolver.isLaunched(),
+			)
+			if tc.expectLaunch {
+				require.Equal(
+					t, [32]byte(testResPreimage),
+					ctx.resolver.htlcResolution.Preimage,
+				)
+
+				return
+			}
+			require.Zero(t, ctx.resolver.htlcResolution.Preimage)
+		})
+	}
+}
+
+// TestHtlcIncomingResolverLaunchUsesZeroHeightBeforeExpiry asserts that the
+// on-chain lookup bypasses the registry's admission-time CLTV safety margin.
+func TestHtlcIncomingResolverLaunchUsesZeroHeightBeforeExpiry(t *testing.T) {
+	t.Parallel()
+	defer timeout()()
+
+	testHtlcIncomingResolverLaunchBeforeExpiry(t, false)
+}
+
+// TestHtlcIncomingResolverLaunchContinuesAfterLookupExpiry tests that a fresh
+// settlement accepted before expiry still launches if the tip advances while
+// the registry call returns.
+func TestHtlcIncomingResolverLaunchContinuesAfterLookupExpiry(t *testing.T) {
+	t.Parallel()
+	defer timeout()()
+
+	testHtlcIncomingResolverLaunchBeforeExpiry(t, true)
+}
+
+func testHtlcIncomingResolverLaunchBeforeExpiry(t *testing.T, advance bool) {
+	t.Helper()
+
+	ctx := newIncomingResolverTestContext(t, true)
+	ctx.chainIO.setBestHeight(testHtlcExpiry - 1)
+	ctx.registry.notifyResolution = invoices.NewSettleResolution(
+		testResPreimage, testResCircuitKey, testAcceptHeight,
+		invoices.ResultSettled,
+	)
+	if advance {
+		ctx.registry.notifyHook = func() {
+			ctx.chainIO.setBestHeight(testHtlcExpiry)
+		}
+	}
+
+	require.NoError(t, ctx.resolver.Launch())
+	require.True(t, ctx.resolver.isLaunched())
+	require.Len(t, ctx.registry.immediateNotify, 1)
+	require.Equal(
+		t, int32(0), ctx.registry.immediateNotify[0].currentHeight,
+	)
+	require.Equal(
+		t, [32]byte(testResPreimage),
+		ctx.resolver.htlcResolution.Preimage,
+	)
+}
+
 // TestHtlcIncomingResolverExitSettle tests resolution of an exit hop htlc for
 // which the invoice has already been settled when the resolver starts.
 func TestHtlcIncomingResolverExitSettle(t *testing.T) {
@@ -222,6 +364,37 @@ func TestHtlcIncomingResolverExitSettleHodl(t *testing.T) {
 	)
 
 	ctx.waitForResult(true)
+}
+
+// TestHtlcIncomingResolverExitSettleHodlAfterExpiry tests that a durable hodl
+// settlement replay wins over timeout once the HTLC has expired.
+func TestHtlcIncomingResolverExitSettleHodlAfterExpiry(t *testing.T) {
+	t.Parallel()
+	defer timeout()()
+
+	ctx := newIncomingResolverTestContext(t, true)
+	ctx.resolve()
+
+	notifyData := <-ctx.registry.notifyChan
+	require.False(t, ctx.resolver.htlcSuccessResolver.isLaunched())
+	ctx.registry.immediateResult = invoices.NewSettleResolution(
+		testResPreimage, testResCircuitKey, testAcceptHeight,
+		invoices.ResultReplayToSettled,
+	)
+	ctx.chainIO.setBestHeight(testHtlcExpiry)
+	notifyData.hodlChan <- invoices.NewSettleResolution(
+		testResPreimage, testResCircuitKey, testAcceptHeight,
+		invoices.ResultSettled,
+	)
+
+	ctx.waitForResult(true)
+	require.Equal(
+		t, [32]byte(testResPreimage),
+		ctx.resolver.htlcResolution.Preimage,
+	)
+	lastIndex := len(ctx.registry.immediateNotify) - 1
+	lastLookup := ctx.registry.immediateNotify[lastIndex]
+	require.Equal(t, int32(testHtlcExpiry), lastLookup.currentHeight)
 }
 
 // TestHtlcIncomingResolverExitTimeoutHodl tests resolution of an exit hop htlc
@@ -451,11 +624,32 @@ func (m mockCustomHtlcChecker) IsCustomHTLC(lnwire.CustomRecords) bool {
 	return true
 }
 
+type incomingResolverChainIO struct {
+	*mock.ChainIO
+	mu sync.RWMutex
+}
+
+func (i *incomingResolverChainIO) setBestHeight(height int32) {
+	i.mu.Lock()
+	i.BestHeight = height
+	i.mu.Unlock()
+}
+
+func (i *incomingResolverChainIO) GetBestBlock() (*chainhash.Hash, int32,
+	error) {
+
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+
+	return i.ChainIO.GetBestBlock()
+}
+
 type incomingResolverTestContext struct {
 	registry               *mockRegistry
 	witnessBeacon          *mockWitnessBeacon
 	resolver               *htlcIncomingContestResolver
 	notifier               *mock.ChainNotifier
+	chainIO                *incomingResolverChainIO
 	onionProcessor         *mockOnionProcessor
 	htlcNotifier           *mockHTLCNotifier
 	resolveErr             chan error
@@ -472,6 +666,9 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 		ConfChan:  make(chan *chainntnfs.TxConfirmation),
 	}
 	witnessBeacon := newMockWitnessBeacon()
+	chainIO := &incomingResolverChainIO{
+		ChainIO: &mock.ChainIO{BestHeight: testInitialBlockHeight},
+	}
 	registry := &mockRegistry{
 		notifyChan: make(chan notifyExitHopData, 1),
 	}
@@ -485,6 +682,7 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 		registry:       registry,
 		witnessBeacon:  witnessBeacon,
 		notifier:       notifier,
+		chainIO:        chainIO,
 		onionProcessor: onionProcessor,
 		htlcNotifier:   htlcNotifier,
 		t:              t,
@@ -511,6 +709,7 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 				return nil
 			},
 			Sweeper: newMockSweeper(),
+			ChainIO: chainIO,
 		},
 		PutResolverReport: func(_ kvdb.RwTx,
 			_ *channeldb.ResolverReport) error {

--- a/contractcourt/htlc_incoming_contest_resolver_test.go
+++ b/contractcourt/htlc_incoming_contest_resolver_test.go
@@ -5,10 +5,12 @@ import (
 	"io"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	sphinx "github.com/lightningnetwork/lightning-onion"
+	"github.com/lightningnetwork/lnd/chainio"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/fn/v2"
@@ -61,7 +63,7 @@ func TestHtlcIncomingResolverFwdContestedSuccess(t *testing.T) {
 	ctx.resolve()
 
 	// Simulate a new block coming in. HTLC is not yet expired.
-	ctx.notifyEpoch(testInitialBlockHeight + 1)
+	ctx.notifyBlockbeat(testInitialBlockHeight + 1)
 
 	ctx.witnessBeacon.preImageUpdates <- testResPreimage
 	ctx.waitForResult(true)
@@ -78,7 +80,7 @@ func TestHtlcIncomingResolverFwdContestedTimeout(t *testing.T) {
 	// Replace our checkpoint with one which will push reports into a
 	// channel for us to consume. We replace this function on the resolver
 	// itself because it is created by the test context.
-	reportChan := make(chan *channeldb.ResolverReport)
+	reportChan := make(chan *channeldb.ResolverReport, 1)
 	ctx.resolver.Checkpoint = func(_ ContractResolver,
 		reports ...*channeldb.ResolverReport) error {
 
@@ -93,7 +95,7 @@ func TestHtlcIncomingResolverFwdContestedTimeout(t *testing.T) {
 	ctx.resolve()
 
 	// Simulate a new block coming in. HTLC expires.
-	ctx.notifyEpoch(testHtlcExpiry)
+	ctx.notifyBlockbeat(testHtlcExpiry)
 
 	// Assert that we have a failure resolution because our invoice was
 	// cancelled.
@@ -143,6 +145,53 @@ func TestHtlcIncomingResolverNotifiesAfterCheckpoint(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, nextResolver)
 	require.Len(t, ctx.htlcNotifier.finalHtlcEvents, 1)
+}
+
+// TestHtlcIncomingResolverBlockbeatCancelResyncs tests that cancellation makes
+// the resolver resubscribe and process a height missed during dispatch.
+func TestHtlcIncomingResolverBlockbeatCancelResyncs(t *testing.T) {
+	t.Parallel()
+	defer timeout()()
+
+	ctx := newIncomingResolverTestContext(t, false)
+	ctx.resolve()
+	firstSub := ctx.activeSub()
+
+	ctx.chainIO.setBestHeight(testHtlcExpiry)
+	ctx.cancelActiveSub()
+	require.NotSame(t, firstSub, ctx.activeSub())
+
+	ctx.waitForResult(false)
+}
+
+// TestHtlcIncomingResolverLaunchBeforeExpiry tests that ChannelArbitrator
+// retries Launch before delivering the same expiry beat to Resolve.
+func TestHtlcIncomingResolverLaunchBeforeExpiry(t *testing.T) {
+	t.Parallel()
+	defer timeout()()
+
+	ctx := newIncomingResolverTestContext(t, false)
+	chanArb := &ChannelArbitrator{
+		state:           StateContractClosed,
+		activeResolvers: []ContractResolver{ctx.resolver},
+		quit:            make(chan struct{}),
+	}
+	chanArb.BeatConsumer = chainio.NewBeatConsumer(
+		chanArb.quit, "incoming expiry ordering test",
+	)
+	ctx.resolver.subscribeBlockbeats = chanArb.subscribeBlockbeats
+	ctx.chainIO.bestBlockRead = make(chan struct{}, 1)
+	ctx.resolve()
+	<-ctx.chainIO.bestBlockRead
+
+	ctx.chainIO.setBestHeight(testHtlcExpiry)
+	ctx.witnessBeacon.lookupPreimage[testResHash] = testResPreimage
+	require.NoError(t, chanArb.handleBlockbeat(
+		newBeatFromHeight(testHtlcExpiry),
+	))
+	require.True(t, ctx.resolver.isLaunched())
+	ctx.waitForResult(true)
+	require.False(t, ctx.finalHtlcOutcomeStored)
 }
 
 // TestHtlcIncomingResolverFwdExpiredPreimageKnown tests resolution of an
@@ -408,7 +457,7 @@ func TestHtlcIncomingResolverExitTimeoutHodl(t *testing.T) {
 	// Replace our checkpoint with one which will push reports into a
 	// channel for us to consume. We replace this function on the resolver
 	// itself because it is created by the test context.
-	reportChan := make(chan *channeldb.ResolverReport)
+	reportChan := make(chan *channeldb.ResolverReport, 1)
 	ctx.resolver.Checkpoint = func(_ ContractResolver,
 		reports ...*channeldb.ResolverReport) error {
 
@@ -421,7 +470,7 @@ func TestHtlcIncomingResolverExitTimeoutHodl(t *testing.T) {
 	}
 
 	ctx.resolve()
-	ctx.notifyEpoch(testHtlcExpiry)
+	ctx.notifyBlockbeat(testHtlcExpiry)
 
 	// Assert that we have a failure resolution because our invoice was
 	// cancelled.
@@ -626,7 +675,8 @@ func (m mockCustomHtlcChecker) IsCustomHTLC(lnwire.CustomRecords) bool {
 
 type incomingResolverChainIO struct {
 	*mock.ChainIO
-	mu sync.RWMutex
+	mu            sync.RWMutex
+	bestBlockRead chan struct{}
 }
 
 func (i *incomingResolverChainIO) setBestHeight(height int32) {
@@ -641,7 +691,12 @@ func (i *incomingResolverChainIO) GetBestBlock() (*chainhash.Hash, int32,
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 
-	return i.ChainIO.GetBestBlock()
+	hash, height, err := i.ChainIO.GetBestBlock()
+	if i.bestBlockRead != nil {
+		i.bestBlockRead <- struct{}{}
+	}
+
+	return hash, height, err
 }
 
 type incomingResolverTestContext struct {
@@ -650,6 +705,8 @@ type incomingResolverTestContext struct {
 	resolver               *htlcIncomingContestResolver
 	notifier               *mock.ChainNotifier
 	chainIO                *incomingResolverChainIO
+	blockbeatSub           *incomingResolverBlockbeatSub
+	blockbeatSubChan       chan *incomingResolverBlockbeatSub
 	onionProcessor         *mockOnionProcessor
 	htlcNotifier           *mockHTLCNotifier
 	resolveErr             chan error
@@ -687,6 +744,7 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 		htlcNotifier:   htlcNotifier,
 		t:              t,
 	}
+	c.blockbeatSubChan = make(chan *incomingResolverBlockbeatSub, 1)
 
 	chainCfg := ChannelArbitratorConfig{
 		ChainArbitratorConfig: ChainArbitratorConfig{
@@ -716,6 +774,7 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 
 			return nil
 		},
+		subscribeBlockbeats: c.subscribeBeats,
 	}
 
 	cfg := ResolverConfig{
@@ -758,26 +817,81 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 	return c
 }
 
-func (i *incomingResolverTestContext) resolve() {
-	// Start resolver.
-	i.resolveErr = make(chan error, 1)
-	go func() {
-		var err error
-
-		err = i.resolver.Launch()
-		require.NoError(i.t, err)
-
-		i.nextResolver, err = i.resolver.Resolve()
-		i.resolveErr <- err
-	}()
-
-	// Notify initial block height.
-	i.notifyEpoch(testInitialBlockHeight)
+type incomingResolverBlockbeatSub struct {
+	sub    *blockbeatSubscription
+	cancel func()
 }
 
-func (i *incomingResolverTestContext) notifyEpoch(height int32) {
-	i.notifier.EpochChan <- &chainntnfs.BlockEpoch{
-		Height: height,
+func (i *incomingResolverTestContext) resolve() {
+	require.NoError(i.t, i.resolver.Launch())
+
+	i.resolveErr = make(chan error, 1)
+	go func() {
+		nextResolver, err := i.resolver.Resolve()
+		i.nextResolver = nextResolver
+		i.resolveErr <- err
+	}()
+}
+
+func (i *incomingResolverTestContext) subscribeBeats() (
+	*blockbeatSubscription, func()) {
+
+	sub := &blockbeatSubscription{
+		blockbeatChan: make(chan blockbeatUpdate),
+		quit:          make(chan struct{}),
+	}
+	var cancelOnce sync.Once
+	cancel := func() {
+		cancelOnce.Do(func() {
+			close(sub.quit)
+		})
+	}
+
+	i.blockbeatSubChan <- &incomingResolverBlockbeatSub{
+		sub:    sub,
+		cancel: cancel,
+	}
+
+	return sub, cancel
+}
+
+func (i *incomingResolverTestContext) activeSub() *blockbeatSubscription {
+	if i.blockbeatSub != nil {
+		return i.blockbeatSub.sub
+	}
+
+	select {
+	case i.blockbeatSub = <-i.blockbeatSubChan:
+		return i.blockbeatSub.sub
+	case <-time.After(time.Second):
+		i.t.Fatal("timeout waiting for blockbeat subscription")
+		return nil
+	}
+}
+
+func (i *incomingResolverTestContext) cancelActiveSub() {
+	i.blockbeatSub.cancel()
+	i.blockbeatSub = nil
+}
+
+func (i *incomingResolverTestContext) notifyBlockbeat(height int32) {
+	sub := i.activeSub()
+	update := blockbeatUpdate{
+		beat:    newBeatFromHeight(height),
+		errChan: make(chan error, 1),
+	}
+
+	select {
+	case sub.blockbeatChan <- update:
+	case <-time.After(time.Second):
+		i.t.Fatal("timeout sending blockbeat")
+	}
+
+	select {
+	case err := <-update.errChan:
+		require.NoError(i.t, err)
+	case <-time.After(time.Second):
+		i.t.Fatal("timeout waiting for blockbeat ack")
 	}
 }
 

--- a/contractcourt/htlc_incoming_contest_resolver_test.go
+++ b/contractcourt/htlc_incoming_contest_resolver_test.go
@@ -104,17 +104,57 @@ func TestHtlcIncomingResolverFwdContestedTimeout(t *testing.T) {
 	ctx.waitForResult(false)
 }
 
-// TestHtlcIncomingResolverFwdTimeout tests resolution of a forwarded htlc that
-// has already expired when the resolver starts.
-func TestHtlcIncomingResolverFwdTimeout(t *testing.T) {
+// TestHtlcIncomingResolverExpiryRechecksPreimage tests that timeout cannot
+// fail an HTLC whose preimage appeared after the prior Launch.
+func TestHtlcIncomingResolverExpiryRechecksPreimage(t *testing.T) {
 	t.Parallel()
 	defer timeout()()
 
-	ctx := newIncomingResolverTestContext(t, true)
+	ctx := newIncomingResolverTestContext(t, false)
+	require.NoError(t, ctx.resolver.Launch())
+	ctx.witnessBeacon.lookupPreimage[testResHash] = testResPreimage
+
+	nextResolver, err := ctx.resolver.timeoutOrSuccessResolver(
+		testHtlcExpiry,
+	)
+	require.NoError(t, err)
+	require.Same(t, ctx.resolver.htlcSuccessResolver, nextResolver)
+	require.False(t, ctx.finalHtlcOutcomeStored)
+}
+
+// TestHtlcIncomingResolverNotifiesAfterCheckpoint tests that a checkpoint
+// failure does not emit a premature final HTLC notification.
+func TestHtlcIncomingResolverNotifiesAfterCheckpoint(t *testing.T) {
+	t.Parallel()
+	defer timeout()()
+
+	ctx := newIncomingResolverTestContext(t, false)
+	ctx.checkpointErr = io.ErrUnexpectedEOF
+
+	_, err := ctx.resolver.timeoutOrSuccessResolver(testHtlcExpiry)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	require.Empty(t, ctx.htlcNotifier.finalHtlcEvents)
+
+	nextResolver, err := ctx.resolver.timeoutOrSuccessResolver(
+		testHtlcExpiry + 1,
+	)
+	require.NoError(t, err)
+	require.Nil(t, nextResolver)
+	require.Len(t, ctx.htlcNotifier.finalHtlcEvents, 1)
+}
+
+// TestHtlcIncomingResolverFwdExpiredPreimageKnown tests resolution of an
+// expired forwarded HTLC whose preimage is already known when resolution
+// starts.
+func TestHtlcIncomingResolverFwdExpiredPreimageKnown(t *testing.T) {
+	t.Parallel()
+	defer timeout()()
+
+	ctx := newIncomingResolverTestContext(t, false)
 	ctx.witnessBeacon.lookupPreimage[testResHash] = testResPreimage
 	ctx.resolver.htlcExpiry = 90
 	ctx.resolve()
-	ctx.waitForResult(false)
+	ctx.waitForResult(true)
 }
 
 // TestHtlcIncomingResolverExitSettle tests resolution of an exit hop htlc for
@@ -417,9 +457,11 @@ type incomingResolverTestContext struct {
 	resolver               *htlcIncomingContestResolver
 	notifier               *mock.ChainNotifier
 	onionProcessor         *mockOnionProcessor
+	htlcNotifier           *mockHTLCNotifier
 	resolveErr             chan error
 	nextResolver           ContractResolver
 	finalHtlcOutcomeStored bool
+	checkpointErr          error
 	t                      *testing.T
 }
 
@@ -435,6 +477,7 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 	}
 
 	onionProcessor := &mockOnionProcessor{isExit: isExit}
+	htlcNotifier := &mockHTLCNotifier{}
 
 	checkPointChan := make(chan struct{}, 1)
 
@@ -443,10 +486,9 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 		witnessBeacon:  witnessBeacon,
 		notifier:       notifier,
 		onionProcessor: onionProcessor,
+		htlcNotifier:   htlcNotifier,
 		t:              t,
 	}
-
-	htlcNotifier := &mockHTLCNotifier{}
 
 	chainCfg := ChannelArbitratorConfig{
 		ChainArbitratorConfig: ChainArbitratorConfig{
@@ -481,6 +523,13 @@ func newIncomingResolverTestContext(t *testing.T, isExit bool) *incomingResolver
 		ChannelArbitratorConfig: chainCfg,
 		Checkpoint: func(_ ContractResolver,
 			_ ...*channeldb.ResolverReport) error {
+
+			if c.checkpointErr != nil {
+				err := c.checkpointErr
+				c.checkpointErr = nil
+
+				return err
+			}
 
 			checkPointChan <- struct{}{}
 			return nil

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lightningnetwork/lnd/graph/db/models"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/labels"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnutils"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/sweep"
@@ -168,13 +169,38 @@ func (h *htlcSuccessResolver) resolveRemoteCommitOutput() error {
 		return err
 	}
 
-	// TODO(yy): should also update the `RecoveredBalance` and
-	// `LimboBalance` like other paths?
+	isSuccess, err := h.isRemoteCommitSuccessSpend(sweepTxDetails)
+	if err != nil {
+		return err
+	}
+	if !isSuccess {
+		return h.checkpointForeignSpend(sweepTxDetails)
+	}
 
 	// Checkpoint the resolver, and write the outcome to disk.
 	return h.checkpointClaim(
 		sweepTxDetails.SpenderTxHash, h.htlcResolution.ClaimOutpoint,
 	)
+}
+
+// isRemoteCommitSuccessSpend returns true when a remote commitment HTLC was
+// spent through its success path using the preimage held by this resolver.
+func (h *htlcSuccessResolver) isRemoteCommitSuccessSpend(
+	spend *chainntnfs.SpendDetail) (bool, error) {
+
+	spendingInput, err := h.validateSpend(spend)
+	if err != nil {
+		return false, err
+	}
+
+	if !isPreimageSpend(h.isTaproot(), spend, true) {
+		return false, nil
+	}
+
+	var preimage lntypes.Preimage
+	copy(preimage[:], spendingInput.Witness[localPreimageIndex])
+
+	return preimage.Matches(h.htlc.RHash), nil
 }
 
 // checkpointClaim checkpoints the success resolver with the reports it needs.

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -238,6 +238,69 @@ func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash,
 	return h.Checkpoint(h, reports...)
 }
 
+// checkpointForeignSpend checkpoints the resolver as failed when its HTLC
+// outpoint was spent outside the expected success path.
+func (h *htlcSuccessResolver) checkpointForeignSpend(
+	commitSpend *chainntnfs.SpendDetail) error {
+
+	spendTxID := commitSpend.SpenderTxHash
+	h.log.Warnf("HTLC outpoint %v was spent by tx %v outside the "+
+		"expected success path", h.outpoint(), spendTxID)
+
+	err := h.ChainArbitratorConfig.PutFinalHtlcOutcome(
+		h.ChannelArbitratorConfig.ShortChanID, h.htlc.HtlcIndex, false,
+	)
+	if err != nil {
+		return err
+	}
+
+	// The final outcome is a separate durable write. If the resolver
+	// checkpoint below fails, only the live resolver state can be restored;
+	// retrying records the same failed outcome again.
+	report := &channeldb.ResolverReport{
+		OutPoint:        h.outpoint(),
+		Amount:          h.htlc.Amt.ToSatoshis(),
+		ResolverType:    channeldb.ResolverTypeIncomingHtlc,
+		ResolverOutcome: channeldb.ResolverOutcomeTimeout,
+		SpendTxID:       spendTxID,
+	}
+
+	h.reportLock.Lock()
+	previousReport := h.currentReport
+	h.currentReport.RecoveredBalance = 0
+	h.currentReport.LimboBalance = 0
+	h.reportLock.Unlock()
+
+	// A foreign spend leaves no second-level success output to sweep.
+	previousIncubating := h.outputIncubating
+	h.outputIncubating = false
+	h.markResolved()
+
+	if err := h.Checkpoint(h, report); err != nil {
+		h.outputIncubating = previousIncubating
+		h.resolved.Store(false)
+
+		h.reportLock.Lock()
+		h.currentReport = previousReport
+		h.reportLock.Unlock()
+
+		return err
+	}
+
+	h.ChainArbitratorConfig.HtlcNotifier.NotifyFinalHtlcEvent(
+		models.CircuitKey{
+			ChanID: h.ShortChanID,
+			HtlcID: h.htlc.HtlcIndex,
+		},
+		channeldb.FinalHtlcInfo{
+			Settled:  false,
+			Offchain: false,
+		},
+	)
+
+	return nil
+}
+
 // Stop signals the resolver to cancel any current resolution processes, and
 // suspend.
 //
@@ -815,6 +878,13 @@ func (h *htlcSuccessResolver) resolveSuccessTx() error {
 	)
 	if err != nil {
 		return err
+	}
+	matches, err := h.matchSecondLevelOutput(commitSpend)
+	if err != nil {
+		return err
+	}
+	if !matches {
+		return h.checkpointForeignSpend(commitSpend)
 	}
 
 	secondLevelOutpoint := wire.OutPoint{

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -1,6 +1,7 @@
 package contractcourt
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -10,6 +11,7 @@ import (
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/chanstate"
 	"github.com/lightningnetwork/lnd/fn/v2"
@@ -435,6 +437,105 @@ func (h *htlcSuccessResolver) isTaprootFinal() bool {
 	return h.chanType.IsTaprootFinal()
 }
 
+// validateSpend checks that a notifier spend consistently identifies the HTLC
+// outpoint and returns the input which spent it.
+func (h *htlcSuccessResolver) validateSpend(
+	spend *chainntnfs.SpendDetail) (*wire.TxIn, error) {
+
+	switch {
+	case spend == nil:
+		return nil, fmt.Errorf("missing spend detail for %v",
+			h.outpoint())
+
+	case spend.SpendingTx == nil:
+		return nil, fmt.Errorf("missing spending tx for %v",
+			h.outpoint())
+
+	case spend.SpenderTxHash == nil:
+		return nil, fmt.Errorf("missing spender txid for %v",
+			h.outpoint())
+
+	case spend.SpentOutPoint == nil:
+		return nil, fmt.Errorf("missing spent outpoint for %v",
+			h.outpoint())
+
+	case *spend.SpentOutPoint != h.outpoint():
+		return nil, fmt.Errorf("unexpected outpoint %v, expected %v",
+			spend.SpentOutPoint, h.outpoint())
+
+	case spend.SpenderInputIndex >= uint32(len(spend.SpendingTx.TxIn)):
+		return nil, fmt.Errorf("spender input index %d out of range",
+			spend.SpenderInputIndex)
+	}
+	if h.htlcResolution.SweepSignDesc.Output == nil {
+		return nil, fmt.Errorf("missing expected output for %v",
+			h.outpoint())
+	}
+
+	for index, txIn := range spend.SpendingTx.TxIn {
+		if txIn == nil {
+			return nil, fmt.Errorf("spender input %d is nil", index)
+		}
+	}
+	for index, txOut := range spend.SpendingTx.TxOut {
+		if txOut == nil {
+			return nil, fmt.Errorf("output %d is nil", index)
+		}
+	}
+
+	spendingInput := spend.SpendingTx.TxIn[spend.SpenderInputIndex]
+	if spendingInput.PreviousOutPoint != h.outpoint() {
+		return nil, fmt.Errorf("input %v, expected %v",
+			spendingInput.PreviousOutPoint, h.outpoint())
+	}
+
+	txid := spend.SpendingTx.TxHash()
+	if *spend.SpenderTxHash != txid {
+		return nil, fmt.Errorf("spender txid %v does not match tx %v",
+			spend.SpenderTxHash, txid)
+	}
+
+	return spendingInput, nil
+}
+
+// matchSecondLevelOutput checks whether the transaction spending the
+// commitment HTLC created the output expected by our sweep descriptor. The
+// boolean is false for a well-formed foreign spend, while malformed internal
+// data is returned as an error.
+//
+// The HTLC input uses SINGLE|ANYONECANPAY, so it commits to the transaction
+// output at the same index.
+func (h *htlcSuccessResolver) matchSecondLevelOutput(
+	commitSpend *chainntnfs.SpendDetail) (bool, error) {
+
+	if _, err := h.validateSpend(commitSpend); err != nil {
+		return false, err
+	}
+
+	outputIndex := commitSpend.SpenderInputIndex
+	expected := h.htlcResolution.SweepSignDesc.Output
+
+	// The success output should be at the same index as the HTLC input
+	// being spent. If that output is missing, this cannot be our success
+	// tx.
+	if outputIndex >= uint32(len(commitSpend.SpendingTx.TxOut)) {
+		return false, nil
+	}
+
+	actual := commitSpend.SpendingTx.TxOut[outputIndex]
+
+	// The spender consumed the HTLC, but only an exact value/script match
+	// gives us a second-level success output that our sweep descriptor can
+	// spend.
+	if actual.Value != expected.Value ||
+		!bytes.Equal(actual.PkScript, expected.PkScript) {
+
+		return false, nil
+	}
+
+	return true, nil
+}
+
 // sweepRemoteCommitOutput creates a sweep request to sweep the HTLC output on
 // the remote commitment via the direct preimage-spend.
 func (h *htlcSuccessResolver) sweepRemoteCommitOutput() error {
@@ -548,7 +649,8 @@ func (h *htlcSuccessResolver) sweepSuccessTx() error {
 }
 
 // sweepSuccessTxOutput attempts to sweep the output of the second level
-// success tx.
+// success tx. If the second-level success output cannot be found, Resolve will
+// checkpoint the foreign spend through the normal resolver-removal path.
 func (h *htlcSuccessResolver) sweepSuccessTxOutput() error {
 	h.log.Debugf("sweeping output %v from 2nd-level HTLC success tx",
 		h.htlcResolution.ClaimOutpoint)
@@ -563,6 +665,13 @@ func (h *htlcSuccessResolver) sweepSuccessTxOutput() error {
 	)
 	if err != nil {
 		return err
+	}
+	matches, err := h.matchSecondLevelOutput(commitSpend)
+	if err != nil {
+		return err
+	}
+	if !matches {
+		return nil
 	}
 
 	// We'll use this input index to determine the second-level output
@@ -790,8 +899,10 @@ func (h *htlcSuccessResolver) Launch() error {
 	// second-level success tx or the output from the second-level success
 	// tx.
 	case h.isZeroFeeOutput():
-		// If the second-level success tx has already been swept, we
-		// can go ahead and sweep its output.
+		// If the second-level success tx has already confirmed, Launch
+		// can offer the output to the sweeper. It must not checkpoint a
+		// terminal foreign spend because launchResolvers runs before
+		// resolveContract.
 		if h.outputIncubating {
 			return h.sweepSuccessTxOutput()
 		}

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -170,13 +170,17 @@ func (h *htlcSuccessResolver) resolveRemoteCommitOutput() error {
 	// `LimboBalance` like other paths?
 
 	// Checkpoint the resolver, and write the outcome to disk.
-	return h.checkpointClaim(sweepTxDetails.SpenderTxHash)
+	return h.checkpointClaim(
+		sweepTxDetails.SpenderTxHash, h.htlcResolution.ClaimOutpoint,
+	)
 }
 
 // checkpointClaim checkpoints the success resolver with the reports it needs.
 // If this htlc was claimed two stages, it will write reports for both stages,
 // otherwise it will just write for the single htlc claim.
-func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash) error {
+func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash,
+	claimOutpoint wire.OutPoint) error {
+
 	// Mark the htlc as final settled.
 	err := h.ChainArbitratorConfig.PutFinalHtlcOutcome(
 		h.ChannelArbitratorConfig.ShortChanID, h.htlc.HtlcIndex, true,
@@ -201,7 +205,7 @@ func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash) error {
 	amt := btcutil.Amount(h.htlcResolution.SweepSignDesc.Output.Value)
 	reports := []*channeldb.ResolverReport{
 		{
-			OutPoint:        h.htlcResolution.ClaimOutpoint,
+			OutPoint:        claimOutpoint,
 			Amount:          amt,
 			ResolverType:    channeldb.ResolverTypeIncomingHtlc,
 			ResolverOutcome: channeldb.ResolverOutcomeClaimed,
@@ -215,11 +219,10 @@ func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash) error {
 		// If the SignedSuccessTx is not nil, we are claiming the htlc
 		// in two stages, so we need to create a report for the first
 		// stage transaction as well.
-		spendTx := h.htlcResolution.SignedSuccessTx
-		spendTxID := spendTx.TxHash()
+		spendTxID := claimOutpoint.Hash
 
 		report := &channeldb.ResolverReport{
-			OutPoint:        spendTx.TxIn[0].PreviousOutPoint,
+			OutPoint:        h.outpoint(),
 			Amount:          h.htlc.Amt.ToSatoshis(),
 			ResolverType:    channeldb.ResolverTypeIncomingHtlc,
 			ResolverOutcome: channeldb.ResolverOutcomeFirstStage,
@@ -562,6 +565,16 @@ func (h *htlcSuccessResolver) sweepSuccessTxOutput() error {
 		return err
 	}
 
+	// We'll use this input index to determine the second-level output
+	// index on the transaction, as the signature requires the indexes to
+	// be the same. We don't look for the second-level output script
+	// directly, as there might be more than one HTLC output to the same
+	// pkScript.
+	secondLevelOutpoint := wire.OutPoint{
+		Hash:  *commitSpend.SpenderTxHash,
+		Index: commitSpend.SpenderInputIndex,
+	}
+
 	// The HTLC success tx has a CSV lock that we must wait for, and if
 	// this is a lease enforced channel and we're the imitator, we may need
 	// to wait for longer.
@@ -584,16 +597,6 @@ func (h *htlcSuccessResolver) sweepSuccessTxOutput() error {
 			h, h.htlc.RHash[:], waitHeight)
 	}
 
-	// We'll use this input index to determine the second-level output
-	// index on the transaction, as the signatures requires the indexes to
-	// be the same. We don't look for the second-level output script
-	// directly, as there might be more than one HTLC output to the same
-	// pkScript.
-	op := &wire.OutPoint{
-		Hash:  *commitSpend.SpenderTxHash,
-		Index: commitSpend.SpenderInputIndex,
-	}
-
 	// Let the sweeper sweep the second-level output now that the
 	// CSV/CLTV locks have expired.
 	var witType input.StandardWitnessType
@@ -606,7 +609,7 @@ func (h *htlcSuccessResolver) sweepSuccessTxOutput() error {
 		witType = input.HtlcAcceptedSuccessSecondLevel
 	}
 	inp := h.makeSweepInput(
-		op, witType,
+		&secondLevelOutpoint, witType,
 		input.LeaseHtlcAcceptedSuccessSecondLevel,
 		&h.htlcResolution.SweepSignDesc,
 		h.htlcResolution.CsvDelay, uint32(commitSpend.SpendingHeight),
@@ -705,12 +708,7 @@ func (h *htlcSuccessResolver) resolveSuccessTx() error {
 		return err
 	}
 
-	// We'll use this input index to determine the second-level output
-	// index on the transaction, as the signatures requires the indexes to
-	// be the same. We don't look for the second-level output script
-	// directly, as there might be more than one HTLC output to the same
-	// pkScript.
-	op := wire.OutPoint{
+	secondLevelOutpoint := wire.OutPoint{
 		Hash:  *commitSpend.SpenderTxHash,
 		Index: commitSpend.SpenderInputIndex,
 	}
@@ -719,7 +717,7 @@ func (h *htlcSuccessResolver) resolveSuccessTx() error {
 	// fast-forward to start the resolving process for the stage two
 	// output.
 	if h.outputIncubating {
-		return h.resolveSuccessTxOutput(op)
+		return h.resolveSuccessTxOutput(secondLevelOutpoint)
 	}
 
 	// Now that the second-level transaction has confirmed, we checkpoint
@@ -738,7 +736,7 @@ func (h *htlcSuccessResolver) resolveSuccessTx() error {
 		return err
 	}
 
-	return h.resolveSuccessTxOutput(op)
+	return h.resolveSuccessTxOutput(secondLevelOutpoint)
 }
 
 // resolveSuccessTxOutput waits for the spend of the output from the 2nd-level
@@ -763,7 +761,7 @@ func (h *htlcSuccessResolver) resolveSuccessTxOutput(op wire.OutPoint) error {
 	h.currentReport.LimboBalance = 0
 	h.reportLock.Unlock()
 
-	return h.checkpointClaim(spend.SpenderTxHash)
+	return h.checkpointClaim(spend.SpenderTxHash, op)
 }
 
 // Launch creates an input based on the details of the incoming htlc resolution

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/chainntnfs"
@@ -175,65 +176,136 @@ func (i *htlcResolverTestContext) waitForResult() {
 	}
 }
 
-// TestHtlcSuccessSingleStage tests successful sweep of a single stage htlc
-// claim.
+// TestHtlcSuccessSingleStage tests classification of a direct HTLC spend.
 func TestHtlcSuccessSingleStage(t *testing.T) {
-	htlcOutpoint := wire.OutPoint{Index: 3}
-
-	sweepTx := &wire.MsgTx{
-		TxIn:  []*wire.TxIn{{}},
-		TxOut: []*wire.TxOut{{}},
-	}
-
-	// singleStageResolution is a resolution for a htlc on the remote
-	// party's commitment.
-	singleStageResolution := lnwallet.IncomingHtlcResolution{
-		SweepSignDesc: testSignDesc,
-		ClaimOutpoint: htlcOutpoint,
-	}
-
-	sweepTxid := sweepTx.TxHash()
-	claim := &channeldb.ResolverReport{
-		OutPoint:        htlcOutpoint,
-		Amount:          btcutil.Amount(testSignDesc.Output.Value),
-		ResolverType:    channeldb.ResolverTypeIncomingHtlc,
-		ResolverOutcome: channeldb.ResolverOutcomeClaimed,
-		SpendTxID:       &sweepTxid,
-	}
-
-	checkpoints := []checkpoint{
+	taprootPkScript := append(
+		[]byte{txscript.OP_1, txscript.OP_DATA_32}, make([]byte, 32)...,
+	)
+	wrongPreimage := make([]byte, 32)
+	wrongPreimage[0] = 1
+	resolverType := channeldb.ResolverTypeIncomingHtlc
+	testCases := []struct {
+		name    string
+		witness wire.TxWitness
+		success bool
+		taproot bool
+		index   uint32
+	}{
 		{
-			// We send a confirmation for our sweep tx to indicate
-			// that our sweep succeeded.
-			preCheckpoint: func(ctx *htlcResolverTestContext,
-				_ bool) error {
-
-				// The resolver will offer the input to the
-				// sweeper.
-				details := &chainntnfs.SpendDetail{
-					SpendingTx:    sweepTx,
-					SpentOutPoint: &htlcOutpoint,
-					SpenderTxHash: &sweepTxid,
-				}
-				ctx.notifier.SpendChan <- details
-
-				return nil
+			name: "success", success: true, index: 1,
+			witness: wire.TxWitness{
+				dummyBytes, testResPreimage[:], dummyBytes,
 			},
-
-			// After the sweep has confirmed, we expect the
-			// checkpoint to be resolved, and with the above
-			// report.
-			resolved: true,
-			reports: []*channeldb.ResolverReport{
-				claim,
+		},
+		{
+			name: "timeout",
+			witness: wire.TxWitness{
+				nil, dummyBytes, dummyBytes, nil, dummyBytes,
 			},
-			finalHtlcStored: true,
+		},
+		{
+			name: "wrong preimage",
+			witness: wire.TxWitness{
+				dummyBytes, wrongPreimage, dummyBytes,
+			},
+		},
+		{
+			name: "taproot success", success: true, taproot: true,
+			witness: wire.TxWitness{
+				dummyBytes, testResPreimage[:], dummyBytes,
+				dummyBytes,
+			},
+		},
+		{
+			name: "taproot timeout", taproot: true,
+			witness: wire.TxWitness{
+				dummyBytes, dummyBytes, dummyBytes, dummyBytes,
+			},
 		},
 	}
 
-	testHtlcSuccess(
-		t, singleStageResolution, checkpoints,
-	)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			htlcOutpoint := wire.OutPoint{Index: 3}
+			inputs := []*wire.TxIn{{
+				PreviousOutPoint: htlcOutpoint,
+				Witness:          tc.witness,
+			}}
+			if tc.index != 0 {
+				inputs = append([]*wire.TxIn{{
+					PreviousOutPoint: wire.OutPoint{
+						Index: 4,
+					},
+				}}, inputs...)
+			}
+			sweepTx := &wire.MsgTx{
+				TxIn:  inputs,
+				TxOut: []*wire.TxOut{{}},
+			}
+			sweepTxid := sweepTx.TxHash()
+
+			signDesc := testSignDesc
+			if tc.taproot {
+				signDesc.Output = cloneTxOut(
+					testSignDesc.Output,
+				)
+				signDesc.Output.PkScript = taprootPkScript
+			}
+			resolution := lnwallet.IncomingHtlcResolution{
+				Preimage:      testResPreimage,
+				SweepSignDesc: signDesc,
+				ClaimOutpoint: htlcOutpoint,
+			}
+			outcome := channeldb.ResolverOutcomeTimeout
+			amount := testHtlcAmt.ToSatoshis()
+			if tc.success {
+				outcome = channeldb.ResolverOutcomeClaimed
+				amount = btcutil.Amount(
+					testSignDesc.Output.Value,
+				)
+			}
+			report := &channeldb.ResolverReport{
+				OutPoint:        htlcOutpoint,
+				Amount:          amount,
+				ResolverType:    resolverType,
+				ResolverOutcome: outcome,
+				SpendTxID:       &sweepTxid,
+			}
+			checkpoints := []checkpoint{{
+				preCheckpoint: func(
+					ctx *htlcResolverTestContext,
+					_ bool) error {
+
+					spend := newSpendDetail(
+						htlcOutpoint, sweepTx, tc.index,
+					)
+					ctx.notifier.SpendChan <- spend
+
+					return nil
+				},
+				resolved: true,
+				reports: []*channeldb.ResolverReport{
+					report,
+				},
+				finalHtlcStored:  true,
+				finalHtlcSettled: tc.success,
+			}}
+			testHtlcSuccess(t, resolution, checkpoints)
+		})
+	}
+}
+
+func TestHtlcSuccessRemoteSpendValidation(t *testing.T) {
+	resolver := &htlcSuccessResolver{
+		htlcResolution: lnwallet.IncomingHtlcResolution{
+			ClaimOutpoint: wire.OutPoint{Index: 1},
+			SweepSignDesc: testSignDesc,
+		},
+	}
+
+	matches, err := resolver.isRemoteCommitSuccessSpend(nil)
+	require.ErrorContains(t, err, "missing spend detail")
+	require.False(t, matches)
 }
 
 // TestHtlcSuccessSecondStageResolution tests successful sweep of a second
@@ -309,7 +381,8 @@ func TestHtlcSuccessSecondStageResolution(t *testing.T) {
 				secondStage,
 				firstStage,
 			},
-			finalHtlcStored: true,
+			finalHtlcStored:  true,
+			finalHtlcSettled: true,
 		},
 	}
 
@@ -433,7 +506,8 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 				secondStage,
 				firstStage,
 			},
-			finalHtlcStored: true,
+			finalHtlcStored:  true,
+			finalHtlcSettled: true,
 		},
 	}
 
@@ -748,10 +822,11 @@ type checkpoint struct {
 	preCheckpoint func(*htlcResolverTestContext, bool) error
 
 	// data we expect the resolver to be checkpointed with next.
-	incubating      bool
-	resolved        bool
-	reports         []*channeldb.ResolverReport
-	finalHtlcStored bool
+	incubating       bool
+	resolved         bool
+	reports          []*channeldb.ResolverReport
+	finalHtlcStored  bool
+	finalHtlcSettled bool
 }
 
 // testHtlcSuccess tests resolution of a success resolver. It takes a a list of
@@ -864,6 +939,12 @@ func runFromCheckpoint(t *testing.T, ctx *htlcResolverTestContext,
 		if cp.finalHtlcStored != ctx.finalHtlcOutcomeStored {
 			t.Fatal("final htlc store expectation failed")
 		}
+		if cp.finalHtlcStored &&
+			cp.finalHtlcSettled != ctx.finalHtlcSettled {
+
+			t.Fatal("final htlc outcome expectation failed")
+		}
+
 		// Finally encode the resolver, and store it for later use.
 		b := bytes.Buffer{}
 		if err := resolver.Encode(&b); err != nil {

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil/v2"
-	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/chainntnfs"
@@ -236,7 +235,17 @@ func TestHtlcSuccessSingleStage(t *testing.T) {
 // stage htlc claim, going through the Nursery.
 func TestHtlcSuccessSecondStageResolution(t *testing.T) {
 	commitOutpoint := wire.OutPoint{Index: 2}
-	htlcOutpoint := wire.OutPoint{Index: 3}
+	successTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: commitOutpoint,
+		}},
+		TxOut: []*wire.TxOut{{
+			Value:    111,
+			PkScript: []byte{0xaa, 0xaa},
+		}},
+	}
+	successHash := successTx.TxHash()
+	htlcOutpoint := wire.OutPoint{Hash: successHash}
 
 	sweepTx := &wire.MsgTx{
 		TxIn:  []*wire.TxIn{{}},
@@ -247,31 +256,18 @@ func TestHtlcSuccessSecondStageResolution(t *testing.T) {
 	// twoStageResolution is a resolution for htlc on our own commitment
 	// which is spent from the signed success tx.
 	twoStageResolution := lnwallet.IncomingHtlcResolution{
-		Preimage: [32]byte{},
-		SignedSuccessTx: &wire.MsgTx{
-			TxIn: []*wire.TxIn{
-				{
-					PreviousOutPoint: commitOutpoint,
-				},
-			},
-			TxOut: []*wire.TxOut{
-				{
-					Value:    111,
-					PkScript: []byte{0xaa, 0xaa},
-				},
-			},
-		},
-		ClaimOutpoint: htlcOutpoint,
-		SweepSignDesc: testSignDesc,
+		Preimage:        [32]byte{},
+		SignedSuccessTx: successTx,
+		ClaimOutpoint:   htlcOutpoint,
+		SweepSignDesc:   testSignDesc,
 	}
 
-	successTx := twoStageResolution.SignedSuccessTx.TxHash()
 	firstStage := &channeldb.ResolverReport{
 		OutPoint:        commitOutpoint,
 		Amount:          testHtlcAmt.ToSatoshis(),
 		ResolverType:    channeldb.ResolverTypeIncomingHtlc,
 		ResolverOutcome: channeldb.ResolverOutcomeFirstStage,
-		SpendTxID:       &successTx,
+		SpendTxID:       &successHash,
 	}
 
 	secondStage := &channeldb.ResolverReport{
@@ -324,76 +320,39 @@ func TestHtlcSuccessSecondStageResolution(t *testing.T) {
 //nolint:ll
 func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 	commitOutpoint := wire.OutPoint{Index: 2}
-	htlcOutpoint := wire.OutPoint{Index: 3}
-
-	successTx := &wire.MsgTx{
-		TxIn: []*wire.TxIn{
-			{
-				PreviousOutPoint: commitOutpoint,
-			},
-		},
-		TxOut: []*wire.TxOut{
-			{
-				Value:    123,
-				PkScript: []byte{0xff, 0xff},
-			},
-		},
-	}
+	twoStageResolution := newSuccessTestResolution(commitOutpoint)
+	twoStageResolution.CsvDelay = 4
+	successTx := twoStageResolution.SignedSuccessTx
 
 	reSignedSuccessTx := &wire.MsgTx{
 		TxIn: []*wire.TxIn{
 			{
-				PreviousOutPoint: wire.OutPoint{
-					Hash:  chainhash.Hash{0xaa, 0xbb},
-					Index: 0,
-				},
+				PreviousOutPoint: wire.OutPoint{Index: 10},
 			},
 			successTx.TxIn[0],
 			{
-				PreviousOutPoint: wire.OutPoint{
-					Hash:  chainhash.Hash{0xaa, 0xbb},
-					Index: 2,
-				},
+				PreviousOutPoint: wire.OutPoint{Index: 11},
 			},
 		},
-
 		TxOut: []*wire.TxOut{
 			{
 				Value:    111,
 				PkScript: []byte{0xaa, 0xaa},
 			},
-			successTx.TxOut[0],
+			cloneTxOut(successTx.TxOut[0]),
 		},
 	}
-	reSignedHash := successTx.TxHash()
+	reSignedHash := reSignedSuccessTx.TxHash()
+	secondLevelOutpoint := wire.OutPoint{
+		Hash:  reSignedHash,
+		Index: 1,
+	}
 
 	sweepTx := &wire.MsgTx{
-		TxIn: []*wire.TxIn{
-
-			{
-				PreviousOutPoint: wire.OutPoint{
-					Hash:  reSignedHash,
-					Index: 1,
-				},
-			},
-		},
+		TxIn:  []*wire.TxIn{{PreviousOutPoint: secondLevelOutpoint}},
 		TxOut: []*wire.TxOut{{}},
 	}
 	sweepHash := sweepTx.TxHash()
-
-	// twoStageResolution is a resolution for htlc on our own commitment
-	// which is spent from the signed success tx.
-	twoStageResolution := lnwallet.IncomingHtlcResolution{
-		Preimage:        [32]byte{},
-		CsvDelay:        4,
-		SignedSuccessTx: successTx,
-		SignDetails: &input.SignDetails{
-			SignDesc: testSignDesc,
-			PeerSig:  testSig,
-		},
-		ClaimOutpoint: htlcOutpoint,
-		SweepSignDesc: testSignDesc,
-	}
 
 	firstStage := &channeldb.ResolverReport{
 		OutPoint:        commitOutpoint,
@@ -404,7 +363,7 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 	}
 
 	secondStage := &channeldb.ResolverReport{
-		OutPoint:        htlcOutpoint,
+		OutPoint:        secondLevelOutpoint,
 		Amount:          btcutil.Amount(testSignDesc.Output.Value),
 		ResolverType:    channeldb.ResolverTypeIncomingHtlc,
 		ResolverOutcome: channeldb.ResolverOutcomeClaimed,
@@ -418,35 +377,10 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 			preCheckpoint: func(ctx *htlcResolverTestContext,
 				_ bool) error {
 
-				resolver := ctx.resolver.(*htlcSuccessResolver)
-
-				var (
-					inp input.Input
-					ok  bool
+				requireSweptOutpoint(t, ctx.resolver, commitOutpoint)
+				ctx.notifier.SpendChan <- newSpendDetail(
+					commitOutpoint, reSignedSuccessTx, 1,
 				)
-
-				select {
-				case inp, ok = <-resolver.Sweeper.(*mockSweeper).sweptInputs:
-					require.True(t, ok)
-
-				case <-time.After(1 * time.Second):
-					t.Fatal("expected input to be swept")
-				}
-
-				op := inp.OutPoint()
-				if op != commitOutpoint {
-					return fmt.Errorf("outpoint %v swept, "+
-						"expected %v", op,
-						commitOutpoint)
-				}
-
-				ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
-					SpendingTx:        reSignedSuccessTx,
-					SpenderTxHash:     &reSignedHash,
-					SpenderInputIndex: 1,
-					SpendingHeight:    10,
-					SpentOutPoint:     &commitOutpoint,
-				}
 				return nil
 			},
 			// incubating=true is used to signal that the
@@ -463,60 +397,27 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 				// expect the resolver to re-subscribe to a
 				// spend, hence we must resend it.
 				if resumed {
-					ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
-						SpendingTx:        reSignedSuccessTx,
-						SpenderTxHash:     &reSignedHash,
-						SpenderInputIndex: 1,
-						SpendingHeight:    10,
-						SpentOutPoint:     &commitOutpoint,
-					}
+					ctx.notifier.SpendChan <- newSpendDetail(
+						commitOutpoint, reSignedSuccessTx, 1,
+					)
 				}
 
 				// We expect it to sweep the second-level
 				// transaction we notfied about above.
-				resolver := ctx.resolver.(*htlcSuccessResolver)
-
 				// Mock `waitForSpend` to return the commit
 				// spend.
-				ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
-					SpendingTx:        reSignedSuccessTx,
-					SpenderTxHash:     &reSignedHash,
-					SpenderInputIndex: 1,
-					SpendingHeight:    10,
-					SpentOutPoint:     &commitOutpoint,
-				}
-
-				var (
-					inp input.Input
-					ok  bool
+				ctx.notifier.SpendChan <- newSpendDetail(
+					commitOutpoint, reSignedSuccessTx, 1,
 				)
-
-				select {
-				case inp, ok = <-resolver.Sweeper.(*mockSweeper).sweptInputs:
-					require.True(t, ok)
-
-				case <-time.After(1 * time.Second):
-					t.Fatal("expected input to be swept")
-				}
-
-				op := inp.OutPoint()
-				exp := wire.OutPoint{
-					Hash:  reSignedHash,
-					Index: 1,
-				}
-				if op != exp {
-					return fmt.Errorf("swept outpoint %v, expected %v",
-						op, exp)
-				}
+				requireSweptOutpoint(
+					t, ctx.resolver, secondLevelOutpoint,
+				)
 
 				// Notify about the spend, which should resolve
 				// the resolver.
-				ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
-					SpendingTx:     sweepTx,
-					SpenderTxHash:  &sweepHash,
-					SpendingHeight: 14,
-					SpentOutPoint:  &op,
-				}
+				ctx.notifier.SpendChan <- newSpendDetail(
+					secondLevelOutpoint, sweepTx, 0,
+				)
 
 				return nil
 			},
@@ -532,6 +433,84 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 	}
 
 	testHtlcSuccess(t, twoStageResolution, checkpoints)
+}
+
+// cloneTxOut returns a copy of a transaction output.
+func cloneTxOut(txOut *wire.TxOut) *wire.TxOut {
+	pkScript := append([]byte(nil), txOut.PkScript...)
+	return &wire.TxOut{
+		Value:    txOut.Value,
+		PkScript: pkScript,
+	}
+}
+
+func newSuccessTestResolution(
+	commitOutpoint wire.OutPoint) lnwallet.IncomingHtlcResolution {
+
+	successTx := &wire.MsgTx{
+		TxIn:  []*wire.TxIn{{PreviousOutPoint: commitOutpoint}},
+		TxOut: []*wire.TxOut{cloneTxOut(testSignDesc.Output)},
+	}
+
+	return lnwallet.IncomingHtlcResolution{
+		Preimage:        testResPreimage,
+		SignedSuccessTx: successTx,
+		SignDetails: &input.SignDetails{
+			SignDesc: testSignDesc,
+			PeerSig:  testSig,
+		},
+		ClaimOutpoint: wire.OutPoint{Hash: successTx.TxHash()},
+		SweepSignDesc: testSignDesc,
+	}
+}
+
+func newSpendDetail(spent wire.OutPoint, tx *wire.MsgTx,
+	inputIndex uint32) *chainntnfs.SpendDetail {
+
+	txid := tx.TxHash()
+	return &chainntnfs.SpendDetail{
+		SpendingTx:        tx,
+		SpenderTxHash:     &txid,
+		SpenderInputIndex: inputIndex,
+		SpendingHeight:    10,
+		SpentOutPoint:     &spent,
+	}
+}
+
+func requireSuccessResolver(t *testing.T,
+	resolver ContractResolver) *htlcSuccessResolver {
+
+	t.Helper()
+	successResolver, ok := resolver.(*htlcSuccessResolver)
+	require.True(t, ok)
+
+	return successResolver
+}
+
+func requireMockSweeper(t *testing.T,
+	resolver *htlcSuccessResolver) *mockSweeper {
+
+	t.Helper()
+	sweeper, ok := resolver.Sweeper.(*mockSweeper)
+	require.True(t, ok)
+
+	return sweeper
+}
+
+func requireSweptOutpoint(t *testing.T, resolver ContractResolver,
+	expected wire.OutPoint) {
+
+	t.Helper()
+	successResolver := requireSuccessResolver(t, resolver)
+	sweeper := requireMockSweeper(t, successResolver)
+
+	select {
+	case inp := <-sweeper.sweptInputs:
+		require.Equal(t, expected, inp.OutPoint())
+
+	case <-time.After(time.Second):
+		t.Fatal("expected input to be swept")
+	}
 }
 
 // checkpoint holds expected data we expect the resolver to checkpoint itself
@@ -659,7 +638,6 @@ func runFromCheckpoint(t *testing.T, ctx *htlcResolverTestContext,
 		if cp.finalHtlcStored != ctx.finalHtlcOutcomeStored {
 			t.Fatal("final htlc store expectation failed")
 		}
-
 		// Finally encode the resolver, and store it for later use.
 		b := bytes.Buffer{}
 		if err := resolver.Encode(&b); err != nil {

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -2,6 +2,7 @@ package contractcourt
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -33,10 +34,12 @@ type htlcResolverTestContext struct {
 		_ ...*channeldb.ResolverReport) error
 
 	notifier           *mock.ChainNotifier
+	htlcNotifier       *mockHTLCNotifier
 	resolverResultChan chan resolveResult
 	resolutionChan     chan ResolutionMsg
 
 	finalHtlcOutcomeStored bool
+	finalHtlcSettled       bool
 
 	t *testing.T
 }
@@ -59,15 +62,15 @@ func newHtlcResolverTestContext(t *testing.T,
 		SpendChan: make(chan *chainntnfs.SpendDetail, 1),
 		ConfChan:  make(chan *chainntnfs.TxConfirmation, 1),
 	}
+	htlcNotifier := &mockHTLCNotifier{}
 
 	testCtx := &htlcResolverTestContext{
 		checkpoint:     nil,
 		notifier:       notifier,
+		htlcNotifier:   htlcNotifier,
 		resolutionChan: make(chan ResolutionMsg, 1),
 		t:              t,
 	}
-
-	htlcNotifier := &mockHTLCNotifier{}
 
 	witnessBeacon := newMockWitnessBeacon()
 	chainCfg := ChannelArbitratorConfig{
@@ -100,6 +103,7 @@ func newHtlcResolverTestContext(t *testing.T,
 				htlcId uint64, settled bool) error {
 
 				testCtx.finalHtlcOutcomeStored = true
+				testCtx.finalHtlcSettled = settled
 
 				return nil
 			},
@@ -504,6 +508,156 @@ func TestHtlcSuccessMatchSecondLevelOutput(t *testing.T) {
 		matches, err := resolver.matchSecondLevelOutput(spend)
 		require.ErrorContains(t, err, want)
 		require.False(t, matches)
+	}
+}
+
+func TestHtlcSuccessForeignSpendCheckpointError(t *testing.T) {
+	t.Parallel()
+
+	commitOutpoint := wire.OutPoint{Index: 4}
+	resolution := newSuccessTestResolution(commitOutpoint)
+	ctx := newHtlcResolverTestContext(t, func(htlc channeldb.HTLC,
+		cfg ResolverConfig) ContractResolver {
+
+		return newSuccessResolver(resolution, 0, htlc, 0, cfg)
+	})
+	resolver := requireSuccessResolver(t, ctx.resolver)
+	resolver.outputIncubating = true
+	resolver.currentReport.RecoveredBalance = 1
+	previousReport := resolver.currentReport
+
+	errCheckpoint := errors.New("checkpoint failed")
+	checkpointCalls := 0
+	ctx.checkpoint = func(_ ContractResolver,
+		reports ...*channeldb.ResolverReport) error {
+
+		checkpointCalls++
+		require.True(t, resolver.IsResolved())
+		require.False(t, resolver.outputIncubating)
+		require.Zero(t, resolver.currentReport.LimboBalance)
+		require.Zero(t, resolver.currentReport.RecoveredBalance)
+		require.Len(t, reports, 1)
+		require.Equal(t, channeldb.ResolverOutcomeTimeout,
+			reports[0].ResolverOutcome)
+		if checkpointCalls == 1 {
+			return errCheckpoint
+		}
+
+		return nil
+	}
+
+	foreignTx := &wire.MsgTx{
+		TxIn:  []*wire.TxIn{{PreviousOutPoint: commitOutpoint}},
+		TxOut: []*wire.TxOut{{PkScript: []byte{0x51}}},
+	}
+	spend := newSpendDetail(commitOutpoint, foreignTx, 0)
+
+	err := resolver.checkpointForeignSpend(spend)
+	require.ErrorIs(t, err, errCheckpoint)
+	require.False(t, resolver.IsResolved())
+	require.True(t, resolver.outputIncubating)
+	require.Equal(t, previousReport, resolver.currentReport)
+	require.Empty(t, ctx.htlcNotifier.finalHtlcEvents)
+
+	require.NoError(t, resolver.checkpointForeignSpend(spend))
+	require.Equal(t, 2, checkpointCalls)
+	require.True(t, resolver.IsResolved())
+	require.False(t, resolver.outputIncubating)
+	require.Zero(t, resolver.currentReport.LimboBalance)
+	require.Zero(t, resolver.currentReport.RecoveredBalance)
+	require.Equal(t, []channeldb.FinalHtlcInfo{{
+		Settled: false,
+	}}, ctx.htlcNotifier.finalHtlcEvents)
+}
+
+func TestHtlcSuccessForeignSpend(t *testing.T) {
+	commitOutpoint := wire.OutPoint{Index: 2}
+	resolution := newSuccessTestResolution(commitOutpoint)
+	foreignTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{{PreviousOutPoint: commitOutpoint}},
+		TxOut: []*wire.TxOut{{
+			Value:    testSignDesc.Output.Value,
+			PkScript: []byte{0x51},
+		}},
+	}
+	foreignSpend := newSpendDetail(commitOutpoint, foreignTx, 0)
+	resolverType := channeldb.ResolverTypeIncomingHtlc
+	resolverOutcome := channeldb.ResolverOutcomeTimeout
+	for _, restart := range []bool{false, true} {
+		t.Run(fmt.Sprintf("restart=%v", restart), func(t *testing.T) {
+			defer timeout()()
+			ctx := newHtlcResolverTestContext(
+				t, func(htlc channeldb.HTLC,
+					cfg ResolverConfig) ContractResolver {
+
+					resolver := newSuccessResolver(
+						resolution, 0, htlc, 0, cfg,
+					)
+					if !restart {
+						return resolver
+					}
+
+					resolver.outputIncubating = true
+					var state bytes.Buffer
+					err := resolver.Encode(&state)
+					require.NoError(t, err)
+					decode := newSuccessResolverFromReader
+					restored, err := decode(&state, cfg)
+					require.NoError(t, err)
+					restored.Supplement(htlc)
+
+					return restored
+				},
+			)
+
+			var reports []*channeldb.ResolverReport
+			ctx.checkpoint = func(_ ContractResolver,
+				r ...*channeldb.ResolverReport) error {
+
+				reports = r
+				return nil
+			}
+
+			ctx.resolve()
+			resolver := requireSuccessResolver(t, ctx.resolver)
+			if !restart {
+				requireSweptOutpoint(
+					t, resolver, commitOutpoint,
+				)
+			}
+			go func() {
+				ctx.notifier.SpendChan <- foreignSpend
+				if restart {
+					ctx.notifier.SpendChan <- foreignSpend
+				}
+			}()
+			ctx.waitForResult()
+
+			require.True(t, resolver.IsResolved())
+			require.False(t, resolver.outputIncubating)
+			require.Zero(t, resolver.currentReport.LimboBalance)
+			require.Zero(t, resolver.currentReport.RecoveredBalance)
+			require.True(t, ctx.finalHtlcOutcomeStored)
+			require.False(t, ctx.finalHtlcSettled)
+			require.Equal(t, []*channeldb.ResolverReport{{
+				OutPoint:        commitOutpoint,
+				Amount:          testHtlcAmt.ToSatoshis(),
+				ResolverType:    resolverType,
+				ResolverOutcome: resolverOutcome,
+				SpendTxID:       foreignSpend.SpenderTxHash,
+			}}, reports)
+			require.Equal(t, []channeldb.FinalHtlcInfo{{
+				Settled: false,
+			}}, ctx.htlcNotifier.finalHtlcEvents)
+
+			sweeper := requireMockSweeper(t, resolver)
+			select {
+			case sweptInput := <-sweeper.sweptInputs:
+				t.Fatalf("unexpected phantom sweep: %v",
+					sweptInput.OutPoint())
+			default:
+			}
+		})
 	}
 }
 

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/chainntnfs"
@@ -433,6 +434,77 @@ func TestHtlcSuccessSecondStageResolutionSweeper(t *testing.T) {
 	}
 
 	testHtlcSuccess(t, twoStageResolution, checkpoints)
+}
+
+func TestHtlcSuccessMatchSecondLevelOutput(t *testing.T) {
+	claim := wire.OutPoint{Index: 2}
+	newMatch := func() (*htlcSuccessResolver, *chainntnfs.SpendDetail) {
+		tx := &wire.MsgTx{
+			TxIn: []*wire.TxIn{
+				{PreviousOutPoint: wire.OutPoint{Index: 1}},
+				{PreviousOutPoint: claim},
+			},
+			TxOut: []*wire.TxOut{
+				cloneTxOut(testSignDesc.Output),
+				cloneTxOut(testSignDesc.Output),
+			},
+		}
+
+		return &htlcSuccessResolver{
+			htlcResolution: newSuccessTestResolution(claim),
+		}, newSpendDetail(claim, tx, 1)
+	}
+	resolver, spend := newMatch()
+	check := func(expected bool) {
+		matches, err := resolver.matchSecondLevelOutput(spend)
+		require.NoError(t, err)
+		require.Equal(t, expected, matches)
+	}
+	check(true)
+	spend.SpendingTx.TxOut[1].Value++
+	spend = newSpendDetail(claim, spend.SpendingTx, 1)
+	require.Equal(t, testSignDesc.Output, spend.SpendingTx.TxOut[0])
+	check(false)
+	resolver, spend = newMatch()
+	spend.SpendingTx.TxOut = nil
+	spend = newSpendDetail(claim, spend.SpendingTx, 1)
+	check(false)
+	for _, want := range []string{
+		"missing spend detail", "missing spending tx",
+		"missing spender txid", "missing spent outpoint",
+		"unexpected outpoint", "spender input index",
+		"spender input 0 is nil", "missing expected output",
+		"output 0 is nil", "input", "does not match tx",
+	} {
+		resolver, spend := newMatch()
+		switch want {
+		case "missing spend detail":
+			spend = nil
+		case "missing spending tx":
+			spend.SpendingTx = nil
+		case "missing spender txid":
+			spend.SpenderTxHash = nil
+		case "missing spent outpoint":
+			spend.SpentOutPoint = nil
+		case "unexpected outpoint":
+			spend.SpentOutPoint = &wire.OutPoint{}
+		case "spender input index":
+			spend.SpenderInputIndex = 2
+		case "spender input 0 is nil":
+			spend.SpendingTx.TxIn[0] = nil
+		case "missing expected output":
+			resolver.htlcResolution.SweepSignDesc.Output = nil
+		case "output 0 is nil":
+			spend.SpendingTx.TxOut[0] = nil
+		case "input":
+			spend.SpendingTx.TxIn[1].PreviousOutPoint.Index++
+		case "does not match tx":
+			spend.SpenderTxHash = &chainhash.Hash{}
+		}
+		matches, err := resolver.matchSecondLevelOutput(spend)
+		require.ErrorContains(t, err, want)
+		require.False(t, matches)
+	}
 }
 
 // cloneTxOut returns a copy of a transaction output.

--- a/contractcourt/mock_htlcnotifier_test.go
+++ b/contractcourt/mock_htlcnotifier_test.go
@@ -7,9 +7,12 @@ import (
 
 type mockHTLCNotifier struct {
 	HtlcNotifier
+
+	finalHtlcEvents []channeldb.FinalHtlcInfo
 }
 
 func (m *mockHTLCNotifier) NotifyFinalHtlcEvent(key models.CircuitKey,
 	info channeldb.FinalHtlcInfo) {
 
+	m.finalHtlcEvents = append(m.finalHtlcEvents, info)
 }

--- a/contractcourt/mock_registry_test.go
+++ b/contractcourt/mock_registry_test.go
@@ -26,6 +26,7 @@ type mockRegistry struct {
 	notifyCalls      atomic.Int32
 	immediateNotify  []notifyExitHopData
 	notifyHook       func()
+	lookupErr        error
 }
 
 func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
@@ -73,6 +74,10 @@ func (r *mockRegistry) HodlUnsubscribeAll(subscriber chan<- interface{}) {}
 
 func (r *mockRegistry) LookupInvoice(context.Context, lntypes.Hash) (
 	invoices.Invoice, error) {
+
+	if r.lookupErr != nil {
+		return invoices.Invoice{}, r.lookupErr
+	}
 
 	return invoices.Invoice{}, invoices.ErrInvoiceNotFound
 }

--- a/contractcourt/mock_registry_test.go
+++ b/contractcourt/mock_registry_test.go
@@ -22,7 +22,10 @@ type mockRegistry struct {
 	notifyChan       chan notifyExitHopData
 	notifyErr        error
 	notifyResolution invoices.HtlcResolution
+	immediateResult  invoices.HtlcResolution
 	notifyCalls      atomic.Int32
+	immediateNotify  []notifyExitHopData
+	notifyHook       func()
 }
 
 func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
@@ -32,9 +35,23 @@ func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
 	payload invoices.Payload) (invoices.HtlcResolution, error) {
 
 	r.notifyCalls.Add(1)
+	notifyHook := r.notifyHook
 
 	// Exit early if the notification channel is nil.
 	if hodlChan == nil {
+		r.immediateNotify = append(r.immediateNotify, notifyExitHopData{
+			payHash:       payHash,
+			paidAmount:    paidAmount,
+			expiry:        expiry,
+			currentHeight: currentHeight,
+		})
+		if notifyHook != nil {
+			notifyHook()
+		}
+		if r.immediateResult != nil {
+			return r.immediateResult, r.notifyErr
+		}
+
 		return r.notifyResolution, r.notifyErr
 	}
 
@@ -44,6 +61,9 @@ func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
 		paidAmount:    paidAmount,
 		expiry:        expiry,
 		currentHeight: currentHeight,
+	}
+	if notifyHook != nil {
+		notifyHook()
 	}
 
 	return r.notifyResolution, r.notifyErr

--- a/contractcourt/mock_registry_test.go
+++ b/contractcourt/mock_registry_test.go
@@ -22,7 +22,10 @@ type mockRegistry struct {
 	notifyChan       chan notifyExitHopData
 	notifyErr        error
 	notifyResolution invoices.HtlcResolution
+	subscribedResult invoices.HtlcResolution
 	immediateResult  invoices.HtlcResolution
+	immediateErr     error
+	immediateErrAt   int32
 	notifyCalls      atomic.Int32
 	immediateNotify  []notifyExitHopData
 	notifyHook       func()
@@ -50,7 +53,10 @@ func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
 			notifyHook()
 		}
 		if r.immediateResult != nil {
-			return r.immediateResult, r.notifyErr
+			return r.immediateResult, r.immediateErr
+		}
+		if r.immediateErr != nil && currentHeight == r.immediateErrAt {
+			return r.notifyResolution, r.immediateErr
 		}
 
 		return r.notifyResolution, r.notifyErr
@@ -63,8 +69,8 @@ func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
 		expiry:        expiry,
 		currentHeight: currentHeight,
 	}
-	if notifyHook != nil {
-		notifyHook()
+	if r.subscribedResult != nil {
+		return r.subscribedResult, r.notifyErr
 	}
 
 	return r.notifyResolution, r.notifyErr

--- a/docs/release-notes/release-notes-0.21.2.md
+++ b/docs/release-notes/release-notes-0.21.2.md
@@ -47,6 +47,10 @@
   incoming HTLC resolver could treat a foreign commitment spend as its own
   success transaction and offer a phantom input to the sweeper.
 
+* [Fixed an ordering race](https://github.com/lightningnetwork/lnd/pull/10990)
+  where incoming HTLC expiry could be processed before the resolver retried
+  its success path at the same block height.
+
 # New Features
 
 ## Functional Enhancements

--- a/docs/release-notes/release-notes-0.21.2.md
+++ b/docs/release-notes/release-notes-0.21.2.md
@@ -43,6 +43,10 @@
   v0.20-era mandatory version so the v0.21 waiting proof migration runs
   without replaying older migrations against an already-initialized database.
 
+* [Fixed an issue](https://github.com/lightningnetwork/lnd/pull/10869) where an
+  incoming HTLC resolver could treat a foreign commitment spend as its own
+  success transaction and offer a phantom input to the sweeper.
+
 # New Features
 
 ## Functional Enhancements
@@ -87,3 +91,4 @@
 
 * bitromortac
 * Jared Tobin
+* Yong Yu


### PR DESCRIPTION
Depends on #10869.

Part of #10840.

## Summary

- enforce absolute-expiry policy and perform a final durable registry lookup before timing out an incoming HTLC
- deliver incoming resolver expiry through ChannelArbitrator-owned blockbeats after all resolver Launch calls complete
- bound resolver delivery by the inherited block-processing deadline, cancel stale subscriptions, and resynchronize height after cancellation
- retry transient expiry and settlement-finalization errors on subsequent blockbeats
- prefer a newly launched success resolver over a stale pending failure
- emit final failure notifications only after durable resolver checkpointing
- fan out resolver blockbeats concurrently while isolating resolver and channel-local failures from the parent blockbeat acknowledgement

## Stacking

This PR is stacked on #10869. Until #10869 merges, GitHub includes its five spend-classification commits in the diff against master. The intended follow-up diff is `a340a8bf7..abaa69b04`.

## Testing

- `make lint`
- `GOWORK=off go test -race ./contractcourt ./chainio -count=1`
- `GOWORK=off go vet ./contractcourt ./chainio`
- repeated focused resolver, restart, blockbeat, redispatch, hodl-expiry, ordering, and retry tests