### PR TITLE
docs: move XCreateAccount release notes to 0.21.3

### DIFF
--- a/docs/release-notes/release-notes-0.21.3.md
+++ b/docs/release-notes/release-notes-0.21.3.md
@@ -45,7 +45,28 @@
 
 ## RPC Additions
 
+* A new [`walletrpc.XCreateAccount`](https://github.com/lightningnetwork/lnd/pull/11065)
+  RPC creates a named wallet account whose keys are derived from the wallet's
+  master key. Unlike `ImportAccount`, which registers a watch-only account from
+  an extended public key, the resulting account can sign for its own outputs, so
+  a single wallet can be partitioned into isolated pockets of funds: coin
+  selection, change, balance and address derivation can all be scoped to an
+  account by name.
+
+  The RPC is **experimental**, which the `X` prefix marks: it may change or be
+  removed without the usual deprecation period. It is additionally gated on
+  release builds, where a caller must set `i_know_what_i_am_doing`, following
+  the same pattern as `AbandonChannel`. A seed-only restore does not rediscover
+  funds held in an account created this way, because the recovery scan only
+  rederives addresses for the default account, and reconstructing one by hand
+  requires reproducing its key scope, its account index and the addresses it
+  had issued. Both gates come off once recovery handles these accounts.
+
 ## lncli Additions
+
+* A new [`wallet accounts create`](https://github.com/lightningnetwork/lnd/pull/11065)
+  command creates a wallet-owned named account via the new `XCreateAccount`
+  RPC.
 
 # Improvements
 
@@ -79,5 +100,6 @@
 
 # Contributors (Alphabetical Order)
 
+* Elle Mouton
 * Yong Yu
 * Ziggie

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -72,23 +72,6 @@
   the chain backend via bitcoind's `submitpackage`, allowing a zero-fee v3/TRUC
   parent to be accepted together with a fee-paying CPFP child.
 
-* A new [`walletrpc.XCreateAccount`](https://github.com/lightningnetwork/lnd/pull/11065)
-  RPC creates a named wallet account whose keys are derived from the wallet's
-  master key. Unlike `ImportAccount`, which registers a watch-only account from
-  an extended public key, the resulting account can sign for its own outputs, so
-  a single wallet can be partitioned into isolated pockets of funds: coin
-  selection, change, balance and address derivation can all be scoped to an
-  account by name.
-
-  The RPC is **experimental**, which the `X` prefix marks: it may change or be
-  removed without the usual deprecation period. It is additionally gated on
-  release builds, where a caller must set `i_know_what_i_am_doing`, following
-  the same pattern as `AbandonChannel`. A seed-only restore does not rediscover
-  funds held in an account created this way, because the recovery scan only
-  rederives addresses for the default account, and reconstructing one by hand
-  requires reproducing its key scope, its account index and the addresses it
-  had issued. Both gates come off once recovery handles these accounts.
-
 ## lncli Additions
 
 * The `estimateroutefee` command now supports [restricting fee estimates to
@@ -100,10 +83,6 @@
   [`wallet submitpackage`](https://github.com/lightningnetwork/lnd/pull/10900)
   command submits a package of hex-encoded transactions via the new
   `SubmitPackage` RPC.
-
-* A new [`wallet accounts create`](https://github.com/lightningnetwork/lnd/pull/11065)
-  command creates a wallet-owned named account via the new `XCreateAccount`
-  RPC.
 
 # Improvements
 


### PR DESCRIPTION
XCreateAccount (#11065) is being backported to the `v0.21.x` branch in #11086, so its release notes entries belong with the release that first ships it.

This moves both entries — the `walletrpc.XCreateAccount` RPC addition and the `wallet accounts create` lncli addition — from `release-notes-0.22.0.md` to `release-notes-0.21.3.md`, verbatim. `Elle Mouton` is added to the 0.21.3 contributor list.

This matches how every other change backported to 0.21.3 is documented. #11035, #11075 and #10869 all appear **only** in the 0.21.3 notes, never in the 0.22.0 notes, even though their code is on master and will therefore also ship in 0.22.0. #11065 was the sole exception, because at the time its notes were written the backport was not yet on the table.

Net effect is a pure move: 21 lines out of 0.22.0, the same 21 lines into 0.21.3, plus the one contributor line.

### Merge order

**Draft until #11086 lands.** Until the backport merges, 0.21.3 does not actually contain the feature, so merging this first would have master claiming a feature for a release that does not have it. Ready to un-draft the moment #11086 is in.