### PR TITLE
docker-release: fix running from Git worktree and if Go cache dir is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,11 @@ release: clean-mobile
 	./scripts/release.sh build-release "$(VERSION_TAG)" "$(BUILD_SYSTEM)" "$(RELEASE_TAGS)" "$(RELEASE_LDFLAGS)" "$(GO_VERSION)"
 
 #? docker-release: Same as release but within a docker container to support reproducible builds on BSD/MacOS platforms
-docker-release:
+docker-release-cache:
+	$(call check_docker_release_cache,$(DOCKER_RELEASE_GOCACHE))
+	$(call check_docker_release_cache,$(DOCKER_RELEASE_GOMODCACHE))
+
+docker-release: docker-release-cache
 	@$(call print, "Building release helper docker image.")
 	if [ "$(tag)" = "" ]; then echo "Must specify tag=<commit_or_tag>!"; exit 1; fi
 

--- a/make/release_flags.mk
+++ b/make/release_flags.mk
@@ -1,13 +1,42 @@
 VERSION_TAG = $(shell date +%Y%m%d)-01
 VERSION_CHECK = @$(call print, "Building master with date version tag")
 
+# Create these directories before Docker bind mounts them. Docker creates a
+# missing bind-mount source as root, which makes the cache unwritable because
+# the release helper deliberately runs as the invoking user.
+DOCKER_RELEASE_GOCACHE = $(shell bash -c 'cache="$$($(GOCC) env GOCACHE 2>/dev/null)" || cache=/tmp/go-cache; printf "%s" "$$cache"')
+DOCKER_RELEASE_GOMODCACHE = $(shell bash -c 'cache="$$($(GOCC) env GOMODCACHE 2>/dev/null)" || cache=/tmp/go-modcache; printf "%s" "$$cache"')
+
+define check_docker_release_cache
+	@cache="$(1)"; \
+	if ! mkdir -p "$$cache"; then \
+		echo "error: cannot create Docker release cache: $$cache"; \
+		exit 1; \
+	fi; \
+	cache_ok=1; \
+	for shard in $$(printf '%02x\n' $$(seq 0 255)); do \
+		shard_dir="$$cache/$$shard"; created=; \
+		if [ ! -e "$$shard_dir" ]; then \
+			mkdir "$$shard_dir" || { cache_ok=; break; }; created=1; \
+		fi; \
+		test_dir=$$(mktemp -d "$$shard_dir/.lnd-release-cache.XXXXXX" 2>/dev/null) || { cache_ok=; break; }; \
+		rmdir "$$test_dir"; \
+		if [ -n "$$created" ] && ! rmdir "$$shard_dir"; then cache_ok=; break; fi; \
+	done; \
+	if [ -z "$$cache_ok" ]; then \
+		echo "error: Docker release cache cannot create directories: $$cache"; \
+		echo "hint: remove or chown root-owned files in this cache"; \
+		exit 1; \
+	fi
+endef
+
 DOCKER_RELEASE_HELPER = docker run \
   -it \
   --rm \
   --user $(shell id -u):$(shell id -g) \
   -v $(shell pwd):/tmp/build/lnd \
-  -v $(shell bash -c "$(GOCC) env GOCACHE || (mkdir -p /tmp/go-cache; echo /tmp/go-cache)"):/tmp/build/.cache \
-  -v $(shell bash -c "$(GOCC) env GOMODCACHE || (mkdir -p /tmp/go-modcache; echo /tmp/go-modcache)"):/tmp/build/.modcache \
+  -v $(DOCKER_RELEASE_GOCACHE):/tmp/build/.cache \
+  -v $(DOCKER_RELEASE_GOMODCACHE):/tmp/build/.modcache \
   -e SKIP_VERSION_CHECK \
   lnd-release-helper
 

--- a/make/release_flags.mk
+++ b/make/release_flags.mk
@@ -7,6 +7,12 @@ VERSION_CHECK = @$(call print, "Building master with date version tag")
 DOCKER_RELEASE_GOCACHE = $(shell bash -c 'cache="$$($(GOCC) env GOCACHE 2>/dev/null)" || cache=/tmp/go-cache; printf "%s" "$$cache"')
 DOCKER_RELEASE_GOMODCACHE = $(shell bash -c 'cache="$$($(GOCC) env GOMODCACHE 2>/dev/null)" || cache=/tmp/go-modcache; printf "%s" "$$cache"')
 
+# A linked worktree has a .git file that points outside the worktree. Mount
+# its common Git directory at the same absolute path so tag checks and git
+# archive work inside the release helper too.
+DOCKER_RELEASE_GIT_COMMON_DIR = $(shell if [ -f .git ]; then git rev-parse --path-format=absolute --git-common-dir; fi)
+DOCKER_RELEASE_GIT_MOUNT = $(if $(DOCKER_RELEASE_GIT_COMMON_DIR),-v $(DOCKER_RELEASE_GIT_COMMON_DIR):$(DOCKER_RELEASE_GIT_COMMON_DIR):ro)
+
 define check_docker_release_cache
 	@cache="$(1)"; \
 	if ! mkdir -p "$$cache"; then \
@@ -35,6 +41,7 @@ DOCKER_RELEASE_HELPER = docker run \
   --rm \
   --user $(shell id -u):$(shell id -g) \
   -v $(shell pwd):/tmp/build/lnd \
+  $(DOCKER_RELEASE_GIT_MOUNT) \
   -v $(DOCKER_RELEASE_GOCACHE):/tmp/build/.cache \
   -v $(DOCKER_RELEASE_GOMODCACHE):/tmp/build/.modcache \
   -e SKIP_VERSION_CHECK \


### PR DESCRIPTION
## Change Description

I created a fresh VM, checkout a tag (`v0.20.3-beta`) and tried to run `make docker-release tag=v0.20.3-beta`.

```
failed to initialize build cache at /tmp/build/.cache: mkdir /tmp/build/.cache/00: permission denied
make: *** [Makefile:165: release] Error 1
make: *** [Makefile:175: docker-release] Error 2
```

It created `~/.cache/go-build` as root and then tried to use it as a regular user in the host. The fix is to pre-create the dir outside before calling docker. The same situation for `~/go/pkg/mod`


I also tried to run `make docker-release` from a Git worktree. It failed because `.git` dir was left externally and wasn't mounted inside Docker, so it could not find it. Fixed by mounting the source tree as well.

## Steps to Test

Create a fresh VM, download LND, create a Git worktree holding tag `v0.20.3-beta` and from the worktree run `make docker-release tag=v0.20.3-beta`. It will fail. Then create another VM and do the same, but apply this PR's diff locally (do not commit) and repeat - it should work. Note that the first VM may already be spoiled by the first attempt (`~/.cache/go-build` and `~/go/pkg/mod` already belonging to root, preventing normal operation even after the fix).

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
