### PR TITLE
lnwallet/btcwallet: skip 2-hour tip-staleness check on regtest/simnet

### DIFF
--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -1803,9 +1803,13 @@ func (b *BtcWallet) IsSynced() (bool, int64, error) {
 	}
 
 	// If the timestamp on the best header is more than 2 hours in the
-	// past, then we're not yet synced.
-	minus24Hours := time.Now().Add(-2 * time.Hour)
-	if blockHeader.Timestamp.Before(minus24Hours) {
+	// past, then we're not yet synced. This staleness check is skipped on
+	// local networks (regtest/simnet), where blocks are only mined on
+	// demand and the tip is expected to sit idle for long stretches.
+	isLocalNet := b.netParams.Net == wire.TestNet ||
+		b.netParams.Net == wire.SimNet
+	minus2Hours := time.Now().Add(-2 * time.Hour)
+	if !isLocalNet && blockHeader.Timestamp.Before(minus2Hours) {
 		return false, bestTimestamp, nil
 	}
 

--- a/lnwallet/btcwallet/chainsync_test.go
+++ b/lnwallet/btcwallet/chainsync_test.go
@@ -1,0 +1,123 @@
+package btcwallet
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	basewallet "github.com/btcsuite/btcwallet/wallet"
+	"github.com/lightningnetwork/lnd/lnmock"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// mockSyncedWallet is a minimal base wallet fake that satisfies the
+// base.Interface used by BtcWallet. It embeds the interface so the compile-time
+// contract is met, but only the two methods IsSynced actually calls are
+// implemented; any other call would panic on the nil embedded interface, which
+// is what we want as a guard against the test drifting.
+type mockSyncedWallet struct {
+	basewallet.Interface
+
+	stamp       waddrmgr.BlockStamp
+	chainSynced bool
+}
+
+func (m *mockSyncedWallet) SyncedTo() waddrmgr.BlockStamp {
+	return m.stamp
+}
+
+func (m *mockSyncedWallet) ChainSynced() bool {
+	return m.chainSynced
+}
+
+// TestIsSyncedStaleTip asserts that the tip-staleness check in IsSynced is
+// skipped on local networks (regtest/simnet) but still enforced everywhere
+// else. On regtest/simnet blocks are only mined on demand, so an idle chain tip
+// whose timestamp is well in the past must not flip synced_to_chain to false.
+func TestIsSyncedStaleTip(t *testing.T) {
+	t.Parallel()
+
+	const bestHeight = int32(100)
+
+	testCases := []struct {
+		name       string
+		netParams  *chaincfg.Params
+		staleTip   bool
+		wantSynced bool
+	}{{
+		name:       "regtest stale tip is still synced",
+		netParams:  &chaincfg.RegressionNetParams,
+		staleTip:   true,
+		wantSynced: true,
+	}, {
+		name:       "simnet stale tip is still synced",
+		netParams:  &chaincfg.SimNetParams,
+		staleTip:   true,
+		wantSynced: true,
+	}, {
+		name:       "mainnet stale tip is not synced",
+		netParams:  &chaincfg.MainNetParams,
+		staleTip:   true,
+		wantSynced: false,
+	}, {
+		name:       "mainnet fresh tip is synced",
+		netParams:  &chaincfg.MainNetParams,
+		staleTip:   false,
+		wantSynced: true,
+	}, {
+		name:       "testnet3 stale tip is not synced",
+		netParams:  &chaincfg.TestNet3Params,
+		staleTip:   true,
+		wantSynced: false,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Pick a tip timestamp that is either comfortably
+			// outside the 2-hour staleness window or right at the
+			// current time.
+			tipTime := time.Now()
+			if tc.staleTip {
+				tipTime = tipTime.Add(-3 * time.Hour)
+			}
+
+			header := &wire.BlockHeader{Timestamp: tipTime}
+			bestHash := header.BlockHash()
+
+			mockChain := &lnmock.MockChain{}
+			mockChain.On("GetBestBlock").Return(
+				&bestHash, bestHeight, nil,
+			)
+			mockChain.On("GetBlockHeader", mock.Anything).Return(
+				header, nil,
+			)
+
+			// The wallet reports itself fully caught up to the same
+			// height as the backend's best block, so the only thing
+			// left to decide sync status is the tip-staleness check.
+			w := &BtcWallet{
+				wallet: &mockSyncedWallet{
+					stamp: waddrmgr.BlockStamp{
+						Height:    bestHeight,
+						Hash:      bestHash,
+						Timestamp: tipTime,
+					},
+					chainSynced: true,
+				},
+				netParams: tc.netParams,
+				cfg: &Config{
+					ChainSource: mockChain,
+				},
+			}
+
+			synced, _, err := w.IsSynced()
+			require.NoError(t, err)
+			require.Equal(t, tc.wantSynced, synced)
+		})
+	}
+}


### PR DESCRIPTION
IsSynced rejected "synced" status whenever the best block header timestamp was more than 2 hours in the past. On regtest and simnet blocks are only mined on demand, so an idle chain would drive the tip timestamp past that window and report synced_to_chain=false, and could block the startup sync loop indefinitely.

Skip the staleness check on local networks (regtest via wire.TestNet, simnet via wire.SimNet); mainnet and testnet3/testnet4 are unaffected. Also rename the misleading minus24Hours variable to minus2Hours.

Add TestIsSyncedStaleTip covering the skip on regtest/simnet, the still-enforced check on mainnet, and a testnet3 guard case ensuring the skip does not accidentally match real testnet.

Fixes https://github.com/lightningnetwork/lnd/issues/11004