### PR TITLE
build: bump version to v0.21.2

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -51,7 +51,7 @@ const (
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.
-	AppPreRelease = "beta.rc1"
+	AppPreRelease = "beta"
 )
 
 func init() {


### PR DESCRIPTION
Bumps the version from `0.21.2-beta.rc1` to `0.21.2-beta`, dropping the release candidate suffix for the final v0.21.2 release.

This mirrors the previous release-candidate → final transitions done for v0.21.1 (#10918) and v0.20.3 (#11062).
