### PR TITLE
[v0.21.x] kvdb: mark pgx/v5 as direct dependency

### DIFF
--- a/kvdb/go.mod
+++ b/kvdb/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/fergusstrange/embedded-postgres v1.25.0
 	github.com/google/btree v1.0.1
 	github.com/jackc/pgx/v4 v4.18.3
+	github.com/jackc/pgx/v5 v5.7.4
 	github.com/lightningnetwork/lnd/healthcheck v1.2.4
 	github.com/lightningnetwork/lnd/sqldb v1.0.6
 	github.com/stretchr/testify v1.11.1
@@ -63,7 +64,6 @@ require (
 	github.com/jackc/pgproto3/v2 v2.3.3 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgtype v1.14.4 // indirect
-	github.com/jackc/pgx/v5 v5.7.4 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect
 	github.com/json-iterator/go v1.1.11 // indirect


### PR DESCRIPTION
## Description

Follow-up to #10977.

Commit `e7f9a9220` backported the Postgres migration bulk support to
`v0.21.x-branch` and introduced direct imports of `github.com/jackc/pgx/v5`
and `github.com/jackc/pgx/v5/stdlib`.

On master, `pgx/v5` was already a direct kvdb dependency, so the original
commit needed no `go.mod` change. On `v0.21.x-branch`, it was still listed as
indirect. As a result, `go mod tidy` rewrites `kvdb/go.mod` and
`make tidy-module-check` fails. This surfaced again in the static checks for
#11010.

Run `go mod tidy` in the kvdb module to classify `pgx/v5` as a direct
dependency. This does not change the selected version or `go.sum`.

## Testing

```bash
make tidy-module-check
```
