### PR TITLE
lnwallet/chancloser: use valid delivery scripts in RBF closer tests

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -136,6 +136,15 @@
 
 ## Testing
 
+* [Fixed an invalid delivery-script fixture in the RBF cooperative close
+  tests](https://github.com/lightningnetwork/lnd/pull/11042).
+  `TestRbfChannelActiveTransitions` shadowed the package-level delivery
+  addresses with byte blobs that are not well-formed shutdown scripts. The
+  subtests using them all tripped an earlier guard in `validateShutdown`, so the
+  bad fixture was never reached and nothing failed — but reordering those guards
+  would have panicked the package's test binary from inside the mock error
+  reporter, far from the fixture actually at fault.
+
 ## Database
 
 ## Code Health

--- a/lnwallet/chancloser/rbf_coop_test.go
+++ b/lnwallet/chancloser/rbf_coop_test.go
@@ -32,6 +32,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Both of these must stay well-formed delivery scripts (they're P2TR here).
+// Tests that drive a shutdown all the way through validateShutdown depend on
+// them clearing the delivery-script check, and tests that target an earlier
+// guard depend on the script not being what fails.
 var (
 	localAddr = lnwire.DeliveryAddress(append(
 		[]byte{txscript.OP_1, txscript.OP_DATA_32},
@@ -1369,8 +1373,6 @@ func testRemoteInitiatedCloseOkTaproot(t *testing.T, ctx context.Context) {
 // ChannelActive state.
 func TestRbfChannelActiveTransitions(t *testing.T) {
 	ctx := t.Context()
-	localAddr := lnwire.DeliveryAddress(bytes.Repeat([]byte{0x01}, 20))
-	remoteAddr := lnwire.DeliveryAddress(bytes.Repeat([]byte{0x02}, 20))
 
 	feeRate := chainfee.SatPerVByte(1000)
 


### PR DESCRIPTION
## Change Description

`TestRbfChannelActiveTransitions` shadows the package-level `localAddr` and
`remoteAddr` with twenty raw bytes each:

```go
localAddr := lnwire.DeliveryAddress(bytes.Repeat([]byte{0x01}, 20))
remoteAddr := lnwire.DeliveryAddress(bytes.Repeat([]byte{0x02}, 20))
```

Neither is a well-formed delivery script — not a witness program, and not any
other template a co-op close is willing to pay to — so both are rejected by
`validateShutdownScript`.

### Why it goes unnoticed today

`validateShutdown` is a chain of guards with early returns:

| order | guard | error |
|---|---|---|
| 1 | thaw height not reached | `ErrThawHeightNotReached` |
| 2 | taproot shutdown nonce missing | `ErrTaprootShutdownNonceMissing` |
| 3 | delivery script invalid | `ErrInvalidShutdownScript` |

Both subtests that feed the shadowed `remoteAddr` into a `ShutdownReceived` —
`remote_initiated_thaw_height_close_fail` and
`remote_initiated_taproot_no_nonce_fail` — trip an earlier guard on purpose, so
guard 3 is never reached. The one subtest that drives the whole chain,
`remote_initiated_close_ok`, was extracted in #11019 into
`testRemoteInitiatedCloseOkNonTap` / `testRemoteInitiatedCloseOkTaproot`, which
sit outside the shadow and therefore pick up the valid package-level scripts.

To be clear: **nothing currently passes for the wrong reason.** The harness
asserts on specific sentinel errors via `errors.Is`. But that holds only by
accident of where the failures happen to land, not by design.

### Why it is worth fixing anyway

The cost is paid by whoever touches that guard chain next, and it is not paid
in a readable failure. Hoisting the delivery-script check above the thaw-height
check — a reasonable thing to want, since it is the cheaper check — does not
produce an assertion diff. The unexpected `ErrInvalidShutdownScript` reaches the
mock error reporter as an unmatched call and **panics the package's test
binary**:

```
panic: mock: Unexpected Method Call
  ReportError(*errors.errorString)
      0: &errors.errorString{s:"invalid shutdown script"}
```

The stack points into `protofsm/state_machine.go` and `mock.go`, not at the
fixture that is actually wrong.

Deleting the two shadowing locals with that same reorder still applied: the
whole package passes. So the shadow is the sole cause.

There is a second, quieter cost. `local_initiated_close_ok` passes the invalid
`localAddr` as `localUpfrontAddr` and asserts it lands in state unchallenged.
#11019 only added validation on the *remote* side; if anyone later makes that
symmetric, this test breaks for fixture reasons rather than subject reasons.

### The fix

Drop the shadowing locals so those subtests use the valid package-level P2TR
scripts, and record the invariant where the scripts are declared. The general
principle: a negative test's fixture should be valid in every dimension except
the one under test, or it is not isolating what it claims to.

### Where this came from

Found while backporting #11019 to `v0.20.x`. On that branch
`remote_initiated_close_ok` is still an inline subtest rather than an extracted
helper, so it sits *inside* the shadow and picks up the 20-byte blob. Once
#11019 makes delivery-script validation unconditional, that subtest fails with
`invalid shutdown script`. Master escapes this only because of the helper
extraction described above. The backport carries the same fixture fix; this PR
brings it to master, where it is latent rather than active.

## Steps to Test

```
go test ./lnwallet/chancloser/... -race -count=1
```

To reproduce the latent failure this prevents, hoist the
`validateRemoteDeliveryScript` call to the top of `validateShutdown` in
`lnwallet/chancloser/rbf_coop_transitions.go` and run the package tests — on
`master` the binary panics; with this change it passes.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

Added under `## Testing` in `release-notes-0.22.0.md`. This is a test-only
change with no user-visible effect, so `no-changelog` would also be reasonable
if maintainers prefer to keep that section for feature-level test work.
