### PR TITLE
build: bump version to v0.20.3

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -51,7 +51,7 @@ const (
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.
-	AppPreRelease = "beta.rc1"
+	AppPreRelease = "beta"
 )
 
 func init() {


### PR DESCRIPTION
Bumps the version from `0.20.3-beta.rc1` to `0.20.3-beta`, dropping the release candidate suffix for the final v0.20.3 release.

This mirrors the previous release-candidate → final transition done for v0.20.2 (#10953).
