### PR TITLE
lnwallet: fix limboMtx/intentMtx lock order inversion in PsbtFundingVerify

### DIFF
--- a/docs/release-notes/release-notes-0.20.4.md
+++ b/docs/release-notes/release-notes-0.20.4.md
@@ -45,6 +45,14 @@
   associations, causing verification to fail and the migration transaction to
   roll back.
 
+* [Fixed a lock order inversion](https://github.com/lightningnetwork/lnd/pull/11008)
+  between `PsbtFundingVerify` and `handleFundingCancelRequest` in the wallet.
+  With PSBT or batch funding the two could deadlock the wallet's single
+  `requestHandler` goroutine, which permanently disabled all channel funding for
+  the whole node: no new channel could be opened, and channels whose funding
+  transaction confirmed stayed in the `channelReadySent` opening state forever,
+  never added to the graph and never announced. Only a restart recovered.
+
 # New Features
 
 ## Functional Enhancements
@@ -81,5 +89,6 @@
 
 # Contributors (Alphabetical Order)
 
+* LNBiG
 * Yong Yu
 * Ziggie

--- a/docs/release-notes/release-notes-0.21.3.md
+++ b/docs/release-notes/release-notes-0.21.3.md
@@ -45,6 +45,14 @@
   associations, causing verification to fail and the migration transaction to
   roll back.
 
+* [Fixed a lock order inversion](https://github.com/lightningnetwork/lnd/pull/11008)
+  between `PsbtFundingVerify` and `handleFundingCancelRequest` in the wallet.
+  With PSBT or batch funding the two could deadlock the wallet's single
+  `requestHandler` goroutine, which permanently disabled all channel funding for
+  the whole node: no new channel could be opened, and channels whose funding
+  transaction confirmed stayed in the `channelReadySent` opening state forever,
+  never added to the graph and never announced. Only a restart recovered.
+
 # New Features
 
 ## Functional Enhancements
@@ -107,5 +115,6 @@
 # Contributors (Alphabetical Order)
 
 * Elle Mouton
+* LNBiG
 * Yong Yu
 * Ziggie

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -443,7 +443,13 @@ type LightningWallet struct {
 	// as key in the fundingLimbo map. Used to easily look up a channel
 	// reservation given a pending channel ID.
 	reservationIDs map[[32]byte]uint64
-	limboMtx       sync.RWMutex
+
+	// limboMtx guards fundingLimbo and reservationIDs.
+	//
+	// NOTE: Never acquire limboMtx while holding intentMtx. If both
+	// mutexes must be held simultaneously, acquire limboMtx before
+	// intentMtx. See the note on PsbtFundingVerify.
+	limboMtx sync.RWMutex
 
 	// lockedOutPoints is a set of the currently locked outpoint. This
 	// information is kept in order to provide an easy way to unlock all
@@ -746,8 +752,33 @@ func (l *LightningWallet) RegisterFundingIntent(expectedID [32]byte,
 // PsbtFundingVerify looks up a previously registered funding intent by its
 // pending channel ID and tries to advance the state machine by verifying the
 // passed PSBT.
+//
+// NOTE: limboMtx MUST be acquired before intentMtx, never the other way round.
+// handleFundingCancelRequest holds limboMtx for the duration of the call and
+// acquires intentMtx inside it, so acquiring the two in the opposite order here
+// deadlocks the wallet's requestHandler goroutine, which in turn wedges all
+// channel funding for the whole node.
 func (l *LightningWallet) PsbtFundingVerify(pendingChanID [32]byte,
 	packet *psbt.Packet, skipFinalize bool) error {
+
+	// Get the channel reservation that corresponds to this pending channel
+	// ID. This has to happen before intentMtx is acquired, see the note
+	// above.
+	l.limboMtx.Lock()
+	pid, ok := l.reservationIDs[pendingChanID]
+	if !ok {
+		l.limboMtx.Unlock()
+		return fmt.Errorf("no channel reservation found for "+
+			"pendingChannelID(%x)", pendingChanID[:])
+	}
+
+	pendingReservation, ok := l.fundingLimbo[pid]
+	l.limboMtx.Unlock()
+
+	if !ok {
+		return fmt.Errorf("no channel reservation found for "+
+			"reservation ID %v", pid)
+	}
 
 	l.intentMtx.Lock()
 	defer l.intentMtx.Unlock()
@@ -772,28 +803,11 @@ func (l *LightningWallet) PsbtFundingVerify(pendingChanID [32]byte,
 		return fmt.Errorf("error verifying PSBT: %w", err)
 	}
 
-	// Get the channel reservation for that corresponds to this pending
-	// channel ID.
-	l.limboMtx.Lock()
-	pid, ok := l.reservationIDs[pendingChanID]
-	if !ok {
-		l.limboMtx.Unlock()
-		return fmt.Errorf("no channel reservation found for "+
-			"pendingChannelID(%x)", pendingChanID[:])
-	}
-
-	pendingReservation, ok := l.fundingLimbo[pid]
-	l.limboMtx.Unlock()
-
-	if !ok {
-		return fmt.Errorf("no channel reservation found for "+
-			"reservation ID %v", pid)
-	}
-
 	// Now the PSBT has been populated and verified, we can again check
 	// whether the value reserved for anchor fee bumping is respected.
 	isPublic := pendingReservation.partialState.ChannelFlags&lnwire.FFAnnounceChannel != 0
 	hasAnchors := pendingReservation.partialState.ChanType.HasAnchors()
+
 	return l.enforceNewReservedValue(intent, isPublic, hasAnchors)
 }
 


### PR DESCRIPTION
### Change Description

`PsbtFundingVerify` acquires `intentMtx` and then `limboMtx`, while
`handleFundingCancelRequest` — which runs in the wallet's single `requestHandler`
goroutine — acquires the two in the opposite order. With PSBT or batch funding
both paths run concurrently, so the two goroutines can deadlock.

This was hit in production on `v0.20.2-beta` and confirmed with a goroutine dump
taken from the still-wedged process. The inversion is unchanged in `master` and
in `v0.21.1-beta`, so it is not fixed by upgrading. The full analysis, the
four-goroutine deadlock cycle and the stacks are in #11011.

The consequences are node wide and completely silent. `requestHandler` is the
only executor of every `ChannelReservation` method, and those methods are
unconditional round trips with neither a timeout nor a `quit` escape. Once it is
stuck, a peer disconnect parks `funding.Manager`'s `resMtx` forever in
`CancelPeerReservations`, and the next zombie sweeper tick kills
`reservationCoordinator` on `resMtx.RLock`. From that point the node can neither
open nor accept channels, channels whose funding transaction confirmed stay in
the `channelReadySent` opening state forever and are never added to the graph nor
announced, and nothing is logged about any of it. Only a restart recovers.

The fix looks the channel reservation up, and releases `limboMtx`, before
acquiring `intentMtx`, and documents the required order on the mutex
declaration. The only behavioural change is which of two "not found" errors is
returned first.

The issue also lists several contributing factors that are out of scope here and
would each need their own change: the wallet round trip performed while holding
`resMtx`, the reservation leaked when `Cancel()` fails, the missing timeouts on
`ChannelReservation` methods, and `BatchOpenChannel` not honouring its request
context.

Fixes #11011

### Steps to Test

`go test ./funding/` passes, including the `TestBatchFund/initial_negotiation_failure`
subtest. `gofmt`, `go vet ./lnwallet/` and `go build ./lnwallet/` are clean on
both `master` and `v0.20.2-beta`. Integration tests were not run locally.