### PR TITLE
docs: add 11035 entries to the 0.20.4 release notes

### DIFF
--- a/docs/release-notes/release-notes-0.20.4.md
+++ b/docs/release-notes/release-notes-0.20.4.md
@@ -21,6 +21,15 @@
 
 # Bug Fixes
 
+* Channel funding attempts [now return
+  cleanly](https://github.com/lightningnetwork/lnd/pull/11035) when their
+  pending wallet reservation is no longer present.
+
+* Zero-block [`query_channel_range` and `reply_channel_range`
+  messages](https://github.com/lightningnetwork/lnd/pull/11035) now retain their
+  first block height when calculating a defensive range boundary, and dense
+  first blocks no longer produce zero-block reply prefixes.
+
 * [`GetTransactions`
   pagination](https://github.com/lightningnetwork/lnd/pull/11075) now handles
   overflowing offset and limit combinations without reaching a slice-bounds
@@ -62,4 +71,5 @@
 
 # Contributors (Alphabetical Order)
 
+* Yong Yu
 * Ziggie


### PR DESCRIPTION
The p2p wedge fixes from #11035 are being backported to the `v0.20.x-branch` (see the backport PR for 11035), so this mirrors their entries in `release-notes-0.20.4.md` on master.

Master already carries these entries in `release-notes-0.21.3.md`; this only fills in the 0.20.4 file, which was still empty.

No code changes.