### PR TITLE
lnrpc: clarify payment request expiry semantics

### DIFF
--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -14624,23 +14624,52 @@ func (x *PayReqString) GetPayReq() string {
 }
 
 type PayReq struct {
-	state           protoimpl.MessageState `protogen:"open.v1"`
-	Destination     string                 `protobuf:"bytes,1,opt,name=destination,proto3" json:"destination,omitempty"`
-	PaymentHash     string                 `protobuf:"bytes,2,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
-	NumSatoshis     int64                  `protobuf:"varint,3,opt,name=num_satoshis,json=numSatoshis,proto3" json:"num_satoshis,omitempty"`
-	Timestamp       int64                  `protobuf:"varint,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
-	Expiry          int64                  `protobuf:"varint,5,opt,name=expiry,proto3" json:"expiry,omitempty"`
-	Description     string                 `protobuf:"bytes,6,opt,name=description,proto3" json:"description,omitempty"`
-	DescriptionHash string                 `protobuf:"bytes,7,opt,name=description_hash,json=descriptionHash,proto3" json:"description_hash,omitempty"`
-	FallbackAddr    string                 `protobuf:"bytes,8,opt,name=fallback_addr,json=fallbackAddr,proto3" json:"fallback_addr,omitempty"`
-	CltvExpiry      int64                  `protobuf:"varint,9,opt,name=cltv_expiry,json=cltvExpiry,proto3" json:"cltv_expiry,omitempty"`
-	RouteHints      []*RouteHint           `protobuf:"bytes,10,rep,name=route_hints,json=routeHints,proto3" json:"route_hints,omitempty"`
-	PaymentAddr     []byte                 `protobuf:"bytes,11,opt,name=payment_addr,json=paymentAddr,proto3" json:"payment_addr,omitempty"`
-	NumMsat         int64                  `protobuf:"varint,12,opt,name=num_msat,json=numMsat,proto3" json:"num_msat,omitempty"`
-	Features        map[uint32]*Feature    `protobuf:"bytes,13,rep,name=features,proto3" json:"features,omitempty" protobuf_key:"varint,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	BlindedPaths    []*BlindedPaymentPath  `protobuf:"bytes,14,rep,name=blinded_paths,json=blindedPaths,proto3" json:"blinded_paths,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The hex-encoded compressed public key of the payment request signer. For
+	// non-blinded payment requests, this is the payee's node public key.
+	Destination string `protobuf:"bytes,1,opt,name=destination,proto3" json:"destination,omitempty"`
+	// The hex-encoded payment hash (BOLT-11 `p` field).
+	PaymentHash string `protobuf:"bytes,2,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
+	// The amount in satoshis. 0 if the payment request does not specify an
+	// amount. Any millisatoshi remainder is truncated; see `num_msat` for the
+	// exact value.
+	NumSatoshis int64 `protobuf:"varint,3,opt,name=num_satoshis,json=numSatoshis,proto3" json:"num_satoshis,omitempty"`
+	// The creation time of the payment request as a Unix timestamp (seconds).
+	Timestamp int64 `protobuf:"varint,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	// The expiry duration in seconds relative to the `timestamp` field. If
+	// the payment request omits the BOLT-11 `x` expiry field, the BOLT-11
+	// default of 3600 seconds is returned.
+	Expiry int64 `protobuf:"varint,5,opt,name=expiry,proto3" json:"expiry,omitempty"`
+	// The description (memo) of the payment (BOLT-11 `d` field). Empty if the
+	// payment request carries a description hash instead.
+	Description string `protobuf:"bytes,6,opt,name=description,proto3" json:"description,omitempty"`
+	// The hex-encoded SHA-256 hash of the payment description (BOLT-11 `h`
+	// field). Empty if not present.
+	DescriptionHash string `protobuf:"bytes,7,opt,name=description_hash,json=descriptionHash,proto3" json:"description_hash,omitempty"`
+	// The on-chain fallback address (BOLT-11 `f` field), encoded for the active
+	// network. Empty if not present.
+	FallbackAddr string `protobuf:"bytes,8,opt,name=fallback_addr,json=fallbackAddr,proto3" json:"fallback_addr,omitempty"`
+	// The minimum CLTV expiry delta for the final hop (BOLT-11 `c` field). If
+	// the payment request omits it, `zpay32.DefaultAssumedFinalCLTVDelta` is
+	// returned. This field is ignored for blinded payment paths.
+	CltvExpiry int64 `protobuf:"varint,9,opt,name=cltv_expiry,json=cltvExpiry,proto3" json:"cltv_expiry,omitempty"`
+	// Route hints that can each be individually used to assist in reaching the
+	// payment request's destination (BOLT-11 `r` field).
+	RouteHints []*RouteHint `protobuf:"bytes,10,rep,name=route_hints,json=routeHints,proto3" json:"route_hints,omitempty"`
+	// The payment address, also known as the payment secret (BOLT-11 `s`
+	// field). This value is used in MPP payments and required by newer payment
+	// requests. It is 32 zero bytes if not present. When using REST, this field
+	// is base64 encoded.
+	PaymentAddr []byte `protobuf:"bytes,11,opt,name=payment_addr,json=paymentAddr,proto3" json:"payment_addr,omitempty"`
+	// The amount in millisatoshis. 0 if the payment request does not specify an
+	// amount.
+	NumMsat int64 `protobuf:"varint,12,opt,name=num_msat,json=numMsat,proto3" json:"num_msat,omitempty"`
+	// The feature bits advertised in the payment request (BOLT-11 `9` field).
+	Features map[uint32]*Feature `protobuf:"bytes,13,rep,name=features,proto3" json:"features,omitempty" protobuf_key:"varint,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// The blinded payment paths included in the payment request, if any.
+	BlindedPaths  []*BlindedPaymentPath `protobuf:"bytes,14,rep,name=blinded_paths,json=blindedPaths,proto3" json:"blinded_paths,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PayReq) Reset() {

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -4529,19 +4529,61 @@ message PayReqString {
     string pay_req = 1;
 }
 message PayReq {
+    // The hex-encoded compressed public key of the payment request signer. For
+    // non-blinded payment requests, this is the payee's node public key.
     string destination = 1;
+
+    // The hex-encoded payment hash (BOLT-11 `p` field).
     string payment_hash = 2;
+
+    // The amount in satoshis. 0 if the payment request does not specify an
+    // amount. Any millisatoshi remainder is truncated; see `num_msat` for the
+    // exact value.
     int64 num_satoshis = 3;
+
+    // The creation time of the payment request as a Unix timestamp (seconds).
     int64 timestamp = 4;
+
+    // The expiry duration in seconds relative to the `timestamp` field. If
+    // the payment request omits the BOLT-11 `x` expiry field, the BOLT-11
+    // default of 3600 seconds is returned.
     int64 expiry = 5;
+
+    // The description (memo) of the payment (BOLT-11 `d` field). Empty if the
+    // payment request carries a description hash instead.
     string description = 6;
+
+    // The hex-encoded SHA-256 hash of the payment description (BOLT-11 `h`
+    // field). Empty if not present.
     string description_hash = 7;
+
+    // The on-chain fallback address (BOLT-11 `f` field), encoded for the active
+    // network. Empty if not present.
     string fallback_addr = 8;
+
+    // The minimum CLTV expiry delta for the final hop (BOLT-11 `c` field). If
+    // the payment request omits it, `zpay32.DefaultAssumedFinalCLTVDelta` is
+    // returned. This field is ignored for blinded payment paths.
     int64 cltv_expiry = 9;
+
+    // Route hints that can each be individually used to assist in reaching the
+    // payment request's destination (BOLT-11 `r` field).
     repeated RouteHint route_hints = 10;
+
+    // The payment address, also known as the payment secret (BOLT-11 `s`
+    // field). This value is used in MPP payments and required by newer payment
+    // requests. It is 32 zero bytes if not present. When using REST, this field
+    // is base64 encoded.
     bytes payment_addr = 11;
+
+    // The amount in millisatoshis. 0 if the payment request does not specify an
+    // amount.
     int64 num_msat = 12;
+
+    // The feature bits advertised in the payment request (BOLT-11 `9` field).
     map<uint32, Feature> features = 13;
+
+    // The blinded payment paths included in the payment request, if any.
     repeated BlindedPaymentPath blinded_paths = 14;
 }
 

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -6751,63 +6751,77 @@
       "type": "object",
       "properties": {
         "destination": {
-          "type": "string"
+          "type": "string",
+          "description": "The hex-encoded compressed public key of the payment request signer. For\nnon-blinded payment requests, this is the payee's node public key."
         },
         "payment_hash": {
-          "type": "string"
+          "type": "string",
+          "description": "The hex-encoded payment hash (BOLT-11 `p` field)."
         },
         "num_satoshis": {
           "type": "string",
-          "format": "int64"
+          "format": "int64",
+          "description": "The amount in satoshis. 0 if the payment request does not specify an\namount. Any millisatoshi remainder is truncated; see `num_msat` for the\nexact value."
         },
         "timestamp": {
           "type": "string",
-          "format": "int64"
+          "format": "int64",
+          "description": "The creation time of the payment request as a Unix timestamp (seconds)."
         },
         "expiry": {
           "type": "string",
-          "format": "int64"
+          "format": "int64",
+          "description": "The expiry duration in seconds relative to the `timestamp` field. If\nthe payment request omits the BOLT-11 `x` expiry field, the BOLT-11\ndefault of 3600 seconds is returned."
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "The description (memo) of the payment (BOLT-11 `d` field). Empty if the\npayment request carries a description hash instead."
         },
         "description_hash": {
-          "type": "string"
+          "type": "string",
+          "description": "The hex-encoded SHA-256 hash of the payment description (BOLT-11 `h`\nfield). Empty if not present."
         },
         "fallback_addr": {
-          "type": "string"
+          "type": "string",
+          "description": "The on-chain fallback address (BOLT-11 `f` field), encoded for the active\nnetwork. Empty if not present."
         },
         "cltv_expiry": {
           "type": "string",
-          "format": "int64"
+          "format": "int64",
+          "description": "The minimum CLTV expiry delta for the final hop (BOLT-11 `c` field). If\nthe payment request omits it, `zpay32.DefaultAssumedFinalCLTVDelta` is\nreturned. This field is ignored for blinded payment paths."
         },
         "route_hints": {
           "type": "array",
           "items": {
             "type": "object",
             "$ref": "#/definitions/lnrpcRouteHint"
-          }
+          },
+          "description": "Route hints that can each be individually used to assist in reaching the\npayment request's destination (BOLT-11 `r` field)."
         },
         "payment_addr": {
           "type": "string",
-          "format": "byte"
+          "format": "byte",
+          "description": "The payment address, also known as the payment secret (BOLT-11 `s`\nfield). This value is used in MPP payments and required by newer payment\nrequests. It is 32 zero bytes if not present. When using REST, this field\nis base64 encoded."
         },
         "num_msat": {
           "type": "string",
-          "format": "int64"
+          "format": "int64",
+          "description": "The amount in millisatoshis. 0 if the payment request does not specify an\namount."
         },
         "features": {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/lnrpcFeature"
-          }
+          },
+          "description": "The feature bits advertised in the payment request (BOLT-11 `9` field)."
         },
         "blinded_paths": {
           "type": "array",
           "items": {
             "type": "object",
             "$ref": "#/definitions/lnrpcBlindedPaymentPath"
-          }
+          },
+          "description": "The blinded payment paths included in the payment request, if any."
         }
       }
     },


### PR DESCRIPTION
## Change Description
The DecodePayReq response exposes an absolute invoice timestamp and a relative expiry duration, but the expiry field did not document that distinction. Clarify that expiry is measured in seconds from timestamp to avoid it being interpreted as an absolute Unix timestamp.

This is a documentation-only change and does not alter RPC behavior.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
