### PR TITLE
lnwallet: reject commitments missing aux HTLC signatures

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -22,6 +22,19 @@
 
 # Bug Fixes
 
+* [Tightened the validation](https://github.com/lightningnetwork/lnd/pull/11068)
+  of auxiliary HTLC signatures on taproot overlay channels. Their count is now
+  checked against the number of HTLCs on the commitment, mirroring the check
+  that already exists for the BTC level signatures. A commitment that fails the
+  check is rejected as an invalid commitment, which force closes the channel.
+  This is a change in behaviour for one configuration in particular: a taproot
+  overlay channel whose peer runs `lnd` with no aux signer attached (`tapd`
+  stopped, or `lnd` started standalone). Such a peer's commitments used to be
+  accepted, leaving HTLCs on disk with an empty auxiliary signature that could
+  not be swept at force close time. They now force close the channel as soon as
+  a commitment carries an HTLC. Peers running an older `tapd` with the aux
+  signer attached are unaffected.
+
 * Bitcoind outbound peer health checks [now use](https://github.com/lightningnetwork/lnd/pull/10686)
   `getnetworkinfo.connections_out` instead of `getpeerinfo`. The same PR also
   [clarifies](https://github.com/lightningnetwork/lnd/issues/10568) the ZMQ
@@ -158,4 +171,5 @@
 * bitromortac
 * Boris Nagaev
 * Erick Cestari
+* George Tsagkarelis
 * Jared Tobin

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -5273,6 +5273,28 @@ func genHtlcSigValidationJobs(chanState *chanstate.OpenChannel,
 			"Expected %v sigs, got %v", i, len(htlcSigs))
 	}
 
+	// The same has to hold for the aux signatures on a custom channel. An
+	// aux signer emits one entry per non-dust HTLC, in lockstep with the
+	// BTC level signatures, so a peer sending fewer has withheld a
+	// signature we need to resolve that HTLC on chain later. The blob
+	// carries no count of its own, and a missing entry produces no
+	// verification job, so this is the only place the omission is visible.
+	//
+	// This is gated on the channel being a taproot overlay one, and not
+	// merely on an aux signer being present: the signer is configured node
+	// wide, so it is also attached to plain channels, whose peers
+	// correctly send no aux signatures at all. The tapscript root bit is
+	// set at funding time if and only if the commitment type is a taproot
+	// overlay, so it identifies precisely the channels whose peers owe us
+	// aux signatures. It is still also gated on the aux signer, since
+	// without one there is nothing that could consume those signatures.
+	if auxSigner.IsSome() && chanType.HasTapscriptRoot() &&
+		len(auxHtlcSigs) != i {
+
+		return nil, nil, fmt.Errorf("number of aux htlc sig mismatch. "+
+			"Expected %v sigs, got %v", i, len(auxHtlcSigs))
+	}
+
 	return verifyJobs, auxVerifyJobs, nil
 }
 

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -3244,9 +3244,21 @@ func restartChannel(channelOld *LightningChannel) (*LightningChannel, error) {
 		return nil, err
 	}
 
+	// The aux components are re-applied every time a channel is loaded in
+	// production, so a restart must not silently drop them here either.
+	// Otherwise the restarted side stops producing aux signatures while
+	// its peer still expects them.
+	var chanOpts []ChannelOpt
+	channelOld.leafStore.WhenSome(func(s AuxLeafStore) {
+		chanOpts = append(chanOpts, WithLeafStore(s))
+	})
+	channelOld.auxSigner.WhenSome(func(s AuxSigner) {
+		chanOpts = append(chanOpts, WithAuxSigner(s))
+	})
+
 	channelNew, err := NewLightningChannel(
 		channelOld.Signer, nodeChannels[0],
-		channelOld.sigPool,
+		channelOld.sigPool, chanOpts...,
 	)
 	if err != nil {
 		return nil, err
@@ -3490,10 +3502,16 @@ func testChanSyncOweCommitment(t *testing.T,
 	// At this point, we should be able to resume the prior state update
 	// without any issues, resulting in Alice settling the 3 htlc's, and
 	// adding one of her own.
+	// The link carries the aux signatures across from the wire message, so
+	// a faithful simulation of the restart has to do so as well.
+	aliceReAuxBlob, err := aliceReCommitSig.CustomRecords.Serialize()
+	require.NoError(t, err, "unable to serialize aux sig blob")
+
 	err = bobChannel.ReceiveNewCommitment(&CommitSigs{
 		CommitSig:  aliceReCommitSig.CommitSig,
 		HtlcSigs:   aliceReCommitSig.HtlcSigs,
 		PartialSig: aliceReCommitSig.PartialSig,
+		AuxSigBlob: aliceReAuxBlob,
 	})
 	require.NoError(t, err, "bob unable to process alice's commitment")
 	bobRevocation, _, _, err := bobChannel.RevokeCurrentCommitment()
@@ -4826,10 +4844,14 @@ func testChanSyncOweRevocationAndCommitForceTransition(t *testing.T,
 	// message to Bob.
 	_, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
 	require.NoError(t, err, "alice unable to recv revocation")
+	bobAuxBlob, err := bobSigMsg.CustomRecords.Serialize()
+	require.NoError(t, err, "unable to serialize aux sig blob")
+
 	err = aliceChannel.ReceiveNewCommitment(&CommitSigs{
 		CommitSig:  bobSigMsg.CommitSig,
 		HtlcSigs:   bobSigMsg.HtlcSigs,
 		PartialSig: bobSigMsg.PartialSig,
+		AuxSigBlob: bobAuxBlob,
 	})
 	require.NoError(t, err, "alice unable to rev bob's commitment")
 	aliceRevocation, _, _, err = aliceChannel.RevokeCurrentCommitment()

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -11978,3 +11978,304 @@ func TestEvaluateNoOpHtlc(t *testing.T) {
 		require.Equal(t, tc.expectedDeltas, tc.balanceDeltas)
 	}
 }
+
+// taprootOverlayChanType is the channel type of a taproot overlay channel. The
+// tapscript root bit is what marks it as one, and therefore as a channel whose
+// peer owes us an aux signature for every HTLC.
+var taprootOverlayChanType = channeldb.SingleFunderTweaklessBit |
+	channeldb.AnchorOutputsBit | channeldb.SimpleTaprootFeatureBit |
+	channeldb.TapscriptRootBit
+
+// auxHtlcAmt is the amount of the HTLCs added by createAuxHtlcChannels. It is
+// well above both channels' dust limit, so each such HTLC gets its own
+// commitment output and therefore its own signature.
+const auxHtlcAmt = btcutil.Amount(20000)
+
+// auxDustHtlcAmt is an amount below Bob's dust limit, so an HTLC of this size
+// gets no output on the commitment Alice signs for Bob, and therefore no
+// signature of either kind.
+const auxDustHtlcAmt = btcutil.Amount(1000)
+
+// addAuxHtlc adds a single HTLC of the given amount, offered by Alice and
+// received by Bob. The index seeds the payment preimage, so callers must pass a
+// distinct index for each HTLC added to the same pair of channels.
+func addAuxHtlc(t *testing.T, aliceChannel, bobChannel *LightningChannel,
+	idx int, amt btcutil.Amount) {
+
+	var fakeOnionBlob [lnwire.OnionPacketSize]byte
+	copy(
+		fakeOnionBlob[:],
+		bytes.Repeat([]byte{0x05}, lnwire.OnionPacketSize),
+	)
+
+	var preimage [32]byte
+	copy(preimage[:], bytes.Repeat([]byte{byte(idx)}, 32))
+
+	htlc := &lnwire.UpdateAddHTLC{
+		PaymentHash: sha256.Sum256(preimage[:]),
+		Amount:      lnwire.NewMSatFromSatoshis(amt),
+		Expiry:      uint32(10),
+		OnionBlob:   fakeOnionBlob,
+	}
+
+	htlcIndex, err := aliceChannel.AddHTLC(htlc, nil)
+	require.NoError(t, err, "unable to add htlc")
+
+	htlc.ID = htlcIndex
+	_, err = bobChannel.ReceiveHTLC(htlc)
+	require.NoError(t, err, "unable to recv htlc")
+}
+
+// createAuxHtlcChannels creates a pair of channels of the given type, with the
+// given number of HTLCs offered by Alice and received by Bob. The HTLCs are
+// well above the dust limit, so each of them gets its own commitment output
+// and therefore its own signature.
+func createAuxHtlcChannels(t *testing.T, chanType channeldb.ChannelType,
+	numHtlcs int) (*LightningChannel, *LightningChannel) {
+
+	aliceChannel, bobChannel, err := CreateTestChannels(t, chanType)
+	require.NoError(t, err, "unable to create test channels")
+
+	for idx := range numHtlcs {
+		addAuxHtlc(t, aliceChannel, bobChannel, idx, auxHtlcAmt)
+	}
+
+	return aliceChannel, bobChannel
+}
+
+// mockAuxSignerWithSigs installs an aux signer on the given channel that
+// reports the given number of unpacked signature slots, regardless of what the
+// remote party actually sent. That stands in for a peer whose commit_sig
+// carried that many aux signatures.
+func mockAuxSignerWithSigs(channel *LightningChannel,
+	numSigs int) *MockAuxSigner {
+
+	auxSigner := NewAuxSignerMock(EmptyMockJobHandler)
+	channel.auxSigner = fn.Some[AuxSigner](auxSigner)
+
+	slots := make([]fn.Option[tlv.Blob], numSigs)
+	for idx := range slots {
+		slots[idx] = fn.Some(tlv.Blob{0x01})
+	}
+
+	auxSigner.On("UnpackSigs", mock.Anything).Return(fn.Ok(slots))
+	auxSigner.On(
+		"VerifySecondLevelSigs", mock.Anything, mock.Anything,
+		mock.Anything,
+	).Return(nil)
+
+	return auxSigner
+}
+
+// TestAuxSigCount tests that a taproot overlay commitment is accepted only
+// when the remote party supplied exactly one aux signature per HTLC.
+//
+// A peer can otherwise withhold the aux signature for an HTLC: no verification
+// job is produced for it, nothing reports the omission, and the commitment
+// becomes our state carrying a signature we never received. At force close the
+// resolver then reads an empty signature out of that HTLC's custom records and
+// the second level HTLC cannot be swept.
+func TestAuxSigCount(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		numHtlcs     int
+		numDustHtlcs int
+		numSigs      int
+		expectErr    bool
+	}{{
+		// The honest case: an aux signer emits one signature per
+		// non-dust HTLC, so the counts line up.
+		name:     "one signature per htlc",
+		numHtlcs: 2,
+		numSigs:  2,
+	}, {
+		name:      "all signatures withheld",
+		numHtlcs:  1,
+		numSigs:   0,
+		expectErr: true,
+	}, {
+		// The subtler withholding: enough signatures to look
+		// plausible, but one HTLC left unsigned.
+		name:      "one signature withheld",
+		numHtlcs:  2,
+		numSigs:   1,
+		expectErr: true,
+	}, {
+		name:      "more signatures than htlcs",
+		numHtlcs:  1,
+		numSigs:   2,
+		expectErr: true,
+	}, {
+		// A dust HTLC has no output on the commitment, so it gets
+		// neither a BTC level nor an aux signature. This pins the
+		// invariant the count check relies on: the aux signatures are
+		// emitted on the same non-dust basis as the BTC level ones.
+		name:         "dust htlc gets no signature",
+		numHtlcs:     1,
+		numDustHtlcs: 1,
+		numSigs:      1,
+	}, {
+		// Signing the dust HTLC as well is exactly the divergence that
+		// the count check is there to catch.
+		name:         "dust htlc signed anyway",
+		numHtlcs:     1,
+		numDustHtlcs: 1,
+		numSigs:      2,
+		expectErr:    true,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			aliceChannel, bobChannel := createAuxHtlcChannels(
+				t, taprootOverlayChanType, tc.numHtlcs,
+			)
+			for idx := range tc.numDustHtlcs {
+				addAuxHtlc(
+					t, aliceChannel, bobChannel,
+					tc.numHtlcs+idx, auxDustHtlcAmt,
+				)
+			}
+
+			mockAuxSignerWithSigs(bobChannel, tc.numSigs)
+
+			aliceNewCommit, err := aliceChannel.SignNextCommitment(
+				ctxb,
+			)
+			require.NoError(t, err, "unable to sign commitment")
+
+			err = bobChannel.ReceiveNewCommitment(
+				aliceNewCommit.CommitSigs,
+			)
+			if !tc.expectErr {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.ErrorContains(
+				t, err, "number of aux htlc sig mismatch",
+			)
+		})
+	}
+}
+
+// TestAuxSigBlobOmittedFailsCommitment tests the same rejection, but driven by
+// the field a remote party actually controls: a commit_sig that carries no aux
+// signature custom record at all. ReceiveNewCommitment turns a nil AuxSigBlob
+// into fn.None, and a real aux signer unpacks that into no signatures.
+func TestAuxSigBlobOmittedFailsCommitment(t *testing.T) {
+	t.Parallel()
+
+	aliceChannel, bobChannel := createAuxHtlcChannels(
+		t, taprootOverlayChanType, 1,
+	)
+
+	// Bob's aux signer mirrors the real one: an absent blob unpacks to no
+	// signatures at all. We record what it was handed, so the test can
+	// show it exercised the absent blob branch rather than assuming it.
+	auxSigner := NewAuxSignerMock(EmptyMockJobHandler)
+	bobChannel.auxSigner = fn.Some[AuxSigner](auxSigner)
+
+	var unpackedBlob fn.Option[tlv.Blob]
+	auxSigner.On("UnpackSigs", mock.Anything).Run(func(a mock.Arguments) {
+		blob, ok := a.Get(0).(fn.Option[tlv.Blob])
+		require.True(t, ok)
+		unpackedBlob = blob
+	}).Return(fn.Ok[[]fn.Option[tlv.Blob]](nil))
+
+	aliceNewCommit, err := aliceChannel.SignNextCommitment(ctxb)
+	require.NoError(t, err, "unable to sign commitment")
+
+	// Alice's commit_sig does carry an aux signature blob. Stripping it is
+	// precisely what a peer omitting the custom record looks like here.
+	require.NotNil(t, aliceNewCommit.AuxSigBlob)
+	aliceNewCommit.AuxSigBlob = nil
+
+	err = bobChannel.ReceiveNewCommitment(aliceNewCommit.CommitSigs)
+	require.ErrorContains(t, err, "number of aux htlc sig mismatch")
+
+	// The blob really was absent by the time lnd asked the aux signer to
+	// unpack it, so this was the wire level case.
+	require.True(t, unpackedBlob.IsNone())
+}
+
+// TestAuxSigNotRequiredOnPlainChannel tests that a channel without the
+// tapscript root bit still accepts commitments carrying no aux signatures. The
+// aux signer is configured node wide, so a node running one also attaches it to
+// its plain channels, whose peers correctly send none. Requiring them there
+// would force close those channels.
+func TestAuxSigNotRequiredOnPlainChannel(t *testing.T) {
+	t.Parallel()
+
+	// The same channel type as the overlay one, minus the tapscript root
+	// bit, which is the only thing that marks a channel as an overlay.
+	plainChanType := taprootOverlayChanType &^ channeldb.TapscriptRootBit
+	aliceChannel, bobChannel := createAuxHtlcChannels(t, plainChanType, 1)
+
+	mockAuxSignerWithSigs(bobChannel, 0)
+
+	aliceNewCommit, err := aliceChannel.SignNextCommitment(ctxb)
+	require.NoError(t, err, "unable to sign commitment")
+
+	require.NoError(t, bobChannel.ReceiveNewCommitment(
+		aliceNewCommit.CommitSigs,
+	))
+}
+
+// TestAuxSigNotRequiredWithoutAuxSigner tests that an overlay channel on a node
+// with no aux signer configured still accepts commitments carrying no aux
+// signatures. Without a signer there is nothing that could consume them, so
+// demanding them would only strand the channel.
+func TestAuxSigNotRequiredWithoutAuxSigner(t *testing.T) {
+	t.Parallel()
+
+	aliceChannel, bobChannel := createAuxHtlcChannels(
+		t, taprootOverlayChanType, 1,
+	)
+
+	bobChannel.auxSigner = fn.None[AuxSigner]()
+
+	aliceNewCommit, err := aliceChannel.SignNextCommitment(ctxb)
+	require.NoError(t, err, "unable to sign commitment")
+
+	require.NoError(t, bobChannel.ReceiveNewCommitment(
+		aliceNewCommit.CommitSigs,
+	))
+}
+
+// TestAuxSigRejectionFailsCommitment tests that when the aux signer rejects a
+// verification job, the new commitment is rejected as a whole. The count check
+// only establishes that a signature arrived for every HTLC; this is what makes
+// the aux signer's verdict on those signatures binding.
+func TestAuxSigRejectionFailsCommitment(t *testing.T) {
+	t.Parallel()
+
+	aliceChannel, bobChannel := createAuxHtlcChannels(
+		t, taprootOverlayChanType, 1,
+	)
+
+	auxSigner := NewAuxSignerMock(EmptyMockJobHandler)
+	bobChannel.auxSigner = fn.Some[AuxSigner](auxSigner)
+
+	// The peer sends a well formed blob with one entry for the single
+	// HTLC, so the count check passes and the aux signer gets to weigh in
+	// on the signature itself. It rejects.
+	auxSigner.On("UnpackSigs", mock.Anything).Return(
+		fn.Ok([]fn.Option[tlv.Blob]{fn.Some(tlv.Blob{0x01})}),
+	)
+	auxSigner.On(
+		"VerifySecondLevelSigs", mock.Anything, mock.Anything,
+		mock.Anything,
+	).Return(fmt.Errorf("second level sig verification failed"))
+
+	aliceNewCommit, err := aliceChannel.SignNextCommitment(ctxb)
+	require.NoError(t, err, "unable to sign commitment")
+
+	err = bobChannel.ReceiveNewCommitment(aliceNewCommit.CommitSigs)
+	require.ErrorContains(t, err, "unable to validate aux sigs")
+	require.ErrorContains(t, err, "second level sig verification failed")
+}

--- a/lnwallet/mock.go
+++ b/lnwallet/mock.go
@@ -495,12 +495,26 @@ func (a *MockAuxSigner) SubmitSecondLevelSigBatch(chanState AuxChanState,
 	return args.Error(0)
 }
 
+// PackSigsFunc packs aux signatures into a blob. A test can register one of
+// these with the mock instead of a fixed value, so that the packed blob can
+// depend on the signatures handed in. That matters because a real aux signer
+// emits exactly one slot per HTLC.
+type PackSigsFunc func([]fn.Option[tlv.Blob]) fn.Result[fn.Option[tlv.Blob]]
+
+// UnpackSigsFunc is the counterpart of PackSigsFunc, recovering the per-HTLC
+// slots from a packed blob.
+type UnpackSigsFunc func(fn.Option[tlv.Blob]) fn.Result[[]fn.Option[tlv.Blob]]
+
 // PackSigs takes a series of aux signatures and packs them into a
 // single blob that can be sent alongside the CommitSig messages.
 func (a *MockAuxSigner) PackSigs(
 	sigs []fn.Option[tlv.Blob]) fn.Result[fn.Option[tlv.Blob]] {
 
 	args := a.Called(sigs)
+
+	if f, ok := args.Get(0).(PackSigsFunc); ok {
+		return f(sigs)
+	}
 
 	return args.Get(0).(fn.Result[fn.Option[tlv.Blob]])
 }
@@ -511,6 +525,10 @@ func (a *MockAuxSigner) UnpackSigs(
 	sigs fn.Option[tlv.Blob]) fn.Result[[]fn.Option[tlv.Blob]] {
 
 	args := a.Called(sigs)
+
+	if f, ok := args.Get(0).(UnpackSigsFunc); ok {
+		return f(sigs)
+	}
 
 	return args.Get(0).(fn.Result[[]fn.Option[tlv.Blob]])
 }

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -606,14 +606,67 @@ func NewDefaultAuxSignerMock(t *testing.T) *MockAuxSigner {
 		"SubmitSecondLevelSigBatch", mock.Anything, mock.Anything,
 		mock.Anything,
 	).Return(nil)
-	auxSigner.On(
-		"PackSigs", mock.Anything,
-	).Return(fn.Ok(fn.Some(sigBlobBuf.Bytes())))
-	auxSigner.On(
-		"UnpackSigs", mock.Anything,
-	).Return(fn.Ok([]fn.Option[tlv.Blob]{
-		fn.Some(sigBlobBuf.Bytes()),
-	}))
+	// A real aux signer emits exactly one slot per HTLC and recovers the
+	// same number of slots when unpacking. Code that pairs the unpacked
+	// slots with HTLCs by index relies on that, so the default mock has to
+	// honour it rather than always reporting a single slot regardless of
+	// how many HTLCs there are.
+	//
+	// The packed blob has to stay a canonical TLV stream, since it is
+	// parsed into custom records on the way out, so the slot count is
+	// carried in the dummy record's value rather than by repeating it.
+	packSlotCount := func(numSlots uint16) fn.Result[fn.Option[tlv.Blob]] {
+		rec := tlv.NewPrimitiveRecord[tlv.TlvType65634](numSlots)
+		stream, err := tlv.NewStream(rec.Record())
+		if err != nil {
+			return fn.Err[fn.Option[tlv.Blob]](err)
+		}
+
+		var buf bytes.Buffer
+		if err := stream.Encode(&buf); err != nil {
+			return fn.Err[fn.Option[tlv.Blob]](err)
+		}
+
+		return fn.Ok(fn.Some(buf.Bytes()))
+	}
+
+	auxSigner.On("PackSigs", mock.Anything).Return(
+		PackSigsFunc(func(
+			sigs []fn.Option[tlv.Blob],
+		) fn.Result[fn.Option[tlv.Blob]] {
+
+			return packSlotCount(uint16(len(sigs)))
+		}),
+	)
+	auxSigner.On("UnpackSigs", mock.Anything).Return(
+		UnpackSigsFunc(func(
+			packed fn.Option[tlv.Blob],
+		) fn.Result[[]fn.Option[tlv.Blob]] {
+
+			blob := packed.UnwrapOr(nil)
+			if len(blob) == 0 {
+				return fn.Ok[[]fn.Option[tlv.Blob]](nil)
+			}
+
+			rec := tlv.ZeroRecordT[tlv.TlvType65634, uint16]()
+			stream, err := tlv.NewStream(rec.Record())
+			if err != nil {
+				return fn.Err[[]fn.Option[tlv.Blob]](err)
+			}
+			if err := stream.Decode(
+				bytes.NewReader(blob),
+			); err != nil {
+				return fn.Err[[]fn.Option[tlv.Blob]](err)
+			}
+
+			slots := make([]fn.Option[tlv.Blob], rec.Val)
+			for idx := range slots {
+				slots[idx] = fn.Some(sigBlobBuf.Bytes())
+			}
+
+			return fn.Ok(slots)
+		}),
+	)
 	auxSigner.On(
 		"VerifySecondLevelSigs", mock.Anything, mock.Anything,
 		mock.Anything,


### PR DESCRIPTION
### Description

This adds a consistency check on the auxiliary HTLC signatures received on taproot overlay channels: their count must match the number of HTLCs on the commitment, mirroring the check that already exists for the BTC-level signatures. It also makes the aux signer test doubles model the one-signature-per-HTLC behaviour of a real aux signer, which the previous mocks did not, along with a few test helpers that were not carrying the aux signature blob the way production does.

Complementary to https://github.com/lightninglabs/taproot-assets/pull/2234