### PR TITLE
docs: align SECURITY.md supported versions with support policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,16 @@
 
 ## Supported Versions
 
-The last major lnd release is to be considered the current support version. Given an issue severe enough, a backport will be issued either to the prior major release or the set of releases considered utilized enough. 
+Lightning Labs maintains the <ins>**two most recent lnd release lines**</ins>: the current major line and the one immediately before it. Both maintained lines receive security fixes. When a fix lands on the current line and applies to the previous line, it is normally backported and shipped in a minor release on that line.
+
+lnd releases are tagged `v0.MAJOR.MINOR-beta` — the middle component is the major version, so `v0.21` and `v0.20` are different release lines.
+
+When a new major release ships, the older of the two maintained lines reaches end of life that day. An end-of-life line receives **no further releases of any kind, including security fixes**. If a vulnerability affects an end-of-life line, the remedy is an upgrade to a maintained line.
+
+> [!IMPORTANT]
+> We recommend running the latest minor release of the most recent major line you are able to upgrade to. A maintained line only protects you if you are on its latest minor release.
+
+The full support policy, including the per-line maintenance table and the advisory disclosure schedule, is published at https://security.lightning.engineering/lifecycle/
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Problem

The `Supported Versions` section of SECURITY.md still describes the pre-policy situation: only the last major release is the supported version, with backports issued ad hoc "given an issue severe enough".

The published Lightning Labs support policy at https://security.lightning.engineering/lifecycle/ states instead that:

- the **two most recent release lines** are maintained (current major line + the one before it);
- both maintained lines receive security fixes, with fixes normally backported to the previous line;
- a line reaches **end of life** when the second major release after it ships, and EOL lines receive no further releases of any kind — the remedy is an upgrade.

## Change

- Rewrite `Supported Versions` to match the published policy, using its wording so the two documents cannot drift into contradiction.
- Explain the `v0.MAJOR.MINOR-beta` versioning scheme (middle component is the major version), since the old "major release" phrasing was ambiguous under it.
- Link to the lifecycle page as the source of truth for the per-line maintenance table and the advisory disclosure schedule, so this file does not need updating on every release.

The `Reporting a Vulnerability` section is unchanged.