### PR TITLE
discovery: avoid boxing channel update freshness

### DIFF
--- a/discovery/syncer.go
+++ b/discovery/syncer.go
@@ -1055,22 +1055,17 @@ func (g *GossipSyncer) bufferChanRangeReply(_ context.Context,
 	)
 
 	for i, scid := range msg.ShortChanIDs {
+		var t1, t2 time.Time
+		if len(msg.Timestamps) != 0 {
+			t1 = time.Unix(int64(msg.Timestamps[i].Timestamp1), 0)
+			t2 = time.Unix(int64(msg.Timestamps[i].Timestamp2), 0)
+		}
+
 		info := graphdb.NewV1ChannelUpdateInfo(
-			scid, time.Time{}, time.Time{},
+			scid, t1, t2,
 		)
 
 		if len(msg.Timestamps) != 0 {
-			info.Node1Freshness = lnwire.UnixTimestamp(
-				msg.Timestamps[i].Timestamp1,
-			)
-
-			info.Node2Freshness = lnwire.UnixTimestamp(
-				msg.Timestamps[i].Timestamp2,
-			)
-
-			t1 := time.Unix(int64(msg.Timestamps[i].Timestamp1), 0)
-			t2 := time.Unix(int64(msg.Timestamps[i].Timestamp2), 0)
-
 			// Sort out all channels with outdated or skewed
 			// timestamps. Both timestamps need to be out of
 			// boundaries for us to skip the channel and not query

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -97,7 +97,7 @@
 ## Performance Improvements
 
 * Gossip channel-range replies now [store freshness values without interface
-  boxing](https://github.com/lightningnetwork/lnd/pull/11055), reducing each
+  boxing](https://github.com/lightningnetwork/lnd/pull/11056), reducing each
   buffered channel entry by 16 bytes and avoiding two heap allocations when
   timestamps are present.
 

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -96,6 +96,11 @@
 
 ## Performance Improvements
 
+* Gossip channel-range replies now [store freshness values without interface
+  boxing](https://github.com/lightningnetwork/lnd/issues/11006), reducing each
+  buffered channel entry by 16 bytes and avoiding two heap allocations when
+  timestamps are present.
+
 ## Deprecations
 
 # Technical and Architectural Updates

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -97,7 +97,7 @@
 ## Performance Improvements
 
 * Gossip channel-range replies now [store freshness values without interface
-  boxing](https://github.com/lightningnetwork/lnd/issues/11006), reducing each
+  boxing](https://github.com/lightningnetwork/lnd/pull/11055), reducing each
   buffered channel entry by 16 bytes and avoiding two heap allocations when
   timestamps are present.
 

--- a/graph/builder.go
+++ b/graph/builder.go
@@ -542,8 +542,12 @@ func (b *Builder) isZombieChannel(e1,
 // considered a zombie. For v1 channels, freshness is a unix timestamp; for v2+
 // channels it is a block height.
 func (b *Builder) IsZombieChannel(info graphdb.ChannelUpdateInfo) bool {
-	e1Zombie := b.isTimestampStale(info.Version, info.Node1Freshness)
-	e2Zombie := b.isTimestampStale(info.Version, info.Node2Freshness)
+	e1Zombie := b.isTimestampStale(
+		info.Version, info.Node1FreshnessTimestamp(),
+	)
+	e2Zombie := b.isTimestampStale(
+		info.Version, info.Node2FreshnessTimestamp(),
+	)
 
 	if b.cfg.StrictZombiePruning {
 		return e1Zombie || e2Zombie

--- a/graph/db/channel_update_info_test.go
+++ b/graph/db/channel_update_info_test.go
@@ -29,4 +29,13 @@ func TestChannelUpdateInfoFreshness(t *testing.T) {
 		v2.Node1FreshnessTimestamp(),
 	)
 	require.True(t, v2.Node1FreshnessTime().IsZero())
+
+	// A version that is neither v1 nor v2 (including the zero value) must
+	// read as detectably absent rather than as either concrete type.
+	unknown := ChannelUpdateInfo{
+		ShortChannelID: scid,
+		Node1Freshness: 789,
+	}
+	require.Nil(t, unknown.Node1FreshnessTimestamp())
+	require.True(t, unknown.Node1FreshnessTime().IsZero())
 }

--- a/graph/db/channel_update_info_test.go
+++ b/graph/db/channel_update_info_test.go
@@ -1,0 +1,32 @@
+package graphdb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+// TestChannelUpdateInfoFreshness tests that concrete freshness values preserve
+// their version-specific timestamp representation at the API boundary.
+func TestChannelUpdateInfoFreshness(t *testing.T) {
+	t.Parallel()
+
+	scid := lnwire.NewShortChanIDFromInt(1)
+	v1Time := time.Unix(123, 0)
+	v1 := NewV1ChannelUpdateInfo(scid, v1Time, time.Time{})
+
+	require.Equal(
+		t, lnwire.UnixTimestamp(123), v1.Node1FreshnessTimestamp(),
+	)
+	require.Equal(t, v1Time, v1.Node1FreshnessTime())
+
+	v2 := NewV2ChannelUpdateInfo(scid, 456, 0)
+	require.Equal(
+		t, lnwire.BlockHeightTimestamp(456),
+		v2.Node1FreshnessTimestamp(),
+	)
+	require.True(t, v2.Node1FreshnessTime().IsZero())
+}

--- a/graph/db/graph_test.go
+++ b/graph/db/graph_test.go
@@ -3649,15 +3649,9 @@ func testFilterKnownChanIDsZombieRevival(t *testing.T,
 	require.True(t, isZombie(scid2))
 	require.False(t, isZombie(scid3))
 
-	// Build a freshness marker appropriate for the gossip version. V1
-	// uses unix timestamps, v2 uses block heights.
-	var revivalFreshness lnwire.Timestamp
-	switch v {
-	case lnwire.GossipVersion1:
-		revivalFreshness = lnwire.UnixTimestamp(1000)
-	case lnwire.GossipVersion2:
-		revivalFreshness = lnwire.BlockHeightTimestamp(1000)
-	}
+	// Build a freshness marker. Version determines whether this value is
+	// interpreted as a unix timestamp or block height.
+	const revivalFreshness uint64 = 1000
 
 	// Call FilterKnownChanIDs with an isStillZombie call-back that would
 	// result in the current zombies still be considered as zombies.

--- a/graph/db/kv_store.go
+++ b/graph/db/kv_store.go
@@ -2810,19 +2810,17 @@ type ChannelUpdateInfo struct {
 	// Version is the gossip version of the channel.
 	Version lnwire.GossipVersion
 
-	// Node1Freshness is the update-ordering value of the latest received
-	// update from the node 1 channel peer. For v1 channels this is a
-	// lnwire.UnixTimestamp; for v2 channels it is a
-	// lnwire.BlockHeightTimestamp. A zero value means no update has been
-	// received from this node.
-	Node1Freshness lnwire.Timestamp
+	// Node1Freshness is the concrete update-ordering value of the latest
+	// received update from the node 1 channel peer. Version determines
+	// whether this is a unix timestamp or block height. A zero value means
+	// no update has been received from this node.
+	Node1Freshness uint64
 
-	// Node2Freshness is the update-ordering value of the latest received
-	// update from the node 2 channel peer. For v1 channels this is a
-	// lnwire.UnixTimestamp; for v2 channels it is a
-	// lnwire.BlockHeightTimestamp. A zero value means no update has been
-	// received from this node.
-	Node2Freshness lnwire.Timestamp
+	// Node2Freshness is the concrete update-ordering value of the latest
+	// received update from the node 2 channel peer. Version determines
+	// whether this is a unix timestamp or block height. A zero value means
+	// no update has been received from this node.
+	Node2Freshness uint64
 }
 
 // NewV1ChannelUpdateInfo constructs a ChannelUpdateInfo for a v1 gossip
@@ -2843,8 +2841,8 @@ func NewV1ChannelUpdateInfo(scid lnwire.ShortChannelID,
 	return ChannelUpdateInfo{
 		ShortChannelID: scid,
 		Version:        lnwire.GossipVersion1,
-		Node1Freshness: node1Unix,
-		Node2Freshness: node2Unix,
+		Node1Freshness: uint64(node1Unix),
+		Node2Freshness: uint64(node2Unix),
 	}
 }
 
@@ -2857,16 +2855,38 @@ func NewV2ChannelUpdateInfo(scid lnwire.ShortChannelID,
 	return ChannelUpdateInfo{
 		ShortChannelID: scid,
 		Version:        lnwire.GossipVersion2,
-		Node1Freshness: lnwire.BlockHeightTimestamp(node1BlockHeight),
-		Node2Freshness: lnwire.BlockHeightTimestamp(node2BlockHeight),
+		Node1Freshness: uint64(node1BlockHeight),
+		Node2Freshness: uint64(node2BlockHeight),
 	}
+}
+
+// Node1FreshnessTimestamp returns node 1's freshness with the concrete
+// timestamp type selected by the channel's gossip version.
+func (c ChannelUpdateInfo) Node1FreshnessTimestamp() lnwire.Timestamp {
+	return c.freshnessTimestamp(c.Node1Freshness)
+}
+
+// Node2FreshnessTimestamp returns node 2's freshness with the concrete
+// timestamp type selected by the channel's gossip version.
+func (c ChannelUpdateInfo) Node2FreshnessTimestamp() lnwire.Timestamp {
+	return c.freshnessTimestamp(c.Node2Freshness)
+}
+
+// freshnessTimestamp converts a stored freshness value to its versioned wire
+// representation.
+func (c ChannelUpdateInfo) freshnessTimestamp(value uint64) lnwire.Timestamp {
+	if c.Version == lnwire.GossipVersion1 {
+		return lnwire.UnixTimestamp(value)
+	}
+
+	return lnwire.BlockHeightTimestamp(value)
 }
 
 // Node1FreshnessTime returns the v1 unix-time freshness for node 1's latest
 // update. It returns the zero time if the freshness is not a unix timestamp.
 func (c ChannelUpdateInfo) Node1FreshnessTime() time.Time {
-	if u, ok := c.Node1Freshness.(lnwire.UnixTimestamp); ok {
-		return time.Unix(int64(u), 0)
+	if c.Version == lnwire.GossipVersion1 {
+		return time.Unix(int64(c.Node1Freshness), 0)
 	}
 
 	return time.Time{}
@@ -2875,8 +2895,8 @@ func (c ChannelUpdateInfo) Node1FreshnessTime() time.Time {
 // Node2FreshnessTime returns the v1 unix-time freshness for node 2's latest
 // update. It returns the zero time if the freshness is not a unix timestamp.
 func (c ChannelUpdateInfo) Node2FreshnessTime() time.Time {
-	if u, ok := c.Node2Freshness.(lnwire.UnixTimestamp); ok {
-		return time.Unix(int64(u), 0)
+	if c.Version == lnwire.GossipVersion1 {
+		return time.Unix(int64(c.Node2Freshness), 0)
 	}
 
 	return time.Time{}
@@ -2989,9 +3009,7 @@ func (c *KVStore) FilterChannelRange(_ context.Context,
 					return err
 				}
 
-				chanInfo.Node1Freshness = lnwire.UnixTimestamp(
-					edge.LastUpdate.Unix(),
-				)
+				chanInfo.Node1Freshness = uint64(edge.LastUpdate.Unix())
 			}
 
 			rawPolicy = edges.Get(node2Key)
@@ -3006,9 +3024,7 @@ func (c *KVStore) FilterChannelRange(_ context.Context,
 					return err
 				}
 
-				chanInfo.Node2Freshness = lnwire.UnixTimestamp(
-					edge.LastUpdate.Unix(),
-				)
+				chanInfo.Node2Freshness = uint64(edge.LastUpdate.Unix())
 			}
 
 			channelsPerBlock[cid.BlockHeight] = append(

--- a/graph/db/kv_store.go
+++ b/graph/db/kv_store.go
@@ -2873,13 +2873,20 @@ func (c ChannelUpdateInfo) Node2FreshnessTimestamp() lnwire.Timestamp {
 }
 
 // freshnessTimestamp converts a stored freshness value to its versioned wire
-// representation.
+// representation. For an unknown gossip version it returns nil so that the
+// freshness reads as detectably absent rather than as the wrong concrete
+// type.
 func (c ChannelUpdateInfo) freshnessTimestamp(value uint64) lnwire.Timestamp {
-	if c.Version == lnwire.GossipVersion1 {
+	switch c.Version {
+	case lnwire.GossipVersion1:
 		return lnwire.UnixTimestamp(value)
-	}
 
-	return lnwire.BlockHeightTimestamp(value)
+	case lnwire.GossipVersion2:
+		return lnwire.BlockHeightTimestamp(value)
+
+	default:
+		return nil
+	}
 }
 
 // Node1FreshnessTime returns the v1 unix-time freshness for node 1's latest
@@ -3009,7 +3016,9 @@ func (c *KVStore) FilterChannelRange(_ context.Context,
 					return err
 				}
 
-				chanInfo.Node1Freshness = uint64(edge.LastUpdate.Unix())
+				chanInfo.Node1Freshness = uint64(
+					edge.LastUpdate.Unix(),
+				)
 			}
 
 			rawPolicy = edges.Get(node2Key)
@@ -3024,7 +3033,9 @@ func (c *KVStore) FilterChannelRange(_ context.Context,
 					return err
 				}
 
-				chanInfo.Node2Freshness = uint64(edge.LastUpdate.Unix())
+				chanInfo.Node2Freshness = uint64(
+					edge.LastUpdate.Unix(),
+				)
 			}
 
 			channelsPerBlock[cid.BlockHeight] = append(

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -2115,13 +2115,9 @@ func (s *SQLStore) FilterChannelRange(ctx context.Context,
 
 				switch v {
 				case gossipV1:
-					chanInfo.Node1Freshness =
-						lnwire.UnixTimestamp(n1Update)
+					chanInfo.Node1Freshness = uint64(n1Update)
 				case gossipV2:
-					chanInfo.Node1Freshness =
-						lnwire.BlockHeightTimestamp(
-							n1Height,
-						)
+					chanInfo.Node1Freshness = uint64(n1Height)
 				}
 			}
 
@@ -2142,13 +2138,9 @@ func (s *SQLStore) FilterChannelRange(ctx context.Context,
 
 				switch v {
 				case gossipV1:
-					chanInfo.Node2Freshness =
-						lnwire.UnixTimestamp(n2Update)
+					chanInfo.Node2Freshness = uint64(n2Update)
 				case gossipV2:
-					chanInfo.Node2Freshness =
-						lnwire.BlockHeightTimestamp(
-							n2Height,
-						)
+					chanInfo.Node2Freshness = uint64(n2Height)
 				}
 			}
 

--- a/graph/db/sql_store.go
+++ b/graph/db/sql_store.go
@@ -2115,9 +2115,11 @@ func (s *SQLStore) FilterChannelRange(ctx context.Context,
 
 				switch v {
 				case gossipV1:
-					chanInfo.Node1Freshness = uint64(n1Update)
+					chanInfo.Node1Freshness =
+						uint64(n1Update)
 				case gossipV2:
-					chanInfo.Node1Freshness = uint64(n1Height)
+					chanInfo.Node1Freshness =
+						uint64(n1Height)
 				}
 			}
 
@@ -2138,9 +2140,11 @@ func (s *SQLStore) FilterChannelRange(ctx context.Context,
 
 				switch v {
 				case gossipV1:
-					chanInfo.Node2Freshness = uint64(n2Update)
+					chanInfo.Node2Freshness =
+						uint64(n2Update)
 				case gossipV2:
-					chanInfo.Node2Freshness = uint64(n2Height)
+					chanInfo.Node2Freshness =
+						uint64(n2Height)
 				}
 			}
 


### PR DESCRIPTION
## Change Description

Fixes #11006.

Store `ChannelUpdateInfo` freshness values as concrete `uint64` fields, using the existing gossip version as the discriminator. Version-specific `lnwire.Timestamp` values are reconstructed only at the API boundary. This removes the two interface-boxing allocations from each timestamped channel-range entry without changing wire or database formats.

A release-note entry and focused v1/v2 representation tests are included.

## Steps to Test

1. Run `go test ./graph/db -run '^TestChannelUpdateInfoFreshness$' -count=1`.
2. Run `go test ./graph/db ./discovery -run '^$' -count=1` to compile both affected packages.

## Pull Request Checklist

### Testing

- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included where applicable.
- [x] The performance regression has focused representation coverage.

### Code Style and Documentation

- [x] The change is substantial.
- [x] The change obeys documentation, commenting, and 80-column guidelines.
- [x] The commit follows the ideal commit structure.
- [x] No logging statements were added.
- [x] No lncli commands were added.
- [x] A change description is included in the 0.22.0 release notes.
