### PR TITLE
routerrpc: refuse local dispatch on a switchrpc build

### DIFF
--- a/config.go
+++ b/config.go
@@ -481,6 +481,8 @@ type Config struct {
 
 	StoreFinalHtlcResolutions bool `long:"store-final-htlc-resolutions" description:"Persistently store the final resolution of incoming htlcs."`
 
+	EnableLocalPaymentDispatch bool `long:"enable-local-payment-dispatch" description:"Permit the local payment-sending RPCs (SendPaymentV2, SendToRouteV2). Only applies to a binary built with the 'switchrpc' tag, which refuses them by default so an external router dispatching HTLC attempts cannot collide with the embedded router in the shared attempt store. Setting this while an external router is attached reopens that collision. Attempt store cleanup and the external management marker follow the build tag, not this option."`
+
 	DefaultRemoteMaxHtlcs uint16 `long:"default-remote-max-htlcs" description:"The default max_htlc applied when opening or accepting channels. This value limits the number of concurrent HTLCs that the remote party can add to the commitment. The maximum possible value is 483."`
 
 	NumGraphSyncPeers      int           `long:"numgraphsyncpeers" description:"The number of peers that we should receive new graph updates from. This option can be tuned to save bandwidth for light clients or routing nodes."`
@@ -864,6 +866,11 @@ func DefaultConfig() Config {
 		FwdHistoryDeleteBatchSize: defaultFwdHistoryDeleteBatchSize,
 		CoinSelectionStrategy:     defaultCoinSelectionStrategy,
 		KeepFailedPaymentAttempts: defaultKeepFailedPaymentAttempts,
+		// External payment lifecycle defaults to on whenever the binary
+		// was built with the 'switchrpc' tag, since that build exists
+		// specifically to hand the payment lifecycle to an external
+		// router. The itest suite opts back out explicitly.
+		EnableLocalPaymentDispatch: !build.SwitchRPC,
 		RemoteSigner: &lncfg.RemoteSigner{
 			Timeout: lncfg.DefaultRemoteSignerRPCTimeout,
 		},
@@ -999,6 +1006,19 @@ func LoadConfig(interceptor signal.Interceptor) (*Config, error) {
 	logWarningsForDeprecation(*cleanCfg)
 
 	return cleanCfg, nil
+}
+
+// validateLocalPaymentDispatch returns an error when local payment dispatch is
+// refused without the switchrpc build tag that supplies the alternative. Only
+// that direction is rejected; a switchrpc binary permitting local dispatch is
+// supported.
+func validateLocalPaymentDispatch(enabled, switchRPCBuild bool) error {
+	if !enabled && !switchRPCBuild {
+		return errors.New("refusing local payment dispatch requires " +
+			"a binary built with the 'switchrpc' build tag")
+	}
+
+	return nil
 }
 
 // ValidateConfig check the given configuration to be sane. This makes sure no
@@ -1254,6 +1274,24 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 		cfg.MaxOutgoingCltvExpiry, cfg.Bitcoin.TimeLockDelta,
 	); err != nil {
 		return nil, mkErr("%v", err)
+	}
+
+	// Without the switchrpc tag there is no dispatch interface to send
+	// through, so a node that also refuses local dispatch could not send at
+	// all.
+	if err := validateLocalPaymentDispatch(
+		cfg.EnableLocalPaymentDispatch, build.SwitchRPC,
+	); err != nil {
+		return nil, mkErr("%v", err)
+	}
+
+	// A switchrpc build always skips attempt store cleanup and always marks
+	// the HTLC attempt database, whatever this flag is set to.
+	if build.SwitchRPC && cfg.EnableLocalPaymentDispatch {
+		ltndLog.Warnf("Local payment dispatch is permitted, but this " +
+			"binary still skips attempt store cleanup and marks " +
+			"the HTLC attempt database as externally managed. " +
+			"Both follow the 'switchrpc' build tag, not this flag.")
 	}
 
 	// Validate the Tor config parameters.

--- a/config_test.go
+++ b/config_test.go
@@ -232,3 +232,19 @@ func TestValidateChannelPolicyTimeLockDelta(t *testing.T) {
 	)
 	require.ErrorContains(t, err, "exceeds max-cltv-expiry")
 }
+
+// TestValidateLocalPaymentDispatch asserts that refusing local dispatch is
+// rejected only without the switchrpc build tag, and accepted otherwise.
+func TestValidateLocalPaymentDispatch(t *testing.T) {
+	t.Parallel()
+
+	// Refusing local dispatch without the build tag is the one rejected
+	// combination: the node would refuse local sends yet have no switchrpc
+	// dispatcher to send through instead.
+	require.Error(t, validateLocalPaymentDispatch(false, false))
+
+	// Every other combination is valid.
+	require.NoError(t, validateLocalPaymentDispatch(true, false))
+	require.NoError(t, validateLocalPaymentDispatch(true, true))
+	require.NoError(t, validateLocalPaymentDispatch(false, true))
+}

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -132,12 +132,49 @@
   Tying this behavior to a build tag, rather than a runtime flag, makes the
   binary's purpose explicit and prevents potential misconfigurations.
 
+* The embedded `ChannelRouter` can no longer originate payments while an
+  external router owns the payment lifecycle. `routerrpc.SendPaymentV2` and
+  `routerrpc.SendToRouteV2` now return `codes.FailedPrecondition` on a
+  `switchrpc` build unless the new `--enable-local-payment-dispatch` option is
+  set. Both routers draw HTLC
+  attempt IDs from independent sequencers into one shared attempt store, so a
+  payment sent through the embedded router can collide with an in-flight
+  external attempt and deliver one payment's result to the other. This makes
+  the single-dispatcher requirement described above an enforced constraint
+  rather than an operator responsibility.
+
+  This is a **breaking change** for any `switchrpc` build that currently sends
+  payments locally, because the refusal is the default whenever that tag is
+  present. Such a deployment must pass `--enable-local-payment-dispatch` to keep
+  using the embedded router.
+
+  The option governs payment origination only. Skipping attempt store cleanup
+  on startup, and marking the database as externally managed, remain properties
+  of the `switchrpc` build tag and are unaffected by its value. Both are
+  destructive to an external router's state, so they are deliberately not
+  runtime-toggleable. A `switchrpc` node that permits local dispatch logs a
+  warning saying so at startup.
+
+  Code that embeds the `routerrpc` sub-server should note that
+  `routerrpc.Config` gains an `EnableLocalPaymentDispatch` field whose zero
+  value refuses payment dispatch. The build tag is consulted only when lnd
+  builds its own config, so a caller that constructs `routerrpc.Config`
+  directly must set this field to keep sending payments. There is no compile
+  error and no startup diagnostic; the first symptom is `FailedPrecondition`
+  from `SendPaymentV2`.
+
 * Added [`DisableRemoteRouter` rpc](https://github.com/lightningnetwork/lnd/pull/10178)
   to `switchrpc` which marks the database as no longer being used by a remote
   router. This is useful for migrating from a remote router setup back to the
   default embedded router. The external controller should first clean its
   results from the attempt store via `DeleteAttempts` (#10602); this RPC will
   fail if there are any remaining attempt entries.
+
+  Note that clearing the marker only completes the migration if the node is
+  then run from a binary without the `switchrpc` tag. A tagged binary rewrites
+  the marker on its next startup, whatever `--enable-local-payment-dispatch`
+  is set to, so the migration back to local dispatch is a binary swap rather
+  than a configuration change.
 
 * The `ChannelRouter` now supports a [configurable attempt reconciliation
   hook](https://github.com/lightningnetwork/lnd/pull/10621) that runs for each

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -820,6 +820,10 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testPostgresNetworkSeparation,
 	},
 	{
+		Name:     "local payment dispatch guard",
+		TestFunc: testLocalPaymentDispatchGuard,
+	},
+	{
 		Name:     "send onion",
 		TestFunc: testSendOnion,
 	},

--- a/itest/lnd_local_payment_dispatch_test.go
+++ b/itest/lnd_local_payment_dispatch_test.go
@@ -1,0 +1,96 @@
+package itest
+
+import (
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
+	"github.com/lightningnetwork/lnd/lntest"
+	"github.com/lightningnetwork/lnd/lntest/node"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// testLocalPaymentDispatchGuard verifies that a node refusing local payment
+// dispatch rejects the local payment-sending RPCs, so an external router
+// dispatching over the switchrpc interface cannot collide with the embedded
+// router in the shared attempt-ID space, while the read-only routing surface
+// and the HTLC interception stream that an external router depends on keep
+// working.
+func testLocalPaymentDispatchGuard(ht *lntest.HarnessTest) {
+	const (
+		chanAmt    = btcutil.Amount(100000)
+		paymentAmt = 10000
+	)
+
+	// Alice keeps the switchrpc build's default of refusing local dispatch;
+	// every other harness node opts in, so Bob is ordinary.
+	alice := ht.NewNodeWithOpts(
+		"Alice", nil, node.WithRefuseLocalPaymentDispatch(),
+	)
+	ht.FundNumCoins(alice, 1)
+	bob := ht.NewNode("Bob", nil)
+
+	ht.EnsureConnected(alice, bob)
+	chanPoint := ht.OpenChannel(
+		alice, bob, lntest.OpenChannelParams{Amt: chanAmt},
+	)
+	defer ht.CloseChannel(alice, chanPoint)
+
+	ht.AssertChannelInGraph(alice, chanPoint)
+
+	// Bob issues an invoice for the send attempts.
+	inv := bob.RPC.AddInvoice(&lnrpc.Invoice{Value: paymentAmt})
+
+	ctx := ht.Context()
+
+	// SendPaymentV2 is server-streaming; a handler that errors before
+	// sending surfaces the error on the first Recv. It must be refused with
+	// codes.FailedPrecondition.
+	sendStream, err := alice.RPC.Router.SendPaymentV2(
+		ctx, &routerrpc.SendPaymentRequest{
+			PaymentRequest: inv.PaymentRequest,
+			TimeoutSeconds: 60,
+		},
+	)
+	require.NoError(ht, err)
+	_, err = sendStream.Recv()
+	require.Equal(ht, codes.FailedPrecondition, status.Code(err),
+		"SendPaymentV2 must be refused in external lifecycle mode")
+
+	// QueryRoutes is read-only and must still answer. It also gives us a
+	// route for the SendToRouteV2 attempt below.
+	routes := alice.RPC.QueryRoutes(&lnrpc.QueryRoutesRequest{
+		PubKey: bob.PubKeyStr,
+		Amt:    paymentAmt,
+	})
+	require.NotEmpty(ht, routes.Routes, "QueryRoutes must still answer")
+
+	// SendToRouteV2 is unary; the guard error is returned directly. It must
+	// be refused with codes.FailedPrecondition.
+	_, err = alice.RPC.Router.SendToRouteV2(
+		ctx, &routerrpc.SendToRouteRequest{
+			PaymentHash: inv.RHash,
+			Route:       routes.Routes[0],
+		},
+	)
+	require.Equal(ht, codes.FailedPrecondition, status.Code(err),
+		"SendToRouteV2 must be refused in external lifecycle mode")
+
+	// The graph-based EstimateRouteFee sends no HTLC and must still answer.
+	_, err = alice.RPC.Router.EstimateRouteFee(
+		ctx, &routerrpc.RouteFeeRequest{
+			Dest:   bob.PubKey[:],
+			AmtSat: paymentAmt,
+		},
+	)
+	require.NoError(ht, err, "graph EstimateRouteFee must still answer")
+
+	// HtlcInterceptor must still work: PS holds this stream on every
+	// gateway, and it is the reason routerrpc is not compiled out.
+	_, cancelInterceptor := alice.RPC.HtlcInterceptor()
+	cancelInterceptor()
+
+	// SubscribeHtlcEvents must still work.
+	alice.RPC.SubscribeHtlcEvents()
+}

--- a/lnrpc/routerrpc/config.go
+++ b/lnrpc/routerrpc/config.go
@@ -51,6 +51,12 @@ type Config struct {
 	// AliasMgr is the alias manager instance that is used to handle all the
 	// SCID alias related information for channels.
 	AliasMgr *aliasmgr.Manager
+
+	// EnableLocalPaymentDispatch permits the local payment-sending RPCs.
+	// When it is unset an external router owns the payment lifecycle, and
+	// this sub-server refuses those RPCs so the embedded router cannot
+	// allocate attempt IDs into the store the external router uses.
+	EnableLocalPaymentDispatch bool
 }
 
 // DefaultConfig defines the config defaults.

--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -341,6 +341,23 @@ func (r *ServerShell) CreateSubServer(configRegistry lnrpc.SubServerConfigDispat
 	return subServer, macPermissions, nil
 }
 
+// checkLocalSendAllowed returns an error when the local router must not
+// originate payments because an external router owns the payment lifecycle and
+// the two would share the switch's attempt-ID space.
+func (s *Server) checkLocalSendAllowed() error {
+	if s.cfg.EnableLocalPaymentDispatch {
+		return nil
+	}
+
+	log.Debugf("Refusing local payment dispatch: an external router " +
+		"owns the payment lifecycle")
+
+	return status.Errorf(codes.FailedPrecondition, "local payment "+
+		"dispatch is disabled: an external router owns the payment "+
+		"lifecycle; payments must be dispatched via the switchrpc "+
+		"interface")
+}
+
 // SendPaymentV2 attempts to route a payment described by the passed
 // PaymentRequest to the final destination. If we are unable to route the
 // payment, or cannot find a route that satisfies the constraints in the
@@ -348,6 +365,10 @@ func (r *ServerShell) CreateSubServer(configRegistry lnrpc.SubServerConfigDispat
 // pre-image, along with the final route will be returned.
 func (s *Server) SendPaymentV2(req *SendPaymentRequest,
 	stream Router_SendPaymentV2Server) error {
+
+	if err := s.checkLocalSendAllowed(); err != nil {
+		return err
+	}
 
 	// Set payment request attempt timeout.
 	if req.TimeoutSeconds == 0 {
@@ -1088,6 +1109,10 @@ func timelockAndFee(p *lnrpc.Payment) (int64, int64, error) {
 // this call contains structured error information.
 func (s *Server) SendToRouteV2(ctx context.Context,
 	req *SendToRouteRequest) (*lnrpc.HTLCAttempt, error) {
+
+	if err := s.checkLocalSendAllowed(); err != nil {
+		return nil, err
+	}
 
 	if req.Route == nil {
 		return nil, fmt.Errorf("unable to send, no routes provided")

--- a/lnrpc/routerrpc/router_server_guard_test.go
+++ b/lnrpc/routerrpc/router_server_guard_test.go
@@ -1,0 +1,51 @@
+package routerrpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestCheckLocalSendAllowed verifies the external payment lifecycle guard: local
+// payment sending is refused with codes.FailedPrecondition when an external router owns
+// the payment lifecycle, and permitted otherwise.
+func TestCheckLocalSendAllowed(t *testing.T) {
+	t.Parallel()
+
+	// Guard inactive: local sending is allowed.
+	allowed := &Server{cfg: &Config{EnableLocalPaymentDispatch: true}}
+	require.NoError(t, allowed.checkLocalSendAllowed())
+
+	// Guard active: local sending is refused with codes.FailedPrecondition so an
+	// operator reading the error learns the reason without reading source.
+	refused := &Server{cfg: &Config{EnableLocalPaymentDispatch: false}}
+	err := refused.checkLocalSendAllowed()
+	require.Error(t, err)
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+// TestExternalLifecycleGuardsHandlers verifies the guard is wired into both
+// payment-sending handlers, so neither can dispatch a local payment while
+// external lifecycle mode is active. Both return before touching the router, so
+// a minimal Server with no backend suffices.
+func TestExternalLifecycleGuardsHandlers(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{cfg: &Config{EnableLocalPaymentDispatch: false}}
+
+	// SendPaymentV2 is server-streaming.
+	streamErr := srv.SendPaymentV2(
+		&SendPaymentRequest{}, makeStreamMock(context.Background()),
+	)
+	require.Equal(t, codes.FailedPrecondition, status.Code(streamErr))
+
+	// SendToRouteV2 is unary. The guard runs before the nil-route check,
+	// so an empty request still returns the guard error.
+	_, unaryErr := srv.SendToRouteV2(
+		context.Background(), &SendToRouteRequest{},
+	)
+	require.Equal(t, codes.FailedPrecondition, status.Code(unaryErr))
+}

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -521,6 +521,26 @@ func (h *HarnessTest) NewNode(name string,
 	return node
 }
 
+// NewNodeWithOpts creates a new node, applying the given options to its config
+// before it starts, and is otherwise identical to NewNode.
+//
+// NOTE: The only option today is used by switchrpc builds, to keep a node at
+// the build's default of refusing local payment dispatch.
+func (h *HarnessTest) NewNodeWithOpts(name string, extraArgs []string,
+	opts ...node.Option) *node.HarnessNode {
+
+	node, err := h.manager.newNode(h.T, name, extraArgs, nil, false, opts...)
+	require.NoErrorf(h, err, "unable to create new node for %s", name)
+
+	err = node.Start(h.runCtx)
+	require.NoError(h, err, "failed to start node %s", node.Name())
+
+	bestBlock, _ := h.miner.GetBestBlock()
+	h.WaitForBlockchainSyncTo(node, *bestBlock)
+
+	return node
+}
+
 // NewNodeWithCoins creates a new node and asserts its creation. The node is
 // guaranteed to have finished its initialization and all its subservers are
 // started. In addition, 5 UTXO of 1 BTC each are sent to the node.

--- a/lntest/harness_node_manager.go
+++ b/lntest/harness_node_manager.go
@@ -71,7 +71,8 @@ func (nm *nodeManager) nextNodeID() uint32 {
 // node can be used immediately. Otherwise, the node will require an additional
 // initialization phase where the wallet is either created or restored.
 func (nm *nodeManager) newNode(t *testing.T, name string, extraArgs []string,
-	password []byte, noAuth bool) (*node.HarnessNode, error) {
+	password []byte, noAuth bool,
+	opts ...node.Option) (*node.HarnessNode, error) {
 
 	cfg := &node.BaseNodeConfig{
 		Name:              name,
@@ -86,6 +87,10 @@ func (nm *nodeManager) newNode(t *testing.T, name string, extraArgs []string,
 		LndBinary:         nm.lndBinary,
 		NetParams:         miner.HarnessNetParams,
 		SkipUnlock:        noAuth,
+	}
+
+	for _, opt := range opts {
+		opt(cfg)
 	}
 
 	node, err := node.NewHarnessNode(t, cfg)

--- a/lntest/node/config.go
+++ b/lntest/node/config.go
@@ -100,6 +100,15 @@ const (
 // Option is a function for updating a node's configuration.
 type Option func(*BaseNodeConfig)
 
+// WithRefuseLocalPaymentDispatch leaves the node at the switchrpc build's
+// default of refusing the local payment-sending RPCs, rather than opting in the
+// way every other harness node does.
+func WithRefuseLocalPaymentDispatch() Option {
+	return func(cfg *BaseNodeConfig) {
+		cfg.RefuseLocalPaymentDispatch = true
+	}
+}
+
 // BackendConfig is an interface that abstracts away the specific chain backend
 // node implementation.
 type BackendConfig interface {
@@ -146,9 +155,14 @@ type BaseNodeConfig struct {
 	ReadMacPath    string
 	InvoiceMacPath string
 
-	SkipUnlock        bool
-	Password          []byte
-	WithPeerBootstrap bool
+	SkipUnlock bool
+
+	// RefuseLocalPaymentDispatch leaves the node at the switchrpc build's
+	// default of refusing the local payment-sending RPCs. Every other node
+	// opts in, so the payment suites keep using the embedded router.
+	RefuseLocalPaymentDispatch bool
+	Password                   []byte
+	WithPeerBootstrap          bool
 
 	P2PPort     int
 	RPCPort     int
@@ -291,6 +305,7 @@ func (cfg *BaseNodeConfig) GenArgs() []string {
 		"--accept-keysend",
 		"--keep-failed-payment-attempts",
 		"--logging.no-commit-hash",
+
 		fmt.Sprintf("--db.batch-commit-interval=%v", commitInterval),
 		fmt.Sprintf("--bitcoin.defaultremotedelay=%v", DefaultCSV),
 		fmt.Sprintf("--rpclisten=%v", cfg.RPCAddr()),
@@ -324,6 +339,13 @@ func (cfg *BaseNodeConfig) GenArgs() []string {
 
 	if cfg.Password == nil {
 		args = append(args, "--noseedbackup")
+	}
+
+	// The itest binary carries the 'switchrpc' tag, which refuses local
+	// payment dispatch by default. Opt in so the payment-sending suites
+	// keep using the embedded router.
+	if !cfg.RefuseLocalPaymentDispatch {
+		args = append(args, "--enable-local-payment-dispatch")
 	}
 
 	if !cfg.WithPeerBootstrap {

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -557,6 +557,13 @@
 ; channel.
 ; allow-circular-route=false
 
+; Permit the local payment-sending RPCs (SendPaymentV2, SendToRouteV2).
+;
+; NOTE: Only applies to a binary built with the 'switchrpc' tag. Such a build
+; refuses these RPCs by default so an external router dispatching HTLC attempts
+; cannot collide with the embedded router in the shared attempt store.
+; enable-local-payment-dispatch=false
+
 ; Time in milliseconds between each release of announcements to the network
 ; trickledelay=90000
 

--- a/subrpcserver_config.go
+++ b/subrpcserver_config.go
@@ -417,6 +417,7 @@ func (s *subRPCServerConfigs) PopulateDependencies(cfg *Config,
 	s.RouterRPC.MacService = macService
 	s.RouterRPC.Router = chanRouter
 	s.RouterRPC.RouterBackend = routerBackend
+	s.RouterRPC.EnableLocalPaymentDispatch = cfg.EnableLocalPaymentDispatch
 
 	return nil
 }


### PR DESCRIPTION
## Change Description

The v0.22 release notes say that only one entity, the local router or one external router, may dispatch HTLC attempts through the switch, and that running two "will lead to undefined behavior and potential loss of funds". Nothing enforced it. Both routers draw attempt IDs from independent sequencers into one shared attempt store, so a locally sent payment can collide with an in-flight external attempt and deliver one payment's result to the other caller.

This makes the rule enforced rather than a matter of operational discipline. `routerrpc.SendPaymentV2` and `SendToRouteV2` now return `codes.FailedPrecondition` on a `switchrpc` build; they are the only two RPCs that can originate an attempt. `--enable-local-payment-dispatch` opts back in for a node that wants the embedded router anyway, with a warning at startup.

Attempt store cleanup and the external-management DB marker stay tied to the build tag rather than to this flag. Both are destructive to an external router's state, so a wrong config value should not be able to reach them.

### Alternatives considered

- Guarding at `ControlTower.InitPayment` instead of the handlers. That works, since `SendOnion` never touches the control tower. I chose the handlers to keep the switchrpc concept in the RPC layer. `Switch.SendHTLC` is not an option, since nothing there says which router is calling.
- No flag at all, with the guard always on in a `switchrpc` build. The itest binary is built with that tag, so every itest that sends a payment would fail. Making this work means splitting the itest suite so only some of it builds with the tag.
- Owner-scoping the attempt store, so the two routers cannot collide at all. This is the real fix and makes the guard unnecessary, but it is a much larger change in the switch core.

_NOTE_: This would not be needed if lnd supports a new attempt ID format which ensures that multiple routers do not collide within the switch's attempt result store.

### Testing

- New unit tests in `lnrpc/routerrpc` and `config_test.go` cover the guard decision, both handlers, and the build-tag validation. There is also a new itest:

```
make itest icase='local payment dispatch guard'
```

