### PR TITLE
walletrpc: return the master key birthday from ListAccounts

### DIFF
--- a/cmd/commands/cmd_walletunlocker.go
+++ b/cmd/commands/cmd_walletunlocker.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/lnrpc"
@@ -332,7 +333,9 @@ mnemonicCheck:
 		}
 		extendedRootKey = strings.TrimSpace(extendedRootKey)
 
-		extendedRootKeyBirthday, err = askBirthdayTimestamp()
+		// An extended master key carries no birthday, so there's nothing
+		// to offer as a default here.
+		extendedRootKeyBirthday, err = askBirthdayTimestamp(0)
 		if err != nil {
 			return err
 		}
@@ -939,7 +942,14 @@ func createWatchOnly(ctx *cli.Context) error {
 		return err
 	}
 
-	extendedRootKeyBirthday, err := askBirthdayTimestamp()
+	// A wallet exported by a recent enough lnd tells us the birthday of the
+	// master key its accounts were derived from, which is more accurate than
+	// anything the operator is likely to type in, so we offer it as the
+	// default. An older export leaves this at zero and the prompt behaves as
+	// it always did.
+	extendedRootKeyBirthday, err := askBirthdayTimestamp(
+		jsonAccts.MasterKeyBirthdayTimestamp,
+	)
 	if err != nil {
 		return err
 	}
@@ -1061,11 +1071,27 @@ func askRecoveryWindow() (int32, error) {
 	}
 }
 
-func askBirthdayTimestamp() (uint64, error) {
+// askBirthdayTimestamp prompts for the wallet's birthday as a unix timestamp in
+// seconds. The given default is what an empty answer resolves to, which lets a
+// caller that already knows the birthday offer it up for confirmation, instead
+// of making the user dig it out by hand.
+func askBirthdayTimestamp(defaultTimestamp uint64) (uint64, error) {
+	// Spell a non-zero default out as a date as well. An empty answer
+	// accepts it, and it decides where the rescan starts, so the operator
+	// should be able to sanity check it without converting a bare unix
+	// timestamp in their head.
+	defaultHint := fmt.Sprintf("%d", defaultTimestamp)
+	if defaultTimestamp != 0 {
+		birthday := time.Unix(int64(defaultTimestamp), 0).UTC()
+		defaultHint = fmt.Sprintf("%d, which is %s", defaultTimestamp,
+			birthday.Format(time.RFC3339))
+	}
+
 	for {
 		fmt.Println()
-		fmt.Printf("Input an optional wallet birthday unix timestamp " +
-			"of first block to start scanning from (default 0): ")
+		fmt.Printf("Input an optional wallet birthday unix timestamp "+
+			"of first block to start scanning from (default %s): ",
+			defaultHint)
 
 		reader := bufio.NewReader(os.Stdin)
 		answer, err := reader.ReadString('\n')
@@ -1078,7 +1104,7 @@ func askBirthdayTimestamp() (uint64, error) {
 		answer = strings.TrimSpace(answer)
 
 		if len(answer) == 0 {
-			return 0, nil
+			return defaultTimestamp, nil
 		}
 
 		birthdayTimestamp, err := strconv.ParseUint(answer, 10, 64)

--- a/cmd/commands/cmd_walletunlocker.go
+++ b/cmd/commands/cmd_walletunlocker.go
@@ -333,8 +333,8 @@ mnemonicCheck:
 		}
 		extendedRootKey = strings.TrimSpace(extendedRootKey)
 
-		// An extended master key carries no birthday, so there's nothing
-		// to offer as a default here.
+		// An extended master key carries no birthday, so there is no
+		// default to offer here.
 		extendedRootKeyBirthday, err = askBirthdayTimestamp(0)
 		if err != nil {
 			return err
@@ -942,11 +942,11 @@ func createWatchOnly(ctx *cli.Context) error {
 		return err
 	}
 
-	// A wallet exported by a recent enough lnd tells us the birthday of the
-	// master key its accounts were derived from, which is more accurate than
-	// anything the operator is likely to type in, so we offer it as the
-	// default. An older export leaves this at zero and the prompt behaves as
-	// it always did.
+	// A wallet exported by a recent enough lnd tells us the birthday of
+	// the master key its accounts were derived from. This is more accurate
+	// than anything the operator is likely to type in, so we offer it as
+	// the default. An older export leaves this at zero, and the prompt
+	// behaves as it always did.
 	extendedRootKeyBirthday, err := askBirthdayTimestamp(
 		jsonAccts.MasterKeyBirthdayTimestamp,
 	)

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -90,7 +90,21 @@
 
 ## RPC Updates
 
+* [`walletrpc.ListAccounts` now also returns the birthday of the wallet's master
+  key](https://github.com/lightningnetwork/lnd/pull/10993) in the new
+  `master_key_birthday_timestamp` field. The accounts themselves are extended
+  public keys, which say nothing about when they were created, so a watch-only
+  wallet importing them had no birthday to work with and had to rescan the chain
+  from lnd's default of 2017-08-24. On mainnet that's hundreds of thousands of
+  blocks and several hours, even for a node with no history at all.
+
 ## lncli Updates
+
+* [`createwatchonly` now offers the birthday from the accounts
+  file](https://github.com/lightningnetwork/lnd/pull/10993) as the default for
+  its birthday prompt, so an accounts file exported by a recent enough lnd
+  carries the right value through without the operator having to know it. An
+  older file leaves the field unset and the prompt behaves as before.
 
 ## Breaking Changes
 
@@ -159,3 +173,4 @@
 * Boris Nagaev
 * Erick Cestari
 * Jared Tobin
+* Olaoluwa Osuntokun

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -82,7 +82,21 @@
 
 ## RPC Updates
 
+* [`walletrpc.ListAccounts` now also returns the birthday of the wallet's master
+  key](https://github.com/lightningnetwork/lnd/pull/10993) in the new
+  `master_key_birthday_timestamp` field. The accounts themselves are extended
+  public keys, which say nothing about when they were created, so a watch-only
+  wallet importing them had no birthday to work with and had to rescan the chain
+  from lnd's default of 2017-08-24. On mainnet that's hundreds of thousands of
+  blocks and several hours, even for a node with no history at all.
+
 ## lncli Updates
+
+* [`createwatchonly` now offers the birthday from the accounts
+  file](https://github.com/lightningnetwork/lnd/pull/10993) as the default for
+  its birthday prompt, so an accounts file exported by a recent enough lnd
+  carries the right value through without the operator having to know it. An
+  older file leaves the field unset and the prompt behaves as before.
 
 ## Breaking Changes
 
@@ -178,3 +192,4 @@
 * Erick Cestari
 * Jared Tobin
 * Nishant Bansal
+* Olaoluwa Osuntokun

--- a/lnrpc/walletrpc/walletkit.pb.go
+++ b/lnrpc/walletrpc/walletkit.pb.go
@@ -1262,10 +1262,18 @@ func (x *ListAccountsRequest) GetAddressType() AddressType {
 }
 
 type ListAccountsResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Accounts      []*Account             `protobuf:"bytes,1,rep,name=accounts,proto3" json:"accounts,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	Accounts []*Account             `protobuf:"bytes,1,rep,name=accounts,proto3" json:"accounts,omitempty"`
+	// The birthday of the wallet's master key, expressed in seconds since the unix
+	// epoch. This is the earliest time any of the wallet's keys could have been
+	// used, so it is where a rescan of the chain has to start. The accounts above
+	// are extended public keys, which carry no notion of when they were created,
+	// so this value needs to be transported alongside them when importing them
+	// into a watch-only wallet. It corresponds to the
+	// WatchOnly.master_key_birthday_timestamp field of the InitWallet request.
+	MasterKeyBirthdayTimestamp uint64 `protobuf:"varint,2,opt,name=master_key_birthday_timestamp,json=masterKeyBirthdayTimestamp,proto3" json:"master_key_birthday_timestamp,omitempty"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *ListAccountsResponse) Reset() {
@@ -1303,6 +1311,13 @@ func (x *ListAccountsResponse) GetAccounts() []*Account {
 		return x.Accounts
 	}
 	return nil
+}
+
+func (x *ListAccountsResponse) GetMasterKeyBirthdayTimestamp() uint64 {
+	if x != nil {
+		return x.MasterKeyBirthdayTimestamp
+	}
+	return 0
 }
 
 type RequiredReserveRequest struct {
@@ -4767,9 +4782,10 @@ const file_walletrpc_walletkit_proto_rawDesc = "" +
 	"\taddresses\x18\x04 \x03(\v2\x1a.walletrpc.AddressPropertyR\taddresses\"d\n" +
 	"\x13ListAccountsRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x129\n" +
-	"\faddress_type\x18\x02 \x01(\x0e2\x16.walletrpc.AddressTypeR\vaddressType\"F\n" +
+	"\faddress_type\x18\x02 \x01(\x0e2\x16.walletrpc.AddressTypeR\vaddressType\"\x89\x01\n" +
 	"\x14ListAccountsResponse\x12.\n" +
-	"\baccounts\x18\x01 \x03(\v2\x12.walletrpc.AccountR\baccounts\"V\n" +
+	"\baccounts\x18\x01 \x03(\v2\x12.walletrpc.AccountR\baccounts\x12A\n" +
+	"\x1dmaster_key_birthday_timestamp\x18\x02 \x01(\x04R\x1amasterKeyBirthdayTimestamp\"V\n" +
 	"\x16RequiredReserveRequest\x12<\n" +
 	"\x1aadditional_public_channels\x18\x01 \x01(\rR\x18additionalPublicChannels\"D\n" +
 	"\x17RequiredReserveResponse\x12)\n" +

--- a/lnrpc/walletrpc/walletkit.pb.go
+++ b/lnrpc/walletrpc/walletkit.pb.go
@@ -1290,10 +1290,18 @@ func (x *ListAccountsRequest) GetAddressType() AddressType {
 }
 
 type ListAccountsResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Accounts      []*Account             `protobuf:"bytes,1,rep,name=accounts,proto3" json:"accounts,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	Accounts []*Account             `protobuf:"bytes,1,rep,name=accounts,proto3" json:"accounts,omitempty"`
+	// The birthday of the wallet's master key, expressed in seconds since the unix
+	// epoch. This is the earliest time any of the wallet's keys could have been
+	// used, so it is where a rescan of the chain has to start. The accounts above
+	// are extended public keys, which carry no notion of when they were created,
+	// so this value needs to be transported alongside them when importing them
+	// into a watch-only wallet. It corresponds to the
+	// WatchOnly.master_key_birthday_timestamp field of the InitWallet request.
+	MasterKeyBirthdayTimestamp uint64 `protobuf:"varint,2,opt,name=master_key_birthday_timestamp,json=masterKeyBirthdayTimestamp,proto3" json:"master_key_birthday_timestamp,omitempty"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *ListAccountsResponse) Reset() {
@@ -1331,6 +1339,13 @@ func (x *ListAccountsResponse) GetAccounts() []*Account {
 		return x.Accounts
 	}
 	return nil
+}
+
+func (x *ListAccountsResponse) GetMasterKeyBirthdayTimestamp() uint64 {
+	if x != nil {
+		return x.MasterKeyBirthdayTimestamp
+	}
+	return 0
 }
 
 type XCreateAccountRequest struct {
@@ -4962,9 +4977,10 @@ const file_walletrpc_walletkit_proto_rawDesc = "" +
 	"\taddresses\x18\x04 \x03(\v2\x1a.walletrpc.AddressPropertyR\taddresses\"d\n" +
 	"\x13ListAccountsRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x129\n" +
-	"\faddress_type\x18\x02 \x01(\x0e2\x16.walletrpc.AddressTypeR\vaddressType\"F\n" +
+	"\faddress_type\x18\x02 \x01(\x0e2\x16.walletrpc.AddressTypeR\vaddressType\"\x89\x01\n" +
 	"\x14ListAccountsResponse\x12.\n" +
-	"\baccounts\x18\x01 \x03(\v2\x12.walletrpc.AccountR\baccounts\"\x99\x01\n" +
+	"\baccounts\x18\x01 \x03(\v2\x12.walletrpc.AccountR\baccounts\x12A\n" +
+	"\x1dmaster_key_birthday_timestamp\x18\x02 \x01(\x04R\x1amasterKeyBirthdayTimestamp\"\x99\x01\n" +
 	"\x15XCreateAccountRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x129\n" +
 	"\faddress_type\x18\x02 \x01(\x0e2\x16.walletrpc.AddressTypeR\vaddressType\x121\n" +

--- a/lnrpc/walletrpc/walletkit.proto
+++ b/lnrpc/walletrpc/walletkit.proto
@@ -585,6 +585,17 @@ message ListAccountsRequest {
 
 message ListAccountsResponse {
     repeated Account accounts = 1;
+
+    /*
+    The birthday of the wallet's master key, expressed in seconds since the unix
+    epoch. This is the earliest time any of the wallet's keys could have been
+    used, so it is where a rescan of the chain has to start. The accounts above
+    are extended public keys, which carry no notion of when they were created,
+    so this value needs to be transported alongside them when importing them
+    into a watch-only wallet. It corresponds to the
+    WatchOnly.master_key_birthday_timestamp field of the InitWallet request.
+    */
+    uint64 master_key_birthday_timestamp = 2;
 }
 
 message RequiredReserveRequest {

--- a/lnrpc/walletrpc/walletkit.proto
+++ b/lnrpc/walletrpc/walletkit.proto
@@ -673,6 +673,17 @@ message ListAccountsRequest {
 
 message ListAccountsResponse {
     repeated Account accounts = 1;
+
+    /*
+    The birthday of the wallet's master key, expressed in seconds since the unix
+    epoch. This is the earliest time any of the wallet's keys could have been
+    used, so it is where a rescan of the chain has to start. The accounts above
+    are extended public keys, which carry no notion of when they were created,
+    so this value needs to be transported alongside them when importing them
+    into a watch-only wallet. It corresponds to the
+    WatchOnly.master_key_birthday_timestamp field of the InitWallet request.
+    */
+    uint64 master_key_birthday_timestamp = 2;
 }
 
 message XCreateAccountRequest {

--- a/lnrpc/walletrpc/walletkit.swagger.json
+++ b/lnrpc/walletrpc/walletkit.swagger.json
@@ -1882,6 +1882,11 @@
             "type": "object",
             "$ref": "#/definitions/walletrpcAccount"
           }
+        },
+        "master_key_birthday_timestamp": {
+          "type": "string",
+          "format": "uint64",
+          "description": "The birthday of the wallet's master key, expressed in seconds since the unix\nepoch. This is the earliest time any of the wallet's keys could have been\nused, so it is where a rescan of the chain has to start. The accounts above\nare extended public keys, which carry no notion of when they were created,\nso this value needs to be transported alongside them when importing them\ninto a watch-only wallet. It corresponds to the\nWatchOnly.master_key_birthday_timestamp field of the InitWallet request."
         }
       }
     },

--- a/lnrpc/walletrpc/walletkit.swagger.json
+++ b/lnrpc/walletrpc/walletkit.swagger.json
@@ -1932,6 +1932,11 @@
             "type": "object",
             "$ref": "#/definitions/walletrpcAccount"
           }
+        },
+        "master_key_birthday_timestamp": {
+          "type": "string",
+          "format": "uint64",
+          "description": "The birthday of the wallet's master key, expressed in seconds since the unix\nepoch. This is the earliest time any of the wallet's keys could have been\nused, so it is where a rescan of the chain has to start. The accounts above\nare extended public keys, which carry no notion of when they were created,\nso this value needs to be transported alongside them when importing them\ninto a watch-only wallet. It corresponds to the\nWatchOnly.master_key_birthday_timestamp field of the InitWallet request."
         }
       }
     },

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -2689,7 +2689,28 @@ func (w *WalletKit) ListAccounts(ctx context.Context,
 		rpcAccounts = append(rpcAccounts, rpcAccount)
 	}
 
-	return &ListAccountsResponse{Accounts: rpcAccounts}, nil
+	// The accounts above are extended public keys, which say nothing about
+	// when they were created. We return the wallet's birthday along with
+	// them so that a watch-only wallet importing this response doesn't have
+	// to rescan the chain from lnd's default birthday.
+	//
+	// A wallet that somehow has no birthday at all reports zero rather than
+	// the nonsense a uint64 cast of a pre-epoch time would produce, since
+	// zero is what the InitWallet request already reads as "unknown".
+	//
+	// The comparison has to stay a positivity check and not become an
+	// IsZero one: a non-zero time before 1970 has a negative Unix value,
+	// which is exactly what the cast below would turn into a timestamp
+	// somewhere past the year 292 billion.
+	var birthdayTimestamp uint64
+	if birthday := w.cfg.Wallet.Birthday(); birthday.Unix() > 0 {
+		birthdayTimestamp = uint64(birthday.Unix())
+	}
+
+	return &ListAccountsResponse{
+		Accounts:                   rpcAccounts,
+		MasterKeyBirthdayTimestamp: birthdayTimestamp,
+	}, nil
 }
 
 // RequiredReserve returns the minimum amount of satoshis that should be

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -2781,7 +2781,28 @@ func (w *WalletKit) ListAccounts(ctx context.Context,
 		rpcAccounts = append(rpcAccounts, rpcAccount)
 	}
 
-	return &ListAccountsResponse{Accounts: rpcAccounts}, nil
+	// The accounts above are extended public keys, which say nothing about
+	// when they were created. We return the wallet's birthday along with
+	// them so that a watch-only wallet importing this response doesn't have
+	// to rescan the chain from lnd's default birthday.
+	//
+	// A wallet that somehow has no birthday at all reports zero rather than
+	// the nonsense a uint64 cast of a pre-epoch time would produce, since
+	// zero is what the InitWallet request already reads as "unknown".
+	//
+	// The comparison has to stay a positivity check and not become an
+	// IsZero one: a non-zero time before 1970 has a negative Unix value,
+	// which is exactly what the cast below would turn into a timestamp
+	// somewhere past the year 292 billion.
+	var birthdayTimestamp uint64
+	if birthday := w.cfg.Wallet.Birthday(); birthday.Unix() > 0 {
+		birthdayTimestamp = uint64(birthday.Unix())
+	}
+
+	return &ListAccountsResponse{
+		Accounts:                   rpcAccounts,
+		MasterKeyBirthdayTimestamp: birthdayTimestamp,
+	}, nil
 }
 
 // errAccountCreationNotAcked is returned on a release build when the caller

--- a/lnrpc/walletrpc/walletkit_server_test.go
+++ b/lnrpc/walletrpc/walletkit_server_test.go
@@ -5,13 +5,16 @@ package walletrpc
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/psbt/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
@@ -717,6 +720,58 @@ func TestFundPsbtCoinSelect(t *testing.T) {
 					changeOut.Value,
 				)
 			}
+		})
+	}
+}
+
+// TestListAccountsBirthday makes sure ListAccounts reports the birthday of the
+// wallet's master key. The exported accounts are extended public keys, which
+// carry no creation time of their own, so this timestamp is the only thing that
+// lets an importing watch-only wallet start its rescan at the right height
+// instead of at lnd's default birthday.
+func TestListAccountsBirthday(t *testing.T) {
+	t.Parallel()
+
+	birthday := time.Unix(1719792000, 0)
+
+	testCases := []struct {
+		name     string
+		birthday time.Time
+		expected uint64
+	}{{
+		name:     "birthday is reported in unix seconds",
+		birthday: birthday,
+		expected: uint64(birthday.Unix()),
+	}, {
+		// A wallet without a birthday must report zero, which is what
+		// InitWallet already reads as "unknown". Casting a pre-epoch
+		// time to uint64 would instead produce a nonsense timestamp
+		// somewhere in the year 292 billion.
+		name:     "wallet without a birthday reports zero",
+		birthday: time.Time{},
+		expected: 0,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(tt *testing.T) {
+			tt.Parallel()
+
+			rpcServer, _, err := New(&Config{
+				Wallet: &mock.WalletController{
+					WalletBirthday: tc.birthday,
+				},
+				ChainParams: &chaincfg.RegressionNetParams,
+			})
+			require.NoError(tt, err)
+
+			resp, err := rpcServer.ListAccounts(
+				context.Background(), &ListAccountsRequest{},
+			)
+			require.NoError(tt, err)
+			require.Equal(
+				tt, tc.expected,
+				resp.MasterKeyBirthdayTimestamp,
+			)
 		})
 	}
 }

--- a/lnrpc/walletrpc/walletkit_server_test.go
+++ b/lnrpc/walletrpc/walletkit_server_test.go
@@ -5,7 +5,6 @@ package walletrpc
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -961,7 +960,7 @@ func TestListAccountsBirthday(t *testing.T) {
 			require.NoError(tt, err)
 
 			resp, err := rpcServer.ListAccounts(
-				context.Background(), &ListAccountsRequest{},
+				tt.Context(), &ListAccountsRequest{},
 			)
 			require.NoError(tt, err)
 			require.Equal(

--- a/lnrpc/walletrpc/walletkit_server_test.go
+++ b/lnrpc/walletrpc/walletkit_server_test.go
@@ -5,6 +5,7 @@ package walletrpc
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/psbt/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
@@ -914,6 +916,58 @@ func TestFundPsbtCoinSelect(t *testing.T) {
 					changeOut.Value,
 				)
 			}
+		})
+	}
+}
+
+// TestListAccountsBirthday makes sure ListAccounts reports the birthday of the
+// wallet's master key. The exported accounts are extended public keys, which
+// carry no creation time of their own, so this timestamp is the only thing that
+// lets an importing watch-only wallet start its rescan at the right height
+// instead of at lnd's default birthday.
+func TestListAccountsBirthday(t *testing.T) {
+	t.Parallel()
+
+	birthday := time.Unix(1719792000, 0)
+
+	testCases := []struct {
+		name     string
+		birthday time.Time
+		expected uint64
+	}{{
+		name:     "birthday is reported in unix seconds",
+		birthday: birthday,
+		expected: uint64(birthday.Unix()),
+	}, {
+		// A wallet without a birthday must report zero, which is what
+		// InitWallet already reads as "unknown". Casting a pre-epoch
+		// time to uint64 would instead produce a nonsense timestamp
+		// somewhere in the year 292 billion.
+		name:     "wallet without a birthday reports zero",
+		birthday: time.Time{},
+		expected: 0,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(tt *testing.T) {
+			tt.Parallel()
+
+			rpcServer, _, err := New(&Config{
+				Wallet: &mock.WalletController{
+					WalletBirthday: tc.birthday,
+				},
+				ChainParams: &chaincfg.RegressionNetParams,
+			})
+			require.NoError(tt, err)
+
+			resp, err := rpcServer.ListAccounts(
+				context.Background(), &ListAccountsRequest{},
+			)
+			require.NoError(tt, err)
+			require.Equal(
+				tt, tc.expected,
+				resp.MasterKeyBirthdayTimestamp,
+			)
 		})
 	}
 }

--- a/lntest/mock/walletcontroller.go
+++ b/lntest/mock/walletcontroller.go
@@ -34,6 +34,7 @@ type WalletController struct {
 	PublishedTransactions chan *wire.MsgTx
 	index                 uint32
 	Utxos                 []*lnwallet.Utxo
+	WalletBirthday        time.Time
 }
 
 // A compile time check to ensure this mocked WalletController implements the
@@ -283,6 +284,12 @@ func (w *WalletController) IsSynced() (bool, int64, error) {
 // GetRecoveryInfo currently returns dummy values.
 func (w *WalletController) GetRecoveryInfo() (bool, float64, error) {
 	return true, float64(1), nil
+}
+
+// Birthday returns the mock wallet's birthday, which is the zero time unless a
+// test set one explicitly.
+func (w *WalletController) Birthday() time.Time {
+	return w.WalletBirthday
 }
 
 // Start currently does nothing.

--- a/lntest/mock/walletcontroller.go
+++ b/lntest/mock/walletcontroller.go
@@ -35,6 +35,7 @@ type WalletController struct {
 	PublishedTransactions chan *wire.MsgTx
 	index                 uint32
 	Utxos                 []*lnwallet.Utxo
+	WalletBirthday        time.Time
 }
 
 // A compile time check to ensure this mocked WalletController implements the
@@ -291,6 +292,12 @@ func (w *WalletController) IsSynced() (bool, int64, error) {
 // GetRecoveryInfo currently returns dummy values.
 func (w *WalletController) GetRecoveryInfo() (bool, float64, error) {
 	return true, float64(1), nil
+}
+
+// Birthday returns the mock wallet's birthday, which is the zero time unless a
+// test set one explicitly.
+func (w *WalletController) Birthday() time.Time {
+	return w.WalletBirthday
 }
 
 // Start currently does nothing.

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -1883,6 +1883,14 @@ func (b *BtcWallet) GetRecoveryInfo() (bool, float64, error) {
 	return isRecoveryMode, progress, nil
 }
 
+// Birthday returns the birthday of the wallet's master key, meaning the
+// earliest time at which any of its keys could have been used.
+//
+// This is a part of the WalletController interface.
+func (b *BtcWallet) Birthday() time.Time {
+	return b.wallet.AddrManager().Birthday()
+}
+
 // FetchTx attempts to fetch a transaction in the wallet's database identified
 // by the passed transaction hash. If the transaction can't be found, then a
 // nil pointer is returned.

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -2065,6 +2065,14 @@ func (b *BtcWallet) GetRecoveryInfo() (bool, float64, error) {
 	return isRecoveryMode, progress, nil
 }
 
+// Birthday returns the birthday of the wallet's master key, meaning the
+// earliest time at which any of its keys could have been used.
+//
+// This is a part of the WalletController interface.
+func (b *BtcWallet) Birthday() time.Time {
+	return b.wallet.AddrManager().Birthday()
+}
+
 // FetchTx attempts to fetch a transaction in the wallet's database identified
 // by the passed transaction hash. If the transaction can't be found, then a
 // nil pointer is returned.

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -550,6 +550,12 @@ type WalletController interface {
 	// recovery progress made so far.
 	GetRecoveryInfo() (bool, float64, error)
 
+	// Birthday returns the birthday of the wallet's master key, meaning the
+	// earliest time at which any of its keys could have been used. Blocks
+	// before that point cannot contain any of the wallet's outputs, so this
+	// is where a rescan of the chain starts.
+	Birthday() time.Time
+
 	// Start initializes the wallet, making any necessary connections,
 	// starting up required goroutines etc.
 	Start() error

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -604,6 +604,12 @@ type WalletController interface {
 	// recovery progress made so far.
 	GetRecoveryInfo() (bool, float64, error)
 
+	// Birthday returns the birthday of the wallet's master key, meaning the
+	// earliest time at which any of its keys could have been used. Blocks
+	// before that point cannot contain any of the wallet's outputs, so this
+	// is where a rescan of the chain starts.
+	Birthday() time.Time
+
 	// Start initializes the wallet, making any necessary connections,
 	// starting up required goroutines etc.
 	Start() error

--- a/lnwallet/mock.go
+++ b/lnwallet/mock.go
@@ -40,6 +40,7 @@ type mockWalletController struct {
 	PublishedTransactions chan *wire.MsgTx
 	index                 uint32
 	Utxos                 []*Utxo
+	walletBirthday        time.Time
 }
 
 // A compile time check to ensure that mockWalletController implements the
@@ -299,6 +300,12 @@ func (w *mockWalletController) IsSynced() (bool, int64, error) {
 // GetRecoveryInfo currently returns dummy values.
 func (w *mockWalletController) GetRecoveryInfo() (bool, float64, error) {
 	return true, float64(1), nil
+}
+
+// Birthday returns the mock wallet's birthday, which is the zero time unless a
+// test set one explicitly.
+func (w *mockWalletController) Birthday() time.Time {
+	return w.walletBirthday
 }
 
 // Start currently does nothing.

--- a/lnwallet/mock.go
+++ b/lnwallet/mock.go
@@ -41,6 +41,7 @@ type mockWalletController struct {
 	PublishedTransactions chan *wire.MsgTx
 	index                 uint32
 	Utxos                 []*Utxo
+	walletBirthday        time.Time
 }
 
 // A compile time check to ensure that mockWalletController implements the
@@ -307,6 +308,12 @@ func (w *mockWalletController) IsSynced() (bool, int64, error) {
 // GetRecoveryInfo currently returns dummy values.
 func (w *mockWalletController) GetRecoveryInfo() (bool, float64, error) {
 	return true, float64(1), nil
+}
+
+// Birthday returns the mock wallet's birthday, which is the zero time unless a
+// test set one explicitly.
+func (w *mockWalletController) Birthday() time.Time {
+	return w.walletBirthday
 }
 
 // Start currently does nothing.


### PR DESCRIPTION
In this PR, we teach `walletrpc.ListAccounts` to also return the birthday of the
wallet's master key, so that exporting a signer's accounts and importing them into
a watch-only wallet no longer loses the one piece of information that decides where
the rescan starts.

The accounts in that response are extended public keys, and an xpub says nothing
about when it was created. That's awkward for the main thing the response is used
for, `lncli wallet accounts list` on a signer feeding `lncli createwatchonly` (or
`lndinit init-wallet --init-rpc.watch-only`) on the gateway. The importing side has
no birthday to work with, so we substitute the aezeed "Bitcoin Days Genesis" epoch
of `2017-08-24` and rescan from there. On mainnet today that's ~478k blocks and
several hours parked at `Wallet is not synced to height <tip> yet`, for a node that
may have been created this morning and has nothing at all to find:

```
BTWL: Locating suitable block for birthday 2017-08-22 01:57:37 +0000 UTC between blocks 0-959360
BTWL: Found birthday block: height=481582 ...
BTWL: Started rescan from block ... (height 481582) for 0 addrs, 0 outpoints
BTWL: Rescanning from block height 481583 to 959360
```

That's from lightninglabs/lndinit#97, filed against a fresh remote-signing gateway
on mainnet. `lndinit` has its own half of the fix in
lightninglabs/lndinit#98, adding a flag so the operator can supply the birthday by
hand. This PR is the half that makes the flag unnecessary in the common case: the
value already exists on the signer, it just never made it into the export.

## The pieces

`lnwallet.WalletController` grows a `Birthday()` method, backed by btcwallet's
address manager, which has held this all along. There was simply no way to ask for
it from the RPC layer.

`ListAccountsResponse` grows `master_key_birthday_timestamp`, named to match
`WatchOnly.master_key_birthday_timestamp` on the `InitWallet` request since that's
where the value ends up. Because the accounts JSON file that `createwatchonly`
consumes is a marshaled `ListAccountsResponse`, the birthday round-trips through
the file with no format changes on either end. A wallet that somehow has no
birthday reports zero rather than the nonsense a `uint64` cast of a pre-epoch time
would give, zero being what `InitWallet` already reads as "unknown".

`createwatchonly` then offers that value as the default for its birthday prompt.
The prompt stays, since an operator may know better than the file does, and an
older accounts file without the field leaves the default at zero, which is exactly
how the prompt behaved before.

## Testing

`TestListAccountsBirthday` covers both the normal case and the no-birthday wallet.
Beyond that, I ran the whole thing on regtest against a real signer/watch-only
split: a signer holding an aezeed generated today, its accounts exported with
`wallet accounts list`, and a gateway with `--remotesigner.enable` importing them.

A stock regtest chain stamps every block with roughly the same time, so every
birthday resolves to the same block and there's nothing to see. Mining 200 blocks
under `setmocktime` with timestamps spread from 2017-01 to 2026-06 (~17 days per
block) puts the aezeed epoch at height 13 and a recent birthday at height 190,
which makes the difference visible: the rescan goes from 187 blocks to 10, and the
resulting wallet is fully functional afterwards (identity pubkey matching the
signer, `newaddress` going out to the remote signer, on-chain funds detected).

See each commit message for the detailed reasoning w.r.t the individual pieces.
