### PR TITLE
funding: require explicit channel type in all negotiations 

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -109,6 +109,13 @@
   later in the reservation flow as a funder-balance-dust error; they now
   surface a clearer, spec-aligned error string up front.
 
+* [Require an explicit `channel_type` during channel
+  funding](https://github.com/lightningnetwork/lnd/pull/11064). It is now always
+  set in `open_channel` and echoed back in `accept_channel`, and an
+  `open_channel` that omits it is rejected. Implicit commitment type negotiation
+  is removed; if the RPC caller doesn't request a type, a default is derived
+  from both peers' features and signaled explicitly.
+
 ## BOLT 12 (Offers)
 
 * [Initial BOLT 12 Offer codec](https://github.com/lightningnetwork/lnd/pull/10789):
@@ -159,3 +166,4 @@
 * Boris Nagaev
 * Erick Cestari
 * Jared Tobin
+* Nishant Bansal

--- a/feature/default_sets.go
+++ b/feature/default_sets.go
@@ -60,6 +60,10 @@ var defaultSetDesc = setDesc{
 	lnwire.AMPRequired: {
 		SetInvoiceAmp: {}, // 9A
 	},
+	// NOTE: Funding requires an explicit channel type and older peers only
+	// take their explicit negotiation path once they see this bit from us,
+	// so removing it would break funding against them until those versions
+	// age out.
 	lnwire.ExplicitChannelTypeRequired: {
 		SetInit:    {}, // I
 		SetNodeAnn: {}, // N

--- a/funding/commitment_type_negotiation.go
+++ b/funding/commitment_type_negotiation.go
@@ -8,71 +8,39 @@ import (
 )
 
 var (
-	// errUnsupportedCommitmentType is an error returned when a specific
+	// errUnsupportedChannelType is an error returned when a specific
 	// channel commitment type is being explicitly negotiated but either
 	// peer of the channel does not support it.
 	errUnsupportedChannelType = errors.New("requested channel type " +
 		"not supported")
 )
 
-// negotiateCommitmentType negotiates the commitment type of a newly opened
-// channel. If a desiredChanType is provided, explicit negotiation for said type
-// will be attempted if the set of both local and remote features support it.
-// Otherwise, implicit negotiation will be attempted.
+// negotiateCommitmentType determines the commitment type of a newly opened
+// channel. If desiredChanType is provided, it is validated against the
+// commitment features supported by both peers. Otherwise, a default type is
+// selected from those features.
 //
-// The returned ChannelType is nil when implicit negotiation is used. An error
-// is only returned if desiredChanType is not supported.
+// The returned ChannelType is always non-nil and is always signaled on the
+// wire. An error is only returned if desiredChanType is not supported.
 func negotiateCommitmentType(desiredChanType *lnwire.ChannelType, local,
 	remote *lnwire.FeatureVector) (*lnwire.ChannelType,
 	lnwallet.CommitmentType, error) {
 
-	// BOLT#2 specifies we MUST use explicit negotiation if both peers
-	// signal for it.
-	explicitNegotiation := hasFeatures(
-		local, remote, lnwire.ExplicitChannelTypeOptional,
-	)
-
-	chanTypeRequested := desiredChanType != nil
-
-	switch {
-	case explicitNegotiation && chanTypeRequested:
+	// If a specific channel type was provided, verify it's supported.
+	if desiredChanType != nil {
 		commitType, err := explicitNegotiateCommitmentType(
 			*desiredChanType, local, remote,
 		)
 
 		return desiredChanType, commitType, err
-
-	// We don't have a specific channel type requested, so we select a
-	// default type as if implicit negotiation were used, and then we
-	// explicitly signal that default type.
-	case explicitNegotiation && !chanTypeRequested:
-		defaultChanType, commitType := implicitNegotiateCommitmentType(
-			local, remote,
-		)
-
-		return defaultChanType, commitType, nil
-
-	// A specific channel type was requested, but we can't explicitly signal
-	// it. So if implicit negotiation wouldn't select the desired channel
-	// type, we must return an error.
-	case !explicitNegotiation && chanTypeRequested:
-		implicitChanType, commitType := implicitNegotiateCommitmentType(
-			local, remote,
-		)
-
-		expected := lnwire.RawFeatureVector(*desiredChanType)
-		actual := lnwire.RawFeatureVector(*implicitChanType)
-		if !expected.Equals(&actual) {
-			return nil, 0, errUnsupportedChannelType
-		}
-
-		return nil, commitType, nil
-
-	default: // !explicitNegotiation && !chanTypeRequested
-		_, commitType := implicitNegotiateCommitmentType(local, remote)
-
-		return nil, commitType, nil
 	}
+
+	// No specific channel type was requested. Select a default type based
+	// on locally-known feature compatibility. This default is then sent
+	// explicitly over the wire.
+	defaultChanType, commitType := selectDefaultChannelType(local, remote)
+
+	return defaultChanType, commitType, nil
 }
 
 // explicitNegotiateCommitmentType attempts to explicitly negotiate for a
@@ -454,15 +422,14 @@ func explicitNegotiateCommitmentType(channelType lnwire.ChannelType, local,
 	}
 }
 
-// implicitNegotiateCommitmentType negotiates the commitment type of a channel
-// implicitly by choosing the latest non-taproot type supported by the local and
-// remote features. Taproot channels must be requested explicitly, keeping
-// implicit opens on channel types that can be used for both public and private
-// channels.
+// selectDefaultChannelType selects a default channel type by choosing the most
+// preferred non-taproot type supported by the local and remote features.
+// Taproot channels must be requested explicitly, so that defaults stay on
+// channel types usable for both public and private channels.
 //
-// TODO(yy): Revisit implicit taproot negotiation once public taproot channel
+// TODO(yy): Revisit taproot channel selection once public taproot channel
 // announcements are supported.
-func implicitNegotiateCommitmentType(local,
+func selectDefaultChannelType(local,
 	remote *lnwire.FeatureVector) (*lnwire.ChannelType,
 	lnwallet.CommitmentType) {
 

--- a/funding/commitment_type_negotiation_test.go
+++ b/funding/commitment_type_negotiation_test.go
@@ -25,7 +25,7 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 		expectsErr        error
 	}{
 		{
-			name: "explicit missing remote negotiation feature",
+			name: "explicit type without remote negotiation bit",
 			channelFeatures: lnwire.NewRawFeatureVector(
 				lnwire.StaticRemoteKeyRequired,
 				lnwire.AnchorsZeroFeeHtlcTxRequired,
@@ -33,16 +33,19 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 			localFeatures: lnwire.NewRawFeatureVector(
 				lnwire.StaticRemoteKeyRequired,
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			remoteFeatures: lnwire.NewRawFeatureVector(
 				lnwire.StaticRemoteKeyOptional,
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
 			),
-			//nolint:ll
 			expectsCommitType: lnwallet.CommitmentTypeAnchorsZeroFeeHtlcTx,
-			expectsChanType:   nil,
-			expectsErr:        nil,
+			expectsChanType: (*lnwire.ChannelType)(
+				lnwire.NewRawFeatureVector(
+					lnwire.StaticRemoteKeyRequired,
+					lnwire.AnchorsZeroFeeHtlcTxRequired,
+				),
+			),
+			expectsErr: nil,
 		},
 		{
 			name: "explicit missing remote commitment feature",
@@ -53,11 +56,9 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 			localFeatures: lnwire.NewRawFeatureVector(
 				lnwire.StaticRemoteKeyRequired,
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			remoteFeatures: lnwire.NewRawFeatureVector(
 				lnwire.StaticRemoteKeyOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsErr: errUnsupportedChannelType,
 		},
@@ -74,14 +75,12 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 				lnwire.StaticRemoteKeyRequired,
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
 				lnwire.ScriptEnforcedLeaseOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			remoteFeatures: lnwire.NewRawFeatureVector(
 				lnwire.ZeroConfOptional,
 				lnwire.StaticRemoteKeyOptional,
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
 				lnwire.ScriptEnforcedLeaseOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeScriptEnforcedLease,
 			expectsChanType: (*lnwire.ChannelType)(
@@ -106,13 +105,11 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 				lnwire.ZeroConfOptional,
 				lnwire.StaticRemoteKeyRequired,
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			remoteFeatures: lnwire.NewRawFeatureVector(
 				lnwire.ZeroConfOptional,
 				lnwire.StaticRemoteKeyOptional,
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeAnchorsZeroFeeHtlcTx,
 			expectsChanType: (*lnwire.ChannelType)(
@@ -138,14 +135,12 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 				lnwire.StaticRemoteKeyRequired,
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
 				lnwire.ScriptEnforcedLeaseOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			remoteFeatures: lnwire.NewRawFeatureVector(
 				lnwire.ScidAliasOptional,
 				lnwire.StaticRemoteKeyOptional,
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
 				lnwire.ScriptEnforcedLeaseOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeScriptEnforcedLease,
 			expectsChanType: (*lnwire.ChannelType)(
@@ -170,13 +165,11 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 				lnwire.ScidAliasOptional,
 				lnwire.StaticRemoteKeyRequired,
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			remoteFeatures: lnwire.NewRawFeatureVector(
 				lnwire.ScidAliasOptional,
 				lnwire.StaticRemoteKeyOptional,
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeAnchorsZeroFeeHtlcTx,
 			expectsChanType: (*lnwire.ChannelType)(
@@ -198,12 +191,10 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 			localFeatures: lnwire.NewRawFeatureVector(
 				lnwire.StaticRemoteKeyRequired,
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			remoteFeatures: lnwire.NewRawFeatureVector(
 				lnwire.StaticRemoteKeyOptional,
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeAnchorsZeroFeeHtlcTx,
 			expectsChanType: (*lnwire.ChannelType)(
@@ -222,12 +213,10 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 			localFeatures: lnwire.NewRawFeatureVector(
 				lnwire.StaticRemoteKeyRequired,
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			remoteFeatures: lnwire.NewRawFeatureVector(
 				lnwire.StaticRemoteKeyOptional,
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeTweakless,
 			expectsChanType: (*lnwire.ChannelType)(
@@ -243,12 +232,10 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 			localFeatures: lnwire.NewRawFeatureVector(
 				lnwire.StaticRemoteKeyRequired,
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			remoteFeatures: lnwire.NewRawFeatureVector(
 				lnwire.StaticRemoteKeyOptional,
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeLegacy,
 			expectsChanType: (*lnwire.ChannelType)(
@@ -256,21 +243,19 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 			),
 			expectsErr: nil,
 		},
-		// Both sides signal the explicit chan type bit, so we expect
-		// that we return the corresponding chan type feature bits,
-		// even though we didn't set a desired channel type.
+		// No desired channel type is set, so we expect the default
+		// selection to return the corresponding chan type feature bits,
+		// which are then signaled on the wire.
 		{
-			name:            "default explicit anchors",
+			name:            "default anchors",
 			channelFeatures: nil,
 			localFeatures: lnwire.NewRawFeatureVector(
 				lnwire.StaticRemoteKeyRequired,
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			remoteFeatures: lnwire.NewRawFeatureVector(
 				lnwire.StaticRemoteKeyOptional,
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeAnchorsZeroFeeHtlcTx,
 			expectsChanType: (*lnwire.ChannelType)(
@@ -282,7 +267,7 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 			expectsErr: nil,
 		},
 		{
-			name:            "implicit tweakless",
+			name:            "default tweakless",
 			channelFeatures: nil,
 			localFeatures: lnwire.NewRawFeatureVector(
 				lnwire.StaticRemoteKeyRequired,
@@ -292,11 +277,15 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 				lnwire.StaticRemoteKeyOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeTweakless,
-			expectsChanType:   nil,
-			expectsErr:        nil,
+			expectsChanType: (*lnwire.ChannelType)(
+				lnwire.NewRawFeatureVector(
+					lnwire.StaticRemoteKeyRequired,
+				),
+			),
+			expectsErr: nil,
 		},
 		{
-			name:            "implicit legacy",
+			name:            "default legacy",
 			channelFeatures: nil,
 			localFeatures:   lnwire.NewRawFeatureVector(),
 			remoteFeatures: lnwire.NewRawFeatureVector(
@@ -304,8 +293,10 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeLegacy,
-			expectsChanType:   nil,
-			expectsErr:        nil,
+			expectsChanType: (*lnwire.ChannelType)(
+				lnwire.NewRawFeatureVector(),
+			),
+			expectsErr: nil,
 		},
 
 		// Test cases for final taproot channels with explicit
@@ -317,11 +308,9 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 			),
 			localFeatures: lnwire.NewRawFeatureVector(
 				lnwire.SimpleTaprootChannelsOptionalFinal,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			remoteFeatures: lnwire.NewRawFeatureVector(
 				lnwire.SimpleTaprootChannelsOptionalFinal,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeSimpleTaprootFinal, //nolint:ll
 			expectsChanType: (*lnwire.ChannelType)(
@@ -340,12 +329,10 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 			localFeatures: lnwire.NewRawFeatureVector(
 				lnwire.SimpleTaprootChannelsOptionalFinal,
 				lnwire.ScidAliasOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			remoteFeatures: lnwire.NewRawFeatureVector(
 				lnwire.SimpleTaprootChannelsOptionalFinal,
 				lnwire.ScidAliasOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeSimpleTaprootFinal, //nolint:ll
 			expectsChanType: (*lnwire.ChannelType)(
@@ -366,12 +353,10 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 			localFeatures: lnwire.NewRawFeatureVector(
 				lnwire.SimpleTaprootChannelsOptionalFinal,
 				lnwire.ZeroConfOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			remoteFeatures: lnwire.NewRawFeatureVector(
 				lnwire.SimpleTaprootChannelsOptionalFinal,
 				lnwire.ZeroConfOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeSimpleTaprootFinal, //nolint:ll
 			expectsChanType: (*lnwire.ChannelType)(
@@ -395,13 +380,11 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 				lnwire.SimpleTaprootChannelsOptionalFinal,
 				lnwire.ScidAliasOptional,
 				lnwire.ZeroConfOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			remoteFeatures: lnwire.NewRawFeatureVector(
 				lnwire.SimpleTaprootChannelsOptionalFinal,
 				lnwire.ScidAliasOptional,
 				lnwire.ZeroConfOptional,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeSimpleTaprootFinal, //nolint:ll
 			expectsChanType: (*lnwire.ChannelType)(
@@ -423,32 +406,28 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 			),
 			localFeatures: lnwire.NewRawFeatureVector(
 				lnwire.SimpleTaprootChannelsOptionalFinal,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			remoteFeatures: lnwire.NewRawFeatureVector(
 				lnwire.SimpleTaprootChannelsOptionalStaging,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsErr: errUnsupportedChannelType,
 		},
 
-		// Test cases for implicit negotiation ignoring taproot feature
+		// Test cases for default negotiation ignoring taproot feature
 		// bits. Taproot channels require an explicit channel type.
 		{
 			//nolint:ll
-			name:            "implicit anchors preferred over taproot",
+			name:            "default anchors preferred over taproot",
 			channelFeatures: nil,
 			localFeatures: lnwire.NewRawFeatureVector(
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
 				lnwire.SimpleTaprootChannelsOptionalFinal,
 				lnwire.SimpleTaprootChannelsOptionalStaging,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			remoteFeatures: lnwire.NewRawFeatureVector(
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
 				lnwire.SimpleTaprootChannelsOptionalFinal,
 				lnwire.SimpleTaprootChannelsOptionalStaging,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeAnchorsZeroFeeHtlcTx, //nolint:ll
 			expectsChanType: (*lnwire.ChannelType)(
@@ -461,16 +440,14 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 		},
 		{
 			//nolint:ll
-			name:            "implicit ignores staging taproot without anchors",
+			name:            "default ignores staging taproot without anchors",
 			channelFeatures: nil,
 			localFeatures: lnwire.NewRawFeatureVector(
 				lnwire.SimpleTaprootChannelsOptionalFinal,
 				lnwire.SimpleTaprootChannelsOptionalStaging,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			remoteFeatures: lnwire.NewRawFeatureVector(
 				lnwire.SimpleTaprootChannelsOptionalStaging,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeLegacy,
 			expectsChanType: (*lnwire.ChannelType)(
@@ -480,15 +457,13 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 		},
 		{
 			//nolint:ll
-			name:            "implicit ignores final taproot without anchors",
+			name:            "default ignores final taproot without anchors",
 			channelFeatures: nil,
 			localFeatures: lnwire.NewRawFeatureVector(
 				lnwire.SimpleTaprootChannelsOptionalFinal,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			remoteFeatures: lnwire.NewRawFeatureVector(
 				lnwire.SimpleTaprootChannelsOptionalFinal,
-				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeLegacy,
 			expectsChanType: (*lnwire.ChannelType)(

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -289,8 +289,8 @@ type InitFundingMsg struct {
 	PendingChanID PendingChanID
 
 	// ChannelType allows the caller to use an explicit channel type for the
-	// funding negotiation. This type will only be observed if BOTH sides
-	// support explicit channel type negotiation.
+	// funding negotiation. If unset, a default is selected from the
+	// features supported by both peers.
 	ChannelType *lnwire.ChannelType
 
 	// Memo is any arbitrary information we wish to store locally about the
@@ -1567,6 +1567,14 @@ func (f *Manager) fundeeProcessOpenChannel(peer lnpeer.Peer,
 		return
 	}
 
+	// Enforce BOLT-02: The funder MUST set the channel_type in
+	// open_channel. Reject if it's omitted.
+	if msg.ChannelType == nil {
+		f.failFundingFlow(peer, cid, lnwire.ErrChanTypeRequired)
+
+		return
+	}
+
 	// Send the OpenChannel request to the ChannelAcceptor to determine
 	// whether this node will accept the channel.
 	chanReq := &chanacceptor.ChannelAcceptRequest{
@@ -1594,10 +1602,9 @@ func (f *Manager) fundeeProcessOpenChannel(peer lnpeer.Peer,
 	// funds to the channel ourselves.
 	//
 	// Before we init the channel, we'll also check to see what commitment
-	// format we can use with this peer. This is dependent on *both* us and
-	// the remote peer are signaling the proper feature bit if we're using
-	// implicit negotiation, and simply the channel type sent over if we're
-	// using explicit negotiation.
+	// format we can use with this peer. This is dependent on the channel
+	// type sent by the funder and the feature bits both peers are
+	// signaling.
 	chanType, commitType, err := negotiateCommitmentType(
 		msg.ChannelType, peer.LocalFeatures(), peer.RemoteFeatures(),
 	)
@@ -1617,52 +1624,45 @@ func (f *Manager) fundeeProcessOpenChannel(peer lnpeer.Peer,
 		scidFeatureVal = true
 	}
 
-	var (
-		zeroConf bool
-		scid     bool
-	)
+	// Since we always negotiate an explicit channel type now, chanType is
+	// guaranteed to be non-nil.
+	//
+	// Check if the channel type includes the zero-conf or scid-alias bits.
+	featureVec := lnwire.RawFeatureVector(*chanType)
+	zeroConf := featureVec.IsSet(lnwire.ZeroConfRequired)
+	scid := featureVec.IsSet(lnwire.ScidAliasRequired)
 
-	// Only echo back a channel type in AcceptChannel if we actually used
-	// explicit negotiation above.
-	if chanType != nil {
-		// Check if the channel type includes the zero-conf or
-		// scid-alias bits.
-		featureVec := lnwire.RawFeatureVector(*chanType)
-		zeroConf = featureVec.IsSet(lnwire.ZeroConfRequired)
-		scid = featureVec.IsSet(lnwire.ScidAliasRequired)
+	// If the zero-conf channel type was negotiated, ensure that the
+	// acceptor allows it.
+	if zeroConf && !acceptorResp.ZeroConf {
+		// Fail the funding flow.
+		flowErr := fmt.Errorf("channel acceptor blocked zero-conf " +
+			"channel negotiation")
+		log.Errorf("Cancelling funding flow for %v based on channel "+
+			"acceptor response: %v", cid, flowErr)
+		f.failFundingFlow(peer, cid, flowErr)
 
-		// If the zero-conf channel type was negotiated, ensure that
-		// the acceptor allows it.
-		if zeroConf && !acceptorResp.ZeroConf {
+		return
+	}
+
+	// If the zero-conf channel type wasn't negotiated and the fundee still
+	// wants a zero-conf channel, perform more checks. Require that both
+	// sides have the scid-alias feature bit set. We don't require anchors
+	// here - this is for compatibility with LDK.
+	if !zeroConf && acceptorResp.ZeroConf {
+		if !scidFeatureVal {
 			// Fail the funding flow.
-			flowErr := fmt.Errorf("channel acceptor blocked " +
-				"zero-conf channel negotiation")
-			log.Errorf("Cancelling funding flow for %v based on "+
-				"channel acceptor response: %v", cid, flowErr)
+			flowErr := fmt.Errorf("scid-alias feature must be " +
+				"negotiated for zero-conf")
+			log.Errorf("Cancelling funding flow for zero-conf "+
+				"channel %v: %v", cid,
+				flowErr)
 			f.failFundingFlow(peer, cid, flowErr)
 			return
 		}
 
-		// If the zero-conf channel type wasn't negotiated and the
-		// fundee still wants a zero-conf channel, perform more checks.
-		// Require that both sides have the scid-alias feature bit set.
-		// We don't require anchors here - this is for compatibility
-		// with LDK.
-		if !zeroConf && acceptorResp.ZeroConf {
-			if !scidFeatureVal {
-				// Fail the funding flow.
-				flowErr := fmt.Errorf("scid-alias feature " +
-					"must be negotiated for zero-conf")
-				log.Errorf("Cancelling funding flow for "+
-					"zero-conf channel %v: %v", cid,
-					flowErr)
-				f.failFundingFlow(peer, cid, flowErr)
-				return
-			}
-
-			// Set zeroConf to true to enable the zero-conf flow.
-			zeroConf = true
-		}
+		// Set zeroConf to true to enable the zero-conf flow.
+		zeroConf = true
 	}
 
 	public := msg.ChannelFlags&lnwire.FFAnnounceChannel != 0
@@ -2063,65 +2063,42 @@ func (f *Manager) funderProcessAcceptChannel(peer lnpeer.Peer,
 	// Create the channel identifier.
 	cid := newChanIdentifier(msg.PendingChannelID)
 
-	// Perform some basic validation of any custom TLV records included.
-	//
+	// Channel type in our reservation should never be nil since we always
+	// negotiate the channel type explicitly and fall back to the default
+	// only when the RPC caller does not request one.
+	if resCtx.channelType == nil {
+		err := errors.New("channel type not set by funder")
+		f.failFundingFlow(peer, cid, err)
+		return
+	}
+
+	// We'll want to quickly check that the ChannelType echoed by the
+	// channel request recipient matches what we proposed.
 	// TODO: Return errors as funding.Error to give context to remote peer?
-	if resCtx.channelType != nil {
-		// We'll want to quickly check that the ChannelType echoed by
-		// the channel request recipient matches what we proposed.
-		if msg.ChannelType == nil {
-			err := errors.New("explicit channel type not echoed " +
-				"back")
+	if msg.ChannelType == nil {
+		err := errors.New("explicit channel type not echoed back")
+		f.failFundingFlow(peer, cid, err)
+		return
+	}
+	proposedFeatures := lnwire.RawFeatureVector(*resCtx.channelType)
+	ackedFeatures := lnwire.RawFeatureVector(*msg.ChannelType)
+	if !proposedFeatures.Equals(&ackedFeatures) {
+		err := errors.New("channel type mismatch")
+		f.failFundingFlow(peer, cid, err)
+		return
+	}
+
+	// We'll want to do the same with the LeaseExpiry if one should be set.
+	if resCtx.reservation.LeaseExpiry() != 0 {
+		if msg.LeaseExpiry == nil {
+			err := errors.New("lease expiry not echoed back")
 			f.failFundingFlow(peer, cid, err)
 			return
 		}
-		proposedFeatures := lnwire.RawFeatureVector(*resCtx.channelType)
-		ackedFeatures := lnwire.RawFeatureVector(*msg.ChannelType)
-		if !proposedFeatures.Equals(&ackedFeatures) {
-			err := errors.New("channel type mismatch")
-			f.failFundingFlow(peer, cid, err)
-			return
-		}
+		if uint32(*msg.LeaseExpiry) !=
+			resCtx.reservation.LeaseExpiry() {
 
-		// We'll want to do the same with the LeaseExpiry if one should
-		// be set.
-		if resCtx.reservation.LeaseExpiry() != 0 {
-			if msg.LeaseExpiry == nil {
-				err := errors.New("lease expiry not echoed " +
-					"back")
-				f.failFundingFlow(peer, cid, err)
-				return
-			}
-			if uint32(*msg.LeaseExpiry) !=
-				resCtx.reservation.LeaseExpiry() {
-
-				err := errors.New("lease expiry mismatch")
-				f.failFundingFlow(peer, cid, err)
-				return
-			}
-		}
-	} else if msg.ChannelType != nil {
-		// The spec isn't too clear about whether it's okay to set the
-		// channel type in the accept_channel response if we didn't
-		// explicitly set it in the open_channel message. For now, we
-		// check that it's the same type we'd have arrived through
-		// implicit negotiation. If it's another type, we fail the flow.
-		_, implicitCommitType := implicitNegotiateCommitmentType(
-			peer.LocalFeatures(), peer.RemoteFeatures(),
-		)
-
-		_, negotiatedCommitType, err := negotiateCommitmentType(
-			msg.ChannelType, peer.LocalFeatures(),
-			peer.RemoteFeatures(),
-		)
-		if err != nil {
-			err := errors.New("received unexpected channel type")
-			f.failFundingFlow(peer, cid, err)
-			return
-		}
-
-		if implicitCommitType != negotiatedCommitType {
-			err := errors.New("negotiated unexpected channel type")
+			err := errors.New("lease expiry mismatch")
 			f.failFundingFlow(peer, cid, err)
 			return
 		}
@@ -4981,9 +4958,9 @@ func (f *Manager) handleInitFundingMsg(msg *InitFundingMsg) {
 	// wallet doesn't have enough funds to commit to this channel, then the
 	// request will fail, and be aborted.
 	//
-	// Before we init the channel, we'll also check to see what commitment
-	// format we can use with this peer. This is dependent on *both* us and
-	// the remote peer are signaling the proper feature bit.
+	// Before initializing the reservation, validate the caller-requested
+	// channel type or select a default from the peers' mutually supported
+	// commitment features.
 	chanType, commitType, err := negotiateCommitmentType(
 		msg.ChannelType, msg.Peer.LocalFeatures(),
 		msg.Peer.RemoteFeatures(),
@@ -4994,28 +4971,23 @@ func (f *Manager) handleInitFundingMsg(msg *InitFundingMsg) {
 		return
 	}
 
-	var (
-		zeroConf bool
-		scid     bool
-	)
+	// Since we always negotiate an explicit channel type now, chanType is
+	// guaranteed to be non-nil.
+	//
+	// Check if the returned chanType includes either the zero-conf or
+	// scid-alias bits.
+	featureVec := lnwire.RawFeatureVector(*chanType)
+	zeroConf := featureVec.IsSet(lnwire.ZeroConfRequired)
+	scid := featureVec.IsSet(lnwire.ScidAliasRequired)
 
-	if chanType != nil {
-		// Check if the returned chanType includes either the zero-conf
-		// or scid-alias bits.
-		featureVec := lnwire.RawFeatureVector(*chanType)
-		zeroConf = featureVec.IsSet(lnwire.ZeroConfRequired)
-		scid = featureVec.IsSet(lnwire.ScidAliasRequired)
+	// The option-scid-alias channel type for a public channel is disallowed
+	if scid && !msg.Private {
+		err = fmt.Errorf("option-scid-alias chantype for public " +
+			"channel")
+		log.Error(err)
+		msg.Err <- err
 
-		// The option-scid-alias channel type for a public channel is
-		// disallowed.
-		if scid && !msg.Private {
-			err = fmt.Errorf("option-scid-alias chantype for " +
-				"public channel")
-			log.Error(err)
-			msg.Err <- err
-
-			return
-		}
+		return
 	}
 
 	// The current variant of taproot channels can only be used with

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -1599,7 +1599,7 @@ func testNormalWorkflow(t *testing.T, chanType *lnwire.ChannelType) {
 	})
 
 	// If the channel type is set, then we need to make sure both parties
-	// support explicit channel type negotiation.
+	// support the features underlying that type.
 	if chanType != nil {
 		// Alice and Bob will have the same set of feature bits in our
 		// test.
@@ -5087,6 +5087,110 @@ func TestFundingManagerNoEchoChanType(t *testing.T) {
 	acceptChanMsg.ChannelType = nil
 	alice.fundingMgr.ProcessFundingMsg(acceptChanMsg, bob)
 	assertFundingMsgSent(t, alice.msgChan, "Error")
+}
+
+// TestFundingManagerRejectMissingChanType verifies that the fundee rejects an
+// OpenChannel message that omits the ChannelType field.
+func TestFundingManagerRejectMissingChanType(t *testing.T) {
+	t.Parallel()
+
+	alice, bob := setupFundingManagers(t)
+	t.Cleanup(func() {
+		tearDownFundingManagers(t, alice, bob)
+	})
+
+	// Build an OpenChannel with the ChannelType field omitted.
+	openChannelReq := &lnwire.OpenChannel{
+		ChainHash:            *fundingNetParams.GenesisHash,
+		PendingChannelID:     [32]byte{0x01},
+		FundingAmount:        btcutil.Amount(10000000),
+		PushAmount:           0,
+		DustLimit:            btcutil.Amount(546),
+		MaxValueInFlight:     lnwire.MilliSatoshi(100000000),
+		ChannelReserve:       btcutil.Amount(10000),
+		HtlcMinimum:          lnwire.MilliSatoshi(1000),
+		FeePerKiloWeight:     15000,
+		CsvDelay:             144,
+		MaxAcceptedHTLCs:     483,
+		FundingKey:           alice.privKey.PubKey(),
+		RevocationPoint:      alice.privKey.PubKey(),
+		PaymentPoint:         alice.privKey.PubKey(),
+		DelayedPaymentPoint:  alice.privKey.PubKey(),
+		HtlcPoint:            alice.privKey.PubKey(),
+		FirstCommitmentPoint: alice.privKey.PubKey(),
+		ChannelType:          nil,
+	}
+	bob.fundingMgr.ProcessFundingMsg(openChannelReq, alice)
+
+	// Bob should reject the OpenChannel message with an Error.
+	errMsg := assertFundingMsgSent(t, bob.msgChan, "Error")
+	err, ok := errMsg.(*lnwire.Error)
+	require.True(t, ok)
+	require.Equal(t, lnwire.ErrChanTypeRequired.Error(), string(err.Data))
+	assertNumPendingReservations(t, bob, alicePubKey, 0)
+}
+
+// TestFundingManagerAcceptChanType verifies that the fundee accepts an
+// OpenChannel message that includes the ChannelType field and echoes it back
+// in AcceptChannel, even when neither peer advertises the explicit channel
+// type feature bit.
+func TestFundingManagerAcceptChanType(t *testing.T) {
+	t.Parallel()
+
+	alice, bob := setupFundingManagers(t)
+	t.Cleanup(func() {
+		tearDownFundingManagers(t, alice, bob)
+	})
+
+	// Set up only the features underlying the requested channel type.
+	featureBits := []lnwire.FeatureBit{
+		lnwire.StaticRemoteKeyOptional,
+		lnwire.AnchorsZeroFeeHtlcTxOptional,
+	}
+	alice.localFeatures = featureBits
+	alice.remoteFeatures = featureBits
+	bob.localFeatures = featureBits
+	bob.remoteFeatures = featureBits
+
+	expectedChanType := (*lnwire.ChannelType)(lnwire.NewRawFeatureVector(
+		lnwire.StaticRemoteKeyRequired,
+		lnwire.AnchorsZeroFeeHtlcTxRequired,
+	))
+
+	// Build an OpenChannel with the ChannelType field properly set.
+	openChannelReq := &lnwire.OpenChannel{
+		ChainHash:            *fundingNetParams.GenesisHash,
+		PendingChannelID:     [32]byte{0x01},
+		FundingAmount:        btcutil.Amount(10000000),
+		PushAmount:           0,
+		DustLimit:            btcutil.Amount(546),
+		MaxValueInFlight:     lnwire.MilliSatoshi(100000000),
+		ChannelReserve:       btcutil.Amount(10000),
+		HtlcMinimum:          lnwire.MilliSatoshi(1000),
+		FeePerKiloWeight:     15000,
+		CsvDelay:             144,
+		MaxAcceptedHTLCs:     483,
+		FundingKey:           alice.privKey.PubKey(),
+		RevocationPoint:      alice.privKey.PubKey(),
+		PaymentPoint:         alice.privKey.PubKey(),
+		DelayedPaymentPoint:  alice.privKey.PubKey(),
+		HtlcPoint:            alice.privKey.PubKey(),
+		FirstCommitmentPoint: alice.privKey.PubKey(),
+		ChannelType:          expectedChanType,
+	}
+	bob.fundingMgr.ProcessFundingMsg(openChannelReq, alice)
+
+	// Bob should accept the OpenChannel message and send AcceptChannel.
+	acceptChannelResponse, ok := assertFundingMsgSent(
+		t, bob.msgChan, "AcceptChannel",
+	).(*lnwire.AcceptChannel)
+	require.True(t, ok)
+
+	// Verify the channel type is echoed back.
+	require.Equal(t, expectedChanType, acceptChannelResponse.ChannelType)
+
+	// Bob should have a new pending reservation.
+	assertNumPendingReservations(t, bob, alicePubKey, 1)
 }
 
 // TestFundingManagerZeroConf tests that the fundingmanager properly handles

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -7331,8 +7331,9 @@ type BatchOpenChannel struct {
 	// pending channel ID to identify the channel while it is in the pre-pending
 	// state.
 	PendingChanId []byte `protobuf:"bytes,8,opt,name=pending_chan_id,json=pendingChanId,proto3" json:"pending_chan_id,omitempty"`
-	// The explicit commitment type to use. Note this field will only be used if
-	// the remote peer supports explicit channel negotiation.
+	// The commitment type to request. If UNKNOWN, lnd selects a default from
+	// both peers' supported features; the selected type is always sent
+	// explicitly.
 	CommitmentType CommitmentType `protobuf:"varint,9,opt,name=commitment_type,json=commitmentType,proto3,enum=lnrpc.CommitmentType" json:"commitment_type,omitempty"`
 	// The maximum amount of coins in millisatoshi that can be pending within
 	// the channel. It only applies to the remote party.
@@ -7655,8 +7656,9 @@ type OpenChannelRequest struct {
 	// Max local csv is the maximum csv delay we will allow for our own commitment
 	// transaction.
 	MaxLocalCsv uint32 `protobuf:"varint,17,opt,name=max_local_csv,json=maxLocalCsv,proto3" json:"max_local_csv,omitempty"`
-	// The explicit commitment type to use. Note this field will only be used if
-	// the remote peer supports explicit channel negotiation.
+	// The commitment type to request. If UNKNOWN, lnd selects a default from
+	// both peers' supported features; the selected type is always sent
+	// explicitly.
 	CommitmentType CommitmentType `protobuf:"varint,18,opt,name=commitment_type,json=commitmentType,proto3,enum=lnrpc.CommitmentType" json:"commitment_type,omitempty"`
 	// If this is true, then a zero-conf channel open will be attempted.
 	ZeroConf bool `protobuf:"varint,19,opt,name=zero_conf,json=zeroConf,proto3" json:"zero_conf,omitempty"`

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -2237,8 +2237,9 @@ message BatchOpenChannel {
     bytes pending_chan_id = 8;
 
     /*
-    The explicit commitment type to use. Note this field will only be used if
-    the remote peer supports explicit channel negotiation.
+    The commitment type to request. If UNKNOWN, lnd selects a default from
+    both peers' supported features; the selected type is always sent
+    explicitly.
     */
     CommitmentType commitment_type = 9;
 
@@ -2410,8 +2411,9 @@ message OpenChannelRequest {
     uint32 max_local_csv = 17;
 
     /*
-    The explicit commitment type to use. Note this field will only be used if
-    the remote peer supports explicit channel negotiation.
+    The commitment type to request. If UNKNOWN, lnd selects a default from
+    both peers' supported features; the selected type is always sent
+    explicitly.
     */
     CommitmentType commitment_type = 18;
 

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -3571,7 +3571,7 @@
         },
         "commitment_type": {
           "$ref": "#/definitions/lnrpcCommitmentType",
-          "description": "The explicit commitment type to use. Note this field will only be used if\nthe remote peer supports explicit channel negotiation."
+          "description": "The commitment type to request. If UNKNOWN, lnd selects a default from\nboth peers' supported features; the selected type is always sent\nexplicitly."
         },
         "remote_max_value_in_flight_msat": {
           "type": "string",
@@ -6608,7 +6608,7 @@
         },
         "commitment_type": {
           "$ref": "#/definitions/lnrpcCommitmentType",
-          "description": "The explicit commitment type to use. Note this field will only be used if\nthe remote peer supports explicit channel negotiation."
+          "description": "The commitment type to request. If UNKNOWN, lnd selects a default from\nboth peers' supported features; the selected type is always sent\nexplicitly."
         },
         "zero_conf": {
           "type": "boolean",

--- a/lnwire/error.go
+++ b/lnwire/error.go
@@ -26,6 +26,11 @@ const (
 	// FundingOpen request for a channel that is above their current
 	// soft-limit.
 	ErrChanTooLarge FundingError = 2
+
+	// ErrChanTypeRequired is returned by a remote peer that receives a
+	// FundingOpen request which doesn't specify an explicit channel type,
+	// as mandated by BOLT-02.
+	ErrChanTypeRequired FundingError = 3
 )
 
 // String returns a human readable version of the target FundingError.
@@ -35,6 +40,8 @@ func (e FundingError) String() string {
 		return "Number of pending channels exceed maximum"
 	case ErrChanTooLarge:
 		return "channel too large"
+	case ErrChanTypeRequired:
+		return "channel type required"
 	default:
 		return "unknown error"
 	}


### PR DESCRIPTION
Currently, BOLT assumes `ExplicitChannelType`, and LND sends it as required (https://github.com/lightningnetwork/lnd/pull/9637). However, when receiving an `OpenChannel` from peer, LND doesn’t enforce an explicit `ChannelType` and falls back to implicit negotiation, even though both peers have negotiated `ExplicitChannelType`. According to BOLT 2, I think we should fail the funding flow if `ChannelType` is omitted from the received `OpenChannel` message and echo the same channel type (if valid) in `AcceptChannel`.

So, we should remove implicit negotiation entirely. If the RPC caller doesn’t request a channel type, a default should be derived from both peers' features and signaled explicitly.

> This bug was discovered while fuzzing the funding flow using the [smite](https://github.com/lnfuzz/smite)