### PR TITLE
discovery: bound channel range reply memory usage

### DIFF
--- a/discovery/syncer.go
+++ b/discovery/syncer.go
@@ -7,6 +7,7 @@ import (
 	"iter"
 	"math"
 	"math/rand"
+	"slices"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -170,6 +171,10 @@ const (
 	// maxQueryChanRangeRepliesZlibFactor specifies the factor applied to
 	// the maximum number of replies allowed for zlib encoded replies.
 	maxQueryChanRangeRepliesZlibFactor = 4
+
+	// maxChanRangeReplySCIDs is the maximum number of short channel IDs
+	// we'll process for a single QueryChannelRange request.
+	maxChanRangeReplySCIDs = 100_000
 
 	// chanRangeQueryBuffer is the number of blocks back that we'll go when
 	// asking the remote peer for their any channels they know of beyond
@@ -378,6 +383,10 @@ type GossipSyncer struct {
 	// received as part of a QueryChannelRange. This field is primarily used
 	// within the waitingQueryChanReply state.
 	numChanRangeRepliesRcvd uint32
+
+	// numChanRangeReplySCIDsRcvd tracks the total number of short channel
+	// IDs received as part of a QueryChannelRange response.
+	numChanRangeReplySCIDsRcvd uint32
 
 	// newChansToQuery is used to pass the set of channels we should query
 	// for from the waitingQueryChanReply state to the queryNewChannels
@@ -920,8 +929,40 @@ func isLegacyReplyChannelRange(query *lnwire.QueryChannelRange,
 // processChanRangeReply is called each time the GossipSyncer receives a new
 // reply to the initial range query to discover new channels that it didn't
 // previously know of.
-func (g *GossipSyncer) processChanRangeReply(_ context.Context,
+func (g *GossipSyncer) processChanRangeReply(ctx context.Context,
 	msg *lnwire.ReplyChannelRange) error {
+
+	// Any error here terminates the range sync, so we release whatever we
+	// accumulated to stop the peer from pinning it by deliberately forcing
+	// an error. Our caller exits the state machine on any error we return,
+	// and nothing prunes a syncer until its peer disconnects, so otherwise
+	// the buffer stays reachable from a syncer that will never run again.
+	err := g.bufferChanRangeReply(ctx, msg)
+	if err != nil {
+		g.resetChanRangeReplyState()
+	}
+
+	return err
+}
+
+// bufferChanRangeReply validates a single ReplyChannelRange against the query
+// that prompted it, buffers the channels it announces, and advances the
+// syncer's state once the reply stream is complete.
+func (g *GossipSyncer) bufferChanRangeReply(_ context.Context,
+	msg *lnwire.ReplyChannelRange) error {
+
+	// A reply only means anything in the context of the query that
+	// prompted it, and every check below reads that query. Today this is
+	// unreachable, as we only accept a reply in waitingQueryRangeReply and
+	// we always set the query before entering that state. It is worth
+	// guarding anyway: an error leaves the syncer sitting in
+	// waitingQueryRangeReply with the query cleared, so any future change
+	// that recovers the handler instead of tearing it down would turn this
+	// into a remote panic.
+	if g.curQueryRangeMsg == nil {
+		return fmt.Errorf("received channel range reply without an " +
+			"active query")
+	}
 
 	// isStale returns whether the timestamp is too far into the past.
 	isStale := func(timestamp time.Time) bool {
@@ -975,7 +1016,43 @@ func (g *GossipSyncer) processChanRangeReply(_ context.Context,
 		}
 	}
 
+	// Charge the reply budget using the encoding that was actually
+	// received. The configured encoding is a local preference and does
+	// not describe the responder's message.
+	var replyCount uint32
+	switch msg.EncodingType {
+	case lnwire.EncodingSortedPlain:
+		replyCount = 1
+
+	case lnwire.EncodingSortedZlib:
+		replyCount = maxQueryChanRangeRepliesZlibFactor
+
+	default:
+		return fmt.Errorf(
+			"unhandled encoding type %v", msg.EncodingType,
+		)
+	}
+
+	numReplySCIDs := uint32(len(msg.ShortChanIDs))
+	if g.numChanRangeReplySCIDsRcvd > maxChanRangeReplySCIDs ||
+		numReplySCIDs > maxChanRangeReplySCIDs-
+			g.numChanRangeReplySCIDsRcvd {
+
+		return fmt.Errorf("channel range reply exceeds maximum "+
+			"number of short channel IDs: max=%v",
+			maxChanRangeReplySCIDs)
+	}
+
+	g.numChanRangeRepliesRcvd += replyCount
+	g.numChanRangeReplySCIDsRcvd += numReplySCIDs
 	g.prevReplyChannelRange = msg
+
+	// Reserve room for this reply in one shot instead of letting append
+	// grow the buffer an element at a time. Over a full reply stream this
+	// cuts the number of reallocations by about 3x.
+	g.bufferedChanRangeReplies = slices.Grow(
+		g.bufferedChanRangeReplies, int(numReplySCIDs),
+	)
 
 	for i, scid := range msg.ShortChanIDs {
 		info := graphdb.NewV1ChannelUpdateInfo(
@@ -1020,15 +1097,6 @@ func (g *GossipSyncer) processChanRangeReply(_ context.Context,
 		g.bufferedChanRangeReplies = append(
 			g.bufferedChanRangeReplies, info,
 		)
-	}
-
-	switch g.cfg.encodingType {
-	case lnwire.EncodingSortedPlain:
-		g.numChanRangeRepliesRcvd++
-	case lnwire.EncodingSortedZlib:
-		g.numChanRangeRepliesRcvd += maxQueryChanRangeRepliesZlibFactor
-	default:
-		return fmt.Errorf("unhandled encoding type %v", g.cfg.encodingType)
 	}
 
 	log.Infof("GossipSyncer(%x): buffering chan range reply of size=%v",
@@ -1077,10 +1145,7 @@ func (g *GossipSyncer) processChanRangeReply(_ context.Context,
 	// As we've received the entirety of the reply, we no longer need to
 	// hold on to the set of buffered replies or the original query that
 	// prompted the replies, so we'll let that be garbage collected now.
-	g.curQueryRangeMsg = nil
-	g.prevReplyChannelRange = nil
-	g.bufferedChanRangeReplies = nil
-	g.numChanRangeRepliesRcvd = 0
+	g.resetChanRangeReplyState()
 
 	// If there aren't any channels that we don't know of, then we can
 	// switch straight to our terminal state.
@@ -1106,6 +1171,16 @@ func (g *GossipSyncer) processChanRangeReply(_ context.Context,
 		g.cfg.peerPub[:], len(newChans))
 
 	return nil
+}
+
+// resetChanRangeReplyState releases all state accumulated while processing a
+// ReplyChannelRange stream.
+func (g *GossipSyncer) resetChanRangeReplyState() {
+	g.curQueryRangeMsg = nil
+	g.prevReplyChannelRange = nil
+	g.bufferedChanRangeReplies = nil
+	g.numChanRangeRepliesRcvd = 0
+	g.numChanRangeReplySCIDsRcvd = 0
 }
 
 // genChanRangeQuery generates the initial message we'll send to the remote

--- a/discovery/syncer_test.go
+++ b/discovery/syncer_test.go
@@ -2570,6 +2570,183 @@ func TestGossipSyncerMaxChannelRangeReplies(t *testing.T) {
 	}, nil))
 }
 
+// TestGossipSyncerMaxChannelRangeSCIDs ensures that a gossip syncer rejects a
+// range response once the aggregate number of short channel IDs exceeds its
+// resource limit.
+func TestGossipSyncerMaxChannelRangeSCIDs(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	_, syncer, _ := newTestSyncer(
+		lnwire.ShortChannelID{BlockHeight: latestKnownHeight},
+		defaultEncoding, defaultChunkSize,
+	)
+
+	query, err := syncer.genChanRangeQuery(ctx, true)
+	require.NoError(t, err)
+
+	scids := make([]lnwire.ShortChannelID, defaultChunkSize)
+	for i := range scids {
+		scids[i] = lnwire.NewShortChanIDFromInt(uint64(i))
+	}
+
+	reply := &lnwire.ReplyChannelRange{
+		ChainHash:        query.ChainHash,
+		FirstBlockHeight: query.FirstBlockHeight,
+		NumBlocks:        query.NumBlocks,
+		EncodingType:     lnwire.EncodingSortedPlain,
+		ShortChanIDs:     scids,
+	}
+
+	numFullReplies := maxChanRangeReplySCIDs / len(scids)
+	for i := 0; i < numFullReplies; i++ {
+		require.NoError(t, syncer.processChanRangeReply(ctx, reply))
+	}
+
+	require.Len(
+		t, syncer.bufferedChanRangeReplies,
+		numFullReplies*len(scids),
+	)
+
+	numRemaining := maxChanRangeReplySCIDs -
+		numFullReplies*len(scids)
+	reply.ShortChanIDs = scids[:numRemaining]
+	require.NoError(t, syncer.processChanRangeReply(ctx, reply))
+	require.Len(
+		t, syncer.bufferedChanRangeReplies,
+		maxChanRangeReplySCIDs,
+	)
+
+	reply.ShortChanIDs = []lnwire.ShortChannelID{
+		lnwire.NewShortChanIDFromInt(uint64(len(scids))),
+	}
+	err = syncer.processChanRangeReply(ctx, reply)
+	require.ErrorContains(
+		t, err, "exceeds maximum number of short channel IDs",
+	)
+	require.Empty(t, syncer.bufferedChanRangeReplies)
+	require.Zero(t, syncer.numChanRangeReplySCIDsRcvd)
+	require.Nil(t, syncer.curQueryRangeMsg)
+}
+
+// TestGossipSyncerChanRangeReplyNoQuery ensures that a range reply which
+// arrives without an active query is rejected rather than dereferencing the
+// nil query.
+func TestGossipSyncerChanRangeReplyNoQuery(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	_, syncer, _ := newTestSyncer(
+		lnwire.ShortChannelID{BlockHeight: latestKnownHeight},
+		defaultEncoding, defaultChunkSize,
+	)
+
+	// Note that we deliberately skip genChanRangeQuery here, so
+	// curQueryRangeMsg is still nil.
+	require.Nil(t, syncer.curQueryRangeMsg)
+
+	err := syncer.processChanRangeReply(ctx, &lnwire.ReplyChannelRange{
+		FirstBlockHeight: 0,
+		NumBlocks:        100,
+		EncodingType:     lnwire.EncodingSortedPlain,
+		ShortChanIDs: []lnwire.ShortChannelID{
+			lnwire.NewShortChanIDFromInt(1),
+		},
+	})
+	require.ErrorContains(t, err, "without an active query")
+}
+
+// TestGossipSyncerCountsReceivedEncoding ensures that compressed range
+// replies consume the larger reply budget even when the local syncer uses
+// plain encoding.
+func TestGossipSyncerCountsReceivedEncoding(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	_, syncer, _ := newTestSyncer(
+		lnwire.ShortChannelID{BlockHeight: latestKnownHeight},
+		defaultEncoding, defaultChunkSize,
+	)
+
+	query, err := syncer.genChanRangeQuery(ctx, true)
+	require.NoError(t, err)
+
+	reply := &lnwire.ReplyChannelRange{
+		ChainHash:        query.ChainHash,
+		FirstBlockHeight: query.FirstBlockHeight,
+		NumBlocks:        query.NumBlocks,
+		EncodingType:     lnwire.EncodingSortedZlib,
+	}
+	require.NoError(t, syncer.processChanRangeReply(ctx, reply))
+	require.Equal(
+		t, uint32(maxQueryChanRangeRepliesZlibFactor),
+		syncer.numChanRangeRepliesRcvd,
+	)
+}
+
+// deliverOverBudgetRangeReply waits for the syncer to send its initial range
+// query, then answers it with a single reply that overruns the aggregate SCID
+// budget. Sending the query is what populates curQueryRangeMsg and moves the
+// syncer into waitingQueryRangeReply, both of which ProcessQueryMsg requires.
+func deliverOverBudgetRangeReply(t *testing.T, syncer *GossipSyncer,
+	msgChan chan []lnwire.Message) {
+
+	t.Helper()
+
+	var query *lnwire.QueryChannelRange
+	select {
+	case msgs := <-msgChan:
+		require.Len(t, msgs, 1)
+
+		q, ok := msgs[0].(*lnwire.QueryChannelRange)
+		require.True(t, ok)
+		query = q
+
+	case <-time.After(time.Second):
+		t.Fatal("expected query channel range request msg")
+	}
+
+	scids := make([]lnwire.ShortChannelID, maxChanRangeReplySCIDs+1)
+	for i := range scids {
+		scids[i] = lnwire.NewShortChanIDFromInt(uint64(i))
+	}
+
+	// Complete is set so that, absent the budget check, this reply would be
+	// taken as the final one and carry on to the completion path. That is
+	// what lets assertRangeSyncAborted tell the two apart.
+	reply := &lnwire.ReplyChannelRange{
+		ChainHash:        query.ChainHash,
+		FirstBlockHeight: query.FirstBlockHeight,
+		NumBlocks:        query.NumBlocks,
+		Complete:         1,
+		EncodingType:     lnwire.EncodingSortedPlain,
+		ShortChanIDs:     scids,
+	}
+	require.NoError(t, syncer.ProcessQueryMsg(reply, nil))
+}
+
+// assertRangeSyncAborted asserts that the syncer bailed out of its range sync
+// rather than treating the reply stream as complete. Reaching the completion
+// path would filter the buffered SCIDs against our local graph, so the absence
+// of that request is what tells us the sync was torn down instead.
+//
+// NOTE: we cannot instead wait on the syncer's wait group, as ContextGuard
+// holds a reference on it until the syncer is signalled to quit.
+func assertRangeSyncAborted(t *testing.T, syncer *GossipSyncer) {
+	t.Helper()
+
+	series, ok := syncer.cfg.channelSeries.(*mockChannelGraphTimeSeries)
+	require.True(t, ok)
+
+	select {
+	case <-series.filterReq:
+		t.Fatal("syncer treated an over-budget reply stream as a " +
+			"completed response")
+
+	default:
+	}
+}
+
 // TestGossipSyncerStateHandlerErrors tests that errors in state handlers cause
 // the channelGraphSyncer goroutine to exit cleanly without endless retry loops.
 // This is a table-driven test covering various error types and states.
@@ -2582,6 +2759,16 @@ func TestGossipSyncerStateHandlerErrors(t *testing.T) {
 		setupState  func(*GossipSyncer)
 		chunkSize   int32
 		injectedErr error
+
+		// deliverMsg, if set, is run after the syncer has been started
+		// and is used to drive the syncer into an error through the
+		// public message path rather than through sendMsg injection.
+		deliverMsg func(*testing.T, *GossipSyncer,
+			chan []lnwire.Message)
+
+		// assertOutcome, if set, asserts the terminal state the syncer
+		// is left in once its goroutine has stopped.
+		assertOutcome func(*testing.T, *GossipSyncer)
 	}{
 		{
 			name:        "context cancel during syncingChans",
@@ -2622,6 +2809,41 @@ func TestGossipSyncerStateHandlerErrors(t *testing.T) {
 				}
 			},
 		},
+		{
+			// Unlike the cases above, this one drives the error in
+			// through ProcessQueryMsg so that we exercise the
+			// syncer's lifecycle rather than calling
+			// processChanRangeReply directly. The syncer starts in
+			// syncingChans and moves itself into
+			// waitingQueryRangeReply once it has sent its query.
+			name:        "SCID budget exceeded while waiting",
+			state:       syncingChans,
+			chunkSize:   defaultChunkSize,
+			injectedErr: nil,
+			setupState:  func(s *GossipSyncer) {},
+			deliverMsg:  deliverOverBudgetRangeReply,
+			assertOutcome: func(t *testing.T, s *GossipSyncer) {
+				// The budget check must abort the sync rather
+				// than let the partial stream be taken as a
+				// completed response.
+				//
+				// NOTE: the release of the buffered reply
+				// state is asserted by
+				// TestGossipSyncerMaxChannelRangeSCIDs, which
+				// can read those fields directly without
+				// racing the syncer's own goroutine.
+				assertRangeSyncAborted(t, s)
+
+				// NOTE: the syncer is left in
+				// waitingQueryRangeReply with no live handler.
+				// That matches how every other terminal error
+				// in this state machine behaves today.
+				require.Equal(
+					t, waitingQueryRangeReply,
+					s.syncState(),
+				)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -2630,7 +2852,7 @@ func TestGossipSyncerStateHandlerErrors(t *testing.T) {
 
 			// Create syncer with error injection capability.
 			hID := lnwire.NewShortChanIDFromInt(10)
-			syncer, errInj, _ := newErrorInjectingSyncer(
+			syncer, errInj, msgChan := newErrorInjectingSyncer(
 				hID, tt.chunkSize,
 			)
 
@@ -2645,6 +2867,12 @@ func TestGossipSyncerStateHandlerErrors(t *testing.T) {
 			// Start the syncer which spawns the channelGraphSyncer
 			// goroutine.
 			syncer.Start()
+
+			// If this case drives its error in over the wire, do
+			// so now that the goroutine is running.
+			if tt.deliverMsg != nil {
+				tt.deliverMsg(t, syncer, msgChan)
+			}
 
 			// Wait long enough that an endless loop would
 			// accumulate many attempts. With the fix, we should
@@ -2666,6 +2894,12 @@ func TestGossipSyncerStateHandlerErrors(t *testing.T) {
 					"not fixed",
 				attemptCount,
 			)
+
+			// Verify the terminal state, if this case cares about
+			// it, before we signal the syncer to quit.
+			if tt.assertOutcome != nil {
+				tt.assertOutcome(t, syncer)
+			}
 
 			// Verify the syncer exits cleanly without hanging.
 			assertSyncerExitsCleanly(t, syncer, 2*time.Second)

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -55,6 +55,16 @@
   the reported network statistics such as total network capacity, channel
   count and max out degree.
 
+* [Bounded the memory used while syncing the channel
+  graph](https://github.com/lightningnetwork/lnd/pull/10992). A peer replying
+  to our `query_channel_range` could previously make us buffer an
+  unpredictable number of short channel IDs, as the only limit was a coarse
+  67MB cap on the bytes a single zlib-compressed reply could decompress to.
+  Replies are now capped at a precise number of short channel IDs, both
+  per-message and in aggregate across a single query, and the accumulated
+  reply state is released as soon as any reply fails validation so that a
+  peer cannot pin it by deliberately forcing an error.
+
 # New Features
 
 ## Functional Enhancements
@@ -159,3 +169,4 @@
 * Boris Nagaev
 * Erick Cestari
 * Jared Tobin
+* Olaoluwa Osuntokun

--- a/lnwire/query_short_chan_ids.go
+++ b/lnwire/query_short_chan_ids.go
@@ -3,6 +3,7 @@ package lnwire
 import (
 	"bytes"
 	"compress/zlib"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -12,10 +13,10 @@ import (
 )
 
 const (
-	// maxZlibBufSize is the max number of bytes that we'll accept from a
-	// zlib decoding instance. We do this in order to limit the total
-	// amount of memory allocated during a decoding instance.
-	maxZlibBufSize = 67413630
+	// maxDecodedShortChanIDs is the maximum number of short channel IDs
+	// accepted from a single message. The plain encoding is also bounded
+	// by the wire size, so its check is defense in depth.
+	maxDecodedShortChanIDs = 100_000
 )
 
 // ErrUnsortedSIDs is returned when decoding a QueryShortChannelID request whose
@@ -164,6 +165,12 @@ func decodeShortChanIDs(r io.Reader) (QueryEncoding, []ShortChannelID, error) {
 		// compute the number of bytes encoded based on the size of the
 		// query body.
 		numShortChanIDs := len(queryBody) / 8
+		if numShortChanIDs > maxDecodedShortChanIDs {
+			return 0, nil, fmt.Errorf(
+				"too many short channel IDs: max=%v, got=%v",
+				maxDecodedShortChanIDs, numShortChanIDs,
+			)
+		}
 		if numShortChanIDs == 0 {
 			return encodingType, nil, nil
 		}
@@ -210,61 +217,28 @@ func decodeShortChanIDs(r io.Reader) (QueryEncoding, []ShortChannelID, error) {
 			return encodingType, nil, nil
 		}
 
-		// Before we start to decode, we'll create a limit reader over
-		// the current reader. This will ensure that we can control how
-		// much memory we're allocating during the decoding process.
-		limitedDecompressor, err := zlib.NewReader(&io.LimitedReader{
-			R: bytes.NewReader(queryBody),
-			N: maxZlibBufSize,
-		})
+		decompressor, err := zlib.NewReader(bytes.NewReader(queryBody))
 		if err != nil {
 			return 0, nil, fmt.Errorf("unable to create zlib "+
 				"reader: %w", err)
 		}
 
-		var (
-			shortChanIDs []ShortChannelID
-			lastChanID   ShortChannelID
-			i            int
+		shortChanIDs, decodeErr := decodeCompressedShortChanIDs(
+			decompressor,
 		)
-		for {
-			// We'll now attempt to read the next short channel ID
-			// encoded in the payload.
-			var cid ShortChannelID
-			err := ReadElements(limitedDecompressor, &cid)
+		closeErr := decompressor.Close()
 
-			switch {
-			// If we get an EOF error, then that either means we've
-			// read all that's contained in the buffer, or have hit
-			// our limit on the number of bytes we'll read. In
-			// either case, we'll return what we have so far.
-			case err == io.ErrUnexpectedEOF || err == io.EOF:
-				return encodingType, shortChanIDs, nil
+		switch {
+		case decodeErr != nil:
+			return 0, nil, decodeErr
 
-			// Otherwise, we hit some other sort of error, possibly
-			// an invalid payload, so we'll exit early with the
-			// error.
-			case err != nil:
-				return 0, nil, fmt.Errorf("unable to "+
-					"deflate next short chan "+
-					"ID: %v", err)
-			}
+		case closeErr != nil:
+			return 0, nil, fmt.Errorf(
+				"unable to close zlib reader: %w", closeErr,
+			)
 
-			// We successfully read the next ID, so we'll collect
-			// that in the set of final ID's to return.
-			shortChanIDs = append(shortChanIDs, cid)
-
-			// Finally, we'll ensure that this short chan ID is
-			// greater than the last one. This is a requirement
-			// within the encoding, and if violated can aide us in
-			// detecting malicious payloads. This can only be true
-			// starting at the second chanID.
-			if i > 0 && cid.ToUint64() <= lastChanID.ToUint64() {
-				return 0, nil, ErrUnsortedSIDs{lastChanID, cid}
-			}
-
-			lastChanID = cid
-			i++
+		default:
+			return encodingType, shortChanIDs, nil
 		}
 
 	default:
@@ -272,6 +246,45 @@ func decodeShortChanIDs(r io.Reader) (QueryEncoding, []ShortChannelID, error) {
 		// then we'll return a parsing error as we can't continue if
 		// we're unable to encode them.
 		return 0, nil, ErrUnknownShortChanIDEncoding(encodingType)
+	}
+}
+
+// decodeCompressedShortChanIDs decodes and validates the decompressed short
+// channel ID stream.
+func decodeCompressedShortChanIDs(r io.Reader) ([]ShortChannelID, error) {
+	var (
+		shortChanIDs []ShortChannelID
+		lastChanID   ShortChannelID
+	)
+
+	for {
+		var cid ShortChannelID
+		err := ReadElements(r, &cid)
+
+		switch {
+		// Only a clean EOF terminates the stream. A partial final ID
+		// returns io.ErrUnexpectedEOF and remains an error.
+		case errors.Is(err, io.EOF):
+			return shortChanIDs, nil
+
+		case err != nil:
+			return nil, fmt.Errorf("unable to deflate next short "+
+				"chan ID: %w", err)
+		}
+
+		if len(shortChanIDs) == maxDecodedShortChanIDs {
+			return nil, fmt.Errorf("too many short channel IDs: "+
+				"max=%v", maxDecodedShortChanIDs)
+		}
+
+		if len(shortChanIDs) > 0 &&
+			cid.ToUint64() <= lastChanID.ToUint64() {
+
+			return nil, ErrUnsortedSIDs{lastChanID, cid}
+		}
+
+		shortChanIDs = append(shortChanIDs, cid)
+		lastChanID = cid
 	}
 }
 

--- a/lnwire/query_short_chan_ids_test.go
+++ b/lnwire/query_short_chan_ids_test.go
@@ -3,6 +3,9 @@ package lnwire
 import (
 	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
 )
 
 type unsortedSidTest struct {
@@ -113,6 +116,211 @@ func TestQueryShortChanIDsZero(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected decoding error: %v", err)
 			}
+		})
+	}
+}
+
+// TestQueryShortChanIDsRoundTrip uses property-based testing to ensure both
+// supported encodings preserve sorted short channel ID sets.
+func TestQueryShortChanIDsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(t *rapid.T) {
+		encoding := rapid.SampledFrom([]QueryEncoding{
+			EncodingSortedPlain,
+			EncodingSortedZlib,
+		}).Draw(t, "encoding")
+
+		numSCIDs := rapid.IntRange(0, 512).Draw(t, "num-scids")
+		var scids []ShortChannelID
+		if numSCIDs > 0 {
+			scids = make([]ShortChannelID, numSCIDs)
+		}
+
+		offset := rapid.IntRange(0, 1_000_000).Draw(t, "offset")
+		step := rapid.IntRange(1, 1_000_000).Draw(t, "step")
+		for i := range scids {
+			scid := uint64(offset + i*step)
+			scids[i] = NewShortChanIDFromInt(scid)
+		}
+
+		var b bytes.Buffer
+		require.NoError(t, encodeShortChanIDs(
+			&b, encoding, scids,
+		))
+
+		decodedEncoding, decoded, err := decodeShortChanIDs(
+			bytes.NewReader(b.Bytes()),
+		)
+		require.NoError(t, err)
+		require.Equal(t, encoding, decodedEncoding)
+		require.Equal(t, scids, decoded)
+	})
+}
+
+// TestQueryShortChanIDsDecodeLimit ensures that a decompressed short channel
+// ID stream cannot exceed its resource limit.
+func TestQueryShortChanIDsDecodeLimit(t *testing.T) {
+	t.Parallel()
+
+	var stream bytes.Buffer
+	for i := 0; i <= maxDecodedShortChanIDs; i++ {
+		require.NoError(t, WriteElements(
+			&stream, NewShortChanIDFromInt(uint64(i)),
+		))
+	}
+
+	decoded, err := decodeCompressedShortChanIDs(bytes.NewReader(
+		stream.Bytes()[:maxDecodedShortChanIDs*8],
+	))
+	require.NoError(t, err)
+	require.Len(t, decoded, maxDecodedShortChanIDs)
+
+	_, err = decodeCompressedShortChanIDs(
+		bytes.NewReader(stream.Bytes()),
+	)
+	require.ErrorContains(t, err, "too many short channel IDs")
+}
+
+// TestQueryShortChanIDsZlibCompatibility ensures that a protocol-valid
+// compressed reply can contain far more short channel IDs than a plain reply.
+// The plain encoding is bounded by the wire size at maxPlainReplySCIDs, so it
+// is the compressed encoding that determines how much headroom a single reply
+// actually has.
+func TestQueryShortChanIDsZlibCompatibility(t *testing.T) {
+	t.Parallel()
+
+	const (
+		// maxWireMsgSize is the largest a message may be on the wire,
+		// including its type prefix.
+		maxWireMsgSize = MaxMsgBody + MessageTypeSize
+
+		// maxPlainReplySCIDs is the number of SCIDs that saturate a
+		// ReplyChannelRange under the plain encoding. The message
+		// carries 41 bytes of fixed fields, and the SCID blob adds a
+		// 2-byte length prefix plus a 1-byte encoding type, leaving
+		// (65533 - 44) / 8 SCIDs.
+		maxPlainReplySCIDs = 8186
+
+		// maxZlibReplySCIDs is the number of consecutive SCIDs that
+		// saturate the same message under the zlib encoding. Runs of
+		// consecutive SCIDs are the best case for the compressor, so
+		// this is an upper bound rather than a figure real peers hit.
+		maxZlibReplySCIDs = 30_794
+	)
+
+	// A reply full of consecutive SCIDs is what we'll size both encodings
+	// against.
+	newReply := func(enc QueryEncoding, n int) *ReplyChannelRange {
+		scids := make([]ShortChannelID, n)
+		for i := range scids {
+			scids[i] = NewShortChanIDFromInt(uint64(i))
+		}
+
+		return &ReplyChannelRange{
+			Complete:     1,
+			EncodingType: enc,
+			ShortChanIDs: scids,
+			ExtraData:    make([]byte, 0),
+		}
+	}
+
+	// The plain encoding tops out at maxPlainReplySCIDs: that many SCIDs
+	// fit, and one more overflows the message.
+	plain := newReply(EncodingSortedPlain, maxPlainReplySCIDs)
+	size, err := plain.SerializedSize()
+	require.NoError(t, err)
+	require.LessOrEqual(t, size, uint32(maxWireMsgSize))
+
+	plain = newReply(EncodingSortedPlain, maxPlainReplySCIDs+1)
+	size, err = plain.SerializedSize()
+	require.NoError(t, err)
+	require.Greater(t, size, uint32(maxWireMsgSize))
+
+	// The zlib encoding fits far more SCIDs into the very same message,
+	// which is the compatibility property we care about: a compressed
+	// reply can carry a much larger slice of the graph than a plain one.
+	zlib := newReply(EncodingSortedZlib, maxZlibReplySCIDs)
+	size, err = zlib.SerializedSize()
+	require.NoError(t, err)
+	require.LessOrEqual(t, size, uint32(maxWireMsgSize))
+	require.Greater(t, maxZlibReplySCIDs, maxPlainReplySCIDs)
+
+	// One more SCID pushes the compressed reply over the wire limit, so
+	// maxZlibReplySCIDs really is the ceiling.
+	over := newReply(EncodingSortedZlib, maxZlibReplySCIDs+1)
+	size, err = over.SerializedSize()
+	require.NoError(t, err)
+	require.Greater(t, size, uint32(maxWireMsgSize))
+
+	// Finally, the saturated compressed reply must still round trip
+	// cleanly through the decoder.
+	var b bytes.Buffer
+	require.NoError(t, encodeShortChanIDs(
+		&b, EncodingSortedZlib, zlib.ShortChanIDs,
+	))
+
+	encoding, decoded, err := decodeShortChanIDs(
+		bytes.NewReader(b.Bytes()),
+	)
+	require.NoError(t, err)
+	require.Equal(t, EncodingSortedZlib, encoding)
+	require.Equal(t, zlib.ShortChanIDs, decoded)
+}
+
+// TestQueryShortChanIDsRejectsCorruptZlib ensures that truncated or corrupt
+// compressed streams are not accepted as valid partial replies.
+func TestQueryShortChanIDsRejectsCorruptZlib(t *testing.T) {
+	t.Parallel()
+
+	scids := []ShortChannelID{
+		NewShortChanIDFromInt(1),
+		NewShortChanIDFromInt(2),
+		NewShortChanIDFromInt(3),
+	}
+
+	var encoded bytes.Buffer
+	require.NoError(t, encodeShortChanIDs(
+		&encoded, EncodingSortedZlib, scids,
+	))
+
+	body := encoded.Bytes()[2:]
+	corruptChecksum := append([]byte(nil), body...)
+	corruptChecksum[len(corruptChecksum)-1] ^= 1
+
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "truncated header",
+			body: body[:2],
+		},
+		{
+			name: "truncated checksum",
+			body: body[:len(body)-1],
+		},
+		{
+			name: "corrupt checksum",
+			body: corruptChecksum,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var message bytes.Buffer
+			require.NoError(t, WriteElements(
+				&message, uint16(len(test.body)),
+			))
+			_, err := message.Write(test.body)
+			require.NoError(t, err)
+
+			_, _, err = decodeShortChanIDs(
+				bytes.NewReader(message.Bytes()),
+			)
+			require.Error(t, err)
 		})
 	}
 }


### PR DESCRIPTION
In this PR, we bound the memory used while decoding and buffering short
channel IDs during channel range synchronization. Compressed replies can
carry more IDs than plain replies, and a query can be answered across many
messages, so the temporary working set can grow well beyond the graph data
we actually need to process.

We now cap decoded ID sets and the aggregate IDs accepted for a single range
query. We also count reply budgets from the encoding carried by each reply,
clear accumulated range state on errors, and reject incomplete compressed
streams. The limits leave headroom above the current graph while keeping the
working set predictable.

See each commit message for a detailed description w.r.t. the incremental
changes.

## Testing

- `go test -count=1 ./lnwire ./discovery`
- `go test -race -count=1 ./lnwire ./discovery`
- Native Go fuzzing for `QueryShortChanIDs` and `ReplyChannelRange`
- 10,000 rapid plain+zlib round-trip checks
