### PR TITLE
htlcswitch/routerrpc: signal when intercepted forward is on-chain

### DIFF
--- a/htlcswitch/held_htlc_set_test.go
+++ b/htlcswitch/held_htlc_set_test.go
@@ -600,3 +600,15 @@ func TestInterceptableSwitchForwardPacketReturnsHoldError(t *testing.T) {
 	err = s.ForwardPacket(nil)
 	require.ErrorIs(t, err, errNilHeldForward)
 }
+
+// TestIsOnChain ensures that mock forwards signal their on-chain/off-chain
+// state correctly.
+func TestIsOnChain(t *testing.T) {
+	key := testCircuitKey()
+
+	offChainForward := newMockInterceptedForward(key, 100)
+	require.False(t, offChainForward.packet.IsOnChain())
+
+	onChainForward := newMockOnChainInterceptedForward(key, 100)
+	require.True(t, onChainForward.packet.IsOnChain())
+}

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -466,6 +466,21 @@ func (p InterceptedPacket) AutoFailHeight() int32 {
 	)
 }
 
+// IsOnChain returns true when the intercepted packet is on-chain, or false if
+// off-chain. This can be passed to the interceptor to let it know that we
+// expect settle-only semantics for the response.
+func (p InterceptedPacket) IsOnChain() bool {
+	return fn.ElimEither(
+		p.Deadline,
+		func(h OffChainAutoFailHeight) bool {
+			return false
+		},
+		func(d OnChainSettleDeadline) bool {
+			return true
+		},
+	)
+}
+
 // InterceptedForward is passed to the ForwardInterceptor for every forwarded
 // htlc. It contains all the information about the packet which accordingly
 // the interceptor decides if to hold or not.

--- a/itest/lnd_forward_interceptor_test.go
+++ b/itest/lnd_forward_interceptor_test.go
@@ -84,6 +84,7 @@ func testForwardInterceptorDedupHtlc(ht *lntest.HarnessTest) {
 	// saves all intercepted packets. These packets are held to simulate a
 	// pending payment.
 	packet := ht.ReceiveHtlcInterceptor(interceptor)
+	require.False(ht, packet.IsOnChain)
 
 	// Here we should wait for the channel to contain a pending htlc, and
 	// also be shown as being active.
@@ -232,6 +233,7 @@ func testForwardInterceptorBasic(ht *lntest.HarnessTest) {
 	// we check the payment statuses.
 	for _, tc := range testCases {
 		request := ht.ReceiveHtlcInterceptor(interceptor)
+		require.False(ht, request.IsOnChain)
 
 		// Assert sanity of informational packet data.
 		require.NotZero(ht, request.OutgoingRequestedChanId)
@@ -387,6 +389,7 @@ func testForwardInterceptorRestart(ht *lntest.HarnessTest) {
 	// all intercepted packets. These packets are held to simulate a
 	// pending payment.
 	packet := ht.ReceiveHtlcInterceptor(bobInterceptor)
+	require.False(ht, packet.IsOnChain)
 	require.Equal(ht, lntest.CustomRecordsWithUnaccountable(
 		customRecords,
 	), packet.InWireCustomRecords)
@@ -431,6 +434,7 @@ func testForwardInterceptorRestart(ht *lntest.HarnessTest) {
 
 	// We should get another notification about the held HTLC.
 	packet = ht.ReceiveHtlcInterceptor(bobInterceptor)
+	require.False(ht, packet.IsOnChain)
 
 	require.Len(ht, packet.InWireCustomRecords, 2)
 	require.Equal(ht, lntest.CustomRecordsWithUnaccountable(customRecords),
@@ -439,6 +443,7 @@ func testForwardInterceptorRestart(ht *lntest.HarnessTest) {
 	// And now we forward the payment at Carol, expecting only an
 	// accountability signal in our incoming custom records.
 	packet = ht.ReceiveHtlcInterceptor(carolInterceptor)
+	require.False(ht, packet.IsOnChain)
 	require.Len(ht, packet.InWireCustomRecords, 1)
 	err = carolInterceptor.Send(&routerrpc.ForwardHtlcInterceptResponse{
 		IncomingCircuitKey: packet.IncomingCircuitKey,
@@ -522,7 +527,8 @@ func testForwardInterceptorOnChainSettleAfterRestart(ht *lntest.HarnessTest) {
 	}
 	ht.SendPaymentAssertInflight(alice, req)
 
-	_ = ht.ReceiveHtlcInterceptor(interceptor)
+	intercepted := ht.ReceiveHtlcInterceptor(interceptor)
+	require.False(ht, intercepted.IsOnChain)
 	ht.AssertIncomingHTLCActive(bob, cpAB, invoice.RHash)
 	ht.AssertPaymentStatus(alice, payHash, lnrpc.Payment_IN_FLIGHT)
 
@@ -545,7 +551,8 @@ func testForwardInterceptorOnChainSettleAfterRestart(ht *lntest.HarnessTest) {
 
 	// After restart, the incoming contest resolver re-offers the HTLC to
 	// the interceptor through the on-chain path.
-	intercepted := ht.ReceiveHtlcInterceptor(interceptor)
+	intercepted = ht.ReceiveHtlcInterceptor(interceptor)
+	require.True(ht, intercepted.IsOnChain)
 
 	// Mine one block after the on-chain intercept has been offered. With
 	// the current bug, the held entry is evicted here because the on-chain
@@ -616,6 +623,7 @@ func testForwardInterceptorOnChainSettleNoRestart(ht *lntest.HarnessTest) {
 	ht.SendPaymentAssertInflight(alice, req)
 
 	intercepted := ht.ReceiveHtlcInterceptor(interceptor)
+	require.False(ht, intercepted.IsOnChain)
 	ht.AssertIncomingHTLCActive(bob, cpAB, invoice.RHash)
 	ht.AssertPaymentStatus(alice, payHash, lnrpc.Payment_IN_FLIGHT)
 

--- a/lnrpc/routerrpc/forward_interceptor.go
+++ b/lnrpc/routerrpc/forward_interceptor.go
@@ -98,6 +98,7 @@ func (r *forwardInterceptor) onIntercept(
 		OnionBlob:               htlc.OnionBlob[:],
 		AutoFailHeight:          htlc.AutoFailHeight(),
 		InWireCustomRecords:     htlc.InWireCustomRecords,
+		IsOnChain:               htlc.IsOnChain(),
 	}
 
 	// A node-ID forward has no requested outgoing channel. Expose the

--- a/lnrpc/routerrpc/router.pb.go
+++ b/lnrpc/routerrpc/router.pb.go
@@ -2857,8 +2857,10 @@ type ForwardHtlcInterceptRequest struct {
 	//	node ID empty, ordinary channel ID: channel-addressed forward;
 	//	node ID present, channel ID MaxUint64: node-addressed forward.
 	OutgoingRequestedNodeId []byte `protobuf:"bytes,12,opt,name=outgoing_requested_node_id,json=outgoingRequestedNodeId,proto3" json:"outgoing_requested_node_id,omitempty"`
-	unknownFields           protoimpl.UnknownFields
-	sizeCache               protoimpl.SizeCache
+	// Whether this forward is on-chain, requiring settle-only semantics.
+	IsOnChain     bool `protobuf:"varint,13,opt,name=is_on_chain,json=isOnChain,proto3" json:"is_on_chain,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ForwardHtlcInterceptRequest) Reset() {
@@ -2973,6 +2975,13 @@ func (x *ForwardHtlcInterceptRequest) GetOutgoingRequestedNodeId() []byte {
 		return x.OutgoingRequestedNodeId
 	}
 	return nil
+}
+
+func (x *ForwardHtlcInterceptRequest) GetIsOnChain() bool {
+	if x != nil {
+		return x.IsOnChain
+	}
+	return false
 }
 
 // *
@@ -3813,7 +3822,7 @@ const file_routerrpc_router_proto_rawDesc = "" +
 	"\n" +
 	"CircuitKey\x12\x17\n" +
 	"\achan_id\x18\x01 \x01(\x04R\x06chanId\x12\x17\n" +
-	"\ahtlc_id\x18\x02 \x01(\x04R\x06htlcId\"\xe4\x06\n" +
+	"\ahtlc_id\x18\x02 \x01(\x04R\x06htlcId\"\x84\a\n" +
 	"\x1bForwardHtlcInterceptRequest\x12G\n" +
 	"\x14incoming_circuit_key\x18\x01 \x01(\v2\x15.routerrpc.CircuitKeyR\x12incomingCircuitKey\x120\n" +
 	"\x14incoming_amount_msat\x18\x05 \x01(\x04R\x12incomingAmountMsat\x12'\n" +
@@ -3828,7 +3837,8 @@ const file_routerrpc_router_proto_rawDesc = "" +
 	"\x10auto_fail_height\x18\n" +
 	" \x01(\x05R\x0eautoFailHeight\x12t\n" +
 	"\x16in_wire_custom_records\x18\v \x03(\v2?.routerrpc.ForwardHtlcInterceptRequest.InWireCustomRecordsEntryR\x13inWireCustomRecords\x12;\n" +
-	"\x1aoutgoing_requested_node_id\x18\f \x01(\fR\x17outgoingRequestedNodeId\x1a@\n" +
+	"\x1aoutgoing_requested_node_id\x18\f \x01(\fR\x17outgoingRequestedNodeId\x12\x1e\n" +
+	"\vis_on_chain\x18\r \x01(\bR\tisOnChain\x1a@\n" +
 	"\x12CustomRecordsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\x04R\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01\x1aF\n" +

--- a/lnrpc/routerrpc/router.proto
+++ b/lnrpc/routerrpc/router.proto
@@ -968,6 +968,9 @@ message ForwardHtlcInterceptRequest {
     //   node ID empty, ordinary channel ID: channel-addressed forward;
     //   node ID present, channel ID MaxUint64: node-addressed forward.
     bytes outgoing_requested_node_id = 12;
+
+    // Whether this forward is on-chain, requiring settle-only semantics.
+    bool is_on_chain = 13;
 }
 
 /**

--- a/lnrpc/routerrpc/router.swagger.json
+++ b/lnrpc/routerrpc/router.swagger.json
@@ -1614,6 +1614,10 @@
           "type": "string",
           "format": "byte",
           "description": "The requested outgoing node for a blinded forward. When non-empty, this\nfield contains exactly one 33-byte compressed public key and\noutgoing_requested_chan_id is set to 18446744073709551615\n(0xffffffffffffffff). Clients MUST NOT interpret that value as an actual\nchannel ID; the presence of this field identifies a node-addressed\nforward.\n\nThe possible next-hop representations are:\n  node ID empty, channel ID 0: final receive;\n  node ID empty, ordinary channel ID: channel-addressed forward;\n  node ID present, channel ID MaxUint64: node-addressed forward."
+        },
+        "is_on_chain": {
+          "type": "boolean",
+          "description": "Whether this forward is on-chain, requiring settle-only semantics."
         }
       }
     },


### PR DESCRIPTION
This PR allows LND to signal HTLC interceptors that a forward is on-chain, allowing it to use settle-only semantics when responding to avoid errors. Fixes #11021.

## Change Description
I extended the `IntersectedPacket` struct with an `IsOnChain()` function in `htlcswitch`, and added a test for its functionality.

Then I used it to signal the same in the `forwardInterceptor.onIntercept()` function in `routerrpc`.

Finally, I updated the integration tests to check this field in the RPC requests.

## Steps to Test
The unit and integration test updates should be sufficient.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.