### PR TITLE
ci: bind check-label composite inputs via env before shell

### DIFF
--- a/.github/actions/check-label/action.yml
+++ b/.github/actions/check-label/action.yml
@@ -20,11 +20,14 @@ runs:
     - name: Check for label
       id: check
       shell: bash
+      env:
+        HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, inputs.label) }}
+        SKIP_MESSAGE: ${{ inputs.skip-message }}
       run: |
-        if [[ "${{ contains(github.event.pull_request.labels.*.name, inputs.label) }}" == "true" ]]; then
-          echo "::notice::${{ inputs.skip-message }}"
-          echo "${{ inputs.skip-message }}" >> $GITHUB_STEP_SUMMARY
-          echo "skip=true" >> $GITHUB_OUTPUT
+        if [[ "$HAS_LABEL" == "true" ]]; then
+          echo "::notice::$SKIP_MESSAGE"
+          echo "$SKIP_MESSAGE" >> "$GITHUB_STEP_SUMMARY"
+          echo "skip=true" >> "$GITHUB_OUTPUT"
         else
-          echo "skip=false" >> $GITHUB_OUTPUT
+          echo "skip=false" >> "$GITHUB_OUTPUT"
         fi


### PR DESCRIPTION
## Summary
- Bind `inputs.skip-message` and the computed label-contains result through `env:` before shell echo/notice steps in the check-label composite action.
- Same class as GitHub’s documented script-injection guidance for interpolating composite action inputs into `run:` scripts.

## Test plan
- [ ] PRs with the configured label still set `skip=true` and print the skip message
- [ ] PRs without the label still set `skip=false`


Made with [Cursor](https://cursor.com)