### PR TITLE
multi: improve resolution lifecycle safety

### DIFF
--- a/chainntnfs/bitcoindnotify/bitcoind.go
+++ b/chainntnfs/bitcoindnotify/bitcoind.go
@@ -717,13 +717,16 @@ func (b *BitcoindNotifier) notifyBlockEpochClient(epochClient *blockEpochRegistr
 // Once a spend of has been detected, the details of the spending event will be
 // sent across the 'Spend' channel.
 func (b *BitcoindNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	pkScript []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	pkScript []byte, heightHint uint32,
+	opts ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
 	// Register the conf notification with the TxNotifier. A non-nil value
 	// for `dispatch` will be returned if we are required to perform a
 	// manual scan for the confirmation. Otherwise the notifier will begin
 	// watching at tip for the transaction to confirm.
-	ntfn, err := b.txNotifier.RegisterSpend(outpoint, pkScript, heightHint)
+	ntfn, err := b.txNotifier.RegisterSpend(
+		outpoint, pkScript, heightHint, opts...,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/chainntnfs/btcdnotify/btcd.go
+++ b/chainntnfs/btcdnotify/btcd.go
@@ -787,13 +787,16 @@ func (b *BtcdNotifier) notifyBlockEpochClient(epochClient *blockEpochRegistratio
 // Once a spend of has been detected, the details of the spending event will be
 // sent across the 'Spend' channel.
 func (b *BtcdNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	pkScript []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	pkScript []byte, heightHint uint32,
+	opts ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
 	// Register the conf notification with the TxNotifier. A non-nil value
 	// for `dispatch` will be returned if we are required to perform a
 	// manual scan for the confirmation. Otherwise the notifier will begin
 	// watching at tip for the transaction to confirm.
-	ntfn, err := b.txNotifier.RegisterSpend(outpoint, pkScript, heightHint)
+	ntfn, err := b.txNotifier.RegisterSpend(
+		outpoint, pkScript, heightHint, opts...,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/chainntnfs/interface.go
+++ b/chainntnfs/interface.go
@@ -95,6 +95,53 @@ func WithIncludeBlock() NotifierOption {
 	}
 }
 
+// SpendOptions is the caller-selected policy for a spend notification.
+type SpendOptions struct {
+	// NumConfs is the number of confirmations required before the spend is
+	// delivered as mature.
+	NumConfs uint32
+}
+
+// DefaultSpendOptions preserves the historical one-confirmation spend
+// notification behavior for callers that do not supply an option.
+func DefaultSpendOptions() *SpendOptions {
+	return &SpendOptions{NumConfs: 1}
+}
+
+// SpendOption changes one aspect of a spend notification policy.
+type SpendOption func(*SpendOptions)
+
+// WithSpendNumConfs requests delivery only after the spending transaction has
+// reached numConfs confirmations. Registration rejects values outside the
+// notifier's supported reorg window.
+func WithSpendNumConfs(numConfs uint32) SpendOption {
+	return func(o *SpendOptions) {
+		// Store the requested depth here so every notifier backend
+		// applies the same maturity policy through TxNotifier.
+		o.NumConfs = numConfs
+	}
+}
+
+// ParseSpendOptions applies caller options to the compatibility default and
+// rejects values no notifier is allowed to support. A concrete TxNotifier
+// performs its possibly smaller reorg-window check during registration.
+func ParseSpendOptions(optFuncs ...SpendOption) (*SpendOptions, error) {
+	opts := DefaultSpendOptions()
+	for _, optFunc := range optFuncs {
+		// Apply options in call order so the last value follows the
+		// established functional-option convention.
+		optFunc(opts)
+	}
+
+	if opts.NumConfs == 0 || opts.NumConfs > MaxNumConfs {
+		// Reject unsupported depths before a backend installs watches
+		// or mutates registration state.
+		return nil, ErrNumConfsOutOfRange
+	}
+
+	return opts, nil
+}
+
 // ChainNotifier represents a trusted source to receive notifications concerning
 // targeted events on the Bitcoin blockchain. The interface specification is
 // intentionally general in order to support a wide array of chain notification
@@ -143,13 +190,14 @@ type ChainNotifier interface {
 	// light clients. It denotes the earliest height in the blockchain in
 	// which the target output could have been spent.
 	//
-	// NOTE: The notification should only be triggered when the spending
-	// transaction receives a single confirmation.
+	// By default, the notification is triggered when the spending
+	// transaction receives one confirmation. A SpendOption can request a
+	// deeper notification within the notifier's supported reorg window.
 	//
 	// NOTE: Dispatching notifications to multiple clients subscribed to a
 	// spend of the same outpoint MUST be supported.
 	RegisterSpendNtfn(outpoint *wire.OutPoint, pkScript []byte,
-		heightHint uint32) (*SpendEvent, error)
+		heightHint uint32, opts ...SpendOption) (*SpendEvent, error)
 
 	// RegisterBlockEpochNtfn registers an intent to be notified of each
 	// new block connected to the tip of the main chain. The returned

--- a/chainntnfs/mocks.go
+++ b/chainntnfs/mocks.go
@@ -77,9 +77,18 @@ func (m *MockChainNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash,
 // RegisterSpendNtfn registers an intent to be notified once the target
 // outpoint is successfully spent within a transaction.
 func (m *MockChainNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	pkScript []byte, heightHint uint32) (*SpendEvent, error) {
+	pkScript []byte, heightHint uint32,
+	opts ...SpendOption) (*SpendEvent, error) {
 
-	args := m.Called(outpoint, pkScript, heightHint)
+	// Preserve existing three-argument expectations, while exposing the
+	// option slice when a test needs to verify a requested spend depth.
+	callArgs := []interface{}{outpoint, pkScript, heightHint}
+	if len(opts) != 0 {
+		// Keep all options in one argument. This lets mock expectations
+		// compare the exact policy passed through an adapter.
+		callArgs = append(callArgs, opts)
+	}
+	args := m.Called(callArgs...)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/chainntnfs/neutrinonotify/neutrino.go
+++ b/chainntnfs/neutrinonotify/neutrino.go
@@ -761,13 +761,16 @@ func (n *NeutrinoNotifier) notifyBlockEpochClient(epochClient *blockEpochRegistr
 // Once a spend of has been detected, the details of the spending event will be
 // sent across the 'Spend' channel.
 func (n *NeutrinoNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	pkScript []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	pkScript []byte, heightHint uint32,
+	opts ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
 	// Register the conf notification with the TxNotifier. A non-nil value
 	// for `dispatch` will be returned if we are required to perform a
 	// manual scan for the confirmation. Otherwise the notifier will begin
 	// watching at tip for the transaction to confirm.
-	ntfn, err := n.txNotifier.RegisterSpend(outpoint, pkScript, heightHint)
+	ntfn, err := n.txNotifier.RegisterSpend(
+		outpoint, pkScript, heightHint, opts...,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/chainntnfs/test/test_interface.go
+++ b/chainntnfs/test/test_interface.go
@@ -406,6 +406,129 @@ func testSpendNotificationDepth(
 	require.Equal(t, spendHeight, atThree.SpendingHeight)
 }
 
+// testHistoricalSpendNotificationDepth proves each backend applies explicit
+// maturity to a spend found by its historical dispatch path.
+func testHistoricalSpendNotificationDepth(
+	miner *rpctest.Harness, notifier chainntnfs.TestChainNotifier,
+	scriptDispatch bool, t *testing.T) {
+
+	// Arrange a spend and an epoch client before mining so the depth-aware
+	// registration can begin only after the transaction is historical.
+	const numConfs = uint32(3)
+	outpoint, output, privKey := chainntnfs.CreateSpendableOutput(t, miner)
+	tipHash, heightHint, err := miner.Client.GetBestBlock()
+	require.NoError(t, err, "unable to get current height")
+	spendingTx := chainntnfs.CreateSpendTx(t, outpoint, output, privKey)
+	spenderHash, err := miner.Client.SendRawTransaction(spendingTx, true)
+	require.NoError(t, err, "unable to broadcast spend")
+	require.NoError(
+		t, chainntnfs.WaitForMempoolTx(miner, spenderHash),
+		"spend was not relayed to miner",
+	)
+	epochClient, err := notifier.RegisterBlockEpochNtfn(nil)
+	require.NoError(t, err, "unable to register for block epochs")
+	t.Cleanup(epochClient.Cancel)
+	// Drain the registration-time tip event so the Act phase synchronizes
+	// exclusively with blocks mined after the historical setup completes.
+	waitForNotifierEpoch(t, epochClient, tipHash)
+
+	// Act by mining the spend first, registering from the earlier hint, and
+	// advancing through its remaining depth. An extra block before the
+	// second registration exercises cached delivery strictly after, rather
+	// than exactly at, the maturity boundary.
+	blockHashes, err := miner.Client.Generate(1)
+	require.NoError(t, err, "unable to mine historical spend")
+	waitForNotifierEpoch(t, epochClient, blockHashes[0])
+	_, spendHeight, err := miner.Client.GetBestBlock()
+	require.NoError(t, err, "unable to get historical spend height")
+	var spendClient *chainntnfs.SpendEvent
+	if scriptDispatch {
+		// Register the historical script-only path here so this test
+		// visibly applies the option to the subject API.
+		spendClient, err = notifier.RegisterSpendNtfn(
+			nil, output.PkScript, uint32(heightHint),
+			chainntnfs.WithSpendNumConfs(numConfs),
+		)
+	} else {
+		// Register the historical outpoint path with the same option
+		// so every backend dispatch mode is exercised directly.
+		spendClient, err = notifier.RegisterSpendNtfn(
+			outpoint, output.PkScript, uint32(heightHint),
+			chainntnfs.WithSpendNumConfs(numConfs),
+		)
+	}
+	require.NoError(t, err, "unable to register historical spend")
+	t.Cleanup(spendClient.Cancel)
+
+	blockHashes, err = miner.Client.Generate(1)
+	require.NoError(t, err, "unable to mine pre-maturity block")
+	waitForNotifierEpoch(t, epochClient, blockHashes[0])
+	beforeMaturity, beforeMaturityOK := pollSpendNotification(
+		spendClient.Spend,
+	)
+
+	blockHashes, err = miner.Client.Generate(1)
+	require.NoError(t, err, "unable to mine historical maturity")
+	waitForNotifierEpoch(t, epochClient, blockHashes[0])
+	var matureSpend *chainntnfs.SpendDetail
+	select {
+	case matureSpend = <-spendClient.Spend:
+		// Retain asynchronous delivery so semantic checks remain in the
+		// dedicated Assert phase below.
+
+	case <-time.After(30 * time.Second):
+		t.Fatalf("historical spend did not mature")
+	}
+
+	blockHashes, err = miner.Client.Generate(1)
+	require.NoError(t, err, "unable to mine past historical maturity")
+	waitForNotifierEpoch(t, epochClient, blockHashes[0])
+
+	var cachedClient *chainntnfs.SpendEvent
+	if scriptDispatch {
+		// Repeat the script-only subject call after maturity to prove
+		// cached delivery retains the explicit depth contract.
+		cachedClient, err = notifier.RegisterSpendNtfn(
+			nil, output.PkScript, uint32(heightHint),
+			chainntnfs.WithSpendNumConfs(numConfs),
+		)
+	} else {
+		// Repeat the outpoint subject call after maturity so cached
+		// delivery is covered without hiding the registration option.
+		cachedClient, err = notifier.RegisterSpendNtfn(
+			outpoint, output.PkScript, uint32(heightHint),
+			chainntnfs.WithSpendNumConfs(numConfs),
+		)
+	}
+	require.NoError(t, err, "unable to register cached mature spend")
+	t.Cleanup(cachedClient.Cancel)
+	var cachedSpend *chainntnfs.SpendDetail
+	select {
+	case cachedSpend = <-cachedClient.Spend:
+		// Historical dispatch is asynchronous, so retain its result
+		// after bounded delivery for comparison in the Assert phase.
+
+	case <-time.After(30 * time.Second):
+		t.Fatalf("cached historical spend was not delivered")
+	}
+
+	// Assert the historical candidate remains hidden at depth two, then is
+	// delivered to both the pending client and a post-maturity
+	// registration.
+	require.False(t, beforeMaturityOK)
+	require.Nil(t, beforeMaturity)
+	require.NotNil(t, matureSpend)
+	require.Equal(t, *outpoint, *matureSpend.SpentOutPoint)
+	require.Equal(t, *spenderHash, *matureSpend.SpenderTxHash)
+	require.Zero(t, matureSpend.SpenderInputIndex)
+	require.Equal(t, spendHeight, matureSpend.SpendingHeight)
+	require.NotNil(t, cachedSpend)
+	require.Equal(t, *outpoint, *cachedSpend.SpentOutPoint)
+	require.Equal(t, *spenderHash, *cachedSpend.SpenderTxHash)
+	require.Zero(t, cachedSpend.SpenderInputIndex)
+	require.Equal(t, spendHeight, cachedSpend.SpendingHeight)
+}
+
 func testSpendNotification(miner *rpctest.Harness,
 	notifier chainntnfs.TestChainNotifier, scriptDispatch bool, t *testing.T) {
 
@@ -1975,6 +2098,10 @@ var txNtfnTests = []txNtfnTestCase{
 	{
 		name: "historical spend dispatch",
 		test: testSpendBeforeNtfnRegistration,
+	},
+	{
+		name: "historical spend depth dispatch",
+		test: testHistoricalSpendNotificationDepth,
 	},
 	{
 		name: "reorg spend",

--- a/chainntnfs/test/test_interface.go
+++ b/chainntnfs/test/test_interface.go
@@ -273,6 +273,139 @@ func checkNotificationFields(ntfn *chainntnfs.SpendDetail,
 	}
 }
 
+// waitForNotifierEpoch ignores stale epochs until the exact block arrives.
+func waitForNotifierEpoch(t *testing.T,
+	epochClient *chainntnfs.BlockEpochEvent,
+	expectedHash *chainhash.Hash) {
+
+	t.Helper()
+
+	// A bounded wait turns backend synchronization failures into a focused
+	// test error instead of allowing later spend assertions to race.
+	timeout := time.After(30 * time.Second)
+	for {
+		select {
+		case epoch, ok := <-epochClient.Epochs:
+			if !ok {
+				t.Fatalf("epoch channel closed before " +
+					"synchronization")
+			}
+			if epoch.Hash.IsEqual(expectedHash) {
+				return
+			}
+
+		case <-timeout:
+			t.Fatalf(
+				"notifier did not report "+
+					"block %v", expectedHash,
+			)
+		}
+	}
+}
+
+// pollSpendNotification records whether a backend has delivered a spend
+// without delaying the maturity-boundary assertions.
+func pollSpendNotification(spend <-chan *chainntnfs.SpendDetail) (
+	*chainntnfs.SpendDetail, bool) {
+
+	// Non-blocking observation distinguishes an immature registration from
+	// one dispatched by the just-synchronized block.
+	select {
+	case details := <-spend:
+		return details, true
+
+	default:
+		return nil, false
+	}
+}
+
+// testSpendNotificationDepth proves each backend forwards an explicit spend
+// depth for a transaction discovered after registration.
+func testSpendNotificationDepth(
+	miner *rpctest.Harness, notifier chainntnfs.TestChainNotifier,
+	scriptDispatch bool, t *testing.T) {
+
+	// Arrange a spendable output, a synchronized epoch client, and a depth-
+	// three notification before broadcasting the spending transaction.
+	const numConfs = uint32(3)
+	outpoint, output, privKey := chainntnfs.CreateSpendableOutput(t, miner)
+	tipHash, heightHint, err := miner.Client.GetBestBlock()
+	require.NoError(t, err, "unable to get current height")
+	epochClient, err := notifier.RegisterBlockEpochNtfn(nil)
+	require.NoError(t, err, "unable to register for block epochs")
+	t.Cleanup(epochClient.Cancel)
+
+	// A nil best block produces one immediate tip event. Drain it during
+	// Arrange so each later wait corresponds to a newly generated block.
+	waitForNotifierEpoch(t, epochClient, tipHash)
+	var spendClient *chainntnfs.SpendEvent
+	if scriptDispatch {
+		// Register the script-only path here so the subject API and the
+		// exact depth option remain visible in this backend test.
+		spendClient, err = notifier.RegisterSpendNtfn(
+			nil, output.PkScript, uint32(heightHint),
+			chainntnfs.WithSpendNumConfs(numConfs),
+		)
+	} else {
+		// Register the outpoint path with the same explicit option so
+		// both backend dispatch modes prove the public contract.
+		spendClient, err = notifier.RegisterSpendNtfn(
+			outpoint, output.PkScript, uint32(heightHint),
+			chainntnfs.WithSpendNumConfs(numConfs),
+		)
+	}
+	require.NoError(t, err, "unable to register depth-aware spend")
+	t.Cleanup(spendClient.Cancel)
+	spendingTx := chainntnfs.CreateSpendTx(t, outpoint, output, privKey)
+	spenderHash, err := miner.Client.SendRawTransaction(spendingTx, true)
+	require.NoError(t, err, "unable to broadcast spend")
+	require.NoError(
+		t, chainntnfs.WaitForMempoolTx(miner, spenderHash),
+		"spend was not relayed to miner",
+	)
+
+	// Act by mining the inclusion block and two successors, synchronizing
+	// after each one, and recording delivery at every depth boundary.
+	blockHashes, err := miner.Client.Generate(1)
+	require.NoError(t, err, "unable to mine spend inclusion")
+	waitForNotifierEpoch(t, epochClient, blockHashes[0])
+	atOne, atOneOK := pollSpendNotification(spendClient.Spend)
+	_, spendHeight, err := miner.Client.GetBestBlock()
+	require.NoError(t, err, "unable to get spend height")
+
+	blockHashes, err = miner.Client.Generate(1)
+	require.NoError(t, err, "unable to mine second confirmation")
+	waitForNotifierEpoch(t, epochClient, blockHashes[0])
+	atTwo, atTwoOK := pollSpendNotification(spendClient.Spend)
+
+	blockHashes, err = miner.Client.Generate(1)
+	require.NoError(t, err, "unable to mine maturity confirmation")
+	waitForNotifierEpoch(t, epochClient, blockHashes[0])
+	var atThree *chainntnfs.SpendDetail
+	// Block epochs and spend results use independent delivery channels.
+	// Allow a bounded asynchronous handoff after maturity processing.
+	select {
+	case atThree = <-spendClient.Spend:
+		// Retain the result so Assert can verify its transaction and
+		// block metadata.
+
+	case <-time.After(30 * time.Second):
+		t.Fatalf("live spend did not mature")
+	}
+
+	// Assert no backend delivers before the requested depth and every
+	// backend supplies the canonical spend exactly at three confirmations.
+	require.False(t, atOneOK)
+	require.Nil(t, atOne)
+	require.False(t, atTwoOK)
+	require.Nil(t, atTwo)
+	require.NotNil(t, atThree)
+	require.Equal(t, *outpoint, *atThree.SpentOutPoint)
+	require.Equal(t, *spenderHash, *atThree.SpenderTxHash)
+	require.Zero(t, atThree.SpenderInputIndex)
+	require.Equal(t, spendHeight, atThree.SpendingHeight)
+}
+
 func testSpendNotification(miner *rpctest.Harness,
 	notifier chainntnfs.TestChainNotifier, scriptDispatch bool, t *testing.T) {
 
@@ -1834,6 +1967,10 @@ var txNtfnTests = []txNtfnTestCase{
 	{
 		name: "spend ntfn",
 		test: testSpendNotification,
+	},
+	{
+		name: "spend depth ntfn",
+		test: testSpendNotificationDepth,
 	},
 	{
 		name: "historical spend dispatch",

--- a/chainntnfs/txnotifier.go
+++ b/chainntnfs/txnotifier.go
@@ -530,6 +530,12 @@ type TxNotifier struct {
 	// being reorged out of the chain.
 	spendsByHeight map[uint32]map[SpendRequest]struct{}
 
+	// ntfnsBySpendConfirmHeight indexes individual spend clients by the
+	// height at which their shared candidate reaches the requested depth.
+	// Keeping this index separate lets clients use independent depths while
+	// retaining one inclusion record for reorg handling.
+	ntfnsBySpendConfirmHeight map[uint32]map[*SpendNtfn]struct{}
+
 	// confirmHintCache is a cache used to maintain the latest height hints
 	// for transactions/output scripts. Each height hint represents the
 	// earliest height at which they scripts could have been confirmed
@@ -564,9 +570,12 @@ func NewTxNotifier(startHeight uint32, reorgSafetyLimit uint32,
 		ntfnsByConfirmHeight: make(map[uint32]map[*ConfNtfn]struct{}),
 		spendNotifications:   make(map[SpendRequest]*spendNtfnSet),
 		spendsByHeight:       make(map[uint32]map[SpendRequest]struct{}),
-		confirmHintCache:     confirmHintCache,
-		spendHintCache:       spendHintCache,
-		quit:                 make(chan struct{}),
+		ntfnsBySpendConfirmHeight: make(
+			map[uint32]map[*SpendNtfn]struct{},
+		),
+		confirmHintCache: confirmHintCache,
+		spendHintCache:   spendHintCache,
+		quit:             make(chan struct{}),
 	}
 }
 
@@ -1138,7 +1147,7 @@ func (n *TxNotifier) RegisterSpend(
 			"registration since rescan has finished",
 			ntfn.SpendRequest)
 
-		err := n.dispatchSpendDetails(ntfn, spendSet.details)
+		err := n.scheduleSpendNtfn(ntfn, spendSet.details, false)
 		if err != nil {
 			return nil, err
 		}
@@ -1227,6 +1236,8 @@ func (n *TxNotifier) CancelSpend(spendRequest SpendRequest, spendID uint64) {
 
 	Log.Debugf("Canceling spend notification: spend_id=%d, %v", spendID,
 		spendRequest)
+
+	n.removeSpendMaturity(ntfn)
 
 	// We'll close all the notification channels to let the client know
 	// their cancel request has been fulfilled.
@@ -1396,13 +1407,78 @@ func (n *TxNotifier) updateSpendDetails(spendRequest SpendRequest,
 
 	spendSet.details = details
 	for _, ntfn := range spendSet.ntfns {
-		err := n.dispatchSpendDetails(ntfn, spendSet.details)
+		err := n.scheduleSpendNtfn(ntfn, spendSet.details, false)
 		if err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// scheduleSpendNtfn records a canonical spend candidate for one client and
+// either queues it at the requested maturity height or dispatches an already
+// mature historical candidate. A tip candidate waits for NotifyHeight even at
+// depth one so ConnectTip and notification delivery remain separate phases.
+//
+// NOTE: This must be called with the TxNotifier's lock held.
+func (n *TxNotifier) scheduleSpendNtfn(ntfn *SpendNtfn,
+	details *SpendDetail, waitForNotify bool) error {
+
+	// A missing candidate has nothing to schedule, while a delivered client
+	// must not receive the shared candidate a second time.
+	if details == nil || ntfn.dispatched {
+		return nil
+	}
+
+	spendHeight := uint32(details.SpendingHeight)
+	spendConfirmHeight := spendHeight + ntfn.NumConfirmations - 1
+
+	// Historical candidates at or behind the processed tip are already
+	// mature. A live tip candidate at the current height waits until the
+	// caller completes block processing through NotifyHeight.
+	if spendConfirmHeight < n.currentHeight ||
+		(spendConfirmHeight == n.currentHeight && !waitForNotify) {
+
+		return n.dispatchSpendDetails(ntfn, details)
+	}
+
+	ntfnSet, ok := n.ntfnsBySpendConfirmHeight[spendConfirmHeight]
+	if !ok {
+		// Allocate one bucket per maturity height so NotifyHeight can
+		// dispatch clients without scanning unrelated spend requests.
+		ntfnSet = make(map[*SpendNtfn]struct{})
+		n.ntfnsBySpendConfirmHeight[spendConfirmHeight] = ntfnSet
+	}
+	ntfnSet[ntfn] = struct{}{}
+
+	return nil
+}
+
+// removeSpendMaturity removes a pending client from its candidate's maturity
+// index. It is safe to call for an already-dispatched or candidate-free client
+// because deleting a missing map entry is a no-op.
+//
+// NOTE: This must be called with the TxNotifier's lock held.
+func (n *TxNotifier) removeSpendMaturity(ntfn *SpendNtfn) {
+	spendSet := n.spendNotifications[ntfn.SpendRequest]
+
+	// A canceled request without a candidate was never entered in the
+	// maturity index, so cleanup is complete without computing a height.
+	if spendSet == nil || spendSet.details == nil {
+		return
+	}
+
+	spendHeight := uint32(spendSet.details.SpendingHeight)
+	spendConfirmHeight := spendHeight + ntfn.NumConfirmations - 1
+	ntfnSet := n.ntfnsBySpendConfirmHeight[spendConfirmHeight]
+	delete(ntfnSet, ntfn)
+
+	if len(ntfnSet) == 0 {
+		// Drop empty height buckets to keep the index bounded by active
+		// spend clients rather than previously observed chain heights.
+		delete(n.ntfnsBySpendConfirmHeight, spendConfirmHeight)
+	}
 }
 
 // dispatchSpendDetails dispatches a spend notification to the client.
@@ -1527,6 +1603,18 @@ func (n *TxNotifier) ConnectTip(block *btcutil.Block,
 		for spendRequest := range n.spendsByHeight[matureBlockHeight] {
 			spendSet := n.spendNotifications[spendRequest]
 			for _, ntfn := range spendSet.ntfns {
+				// NotifyHeight normally dispatches this
+				// notification at its maturity height. Schedule
+				// it defensively if pruning is reached before
+				// that height is processed.
+				err := n.scheduleSpendNtfn(
+					ntfn, spendSet.details, false,
+				)
+				if err != nil {
+					return err
+				}
+				n.removeSpendMaturity(ntfn)
+
 				select {
 				case ntfn.Event.Done <- struct{}{}:
 				case <-n.quit:
@@ -1739,6 +1827,13 @@ func (n *TxNotifier) handleSpendDetailsAtTip(spendRequest SpendRequest,
 		case <-ntfn.Event.Reorg:
 		default:
 		}
+
+		// Queue tip candidates even at depth one so callers cannot
+		// observe them until NotifyHeight completes the block.
+		if err := n.scheduleSpendNtfn(ntfn, details, true); err != nil {
+			Log.Errorf("Unable to schedule spend for %v: %v",
+				spendRequest, err)
+		}
 	}
 
 	// We'll note the spending height of the request in order to correctly
@@ -1834,17 +1929,25 @@ func (n *TxNotifier) NotifyHeight(height uint32) error {
 	}
 	delete(n.ntfnsByConfirmHeight, height)
 
-	// Finally, we'll dispatch spend notifications for all the requests that
-	// were spent at this new block height.
-	for spendRequest := range n.spendsByHeight[height] {
-		spendSet := n.spendNotifications[spendRequest]
-		for _, ntfn := range spendSet.ntfns {
-			err := n.dispatchSpendDetails(ntfn, spendSet.details)
-			if err != nil {
-				return err
-			}
+	// Finally, we'll dispatch spend notifications whose individual maturity
+	// height has been reached. Their shared inclusion index remains intact
+	// until the candidate is reorg safe.
+	for ntfn := range n.ntfnsBySpendConfirmHeight[height] {
+		spendSet := n.spendNotifications[ntfn.SpendRequest]
+		if spendSet == nil {
+			// Cancellation can remove a registration before its
+			// queued height. Skip stale index entries.
+			continue
+		}
+
+		// Deliver the canonical details only after this client's own
+		// maturity height has been reached.
+		err := n.dispatchSpendDetails(ntfn, spendSet.details)
+		if err != nil {
+			return err
 		}
 	}
+	delete(n.ntfnsBySpendConfirmHeight, height)
 
 	return nil
 }
@@ -1929,10 +2032,17 @@ func (n *TxNotifier) DisconnectTip(blockHeight uint32) error {
 	// requests whose spending transaction was included at the height being
 	// disconnected.
 	for op := range n.spendsByHeight[blockHeight] {
+		spendSet := n.spendNotifications[op]
+
+		// Remove each queued maturity before clearing its shared
+		// candidate so a replacement cannot trigger a stale delivery.
+		for _, ntfn := range spendSet.ntfns {
+			n.removeSpendMaturity(ntfn)
+		}
+
 		// Since the spending transaction is being reorged out of the
 		// chain, we'll need to clear out the spending details of the
 		// request.
-		spendSet := n.spendNotifications[op]
 		spendSet.details = nil
 
 		// For all requests which have had a spend notification

--- a/chainntnfs/txnotifier.go
+++ b/chainntnfs/txnotifier.go
@@ -1406,6 +1406,7 @@ func (n *TxNotifier) updateSpendDetails(spendRequest SpendRequest,
 		"request %v", details.SpendingHeight, spendRequest)
 
 	spendSet.details = details
+	n.trackSpendByHeight(spendRequest, details)
 	for _, ntfn := range spendSet.ntfns {
 		err := n.scheduleSpendNtfn(ntfn, spendSet.details, false)
 		if err != nil {
@@ -1414,6 +1415,31 @@ func (n *TxNotifier) updateSpendDetails(spendRequest SpendRequest,
 	}
 
 	return nil
+}
+
+// trackSpendByHeight indexes shared candidate ownership independently of the
+// current client count, ensuring cancellation cannot hide cached details from
+// the disconnect path that must clear them after a reorg.
+//
+// NOTE: This must be called with the TxNotifier's lock held.
+func (n *TxNotifier) trackSpendByHeight(spendRequest SpendRequest,
+	details *SpendDetail) {
+
+	// Candidates beyond the notifier's reorg window no longer need reverse
+	// indexing because a supported DisconnectTip cannot reach their block.
+	spendHeight := uint32(details.SpendingHeight)
+	if spendHeight+n.reorgSafetyLimit <= n.currentHeight {
+		return
+	}
+
+	spendSet, ok := n.spendsByHeight[spendHeight]
+	if !ok {
+		// Allocate one bucket per inclusion height so every cached
+		// request is invalidated when the block disconnects.
+		spendSet = make(map[SpendRequest]struct{})
+		n.spendsByHeight[spendHeight] = spendSet
+	}
+	spendSet[spendRequest] = struct{}{}
 }
 
 // scheduleSpendNtfn records a canonical spend candidate for one client and
@@ -1503,19 +1529,6 @@ func (n *TxNotifier) dispatchSpendDetails(ntfn *SpendNtfn, details *SpendDetail)
 		ntfn.dispatched = true
 	case <-n.quit:
 		return ErrTxNotifierExiting
-	}
-
-	spendHeight := uint32(details.SpendingHeight)
-
-	// We also add to spendsByHeight to notify on chain reorgs.
-	reorgSafeHeight := spendHeight + n.reorgSafetyLimit
-	if reorgSafeHeight > n.currentHeight {
-		txSet, exists := n.spendsByHeight[spendHeight]
-		if !exists {
-			txSet = make(map[SpendRequest]struct{})
-			n.spendsByHeight[spendHeight] = txSet
-		}
-		txSet[ntfn.SpendRequest] = struct{}{}
 	}
 
 	return nil
@@ -1817,6 +1830,7 @@ func (n *TxNotifier) handleSpendDetailsAtTip(spendRequest SpendRequest,
 	spendSet := n.spendNotifications[spendRequest]
 	spendSet.rescanStatus = rescanComplete
 	spendSet.details = details
+	n.trackSpendByHeight(spendRequest, details)
 
 	for _, ntfn := range spendSet.ntfns {
 		// In the event that this notification was aware that the
@@ -1836,19 +1850,8 @@ func (n *TxNotifier) handleSpendDetailsAtTip(spendRequest SpendRequest,
 		}
 	}
 
-	// We'll note the spending height of the request in order to correctly
-	// handle dispatching notifications when the spending transactions gets
-	// reorged out of the chain.
-	spendHeight := uint32(details.SpendingHeight)
-	opSet, exists := n.spendsByHeight[spendHeight]
-	if !exists {
-		opSet = make(map[SpendRequest]struct{})
-		n.spendsByHeight[spendHeight] = opSet
-	}
-	opSet[spendRequest] = struct{}{}
-
 	Log.Debugf("Spend request %v spent at tip=%d", spendRequest,
-		spendHeight)
+		details.SpendingHeight)
 }
 
 // NotifyHeight dispatches confirmation and spend notifications to the clients

--- a/chainntnfs/txnotifier.go
+++ b/chainntnfs/txnotifier.go
@@ -432,6 +432,10 @@ type SpendNtfn struct {
 	// an entry for it.
 	HeightHint uint32
 
+	// NumConfirmations is the depth at which the spend becomes safe to
+	// deliver.
+	NumConfirmations uint32
+
 	// dispatched signals whether a spend notification has been dispatched
 	// to the client.
 	dispatched bool
@@ -1019,7 +1023,8 @@ func (n *TxNotifier) dispatchConfDetails(
 // newSpendNtfn validates all of the parameters required to successfully create
 // and register a spend notification.
 func (n *TxNotifier) newSpendNtfn(outpoint *wire.OutPoint,
-	pkScript []byte, heightHint uint32) (*SpendNtfn, error) {
+	pkScript []byte, heightHint uint32,
+	opts *SpendOptions) (*SpendNtfn, error) {
 
 	// An accompanying output script must always be provided.
 	if len(pkScript) == 0 {
@@ -1032,6 +1037,13 @@ func (n *TxNotifier) newSpendNtfn(outpoint *wire.OutPoint,
 		return nil, ErrNoHeightHint
 	}
 
+	// Keep the requested maturity inside this notifier's retained reorg
+	// history so the candidate cannot be pruned before delivery. Production
+	// notifiers retain ReorgSafetyLimit, currently 144 blocks.
+	if opts.NumConfs > n.reorgSafetyLimit {
+		return nil, ErrNumConfsOutOfRange
+	}
+
 	// Ensure the output script is of a supported type.
 	spendRequest, err := NewSpendRequest(outpoint, pkScript)
 	if err != nil {
@@ -1040,8 +1052,9 @@ func (n *TxNotifier) newSpendNtfn(outpoint *wire.OutPoint,
 
 	spendID := atomic.AddUint64(&n.spendClientCounter, 1)
 	return &SpendNtfn{
-		SpendID:      spendID,
-		SpendRequest: spendRequest,
+		SpendID:          spendID,
+		SpendRequest:     spendRequest,
+		NumConfirmations: opts.NumConfs,
 		Event: NewSpendEvent(func() {
 			n.CancelSpend(spendRequest, spendID)
 		}),
@@ -1057,8 +1070,9 @@ func (n *TxNotifier) newSpendNtfn(outpoint *wire.OutPoint,
 // before the notifier's current tip, the spend details must be provided with
 // the UpdateSpendDetails method, otherwise we will wait for the outpoint/output
 // script to be spent at tip, even though it already has.
-func (n *TxNotifier) RegisterSpend(outpoint *wire.OutPoint, pkScript []byte,
-	heightHint uint32) (*SpendRegistration, error) {
+func (n *TxNotifier) RegisterSpend(
+	outpoint *wire.OutPoint, pkScript []byte, heightHint uint32,
+	optFuncs ...SpendOption) (*SpendRegistration, error) {
 
 	select {
 	case <-n.quit:
@@ -1066,8 +1080,15 @@ func (n *TxNotifier) RegisterSpend(outpoint *wire.OutPoint, pkScript []byte,
 	default:
 	}
 
-	// We'll start by performing a series of validation checks.
-	ntfn, err := n.newSpendNtfn(outpoint, pkScript, heightHint)
+	// Parse the globally valid policy before creating any client state.
+	opts, err := ParseSpendOptions(optFuncs...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Apply request and notifier-specific validation before touching caches
+	// or registration maps.
+	ntfn, err := n.newSpendNtfn(outpoint, pkScript, heightHint, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/chainntnfs/txnotifier.go
+++ b/chainntnfs/txnotifier.go
@@ -1828,6 +1828,17 @@ func (n *TxNotifier) handleSpendDetailsAtTip(spendRequest SpendRequest,
 
 	// TODO(wilmer): cancel pending historical rescans if any?
 	spendSet := n.spendNotifications[spendRequest]
+
+	// A script-only request can match several outpoints that reuse one
+	// script. Preserve the first candidate until it disconnects or ages out
+	// so queued clients cannot be retargeted to a less mature replacement.
+	if spendSet.details != nil {
+		Log.Warnf("Ignoring output script reuse for %s at height %d.",
+			spendRequest, details.SpendingHeight)
+
+		return
+	}
+
 	spendSet.rescanStatus = rescanComplete
 	spendSet.details = details
 	n.trackSpendByHeight(spendRequest, details)

--- a/chainntnfs/txnotifier_test.go
+++ b/chainntnfs/txnotifier_test.go
@@ -126,6 +126,285 @@ func newMockHintCache() *mockHintCache {
 	}
 }
 
+// createSpendTestTx builds a distinct transaction that spends outpoint. The
+// version differentiates replacement transactions without changing which
+// registered request TxNotifier matches.
+func createSpendTestTx(outpoint wire.OutPoint, version int32) *wire.MsgTx {
+	spendTx := wire.NewMsgTx(version)
+
+	// Include witness and signature data so the transaction resembles
+	// spend forms covered by existing notifier regression tests.
+	spendTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: outpoint,
+		Witness:          testWitness,
+		SignatureScript:  testSigScript,
+	})
+
+	return spendTx
+}
+
+// pollSpendTest performs a non-blocking observation of a spend channel. It
+// lets tests record delivery at each height and defer all conclusions to a
+// distinct Assert phase.
+func pollSpendTest(spend <-chan *chainntnfs.SpendDetail) (
+	*chainntnfs.SpendDetail, bool) {
+
+	// A non-blocking select distinguishes an eligible notification from a
+	// client that must remain pending at its configured depth.
+	select {
+	case details := <-spend:
+		return details, true
+
+	default:
+		return nil, false
+	}
+}
+
+// TestTxNotifierSpendDepth verifies that clients sharing a spend candidate
+// are delivered independently at the compatibility default and explicit
+// confirmation depths.
+func TestTxNotifierSpendDepth(t *testing.T) {
+	t.Parallel()
+
+	// Arrange a notifier at height 10, two clients for the same outpoint,
+	// and one spend entering the next block. The default client requests no
+	// option, while the second explicitly requires three confirmations.
+	const startHeight = uint32(10)
+	hintCache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, hintCache, hintCache,
+	)
+	outpoint := wire.OutPoint{Index: 1}
+	defaultNtfn, err := n.RegisterSpend(
+		&outpoint, testRawScript, startHeight+1,
+	)
+	require.NoError(t, err)
+	t.Cleanup(defaultNtfn.Event.Cancel)
+
+	deepNtfn, err := n.RegisterSpend(
+		&outpoint, testRawScript, startHeight+1,
+		chainntnfs.WithSpendNumConfs(3),
+	)
+	require.NoError(t, err)
+	t.Cleanup(deepNtfn.Event.Cancel)
+	spendTx := createSpendTestTx(outpoint, 2)
+
+	// Act by processing the inclusion block and two successors. Observe
+	// both client channels after each height so the Assert phase can prove
+	// the exact delivery boundary instead of merely eventual delivery.
+	require.NoError(t, n.ConnectTip(btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{spendTx},
+	}), 11))
+	require.NoError(t, n.NotifyHeight(11))
+	defaultAtOne, defaultAtOneOK := pollSpendTest(defaultNtfn.Event.Spend)
+	deepAtOne, deepAtOneOK := pollSpendTest(deepNtfn.Event.Spend)
+
+	require.NoError(t, n.ConnectTip(
+		btcutil.NewBlock(&wire.MsgBlock{}), 12,
+	))
+	require.NoError(t, n.NotifyHeight(12))
+	deepAtTwo, deepAtTwoOK := pollSpendTest(deepNtfn.Event.Spend)
+
+	require.NoError(t, n.ConnectTip(
+		btcutil.NewBlock(&wire.MsgBlock{}), 13,
+	))
+	require.NoError(t, n.NotifyHeight(13))
+	deepAtThree, deepAtThreeOK := pollSpendTest(deepNtfn.Event.Spend)
+
+	// Assert the legacy client receives the canonical spend at one
+	// confirmation, while the explicit client stays silent through depth
+	// two and receives the same candidate exactly at depth three.
+	require.True(t, defaultAtOneOK)
+	require.NotNil(t, defaultAtOne)
+	require.Equal(t, int32(11), defaultAtOne.SpendingHeight)
+	require.False(t, deepAtOneOK)
+	require.Nil(t, deepAtOne)
+	require.False(t, deepAtTwoOK)
+	require.Nil(t, deepAtTwo)
+	require.True(t, deepAtThreeOK)
+	require.NotNil(t, deepAtThree)
+	require.Equal(t, spendTx.TxHash(), *deepAtThree.SpenderTxHash)
+}
+
+// TestTxNotifierHistoricalSpendDepth verifies that cached spend details obey
+// each newly registered client's depth rather than inheriting the first
+// client's delivery state.
+func TestTxNotifierHistoricalSpendDepth(t *testing.T) {
+	t.Parallel()
+
+	// Arrange a notifier one block before a three-confirmation candidate
+	// matures. Register the deep client before supplying historical details
+	// so a later default client must reuse the same cached candidate.
+	const startHeight = uint32(12)
+	hintCache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, hintCache, hintCache,
+	)
+	outpoint := wire.OutPoint{Index: 2}
+	spendTx := createSpendTestTx(outpoint, 2)
+	spendHash := spendTx.TxHash()
+	spendDetails := &chainntnfs.SpendDetail{
+		SpentOutPoint:     &outpoint,
+		SpenderTxHash:     &spendHash,
+		SpendingTx:        spendTx,
+		SpenderInputIndex: 0,
+		SpendingHeight:    11,
+	}
+	deepNtfn, err := n.RegisterSpend(
+		&outpoint, testRawScript, 1,
+		chainntnfs.WithSpendNumConfs(3),
+	)
+	require.NoError(t, err)
+	t.Cleanup(deepNtfn.Event.Cancel)
+
+	// Act by caching the historical inclusion, registering a default-depth
+	// client against that cache, and then advancing to the deep client's
+	// maturity height. Record both pre- and post-maturity observations.
+	require.NoError(t, n.UpdateSpendDetails(
+		deepNtfn.HistoricalDispatch.SpendRequest, spendDetails,
+	))
+	deepBefore, deepBeforeOK := pollSpendTest(deepNtfn.Event.Spend)
+
+	defaultNtfn, err := n.RegisterSpend(&outpoint, testRawScript, 1)
+	require.NoError(t, err)
+	t.Cleanup(defaultNtfn.Event.Cancel)
+	defaultCached, defaultCachedOK := pollSpendTest(
+		defaultNtfn.Event.Spend,
+	)
+
+	require.NoError(t, n.ConnectTip(
+		btcutil.NewBlock(&wire.MsgBlock{}), 13,
+	))
+	require.NoError(t, n.NotifyHeight(13))
+	deepMature, deepMatureOK := pollSpendTest(deepNtfn.Event.Spend)
+
+	// Assert the depth-three client remains queued at height 12, the cached
+	// default client receives the already mature spend immediately, and the
+	// queued client receives identical details when height 13 is processed.
+	require.False(t, deepBeforeOK)
+	require.Nil(t, deepBefore)
+	require.True(t, defaultCachedOK)
+	require.Equal(t, spendHash, *defaultCached.SpenderTxHash)
+	require.True(t, deepMatureOK)
+	require.Equal(t, spendHash, *deepMature.SpenderTxHash)
+}
+
+// TestTxNotifierSpendDepthReorg verifies that a candidate disconnected before
+// maturity is discarded and a replacement candidate can satisfy the same
+// registration at the requested depth.
+func TestTxNotifierSpendDepthReorg(t *testing.T) {
+	t.Parallel()
+
+	// Arrange a three-confirmation client and two transactions. Both spend
+	// the same outpoint, while the second represents the replacement after
+	// the first inclusion is disconnected.
+	const startHeight = uint32(10)
+	hintCache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, hintCache, hintCache,
+	)
+	outpoint := wire.OutPoint{Index: 3}
+	ntfn, err := n.RegisterSpend(
+		&outpoint, testRawScript, startHeight+1,
+		chainntnfs.WithSpendNumConfs(3),
+	)
+	require.NoError(t, err)
+	t.Cleanup(ntfn.Event.Cancel)
+	originalTx := createSpendTestTx(outpoint, 2)
+	replacementTx := createSpendTestTx(outpoint, 3)
+
+	// Act by advancing the original candidate to depth two, disconnecting
+	// both blocks so its inclusion leaves the canonical chain, and then
+	// mining the replacement candidate through depth three.
+	require.NoError(t, n.ConnectTip(btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{originalTx},
+	}), 11))
+	require.NoError(t, n.NotifyHeight(11))
+	require.NoError(t, n.ConnectTip(
+		btcutil.NewBlock(&wire.MsgBlock{}), 12,
+	))
+	require.NoError(t, n.NotifyHeight(12))
+	originalBeforeReorg, originalBeforeReorgOK := pollSpendTest(
+		ntfn.Event.Spend,
+	)
+
+	require.NoError(t, n.DisconnectTip(12))
+	require.NoError(t, n.DisconnectTip(11))
+	afterReorg, afterReorgOK := pollSpendTest(ntfn.Event.Spend)
+
+	require.NoError(t, n.ConnectTip(btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{replacementTx},
+	}), 11))
+	require.NoError(t, n.NotifyHeight(11))
+	require.NoError(t, n.ConnectTip(
+		btcutil.NewBlock(&wire.MsgBlock{}), 12,
+	))
+	require.NoError(t, n.NotifyHeight(12))
+	require.NoError(t, n.ConnectTip(
+		btcutil.NewBlock(&wire.MsgBlock{}), 13,
+	))
+	require.NoError(t, n.NotifyHeight(13))
+	replacementMature, replacementMatureOK := pollSpendTest(
+		ntfn.Event.Spend,
+	)
+
+	// Assert the original candidate never escaped before or during the
+	// reorg, and only the replacement transaction is delivered once its own
+	// three-confirmation boundary is reached.
+	require.False(t, originalBeforeReorgOK)
+	require.Nil(t, originalBeforeReorg)
+	require.False(t, afterReorgOK)
+	require.Nil(t, afterReorg)
+	require.True(t, replacementMatureOK)
+	require.Equal(
+		t, replacementTx.TxHash(), *replacementMature.SpenderTxHash,
+	)
+}
+
+// TestTxNotifierSpendDepthCancel verifies cancellation removes a queued
+// maturity entry before its height is processed.
+func TestTxNotifierSpendDepthCancel(t *testing.T) {
+	t.Parallel()
+
+	// Arrange a deep client with a spend candidate at one confirmation so
+	// cancellation occurs while the client is present in both the shared
+	// inclusion index and its client-specific maturity bucket.
+	const startHeight = uint32(10)
+	hintCache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, hintCache, hintCache,
+	)
+	outpoint := wire.OutPoint{Index: 4}
+	ntfn, err := n.RegisterSpend(
+		&outpoint, testRawScript, startHeight+1,
+		chainntnfs.WithSpendNumConfs(3),
+	)
+	require.NoError(t, err)
+	spendTx := createSpendTestTx(outpoint, 2)
+
+	// Act by queueing the candidate, canceling the only client, and then
+	// processing the two blocks that would otherwise trigger delivery.
+	require.NoError(t, n.ConnectTip(btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{spendTx},
+	}), 11))
+	require.NoError(t, n.NotifyHeight(11))
+	ntfn.Event.Cancel()
+	require.NoError(t, n.ConnectTip(
+		btcutil.NewBlock(&wire.MsgBlock{}), 12,
+	))
+	require.NoError(t, n.NotifyHeight(12))
+	require.NoError(t, n.ConnectTip(
+		btcutil.NewBlock(&wire.MsgBlock{}), 13,
+	))
+	require.NoError(t, n.NotifyHeight(13))
+	_, spendOpen := <-ntfn.Event.Spend
+
+	// Assert cancellation closed the client channel and processing the old
+	// maturity height succeeded, proving no stale delivery attempted to use
+	// the removed registration.
+	require.False(t, spendOpen)
+}
+
 // TestTxNotifierRegistrationValidation ensures that we are not able to register
 // requests with invalid parameters.
 func TestTxNotifierRegistrationValidation(t *testing.T) {

--- a/chainntnfs/txnotifier_test.go
+++ b/chainntnfs/txnotifier_test.go
@@ -405,6 +405,168 @@ func TestTxNotifierSpendDepthCancel(t *testing.T) {
 	require.False(t, spendOpen)
 }
 
+// TestTxNotifierScriptSpendCandidateOwnership verifies a script notification
+// keeps its first canonical spend while that candidate is awaiting maturity.
+func TestTxNotifierScriptSpendCandidateOwnership(t *testing.T) {
+	t.Parallel()
+
+	// Arrange two depth-three clients for one script and two distinct
+	// outpoints that reuse it in consecutive blocks. The second client lets
+	// cancellation expose a stale first-candidate maturity entry.
+	const startHeight = uint32(10)
+	hintCache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, hintCache, hintCache,
+	)
+	firstClient, err := n.RegisterSpend(
+		nil, testRawScript, startHeight+1,
+		chainntnfs.WithSpendNumConfs(3),
+	)
+	require.NoError(t, err)
+	t.Cleanup(firstClient.Event.Cancel)
+	secondClient, err := n.RegisterSpend(
+		nil, testRawScript, startHeight+1,
+		chainntnfs.WithSpendNumConfs(3),
+	)
+	require.NoError(t, err)
+	firstOutpoint := wire.OutPoint{Hash: chainhash.Hash{1}, Index: 1}
+	secondOutpoint := wire.OutPoint{Hash: chainhash.Hash{2}, Index: 2}
+	firstSpend := createSpendTestTx(firstOutpoint, 2)
+	secondSpend := createSpendTestTx(secondOutpoint, 3)
+
+	// Act by queueing the first candidate, processing a later same-script
+	// spend, canceling one client, and advancing to the original maturity
+	// height. A stale bucket would either deliver the immature replacement
+	// or attempt to send it through the canceled client's closed channel.
+	require.NoError(t, n.ConnectTip(btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{firstSpend},
+	}), 11))
+	require.NoError(t, n.NotifyHeight(11))
+	require.NoError(t, n.ConnectTip(btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{secondSpend},
+	}), 12))
+	require.NoError(t, n.NotifyHeight(12))
+	secondClient.Event.Cancel()
+	require.NoError(t, n.ConnectTip(
+		btcutil.NewBlock(&wire.MsgBlock{}), 13,
+	))
+	require.NoError(t, n.NotifyHeight(13))
+	delivered, deliveredOK := pollSpendTest(firstClient.Event.Spend)
+	_, canceledOpen := <-secondClient.Event.Spend
+
+	// Assert only the first candidate is delivered at its own depth and
+	// the canceled client stays closed. Reaching the height without a panic
+	// also proves cancellation removed the immutable maturity entry.
+	require.True(t, deliveredOK)
+	require.NotNil(t, delivered)
+	require.Equal(t, firstSpend.TxHash(), *delivered.SpenderTxHash)
+	require.False(t, canceledOpen)
+}
+
+// TestTxNotifierCanceledSpendReorg checks that a spend discovered after its
+// last client cancels cannot remain cached across a block disconnection.
+func TestTxNotifierCanceledSpendReorg(t *testing.T) {
+	t.Parallel()
+
+	// Arrange a notifier with one request whose only client cancels before
+	// the original spend. Distinct transaction versions let the assertions
+	// distinguish stale delivery from the canonical replacement.
+	const startHeight = uint32(10)
+	hintCache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, hintCache, hintCache,
+	)
+	outpoint := wire.OutPoint{Index: 8}
+	canceledNtfn, err := n.RegisterSpend(
+		&outpoint, testRawScript, startHeight+1,
+	)
+	require.NoError(t, err)
+	canceledNtfn.Event.Cancel()
+	originalTx := createSpendTestTx(outpoint, 2)
+	replacementTx := createSpendTestTx(outpoint, 3)
+
+	// Act by discovering the original spend with no active clients, then
+	// disconnect its block and register a fresh client. Process an empty
+	// block to expose stale candidates, reorg it, and connect the actual
+	// replacement spend at the same height.
+	require.NoError(t, n.ConnectTip(btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{originalTx},
+	}), 11))
+	require.NoError(t, n.NotifyHeight(11))
+	require.NoError(t, n.DisconnectTip(11))
+
+	freshNtfn, err := n.RegisterSpend(
+		&outpoint, testRawScript, startHeight+1,
+	)
+	require.NoError(t, err)
+	t.Cleanup(freshNtfn.Event.Cancel)
+	require.NoError(t, n.ConnectTip(
+		btcutil.NewBlock(&wire.MsgBlock{}), 11,
+	))
+	require.NoError(t, n.NotifyHeight(11))
+	staleSpend, staleSpendOK := pollSpendTest(freshNtfn.Event.Spend)
+
+	require.NoError(t, n.DisconnectTip(11))
+	require.NoError(t, n.ConnectTip(btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{replacementTx},
+	}), 11))
+	require.NoError(t, n.NotifyHeight(11))
+	replacementSpend, replacementSpendOK := pollSpendTest(
+		freshNtfn.Event.Spend,
+	)
+
+	// Assert the empty block cannot deliver the disconnected transaction.
+	// The registration must stay live for only the canonical replacement,
+	// proving request-level reorg tracking survives client turnover.
+	require.False(t, staleSpendOK)
+	require.Nil(t, staleSpend)
+	require.True(t, replacementSpendOK)
+	require.NotNil(t, replacementSpend)
+	require.Equal(
+		t, replacementTx.TxHash(), *replacementSpend.SpenderTxHash,
+	)
+}
+
+// TestTxNotifierSpendDepthValidation verifies invalid depth requests fail
+// before a spend registration is created.
+func TestTxNotifierSpendDepthValidation(t *testing.T) {
+	t.Parallel()
+
+	// Arrange one standard notifier for global boundary checks and one with
+	// a smaller retained reorg window for its stricter backend boundary.
+	hintCache := newMockHintCache()
+	standard := chainntnfs.NewTxNotifier(
+		10, chainntnfs.ReorgSafetyLimit, hintCache, hintCache,
+	)
+	narrow := chainntnfs.NewTxNotifier(10, 2, hintCache, hintCache)
+	outpoint := wire.OutPoint{Index: 5}
+
+	// Act by requesting zero confirmations, more than the global maximum,
+	// and a globally valid depth that exceeds the narrow notifier's reorg
+	// window. Capture registrations to verify failure is mutation-free.
+	zeroReg, zeroErr := standard.RegisterSpend(
+		&outpoint, testRawScript, 1,
+		chainntnfs.WithSpendNumConfs(0),
+	)
+	globalReg, globalErr := standard.RegisterSpend(
+		&outpoint, testRawScript, 1,
+		chainntnfs.WithSpendNumConfs(chainntnfs.MaxNumConfs+1),
+	)
+	narrowReg, narrowErr := narrow.RegisterSpend(
+		&outpoint, testRawScript, 1,
+		chainntnfs.WithSpendNumConfs(3),
+	)
+
+	// Assert both validation layers return the shared public sentinel and
+	// none exposes a partially registered client to the caller.
+	require.ErrorIs(t, zeroErr, chainntnfs.ErrNumConfsOutOfRange)
+	require.Nil(t, zeroReg)
+	require.ErrorIs(t, globalErr, chainntnfs.ErrNumConfsOutOfRange)
+	require.Nil(t, globalReg)
+	require.ErrorIs(t, narrowErr, chainntnfs.ErrNumConfsOutOfRange)
+	require.Nil(t, narrowReg)
+}
+
 // TestTxNotifierRegistrationValidation ensures that we are not able to register
 // requests with invalid parameters.
 func TestTxNotifierRegistrationValidation(t *testing.T) {

--- a/chainreg/no_chain_backend.go
+++ b/chainreg/no_chain_backend.go
@@ -66,7 +66,7 @@ func (n *NoChainBackend) RegisterConfirmationsNtfn(*chainhash.Hash, []byte,
 }
 
 func (n *NoChainBackend) RegisterSpendNtfn(*wire.OutPoint, []byte,
-	uint32) (*chainntnfs.SpendEvent, error) {
+	uint32, ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
 	return nil, errNotImplemented
 }

--- a/contractcourt/anchor_resolver.go
+++ b/contractcourt/anchor_resolver.go
@@ -231,6 +231,8 @@ func (c *anchorResolver) Launch() error {
 	resultChan, err := c.Sweeper.SweepInput(
 		&anchorInput,
 		sweep.Params{
+			RequiredConfs: c.SpendConfDepth,
+
 			// For normal anchor sweeping, the budget is 330 sats.
 			Budget: btcutil.Amount(
 				anchorInput.SignDesc().Output.Value,

--- a/contractcourt/breach_arbitrator.go
+++ b/contractcourt/breach_arbitrator.go
@@ -429,6 +429,21 @@ type breachSpendSubscription struct {
 	terminal *chainntnfs.SpendEvent
 }
 
+// needsEarlyBreachSpend reports whether a first-level HTLC spend changes the
+// justice target and therefore must be observed before terminal depth.
+func needsEarlyBreachSpend(witnessType input.StandardWitnessType) bool {
+	switch witnessType {
+	case input.TaprootHtlcAcceptedRevoke,
+		input.TaprootHtlcOfferedRevoke,
+		input.HtlcAcceptedRevoke,
+		input.HtlcOfferedRevoke:
+
+		return true
+	default:
+		return false
+	}
+}
+
 // waitForSpendEvent waits for any of the breached outputs to get spent, and
 // returns the spend details for those outputs. The spendNtfns map is a cache
 // used to store registered spend subscriptions, in case we must call this
@@ -475,6 +490,25 @@ func (b *BreachArbitrator) waitForSpendEvent(
 				),
 			)
 			spendNtfn = &breachSpendSubscription{terminal: terminal}
+
+			// Only first-level HTLC spends need an early observer.
+			// They redirect justice before terminal depth.
+			witnessType := breachedOutput.witnessType
+			needsEarly := needsEarlyBreachSpend(witnessType)
+			depthEnabled := breachSpendConfDepth() > 1
+			if err == nil && depthEnabled && needsEarly {
+				register := b.cfg.Notifier.RegisterSpendNtfn
+				signDesc := breachedOutput.signDesc
+				spendNtfn.early, err = register(
+					&breachedOutput.outpoint,
+					signDesc.Output.PkScript,
+					breachInfo.breachHeight,
+					chainntnfs.WithSpendNumConfs(1),
+				)
+				if err != nil {
+					terminal.Cancel()
+				}
+			}
 			if err != nil {
 				brarLog.Errorf("Unable to check for spentness "+
 					"of outpoint=%v: %v",
@@ -647,16 +681,29 @@ func convertToSecondLevelRevoke(bo *breachedOutput, breachInfo *retributionInfo,
 // updateBreachInfo mutates the passed breachInfo by removing or converting any
 // outputs among the spends. It also counts the total and revoked funds swept
 // by our justice spends.
-func updateBreachInfo(breachInfo *retributionInfo, spends []spend) (
-	btcutil.Amount, btcutil.Amount) {
+func updateBreachInfo(breachInfo *retributionInfo,
+	provisionalOutputs map[wire.OutPoint]breachedOutput,
+	spends []spend) (btcutil.Amount, btcutil.Amount) {
 
 	inputs := breachInfo.breachedOutputs
 	doneOutputs := make(map[int]struct{})
 
 	var totalFunds, revokedFunds btcutil.Amount
 	for _, s := range spends {
+		// Reorg evidence invalidates only the temporary justice target.
+		// The original output was intentionally retained in breachInfo.
+		if s.reorg {
+			delete(provisionalOutputs, s.outpoint)
+			continue
+		}
+
 		breachedOutput := &inputs[s.index]
 		txIn := s.detail.SpendingTx.TxIn[s.detail.SpenderInputIndex]
+		if !s.provisional {
+			// Terminal evidence owns the durable transition.
+			// It makes any in-memory candidate obsolete.
+			delete(provisionalOutputs, s.outpoint)
+		}
 
 		switch breachedOutput.witnessType {
 		case input.TaprootHtlcAcceptedRevoke:
@@ -690,10 +737,38 @@ func updateBreachInfo(breachInfo *retributionInfo, spends []spend) (
 				breachedOutput.witnessType,
 				breachedOutput.outpoint, breachInfo.chanPoint)
 
-			// Morph the initial revoke spend to the second-level output
-			// only after its notifier reaches the configured depth.
+			// A shallow transition redirects the next attempt.
+			// Retain the first-level owner until terminal depth.
+			// Copy the descriptor output because
+			// conversion mutates the pointed-to transaction output.
+			if s.provisional {
+				candidate := *breachedOutput
+				output := *breachedOutput.signDesc.Output
+				candidate.signDesc.Output = &output
+				convertToSecondLevelRevoke(
+					&candidate, breachInfo, s.detail,
+				)
+				provisionalOutputs[s.outpoint] = candidate
+				continue
+			}
+
+			// Terminal depth makes the new target durable.
+			// Store it in the existing recovery record.
 			convertToSecondLevelRevoke(
 				breachedOutput, breachInfo, s.detail,
+			)
+
+			continue
+		}
+
+		// A shallow justice spend is reorgable, so keep its output
+		// persisted until the terminal observer delivers.
+		if s.provisional {
+			brarLog.Infof("Spend on %s(%v) remains "+
+				"provisional for %v",
+				breachedOutput.witnessType,
+				breachedOutput.outpoint,
+				breachInfo.chanPoint,
 			)
 
 			continue
@@ -782,11 +857,29 @@ func (b *BreachArbitrator) exactRetribution(
 	// amount of funds that were revoked from the counter party.
 	var totalFunds, revokedFunds btcutil.Amount
 
+	// Provisional outputs redirect justice after a one-confirmation HTLC
+	// transition without replacing the durable first-level recovery owner.
+	provisionalOutputs := make(map[wire.OutPoint]breachedOutput)
+
 justiceTxBroadcast:
 	// With the breach transaction confirmed, we now create the
 	// justice tx which will claim ALL the funds within the
 	// channel.
-	justiceTxs, err := b.createJusticeTx(breachInfo.breachedOutputs)
+	justiceOutputs := breachInfo.breachedOutputs
+	if len(provisionalOutputs) != 0 {
+		// Build a temporary signing view so shallow transitions can be
+		// discarded without mutating persisted recovery data.
+		justiceOutputs = append(
+			[]breachedOutput(nil), justiceOutputs...,
+		)
+		for i := range justiceOutputs {
+			outpoint := justiceOutputs[i].outpoint
+			if candidate, ok := provisionalOutputs[outpoint]; ok {
+				justiceOutputs[i] = candidate
+			}
+		}
+	}
+	justiceTxs, err := b.createJusticeTx(justiceOutputs)
 	if err != nil {
 		brarLog.Errorf("Unable to create justice tx: %v", err)
 		return
@@ -858,9 +951,11 @@ Loop:
 	for {
 		select {
 		case spends := <-spendChan:
-			// Update the breach info only after the notifier has delivered
-			// terminal-depth spend evidence.
-			t, r := updateBreachInfo(breachInfo, spends)
+			// Update durable recovery only at terminal depth.
+			// The overlay isolates shallow transitions.
+			t, r := updateBreachInfo(
+				breachInfo, provisionalOutputs, spends,
+			)
 			totalFunds += t
 			revokedFunds += r
 

--- a/contractcourt/breach_arbitrator.go
+++ b/contractcourt/breach_arbitrator.go
@@ -415,16 +415,28 @@ func (b *BreachArbitrator) contractObserver() {
 // spend is used to wrap the index of the retributionInfo output that gets
 // spent together with the spend details.
 type spend struct {
-	index  int
-	detail *chainntnfs.SpendDetail
+	index       int
+	outpoint    wire.OutPoint
+	detail      *chainntnfs.SpendDetail
+	provisional bool
+	reorg       bool
+}
+
+// breachSpendSubscription keeps an optional shallow observer beside the
+// terminal cleanup observer so both events retain one recovery owner.
+type breachSpendSubscription struct {
+	early    *chainntnfs.SpendEvent
+	terminal *chainntnfs.SpendEvent
 }
 
 // waitForSpendEvent waits for any of the breached outputs to get spent, and
 // returns the spend details for those outputs. The spendNtfns map is a cache
 // used to store registered spend subscriptions, in case we must call this
 // method multiple times.
-func (b *BreachArbitrator) waitForSpendEvent(breachInfo *retributionInfo,
-	spendNtfns map[wire.OutPoint]*chainntnfs.SpendEvent) ([]spend, error) {
+func (b *BreachArbitrator) waitForSpendEvent(
+	breachInfo *retributionInfo,
+	spendNtfns map[wire.OutPoint]*breachSpendSubscription) ([]spend,
+	error) {
 
 	inputs := breachInfo.breachedOutputs
 
@@ -454,8 +466,7 @@ func (b *BreachArbitrator) waitForSpendEvent(breachInfo *retributionInfo,
 		// output, we'll reuse it.
 		spendNtfn, ok := spendNtfns[breachedOutput.outpoint]
 		if !ok {
-			var err error
-			spendNtfn, err = b.cfg.Notifier.RegisterSpendNtfn(
+			terminal, err := b.cfg.Notifier.RegisterSpendNtfn(
 				&breachedOutput.outpoint,
 				breachedOutput.signDesc.Output.PkScript,
 				breachInfo.breachHeight,
@@ -463,6 +474,7 @@ func (b *BreachArbitrator) waitForSpendEvent(breachInfo *retributionInfo,
 					breachSpendConfDepth(),
 				),
 			)
+			spendNtfn = &breachSpendSubscription{terminal: terminal}
 			if err != nil {
 				brarLog.Errorf("Unable to check for spentness "+
 					"of outpoint=%v: %v",
@@ -484,32 +496,74 @@ func (b *BreachArbitrator) waitForSpendEvent(breachInfo *retributionInfo,
 		// Launch a goroutine waiting for a spend event.
 		b.wg.Add(1)
 		wg.Add(1)
-		go func(index int, spendEv *chainntnfs.SpendEvent) {
+		go func(index int, spendEv *breachSpendSubscription) {
 			defer b.wg.Done()
 			defer wg.Done()
 
+			var (
+				earlySpends <-chan *chainntnfs.SpendDetail
+				earlyReorg  <-chan struct{}
+			)
+			if spendEv.early != nil {
+				earlySpends = spendEv.early.Spend
+				earlyReorg = spendEv.early.Reorg
+			}
+
+			var (
+				sp          *chainntnfs.SpendDetail
+				provisional bool
+				reorg       bool
+			)
 			select {
-			// The output has been taken to the second level!
-			case sp, ok := <-spendEv.Spend:
+			case sp = <-earlySpends:
+				provisional = true
+			case _, ok := <-earlyReorg:
+				// Send reorgs to the provisional owner.
+				// This keeps reversal serialized.
 				if !ok {
 					return
 				}
-				brarLog.Infof("Detected spend on %s(%v) by "+
-					"txid(%v) for ChannelPoint(%v)",
-					inputs[index].witnessType,
-					inputs[index].outpoint,
-					sp.SpenderTxHash, breachInfo.chanPoint)
-
-				// Pass the spend to the caller only after every waiter
-				// has stopped, preventing concurrent cache mutation.
-				allSpends <- spend{index, sp}
-
-				anySpend <- struct{}{}
+				provisional = true
+				reorg = true
+			case sp = <-spendEv.terminal.Spend:
 			case <-exit:
 				return
 			case <-b.quit:
 				return
 			}
+
+			// Closed spend channels signal notifier shutdown. Reorg
+			// notifications intentionally carry no spend details.
+			if !reorg && sp == nil {
+				return
+			}
+
+			outpoint := inputs[index].outpoint
+			if reorg {
+				brarLog.Infof(
+					"Shallow spend reorg on %s(%v) for "+
+						"ChannelPoint(%v)",
+					inputs[index].witnessType, outpoint,
+					breachInfo.chanPoint,
+				)
+			} else {
+				brarLog.Infof("Detected spend on %s(%v) by "+
+					"txid(%v) for ChannelPoint(%v)",
+					inputs[index].witnessType, outpoint,
+					sp.SpenderTxHash, breachInfo.chanPoint)
+			}
+
+			// Preserve lifecycle metadata for the caller.
+			// It distinguishes reversible and terminal evidence.
+			allSpends <- spend{
+				index:       index,
+				outpoint:    outpoint,
+				detail:      sp,
+				provisional: provisional,
+				reorg:       reorg,
+			}
+
+			anySpend <- struct{}{}
 		}(i, spendNtfn)
 	}
 
@@ -530,10 +584,6 @@ func (b *BreachArbitrator) waitForSpendEvent(breachInfo *retributionInfo,
 		// Gather all detected spends and return them.
 		var spends []spend
 		for s := range allSpends {
-			breachedOutput := &inputs[s.index]
-			spendNtfns[breachedOutput.outpoint].Cancel()
-			delete(spendNtfns, breachedOutput.outpoint)
-
 			spends = append(spends, s)
 		}
 
@@ -726,7 +776,7 @@ func (b *BreachArbitrator) exactRetribution(
 	// We may have to wait for some of the HTLC outputs to be spent to the
 	// second level before broadcasting the justice tx. We'll store the
 	// SpendEvents between each attempt to not re-register unnecessarily.
-	spendNtfns := make(map[wire.OutPoint]*chainntnfs.SpendEvent)
+	spendNtfns := make(map[wire.OutPoint]*breachSpendSubscription)
 
 	// Compute both the total value of funds being swept and the
 	// amount of funds that were revoked from the counter party.
@@ -813,6 +863,21 @@ Loop:
 			t, r := updateBreachInfo(breachInfo, spends)
 			totalFunds += t
 			revokedFunds += r
+
+			// Terminal events release their subscription pair.
+			// Shallow events retain both observers.
+			for _, spend := range spends {
+				if spend.provisional {
+					continue
+				}
+
+				notify := spendNtfns[spend.outpoint]
+				notify.terminal.Cancel()
+				if notify.early != nil {
+					notify.early.Cancel()
+				}
+				delete(spendNtfns, spend.outpoint)
+			}
 
 			brarLog.Infof("%v spends from breach tx for "+
 				"ChannelPoint(%v) has been detected, %v "+

--- a/contractcourt/breach_arbitrator.go
+++ b/contractcourt/breach_arbitrator.go
@@ -43,6 +43,13 @@ const (
 	blocksPassedSplitPublish = 4
 )
 
+// breachSpendConfDepth derives the conservative maximum of the existing
+// channel-close policy. Recomputing this deterministic value after restart
+// keeps terminal breach cleanup safe without changing the persisted format.
+func breachSpendConfDepth() uint32 {
+	return lnwallet.CloseConfsForCapacity(btcutil.MaxSatoshi)
+}
+
 var (
 	// retributionBucket stores retribution state on disk between detecting
 	// a contract breach, broadcasting a justice transaction that sweeps the
@@ -452,6 +459,9 @@ func (b *BreachArbitrator) waitForSpendEvent(breachInfo *retributionInfo,
 				&breachedOutput.outpoint,
 				breachedOutput.signDesc.Output.PkScript,
 				breachInfo.breachHeight,
+				chainntnfs.WithSpendNumConfs(
+					breachSpendConfDepth(),
+				),
 			)
 			if err != nil {
 				brarLog.Errorf("Unable to check for spentness "+
@@ -484,22 +494,16 @@ func (b *BreachArbitrator) waitForSpendEvent(breachInfo *retributionInfo,
 				if !ok {
 					return
 				}
-
 				brarLog.Infof("Detected spend on %s(%v) by "+
 					"txid(%v) for ChannelPoint(%v)",
 					inputs[index].witnessType,
 					inputs[index].outpoint,
-					sp.SpenderTxHash,
-					breachInfo.chanPoint)
+					sp.SpenderTxHash, breachInfo.chanPoint)
 
-				// First we send the spend event on the
-				// allSpends channel, such that it can be
-				// handled after all go routines have exited.
+				// Pass the spend to the caller only after every waiter
+				// has stopped, preventing concurrent cache mutation.
 				allSpends <- spend{index, sp}
 
-				// Finally we'll signal the anySpend channel
-				// that a spend was detected, such that the
-				// other goroutines can be shut down.
 				anySpend <- struct{}{}
 			case <-exit:
 				return
@@ -527,6 +531,7 @@ func (b *BreachArbitrator) waitForSpendEvent(breachInfo *retributionInfo,
 		var spends []spend
 		for s := range allSpends {
 			breachedOutput := &inputs[s.index]
+			spendNtfns[breachedOutput.outpoint].Cancel()
 			delete(spendNtfns, breachedOutput.outpoint)
 
 			spends = append(spends, s)
@@ -635,10 +640,8 @@ func updateBreachInfo(breachInfo *retributionInfo, spends []spend) (
 				breachedOutput.witnessType,
 				breachedOutput.outpoint, breachInfo.chanPoint)
 
-			// In this case we'll morph our initial revoke
-			// spend to instead point to the second level
-			// output, and update the sign descriptor in the
-			// process.
+			// Morph the initial revoke spend to the second-level output
+			// only after its notifier reaches the configured depth.
 			convertToSecondLevelRevoke(
 				breachedOutput, breachInfo, s.detail,
 			)
@@ -805,7 +808,8 @@ Loop:
 	for {
 		select {
 		case spends := <-spendChan:
-			// Update the breach info with the new spends.
+			// Update the breach info only after the notifier has delivered
+			// terminal-depth spend evidence.
 			t, r := updateBreachInfo(breachInfo, spends)
 			totalFunds += t
 			revokedFunds += r

--- a/contractcourt/breach_arbitrator_test.go
+++ b/contractcourt/breach_arbitrator_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/shachain"
 	"github.com/lightningnetwork/lnd/tlv"
+	testifymock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1775,6 +1776,10 @@ func testBreachSpends(t *testing.T, test breachTest) {
 // "split" the justice tx in case the first justice tx doesn't confirm within
 // a reasonable time.
 func TestBreachDelayedJusticeConfirmation(t *testing.T) {
+	// Arrange: Start a breached channel and give the publisher room for the
+	// one intermediate rebroadcast that can follow shallow HTLC evidence.
+	// This lets the queued terminal-depth event drive cleanup instead of
+	// blocking the arbiter on a publication the test no longer consumes.
 	brar, alice, _, bobClose, contractBreaches := initBreachedState(t)
 
 	var (
@@ -1782,7 +1787,7 @@ func TestBreachDelayedJusticeConfirmation(t *testing.T) {
 		blockHeight  = int32(10)
 		forceCloseTx = bobClose.CloseTx
 		chanPoint    = alice.ChannelPoint()
-		publTx       = make(chan *wire.MsgTx)
+		publTx       = make(chan *wire.MsgTx, 1)
 	)
 
 	// Make PublishTransaction always return succeed.
@@ -1795,7 +1800,9 @@ func TestBreachDelayedJusticeConfirmation(t *testing.T) {
 		return nil
 	}
 
-	// Notify the breach arbiter about the breach.
+	// Act: Hand the persisted breach to the arbiter, advance its block
+	// observer until it splits the stalled justice transaction, and deliver
+	// spend evidence for both split transactions below.
 	retribution, err := lnwallet.NewBreachRetribution(
 		alice.State(), height, uint32(blockHeight), forceCloseTx,
 		fn.Some[lnwallet.AuxLeafStore](&lnwallet.MockAuxLeafStore{}),
@@ -1972,7 +1979,8 @@ func TestBreachDelayedJusticeConfirmation(t *testing.T) {
 		notifier.Spend(op, blockHeight+6, splits[1])
 	}
 
-	// Assert that the channel is fully resolved.
+	// Assert: Wait for terminal-depth evidence to remove every recovery
+	// output and mark the breached channel fully resolved in both stores.
 	assertBrarCleanup(
 		t, brar, &chanPoint, testChannelStateDB(t, alice.State()),
 	)
@@ -2618,7 +2626,7 @@ func TestUpdateBreachInfoCountsFinalTaprootRevokedFunds(t *testing.T) {
 	}
 
 	// Act: Process a spend for that revoked output.
-	total, revoked := updateBreachInfo(breachInfo, []spend{{
+	total, revoked := updateBreachInfo(breachInfo, nil, []spend{{
 		index: 0,
 		detail: &chainntnfs.SpendDetail{
 			SpendingTx:        &wire.MsgTx{TxIn: []*wire.TxIn{{}}},
@@ -2631,4 +2639,164 @@ func TestUpdateBreachInfoCountsFinalTaprootRevokedFunds(t *testing.T) {
 	require.Equal(t, revokedAmt, total)
 	require.Equal(t, revokedAmt, revoked)
 	require.Empty(t, breachInfo.breachedOutputs)
+}
+
+// TestUpdateBreachInfoSpendDepth verifies terminal mutation depends on the
+// observer that supplied an otherwise identical justice spend.
+func TestUpdateBreachInfoSpendDepth(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Build independent recovery records for the same revoked
+	// output and one justice spend. Keeping the records separate exposes
+	// only the provisional marker as the behavior-changing input.
+	outpoint := wire.OutPoint{Hash: chainhash.Hash{1}, Index: 2}
+	newBreachInfo := func() *retributionInfo {
+		return &retributionInfo{breachedOutputs: []breachedOutput{{
+			amt:         1000,
+			outpoint:    outpoint,
+			witnessType: input.CommitmentRevoke,
+		}}}
+	}
+	spendDetail := &chainntnfs.SpendDetail{
+		SpendingTx:        &wire.MsgTx{TxIn: []*wire.TxIn{{}}},
+		SpenderInputIndex: 0,
+	}
+	shallowInfo := newBreachInfo()
+	terminalInfo := newBreachInfo()
+
+	// Act: Apply the same spend first as provisional evidence and then as
+	// terminal-depth evidence to the independent recovery records.
+	shallowTotal, shallowRevoked := updateBreachInfo(
+		shallowInfo, nil, []spend{{
+			index: 0, detail: spendDetail, provisional: true,
+		}},
+	)
+	terminalTotal, terminalRevoked := updateBreachInfo(
+		terminalInfo, nil,
+		[]spend{{index: 0, detail: spendDetail}},
+	)
+
+	// Assert: One-confirmation evidence retains recovery ownership and no
+	// accounting, while terminal evidence removes and accounts for the
+	// exact revoked output.
+	require.Zero(t, shallowTotal)
+	require.Zero(t, shallowRevoked)
+	require.Len(t, shallowInfo.breachedOutputs, 1)
+	require.Equal(t, outpoint, shallowInfo.breachedOutputs[0].outpoint)
+	require.Equal(t, btcutil.Amount(1000), terminalTotal)
+	require.Equal(t, btcutil.Amount(1000), terminalRevoked)
+	require.Empty(t, terminalInfo.breachedOutputs)
+}
+
+// TestBreachEarlyHTLCSpendDepth verifies a first-level HTLC transition can
+// redirect justice at one confirmation and return to its original target when
+// that shallow spend is reorged.
+func TestBreachEarlyHTLCSpendDepth(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Register terminal and one-confirmation observers. A
+	// two-element taproot witness makes the early spend a second-level
+	// transition instead of a justice-key spend.
+	const breachHeight = uint32(50)
+	outpoint := wire.OutPoint{Hash: chainhash.Hash{2}, Index: 3}
+	pkScript := append(
+		[]byte{txscript.OP_1, 0x20}, bytes.Repeat([]byte{3}, 32)...,
+	)
+	terminalEvent := chainntnfs.NewSpendEvent(func() {})
+	earlyEvent := chainntnfs.NewSpendEvent(func() {})
+	notifier := &chainntnfs.MockChainNotifier{}
+	notifier.On(
+		"RegisterSpendNtfn", &outpoint, pkScript, breachHeight,
+		testifymock.MatchedBy(func(opts []chainntnfs.SpendOption) bool {
+			// Parse the option here so the terminal policy remains
+			// visible in the Arrange phase.
+			parsed, err := chainntnfs.ParseSpendOptions(opts...)
+			return err == nil &&
+				parsed.NumConfs == breachSpendConfDepth()
+		}),
+	).Return(terminalEvent, nil).Once()
+	notifier.On(
+		"RegisterSpendNtfn", &outpoint, pkScript, breachHeight,
+		testifymock.MatchedBy(func(opts []chainntnfs.SpendOption) bool {
+			// Parse options to assert the urgent depth
+			// independently of terminal cleanup.
+			parsed, err := chainntnfs.ParseSpendOptions(opts...)
+			return err == nil && parsed.NumConfs == 1
+		}),
+	).Return(earlyEvent, nil).Once()
+	spendingTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: outpoint,
+			Witness:          wire.TxWitness{{1}, {2}},
+		}},
+		TxOut: []*wire.TxOut{{Value: 900, PkScript: pkScript}},
+	}
+	spendingHash := spendingTx.TxHash()
+	earlyEvent.Spend <- &chainntnfs.SpendDetail{
+		SpentOutPoint:     &outpoint,
+		SpenderTxHash:     &spendingHash,
+		SpendingTx:        spendingTx,
+		SpenderInputIndex: 0,
+	}
+	breachInfo := &retributionInfo{
+		breachHeight: breachHeight,
+		breachedOutputs: []breachedOutput{{
+			amt:         1000,
+			outpoint:    outpoint,
+			witnessType: input.TaprootHtlcOfferedRevoke,
+			signDesc: input.SignDescriptor{
+				Output: &wire.TxOut{
+					Value: 1000, PkScript: pkScript,
+				},
+			},
+			secondLevelWitnessScript: []byte{txscript.OP_TRUE},
+		}},
+	}
+	arbitrator := &BreachArbitrator{
+		cfg:  &BreachConfig{Notifier: notifier},
+		quit: make(chan struct{}),
+	}
+	subscriptions := make(
+		map[wire.OutPoint]*breachSpendSubscription,
+	)
+	provisionalOutputs := make(map[wire.OutPoint]breachedOutput)
+
+	// Act: Consume the ready one-confirmation event into the reversible
+	// overlay, then deliver its reorg through the same subscription and
+	// apply that lifecycle reversal before terminal depth.
+	spends, err := arbitrator.waitForSpendEvent(
+		breachInfo, subscriptions,
+	)
+	require.NoError(t, err)
+	require.Len(t, spends, 1)
+	updateBreachInfo(breachInfo, provisionalOutputs, spends)
+	shallowOutput := provisionalOutputs[outpoint]
+	earlyEvent.Reorg <- struct{}{}
+	reorgs, err := arbitrator.waitForSpendEvent(
+		breachInfo, subscriptions,
+	)
+	require.NoError(t, err)
+	require.Len(t, reorgs, 1)
+	updateBreachInfo(breachInfo, provisionalOutputs, reorgs)
+	subscriptions[outpoint].terminal.Cancel()
+	subscriptions[outpoint].early.Cancel()
+
+	// Assert: Shallow evidence produced a second-level candidate without
+	// mutating durable recovery, while the reorg removed that candidate and
+	// left the original first-level output ready for a new justice attempt.
+	require.True(t, spends[0].provisional)
+	require.False(t, spends[0].reorg)
+	require.Equal(t, spendingHash, shallowOutput.outpoint.Hash)
+	require.Equal(
+		t, input.TaprootHtlcSecondLevelRevoke,
+		shallowOutput.witnessType,
+	)
+	require.True(t, reorgs[0].provisional)
+	require.True(t, reorgs[0].reorg)
+	require.Empty(t, provisionalOutputs)
+	require.Len(t, breachInfo.breachedOutputs, 1)
+	require.Equal(t, outpoint, breachInfo.breachedOutputs[0].outpoint)
+	require.Equal(t, input.TaprootHtlcOfferedRevoke,
+		breachInfo.breachedOutputs[0].witnessType)
+	notifier.AssertExpectations(t)
 }

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/walletdb"
@@ -451,10 +452,35 @@ func shouldSuppressClosedChannelNotify(closeType channeldb.ClosureType,
 	return closeType == channeldb.CooperativeClose && earlyDispatched
 }
 
+// resolveSpendConfDepth selects an explicit integration override or derives
+// the production policy from authoritative channel capacity, then validates
+// that every consumer can express the final value through ChainNotifier.
+func resolveSpendConfDepth(capacity btcutil.Amount,
+	override fn.Option[uint32]) (uint32, error) {
+
+	depth := override.UnwrapOrFunc(func() uint32 {
+		// Production uses the capacity-scaled close policy. The
+		// option keeps integration scenarios deterministic.
+		return lnwallet.CloseConfsForCapacity(capacity)
+	})
+
+	// Fail before constructing a watcher or resolver so no channel can
+	// start with a policy its notifier is unable to honor.
+	if depth == 0 || depth > chainntnfs.MaxNumConfs {
+		return 0, fmt.Errorf(
+			"invalid spend confirmation depth %d: %w", depth,
+			chainntnfs.ErrNumConfsOutOfRange,
+		)
+	}
+
+	return depth, nil
+}
+
 // newActiveChannelArbitrator creates a new instance of an active channel
 // arbitrator given the state of the target channel.
 func newActiveChannelArbitrator(channel *chanstate.OpenChannel,
-	c *ChainArbitrator, chanEvents *ChainEventSubscription) (*ChannelArbitrator, error) {
+	c *ChainArbitrator, chanEvents *ChainEventSubscription,
+	spendConfDepth uint32) (*ChannelArbitrator, error) {
 
 	// TODO(roasbeef): fetch best height (or pass in) so can ensure block
 	// epoch delivers all the notifications to
@@ -510,6 +536,7 @@ func newActiveChannelArbitrator(channel *chanstate.OpenChannel,
 			return nil
 		},
 		IsPendingClose:        false,
+		SpendConfDepth:        spendConfDepth,
 		ChainArbitratorConfig: c.cfg,
 		ChainEvents:           chanEvents,
 		PutResolverReport: func(tx kvdb.RwTx,
@@ -1187,6 +1214,15 @@ func (c *ChainArbitrator) WatchNewChannel(
 		return nil
 	}
 
+	// Resolve one channel-level policy before constructing either consumer
+	// so the watcher and every resolver cannot drift to different depths.
+	spendConfDepth, err := resolveSpendConfDepth(
+		newChan.Capacity, c.cfg.ChannelCloseConfs,
+	)
+	if err != nil {
+		return err
+	}
+
 	// First, also create an active chainWatcher for this channel to ensure
 	// that we detect any relevant on chain events.
 	chainWatcher, err := newChainWatcher(
@@ -1206,7 +1242,7 @@ func (c *ChainArbitrator) WatchNewChannel(
 			auxLeafStore:         c.cfg.AuxLeafStore,
 			auxResolver:          c.cfg.AuxResolver,
 			auxCloser:            c.cfg.AuxCloser,
-			chanCloseConfs:       c.cfg.ChannelCloseConfs,
+			spendConfDepth:       spendConfDepth,
 			notifyEarlyCoopClose: c.cfg.NotifyEarlyClosedChannel,
 		},
 	)
@@ -1220,6 +1256,7 @@ func (c *ChainArbitrator) WatchNewChannel(
 	// channel, and our internal state.
 	channelArb, err := newActiveChannelArbitrator(
 		newChan, c, chainWatcher.SubscribeChannelEvents(),
+		spendConfDepth,
 	)
 	if err != nil {
 		return err
@@ -1368,6 +1405,15 @@ func (c *ChainArbitrator) loadOpenChannels() error {
 	for _, channel := range openChannels {
 		chanPoint := channel.FundingOutpoint
 
+		// Derive from the persisted open channel so restart and the
+		// dynamic channel path share one capacity authority.
+		spendConfDepth, err := resolveSpendConfDepth(
+			channel.Capacity, c.cfg.ChannelCloseConfs,
+		)
+		if err != nil {
+			return err
+		}
+
 		// First, we'll create an active chainWatcher for this channel
 		// to ensure that we detect any relevant on chain events.
 		breachClosure := func(ret *lnwallet.BreachRetribution) error {
@@ -1386,7 +1432,7 @@ func (c *ChainArbitrator) loadOpenChannels() error {
 				auxLeafStore:         c.cfg.AuxLeafStore,
 				auxResolver:          c.cfg.AuxResolver,
 				auxCloser:            c.cfg.AuxCloser,
-				chanCloseConfs:       c.cfg.ChannelCloseConfs,
+				spendConfDepth:       spendConfDepth,
 				notifyEarlyCoopClose: notifyEarlyClose,
 			},
 		)
@@ -1397,6 +1443,7 @@ func (c *ChainArbitrator) loadOpenChannels() error {
 		c.activeWatchers[chanPoint] = chainWatcher
 		channelArb, err := newActiveChannelArbitrator(
 			channel, c, chainWatcher.SubscribeChannelEvents(),
+			spendConfDepth,
 		)
 		if err != nil {
 			return err
@@ -1442,6 +1489,15 @@ func (c *ChainArbitrator) loadPendingCloseChannels() error {
 		// We can leave off the CloseContract and ForceCloseChan
 		// methods as the channel is already closed at this point.
 		chanPoint := closeChanInfo.ChanPoint
+
+		// A pending-close restart has no live OpenChannel. Use the
+		// closed summary's capacity as the authoritative policy input.
+		spendConfDepth, err := resolveSpendConfDepth(
+			closeChanInfo.Capacity, c.cfg.ChannelCloseConfs,
+		)
+		if err != nil {
+			return err
+		}
 		arbCfg := ChannelArbitratorConfig{
 			ChanPoint:             chanPoint,
 			ShortChanID:           closeChanInfo.ShortChanID,
@@ -1450,6 +1506,7 @@ func (c *ChainArbitrator) loadPendingCloseChannels() error {
 			IsPendingClose:        true,
 			ClosingHeight:         closeChanInfo.CloseHeight,
 			CloseType:             closeChanInfo.CloseType,
+			SpendConfDepth:        spendConfDepth,
 			PutResolverReport: func(tx kvdb.RwTx,
 				report *channeldb.ResolverReport) error {
 

--- a/contractcourt/chain_arbitrator_test.go
+++ b/contractcourt/chain_arbitrator_test.go
@@ -4,18 +4,59 @@ import (
 	"net"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/chanstate"
 	"github.com/lightningnetwork/lnd/clock"
+	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/graph/db/models"
 	"github.com/lightningnetwork/lnd/lntest/mock"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/stretchr/testify/require"
 )
+
+// TestResolveSpendConfDepth verifies production capacity derivation and both
+// validation layers applied to the existing integration override.
+func TestResolveSpendConfDepth(t *testing.T) {
+	t.Parallel()
+
+	// Arrange a representative channel capacity and the expected value from
+	// lnd's existing close-confirmation policy. No watcher or resolver is
+	// constructed, which isolates the shared policy boundary itself.
+	capacity := btcutil.Amount(1_000_000)
+	wantDerived := lnwallet.CloseConfsForCapacity(capacity)
+
+	// Act by resolving production policy, a valid deterministic override,
+	// zero, and a value beyond the notifier's maximum supported depth.
+	derived, derivedErr := resolveSpendConfDepth(
+		capacity, fn.None[uint32](),
+	)
+	overridden, overriddenErr := resolveSpendConfDepth(
+		capacity, fn.Some(uint32(2)),
+	)
+	zero, zeroErr := resolveSpendConfDepth(
+		capacity, fn.Some(uint32(0)),
+	)
+	overLimit, overLimitErr := resolveSpendConfDepth(
+		capacity, fn.Some(uint32(chainntnfs.MaxNumConfs+1)),
+	)
+
+	// Assert capacity remains the production authority, the integration
+	// override is honored exactly, and invalid values cannot leak a usable
+	// depth into partially constructed lifecycle components.
+	require.NoError(t, derivedErr)
+	require.Equal(t, wantDerived, derived)
+	require.NoError(t, overriddenErr)
+	require.Equal(t, uint32(2), overridden)
+	require.ErrorIs(t, zeroErr, chainntnfs.ErrNumConfsOutOfRange)
+	require.Zero(t, zero)
+	require.ErrorIs(t, overLimitErr, chainntnfs.ErrNumConfsOutOfRange)
+	require.Zero(t, overLimit)
+}
 
 // TestChainArbitratorRepulishCloses tests that the chain arbitrator will
 // republish closing transactions for channels marked CommitementBroadcast or

--- a/contractcourt/chain_watcher.go
+++ b/contractcourt/chain_watcher.go
@@ -276,11 +276,9 @@ type chainWatcherConfig struct {
 	// auxCloser is used to finalize cooperative closes.
 	auxCloser fn.Option[AuxChanCloser]
 
-	// chanCloseConfs is an optional override for the number of
-	// confirmations required for channel closes. When set, this overrides
-	// the normal capacity-based scaling. This is only available in
-	// dev/integration builds for testing purposes.
-	chanCloseConfs fn.Option[uint32]
+	// spendConfDepth is the already-validated channel maturity policy used
+	// for every funding-spend lifecycle handled by this watcher.
+	spendConfDepth uint32
 
 	// notifyEarlyCoopClose, if set, is invoked with a synthesized
 	// ChannelCloseSummary the first time a cooperative close spend is
@@ -367,6 +365,15 @@ func (c *chainWatcher) EarlyCoopCloseDispatched() bool {
 // the chan point to watch, and also a notifier instance that will allow us to
 // detect on chain events.
 func newChainWatcher(cfg chainWatcherConfig) (*chainWatcher, error) {
+	// Guard direct test constructors as well as production call sites so a
+	// watcher can never launch with an unusable notifier depth.
+	if cfg.spendConfDepth == 0 ||
+		cfg.spendConfDepth > chainntnfs.MaxNumConfs {
+
+		return nil, fmt.Errorf("invalid spend confirmation depth %d",
+			cfg.spendConfDepth)
+	}
+
 	// In order to be able to detect the nature of a potential channel
 	// closure we'll need to reconstruct the state hint bytes used to
 	// obfuscate the commitment state number encoded in the lock time and
@@ -820,7 +827,7 @@ func (c *chainWatcher) processDetectedSpend(
 	// handled in chain_arbitrator.go via a CloseType check.
 	c.maybeDispatchEarlyCoopClose(spend)
 
-	numConfs := c.requiredConfsForSpend()
+	numConfs := c.cfg.spendConfDepth
 	txid := spend.SpenderTxHash
 
 	// Record the close confirmation height. This is the height at which
@@ -1403,18 +1410,6 @@ func (c *chainWatcher) finalizeCoopClose(aux AuxChanCloser,
 	return aux.FinalizeClose(desc, closeTx)
 }
 
-// requiredConfsForSpend determines the number of confirmations required before
-// processing a spend of the funding output. Uses config override if set
-// (typically for testing), otherwise scales with channel capacity to balance
-// security vs user experience for channels of different sizes.
-func (c *chainWatcher) requiredConfsForSpend() uint32 {
-	return c.cfg.chanCloseConfs.UnwrapOrFunc(func() uint32 {
-		return lnwallet.CloseConfsForCapacity(
-			c.cfg.chanState.Capacity,
-		)
-	})
-}
-
 // isCoopCloseSpend reports whether the supplied spending tx looks like a
 // cooperative close. A coop close has a finalized input sequence number
 // (either MaxTxInSequenceNum or MaxRBFSequence); regular commitment txns
@@ -1877,7 +1872,7 @@ func deriveFundingPkScript(chanState *chanstate.OpenChannel) ([]byte, error) {
 func (c *chainWatcher) handleSpendDispatch(spend *chainntnfs.SpendDetail,
 	source string) bool {
 
-	numConfs := c.requiredConfsForSpend()
+	numConfs := c.cfg.spendConfDepth
 	if numConfs == 1 {
 		log.Infof("ChannelPoint(%v): single confirmation mode, "+
 			"dispatching immediately from %s",

--- a/contractcourt/chain_watcher_test.go
+++ b/contractcourt/chain_watcher_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/chanstate"
-	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/input"
 	lnmock "github.com/lightningnetwork/lnd/lntest/mock"
 	"github.com/lightningnetwork/lnd/lnwallet"
@@ -48,7 +47,8 @@ func TestChainWatcherRemoteUnilateralClose(t *testing.T) {
 		notifier:            aliceNotifier,
 		signer:              aliceChannel.Signer,
 		extractStateNumHint: lnwallet.GetStateNumHint,
-		chanCloseConfs:      fn.Some(uint32(1)),
+		// This scenario deliberately exercises the immediate path.
+		spendConfDepth: 1,
 	})
 	require.NoError(t, err, "unable to create chain watcher")
 	err = aliceChainWatcher.Start()
@@ -95,7 +95,7 @@ func TestChainWatcherRemoteUnilateralClose(t *testing.T) {
 		t.Fatalf("unable to send blockbeat")
 	}
 
-	// With chanCloseConfs set to 1, the fast-path dispatches immediately
+	// With spendConfDepth set to 1, the fast path dispatches immediately
 	// without confirmation registration. The close event should arrive
 	// directly after processing the blockbeat.
 
@@ -165,7 +165,8 @@ func TestChainWatcherRemoteUnilateralClosePendingCommit(t *testing.T) {
 		notifier:            aliceNotifier,
 		signer:              aliceChannel.Signer,
 		extractStateNumHint: lnwallet.GetStateNumHint,
-		chanCloseConfs:      fn.Some(uint32(1)),
+		// This scenario deliberately exercises the immediate path.
+		spendConfDepth: 1,
 	})
 	require.NoError(t, err, "unable to create chain watcher")
 	if err := aliceChainWatcher.Start(); err != nil {
@@ -231,7 +232,7 @@ func TestChainWatcherRemoteUnilateralClosePendingCommit(t *testing.T) {
 		t.Fatalf("unable to send blockbeat")
 	}
 
-	// With chanCloseConfs set to 1, the fast-path dispatches immediately
+	// With spendConfDepth set to 1, the fast path dispatches immediately
 	// without confirmation registration. The close event should arrive
 	// directly after processing the blockbeat.
 
@@ -358,6 +359,11 @@ func TestChainWatcherDataLossProtect(t *testing.T) {
 			chanState: aliceChanState,
 			notifier:  aliceNotifier,
 			signer:    aliceChannel.Signer,
+			// Match production policy because this scenario
+			// does not override the close depth under test.
+			spendConfDepth: lnwallet.CloseConfsForCapacity(
+				aliceChanState.Capacity,
+			),
 			extractStateNumHint: func(*wire.MsgTx,
 				[lnwallet.StateHintSize]byte) uint64 {
 
@@ -563,6 +569,11 @@ func TestChainWatcherLocalForceCloseDetect(t *testing.T) {
 			notifier:            aliceNotifier,
 			signer:              aliceChannel.Signer,
 			extractStateNumHint: lnwallet.GetStateNumHint,
+			// Match production policy because this scenario
+			// does not override the close depth under test.
+			spendConfDepth: lnwallet.CloseConfsForCapacity(
+				aliceChanState.Capacity,
+			),
 		})
 		if err != nil {
 			t.Fatalf("unable to create chain watcher: %v", err)

--- a/contractcourt/chain_watcher_test_harness.go
+++ b/contractcourt/chain_watcher_test_harness.go
@@ -242,13 +242,24 @@ func newChainWatcherTestHarnessFromReporter(t *testing.T,
 		}
 	}
 
+	// Resolve the harness override against channel capacity exactly as the
+	// production constructor does, keeping every test watcher concrete.
+	spendConfDepth, err := resolveSpendConfDepth(
+		aliceChannel.State().Capacity, cfg.requiredConfs,
+	)
+	if err != nil {
+		// Invalid setup prevents a watcher launch, so later lifecycle
+		// assertions would be misleading.
+		reporter.Fatalf("unable to resolve spend depth: %v", err)
+	}
+
 	// Create chain watcher.
 	chainWatcher, err := newChainWatcher(chainWatcherConfig{
 		chanState:            aliceChannel.State(),
 		notifier:             notifier,
 		signer:               aliceChannel.Signer,
 		extractStateNumHint:  lnwallet.GetStateNumHint,
-		chanCloseConfs:       cfg.requiredConfs,
+		spendConfDepth:       spendConfDepth,
 		notifyEarlyCoopClose: notifyEarlyCoopClose,
 		contractBreach: func(
 			retInfo *lnwallet.BreachRetribution,

--- a/contractcourt/chain_watcher_test_harness.go
+++ b/contractcourt/chain_watcher_test_harness.go
@@ -88,7 +88,8 @@ type mockConfirmationEvent struct {
 
 // RegisterSpendNtfn creates a new mock spend event.
 func (m *mockChainNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	pkScript []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	pkScript []byte, heightHint uint32,
+	_ ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
 	// The base mock already has SpendChan, use that.
 	spendEvent := &chainntnfs.SpendEvent{

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -3217,6 +3217,7 @@ func (c *ChannelArbitrator) createSweepRequest(
 	return sweepRequest{
 		input: &anchorInput,
 		params: sweep.Params{
+			RequiredConfs:  c.cfg.SpendConfDepth,
 			ExclusiveGroup: &exclusiveGroup,
 			Budget:         budget,
 			DeadlineHeight: deadlineHeight,

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -154,6 +154,10 @@ type ChannelArbitratorConfig struct {
 	// true. Otherwise this value is unset.
 	CloseType channeldb.ClosureType
 
+	// SpendConfDepth is the validated channel-level maturity policy shared
+	// by the funding watcher and every resolver belonging to this channel.
+	SpendConfDepth uint32
+
 	// NotifyChannelResolved is used by the channel arbitrator to signal
 	// that a given channel has been resolved.
 	NotifyChannelResolved func()

--- a/contractcourt/commit_sweep_resolver.go
+++ b/contractcourt/commit_sweep_resolver.go
@@ -98,18 +98,22 @@ func (c *commitSweepResolver) ResolverKey() []byte {
 	return key[:]
 }
 
-// waitForSpend waits for the given outpoint to be spent, and returns the
-// details of the spending tx.
+// waitForSpend waits for the given outpoint to reach spendConfDepth and returns
+// the canonical spending transaction. Every exit releases the notifier client
+// so resolver restarts do not accumulate stale registrations.
 func waitForSpend(op *wire.OutPoint, pkScript []byte, heightHint uint32,
-	notifier chainntnfs.ChainNotifier, quit <-chan struct{}) (
+	spendConfDepth uint32, notifier chainntnfs.ChainNotifier,
+	quit <-chan struct{}) (
 	*chainntnfs.SpendDetail, error) {
 
 	spendNtfn, err := notifier.RegisterSpendNtfn(
 		op, pkScript, heightHint,
+		chainntnfs.WithSpendNumConfs(spendConfDepth),
 	)
 	if err != nil {
 		return nil, err
 	}
+	defer spendNtfn.Cancel()
 
 	select {
 	case spendDetail, ok := <-spendNtfn.Spend:
@@ -407,7 +411,8 @@ func (c *commitSweepResolver) Launch() error {
 	// With our input constructed, we'll now offer it to the sweeper.
 	resultChan, err := c.Sweeper.SweepInput(
 		inp, sweep.Params{
-			Budget: budget,
+			RequiredConfs: c.SpendConfDepth,
+			Budget:        budget,
 
 			// Specify a nil deadline here as there's no time
 			// pressure.

--- a/contractcourt/htlc_outgoing_contest_resolver.go
+++ b/contractcourt/htlc_outgoing_contest_resolver.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/lnwallet"
@@ -100,14 +101,17 @@ func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 		return nil, err
 	}
 
-	// First, we'll register for a spend notification for this output. If
-	// the remote party sweeps with the pre-image, we'll be notified.
+	// A revealed preimage remains actionable even if its transaction is
+	// reorged. Observe it at the first confirmation so a near-expiry claim
+	// wins the race with the transition to the timeout resolver.
 	spendNtfn, err := h.Notifier.RegisterSpendNtfn(
 		outPointToWatch, scriptToWatch, h.broadcastHeight,
+		chainntnfs.WithSpendNumConfs(1),
 	)
 	if err != nil {
 		return nil, err
 	}
+	defer spendNtfn.Cancel()
 
 	// We'll quickly check to see if the output has already been spent.
 	select {

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -940,12 +940,13 @@ func (h *htlcSuccessResolver) resolveLegacySuccessTx() error {
 
 	h.log.Infof("incubating incoming htlc output")
 
-	// Send the output to the incubator.
+	// Send the output and terminal policy to the incubator so its persisted
+	// claim survives the same shallow reorgs.
 	err = h.IncubateOutputs(
 		h.ChanPoint, fn.None[lnwallet.OutgoingHtlcResolution](),
 		fn.Some(h.htlcResolution),
 		h.broadcastHeight, fn.Some(int32(h.htlc.RefundTimeout)),
-		WithChanType(h.chanType),
+		WithChanType(h.chanType), WithSpendConfDepth(h.SpendConfDepth),
 	)
 	if err != nil {
 		return err

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -170,7 +170,7 @@ func (h *htlcSuccessResolver) resolveRemoteCommitOutput() error {
 	sweepTxDetails, err := waitForSpend(
 		&h.htlcResolution.ClaimOutpoint,
 		h.htlcResolution.SweepSignDesc.Output.PkScript,
-		h.broadcastHeight, h.Notifier, h.quit,
+		h.broadcastHeight, h.SpendConfDepth, h.Notifier, h.quit,
 	)
 	if err != nil {
 		return err
@@ -746,6 +746,7 @@ func (h *htlcSuccessResolver) sweepRemoteCommitOutput() error {
 	_, err := h.Sweeper.SweepInput(
 		inp,
 		sweep.Params{
+			RequiredConfs:  h.SpendConfDepth,
 			Budget:         budget,
 			DeadlineHeight: deadline,
 		},
@@ -792,6 +793,7 @@ func (h *htlcSuccessResolver) sweepSuccessTx() error {
 	_, err := h.Sweeper.SweepInput(
 		&secondLevelInput,
 		sweep.Params{
+			RequiredConfs:  h.SpendConfDepth,
 			Budget:         budget,
 			DeadlineHeight: deadline,
 		},
@@ -807,13 +809,14 @@ func (h *htlcSuccessResolver) sweepSuccessTxOutput() error {
 	h.log.Debugf("sweeping output %v from 2nd-level HTLC success tx",
 		h.htlcResolution.ClaimOutpoint)
 
-	// This should be non-blocking as we will only attempt to sweep the
-	// output when the second level tx has already been confirmed. In other
-	// words, waitForSpend will return immediately.
+	// This preparatory lookup deliberately remains at one confirmation:
+	// Launch can call it synchronously after outputIncubating was
+	// checkpointed, and waiting for terminal depth would stall blockbeat
+	// while no final resolver outcome is being recorded.
 	commitSpend, err := waitForSpend(
 		&h.htlcResolution.SignedSuccessTx.TxIn[0].PreviousOutPoint,
 		h.htlcResolution.SignDetails.SignDesc.Output.PkScript,
-		h.broadcastHeight, h.Notifier, h.quit,
+		h.broadcastHeight, 1, h.Notifier, h.quit,
 	)
 	if err != nil {
 		return err
@@ -897,7 +900,8 @@ func (h *htlcSuccessResolver) sweepSuccessTxOutput() error {
 	_, err = h.Sweeper.SweepInput(
 		inp,
 		sweep.Params{
-			Budget: budget,
+			RequiredConfs: h.SpendConfDepth,
+			Budget:        budget,
 
 			// For second level success tx, there's no rush to get
 			// it confirmed, so we use a nil deadline.
@@ -969,7 +973,8 @@ func (h *htlcSuccessResolver) resolveSuccessTx() error {
 
 	// Wait for the second level transaction to confirm.
 	commitSpend, err := waitForSpend(
-		&outpoint, pkScript, h.broadcastHeight, h.Notifier, h.quit,
+		&outpoint, pkScript, h.broadcastHeight, h.SpendConfDepth,
+		h.Notifier, h.quit,
 	)
 	if err != nil {
 		return err
@@ -1026,7 +1031,7 @@ func (h *htlcSuccessResolver) resolveSuccessTxOutput(op wire.OutPoint) error {
 
 	spend, err := waitForSpend(
 		&op, h.htlcResolution.SweepSignDesc.Output.PkScript,
-		h.broadcastHeight, h.Notifier, h.quit,
+		h.broadcastHeight, h.SpendConfDepth, h.Notifier, h.quit,
 	)
 	if err != nil {
 		return err

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -529,18 +529,26 @@ func (h *htlcTimeoutResolver) sweepTimeoutTx() error {
 // resolveSecondLevelTxLegacy sends a second level timeout transaction to the
 // utxo nursery. This transaction uses the legacy SIGHASH_ALL flag.
 func (h *htlcTimeoutResolver) resolveSecondLevelTxLegacy() error {
-	h.log.Debug("incubating htlc output")
+	// A stage-one checkpoint proves Nursery already accepted this logical
+	// output. Replaying incubation after its store entry graduated can
+	// recreate a stale crib, so only the pre-checkpoint path may hand it
+	// off.
+	if !h.outputIncubating {
+		h.log.Debug("incubating htlc output")
 
-	// The utxo nursery will take care of broadcasting the second-level
-	// timeout tx and sweeping its output once it confirms.
-	err := h.IncubateOutputs(
-		h.ChanPoint, fn.Some(h.htlcResolution),
-		fn.None[lnwallet.IncomingHtlcResolution](),
-		h.broadcastHeight, h.incomingHTLCExpiryHeight,
-		WithChanType(h.chanType),
-	)
-	if err != nil {
-		return err
+		// Nursery broadcasts the second-level timeout transaction and
+		// sweeps its output. Carry terminal policy so neither persisted
+		// transition discards the claim after one confirmation.
+		err := h.IncubateOutputs(
+			h.ChanPoint, fn.Some(h.htlcResolution),
+			fn.None[lnwallet.IncomingHtlcResolution](),
+			h.broadcastHeight, h.incomingHTLCExpiryHeight,
+			WithChanType(h.chanType),
+			WithSpendConfDepth(h.SpendConfDepth),
+		)
+		if err != nil {
+			return err
+		}
 	}
 
 	return h.resolveTimeoutTx()

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -514,6 +514,7 @@ func (h *htlcTimeoutResolver) sweepTimeoutTx() error {
 	_, err := h.Sweeper.SweepInput(
 		inp,
 		sweep.Params{
+			RequiredConfs:  h.SpendConfDepth,
 			Budget:         budget,
 			DeadlineHeight: h.incomingHTLCExpiryHeight,
 		},
@@ -581,7 +582,8 @@ func (h *htlcTimeoutResolver) sweepDirectHtlcOutput() error {
 	_, err := h.Sweeper.SweepInput(
 		sweepInput,
 		sweep.Params{
-			Budget: budget,
+			RequiredConfs: h.SpendConfDepth,
+			Budget:        budget,
 
 			// This is an outgoing HTLC, so we want to make sure
 			// that we sweep it before the incoming HTLC expires.
@@ -598,8 +600,8 @@ func (h *htlcTimeoutResolver) sweepDirectHtlcOutput() error {
 // watchHtlcSpend watches for a spend of the HTLC output. For neutrino backend,
 // it will check blocks for the confirmed spend. For btcd and bitcoind, it will
 // check both the mempool and the blocks.
-func (h *htlcTimeoutResolver) watchHtlcSpend() (*chainntnfs.SpendDetail,
-	error) {
+func (h *htlcTimeoutResolver) watchHtlcSpend(spendConfDepth uint32) (
+	*chainntnfs.SpendDetail, error) {
 
 	// TODO(yy): outpointToWatch is always h.HtlcOutpoint(), can refactor
 	// to remove the redundancy.
@@ -608,25 +610,118 @@ func (h *htlcTimeoutResolver) watchHtlcSpend() (*chainntnfs.SpendDetail,
 		return nil, err
 	}
 
-	// If there's no mempool configured, which is the case for SPV node
-	// such as neutrino, then we will watch for confirmed spend only.
+	// Deep policies retain a one-block view for already-mined preimages.
+	if spendConfDepth > 1 {
+		return h.waitForPreimageOrMatureSpend(
+			outpointToWatch, scriptToWatch, spendConfDepth,
+		)
+	}
+
+	// A block-only backend needs only the terminal view at depth one.
 	if h.Mempool == nil {
-		return h.waitForConfirmedSpend(outpointToWatch, scriptToWatch)
+		return h.waitForConfirmedSpend(
+			outpointToWatch, scriptToWatch, spendConfDepth,
+		)
 	}
 
 	// Watch for a spend of the HTLC output in both the mempool and blocks.
-	return h.waitForMempoolOrBlockSpend(*outpointToWatch, scriptToWatch)
+	return h.waitForMempoolOrBlockSpend(
+		*outpointToWatch, scriptToWatch, spendConfDepth,
+	)
+}
+
+// waitForPreimageOrMatureSpend reveals actionable preimages early while
+// keeping timeout-driven cleanup behind the channel's terminal policy.
+func (h *htlcTimeoutResolver) waitForPreimageOrMatureSpend(
+	op *wire.OutPoint, pkScript []byte, spendConfDepth uint32) (
+	*chainntnfs.SpendDetail, error) {
+
+	// Register both views first so no spend can race their installation.
+	earlySpend, err := h.Notifier.RegisterSpendNtfn(
+		op, pkScript, h.broadcastHeight,
+		chainntnfs.WithSpendNumConfs(1),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("register early spend: %w", err)
+	}
+	defer earlySpend.Cancel()
+
+	matureSpend, err := h.Notifier.RegisterSpendNtfn(
+		op, pkScript, h.broadcastHeight,
+		chainntnfs.WithSpendNumConfs(spendConfDepth),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("register mature spend: %w", err)
+	}
+	defer matureSpend.Cancel()
+
+	// Use the commitment origin to select the preimage witness layout.
+	localCommit := !h.isRemoteCommitOutput()
+
+	// Mempool is an optimization; the early block client closes races.
+	var mempoolSpends <-chan *chainntnfs.SpendDetail
+	if h.Mempool != nil {
+		mempoolEvent, err := h.Mempool.SubscribeMempoolSpent(*op)
+		if err != nil {
+			return nil, fmt.Errorf("register mempool: %w", err)
+		}
+		defer h.Mempool.CancelMempoolSpendEvent(mempoolEvent)
+		mempoolSpends = mempoolEvent.Spend
+	}
+
+	for {
+		select {
+		case spend, ok := <-earlySpend.Spend:
+			if !ok {
+				return nil, errResolverShuttingDown
+			}
+
+			// Preimages persist; other spends wait for maturity.
+			if isPreimageSpend(h.isTaproot(), spend, localCommit) {
+				return spend, nil
+			}
+
+		case _, ok := <-earlySpend.Reorg:
+			if !ok {
+				return nil, errResolverShuttingDown
+			}
+
+			// Drain reorgs so the early client can restart.
+
+		case spend, ok := <-matureSpend.Spend:
+			if !ok {
+				return nil, errResolverShuttingDown
+			}
+
+			return spend, nil
+
+		case spend, ok := <-mempoolSpends:
+			if !ok {
+				return nil, errResolverShuttingDown
+			}
+
+			// Mempool preimages are immediate; timeout spends wait.
+			if isPreimageSpend(h.isTaproot(), spend, localCommit) {
+				return spend, nil
+			}
+
+		case <-h.quit:
+			return nil, errResolverShuttingDown
+		}
+	}
 }
 
 // waitForConfirmedSpend waits for the HTLC output to be spent and confirmed in
 // a block, returns the spend details.
 func (h *htlcTimeoutResolver) waitForConfirmedSpend(op *wire.OutPoint,
-	pkScript []byte) (*chainntnfs.SpendDetail, error) {
+	pkScript []byte, spendConfDepth uint32) (
+	*chainntnfs.SpendDetail, error) {
 
 	// We'll block here until either we exit, or the HTLC output on the
 	// commitment transaction has been spent.
 	spend, err := waitForSpend(
-		op, pkScript, h.broadcastHeight, h.Notifier, h.quit,
+		op, pkScript, h.broadcastHeight, spendConfDepth, h.Notifier,
+		h.quit,
 	)
 	if err != nil {
 		return nil, err
@@ -830,18 +925,22 @@ type spendResult struct {
 // waitForMempoolOrBlockSpend waits for the htlc output to be spent by a
 // transaction that's either be found in the mempool or in a block.
 func (h *htlcTimeoutResolver) waitForMempoolOrBlockSpend(op wire.OutPoint,
-	pkScript []byte) (*chainntnfs.SpendDetail, error) {
+	pkScript []byte, spendConfDepth uint32) (
+	*chainntnfs.SpendDetail, error) {
 
 	log.Infof("%T(%v): waiting for spent of HTLC output %v to be found "+
 		"in mempool or block", h, h.htlcResolution.ClaimOutpoint, op)
 
-	// Subscribe for block spent(confirmed).
+	// Let blocks control terminality while mempool preimages remain an
+	// actionable optimization across reorgs.
 	blockSpent, err := h.Notifier.RegisterSpendNtfn(
 		&op, pkScript, h.broadcastHeight,
+		chainntnfs.WithSpendNumConfs(spendConfDepth),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("register spend: %w", err)
 	}
+	defer blockSpent.Cancel()
 
 	// Subscribe for mempool spent(unconfirmed).
 	mempoolSpent, err := h.Mempool.SubscribeMempoolSpent(op)
@@ -1012,7 +1111,10 @@ func (h *htlcTimeoutResolver) waitHtlcSpendAndCheckPreimage() (
 	//    commitment.
 	// 3. The local party spends the htlc output directlt from the remote
 	//    commitment.
-	spend, err := h.watchHtlcSpend()
+
+	// This preparatory lookup records no final outcome, so keep it at one
+	// confirmation rather than stalling blockbeat at terminal depth.
+	spend, err := h.watchHtlcSpend(1)
 	if err != nil {
 		return nil, err
 	}
@@ -1116,7 +1218,8 @@ func (h *htlcTimeoutResolver) sweepTimeoutTxOutput() error {
 	_, err = h.Sweeper.SweepInput(
 		inp,
 		sweep.Params{
-			Budget: budget,
+			RequiredConfs: h.SpendConfDepth,
+			Budget:        budget,
 
 			// For second level success tx, there's no rush
 			// to get it confirmed, so we use a nil
@@ -1197,7 +1300,7 @@ func (h *htlcTimeoutResolver) resolveRemoteCommitOutput() error {
 	h.log.Debug("waiting for direct-timeout spend of the htlc to confirm")
 
 	// Wait for the direct-timeout HTLC sweep tx to confirm.
-	spend, err := h.watchHtlcSpend()
+	spend, err := h.watchHtlcSpend(h.SpendConfDepth)
 	if err != nil {
 		return err
 	}
@@ -1235,7 +1338,7 @@ func (h *htlcTimeoutResolver) resolveTimeoutTx() error {
 		"confirm")
 
 	// Wait for the second level transaction to confirm.
-	spend, err := h.watchHtlcSpend()
+	spend, err := h.watchHtlcSpend(h.SpendConfDepth)
 	if err != nil {
 		return err
 	}
@@ -1294,7 +1397,7 @@ func (h *htlcTimeoutResolver) resolveTimeoutTxOutput(op wire.OutPoint) error {
 
 	spend, err := waitForSpend(
 		&op, h.htlcResolution.SweepSignDesc.Output.PkScript,
-		h.broadcastHeight, h.Notifier, h.quit,
+		h.broadcastHeight, h.SpendConfDepth, h.Notifier, h.quit,
 	)
 	if err != nil {
 		return err

--- a/contractcourt/interfaces.go
+++ b/contractcourt/interfaces.go
@@ -68,7 +68,8 @@ type UtxoSweeper interface {
 	// in the UtxoSweeper. This function can be used to provide an updated
 	// fee preference that will be used for a new sweep transaction of the
 	// input that will act as a replacement transaction (RBF) of the
-	// original sweeping transaction, if any.
+	// original sweeping transaction, if any. RequiredConfs remains fixed
+	// because the active spend notification owns the admitted depth.
 	UpdateParams(input wire.OutPoint, params sweep.Params) (
 		chan sweep.Result, error)
 }

--- a/contractcourt/nursery_store.go
+++ b/contractcourt/nursery_store.go
@@ -86,14 +86,19 @@ type NurseryStorer interface {
 	// outgoing htlc outputs to be swept back into the user's wallet. The
 	// event is persisted to disk, such that the nursery can resume the
 	// incubation process after a potential crash.
-	Incubate([]kidOutput, []babyOutput) error
+	Incubate([]kidOutput, []babyOutput) (
+		map[wire.OutPoint]struct{}, error)
 
 	// CribToKinder atomically moves a babyOutput in the crib bucket to the
 	// kindergarten bucket. Baby outputs are outgoing HTLC's which require
 	// us to go to the second-layer to claim. The now mature kidOutput
 	// contained in the babyOutput will be stored as it waits out the
 	// kidOutput's CSV delay.
-	CribToKinder(*babyOutput) error
+	//
+	// An additional parameter specifies the last graduated height. A
+	// depth-delayed transition can otherwise insert the output into a class
+	// that Nursery already processed and never visits again.
+	CribToKinder(baby *babyOutput, lastGradHeight uint32) error
 
 	// PreschoolToKinder atomically moves a kidOutput from the preschool
 	// bucket to the kindergarten bucket. This transition should be executed
@@ -263,8 +268,14 @@ func NewNurseryStore(chainHash *chainhash.Hash,
 // Incubate persists the beginning of the incubation process for the
 // CSV-delayed outputs (commitment and incoming HTLC's), commitment output and
 // a list of outgoing two-stage htlc outputs.
-func (ns *NurseryStore) Incubate(kids []kidOutput, babies []babyOutput) error {
-	return kvdb.Update(ns.db, func(tx kvdb.RwTx) error {
+func (ns *NurseryStore) Incubate(kids []kidOutput,
+	babies []babyOutput) (map[wire.OutPoint]struct{}, error) {
+
+	// Report only Crib outputs which remain active after the atomic update.
+	// Callers use this to avoid re-registering a stale promotion after the
+	// same logical output has already advanced to Kindergarten.
+	activeCribs := make(map[wire.OutPoint]struct{}, len(babies))
+	err := kvdb.Update(ns.db, func(tx kvdb.RwTx) error {
 		// If we have any kid outputs to incubate, then we'll attempt
 		// to add each of them to the nursery store. Any duplicate
 		// outputs will be ignored.
@@ -278,19 +289,27 @@ func (ns *NurseryStore) Incubate(kids []kidOutput, babies []babyOutput) error {
 		// Similarly, we'll ignore any outputs that have already been
 		// inserted.
 		for _, baby := range babies {
-			if err := ns.enterCrib(tx, &baby); err != nil {
+			active, err := ns.enterCrib(tx, &baby)
+			if err != nil {
 				return err
+			}
+			if active {
+				activeCribs[baby.OutPoint()] = struct{}{}
 			}
 		}
 
 		return nil
 	}, func() {})
+
+	return activeCribs, err
 }
 
 // CribToKinder atomically moves a babyOutput in the crib bucket to the
 // kindergarten bucket. The now mature kidOutput contained in the babyOutput
 // will be stored as it waits out the kidOutput's CSV delay.
-func (ns *NurseryStore) CribToKinder(bby *babyOutput) error {
+func (ns *NurseryStore) CribToKinder(
+	bby *babyOutput, lastGradHeight uint32) error {
+
 	return kvdb.Update(ns.db, func(tx kvdb.RwTx) error {
 		// First, retrieve or create the channel bucket corresponding to
 		// the baby output's origin channel point.
@@ -307,6 +326,12 @@ func (ns *NurseryStore) CribToKinder(bby *babyOutput) error {
 		pfxOutputKey, err := prefixOutputKey(cribPrefix, bby.OutPoint())
 		if err != nil {
 			return err
+		}
+		if chanBucket.Get(pfxOutputKey) == nil {
+			// A stale confirmation callback must not recreate a
+			// Kindergarten entry after its Crib owner advanced or
+			// another lifecycle attempt graduated it.
+			return ErrContractNotFound
 		}
 
 		// Since the babyOutput is being moved to the kindergarten
@@ -347,6 +372,18 @@ func (ns *NurseryStore) CribToKinder(bby *babyOutput) error {
 		// will expire.  This is done by adding the required delay to
 		// the block height at which the output was confirmed.
 		maturityHeight := bby.ConfHeight() + bby.BlocksToMaturity()
+
+		// A depth-aware confirmation arrives after the inclusion
+		// height. Schedule a past-due CSV output in the next
+		// unprocessed class so Nursery cannot strand it in an index it
+		// already graduated.
+		if maturityHeight <= lastGradHeight {
+			utxnLog.Debugf("Late crib registration for output=%v: "+
+				"maturity_height=%v, last_graduated_height=%v",
+				bby.OutPoint(), maturityHeight, lastGradHeight)
+
+			maturityHeight = lastGradHeight + 1
+		}
 
 		// Retrieve or create a height-channel bucket corresponding to
 		// the kidOutput's maturity height.
@@ -854,27 +891,37 @@ func (ns *NurseryStore) RemoveChannel(chanPoint *wire.OutPoint) error {
 // its two-stage process of sweeping funds back to the user's wallet. These
 // outputs are persisted in the nursery store in the crib state, and will be
 // revisited after the first-stage output's CLTV has expired.
-func (ns *NurseryStore) enterCrib(tx kvdb.RwTx, baby *babyOutput) error {
+func (ns *NurseryStore) enterCrib(tx kvdb.RwTx,
+	baby *babyOutput) (bool, error) {
 	// First, retrieve or create the channel bucket corresponding to the
 	// baby output's origin channel point.
 	chanPoint := baby.OriginChanPoint()
 	chanBucket, err := ns.createChannelBucket(tx, chanPoint)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Since we are inserting this output into the crib bucket, we create a
 	// key that prefixes the baby output's outpoint with the crib prefix.
 	pfxOutputKey, err := prefixOutputKey(cribPrefix, baby.OutPoint())
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// We'll first check that we don't already have an entry for this
 	// output. If we do, then we can exit early.
 	if rawBytes := chanBucket.Get(pfxOutputKey); rawBytes != nil {
-		return nil
+		return true, nil
 	}
+
+	// A restart can replay incubation after this HTLC has already advanced
+	// to kindergarten. Treat that later state as the same logical output so
+	// the replay cannot resurrect a stale crib beside the live claim.
+	copy(pfxOutputKey, kndrPrefix)
+	if rawBytes := chanBucket.Get(pfxOutputKey); rawBytes != nil {
+		return false, nil
+	}
+	copy(pfxOutputKey, cribPrefix)
 
 	// Next, retrieve or create the height-channel bucket located in the
 	// height bucket corresponding to the baby output's CLTV expiry height.
@@ -883,28 +930,32 @@ func (ns *NurseryStore) enterCrib(tx kvdb.RwTx, baby *babyOutput) error {
 	hghtChanBucket, err := ns.createHeightChanBucket(tx,
 		baby.expiry, chanPoint)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Serialize the baby output so that it can be written to the
 	// underlying key-value store.
 	var babyBuffer bytes.Buffer
 	if err := baby.Encode(&babyBuffer); err != nil {
-		return err
+		return false, err
 	}
 	babyBytes := babyBuffer.Bytes()
 
 	// Now, insert the serialized output into its channel bucket under the
 	// prefixed key created above.
 	if err := chanBucket.Put(pfxOutputKey, babyBytes); err != nil {
-		return err
+		return false, err
 	}
 
 	// Finally, create a corresponding bucket in the height-channel bucket
 	// for this crib output. The existence of this bucket indicates that
 	// the serialized output can be retrieved from the channel bucket using
 	// the same prefix key.
-	return hghtChanBucket.Put(pfxOutputKey, []byte{})
+	if err := hghtChanBucket.Put(pfxOutputKey, []byte{}); err != nil {
+		return false, err
+	}
+
+	return true, nil
 }
 
 // enterPreschool accepts a new commitment output that the nursery will incubate

--- a/contractcourt/nursery_store_test.go
+++ b/contractcourt/nursery_store_test.go
@@ -87,7 +87,7 @@ func TestNurseryStoreIncubate(t *testing.T) {
 		if test.commOutput != nil {
 			kids = append(kids, *test.commOutput)
 		}
-		err = ns.Incubate(kids, test.htlcOutputs)
+		_, err = ns.Incubate(kids, test.htlcOutputs)
 		if err != nil {
 			t.Fatalf("unable to incubate outputs"+
 				"on test #%d: %v", i, err)
@@ -203,7 +203,7 @@ func TestNurseryStoreIncubate(t *testing.T) {
 			for i, htlcOutput := range test.htlcOutputs {
 				// Begin by moving each htlc output from the
 				// crib to kindergarten state.
-				err = ns.CribToKinder(&htlcOutput)
+				err = ns.CribToKinder(&htlcOutput, 0)
 				if err != nil {
 					t.Fatalf("unable to move htlc output from "+
 						"crib to kndr: %v", err)
@@ -297,6 +297,77 @@ func TestNurseryStoreIncubate(t *testing.T) {
 	}
 }
 
+// TestNurseryStoreReincubatePromotedHtlc verifies that replaying incubation
+// after restart cannot recreate a crib for an HTLC already in kindergarten.
+func TestNurseryStoreReincubatePromotedHtlc(t *testing.T) {
+	// Arrange a persisted HTLC that has completed its crib transition.
+	// This reproduces the state Nursery reloads while its final sweep is
+	// pending.
+	cdb, err := channeldb.MakeTestDB(t)
+	require.NoError(t, err, "unable to open channel db")
+
+	ns, err := NewNurseryStore(&chainHash, cdb)
+	require.NoError(t, err, "unable to open nursery store")
+
+	htlcOutput := babyOutputs[0]
+	activeCribs, err := ns.Incubate(nil, []babyOutput{htlcOutput})
+	require.NoError(t, err, "unable to incubate HTLC output")
+	require.Contains(t, activeCribs, htlcOutput.OutPoint())
+	err = ns.CribToKinder(&htlcOutput, 0)
+	require.NoError(t, err, "unable to promote HTLC output")
+
+	// Act by replaying the original incubation request, as a restored
+	// legacy resolver does before it resumes watching the second-stage
+	// output.
+	activeCribs, err = ns.Incubate(nil, []babyOutput{htlcOutput})
+	require.NoError(t, err, "unable to replay HTLC incubation")
+	err = ns.CribToKinder(&htlcOutput, 0)
+
+	// Assert the replay reported no active Crib and its stale callback was
+	// rejected, retaining the sole Kindergarten record instead of
+	// recreating lifecycle state after the original promotion.
+	require.Empty(t, activeCribs)
+	require.ErrorIs(t, err, ErrContractNotFound)
+	assertNumChanOutputs(t, ns, htlcOutput.OriginChanPoint(), 1)
+	assertCribNotAtExpiryHeight(t, ns, &htlcOutput)
+	assertKndrAtMaturityHeight(t, ns, &htlcOutput.kidOutput)
+}
+
+// TestNurseryStoreLateCribPromotion verifies a depth-delayed timeout
+// confirmation cannot place its CSV output into an already-graduated class.
+func TestNurseryStoreLateCribPromotion(t *testing.T) {
+	// Arrange a persisted crib whose natural maturity is behind the
+	// Nursery height supplied at promotion time. The gap models a short CSV
+	// delay combined with a deeper channel confirmation policy.
+	cdb, err := channeldb.MakeTestDB(t)
+	require.NoError(t, err, "unable to open channel db")
+	ns, err := NewNurseryStore(&chainHash, cdb)
+	require.NoError(t, err, "unable to open nursery store")
+	htlcOutput := babyOutputs[0]
+	naturalMaturity := htlcOutput.ConfHeight() +
+		htlcOutput.BlocksToMaturity()
+	lastGradHeight := naturalMaturity + 2
+	_, err = ns.Incubate(nil, []babyOutput{htlcOutput})
+	require.NoError(t, err, "unable to incubate HTLC output")
+
+	// Act by promoting after Nursery has already processed the output's
+	// natural class, then load the next class that remains eligible for a
+	// future blockbeat.
+	err = ns.CribToKinder(&htlcOutput, lastGradHeight)
+	require.NoError(t, err, "unable to promote late HTLC output")
+	kids, _, err := ns.FetchClass(lastGradHeight + 1)
+	require.NoError(t, err, "unable to fetch clamped maturity class")
+
+	// Assert the output was indexed exactly once in the next unprocessed
+	// class instead of the stale natural class that Nursery would never
+	// revisit.
+	require.Len(t, kids, 1)
+	require.True(t, reflect.DeepEqual(&kids[0], &htlcOutput.kidOutput))
+	staleKids, _, err := ns.FetchClass(naturalMaturity)
+	require.NoError(t, err, "unable to fetch stale maturity class")
+	require.Empty(t, staleKids)
+}
+
 // TestNurseryStoreGraduate verifies that the nursery store properly removes
 // populated entries from the height index as it is purged, and that the last
 // purged height is set appropriately.
@@ -315,7 +386,7 @@ func TestNurseryStoreGraduate(t *testing.T) {
 
 	// First, add a commitment output to the nursery store, which is
 	// initially inserted in the preschool bucket.
-	err = ns.Incubate([]kidOutput{*kid}, nil)
+	_, err = ns.Incubate([]kidOutput{*kid}, nil)
 	require.NoError(t, err, "unable to incubate commitment output")
 
 	// Then, move the commitment output to the kindergarten bucket, such

--- a/contractcourt/resolver_spend_depth_test.go
+++ b/contractcourt/resolver_spend_depth_test.go
@@ -1,0 +1,271 @@
+package contractcourt
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// closedResolverSpendEvent creates a registration that terminates the wait
+// path immediately and reports whether resolver cleanup invoked Cancel.
+func closedResolverSpendEvent(cancelled chan struct{}) *chainntnfs.SpendEvent {
+	spend := make(chan *chainntnfs.SpendDetail)
+	close(spend)
+
+	return &chainntnfs.SpendEvent{
+		Spend: spend,
+		Reorg: make(chan struct{}),
+		Done:  make(chan struct{}),
+		Cancel: func() {
+			// Signal cleanup without timing sleeps or a mock
+			// assertion unrelated to ChainNotifier.
+			close(cancelled)
+		},
+	}
+}
+
+// resolverSpendCancelled reports cancellation without blocking a failing
+// regression test when the resolver forgets to release its notification.
+func resolverSpendCancelled(cancelled <-chan struct{}) bool {
+	// Cleanup runs synchronously through defer, so an open channel at this
+	// point is direct evidence that the registration leaked.
+	select {
+	case _, open := <-cancelled:
+		return !open
+
+	default:
+		return false
+	}
+}
+
+// TestResolverActionablePreimageSpendDepth verifies a contest resolver learns
+// a durable preimage at one confirmation even when terminal cleanup uses a
+// deeper channel policy.
+func TestResolverActionablePreimageSpendDepth(t *testing.T) {
+	t.Parallel()
+
+	// Arrange a remote-commit output whose contest resolver carries a
+	// three-block terminal policy. The mock.Mock-backed notifier expects a
+	// one-block registration because the revealed preimage remains useful
+	// after a reorg and must be learned before the HTLC expiry transition.
+	const (
+		broadcastHeight = uint32(21)
+		terminalDepth   = uint32(3)
+	)
+	outpoint := wire.OutPoint{Index: 7}
+	pkScript := []byte{0x51}
+	cancelled := make(chan struct{})
+	spendEvent := closedResolverSpendEvent(cancelled)
+	notifier := &chainntnfs.MockChainNotifier{}
+	notifier.On(
+		"RegisterSpendNtfn", &outpoint, pkScript, broadcastHeight,
+		mock.MatchedBy(func(opts []chainntnfs.SpendOption) bool {
+			// Parse the option in this test so the Arrange phase
+			// exposes the one-confirmation contract under test.
+			parsed, err := chainntnfs.ParseSpendOptions(opts...)
+			return err == nil && parsed.NumConfs == 1
+		}),
+	).Return(spendEvent, nil).Once()
+	resolver := newOutgoingContestResolver(
+		lnwallet.OutgoingHtlcResolution{
+			ClaimOutpoint: outpoint,
+			SweepSignDesc: input.SignDescriptor{
+				Output: &wire.TxOut{PkScript: pkScript},
+			},
+		},
+		broadcastHeight, channeldb.HTLC{},
+		channeldb.SingleFunderTweaklessBit,
+		ResolverConfig{
+			ChannelArbitratorConfig: ChannelArbitratorConfig{
+				SpendConfDepth: terminalDepth,
+				ChainArbitratorConfig: ChainArbitratorConfig{
+					Notifier: notifier,
+				},
+			},
+		},
+	)
+
+	// Act by running Resolve until the controlled closed spend channel
+	// returns its shutdown sentinel. Deferred cancellation must complete
+	// before Resolve returns to this test goroutine.
+	nextResolver, err := resolver.Resolve()
+	wasCancelled := resolverSpendCancelled(cancelled)
+
+	// Assert the resolver did not transform after the controlled wait
+	// failure. It must release the one-confirmation preimage registration,
+	// then satisfy the exact option-bearing mock without redundant
+	// call-count assertions.
+	require.ErrorIs(t, err, errResolverShuttingDown)
+	require.Nil(t, nextResolver)
+	require.True(t, wasCancelled)
+	notifier.AssertExpectations(t)
+}
+
+// TestResolverPreparatorySpendDepth verifies the synchronous lookup used to
+// prepare an already-incubating success output remains at one confirmation,
+// independent of the channel's terminal depth.
+func TestResolverPreparatorySpendDepth(t *testing.T) {
+	t.Parallel()
+
+	// Arrange a success resolver with a terminal policy of six but a closed
+	// registration for its already-confirmed second-level transaction. The
+	// mock.Mock-backed notifier must observe the compatibility depth once.
+	const (
+		broadcastHeight = uint32(31)
+		terminalDepth   = uint32(6)
+	)
+	firstStageOutpoint := wire.OutPoint{Index: 8}
+	pkScript := []byte{0x51}
+	cancelled := make(chan struct{})
+	spendEvent := closedResolverSpendEvent(cancelled)
+	notifier := &chainntnfs.MockChainNotifier{}
+	notifier.On(
+		"RegisterSpendNtfn", &firstStageOutpoint, pkScript,
+		broadcastHeight,
+		mock.MatchedBy(func(opts []chainntnfs.SpendOption) bool {
+			// Parse the option in this test so the Arrange phase
+			// exposes the preparatory one-confirmation policy.
+			parsed, err := chainntnfs.ParseSpendOptions(opts...)
+			return err == nil && parsed.NumConfs == 1
+		}),
+	).Return(spendEvent, nil).Once()
+	resolver := newSuccessResolver(
+		lnwallet.IncomingHtlcResolution{
+			SignedSuccessTx: &wire.MsgTx{
+				TxIn: []*wire.TxIn{{
+					PreviousOutPoint: firstStageOutpoint,
+				}},
+				TxOut: []*wire.TxOut{{Value: 1}},
+			},
+			SignDetails: &input.SignDetails{
+				SignDesc: input.SignDescriptor{
+					Output: &wire.TxOut{PkScript: pkScript},
+				},
+			},
+		},
+		broadcastHeight, channeldb.HTLC{},
+		channeldb.SingleFunderTweaklessBit,
+		ResolverConfig{
+			ChannelArbitratorConfig: ChannelArbitratorConfig{
+				SpendConfDepth: terminalDepth,
+				ChainArbitratorConfig: ChainArbitratorConfig{
+					Notifier: notifier,
+				},
+			},
+		},
+	)
+
+	// Act by invoking only the synchronous preparation method. The closed
+	// channel stops before sweep construction, isolating its registration
+	// policy and deferred cleanup from unrelated sweeper behavior.
+	err := resolver.sweepSuccessTxOutput()
+	wasCancelled := resolverSpendCancelled(cancelled)
+
+	// Assert the preparatory path returned the controlled shutdown error,
+	// canceled its registration, and requested one confirmation despite the
+	// resolver carrying a deeper terminal policy.
+	require.ErrorIs(t, err, errResolverShuttingDown)
+	require.True(t, wasCancelled)
+	notifier.AssertExpectations(t)
+}
+
+// TestTimeoutResolverMinedPreimageDepth verifies a mempool-capable resolver
+// learns an already-mined preimage before its terminal confirmation depth.
+func TestTimeoutResolverMinedPreimageDepth(t *testing.T) {
+	t.Parallel()
+
+	// Arrange one remote-commit output, a pending mempool subscription, and
+	// two block clients. The depth-one client carries a preimage missed by
+	// the mempool, while the terminal client stays pending.
+	const (
+		broadcastHeight = uint32(41)
+		terminalDepth   = uint32(3)
+	)
+	outpoint := wire.OutPoint{Index: 10}
+	pkScript := []byte{0x51}
+	earlyCancelled := make(chan struct{})
+	matureCancelled := make(chan struct{})
+	earlyEvent := chainntnfs.NewSpendEvent(func() {
+		close(earlyCancelled)
+	})
+	matureEvent := chainntnfs.NewSpendEvent(func() {
+		close(matureCancelled)
+	})
+	preimageSpend := &chainntnfs.SpendDetail{
+		SpendingTx: &wire.MsgTx{TxIn: []*wire.TxIn{{
+			Witness: wire.TxWitness{
+				{1}, {1}, {1}, make([]byte, 32), {1},
+			},
+		}}},
+		SpenderInputIndex: 0,
+	}
+	earlyEvent.Spend <- preimageSpend
+	mempoolSource := chainntnfs.NewMempoolNotifier()
+	mempoolEvent := mempoolSource.SubscribeInput(outpoint)
+	mempool := chainntnfs.NewMockMempoolWatcher()
+	mempool.On("SubscribeMempoolSpent", outpoint).Return(
+		mempoolEvent, nil,
+	).Once()
+	mempool.On("CancelMempoolSpendEvent", mempoolEvent).Return().Once()
+	notifier := &chainntnfs.MockChainNotifier{}
+	notifier.On(
+		"RegisterSpendNtfn", &outpoint, pkScript, broadcastHeight,
+		mock.MatchedBy(func(opts []chainntnfs.SpendOption) bool {
+			// Parse the early option here so the test visibly
+			// proves actionable preimages are requested at depth
+			// one.
+			parsed, err := chainntnfs.ParseSpendOptions(opts...)
+			return err == nil && parsed.NumConfs == 1
+		}),
+	).Return(earlyEvent, nil).Once()
+	notifier.On(
+		"RegisterSpendNtfn", &outpoint, pkScript, broadcastHeight,
+		mock.MatchedBy(func(opts []chainntnfs.SpendOption) bool {
+			// Parse the terminal option here so the deeper cleanup
+			// depth remains visible beside the early registration.
+			parsed, err := chainntnfs.ParseSpendOptions(opts...)
+			return err == nil && parsed.NumConfs == terminalDepth
+		}),
+	).Return(matureEvent, nil).Once()
+	resolver := &htlcTimeoutResolver{
+		contractResolverKit: *newContractResolverKit(ResolverConfig{
+			ChannelArbitratorConfig: ChannelArbitratorConfig{
+				ChainArbitratorConfig: ChainArbitratorConfig{
+					Notifier: notifier,
+					Mempool:  mempool,
+				},
+			},
+		}),
+		htlcResolution: lnwallet.OutgoingHtlcResolution{
+			ClaimOutpoint: outpoint,
+			SweepSignDesc: input.SignDescriptor{
+				Output: &wire.TxOut{PkScript: pkScript},
+			},
+		},
+		broadcastHeight: broadcastHeight,
+	}
+
+	// Act after the transaction has bypassed the pending mempool channel.
+	// The early block client must still return its remote-commit preimage
+	// without waiting for terminal-depth delivery.
+	spend, err := resolver.waitForPreimageOrMatureSpend(
+		&outpoint, pkScript, terminalDepth,
+	)
+	earlyWasCancelled := resolverSpendCancelled(earlyCancelled)
+	matureWasCancelled := resolverSpendCancelled(matureCancelled)
+
+	// Assert the early preimage won unchanged, every subscription
+	// was released synchronously, and all exact mock calls were consumed.
+	require.NoError(t, err)
+	require.Same(t, preimageSpend, spend)
+	require.True(t, earlyWasCancelled)
+	require.True(t, matureWasCancelled)
+	notifier.AssertExpectations(t)
+	mempool.AssertExpectations(t)
+}

--- a/contractcourt/utxonursery.go
+++ b/contractcourt/utxonursery.go
@@ -178,9 +178,10 @@ type NurseryConfig struct {
 	// height, which drives the incubation of the nursery's outputs.
 	ChainIO lnwallet.BlockChainIO
 
-	// ConfDepth is the number of blocks the nursery store waits before
-	// determining outputs in the chain as confirmed.
-	ConfDepth uint32
+	// ChannelCloseConfs is an optional integration override for the
+	// capacity-derived depth that makes Nursery state transitions durable
+	// against shallow reorgs.
+	ChannelCloseConfs fn.Option[uint32]
 
 	// FetchClosedChannels provides access to a user's channels, such that
 	// they can be marked fully closed after incubation has concluded.
@@ -242,6 +243,36 @@ func NewUtxoNursery(cfg *NurseryConfig) *UtxoNursery {
 	}
 }
 
+// outputSpendConfDepth returns the channel policy for a Nursery output. Live
+// handoffs retain the resolver's validated value, while persisted outputs use
+// their origin channel to reconstruct the same value after restart without a
+// Nursery database migration.
+func (u *UtxoNursery) outputSpendConfDepth(kid *kidOutput) (uint32, error) {
+	if kid.spendConfDepth != 0 {
+		// Revalidate the live handoff at the consumer boundary so a
+		// direct Nursery caller cannot install an unsupported notifier
+		// depth.
+		return resolveSpendConfDepth(
+			0, fn.Some(kid.spendConfDepth),
+		)
+	}
+
+	chanPoint := kid.OriginChanPoint()
+	closeSummary, err := u.cfg.FetchClosedChannel(chanPoint)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"cannot derive spend depth for channel %v: %w",
+			chanPoint, err,
+		)
+	}
+
+	// The origin channel point is already persisted with every output, so
+	// its durable close summary restores the capacity-scaled policy.
+	return resolveSpendConfDepth(
+		closeSummary.Capacity, u.cfg.ChannelCloseConfs,
+	)
+}
+
 // patchZeroHeightHint handles the edge case where a crib output has expiry=0
 // due to a historical bug. This should never happen in normal operation, but
 // we provide a fallback mechanism using the channel close height to determine
@@ -272,6 +303,10 @@ func (u *UtxoNursery) patchZeroHeightHint(baby *babyOutput,
 	}
 
 	heightHint := closeSummary.CloseHeight
+	spendConfDepth, err := u.outputSpendConfDepth(&baby.kidOutput)
+	if err != nil {
+		return 0, err
+	}
 
 	// If the close height is 0, we try to use the short channel ID block
 	// height as a fallback.
@@ -289,20 +324,20 @@ func (u *UtxoNursery) patchZeroHeightHint(baby *babyOutput,
 	// conf depth since channels should have a minimum close height of the
 	// segwit activation height and the conf depth which is a config
 	// parameter should be in the single digit range.
-	if heightHint <= u.cfg.ConfDepth {
+	if heightHint <= spendConfDepth {
 		return 0, fmt.Errorf("cannot use fallback height hint: "+
 			"fallback height hint %v <= confirmation depth %v",
-			heightHint, u.cfg.ConfDepth)
+			heightHint, spendConfDepth)
 	}
 
 	// Use the close height minus the confirmation depth as a conservative
 	// height hint. This ensures we don't miss the confirmation even if it
 	// happened around the close height.
-	heightHint -= u.cfg.ConfDepth
+	heightHint -= spendConfDepth
 
 	utxnLog.Infof("Using fallback height hint %v for crib output "+
 		"%v (channel closed at height %v, conf depth %v)", heightHint,
-		baby.OutPoint(), closeSummary.CloseHeight, u.cfg.ConfDepth)
+		baby.OutPoint(), closeSummary.CloseHeight, spendConfDepth)
 
 	return heightHint, nil
 }
@@ -404,6 +439,10 @@ type IncubateConfig struct {
 	// chanType is the channel type, used to determine which witness type
 	// to select for taproot channels.
 	chanType fn.Option[channeldb.ChannelType]
+
+	// spendConfDepth carries validated policy into early registrations. The
+	// persisted close summary restores it later.
+	spendConfDepth uint32
 }
 
 // IncubateOption is a functional option that can be used to modify the behavior
@@ -416,6 +455,15 @@ type IncubateOption func(*IncubateConfig)
 func WithChanType(ct channeldb.ChannelType) IncubateOption {
 	return func(cfg *IncubateConfig) {
 		cfg.chanType = fn.Some(ct)
+	}
+}
+
+// WithSpendConfDepth returns an IncubateOption that carries the channel's
+// validated spend depth into the Nursery's live confirmation registrations.
+// Persisted outputs reconstruct the same policy from their close summary.
+func WithSpendConfDepth(spendConfDepth uint32) IncubateOption {
+	return func(cfg *IncubateConfig) {
+		cfg.spendConfDepth = spendConfDepth
 	}
 }
 
@@ -491,6 +539,10 @@ func (u *UtxoNursery) IncubateOutputs(chanPoint wire.OutPoint,
 			&htlcRes.ClaimOutpoint, &chanPoint, htlcRes.CsvDelay,
 			witType, &htlcRes.SweepSignDesc, 0, deadlineHeight,
 		)
+		// Keep the live handoff available for the immediate promotion
+		// registration; a later store read reconstructs it from the
+		// channel.
+		htlcOutput.spendConfDepth = cfg.spendConfDepth
 
 		if htlcOutput.Amount() > 0 {
 			kidOutputs = append(kidOutputs, htlcOutput)
@@ -510,6 +562,9 @@ func (u *UtxoNursery) IncubateOutputs(chanPoint wire.OutPoint,
 				&chanPoint, &htlcRes, deadlineHeight,
 				isFinalTaproot,
 			)
+			// Crib registration precedes restart reconstruction, so
+			// retain the validated policy now.
+			htlcOutput.spendConfDepth = cfg.spendConfDepth
 
 			if htlcOutput.Amount() > 0 {
 				babyOutputs = append(babyOutputs, htlcOutput)
@@ -544,6 +599,10 @@ func (u *UtxoNursery) IncubateOutputs(chanPoint wire.OutPoint,
 			witType, &htlcRes.SweepSignDesc, htlcRes.Expiry,
 			deadlineHeight,
 		)
+		// Preserve the live policy for the first confirmation
+		// registration; persisted Kindergarten work will derive it from
+		// originChanPoint.
+		htlcOutput.spendConfDepth = cfg.spendConfDepth
 		kidOutputs = append(kidOutputs, htlcOutput)
 	})
 
@@ -788,10 +847,25 @@ func (u *UtxoNursery) reloadPreschool() error {
 			return err
 		}
 
-		// Use the close height from the channel summary as our height
-		// hint to drive our spend notifications, with our confirmation
-		// depth as a buffer for reorgs.
-		heightHint := closeSummary.CloseHeight - u.cfg.ConfDepth
+		spendConfDepth, err := resolveSpendConfDepth(
+			closeSummary.Capacity, u.cfg.ChannelCloseConfs,
+		)
+		if err != nil {
+			return err
+		}
+
+		// Restore the non-serialized policy before registration so the
+		// promotion and later sweep share one post-restart depth.
+		kid.spendConfDepth = spendConfDepth
+
+		// Use the close height as the notification hint, buffered by
+		// confirmation depth. A corrupt or synthetic low close height
+		// must clamp to the earliest valid notifier height instead of
+		// underflowing past the actual confirmation on restart.
+		heightHint := uint32(1)
+		if closeSummary.CloseHeight > spendConfDepth {
+			heightHint = closeSummary.CloseHeight - spendConfDepth
+		}
 		err = u.registerPreschoolConf(kid, heightHint)
 		if err != nil {
 			return err
@@ -982,8 +1056,13 @@ func (u *UtxoNursery) sweepMatureOutputs(classHeight uint32,
 
 		// Calculate the deadline height and budget for this output.
 		deadline, budget := u.decideDeadlineAndBudget(local)
+		spendConfDepth, err := u.outputSpendConfDepth(&local)
+		if err != nil {
+			return err
+		}
 
 		resultChan, err := u.cfg.SweepInput(&local, sweep.Params{
+			RequiredConfs:  spendConfDepth,
 			DeadlineHeight: deadline,
 			Budget:         budget,
 		})
@@ -1106,10 +1185,15 @@ func (u *UtxoNursery) registerTimeoutConf(baby *babyOutput,
 	heightHint uint32) error {
 
 	birthTxID := baby.timeoutTx.TxHash()
+	spendConfDepth, err := u.outputSpendConfDepth(&baby.kidOutput)
+	if err != nil {
+		return err
+	}
 
-	// Register for the confirmation of presigned htlc txn.
+	// Delay promotion until the parent reaches the final sweep policy. This
+	// preserves the Crib record through shallow reorgs.
 	confChan, err := u.cfg.Notifier.RegisterConfirmationsNtfn(
-		&birthTxID, baby.timeoutTx.TxOut[0].PkScript, u.cfg.ConfDepth,
+		&birthTxID, baby.timeoutTx.TxOut[0].PkScript, spendConfDepth,
 		heightHint,
 	)
 	if err != nil {
@@ -1176,9 +1260,17 @@ func (u *UtxoNursery) registerPreschoolConf(kid *kidOutput, heightHint uint32) e
 	// de-duplicate
 	//  * need to do above?
 
+	spendConfDepth, err := u.outputSpendConfDepth(kid)
+	if err != nil {
+		return err
+	}
+
 	pkScript := kid.signDesc.Output.PkScript
+	// Withhold the persistent Preschool-to-Kindergarten transition until
+	// the parent is deep enough that a shallow reorg cannot orphan the
+	// claim.
 	confChan, err := u.cfg.Notifier.RegisterConfirmationsNtfn(
-		&txID, pkScript, u.cfg.ConfDepth, heightHint,
+		&txID, pkScript, spendConfDepth, heightHint,
 	)
 	if err != nil {
 		return err
@@ -1504,6 +1596,11 @@ type kidOutput struct {
 	breachedOutput
 
 	originChanPoint wire.OutPoint
+
+	// spendConfDepth is intentionally reconstructed instead of serialized.
+	// Live resolver handoffs avoid a database lookup, while restart derives
+	// the identical policy from originChanPoint and the close summary.
+	spendConfDepth uint32
 
 	// isHtlc denotes if this kid output is an HTLC output or not. This
 	// value will be used to determine how to report this output within the

--- a/contractcourt/utxonursery.go
+++ b/contractcourt/utxonursery.go
@@ -618,7 +618,8 @@ func (u *UtxoNursery) IncubateOutputs(chanPoint wire.OutPoint,
 	defer u.mu.Unlock()
 
 	// 2. Persist the outputs we intended to sweep in the nursery store
-	if err := u.cfg.Store.Incubate(kidOutputs, babyOutputs); err != nil {
+	activeCribs, err := u.cfg.Store.Incubate(kidOutputs, babyOutputs)
+	if err != nil {
 		utxnLog.Errorf("unable to begin incubation of Channel(%s): %v",
 			chanPoint, err)
 		return err
@@ -636,6 +637,12 @@ func (u *UtxoNursery) IncubateOutputs(chanPoint wire.OutPoint,
 	// if the output has already expired, then we'll *immediately* sweep
 	// it. This may happen if the caller raced a block to call this method.
 	for i, babyOutput := range babyOutputs {
+		if _, ok := activeCribs[babyOutput.OutPoint()]; !ok {
+			// The store already advanced this replayed HTLC.
+			// A new callback would be stale lifecycle work.
+			continue
+		}
+
 		if uint32(bestHeight) >= babyOutput.expiry {
 			err = u.sweepCribOutput(
 				babyOutput.expiry, &babyOutputs[i],
@@ -1237,7 +1244,11 @@ func (u *UtxoNursery) waitForTimeoutConf(baby *babyOutput,
 
 	// TODO(conner): add retry utxnLogic?
 
-	err := u.cfg.Store.CribToKinder(baby)
+	// The notifier returns the original inclusion height after the
+	// requested depth. Pass Nursery's processed tip so a short CSV delay
+	// cannot create an already-graduated maturity class.
+	lastGradHeight := atomic.LoadUint32(&u.bestHeight)
+	err := u.cfg.Store.CribToKinder(baby, lastGradHeight)
 	if err != nil {
 		utxnLog.Errorf("Unable to move htlc output from "+
 			"crib to kindergarten bucket: %v", err)

--- a/contractcourt/utxonursery_test.go
+++ b/contractcourt/utxonursery_test.go
@@ -983,13 +983,17 @@ func newNurseryStoreInterceptor(ns NurseryStorer) *nurseryStoreInterceptor {
 }
 
 func (i *nurseryStoreInterceptor) Incubate(kidOutputs []kidOutput,
-	babyOutputs []babyOutput) error {
+	babyOutputs []babyOutput) (map[wire.OutPoint]struct{}, error) {
 
 	return i.ns.Incubate(kidOutputs, babyOutputs)
 }
 
-func (i *nurseryStoreInterceptor) CribToKinder(babyOutput *babyOutput) error {
-	err := i.ns.CribToKinder(babyOutput)
+// CribToKinder delegates the state transition to the real store and signals
+// the test only after persistence completes, so assertions cannot race it.
+func (i *nurseryStoreInterceptor) CribToKinder(babyOutput *babyOutput,
+	lastGradHeight uint32) error {
+
+	err := i.ns.CribToKinder(babyOutput, lastGradHeight)
 
 	i.cribToKinderChan <- struct{}{}
 

--- a/contractcourt/utxonursery_test.go
+++ b/contractcourt/utxonursery_test.go
@@ -19,13 +19,15 @@ import (
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/input"
-	"github.com/lightningnetwork/lnd/lntest/mock"
+	lntestmock "github.com/lightningnetwork/lnd/lntest/mock"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/sweep"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -403,7 +405,7 @@ func TestBabyOutputSerialization(t *testing.T) {
 type nurseryTestContext struct {
 	nursery     *UtxoNursery
 	notifier    *sweep.MockNotifier
-	chainIO     *mock.ChainIO
+	chainIO     *lntestmock.ChainIO
 	publishChan chan wire.MsgTx
 	store       *nurseryStoreInterceptor
 	restart     func() bool
@@ -443,7 +445,7 @@ func createNurseryTestContext(t *testing.T,
 
 	timeoutChan := make(chan chan time.Time)
 
-	chainIO := &mock.ChainIO{
+	chainIO := &lntestmock.ChainIO{
 		BestHeight: 0,
 	}
 
@@ -885,6 +887,243 @@ func testNurseryOutgoingHtlcSuccessOnLocal(t *testing.T,
 
 func TestNurseryOutgoingHtlcSuccessOnRemote(t *testing.T) {
 	testRestartLoop(t, testNurseryOutgoingHtlcSuccessOnRemote)
+}
+
+// nurserySweepMock captures the final sweep parameters through mock.Mock so
+// the regression can verify the Nursery-to-sweeper policy boundary directly.
+type nurserySweepMock struct {
+	mock.Mock
+
+	called chan struct{}
+}
+
+// SweepInput records the offered input and parameters, then signals the test
+// after mock.Mock has matched the configured confirmation-depth expectation.
+func (m *nurserySweepMock) SweepInput(inp input.Input,
+	params sweep.Params) (chan sweep.Result, error) {
+
+	args := m.Called(inp, params)
+	m.called <- struct{}{}
+
+	resultChan, ok := args.Get(0).(chan sweep.Result)
+	// Fail loudly if Arrange supplied the wrong mock result type, because
+	// silently returning a nil channel would hide the handoff under test.
+	if !ok {
+		panic("nursery sweep mock returned a non-result channel")
+	}
+
+	return resultChan, args.Error(1)
+}
+
+// TestNurseryPreschoolPromotionRequiredConfs verifies the Nursery retains its
+// Preschool claim until the parent transaction reaches the channel policy.
+func TestNurseryPreschoolPromotionRequiredConfs(t *testing.T) {
+	// Arrange a live legacy output carrying a three-block resolver policy.
+	// A mock.Mock notifier expects that depth before returning an event.
+	// Its undelivered channel keeps the promotion goroutine pending.
+	const (
+		requiredConfs uint32 = 3
+		heightHint    uint32 = 21
+	)
+	pkScript := []byte{0x51}
+	outpoint := wire.OutPoint{Hash: chainhash.Hash{1}, Index: 2}
+	kid := &kidOutput{
+		breachedOutput: breachedOutput{
+			outpoint: outpoint,
+			signDesc: input.SignDescriptor{
+				Output: &wire.TxOut{PkScript: pkScript},
+			},
+		},
+		spendConfDepth: requiredConfs,
+	}
+	event := &chainntnfs.ConfirmationEvent{
+		Confirmed: make(chan *chainntnfs.TxConfirmation),
+	}
+	notifier := &chainntnfs.MockChainNotifier{}
+	notifier.On(
+		"RegisterConfirmationsNtfn", &outpoint.Hash, pkScript,
+		requiredConfs, heightHint,
+	).Return(event, nil).Once()
+	nursery := NewUtxoNursery(&NurseryConfig{Notifier: notifier})
+
+	// Act by registering the parent confirmation, then stop the pending
+	// waiter through the Nursery shutdown channel so no goroutine survives
+	// beyond the assertion boundary.
+	err := nursery.registerPreschoolConf(kid, heightHint)
+	close(nursery.quit)
+	nursery.wg.Wait()
+
+	// Assert registration succeeded and the notifier observed the one exact
+	// depth-bearing call; no independent call-count assertion is necessary.
+	require.NoError(t, err)
+	notifier.AssertExpectations(t)
+}
+
+// TestNurseryReloadPreschoolClampsHeightHint verifies restart registration
+// cannot underflow when a persisted close height is below the spend depth.
+func TestNurseryReloadPreschoolClampsHeightHint(t *testing.T) {
+	// Arrange a serialized Preschool output whose synthetic close height is
+	// below its three-confirmation policy. A mock.Mock-backed notifier
+	// expects the earliest valid height exactly once, proving restart scans
+	// from genesis instead of wrapping the unsigned subtraction.
+	const (
+		spendConfDepth = uint32(3)
+		closeHeight    = uint32(2)
+		heightHint     = uint32(1)
+	)
+	kid := kidOutputs[0]
+	db, err := channeldb.MakeTestDB(t)
+	require.NoError(t, err)
+	store, err := NewNurseryStore(&chainhash.Hash{}, db)
+	require.NoError(t, err)
+	_, err = store.Incubate([]kidOutput{kid}, nil)
+	require.NoError(t, err)
+
+	pkScript := kid.SignDesc().Output.PkScript
+	txID := kid.OutPoint().Hash
+	confEvent := &chainntnfs.ConfirmationEvent{
+		Confirmed: make(chan *chainntnfs.TxConfirmation, 1),
+	}
+	notifier := &chainntnfs.MockChainNotifier{}
+	notifier.On(
+		"RegisterConfirmationsNtfn", &txID, pkScript,
+		spendConfDepth, heightHint,
+	).Return(confEvent, nil).Once()
+	nursery := NewUtxoNursery(&NurseryConfig{
+		Notifier:          notifier,
+		Store:             store,
+		ChannelCloseConfs: fn.Some(spendConfDepth),
+		FetchClosedChannel: func(*wire.OutPoint) (
+			*channeldb.ChannelCloseSummary, error) {
+
+			// Return the low height that previously wrapped around
+			// to MaxUint32 and caused the notifier to skip the
+			// output.
+			return &channeldb.ChannelCloseSummary{
+				CloseHeight: closeHeight,
+			}, nil
+		},
+	})
+
+	// Act by reloading the persisted Preschool record, then stop the
+	// pending confirmation waiter through Nursery shutdown so the test
+	// leaves no goroutine behind.
+	err = nursery.reloadPreschool()
+	close(nursery.quit)
+	nursery.wg.Wait()
+
+	// Assert restart completed and registered from height one. Direct mock
+	// expectation verification covers both the arguments and cardinality
+	// without a redundant call-count assertion.
+	require.NoError(t, err)
+	notifier.AssertExpectations(t)
+}
+
+// TestNurseryCribPromotionRequiredConfs verifies the Nursery retains its Crib
+// claim until the presigned timeout transaction reaches the channel policy.
+func TestNurseryCribPromotionRequiredConfs(t *testing.T) {
+	// Arrange a live legacy timeout output carrying a six-block resolver
+	// policy. The mock requires that depth for the timeout transaction,
+	// then returns a pending event to the promotion code.
+	const (
+		requiredConfs uint32 = 6
+		heightHint    uint32 = 31
+	)
+	pkScript := []byte{0x51}
+	timeoutTx := &wire.MsgTx{TxOut: []*wire.TxOut{{PkScript: pkScript}}}
+	timeoutTxID := timeoutTx.TxHash()
+	baby := &babyOutput{
+		timeoutTx: timeoutTx,
+		kidOutput: kidOutput{
+			spendConfDepth: requiredConfs,
+		},
+	}
+	event := &chainntnfs.ConfirmationEvent{
+		Confirmed: make(chan *chainntnfs.TxConfirmation),
+	}
+	notifier := &chainntnfs.MockChainNotifier{}
+	notifier.On(
+		"RegisterConfirmationsNtfn", &timeoutTxID, pkScript,
+		requiredConfs, heightHint,
+	).Return(event, nil).Once()
+	nursery := NewUtxoNursery(&NurseryConfig{Notifier: notifier})
+
+	// Act by registering the timeout confirmation, then terminate its
+	// waiter through Nursery shutdown. This keeps the goroutine lifecycle
+	// controlled without manufacturing a confirmation.
+	err := nursery.registerTimeoutConf(baby, heightHint)
+	close(nursery.quit)
+	nursery.wg.Wait()
+
+	// Assert registration succeeded and mock.Mock matched the exact depth.
+	// Direct expectation verification proves the required cardinality.
+	require.NoError(t, err)
+	notifier.AssertExpectations(t)
+}
+
+// TestNurseryFinalSweepRequiredConfsAfterRestart verifies a persisted legacy
+// HTLC reconstructs its channel policy and does not request a one-conf result
+// after the resolver has already marked the output as incubating.
+func TestNurseryFinalSweepRequiredConfsAfterRestart(t *testing.T) {
+	// Arrange a remote-commit legacy HTLC whose close summary has a real
+	// capacity. Promote it into the persisted Kindergarten bucket,
+	// then restart so only that durable summary can reconstruct the policy.
+	const channelCapacity btcutil.Amount = 100_000_000
+	requiredConfs := lnwallet.CloseConfsForCapacity(channelCapacity)
+	ctx := createNurseryTestContext(t, func(callback func()) bool {
+		callback()
+
+		return true
+	})
+	t.Cleanup(func() {
+		require.NoError(t, ctx.nursery.Stop())
+	})
+	ctx.nursery.cfg.FetchClosedChannel = func(*wire.OutPoint) (
+		*channeldb.ChannelCloseSummary, error) {
+
+		// Capacity is the durable input that recovers the resolver's
+		// policy after outputIncubating is stored.
+		return &channeldb.ChannelCloseSummary{
+			Capacity: channelCapacity,
+		}, nil
+	}
+
+	outgoingRes := incubateTestOutput(t, ctx.nursery, false)
+	err := ctx.notifier.ConfirmTx(&outgoingRes.ClaimOutpoint.Hash, 124)
+	require.NoError(t, err)
+	select {
+	case <-ctx.store.preschoolToKinderChan:
+	case <-time.After(defaultTestTimeout):
+		t.Fatal("output not promoted to KNDR")
+	}
+	require.True(t, ctx.restart())
+
+	resultChan := make(chan sweep.Result)
+	sweeper := &nurserySweepMock{called: make(chan struct{}, 1)}
+	sweeper.On(
+		"SweepInput", mock.Anything,
+		mock.MatchedBy(func(params sweep.Params) bool {
+			// Matching the whole request proves the restored depth
+			// reaches the component that owns terminality.
+			return params.RequiredConfs == requiredConfs
+		}),
+	).Return(resultChan, nil).Once()
+	ctx.nursery.cfg.SweepInput = sweeper.SweepInput
+
+	// Act by advancing to the output's maturity height. Wait for the mock
+	// signal so the asynchronous incubator has completed the sweep offer
+	// before assertions inspect its expectation state.
+	ctx.notifyEpoch(125)
+	select {
+	case <-sweeper.called:
+	case <-time.After(defaultTestTimeout):
+		t.Fatal("final Nursery sweep not offered")
+	}
+
+	// Assert the one permitted sweep call carried the reconstructed depth.
+	// Leaving resultChan unresolved models the pre-terminal interval.
+	// A shallow spend or reorg must not graduate the persisted output.
+	sweeper.AssertExpectations(t)
 }
 
 func testNurseryOutgoingHtlcSuccessOnRemote(t *testing.T,

--- a/contractcourt/utxonursery_test.go
+++ b/contractcourt/utxonursery_test.go
@@ -1412,7 +1412,7 @@ func TestPatchZeroHeightHint(t *testing.T) {
 			}
 
 			cfg := &NurseryConfig{
-				ConfDepth: tc.confDepth,
+				ChannelCloseConfs: fn.Some(tc.confDepth),
 				FetchClosedChannel: func(
 					chanID *wire.OutPoint) (
 					*channeldb.ChannelCloseSummary,

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -455,7 +455,8 @@ func (m *mockNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash,
 }
 
 func (m *mockNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint, _ []byte,
-	_ uint32) (*chainntnfs.SpendEvent, error) {
+	_ uint32, _ ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
+
 	return nil, nil
 }
 

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -55,6 +55,11 @@
   the reported network statistics such as total network capacity, channel
   count and max out degree.
 
+* [Fixed a reorganization safety
+  bug](https://github.com/lightningnetwork/lnd/pull/11054) where contract
+  resolvers and the sweeper could treat a spend as terminal before it reached
+  the channel's configured close depth.
+
 # New Features
 
 ## Functional Enhancements

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -232,7 +232,9 @@ func (m *mockNotifier) Stop() error {
 }
 
 func (m *mockNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint, _ []byte,
-	heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	heightHint uint32, _ ...chainntnfs.SpendOption) (
+	*chainntnfs.SpendEvent, error) {
+
 	return &chainntnfs.SpendEvent{
 		Spend:  make(chan *chainntnfs.SpendDetail),
 		Cancel: func() {},

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -728,6 +728,10 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testSweepHTLCs,
 	},
 	{
+		Name:     "sweep legacy htlc reorg restart",
+		TestFunc: testSweepLegacyHTLCReorgRestart,
+	},
+	{
 		Name:     "sweep commit output and anchor",
 		TestFunc: testSweepCommitOutputAndAnchor,
 	},

--- a/itest/lnd_sweep_test.go
+++ b/itest/lnd_sweep_test.go
@@ -1222,6 +1222,152 @@ func testSweepHTLCs(ht *lntest.HarnessTest) {
 	ht.MineBlocksAndAssertNumTxes(1, 2)
 }
 
+// testSweepLegacyHTLCReorgRestart verifies a shallow final sweep cannot retire
+// a legacy HTLC claim before its channel confirmation policy is satisfied.
+func testSweepLegacyHTLCReorgRestart(ht *lntest.HarnessTest) {
+	// Neutrino cannot invalidate blocks, so use a full-node backend.
+	if ht.IsNeutrinoBackend() {
+		ht.Skipf("skipping reorg test for neutrino backend")
+	}
+
+	// Arrange a legacy channel whose held HTLC routes through Nursery under
+	// a fixed three-block resolution policy.
+	const (
+		requiredConfs = 3
+
+		// htlcAmt keeps the timeout output above dust.
+		htlcAmt = 100_000
+	)
+
+	// Derive both node flags from the depth asserted by mined blocks.
+	confArg := fmt.Sprintf(
+		"--dev.force-channel-close-confs=%d", requiredConfs,
+	)
+	aliceArgs := []string{
+		"--protocol.legacy.committweak",
+		confArg,
+	}
+	bobArgs := []string{
+		"--protocol.legacy.committweak",
+		confArg,
+		"--hodl.exit-settle",
+	}
+	openParams := lntest.OpenChannelParams{
+		Amt:            chanAmt,
+		CommitmentType: lnrpc.CommitmentType_LEGACY,
+	}
+
+	chanPoints, nodes := ht.CreateSimpleNetwork(
+		[][]string{aliceArgs, bobArgs}, openParams,
+	)
+	alice, bob := nodes[0], nodes[1]
+	chanPoint := chanPoints[0]
+
+	// Arrange one held payment and derive its padded expiry height.
+	paymentHash := ht.Random32Bytes()
+	paymentReq := &routerrpc.SendPaymentRequest{
+		Dest:           bob.PubKey[:],
+		Amt:            htlcAmt,
+		PaymentHash:    paymentHash,
+		FinalCltvDelta: finalCltvDelta,
+		FeeLimitMsat:   noFeeLimitMsat,
+	}
+	ht.SendPaymentAssertInflight(alice, paymentReq)
+	ht.AssertNumActiveHtlcs(alice, 1)
+	ht.AssertNumActiveHtlcs(bob, 1)
+	htlcExpiryHeight := padCLTV(ht.CurrentHeight() + finalCltvDelta)
+
+	// Act by closing and clearing Alice's unrelated CSV-delayed output so
+	// later mempool assertions isolate the HTLC lifecycle.
+	ht.CloseChannelAssertPending(alice, chanPoint, true)
+
+	// Confirm the commitment so its configured close depth starts.
+	ht.MineClosingTx(chanPoint)
+	// Advance the remaining blocks required by the channel-close policy.
+	ht.MineEmptyBlocks(requiredConfs - 1)
+
+	forceClose := ht.AssertChannelPendingForceClose(alice, chanPoint)
+	ht.AssertNumHTLCsAndStage(alice, chanPoint, 1, 1)
+	ht.AssertNumPendingSweeps(alice, 1)
+	require.Positive(ht, forceClose.BlocksTilMaturity)
+
+	// Advance to the last block before Alice's ordinary output matures.
+	ht.MineEmptyBlocks(int(forceClose.BlocksTilMaturity) - 1)
+	// Confirm the ordinary sweep so later mempool checks isolate the HTLC.
+	ht.MineBlocksAndAssertNumTxes(1, 1)
+
+	// Act through the HTLC expiry and Nursery timeout depth, then use the
+	// RPC maturity countdown instead of duplicating Nursery arithmetic.
+	// Advance until the HTLC timeout transaction becomes valid.
+	ht.MineEmptyBlocks(int(htlcExpiryHeight - ht.CurrentHeight()))
+
+	timeoutTx := ht.GetNumTxsFromMempool(1)[0]
+	timeoutTxID := timeoutTx.TxHash()
+
+	// Confirm Nursery's presigned timeout transaction at its first depth.
+	ht.MineBlocksAndAssertNumTxes(1, 1)
+	// Advance the timeout transaction to the channel's terminal depth.
+	ht.MineEmptyBlocks(requiredConfs - 1)
+
+	ht.AssertNumHTLCsAndStage(alice, chanPoint, 1, 2)
+	forceClose = ht.AssertChannelPendingForceClose(alice, chanPoint)
+	require.Len(ht, forceClose.PendingHtlcs, 1)
+	require.Positive(ht, forceClose.PendingHtlcs[0].BlocksTilMaturity)
+
+	// Advance until Nursery can offer the second-level output.
+	ht.MineEmptyBlocks(int(forceClose.PendingHtlcs[0].BlocksTilMaturity))
+
+	// Assert the remaining sweep targets Nursery's persisted output.
+	pendingSweep := ht.AssertNumPendingSweeps(alice, 1)[0]
+	require.Equal(ht, timeoutTxID.String(), pendingSweep.Outpoint.TxidStr)
+	txid := pendingSweep.Outpoint.TxidStr
+	parentHash, err := chainhash.NewHashFromStr(txid)
+	require.NoError(ht, err)
+	htlcOutpoint := wire.OutPoint{
+		Hash:  *parentHash,
+		Index: pendingSweep.Outpoint.OutputIndex,
+	}
+
+	// Mine once more because Nursery offers the output after the same
+	// blockbeat, making the next beat publish its sweep batch.
+	ht.MineEmptyBlocks(1)
+	finalSweep := ht.AssertOutpointInMempool(htlcOutpoint)
+
+	// Confirm the final sweep once, below its three-block terminal depth.
+	shallowBlock := ht.MineBlockWithTx(finalSweep)
+
+	// Wait for Alice so invalidation cannot race shallow-spend processing.
+	ht.WaitForNodeBlockHeight(alice, int32(ht.CurrentHeight()))
+
+	// Assert both lifecycle owners retain the shallow claim.
+	ht.AssertNumHTLCsAndStage(alice, chanPoint, 1, 2)
+	ht.AssertNumPendingSweeps(alice, 1)
+
+	// Act by invalidating the shallow block and extending its replacement.
+	shallowHash := shallowBlock.Header.BlockHash()
+	require.NoError(ht, ht.Miner().InvalidateBlock(&shallowHash))
+	// Extend the replacement chain to keep the old branch detached.
+	ht.MineEmptyBlocks(2)
+
+	// Assert the live sweeper republishes before restart without recovery.
+	ht.AssertOutpointInMempool(htlcOutpoint)
+	ht.RestartNode(alice)
+
+	// Assert restart restores and republishes the reorged Nursery claim.
+	ht.AssertNumHTLCsAndStage(alice, chanPoint, 1, 2)
+	ht.AssertNumPendingSweeps(alice, 1)
+	replacementSweep := ht.AssertOutpointInMempool(htlcOutpoint)
+
+	// Reconfirm the replacement before advancing it to terminal depth.
+	ht.MineBlockWithTx(replacementSweep)
+	// Advance the replacement sweep to its configured terminal depth.
+	ht.MineEmptyBlocks(requiredConfs - 1)
+
+	// Assert maturity permits terminal cleanup without stranding funds.
+	ht.AssertNumPendingForceClose(alice, 0)
+	ht.CleanShutDown()
+}
+
 // testSweepCommitOutputAndAnchor checks when a channel is force closed without
 // any time-sensitive HTLCs, the anchor output is swept without any CPFP
 // attempts. In addition, the to_local output should be swept using the

--- a/lntest/mock/chainnotifier.go
+++ b/lntest/mock/chainnotifier.go
@@ -40,7 +40,8 @@ func (c *ChainNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash,
 // RegisterSpendNtfn returns a SpendEvent that contains a channel that the spend
 // details will go over.
 func (c *ChainNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	pkScript []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	pkScript []byte, heightHint uint32,
+	_ ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
 	return &chainntnfs.SpendEvent{
 		Spend:  c.SpendChan,

--- a/lntest/mock/spendnotifier.go
+++ b/lntest/mock/spendnotifier.go
@@ -31,7 +31,8 @@ func MakeMockSpendNotifier() *SpendNotifier {
 
 // RegisterSpendNtfn registers a spend notification for a specified outpoint.
 func (s *SpendNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	_ []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	_ []byte, heightHint uint32,
+	_ ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
 	s.mtx.Lock()
 	defer s.mtx.Unlock()

--- a/lnwallet/chancloser/mock.go
+++ b/lnwallet/chancloser/mock.go
@@ -73,9 +73,18 @@ func (d *dummyAdapters) RegisterConfirmationsNtfn(txid *chainhash.Hash,
 }
 
 func (d *dummyAdapters) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	pkScript []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	pkScript []byte, heightHint uint32,
+	opts ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
-	args := d.Called(outpoint, pkScript, heightHint)
+	// Preserve existing three-argument expectations, while exposing the
+	// option slice when a focused test verifies the requested spend depth.
+	callArgs := []interface{}{outpoint, pkScript, heightHint}
+	if len(opts) != 0 {
+		// Keep options grouped so the mock can compare the same
+		// variadic boundary used by the production interface.
+		callArgs = append(callArgs, opts)
+	}
+	args := d.Called(callArgs...)
 
 	err := args.Error(0)
 

--- a/lnwallet/mock.go
+++ b/lnwallet/mock.go
@@ -370,7 +370,8 @@ func (c *mockChainNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash,
 // RegisterSpendNtfn returns a SpendEvent that contains a channel that the spend
 // details will go over.
 func (c *mockChainNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	pkScript []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	pkScript []byte, heightHint uint32,
+	_ ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
 	return &chainntnfs.SpendEvent{
 		Spend:  c.SpendChan,

--- a/peer/daemon_adapters.go
+++ b/peer/daemon_adapters.go
@@ -129,10 +129,11 @@ func (l *LndDaemonAdapters) RegisterConfirmationsNtfn(txid *chainhash.Hash,
 // RegisterSpendNtfn registers an intent to be notified once the target
 // outpoint is successfully spent within a transaction.
 func (l *LndDaemonAdapters) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	pkScript []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	pkScript []byte, heightHint uint32,
+	opts ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
 	return l.cfg.ChainNotifier.RegisterSpendNtfn(
-		outpoint, pkScript, heightHint,
+		outpoint, pkScript, heightHint, opts...,
 	)
 }
 

--- a/protofsm/state_machine.go
+++ b/protofsm/state_machine.go
@@ -113,7 +113,8 @@ type DaemonAdapters interface {
 	// the outpoint creates must also be specified. This allows this
 	// interface to be implemented by BIP 158-like filtering.
 	RegisterSpendNtfn(outpoint *wire.OutPoint, pkScript []byte,
-		heightHint uint32) (*chainntnfs.SpendEvent, error)
+		heightHint uint32, opts ...chainntnfs.SpendOption) (
+		*chainntnfs.SpendEvent, error)
 }
 
 // stateQuery is used by outside callers to query the internal state of the

--- a/protofsm/state_machine_test.go
+++ b/protofsm/state_machine_test.go
@@ -395,9 +395,18 @@ func (d *dummyAdapters) RegisterConfirmationsNtfn(txid *chainhash.Hash,
 }
 
 func (d *dummyAdapters) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	pkScript []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	pkScript []byte, heightHint uint32,
+	opts ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
-	args := d.Called(outpoint, pkScript, heightHint)
+	// Preserve existing three-argument expectations, while exposing the
+	// option slice when a focused test verifies the requested spend depth.
+	callArgs := []interface{}{outpoint, pkScript, heightHint}
+	if len(opts) != 0 {
+		// Keep options grouped so the mock can compare the same
+		// variadic boundary used by the production interface.
+		callArgs = append(callArgs, opts)
+	}
+	args := d.Called(callArgs...)
 
 	err := args.Error(0)
 

--- a/server.go
+++ b/server.go
@@ -1327,7 +1327,7 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 
 	s.utxoNursery = contractcourt.NewUtxoNursery(&contractcourt.NurseryConfig{
 		ChainIO:             cc.ChainIO,
-		ConfDepth:           1,
+		ChannelCloseConfs:   s.cfg.Dev.ChannelCloseConfs(),
 		FetchClosedChannels: s.chanStateDB.FetchClosedChannels,
 		FetchClosedChannel:  s.chanStateDB.FetchClosedChannel,
 		Notifier:            cc.ChainNotifier,

--- a/sweep/fee_bumper.go
+++ b/sweep/fee_bumper.go
@@ -1285,9 +1285,9 @@ func (t *TxPublisher) createUnknownSpentBumpResult(
 	// Calculate the next fee rate for the retry.
 	feeRate, err := t.calculateRetryFeeRate(r)
 	if err != nil {
-		// Overwrite the event and error so the sweeper will
-		// remove this input.
-		result.Event = TxFatal
+		// Preserve the unknown-spend event because its per-outpoint
+		// evidence remains authoritative even when the viable siblings
+		// cannot obtain a retry fee rate.
 		result.Err = err
 	}
 

--- a/sweep/fee_bumper_test.go
+++ b/sweep/fee_bumper_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/lightningnetwork/lnd/chainntnfs"
@@ -1801,6 +1802,45 @@ func TestProcessRecordsSpent(t *testing.T) {
 		require.ErrorIs(t, result.Err, ErrUnknownSpent)
 		require.Equal(t, requestID, result.requestID)
 	}
+}
+
+// TestUnknownSpentRetryErrorPreservesEvidence verifies fee initialization
+// failure does not discard the outpoints already proven spent by another tx.
+func TestUnknownSpentRetryErrorPreservesEvidence(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Build a monitor record with one observed external spend and
+	// an invalid delivery script. The invalid script makes retry fee
+	// initialization fail after the publisher has collected spend evidence.
+	publisher, _ := createTestPublisher(t)
+	inp := createTestInput(1000, input.WitnessKeyHash)
+	outpoint := inp.OutPoint()
+	spendingTx := &wire.MsgTx{LockTime: 2}
+	spentInputs := map[wire.OutPoint]*wire.MsgTx{
+		outpoint: spendingTx,
+	}
+	record := &monitorRecord{
+		req: &BumpRequest{
+			DeliveryAddress: lnwallet.AddrWithKey{
+				DeliveryAddress: []byte{txscript.OP_TRUE},
+			},
+			Inputs: []input.Input{&inp},
+			Budget: btcutil.Amount(1000),
+		},
+		tx:          &wire.MsgTx{LockTime: 1},
+		spentInputs: spentInputs,
+	}
+
+	// Act: Create the result that partitions observed spends from inputs
+	// which would otherwise be eligible for a new fee-bump attempt.
+	result := publisher.createUnknownSpentBumpResult(record)
+
+	// Assert: The event remains per-outpoint unknown-spend evidence even
+	// though retry policy failed. The sweeper can depth-gate that member
+	// instead of terminalizing the whole request.
+	require.Equal(t, TxUnknownSpend, result.Event)
+	require.Error(t, result.Err)
+	require.Equal(t, spentInputs, result.SpentInputs)
 }
 
 // TestHandleInitialBroadcastSuccess checks `handleInitialBroadcast` method can

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1971,6 +1971,30 @@ func (s *UtxoSweeper) handleBumpEventTxPublished(resp *bumpResp) error {
 func (s *UtxoSweeper) handleBumpEventTxFatal(resp *bumpResp) error {
 	r := resp.result
 
+	// Delay while shallow discovery can explain the missing input; then
+	// fall through so a genuine orphan becomes terminal.
+	if resp.deferTerminal && errors.Is(r.Err, ErrInputMissing) {
+		deferMissing := false
+		for _, inp := range resp.set.Inputs() {
+			pending, ok := s.inputs[inp.OutPoint()]
+			if !ok {
+				continue
+			}
+
+			since := pending.missingSince.UnwrapOr(s.currentHeight)
+			pending.missingSince = fn.Some(since)
+			age := s.currentHeight - since
+			if age < int32(pending.params.RequiredConfs) {
+				deferMissing = true
+			}
+		}
+
+		if deferMissing {
+			s.markInputsPublishFailed(resp.set, r.FeeRate)
+			return nil
+		}
+	}
+
 	// Remove the tx from the sweeper store if there is one. Since this is
 	// a broadcast error, it's likely there isn't a tx here.
 	if r.Tx != nil {
@@ -2153,6 +2177,8 @@ func (s *UtxoSweeper) handleBumpEventTxUnknownSpend(r *bumpResp) {
 
 	// Get all the inputs that are not spent in the current sweeping tx.
 	spentInputs := r.result.SpentInputs
+	canRetry := r.result.Err == nil ||
+		errors.Is(r.result.Err, ErrUnknownSpent)
 
 	// Create a slice to track inputs to be retried.
 	inputsToRetry := make([]input.Input, 0, len(r.set.Inputs()))
@@ -2198,6 +2224,14 @@ func (s *UtxoSweeper) handleBumpEventTxUnknownSpend(r *bumpResp) {
 
 			continue
 		}
+		if !canRetry {
+			// A fee-policy failure applies only to viable siblings.
+			// Shallow evidence retains its depth monitor.
+			// It cannot be terminalized batch-wide.
+			s.markInputFatal(input, nil, r.result.Err)
+			continue
+		}
+
 		log.Debugf("Input(%v): updating params: immediate [%v -> true]",
 			op, r.result.FeeRate, input.params.Immediate)
 

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -37,13 +37,23 @@ var (
 	// it is/has already been stopped.
 	ErrSweeperShuttingDown = errors.New("utxo sweeper shutting down")
 
+	// ErrRequiredConfsMismatch rejects updates to an admitted spend policy.
+	ErrRequiredConfsMismatch = errors.New("required confirmations mismatch")
+
 	// DefaultDeadlineDelta defines a default deadline delta (1 week) to be
 	// used when sweeping inputs with no deadline pressure.
 	DefaultDeadlineDelta = int32(1008)
+
+	// DefaultRequiredConfs preserves maturity when callers omit policy.
+	DefaultRequiredConfs uint32 = 1
 )
 
 // Params contains the parameters that control the sweeping process.
 type Params struct {
+	// RequiredConfs is the immutable spend maturity for this input. Zero
+	// selects DefaultRequiredConfs only when the input is first admitted.
+	RequiredConfs uint32
+
 	// ExclusiveGroup is an identifier that, if set, ensures this input is
 	// swept in a transaction by itself, and not batched with any other
 	// inputs.
@@ -81,8 +91,10 @@ func (p Params) String() string {
 	}
 
 	return fmt.Sprintf("startingFeeRate=%v, immediate=%v, "+
-		"exclusive_group=%v, budget=%v, deadline=%v", p.StartingFeeRate,
-		p.Immediate, exclusiveGroup, p.Budget, deadline)
+		"exclusive_group=%v, budget=%v, deadline=%v, required_confs=%v",
+		p.StartingFeeRate, p.Immediate, exclusiveGroup, p.Budget,
+		deadline, p.RequiredConfs,
+	)
 }
 
 // SweepState represents the current state of a pending input.
@@ -340,6 +352,10 @@ type UtxoSweeper struct {
 	newInputs chan *sweepInputMessage
 	spendChan chan *chainntnfs.SpendDetail
 
+	// spendReorgChan carries the exact outpoint whose provisional spend
+	// disappeared, allowing the collector to retry only that input.
+	spendReorgChan chan wire.OutPoint
+
 	// pendingSweepsReq is a channel that will be sent requests by external
 	// callers in order to retrieve the set of pending inputs the
 	// UtxoSweeper is attempting to sweep.
@@ -449,6 +465,7 @@ func New(cfg *UtxoSweeperConfig) *UtxoSweeper {
 		cfg:               cfg,
 		newInputs:         make(chan *sweepInputMessage),
 		spendChan:         make(chan *chainntnfs.SpendDetail),
+		spendReorgChan:    make(chan wire.OutPoint),
 		updateReqs:        make(chan *updateReq),
 		pendingSweepsReqs: make(chan *pendingSweepsReq),
 		quit:              make(chan struct{}),
@@ -530,6 +547,16 @@ func (s *UtxoSweeper) SweepInput(inp input.Input,
 		inp.SignDesc() == nil {
 
 		return nil, errors.New("nil input received")
+	}
+
+	// Reject an invalid maturity policy before it reaches the collector.
+	// A notifier registration error inside the collector would otherwise
+	// stop the node-wide sweep loop instead of failing only this request.
+	if params.RequiredConfs > chainntnfs.MaxNumConfs {
+		return nil, fmt.Errorf(
+			"required confirmations %d: %w",
+			params.RequiredConfs, chainntnfs.ErrNumConfsOutOfRange,
+		)
 	}
 
 	absoluteTimeLock, _ := inp.RequiredLockTime()
@@ -682,6 +709,15 @@ func (s *UtxoSweeper) collector() {
 		// results to the caller(s).
 		case spend := <-s.spendChan:
 			s.handleInputSpent(spend)
+
+		// A provisional spend was disconnected before reaching the
+		// input's requested depth. Requeue only its owning input; the
+		// next blockbeat will drive the existing retry path.
+		case outpoint := <-s.spendReorgChan:
+			input, ok := s.inputs[outpoint]
+			if ok && input.state == Published {
+				input.state = PublishFailed
+			}
 
 		// A new external request has been received to retrieve all of
 		// the inputs we're currently attempting to sweep.
@@ -1005,19 +1041,39 @@ func (s *UtxoSweeper) markInputsPublishFailed(set InputSet,
 	}
 }
 
-// monitorSpend registers a spend notification with the chain notifier. It
-// returns a cancel function that can be used to cancel the registration.
+// monitorSpend registers a terminal observer at the input's policy and a
+// one-confirmation reorg observer for deep inputs, returning one shared cancel.
 func (s *UtxoSweeper) monitorSpend(outpoint wire.OutPoint,
-	script []byte, heightHint uint32) (func(), error) {
+	script []byte, heightHint, requiredConfs uint32) (func(), error) {
 
 	log.Tracef("Wait for spend of %v at heightHint=%v",
 		outpoint, heightHint)
 
-	spendEvent, err := s.cfg.Notifier.RegisterSpendNtfn(
+	// The input monitor owns terminal delivery, so the notifier hides
+	// candidates until the input's immutable policy is met.
+	terminalEvent, err := s.cfg.Notifier.RegisterSpendNtfn(
 		&outpoint, script, heightHint,
+		chainntnfs.WithSpendNumConfs(requiredConfs),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("register spend ntfn: %w", err)
+	}
+
+	var shallowEvent *chainntnfs.SpendEvent
+	if requiredConfs > DefaultRequiredConfs {
+		// The early observer exposes candidate reorgs before terminal
+		// depth. Only the terminal observer reports final spends.
+		shallowEvent, err = s.cfg.Notifier.RegisterSpendNtfn(
+			&outpoint, script, heightHint,
+			chainntnfs.WithSpendNumConfs(DefaultRequiredConfs),
+		)
+		if err != nil {
+			terminalEvent.Cancel()
+
+			return nil, fmt.Errorf(
+				"register shallow spend ntfn: %w", err,
+			)
+		}
 	}
 
 	s.wg.Add(1)
@@ -1025,15 +1081,13 @@ func (s *UtxoSweeper) monitorSpend(outpoint wire.OutPoint,
 		defer s.wg.Done()
 
 		select {
-		case spend, ok := <-spendEvent.Spend:
+		case spend, ok := <-terminalEvent.Spend:
 			if !ok {
-				log.Debugf("Spend ntfn for %v canceled",
-					outpoint)
+				log.Debugf("Spend %v watch canceled", outpoint)
 				return
 			}
 
 			log.Debugf("Delivering spend ntfn for %v", outpoint)
-
 			select {
 			case s.spendChan <- spend:
 				log.Debugf("Delivered spend ntfn for %v",
@@ -1041,11 +1095,56 @@ func (s *UtxoSweeper) monitorSpend(outpoint wire.OutPoint,
 
 			case <-s.quit:
 			}
+
 		case <-s.quit:
 		}
 	}()
 
-	return spendEvent.Cancel, nil
+	if shallowEvent != nil {
+		s.wg.Add(1)
+		go s.monitorShallowSpend(outpoint, shallowEvent)
+	}
+
+	return func() {
+		// Both observers share the admitted input's terminal lifetime.
+		terminalEvent.Cancel()
+		if shallowEvent != nil {
+			shallowEvent.Cancel()
+		}
+	}, nil
+}
+
+// monitorShallowSpend routes provisional reorgs back to the owning input while
+// leaving terminal spend delivery to the separate depth-aware observer.
+func (s *UtxoSweeper) monitorShallowSpend(outpoint wire.OutPoint,
+	spendEvent *chainntnfs.SpendEvent) {
+
+	defer s.wg.Done()
+
+	for {
+		select {
+		case _, ok := <-spendEvent.Spend:
+			if !ok {
+				return
+			}
+
+			// Consume the spend without reporting terminal success.
+
+		case _, ok := <-spendEvent.Reorg:
+			if !ok {
+				return
+			}
+
+			select {
+			case s.spendReorgChan <- outpoint:
+			case <-s.quit:
+				return
+			}
+
+		case <-s.quit:
+			return
+		}
+	}
 }
 
 // PendingInputs returns the set of inputs that the UtxoSweeper is currently
@@ -1115,6 +1214,8 @@ func (s *UtxoSweeper) handlePendingSweepsReq(
 // and force flag that will be used for a new sweep transaction of the input
 // that will act as a replacement transaction (RBF) of the original sweeping
 // transaction, if any. The exclusive group is left unchanged.
+// RequiredConfs is also left unchanged because the active spend notification
+// owns the depth selected when the input was admitted.
 //
 // NOTE: This currently doesn't do any fee rate validation to ensure that a bump
 // is actually successful. The responsibility of doing so should be handled by
@@ -1168,11 +1269,22 @@ func (s *UtxoSweeper) handleUpdateReq(req *updateReq) (
 	// Create the updated parameters struct. Leave the exclusive group
 	// unchanged.
 	newParams := Params{
+		RequiredConfs:   sweeperInput.params.RequiredConfs,
 		StartingFeeRate: req.params.StartingFeeRate,
 		Immediate:       req.params.Immediate,
 		Budget:          req.params.Budget,
 		DeadlineHeight:  req.params.DeadlineHeight,
 		ExclusiveGroup:  sweeperInput.params.ExclusiveGroup,
+	}
+
+	// Omitted depth means a fee-only update, while an explicit mismatch
+	// would desynchronize the existing notifier client from stored policy.
+	if req.params.RequiredConfs != 0 &&
+		req.params.RequiredConfs != newParams.RequiredConfs {
+
+		return nil, fmt.Errorf("%w: admitted=%d, requested=%d",
+			ErrRequiredConfsMismatch, newParams.RequiredConfs,
+			req.params.RequiredConfs)
 	}
 
 	log.Debugf("Updating parameters for %v(state=%v) from (%v) to (%v)",
@@ -1253,6 +1365,12 @@ func (s *UtxoSweeper) handleNewInput(input *sweepInputMessage) error {
 		return nil
 	}
 
+	// Apply the compatibility default once, before the pending record and
+	// its eventual spend monitor take ownership of immutable policy.
+	if input.params.RequiredConfs == 0 {
+		input.params.RequiredConfs = DefaultRequiredConfs
+	}
+
 	// This is a new input, and we want to query the mempool to see if this
 	// input has already been spent. If so, we'll start the input with the
 	// RBFInfo.
@@ -1292,7 +1410,7 @@ func (s *UtxoSweeper) handleNewInput(input *sweepInputMessage) error {
 	// party.
 	cancel, err := s.monitorSpend(
 		outpoint, input.input.SignDesc().Output.PkScript,
-		input.input.HeightHint(),
+		input.input.HeightHint(), pi.params.RequiredConfs,
 	)
 	if err != nil {
 		err := fmt.Errorf("wait for spend: %w", err)
@@ -1374,6 +1492,23 @@ func (s *UtxoSweeper) decideRBFInfo(
 // It will overwrite the params of the old input with the new ones.
 func (s *UtxoSweeper) handleExistingInput(input *sweepInputMessage,
 	oldInput *SweeperInput) {
+
+	// A duplicate offer may omit policy and inherit the admitted depth, but
+	// it cannot replace the value owned by the active spend registration.
+	if input.params.RequiredConfs == 0 {
+		input.params.RequiredConfs = oldInput.params.RequiredConfs
+	} else if input.params.RequiredConfs !=
+		oldInput.params.RequiredConfs {
+
+		input.resultChan <- Result{Err: fmt.Errorf(
+			"%w: admitted=%d, requested=%d",
+			ErrRequiredConfsMismatch,
+			oldInput.params.RequiredConfs,
+			input.params.RequiredConfs,
+		)}
+
+		return
+	}
 
 	// Before updating the input details, check if a previous exclusive
 	// group was set. In case the same input is registered again, the

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -202,6 +202,9 @@ type SweeperInput struct {
 	// made to sweep this tx.
 	publishAttempts int
 
+	// missingSince starts the shallow-discovery grace period.
+	missingSince fn.Option[int32]
+
 	// params contains the parameters that control the sweeping process.
 	params Params
 
@@ -667,6 +670,27 @@ func (s *UtxoSweeper) removeConflictSweepDescendants(
 	return nil
 }
 
+// conflictCleanupOutpoints returns transaction inputs whose conflicts are safe
+// to retire. The mature outpoint is authoritative, untracked inputs have no
+// pending lifecycle policy, and terminal tracked inputs cannot be revived;
+// tracked non-terminal siblings remain owned until their own depth matures.
+func (s *UtxoSweeper) conflictCleanupOutpoints(tx *wire.MsgTx,
+	matureOutpoint wire.OutPoint) map[wire.OutPoint]struct{} {
+
+	outpoints := map[wire.OutPoint]struct{}{
+		matureOutpoint: {},
+	}
+	for _, txIn := range tx.TxIn {
+		outpoint := txIn.PreviousOutPoint
+		input, tracked := s.inputs[outpoint]
+		if !tracked || input.terminated() {
+			outpoints[outpoint] = struct{}{}
+		}
+	}
+
+	return outpoints
+}
+
 // collector is the sweeper main loop. It processes new inputs, spend
 // notifications and counts down to publication of the sweep tx.
 func (s *UtxoSweeper) collector() {
@@ -885,6 +909,17 @@ func (s *UtxoSweeper) sweep(set InputSet) error {
 		return err
 	}
 
+	// Publisher results stay provisional if any lifecycle input needs
+	// multiple confirmations; input monitors remain terminal authority.
+	deferTerminal := false
+	for _, inp := range set.Inputs() {
+		pending, ok := s.inputs[inp.OutPoint()]
+		if ok && pending.params.RequiredConfs > DefaultRequiredConfs {
+			deferTerminal = true
+			break
+		}
+	}
+
 	// Create a fee bump request and ask the publisher to broadcast it. The
 	// publisher will then take over and start monitoring the tx for
 	// potential fee bump.
@@ -912,7 +947,7 @@ func (s *UtxoSweeper) sweep(set InputSet) error {
 	// subscribing to the result chan and listen for future updates about
 	// this tx.
 	s.wg.Add(1)
-	go s.monitorFeeBumpResult(set, resp)
+	go s.monitorFeeBumpResult(set, resp, deferTerminal)
 
 	return nil
 }
@@ -991,6 +1026,8 @@ func (s *UtxoSweeper) markInputsPublished(tr *TxRecord, set InputSet) error {
 
 		// Update the input's state.
 		pi.state = Published
+		// Successful publication starts future missing windows anew.
+		pi.missingSince = fn.None[int32]()
 
 		// Update the input's latest fee rate.
 		pi.lastFeeRate = chainfee.SatPerKWeight(tr.FeeRate)
@@ -1552,19 +1589,22 @@ func (s *UtxoSweeper) handleInputSpent(spend *chainntnfs.SpendDetail) {
 	spendHash := *spend.SpenderTxHash
 	isOurTx := s.cfg.Store.IsOurTx(spendHash)
 
+	// Deep inputs retain wallet rebroadcast ownership after the publisher's
+	// shallow confirmation. Release it only when the input monitor supplies
+	// the mature terminal spend handled below.
+	if isOurTx {
+		s.cfg.Wallet.CancelRebroadcast(spendHash)
+	}
+
 	// If this isn't our transaction, it means someone else swept outputs
 	// that we were attempting to sweep. This can happen for anchor outputs
 	// as well as justice transactions. In this case, we'll notify the
 	// wallet to remove any spends that descent from this output.
 	if !isOurTx {
-		// Construct a map of the inputs this transaction spends.
 		spendingTx := spend.SpendingTx
-		inputsSpent := make(
-			map[wire.OutPoint]struct{}, len(spendingTx.TxIn),
+		inputsSpent := s.conflictCleanupOutpoints(
+			spendingTx, *spend.SpentOutPoint,
 		)
-		for _, txIn := range spendingTx.TxIn {
-			inputsSpent[txIn.PreviousOutPoint] = struct{}{}
-		}
 
 		log.Debugf("Attempting to remove descendant txns invalidated "+
 			"by (txid=%v): %v", spendingTx.TxHash(),
@@ -1581,62 +1621,43 @@ func (s *UtxoSweeper) handleInputSpent(spend *chainntnfs.SpendDetail) {
 			lnutils.SpewLogClosure(spend.SpendingTx))
 	}
 
-	// We now use the spending tx to update the state of the inputs.
-	s.markInputsSwept(spend.SpendingTx, isOurTx)
+	// Only this mature notification's outpoint is terminal. Other inputs
+	// keep their independent depth registrations.
+	s.markNotifiedInputSwept(
+		*spend.SpentOutPoint, spend.SpendingTx, isOurTx,
+	)
 }
 
-// markInputsSwept marks all inputs swept by the spending transaction as swept.
-// It will also notify all the subscribers of this input.
-func (s *UtxoSweeper) markInputsSwept(tx *wire.MsgTx, isOurTx bool) {
-	for _, txIn := range tx.TxIn {
-		outpoint := txIn.PreviousOutPoint
+// markNotifiedInputSwept finalizes the independently notified outpoint while
+// leaving other transaction inputs viable until their own mature events.
+func (s *UtxoSweeper) markNotifiedInputSwept(outpoint wire.OutPoint,
+	tx *wire.MsgTx, isOurTx bool) {
 
-		// Check if this input is known to us. It could probably be
-		// unknown if we canceled the registration, deleted from inputs
-		// map but the ntfn was in-flight already. Or this could be not
-		// one of our inputs.
-		input, ok := s.inputs[outpoint]
-		if !ok {
-			// It's very likely that a spending tx contains inputs
-			// that we don't know.
-			log.Tracef("Skipped marking input as swept: %v not "+
-				"found in pending inputs", outpoint)
+	// An in-flight notification may arrive after its input was removed, or
+	// after another terminal path won, so both cases are safe no-ops.
+	inp, ok := s.inputs[outpoint]
+	if !ok || inp.terminated() {
+		return
+	}
 
-			continue
-		}
+	inp.state = Swept
 
-		// This input may already been marked as swept by a previous
-		// spend notification, which is likely to happen as one sweep
-		// transaction usually sweeps multiple inputs.
-		if input.terminated() {
-			log.Debugf("Skipped marking input as swept: %v "+
-				"state=%v", outpoint, input.state)
+	// Our mature spend reports success. A mature competing spend reports
+	// the existing remote-spend result through the same listener path.
+	var err error
+	if !isOurTx {
+		log.Warnf(
+			"Input=%v was spent by remote or third party in tx=%v",
+			outpoint, tx.TxHash(),
+		)
+		err = ErrRemoteSpend
+	}
+	s.signalResult(inp, Result{Tx: tx, Err: err})
 
-			continue
-		}
-
-		input.state = Swept
-
-		// Return either a nil or a remote spend result.
-		var err error
-		if !isOurTx {
-			log.Warnf("Input=%v was spent by remote or third "+
-				"party in tx=%v", outpoint, tx.TxHash())
-			err = ErrRemoteSpend
-		}
-
-		// Signal result channels.
-		s.signalResult(input, Result{
-			Tx:  tx,
-			Err: err,
-		})
-
-		// Remove all other inputs in this exclusive group.
-		if input.params.ExclusiveGroup != nil {
-			s.removeExclusiveGroup(
-				*input.params.ExclusiveGroup, outpoint,
-			)
-		}
+	// Exclusive siblings become unspendable only after this input's own
+	// policy is satisfied, preserving the pre-maturity reorg window.
+	if inp.params.ExclusiveGroup != nil {
+		s.removeExclusiveGroup(*inp.params.ExclusiveGroup, outpoint)
 	}
 }
 
@@ -1768,6 +1789,10 @@ type bumpResp struct {
 
 	// set is the input set that was used in the bump attempt.
 	set InputSet
+
+	// deferTerminal keeps one-confirmation publisher observations from
+	// retiring inputs whose own spend monitors require greater depth.
+	deferTerminal bool
 }
 
 // monitorFeeBumpResult subscribes to the passed result chan to listen for
@@ -1775,7 +1800,7 @@ type bumpResp struct {
 //
 // NOTE: must run as a goroutine.
 func (s *UtxoSweeper) monitorFeeBumpResult(set InputSet,
-	resultChan <-chan *BumpResult) {
+	resultChan <-chan *BumpResult, deferTerminal bool) {
 
 	defer s.wg.Done()
 
@@ -1789,8 +1814,9 @@ func (s *UtxoSweeper) monitorFeeBumpResult(set InputSet,
 			}
 
 			resp := &bumpResp{
-				result: r,
-				set:    set,
+				result:        r,
+				set:           set,
+				deferTerminal: deferTerminal,
 			}
 
 			// Send the result back to the main event loop.
@@ -1809,7 +1835,8 @@ func (s *UtxoSweeper) monitorFeeBumpResult(set InputSet,
 			// TODO(yy): can instead remove the spend subscription
 			// in sweeper and rely solely on this event to mark
 			// inputs as Swept?
-			if r.Event == TxConfirmed || r.Event == TxFailed {
+			switch r.Event {
+			case TxConfirmed, TxFailed, TxFatal, TxUnknownSpend:
 				// Exit if the tx is failed to be created.
 				if r.Tx == nil {
 					log.Debugf("Received %v for nil tx, "+
@@ -1822,8 +1849,13 @@ func (s *UtxoSweeper) monitorFeeBumpResult(set InputSet,
 					"fee bump monitor", r.Event,
 					r.Tx.TxHash())
 
-				// Cancel the rebroadcasting of the failed tx.
-				s.cfg.Wallet.CancelRebroadcast(r.Tx.TxHash())
+				// A deep input retains rebroadcast ownership
+				// until its independent mature spend arrives.
+				if r.Event == TxFailed || !deferTerminal {
+					s.cfg.Wallet.CancelRebroadcast(
+						r.Tx.TxHash(),
+					)
+				}
 
 				return
 			}
@@ -1991,12 +2023,19 @@ func (s *UtxoSweeper) markInputsFatal(set InputSet, err error) {
 // handleBumpEvent handles the result sent from the bumper based on its event
 // type.
 //
-// NOTE: TxConfirmed event is not handled, since we already subscribe to the
-// input's spending event, we don't need to do anything here.
+// NOTE: The input spend registration remains the terminal authority. The
+// shallow observer requeues a deeper input only if its confirmed spend is
+// actually disconnected.
 func (s *UtxoSweeper) handleBumpEvent(r *bumpResp) error {
 	log.Debugf("Received bump result %v", r.result)
 
 	switch r.result.Event {
+	// A shallow publisher result is provisional for a deeper input.
+	// Keep the input published while that spend remains confirmed; its
+	// shallow observer will requeue only the affected outpoint on a reorg.
+	case TxConfirmed:
+		return nil
+
 	// The tx has been published, we update the inputs' state and create a
 	// record to be stored in the sweeper db.
 	case TxPublished:
@@ -2085,11 +2124,7 @@ func (s *UtxoSweeper) handleUnknownSpendTx(inp *SweeperInput, tx *wire.MsgTx) {
 	log.Debugf("Removing descendant txns invalidated by (txid=%v): %v",
 		txid, lnutils.SpewLogClosure(tx))
 
-	// Construct a map of the inputs this transaction spends.
-	spentInputs := make(map[wire.OutPoint]struct{}, len(tx.TxIn))
-	for _, txIn := range tx.TxIn {
-		spentInputs[txIn.PreviousOutPoint] = struct{}{}
-	}
+	spentInputs := s.conflictCleanupOutpoints(tx, op)
 
 	err := s.removeConflictSweepDescendants(spentInputs)
 	if err != nil {
@@ -2103,6 +2138,15 @@ func (s *UtxoSweeper) handleUnknownSpendTx(inp *SweeperInput, tx *wire.MsgTx) {
 // by another party with their tx being confirmed. It will retry sweeping the
 // "good" inputs once the "bad" ones are kicked out.
 func (s *UtxoSweeper) handleBumpEventTxUnknownSpend(r *bumpResp) {
+	// Snapshot inputs already returned by a shallow reorg before the stale
+	// batch response mutates states. Such inputs must remain retryable.
+	requeued := make(map[wire.OutPoint]struct{})
+	for op, pending := range s.inputs {
+		if pending.state == PublishFailed {
+			requeued[op] = struct{}{}
+		}
+	}
+
 	// Mark the inputs as publish failed, which means they will be retried
 	// later.
 	s.markInputsPublishFailed(r.set, r.result.FeeRate)
@@ -2128,17 +2172,32 @@ func (s *UtxoSweeper) handleBumpEventTxUnknownSpend(r *bumpResp) {
 
 			continue
 		}
+		if input.terminated() {
+			// A stale batch cannot revive a terminal input.
+			// Its lifecycle observer already settled it.
+			continue
+		}
 
 		// Check whether this input has been spent, if so we mark it as
 		// fatal or swept based on whether this is one of our previous
 		// sweeping txns, then move to the next.
 		tx, spent := spentInputs[op]
 		if spent {
+			if input.params.RequiredConfs > DefaultRequiredConfs {
+				if _, ok := requeued[op]; ok {
+					continue
+				}
+
+				// Its observer owns reorgs until maturity.
+				input.state = Published
+
+				continue
+			}
+
 			s.handleUnknownSpendTx(input, tx)
 
 			continue
 		}
-
 		log.Debugf("Input(%v): updating params: immediate [%v -> true]",
 			op, r.result.FeeRate, input.params.Immediate)
 

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -282,83 +282,257 @@ func TestMarkInputsPublishFailed(t *testing.T) {
 	mockStore.AssertExpectations(t)
 }
 
-// TestMarkInputsSwept checks that given a list of inputs with different
-// states, only the non-terminal state will be marked as `Swept`.
-func TestMarkInputsSwept(t *testing.T) {
+// TestMarkNotifiedInputSwept checks that a mature notification terminalizes
+// only its independently registered outpoint.
+func TestMarkNotifiedInputSwept(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
 
-	// Create a mock input.
+	// Arrange one notified input and one batch sibling around a transaction
+	// that spends both. The mock expectation proves listener delivery uses
+	// only the notified input's identity.
 	mockInput := &input.MockInput{}
-	defer mockInput.AssertExpectations(t)
-
-	// Mock the `OutPoint` to return a dummy outpoint.
-	mockInput.On("OutPoint").Return(wire.OutPoint{Hash: chainhash.Hash{1}})
-
-	// Create a test sweeper.
+	notified := wire.OutPoint{Hash: chainhash.Hash{1}, Index: 2}
+	sibling := wire.OutPoint{Hash: chainhash.Hash{1}, Index: 3}
+	mockInput.On("OutPoint").Return(notified).Once()
+	notifiedResult := make(chan Result, 1)
 	s := New(&UtxoSweeperConfig{})
-
-	// Create three testing inputs.
-	//
-	// inputNotExist specifies an input that's not found in the sweeper's
-	// `inputs` map.
-	inputNotExist := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 1},
-	}
-
-	// inputInit specifies a newly created input.
-	inputInit := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 2},
-	}
-	s.inputs[inputInit.PreviousOutPoint] = &SweeperInput{
+	s.inputs[notified] = &SweeperInput{
 		state: Init,
 		Input: mockInput,
+		listeners: []chan Result{
+			notifiedResult,
+		},
 	}
-
-	// inputPendingPublish specifies an input that's about to be published.
-	inputPendingPublish := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 3},
-	}
-	s.inputs[inputPendingPublish.PreviousOutPoint] = &SweeperInput{
+	s.inputs[sibling] = &SweeperInput{
 		state: PendingPublish,
-		Input: mockInput,
-	}
-
-	// inputTerminated specifies an input that's terminated.
-	inputTerminated := &wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Index: 4},
-	}
-	s.inputs[inputTerminated.PreviousOutPoint] = &SweeperInput{
-		state: Excluded,
-		Input: mockInput,
 	}
 
 	tx := &wire.MsgTx{
 		TxIn: []*wire.TxIn{
-			inputNotExist, inputInit,
-			inputPendingPublish, inputTerminated,
+			{PreviousOutPoint: notified},
+			{PreviousOutPoint: sibling},
 		},
 	}
 
-	// Mark the test inputs. We expect the inputTerminated to be skipped,
-	// and the rest to be marked as swept.
-	s.markInputsSwept(tx, true)
+	// Act on the single mature outpoint notification even though its
+	// spending transaction also contains the shallower sibling.
+	s.markNotifiedInputSwept(notified, tx, true)
 
-	// We expect unchanged number of pending inputs.
-	require.Len(s.inputs, 3)
+	// Assert the notified input alone is terminal and reports success. The
+	// sibling remains publishable until its own depth-gated event arrives.
+	require.Equal(Swept, s.inputs[notified].state)
+	require.Equal(PendingPublish, s.inputs[sibling].state)
+	result := <-notifiedResult
+	require.Same(tx, result.Tx)
+	require.NoError(result.Err)
+	mockInput.AssertExpectations(t)
+}
 
-	// We expect the init input's state to become swept.
-	require.Equal(Swept,
-		s.inputs[inputInit.PreviousOutPoint].state)
+// TestHandleInputSpentCleansMatureOutpoint verifies an external transaction
+// cannot authorize conflict cleanup for a deeper-policy sibling input.
+func TestHandleInputSpentCleansMatureOutpoint(t *testing.T) {
+	t.Parallel()
 
-	// We expect the pending-publish becomes swept.
-	require.Equal(Swept,
-		s.inputs[inputPendingPublish.PreviousOutPoint].state)
+	// Arrange a mature input, a tracked publishable sibling, and an
+	// untracked input spent by one external transaction. Separate stored
+	// sweeps prove cleanup preserves the tracked sibling while canceling
+	// the conflict whose input has no pending lifecycle owner.
+	store := &MockSweeperStore{}
+	wallet := &MockWallet{}
+	notifiedInput := &input.MockInput{}
+	notified := wire.OutPoint{Hash: chainhash.Hash{3}, Index: 1}
+	sibling := wire.OutPoint{Hash: chainhash.Hash{4}, Index: 2}
+	untracked := wire.OutPoint{Hash: chainhash.Hash{5}, Index: 3}
+	notifiedInput.On("OutPoint").Return(notified).Once()
+	notifiedResult := make(chan Result, 1)
+	externalTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{
+			{PreviousOutPoint: notified},
+			{PreviousOutPoint: sibling},
+			{PreviousOutPoint: untracked},
+		},
+	}
+	externalHash := externalTx.TxHash()
+	siblingSweep := &wire.MsgTx{
+		TxIn: []*wire.TxIn{{PreviousOutPoint: sibling}},
+	}
+	siblingSweepHash := siblingSweep.TxHash()
+	untrackedSweep := &wire.MsgTx{
+		TxIn: []*wire.TxIn{{PreviousOutPoint: untracked}},
+	}
+	untrackedSweepHash := untrackedSweep.TxHash()
+	store.On("IsOurTx", externalHash).Return(false).Once()
+	store.On("ListSweeps").Return(
+		[]chainhash.Hash{siblingSweepHash, untrackedSweepHash}, nil,
+	).Once()
+	wallet.On("FetchTx", siblingSweepHash).Return(
+		siblingSweep, nil,
+	).Once()
+	wallet.On("FetchTx", untrackedSweepHash).Return(
+		untrackedSweep, nil,
+	).Once()
+	wallet.On("RemoveDescendants", untrackedSweep).Return(nil).Once()
+	wallet.On("CancelRebroadcast", untrackedSweepHash).Return().Once()
+	s := New(&UtxoSweeperConfig{
+		Store:  store,
+		Wallet: wallet,
+	})
+	s.inputs[notified] = &SweeperInput{
+		state:     Init,
+		Input:     notifiedInput,
+		listeners: []chan Result{notifiedResult},
+	}
+	s.inputs[sibling] = &SweeperInput{state: PendingPublish}
+	spend := &chainntnfs.SpendDetail{
+		SpentOutPoint:  &notified,
+		SpenderTxHash:  &externalHash,
+		SpendingTx:     externalTx,
+		SpendingHeight: 100,
+	}
 
-	// We expect the terminated to stay unchanged.
-	require.Equal(Excluded,
-		s.inputs[inputTerminated.PreviousOutPoint].state)
+	// Act by handling only the mature input's depth-gated notification. The
+	// cleanup scan must retain the tracked sibling's sweep and cancel the
+	// untracked conflict in the same pass.
+	s.handleInputSpent(spend)
+	result := <-notifiedResult
+
+	// Assert the mature input reports the remote spend while its sibling
+	// and conflicting sweep remain viable while the exact wallet
+	// expectations prove the untracked conflict was removed and canceled.
+	require.Equal(t, Swept, s.inputs[notified].state)
+	require.Equal(t, PendingPublish, s.inputs[sibling].state)
+	require.Same(t, externalTx, result.Tx)
+	require.ErrorIs(t, result.Err, ErrRemoteSpend)
+	store.AssertExpectations(t)
+	wallet.AssertExpectations(t)
+	notifiedInput.AssertExpectations(t)
+}
+
+// TestUnknownSpendCleansMatureOutpoint verifies a TxUnknownSpend result cannot
+// use one mature input to cancel a deeper sibling's conflicting sweep.
+func TestUnknownSpendCleansMatureOutpoint(t *testing.T) {
+	t.Parallel()
+
+	// Arrange a mature lifecycle input, a tracked publishable sibling, and
+	// an untracked input in one external transaction. Separate stored
+	// sweeps prove TxUnknownSpend retains the deeper tracked policy while
+	// retiring the unowned conflict.
+	store := &MockSweeperStore{}
+	wallet := &MockWallet{}
+	matureInput := createTestInput(1000, input.WitnessKeyHash)
+	matureOutpoint := matureInput.OutPoint()
+	siblingOutpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{6},
+		Index: 2,
+	}
+	untrackedOutpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{7},
+		Index: 3,
+	}
+	externalTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{
+			{PreviousOutPoint: matureOutpoint},
+			{PreviousOutPoint: siblingOutpoint},
+			{PreviousOutPoint: untrackedOutpoint},
+		},
+	}
+	externalHash := externalTx.TxHash()
+	siblingSweep := &wire.MsgTx{
+		TxIn: []*wire.TxIn{{PreviousOutPoint: siblingOutpoint}},
+	}
+	siblingSweepHash := siblingSweep.TxHash()
+	untrackedSweep := &wire.MsgTx{
+		TxIn: []*wire.TxIn{{PreviousOutPoint: untrackedOutpoint}},
+	}
+	untrackedSweepHash := untrackedSweep.TxHash()
+	store.On("IsOurTx", externalHash).Return(false).Once()
+	store.On("ListSweeps").Return(
+		[]chainhash.Hash{siblingSweepHash, untrackedSweepHash}, nil,
+	).Once()
+	wallet.On("FetchTx", siblingSweepHash).Return(
+		siblingSweep, nil,
+	).Once()
+	wallet.On("FetchTx", untrackedSweepHash).Return(
+		untrackedSweep, nil,
+	).Once()
+	wallet.On("RemoveDescendants", untrackedSweep).Return(nil).Once()
+	wallet.On("CancelRebroadcast", untrackedSweepHash).Return().Once()
+	s := New(&UtxoSweeperConfig{
+		Store:  store,
+		Wallet: wallet,
+	})
+	matureResult := make(chan Result, 1)
+	s.inputs[matureOutpoint] = &SweeperInput{
+		state:     PendingPublish,
+		Input:     &matureInput,
+		listeners: []chan Result{matureResult},
+	}
+	s.inputs[siblingOutpoint] = &SweeperInput{state: PendingPublish}
+
+	// Act on the fee bumper's mature evidence for only the first input.
+	// handleUnknownSpendTx must preserve the tracked sibling boundary while
+	// still cleaning the transaction's untracked conflict.
+	s.handleUnknownSpendTx(s.inputs[matureOutpoint], externalTx)
+	result := <-matureResult
+
+	// Assert the mature input reports the remote spend while the sibling
+	// and its stored sweep remain publishable. Exact wallet expectations
+	// prove cleanup removed only the untracked conflict.
+	require.Equal(t, Fatal, s.inputs[matureOutpoint].state)
+	require.Equal(t, PendingPublish, s.inputs[siblingOutpoint].state)
+	require.Same(t, externalTx, result.Tx)
+	require.ErrorIs(t, result.Err, ErrRemoteSpend)
+	store.AssertExpectations(t)
+	wallet.AssertExpectations(t)
+}
+
+// TestMonitorSpendDepth checks that the long-lived sweeper monitor requests
+// the admitted input's immutable confirmation depth.
+func TestMonitorSpendDepth(t *testing.T) {
+	t.Parallel()
+
+	// Arrange a mock notifier whose matcher parses the option and accepts
+	// only the requested three-confirmation policy. Its cancel hook
+	// closes the event channel so the monitor goroutine can exit.
+	notifier := &chainntnfs.MockChainNotifier{}
+	outpoint := wire.OutPoint{Hash: chainhash.Hash{2}, Index: 4}
+	script := []byte{0x51}
+	heightHint := uint32(90)
+	requiredConfs := uint32(3)
+	spendChan := make(chan *chainntnfs.SpendDetail)
+	spendEvent := &chainntnfs.SpendEvent{
+		Spend: spendChan,
+		Cancel: func() {
+			close(spendChan)
+		},
+	}
+	depthOption := mock.MatchedBy(
+		func(opts []chainntnfs.SpendOption) bool {
+			parsed, err := chainntnfs.ParseSpendOptions(opts...)
+
+			return err == nil && parsed.NumConfs == requiredConfs
+		},
+	)
+	notifier.On(
+		"RegisterSpendNtfn", &outpoint, script, heightHint,
+		depthOption,
+	).Return(spendEvent, nil).Once()
+	s := New(&UtxoSweeperConfig{Notifier: notifier})
+
+	// Act by installing the monitor, cancel its concrete registration, then
+	// wait for the monitor goroutine to observe closure.
+	cancel, err := s.monitorSpend(
+		outpoint, script, heightHint, requiredConfs,
+	)
+	require.NoError(t, err)
+	cancel()
+	s.wg.Wait()
+
+	// Assert the mock consumed one depth-aware registration. No result is
+	// expected because cancellation closed the event before a spend.
+	notifier.AssertExpectations(t)
 }
 
 // TestMempoolLookup checks that the method `mempoolLookup` works as expected.
@@ -1054,7 +1228,7 @@ func TestMonitorFeeBumpResult(t *testing.T) {
 
 			s.wg.Add(1)
 			go func() {
-				s.monitorFeeBumpResult(set, resultChan)
+				s.monitorFeeBumpResult(set, resultChan, false)
 				close(done)
 			}()
 
@@ -1444,4 +1618,62 @@ func TestHandleBumpEventTxUnknownSpendWithRetry(t *testing.T) {
 
 	// Assert the state of the input is updated.
 	require.Equal(t, PublishFailed, s.inputs[op2].state)
+}
+
+// TestUnknownSpendPreservesTerminalInputs verifies a delayed batch response
+// cannot move inputs backward after a newer observer terminalized them.
+func TestUnknownSpendPreservesTerminalInputs(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Store independently swept and fatal inputs behind a
+	// mock.Mock input set. Both have stale shallow-spend evidence, with
+	// exact input-set cardinality covering every handler traversal.
+	s := New(&UtxoSweeperConfig{})
+	set := &MockInputSet{}
+	sweptInput := createTestInput(1000, input.WitnessKeyHash)
+	fatalInput := createTestInput(1000, input.WitnessKeyHash)
+	sweptOutpoint := sweptInput.OutPoint()
+	fatalOutpoint := fatalInput.OutPoint()
+	set.On("Inputs").Return([]input.Input{
+		&sweptInput, &fatalInput,
+	}).Times(3)
+	s.inputs[sweptOutpoint] = &SweeperInput{
+		Input: &sweptInput,
+		state: Swept,
+		params: Params{
+			RequiredConfs: 3,
+		},
+	}
+	s.inputs[fatalOutpoint] = &SweeperInput{
+		Input: &fatalInput,
+		state: Fatal,
+		params: Params{
+			RequiredConfs: 3,
+		},
+	}
+	spendingTx := &wire.MsgTx{TxIn: []*wire.TxIn{{
+		PreviousOutPoint: sweptOutpoint,
+	}}}
+	resp := &bumpResp{
+		result: &BumpResult{
+			Event: TxUnknownSpend,
+			Err:   ErrUnknownSpent,
+			SpentInputs: map[wire.OutPoint]*wire.MsgTx{
+				sweptOutpoint: spendingTx,
+				fatalOutpoint: spendingTx,
+			},
+		},
+		set: set,
+	}
+
+	// Act: Deliver the stale mixed-batch response after both inputs reached
+	// terminal states through their authoritative lifecycle observers.
+	s.handleBumpEventTxUnknownSpend(resp)
+
+	// Assert: Neither terminal input regresses to Published, and the exact
+	// mock input-set traversals prove the response was processed instead
+	// of bypassed entirely.
+	require.Equal(t, Swept, s.inputs[sweptOutpoint].state)
+	require.Equal(t, Fatal, s.inputs[fatalOutpoint].state)
+	set.AssertExpectations(t)
 }

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -977,6 +977,97 @@ func TestSweeperKeepsPublisherConfirmation(t *testing.T) {
 	require.Equal(t, Published, s.inputs[op].state)
 }
 
+// TestSweeperBoundsMissingInputRetry verifies delayed spend discovery has a
+// finite grace period before a genuine orphan becomes terminal.
+func TestSweeperBoundsMissingInputRetry(t *testing.T) {
+	t.Parallel()
+
+	// Arrange one concrete depth-three input and a mock.Mock input set that
+	// returns it for the provisional update and eventual fatal transition.
+	const startHeight = int32(100)
+	outpoint := wire.OutPoint{Index: 31}
+	inp := input.NewBaseInput(
+		&outpoint, input.CommitmentTimeLock, &input.SignDescriptor{}, 0,
+	)
+	set := &MockInputSet{}
+	set.On("Inputs").Return([]input.Input{inp}).Times(4)
+	s := New(&UtxoSweeperConfig{})
+	s.currentHeight = startHeight
+	s.inputs[outpoint] = &SweeperInput{
+		Input: inp,
+		state: Published,
+		params: Params{
+			RequiredConfs: 3,
+		},
+	}
+	response := &bumpResp{
+		result: &BumpResult{
+			Event:   TxFatal,
+			Err:     ErrInputMissing,
+			FeeRate: 1000,
+		},
+		set:           set,
+		deferTerminal: true,
+	}
+
+	// Act once at first detection, then simulate a retry after the complete
+	// depth window. The second fatal result cannot be a shallow discovery
+	// race and must fall through to normal terminal handling.
+	firstErr := s.handleBumpEventTxFatal(response)
+	firstState := s.inputs[outpoint].state
+	s.inputs[outpoint].state = Published
+	s.currentHeight = startHeight + 3
+	finalErr := s.handleBumpEventTxFatal(response)
+
+	// Assert the first result remained retryable, the same missing-input
+	// window later terminated the orphan, and every mock call was consumed.
+	require.NoError(t, firstErr)
+	require.Equal(t, PublishFailed, firstState)
+	require.NoError(t, finalErr)
+	require.Equal(t, Fatal, s.inputs[outpoint].state)
+	set.AssertExpectations(t)
+}
+
+// TestMonitorFeeBumpResultExitsOnFatal verifies a removed publisher record
+// cannot leave its per-attempt monitor blocked forever.
+func TestMonitorFeeBumpResultExitsOnFatal(t *testing.T) {
+	t.Parallel()
+
+	// Arrange a mock.Mock set and one buffered fatal publisher result.
+	// A nil transaction exercises the record-removal path without unrelated
+	// wallet rebroadcast expectations.
+	set := &MockInputSet{}
+	resultChan := make(chan *BumpResult, 1)
+	resultChan <- &BumpResult{
+		Event: TxFatal,
+		Err:   ErrInputMissing,
+	}
+	s := New(&UtxoSweeperConfig{})
+	done := make(chan struct{})
+
+	// Act by starting the real monitor and receiving the response it must
+	// forward to the serialized collector before terminating its goroutine.
+	s.wg.Add(1)
+	go func() {
+		s.monitorFeeBumpResult(set, resultChan, true)
+		close(done)
+	}()
+	response := <-s.bumpRespChan
+	select {
+	case <-done:
+		// Capture synchronous termination for the Assert phase below.
+
+	case <-time.After(time.Second):
+		require.Fail(t, "fatal publisher monitor did not exit")
+	}
+
+	// Assert the exact fatal result reached the collector and the monitor
+	// exited without waiting for a channel the publisher no longer owns.
+	require.Equal(t, TxFatal, response.result.Event)
+	require.ErrorIs(t, response.result.Err, ErrInputMissing)
+	set.AssertExpectations(t)
+}
+
 // TestSweeperReorgCollectorScoping verifies the collector requeues only the
 // published outpoint named by provisional reorg evidence.
 func TestSweeperReorgCollectorScoping(t *testing.T) {
@@ -1810,6 +1901,60 @@ func TestHandleBumpEventTxUnknownSpendWithRetry(t *testing.T) {
 	siblingInput.AssertExpectations(t)
 	set.AssertExpectations(t)
 	aggregator.AssertExpectations(t)
+}
+
+// TestUnknownSpendRetryErrorPartitionsInputs verifies a retry-policy failure
+// terminalizes only an unspent sibling while preserving depth-owned evidence.
+func TestUnknownSpendRetryErrorPartitionsInputs(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Place one depth-three spent input and one viable sibling
+	// in a mock.Mock input set. Exact Inputs cardinality covers the state
+	// update, retry allocation, and per-outpoint partition pass.
+	s := New(&UtxoSweeperConfig{})
+	set := &MockInputSet{}
+	deepInput := createTestInput(1000, input.WitnessKeyHash)
+	siblingInput := createTestInput(1000, input.WitnessKeyHash)
+	deepOutpoint := deepInput.OutPoint()
+	siblingOutpoint := siblingInput.OutPoint()
+	set.On("Inputs").Return([]input.Input{
+		&deepInput, &siblingInput,
+	}).Times(3)
+	s.inputs[deepOutpoint] = &SweeperInput{
+		Input: &deepInput,
+		state: Published,
+		params: Params{
+			RequiredConfs: 3,
+		},
+	}
+	s.inputs[siblingOutpoint] = &SweeperInput{
+		Input: &siblingInput,
+		state: Published,
+	}
+	spendingTx := &wire.MsgTx{TxIn: []*wire.TxIn{{
+		PreviousOutPoint: deepOutpoint,
+	}}}
+	resp := &bumpResp{
+		result: &BumpResult{
+			Event: TxUnknownSpend,
+			Err:   errDummy,
+			SpentInputs: map[wire.OutPoint]*wire.MsgTx{
+				deepOutpoint: spendingTx,
+			},
+		},
+		set: set,
+	}
+
+	// Act: Apply the mixed result whose retry fee calculation failed after
+	// the publisher had already observed the deep member's external spend.
+	s.handleBumpEventTxUnknownSpend(resp)
+
+	// Assert: The deep input remains published under its maturity monitor,
+	// while only the retryable sibling receives the fee error as a terminal
+	// result. The mock set is consumed with exact cardinality.
+	require.Equal(t, Published, s.inputs[deepOutpoint].state)
+	require.Equal(t, Fatal, s.inputs[siblingOutpoint].state)
+	set.AssertExpectations(t)
 }
 
 // TestUnknownSpendPreservesTerminalInputs verifies a delayed batch response

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -488,50 +488,93 @@ func TestUnknownSpendCleansMatureOutpoint(t *testing.T) {
 	wallet.AssertExpectations(t)
 }
 
-// TestMonitorSpendDepth checks that the long-lived sweeper monitor requests
-// the admitted input's immutable confirmation depth.
+// TestMonitorSpendDepth checks that a deep input uses separate provisional and
+// terminal observers without exposing the provisional spend as final.
 func TestMonitorSpendDepth(t *testing.T) {
 	t.Parallel()
 
-	// Arrange a mock notifier whose matcher parses the option and accepts
-	// only the requested three-confirmation policy. Its cancel hook
-	// closes the event channel so the monitor goroutine can exit.
+	// Arrange a mock.Mock notifier with one terminal depth-three event and
+	// one shallow event. Exact option matchers prove each registration owns
+	// its intended role, and buffered channels make event order explicit.
 	notifier := &chainntnfs.MockChainNotifier{}
 	outpoint := wire.OutPoint{Hash: chainhash.Hash{2}, Index: 4}
 	script := []byte{0x51}
 	heightHint := uint32(90)
 	requiredConfs := uint32(3)
-	spendChan := make(chan *chainntnfs.SpendDetail)
-	spendEvent := &chainntnfs.SpendEvent{
-		Spend: spendChan,
+	terminalSpend := make(chan *chainntnfs.SpendDetail, 1)
+	terminalEvent := &chainntnfs.SpendEvent{
+		Spend: terminalSpend,
 		Cancel: func() {
-			close(spendChan)
+			close(terminalSpend)
 		},
 	}
-	depthOption := mock.MatchedBy(
+	shallowSpend := make(chan *chainntnfs.SpendDetail, 1)
+	shallowReorg := make(chan struct{}, 1)
+	shallowEvent := &chainntnfs.SpendEvent{
+		Spend: shallowSpend,
+		Reorg: shallowReorg,
+		Cancel: func() {
+			close(shallowSpend)
+			close(shallowReorg)
+		},
+	}
+	terminalDepth := mock.MatchedBy(
 		func(opts []chainntnfs.SpendOption) bool {
 			parsed, err := chainntnfs.ParseSpendOptions(opts...)
 
 			return err == nil && parsed.NumConfs == requiredConfs
 		},
 	)
+	shallowDepth := mock.MatchedBy(
+		func(opts []chainntnfs.SpendOption) bool {
+			parsed, err := chainntnfs.ParseSpendOptions(opts...)
+
+			return err == nil &&
+				parsed.NumConfs == DefaultRequiredConfs
+		},
+	)
 	notifier.On(
 		"RegisterSpendNtfn", &outpoint, script, heightHint,
-		depthOption,
-	).Return(spendEvent, nil).Once()
+		terminalDepth,
+	).Return(terminalEvent, nil).Once()
+	notifier.On(
+		"RegisterSpendNtfn", &outpoint, script, heightHint,
+		shallowDepth,
+	).Return(shallowEvent, nil).Once()
 	s := New(&UtxoSweeperConfig{Notifier: notifier})
+	provisional := &chainntnfs.SpendDetail{SpentOutPoint: &outpoint}
+	terminal := &chainntnfs.SpendDetail{SpentOutPoint: &outpoint}
 
-	// Act by installing the monitor, cancel its concrete registration, then
-	// wait for the monitor goroutine to observe closure.
+	// Act by installing both observers, delivering a provisional spend and
+	// its reorg, then delivering the mature result through the terminal
+	// observer. Read each forwarded event so the monitor can make progress.
 	cancel, err := s.monitorSpend(
 		outpoint, script, heightHint, requiredConfs,
 	)
 	require.NoError(t, err)
+	shallowSpend <- provisional
+	shallowReorg <- struct{}{}
+	var reorgedOutpoint wire.OutPoint
+	select {
+	case reorgedOutpoint = <-s.spendReorgChan:
+	case <-time.After(5 * time.Second):
+		t.Fatal("shallow reorg was not forwarded")
+	}
+	terminalSpend <- terminal
+	var deliveredSpend *chainntnfs.SpendDetail
+	select {
+	case deliveredSpend = <-s.spendChan:
+	case <-time.After(5 * time.Second):
+		t.Fatal("terminal spend was not forwarded")
+	}
 	cancel()
 	s.wg.Wait()
 
-	// Assert the mock consumed one depth-aware registration. No result is
-	// expected because cancellation closed the event before a spend.
+	// Assert the reorg identifies only this input while final delivery is
+	// exactly the mature event. Both notifier expectations must be consumed
+	// directly, proving cancellation did not substitute for registration.
+	require.Equal(t, outpoint, reorgedOutpoint)
+	require.Same(t, terminal, deliveredSpend)
 	notifier.AssertExpectations(t)
 }
 
@@ -858,6 +901,162 @@ func TestSweepPendingInputs(t *testing.T) {
 
 	// Call the method under test.
 	s.sweepPendingInputs(pis)
+}
+
+// TestRequiredConfsImmutable verifies update and duplicate-offer paths inherit
+// an admitted spend depth while explicit attempts to replace it are rejected.
+func TestRequiredConfsImmutable(t *testing.T) {
+	t.Parallel()
+
+	// Arrange one admitted depth-three input plus duplicate and update
+	// requests that either omit policy or explicitly conflict with it. The
+	// result channels are buffered so rejection remains synchronous here.
+	op := wire.OutPoint{Index: 8}
+	s := New(&UtxoSweeperConfig{})
+	admitted := &SweeperInput{params: Params{RequiredConfs: 3}}
+	s.inputs[op] = admitted
+	inherited := &sweepInputMessage{
+		params:     Params{Budget: 1},
+		resultChan: make(chan Result, 1),
+	}
+	rejected := &sweepInputMessage{
+		params:     Params{RequiredConfs: 4},
+		resultChan: make(chan Result, 1),
+	}
+
+	// Act by applying both duplicate forms, then repeat the omitted and
+	// conflicting policies through the synchronous fee-update path.
+	s.handleExistingInput(inherited, admitted)
+	s.handleExistingInput(rejected, admitted)
+	_, updateErr := s.handleUpdateReq(&updateReq{
+		input: op, params: Params{Budget: 2},
+	})
+	_, mismatchErr := s.handleUpdateReq(&updateReq{
+		input: op, params: Params{RequiredConfs: 4},
+	})
+
+	// Assert omitted policy preserved the admitted value in both paths and
+	// each explicit mismatch returned the dedicated rejection sentinel.
+	require.NoError(t, updateErr)
+	require.Equal(t, uint32(3), admitted.params.RequiredConfs)
+	require.ErrorIs(
+		t, (<-rejected.resultChan).Err, ErrRequiredConfsMismatch,
+	)
+	require.ErrorIs(t, mismatchErr, ErrRequiredConfsMismatch)
+}
+
+// TestSweeperKeepsPublisherConfirmation verifies a shallow publisher result
+// does not create continuous retries while its transaction remains confirmed.
+func TestSweeperKeepsPublisherConfirmation(t *testing.T) {
+	t.Parallel()
+
+	// Arrange one published depth-three input and a provisional publisher
+	// confirmation. The response omits an input set because this event must
+	// not touch batch state before a concrete shallow reorg is observed.
+	op := wire.OutPoint{Index: 11}
+	s := New(&UtxoSweeperConfig{})
+	s.inputs[op] = &SweeperInput{
+		state:  Published,
+		params: Params{RequiredConfs: 3},
+	}
+	response := &bumpResp{
+		result: &BumpResult{
+			Event:   TxConfirmed,
+			FeeRate: 1000,
+		},
+		deferTerminal: true,
+	}
+
+	// Act by delivering the provisional publisher confirmation through the
+	// collector's event handler without a corresponding reorg notification.
+	err := s.handleBumpEvent(response)
+
+	// Assert the input remains Published, retaining ownership without
+	// repeatedly offering an already-confirmed outpoint to the publisher.
+	require.NoError(t, err)
+	require.Equal(t, Published, s.inputs[op].state)
+}
+
+// TestSweeperReorgCollectorScoping verifies the collector requeues only the
+// published outpoint named by provisional reorg evidence.
+func TestSweeperReorgCollectorScoping(t *testing.T) {
+	t.Parallel()
+
+	// Arrange one mock.Mock-backed quarantined deep input, an untouched
+	// published sibling, and inputs whose non-published or terminal states
+	// must reject reorg transitions. The target's maturity methods are each
+	// required once when the collector queues it for retry after the event.
+	reorgedOutpoint := wire.OutPoint{Index: 12}
+	siblingOutpoint := wire.OutPoint{Index: 13}
+	pendingOutpoint := wire.OutPoint{Index: 14}
+	terminalOutpoint := wire.OutPoint{Index: 15}
+	reorgedInput := &input.MockInput{}
+	reorgedInput.On("RequiredLockTime").Return(uint32(0), false).Once()
+	reorgedInput.On("BlocksToMaturity").Return(uint32(0)).Once()
+	reorgedInput.On("HeightHint").Return(uint32(0)).Once()
+	s := New(&UtxoSweeperConfig{})
+	s.inputs[reorgedOutpoint] = &SweeperInput{
+		Input: reorgedInput,
+		state: Published,
+		params: Params{
+			RequiredConfs: 3,
+		},
+	}
+	s.inputs[siblingOutpoint] = &SweeperInput{state: Published}
+	s.inputs[pendingOutpoint] = &SweeperInput{state: PendingPublish}
+	s.inputs[terminalOutpoint] = &SweeperInput{state: Fatal}
+	// Running the collector directly avoids unrelated startup dependencies
+	// while preserving its serialized event-loop behavior.
+	s.wg.Add(1)
+	go s.collector()
+
+	// Act by delivering guarded-state events first and the published target
+	// last. Each unbuffered send serializes the preceding case; Stop then
+	// joins the collector after it queues the final target for retry.
+	s.spendReorgChan <- pendingOutpoint
+	s.spendReorgChan <- terminalOutpoint
+	s.spendReorgChan <- reorgedOutpoint
+	stopErr := s.Stop()
+
+	// Assert only the named Published input becomes retryable. The sibling,
+	// and pending input keep separate states. The terminal input
+	// follows normal collector cleanup rather than reopening.
+	require.NoError(t, stopErr)
+	require.Equal(t, PublishFailed, s.inputs[reorgedOutpoint].state)
+	require.Equal(t, Published, s.inputs[siblingOutpoint].state)
+	require.Equal(t, PendingPublish, s.inputs[pendingOutpoint].state)
+	require.NotContains(t, s.inputs, terminalOutpoint)
+	reorgedInput.AssertExpectations(t)
+}
+
+// TestSweeperRejectsInvalidSpendDepth verifies one malformed request cannot
+// reach and terminate the shared collector through notifier registration.
+func TestSweeperRejectsInvalidSpendDepth(t *testing.T) {
+	t.Parallel()
+
+	// Arrange one mock.Mock-backed input with the minimum structural
+	// fields needed by SweepInput and a depth just above the notifier's
+	// public limit. Each accessor is expected once because validation
+	// precedes admission.
+	op := wire.OutPoint{Index: 12}
+	inp := &input.MockInput{}
+	inp.On("OutPoint").Return(op).Once()
+	inp.On("SignDesc").Return(&input.SignDescriptor{}).Once()
+	s := New(&UtxoSweeperConfig{})
+
+	// Act by submitting the invalid policy through the public admission
+	// boundary without starting the collector; correct validation therefore
+	// returns synchronously instead of attempting channel delivery.
+	resultChan, err := s.SweepInput(inp, Params{
+		RequiredConfs: chainntnfs.MaxNumConfs + 1,
+	})
+
+	// Assert only this request failed with the stable notifier range
+	// sentinel, no result channel was admitted, and both exact mock calls
+	// were consumed.
+	require.ErrorIs(t, err, chainntnfs.ErrNumConfsOutOfRange)
+	require.Nil(t, resultChan)
+	inp.AssertExpectations(t)
 }
 
 // TestHandleBumpEventTxFailed checks that the sweeper correctly handles the
@@ -1527,97 +1726,90 @@ func TestHandleBumpEventTxUnknownSpendNoRetry(t *testing.T) {
 	require.Equal(t, Swept, s.inputs[op].state)
 }
 
-// TestHandleBumpEventTxUnknownSpendWithRetry checks the case when some the
-// inputs are retried after the bad inputs are filtered out.
+// TestHandleBumpEventTxUnknownSpendWithRetry checks that mature evidence
+// quarantines a deep spent input while an unspent sibling retries immediately.
 func TestHandleBumpEventTxUnknownSpendWithRetry(t *testing.T) {
 	t.Parallel()
 
-	// Create a mock store.
-	store := &MockSweeperStore{}
-	defer store.AssertExpectations(t)
-
-	// Create a mock wallet and aggregator.
-	wallet := &MockWallet{}
-	defer wallet.AssertExpectations(t)
-
+	// Arrange mock.Mock inputs for one known-spent depth-three outpoint and
+	// one viable sibling. Exact call counts cover the initial batch update,
+	// per-input partition, and retry summary without loose expectations.
 	aggregator := &mockUtxoAggregator{}
-	defer aggregator.AssertExpectations(t)
-
-	publisher := &MockBumper{}
-	defer publisher.AssertExpectations(t)
-
-	// Create a test sweeper.
 	s := New(&UtxoSweeperConfig{
-		Wallet:     wallet,
 		Aggregator: aggregator,
-		Publisher:  publisher,
-		GenSweepScript: func() fn.Result[lnwallet.AddrWithKey] {
-			//nolint:ll
-			return fn.Ok(lnwallet.AddrWithKey{
-				DeliveryAddress: testPubKey.SerializeCompressed(),
-			})
-		},
-		NoDeadlineConfTarget: uint32(DefaultDeadlineDelta),
-		Store:                store,
 	})
-
-	// Create a mock input set.
 	set := &MockInputSet{}
-	defer set.AssertExpectations(t)
+	deepInput := &input.MockInput{}
+	siblingInput := &input.MockInput{}
+	deepOutpoint := wire.OutPoint{Index: 21}
+	siblingOutpoint := wire.OutPoint{Index: 22}
+	deepInput.On("OutPoint").Return(deepOutpoint).Twice()
+	deepInput.On("RequiredLockTime").Return(uint32(0), false).Once()
+	deepInput.On("BlocksToMaturity").Return(uint32(0)).Once()
+	deepInput.On("HeightHint").Return(uint32(0)).Once()
+	siblingInput.On("OutPoint").Return(siblingOutpoint).Times(3)
+	siblingInput.On("WitnessType").Return(
+		input.CommitmentTimeLock,
+	).Once()
+	siblingInput.On("RequiredLockTime").Return(uint32(0), false).Once()
+	siblingInput.On("BlocksToMaturity").Return(uint32(0)).Once()
+	siblingInput.On("HeightHint").Return(uint32(0)).Once()
+	set.On("Inputs").Return(
+		[]input.Input{deepInput, siblingInput},
+	).Times(3)
+	aggregator.On(
+		"ClusterInputs", mock.MatchedBy(func(inputs InputsMap) bool {
+			_, hasDeep := inputs[deepOutpoint]
+			_, hasSibling := inputs[siblingOutpoint]
 
-	// Create mock inputs - inp1 will be the bad input, and inp2 will be
-	// retried.
-	inp1 := createMockInput(t, s, PendingPublish)
-	inp2 := createMockInput(t, s, PendingPublish)
-	set.On("Inputs").Return([]input.Input{inp1, inp2})
-
-	op1 := inp1.OutPoint()
-	op2 := inp2.OutPoint()
-
-	inp2.On("RequiredLockTime").Return(
-		uint32(s.currentHeight), false).Once()
-	inp2.On("BlocksToMaturity").Return(uint32(0)).Once()
-	inp2.On("HeightHint").Return(uint32(s.currentHeight)).Once()
-
-	// Create a testing tx that spends inp1.
+			return len(inputs) == 2 && hasDeep && hasSibling
+		}),
+	).Return([]InputSet{}).Once()
+	s.inputs[deepOutpoint] = &SweeperInput{
+		Input: deepInput,
+		state: PublishFailed,
+		params: Params{
+			RequiredConfs: 3,
+		},
+	}
+	s.inputs[siblingOutpoint] = &SweeperInput{
+		Input: siblingInput,
+		state: Published,
+		params: Params{
+			RequiredConfs: DefaultRequiredConfs,
+		},
+	}
 	tx := &wire.MsgTx{
 		LockTime: 1,
 		TxIn: []*wire.TxIn{
-			{PreviousOutPoint: op1},
+			{PreviousOutPoint: deepOutpoint},
 		},
 	}
-	txid := tx.TxHash()
-
-	// Create a testing bump result.
-	br := &BumpResult{
-		Tx:    tx,
-		Event: TxUnknownSpend,
-		SpentInputs: map[wire.OutPoint]*wire.MsgTx{
-			op1: tx,
-		},
-	}
-
-	// Create a testing bump response.
 	resp := &bumpResp{
-		result: br,
-		set:    set,
+		result: &BumpResult{
+			Tx:    tx,
+			Event: TxUnknownSpend,
+			SpentInputs: map[wire.OutPoint]*wire.MsgTx{
+				deepOutpoint: tx,
+			},
+		},
+		set:           set,
+		deferTerminal: true,
 	}
 
-	// Mock the store to return true when calling IsOurTx.
-	store.On("IsOurTx", txid).Return(true).Once()
-
-	// Mock the aggregator to return an empty slice as we are not testing
-	// the actual sweeping behavior.
-	aggregator.On("ClusterInputs", mock.Anything).Return([]InputSet{})
-
-	// Call the method under test.
+	// Act after a shallow reorg has already requeued the deep input. The
+	// stale mixed result must not overwrite that newer lifecycle state.
 	s.handleBumpEventTxUnknownSpend(resp)
 
-	// Assert the first input is removed.
-	require.NotContains(t, s.inputs, op1)
-
-	// Assert the state of the input is updated.
-	require.Equal(t, PublishFailed, s.inputs[op2].state)
+	// Assert the deep input remains retryable and the viable sibling also
+	// enters the immediate retry path without reviving stale quarantine.
+	require.Equal(t, PublishFailed, s.inputs[deepOutpoint].state)
+	require.Equal(t, PublishFailed, s.inputs[siblingOutpoint].state)
+	require.True(t, s.inputs[siblingOutpoint].params.Immediate)
+	deepInput.AssertExpectations(t)
+	siblingInput.AssertExpectations(t)
+	set.AssertExpectations(t)
+	aggregator.AssertExpectations(t)
 }
 
 // TestUnknownSpendPreservesTerminalInputs verifies a delayed batch response

--- a/sweep/test_utils.go
+++ b/sweep/test_utils.go
@@ -209,7 +209,8 @@ func (m *MockNotifier) Stop() error {
 
 // RegisterSpendNtfn registers for spend notifications.
 func (m *MockNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	_ []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	_ []byte, heightHint uint32,
+	_ ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
 	log.Debugf("RegisterSpendNtfn for outpoint %v", outpoint)
 


### PR DESCRIPTION
## Summary

Prevent contract resolutions and owned sweeps from finalizing on shallow spends that can be reorged.

## Change Description

- Let spend notifications wait for a caller-selected depth while preserving one-confirmation defaults.
- Delay terminal resolver, breach, and owned-sweep results until their spends are mature.
- Add focused coverage for reorg, restart, cancellation, and missing-input recovery paths.

## Notes

This is the preserved PR 3 of 3 for the resolution-lifecycle update. It depends on PR #11147 and the forthcoming PR 2 sweep lifecycle layer. Until those prerequisites merge, this PR remains draft and retains the full stack to preserve its review history. After PR 2 merges, this branch will be rebased and reduced to the final resolver, Nursery, and breach-recovery consumer layer before being marked ready.