### PR TITLE
lnwallet: prevent transaction pagination overflow

### DIFF
--- a/docs/release-notes/release-notes-0.20.4.md
+++ b/docs/release-notes/release-notes-0.20.4.md
@@ -21,6 +21,11 @@
 
 # Bug Fixes
 
+* [`GetTransactions`
+  pagination](https://github.com/lightningnetwork/lnd/pull/11075) now handles
+  overflowing offset and limit combinations without reaching a slice-bounds
+  panic.
+
 # New Features
 
 ## Functional Enhancements
@@ -56,3 +61,5 @@
 ## Tooling and Documentation
 
 # Contributors (Alphabetical Order)
+
+* Ziggie

--- a/docs/release-notes/release-notes-0.21.3.md
+++ b/docs/release-notes/release-notes-0.21.3.md
@@ -30,6 +30,11 @@
   first block height when calculating a defensive range boundary, and dense
   first blocks no longer produce zero-block reply prefixes.
 
+* [`GetTransactions`
+  pagination](https://github.com/lightningnetwork/lnd/pull/11075) now handles
+  overflowing offset and limit combinations without reaching a slice-bounds
+  panic.
+
 # New Features
 
 ## Functional Enhancements
@@ -71,3 +76,4 @@
 # Contributors (Alphabetical Order)
 
 * Yong Yu
+* Ziggie

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -1554,6 +1554,38 @@ func unminedTransactionsToDetail(
 	return txDetail, nil
 }
 
+// transactionDetailsPage applies the requested offset and limit to a set of
+// transaction details. A zero limit means that all remaining transactions are
+// returned.
+func transactionDetailsPage(txDetails []*lnwallet.TransactionDetail,
+	indexOffset, maxTransactions uint32) ([]*lnwallet.TransactionDetail,
+	uint64, uint64) {
+
+	total := uint64(len(txDetails))
+	first := uint64(indexOffset)
+	if first >= total {
+		return []*lnwallet.TransactionDetail{}, 0, 0
+	}
+
+	end := total
+	if maxTransactions != 0 {
+		// Compare the limit to the remaining count. This avoids adding
+		// caller-controlled values before deciding whether to clamp the
+		// requested end.
+		limit := uint64(maxTransactions)
+		remaining := total - first
+		if limit < remaining {
+			end = first + limit
+		}
+	}
+
+	// Both bounds are no greater than len(txDetails), so these conversions
+	// are safe on both 32-bit and 64-bit platforms.
+	page := txDetails[int(first):int(end)]
+
+	return page, first, end - 1
+}
+
 // ListTransactionDetails returns a list of all transactions which are relevant
 // to the wallet over [startHeight;endHeight]. If start height is greater than
 // end height, the transactions will be retrieved in reverse order. To include
@@ -1607,32 +1639,11 @@ func (b *BtcWallet) ListTransactionDetails(startHeight, endHeight int32,
 		txDetails = append(txDetails, detail)
 	}
 
-	// Return empty transaction list, if offset is more than all
-	// transactions.
-	if int(indexOffset) >= len(txDetails) {
-		txDetails = []*lnwallet.TransactionDetail{}
+	page, firstIndex, lastIndex := transactionDetailsPage(
+		txDetails, indexOffset, maxTransactions,
+	)
 
-		return txDetails, 0, 0, nil
-	}
-
-	end := indexOffset + maxTransactions
-
-	// If maxTransactions is set to 0, then we'll return all transactions
-	// starting from the offset.
-	if maxTransactions == 0 {
-		end = uint32(len(txDetails))
-		txDetails = txDetails[indexOffset:end]
-
-		return txDetails, uint64(indexOffset), uint64(end - 1), nil
-	}
-
-	if end > uint32(len(txDetails)) {
-		end = uint32(len(txDetails))
-	}
-
-	txDetails = txDetails[indexOffset:end]
-
-	return txDetails, uint64(indexOffset), uint64(end - 1), nil
+	return page, firstIndex, lastIndex, nil
 }
 
 // txSubscriptionClient encapsulates the transaction notification client from

--- a/lnwallet/btcwallet/btcwallet_test.go
+++ b/lnwallet/btcwallet/btcwallet_test.go
@@ -1,6 +1,7 @@
 package btcwallet
 
 import (
+	"math"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcjson"
@@ -134,6 +135,79 @@ func TestPreviousOutpoints(t *testing.T) {
 					respOutpoint.IsOurOutput,
 				)
 			}
+		})
+	}
+}
+
+// TestTransactionDetailsPage verifies the bounds returned for transaction
+// pagination, including requests that would overflow with uint32 addition.
+func TestTransactionDetailsPage(t *testing.T) {
+	t.Parallel()
+
+	txDetails := []*lnwallet.TransactionDetail{{}, {}, {}, {}}
+
+	testCases := []struct {
+		name          string
+		offset        uint32
+		limit         uint32
+		expectedPage  []*lnwallet.TransactionDetail
+		expectedFirst uint64
+		expectedLast  uint64
+	}{
+		{
+			name:          "zero limit returns remainder",
+			offset:        1,
+			expectedPage:  txDetails[1:],
+			expectedFirst: 1,
+			expectedLast:  3,
+		},
+		{
+			name:          "limit selects page",
+			offset:        1,
+			limit:         2,
+			expectedPage:  txDetails[1:3],
+			expectedFirst: 1,
+			expectedLast:  2,
+		},
+		{
+			name:          "limit exceeds remainder",
+			offset:        2,
+			limit:         10,
+			expectedPage:  txDetails[2:],
+			expectedFirst: 2,
+			expectedLast:  3,
+		},
+		{
+			name:          "offset plus limit exceeds uint32",
+			offset:        1,
+			limit:         math.MaxUint32,
+			expectedPage:  txDetails[1:],
+			expectedFirst: 1,
+			expectedLast:  3,
+		},
+		{
+			name:         "offset equals transaction count",
+			offset:       uint32(len(txDetails)),
+			limit:        1,
+			expectedPage: []*lnwallet.TransactionDetail{},
+		},
+		{
+			name:         "maximum offset",
+			offset:       math.MaxUint32,
+			limit:        1,
+			expectedPage: []*lnwallet.TransactionDetail{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			page, first, last := transactionDetailsPage(
+				txDetails, testCase.offset, testCase.limit,
+			)
+
+			require.Equal(t, testCase.expectedPage, page)
+			require.Equal(t, testCase.expectedFirst, first)
+			require.Equal(t, testCase.expectedLast, last)
 		})
 	}
 }


### PR DESCRIPTION
## Change Description

`ListTransactionDetails` accepts `indexOffset` and `maxTransactions` as
`uint32` values and previously added them before clamping the requested
endpoint to the number of available transactions. The `GetTransactions` RPC
passes both request fields through without restricting their sum.

A sufficiently large limit can therefore wrap the endpoint modulo `2^32`.
For example, an offset of one and a limit of `math.MaxUint32` produce an
endpoint of zero. If at least two transactions are available, the resulting
`txDetails[1:0]` operation raises a runtime slice-bounds panic instead of
returning the remaining transactions.

This PR moves pagination into a focused helper. It checks the offset against
the slice length using `uint64`, calculates the requested endpoint in `uint64`,
and converts to `int` only after the value is proven to be within the slice.

The existing pagination behavior is preserved:

* a zero limit returns every transaction from the offset;
* oversized limits are clamped to the available transactions;
* offsets at or beyond the end return an empty page with zero indices.

The wider offset comparison also avoids an unsafe `uint32`-to-`int`
conversion on 32-bit systems.

## User Impact

Malformed but authorized `GetTransactions` pagination values no longer reach a
slice-bounds panic. On versions with RPC panic recovery this avoids an internal
RPC error and recovered-panic log; on versions without that recovery it also
prevents a process-level denial of service.

## Steps to Test

```text
go test ./lnwallet/btcwallet -run TestPaginateTransactionDetails -count=1
go test -race ./lnwallet/btcwallet -run TestPaginateTransactionDetails -count=1
go test ./lnwallet/btcwallet -count=1
```

The regression table covers unlimited, bounded, clamped, overflowing,
end-of-list, and maximum-offset requests. Restoring the old `uint32` addition
makes the overflow case panic with a slice bounds error.

This change is extracted from the second commit in Boris Nagaev's
[additional range fixes gist](https://gist.github.com/starius/22723fb38db981aa2357320921e0cd7c).
