### PR TITLE
docs: move post-0.20.2 entries into new 0.20.3 release notes

### DIFF
--- a/docs/release-notes/release-notes-0.20.2.md
+++ b/docs/release-notes/release-notes-0.20.2.md
@@ -36,45 +36,11 @@
   distinguish off-chain auto-fail heights from on-chain settlement deadlines,
   or `AutoFailHeight()` if they only need the legacy flattened value.
 
-* [Bounded the memory used while syncing the channel
-  graph](https://github.com/lightningnetwork/lnd/pull/10992). A peer replying
-  to our `query_channel_range` could previously make us buffer an
-  unpredictable number of short channel IDs, as the only limit was a coarse
-  67MB cap on the bytes a single zlib-compressed reply could decompress to.
-  Replies are now capped at a precise number of short channel IDs, both
-  per-message and in aggregate across a single query, and the accumulated
-  reply state is released as soon as any reply fails validation so that a
-  peer cannot pin it by deliberately forcing an error.
-
-* [Refined invoice update
-  handling](https://github.com/lightningnetwork/lnd/pull/11024) across MPP, AMP,
-  and legacy payment paths, including keysend records and preimage-dependent
-  settlement outcomes.
-
-* Outgoing contest resolvers now [retain the corresponding incoming HTLC
-  expiry](https://github.com/lightningnetwork/lnd/pull/11032) when transitioning
-  to timeout resolution, allowing the sweeper to continue using an
-  expiry-aware confirmation target.
-
-* [Fixed a data race](https://github.com/lightningnetwork/lnd/pull/11019) in the
-  legacy cooperative close state machine, which was advanced from both the link
-  goroutine and the peer goroutine with nothing synchronizing the two. The link
-  now reports a flushed channel to the peer's channel manager instead of driving
-  the closer itself, so every step of a close runs on a single goroutine. The
-  same change has the RBF closer validate the remote party's delivery script in
-  all cases, rather than only when an upfront shutdown script was on record for
-  that peer, and rejects an absent script instead of treating it as nothing to
-  check.
-
 # New Features
 
 ## Functional Enhancements
 
 ## RPC Additions
-
-* The [HTLC interceptor](https://github.com/lightningnetwork/lnd/pull/10942) now
-  exposes the next hop of a blinded route that identifies it by node ID
-  (`next_node_id`) rather than by channel.
 
 ## lncli Additions
 
@@ -92,20 +58,7 @@
   will now have its `UpdateChannelPolicy` request rejected, and must lower the
   value accordingly below the specified maximum.
 
-* [The HTLC forward interceptor now validates](https://github.com/lightningnetwork/lnd/pull/11028)
-  that derived auto-fail heights are within the supported range before they are
-  exposed through the interceptor API.
-
 ## RPC Updates
-
-* `ForwardHtlcInterceptRequest.outgoing_requested_chan_id` now holds a reserved
-  sentinel value (`18446744073709551615`, all bits set) when the
-  [HTLC interceptor](https://github.com/lightningnetwork/lnd/pull/10942) reports
-  a blinded forward that identifies the next hop by node ID. The sender of such
-  a forward requests no channel, so a zero value here would make a client that
-  detects the exit hop by a zero channel ID classify the forward as a final
-  receive. Clients that switch on this field must handle the sentinel and read
-  `outgoing_requested_node_id` for the next hop.
 
 ## lncli Updates
 
@@ -118,13 +71,6 @@
 # Technical and Architectural Updates
 ## BOLT Spec Updates
 
-* [Fixed an issue](https://github.com/lightningnetwork/lnd/pull/10942) where an
-  lnd node acting as a relaying node (including the introduction node) in a
-  blinded path failed to forward the payment when the next hop was identified by
-  node ID (`next_node_id`) rather than a short channel ID. The next hop's public
-  key is now resolved to one of our channels with that peer using non-strict
-  forwarding.
-
 ## Testing
 
 ## Database
@@ -136,5 +82,4 @@
 # Contributors (Alphabetical Order)
 
 * Erick Cestari
-* Olaoluwa Osuntokun
 * Ziggie

--- a/docs/release-notes/release-notes-0.20.3.md
+++ b/docs/release-notes/release-notes-0.20.3.md
@@ -1,0 +1,116 @@
+# Release Notes
+- [Bug Fixes](#bug-fixes)
+- [New Features](#new-features)
+    - [Functional Enhancements](#functional-enhancements)
+    - [RPC Additions](#rpc-additions)
+    - [lncli Additions](#lncli-additions)
+- [Improvements](#improvements)
+    - [Functional Updates](#functional-updates)
+    - [RPC Updates](#rpc-updates)
+    - [lncli Updates](#lncli-updates)
+    - [Breaking Changes](#breaking-changes)
+    - [Performance Improvements](#performance-improvements)
+    - [Deprecations](#deprecations)
+- [Technical and Architectural Updates](#technical-and-architectural-updates)
+    - [BOLT Spec Updates](#bolt-spec-updates)
+    - [Testing](#testing)
+    - [Database](#database)
+    - [Code Health](#code-health)
+    - [Tooling and Documentation](#tooling-and-documentation)
+- [Contributors (Alphabetical Order)](#contributors-alphabetical-order)
+
+# Bug Fixes
+
+* [Bounded the memory used while syncing the channel
+  graph](https://github.com/lightningnetwork/lnd/pull/10992). A peer replying
+  to our `query_channel_range` could previously make us buffer an
+  unpredictable number of short channel IDs, as the only limit was a coarse
+  67MB cap on the bytes a single zlib-compressed reply could decompress to.
+  Replies are now capped at a precise number of short channel IDs, both
+  per-message and in aggregate across a single query, and the accumulated
+  reply state is released as soon as any reply fails validation so that a
+  peer cannot pin it by deliberately forcing an error.
+
+* [Refined invoice update
+  handling](https://github.com/lightningnetwork/lnd/pull/11024) across MPP, AMP,
+  and legacy payment paths, including keysend records and preimage-dependent
+  settlement outcomes.
+
+* [Fixed a data race](https://github.com/lightningnetwork/lnd/pull/11019) in the
+  legacy cooperative close state machine, which was advanced from both the link
+  goroutine and the peer goroutine with nothing synchronizing the two. The link
+  now reports a flushed channel to the peer's channel manager instead of driving
+  the closer itself, so every step of a close runs on a single goroutine. The
+  same change has the RBF closer validate the remote party's delivery script in
+  all cases, rather than only when an upfront shutdown script was on record for
+  that peer, and rejects an absent script instead of treating it as nothing to
+  check.
+
+* Outgoing contest resolvers now [retain the corresponding incoming HTLC
+  expiry](https://github.com/lightningnetwork/lnd/pull/11032) when transitioning
+  to timeout resolution, allowing the sweeper to continue using an
+  expiry-aware confirmation target.
+
+# New Features
+
+## Functional Enhancements
+
+## RPC Additions
+
+* The [HTLC interceptor](https://github.com/lightningnetwork/lnd/pull/10942) now
+  exposes the next hop of a blinded route that identifies it by node ID
+  (`next_node_id`) rather than by channel.
+
+## lncli Additions
+
+# Improvements
+
+## Functional Updates
+
+* [The HTLC forward interceptor now validates](https://github.com/lightningnetwork/lnd/pull/11028)
+  that derived auto-fail heights are within the supported range before they are
+  exposed through the interceptor API.
+
+## RPC Updates
+
+* `ForwardHtlcInterceptRequest.outgoing_requested_chan_id` now holds a reserved
+  sentinel value (`18446744073709551615`, all bits set) when the
+  [HTLC interceptor](https://github.com/lightningnetwork/lnd/pull/10942) reports
+  a blinded forward that identifies the next hop by node ID. The sender of such
+  a forward requests no channel, so a zero value here would make a client that
+  detects the exit hop by a zero channel ID classify the forward as a final
+  receive. Clients that switch on this field must handle the sentinel and read
+  `outgoing_requested_node_id` for the next hop.
+
+## lncli Updates
+
+## Breaking Changes
+
+## Performance Improvements
+
+## Deprecations
+
+# Technical and Architectural Updates
+
+## BOLT Spec Updates
+
+* [Fixed an issue](https://github.com/lightningnetwork/lnd/pull/10942) where an
+  lnd node acting as a relaying node (including the introduction node) in a
+  blinded path failed to forward the payment when the next hop was identified by
+  node ID (`next_node_id`) rather than a short channel ID. The next hop's public
+  key is now resolved to one of our channels with that peer using non-strict
+  forwarding.
+
+## Testing
+
+## Database
+
+## Code Health
+
+## Tooling and Documentation
+
+# Contributors (Alphabetical Order)
+
+* bitromortac
+* Olaoluwa Osuntokun
+* Ziggie


### PR DESCRIPTION
## Change

`v0.20.2-beta` was tagged on 2026-07-07 and [published as a
release](https://github.com/lightningnetwork/lnd/releases/tag/v0.20.2-beta) the
following day. The seven backports that landed on `v0.20.x-branch` afterwards
all appended their release-note entries to `release-notes-0.20.2.md`, because no
notes file existed yet for the next patch release. As a result the published
0.20.2 notes currently advertise fixes that are not in the 0.20.2 binaries.

This PR creates `release-notes-0.20.3.md` and moves those entries into it,
restoring `release-notes-0.20.2.md` to exactly its content at the
`v0.20.2-beta` tag.

Entries moved (all landed after the tag):

| Section | Entry |
|---|---|
| Bug Fixes | Bounded graph-sync memory (#10992) |
| Bug Fixes | Refined invoice update handling (#11024) |
| Bug Fixes | Coop close state machine data race (#11019) |
| Bug Fixes | Contest resolver retains incoming HTLC expiry (#11032) |
| RPC Additions | Interceptor exposes blinded `next_node_id` (#10942) |
| Functional Updates | Interceptor auto-fail height validation (#11028) |
| RPC Updates | `outgoing_requested_chan_id` sentinel (#10942) |
| BOLT Spec Updates | Blinded path `next_node_id` forwarding (#10942) |

## Notes

- The entry prose is carried over **verbatim** — no rewording. It matches the
  wording already used for the same backports in `release-notes-0.21.2.md` on
  `v0.21.x-branch`, which targeted its notes file correctly.
- Contributors for 0.20.3 are scoped to the authors of the changes that have
  entries above: bitromortac, Olaoluwa Osuntokun and Ziggie.

## Validation

- `release-notes-0.20.2.md` is byte-identical to `git show v0.20.2-beta:docs/release-notes/release-notes-0.20.2.md`.
- All 47 content lines added to the 0.20.2 file after the tag appear verbatim in the new 0.20.3 file; the PR-link sets on both sides match exactly.

Companion to #11044, which bumps the branch to `v0.20.3-beta.rc1`.

## Completeness audit

Every merge on `v0.20.x-branch` after `c863397a4` (the `v0.20.2-beta` tag commit)
was enumerated and mapped to its entry. Nothing reached the branch outside a
backport PR — a first-parent walk shows no direct pushes.

| Original PR | Backport | Entry in 0.20.3 |
|---|---|---|
| #11019 lnwallet/chancloser: fix data race in the legacy coop close state machine | #11030 | yes |
| #11028 htlcswitch: validate intercepted auto-fail height | #11038 | yes |
| #11032 contractcourt: retain deadline across contest resolution | #11033 | yes |
| #11024 invoices: refine update handling | #11026 | yes |
| #10992 discovery: bound channel range reply memory usage | #11016 | yes |
| #10942 htlcswitch: forward blinded payments addressed by node_id | #11009 | yes |
| #10637 Fix linter issue in brontide.go | #11040 | none — see below |

#10637 is a single added blank line in `peer/brontide.go` and is labeled
`no-changelog` upstream, so it correctly has no entry.

