### PR TITLE
lnwallet: fix lnwallet test compilation on v0.21.x

### DIFF
--- a/lnwallet/wallet_test.go
+++ b/lnwallet/wallet_test.go
@@ -3,7 +3,7 @@ package lnwallet
 import (
 	"testing"
 
-	"github.com/lightningnetwork/lnd/chanstate"
+	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,7 +15,7 @@ func TestHandleFundingCounterPartySigsMissingReservation(t *testing.T) {
 	wallet := &LightningWallet{
 		fundingLimbo: make(map[uint64]*ChannelReservation),
 	}
-	completeChan := make(chan *chanstate.OpenChannel, 1)
+	completeChan := make(chan *channeldb.OpenChannel, 1)
 	errChan := make(chan error, 1)
 
 	wallet.handleFundingCounterPartySigs(&addCounterPartySigsMsg{


### PR DESCRIPTION
The `lnwallet` test package does not compile on this branch, which fails CI for **every** PR targeting it, regardless of that PR's own contents.

```
lnwallet/wallet_test.go:6:2: no required module provides package
  github.com/lightningnetwork/lnd/chanstate
```

### Cause

The regression test added by the backport of #11035 was taken verbatim from master, where the `OpenChannel` type lives in the `chanstate` package. That package does not exist on this branch. The cherry-pick applied without a conflict because the commit only *adds* an import line and a new function — there was nothing textual for git to reconcile — so the breakage landed silently.

### Impact

Because the missing package is unresolvable in the module graph, this breaks considerably more than `go test ./lnwallet`:

| Check | Failure |
|---|---|
| Run unit tests (all variants) | `FAIL github.com/lightningnetwork/lnd/lnwallet [setup failed]` |
| Check commits | `no required module provides package .../chanstate` |
| Lint code | `could not load export data for ".../chanstate"` → `Makefile:378: lint-source Error 3` |
| Cross compilation | `no required module provides package` → `Makefile:199: release Error 1` |

`make release` and golangci-lint both resolve test imports, which is why even the build-only jobs fail.

### Fix

Use `channeldb.OpenChannel` — the type `completeChan` actually carries on this branch (`lnwallet/wallet.go:337`, `:366`). Two lines; no production code touched.

### Testing

- `go vet ./...` — clean (previously reported the error above)
- `go build ./...` — clean
- `go test ./lnwallet/ -run TestHandleFundingCounterPartySigsMissingReservation` — passes, having been uncompilable before