### PR TITLE
contractcourt: retain deadline across contest resolution

### DIFF
--- a/contractcourt/htlc_outgoing_contest_resolver.go
+++ b/contractcourt/htlc_outgoing_contest_resolver.go
@@ -230,10 +230,14 @@ func (h *htlcOutgoingContestResolver) Encode(w io.Writer) error {
 	return h.htlcTimeoutResolver.Encode(w)
 }
 
-// SupplementDeadline does nothing for an incoming htlc resolver.
+// SupplementDeadline forwards the incoming HTLC's expiry height to the inner
+// timeout resolver. This resolver morphs into that timeout resolver once the
+// outgoing HTLC expires on-chain, so the deadline is retained across the
+// transition.
 //
 // NOTE: Part of the htlcContractResolver interface.
-func (h *htlcOutgoingContestResolver) SupplementDeadline(_ fn.Option[int32]) {
+func (h *htlcOutgoingContestResolver) SupplementDeadline(d fn.Option[int32]) {
+	h.htlcTimeoutResolver.SupplementDeadline(d)
 }
 
 // newOutgoingContestResolverFromReader attempts to decode an encoded ContractResolver

--- a/contractcourt/htlc_outgoing_contest_resolver_test.go
+++ b/contractcourt/htlc_outgoing_contest_resolver_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/graph/db/models"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/kvdb"
@@ -20,6 +21,10 @@ import (
 
 const (
 	outgoingContestHtlcExpiry = 110
+
+	// outgoingContestIncomingHtlcExpiry is kept distinct from the outgoing
+	// HTLC expiry to verify that the supplied value is retained.
+	outgoingContestIncomingHtlcExpiry = 144
 )
 
 // TestHtlcOutgoingResolverTimeout tests resolution of an offered htlc that
@@ -114,6 +119,36 @@ func TestHtlcOutgoingResolverRemoteClaim(t *testing.T) {
 type resolveResult struct {
 	err          error
 	nextResolver ContractResolver
+}
+
+// TestHtlcOutgoingResolverSupplementDeadline checks that the outgoing contest
+// resolver forwards the incoming HTLC deadline to the timeout resolver it
+// transitions into once the outgoing HTLC expires on-chain.
+func TestHtlcOutgoingResolverSupplementDeadline(t *testing.T) {
+	t.Parallel()
+	defer timeout()()
+
+	ctx := newOutgoingResolverTestContext(t)
+
+	// Initially the embedded timeout resolver carries no deadline.
+	require.True(t, ctx.resolver.incomingHTLCExpiryHeight.IsNone())
+
+	// Supply the deadline through the contest resolver, as the channel
+	// arbitrator does when constructing the resolver.
+	deadline := fn.Some(int32(outgoingContestIncomingHtlcExpiry))
+	ctx.resolver.SupplementDeadline(deadline)
+
+	// Drive the contest resolver to the point where it returns the embedded
+	// timeout resolver.
+	ctx.resolve()
+	ctx.notifyEpoch(outgoingContestHtlcExpiry)
+
+	result := <-ctx.resolverResultChan
+	require.NoError(t, result.err)
+
+	timeoutRes, ok := result.nextResolver.(*htlcTimeoutResolver)
+	require.True(t, ok, "expected htlcTimeoutResolver")
+	require.Equal(t, deadline, timeoutRes.incomingHTLCExpiryHeight)
 }
 
 type outgoingResolverTestContext struct {

--- a/docs/release-notes/release-notes-0.21.2.md
+++ b/docs/release-notes/release-notes-0.21.2.md
@@ -68,6 +68,11 @@
   that peer, and rejects an absent script instead of treating it as nothing to
   check.
 
+* Outgoing contest resolvers now [retain the corresponding incoming HTLC
+  expiry](https://github.com/lightningnetwork/lnd/pull/11032) when transitioning
+  to timeout resolution, allowing the sweeper to continue using an
+  expiry-aware confirmation target.
+
 # New Features
 
 ## Functional Enhancements


### PR DESCRIPTION
## Change Description

Outgoing contest resolvers embed the timeout resolver they transition to once
the outgoing HTLC reaches its expiry. Forward the corresponding incoming HTLC
expiry to that embedded resolver so the existing deadline remains available
after the transition.

The added test exercises the contest-to-timeout transition and checks that the
supplied deadline is retained.

## Steps to Test

```shell
go test ./contractcourt \
  -run 'TestHtlcOutgoingResolver(SupplementDeadline|Timeout|RemoteClaim)$' \
  -count=1
```

## Pull Request Checklist

### Testing

- [ ] Your PR passes all CI checks.
- [x] Tests covering the changed behavior are included.

### Code Style and Documentation

- [x] The change follows the code documentation and line-length guidelines.
- [x] Commits follow the ideal Git commit structure.
- [x] A change description is included in the `0.21.2` release notes.
