### PR TITLE
multi: contain panics at fail-stop async boundaries

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -207,6 +207,9 @@ linters:
       multi-func: true
 
     custom:
+      deferrecover:
+        type: module
+        description: Require fn.RecoverPanic to be deferred directly.
       ll:
         type: module
         description: Custom lll linter with 'S' log line exclusion.

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"runtime/debug"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1739,21 +1738,14 @@ func (d *AuthenticatedGossiper) finalizeGossipProcessing(logCtx context.Context,
 		peerPub = "unknown"
 	}
 
-	log.ErrorS(logCtx, "Panic during gossip message processing",
-		fmt.Errorf("%v", r),
+	fn.LogRecoveredPanicWithDebugStack(
+		logCtx, log, fn.Panic{
+			Value: r,
+			Stack: fn.PanicStack(),
+		},
 		slog.String("context", ctxStr),
 		slog.String("msg_type", msgType),
 		slog.String("peer", peerPub),
-	)
-	// Truncate the stack trace to avoid filling up disk space if an
-	// attacker repeatedly triggers panics.
-	const maxStackSize = 8192
-	stack := debug.Stack()
-	if len(stack) > maxStackSize {
-		stack = stack[:maxStackSize]
-	}
-	log.DebugS(logCtx, "Panic stack trace",
-		slog.String("stack", string(stack)),
 	)
 
 	// Signal any dependents waiting on this message so they don't block

--- a/docs/release-notes/release-notes-0.20.4.md
+++ b/docs/release-notes/release-notes-0.20.4.md
@@ -71,6 +71,13 @@
 
 ## Code Health
 
+* Selected asynchronous boundaries [now contain unexpected
+  panics](https://github.com/lightningnetwork/lnd/pull/11097) when the affected
+  execution unit can be retired safely. Peer handlers disconnect the affected
+  peer, buffer-pool tasks retire their worker state, legacy cooperative-close
+  failures tear down their negotiation, and zombie reservation sweeps retry on
+  a later tick. Recovered failures use consistent bounded stack reporting.
+
 ## Tooling and Documentation
 
 # Contributors (Alphabetical Order)

--- a/docs/release-notes/release-notes-0.21.3.md
+++ b/docs/release-notes/release-notes-0.21.3.md
@@ -96,6 +96,13 @@
 
 ## Code Health
 
+* Selected asynchronous boundaries [now contain unexpected
+  panics](https://github.com/lightningnetwork/lnd/pull/11097) when the affected
+  execution unit can be retired safely. Peer handlers disconnect the affected
+  peer, buffer-pool tasks retire their worker state, legacy cooperative-close
+  failures tear down their negotiation, and zombie reservation sweeps retry on
+  a later tick. Recovered failures use consistent bounded stack reporting.
+
 ## Tooling and Documentation
 
 # Contributors (Alphabetical Order)

--- a/fn/stack.go
+++ b/fn/stack.go
@@ -1,0 +1,234 @@
+package fn
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"runtime/debug"
+)
+
+const (
+	// maxPanicStackSize is the largest recovered-panic stack trace returned
+	// by these helpers. Bounding it keeps repeated reports from consuming
+	// excessive log space.
+	maxPanicStackSize = 8192
+
+	// panicStackTruncatedMsg is appended in place of whatever we cut, so
+	// that whoever reads the log can tell the trace is incomplete instead
+	// of assuming it ended where it stops.
+	panicStackTruncatedMsg = "\n... stack trace truncated ..."
+)
+
+// errRecoveredPanic is the sentinel error attached to every structured log
+// record emitted for a recovered panic.
+var errRecoveredPanic = errors.New("recovered panic")
+
+// Panic carries the details of a panic we stopped: the value handed to panic(),
+// and a stack trace bounded to a size that's safe to log. The trace still
+// covers the frames the panic came from, not just the point we caught it at.
+type Panic struct {
+	// Value is whatever was passed to panic().
+	Value any
+
+	// Stack is the stack trace of the panicking goroutine, truncated to a
+	// bounded size.
+	Stack []byte
+}
+
+// PanicLogger is the minimal structured-logging surface needed to report a
+// recovered panic. Keeping the interface here avoids coupling fn to a concrete
+// logging package.
+type PanicLogger interface {
+	ErrorS(context.Context, string, error, ...any)
+}
+
+// PanicDebugLogger extends PanicLogger with the structured debug logging used
+// when a remotely-triggerable path should keep its stack trace below error
+// level.
+type PanicDebugLogger interface {
+	PanicLogger
+
+	DebugS(context.Context, string, ...any)
+}
+
+// LogRecoveredPanic records a recovered panic in a consistent structured
+// format. The logger's subsystem and the captured stack identify where the
+// panic was recovered. Callers can attach domain-specific context as additional
+// structured attributes.
+//
+// Reporting is best effort. A panic while formatting or writing the record is
+// recovered so the reporting path can return normally.
+func LogRecoveredPanic(ctx context.Context, logger PanicLogger,
+	p Panic, extraAttrs ...any) {
+
+	logRecoveredPanic(ctx, logger, p, true, extraAttrs...)
+}
+
+// LogRecoveredPanicWithDebugStack records the panic summary at error level and
+// its bounded stack trace at debug level. This is intended for paths where an
+// untrusted caller could repeatedly trigger the same panic and amplify error
+// logs. Domain-specific attributes are included in both records so they can be
+// correlated.
+//
+// Reporting is best effort. A panic while formatting or writing either record
+// is recovered so the reporting path can return normally.
+func LogRecoveredPanicWithDebugStack(ctx context.Context,
+	logger PanicDebugLogger, p Panic, extraAttrs ...any) {
+
+	logRecoveredPanic(ctx, logger, p, false, extraAttrs...)
+
+	if logger == nil {
+		return
+	}
+
+	// A panic in the logging path must not interrupt the caller's panic
+	// containment and cleanup.
+	defer func() {
+		_ = recover()
+	}()
+
+	attrs := make([]any, 0, len(extraAttrs)+1)
+	attrs = append(attrs, extraAttrs...)
+	attrs = append(attrs, slog.String("stack", string(p.Stack)))
+
+	logger.DebugS(ctx, "Recovered panic stack trace", attrs...)
+}
+
+// logRecoveredPanic records the common error-level panic fields and optionally
+// includes the stack trace in the same record.
+func logRecoveredPanic(ctx context.Context, logger PanicLogger, p Panic,
+	includeStack bool, extraAttrs ...any) {
+
+	if logger == nil {
+		return
+	}
+
+	// A panic in the logging path must not interrupt the caller's panic
+	// containment and cleanup.
+	defer func() {
+		_ = recover()
+	}()
+
+	attrs := []any{
+		slog.String("panic_type", fmt.Sprintf("%T", p.Value)),
+		slog.Any("panic_value", p.Value),
+	}
+	if includeStack {
+		attrs = append(attrs, slog.String("stack", string(p.Stack)))
+	}
+	attrs = append(attrs, extraAttrs...)
+
+	logger.ErrorS(
+		ctx, "Recovered panic", errRecoveredPanic, attrs...,
+	)
+}
+
+// RecoverPanic stops a panic from unwinding the calling goroutine any further
+// and hands the details to onPanic. If the goroutine isn't panicking, onPanic
+// is never called and no stack is captured.
+//
+// This MUST be deferred directly:
+//
+//	defer fn.RecoverPanic(func(p fn.Panic) {
+//	        fn.LogRecoveredPanic(ctx, logger, p)
+//	        // ...subsystem-specific cleanup...
+//	})
+//
+// Wrapping it in a closure instead, as in
+// `defer func() { fn.RecoverPanic(..) }()`, silently does nothing: the language
+// only lets recover() stop a panic when it's called by the deferred function
+// itself, so one frame further down it returns nil and the panic carries on
+// unwinding.
+//
+// After recovery, the function containing the defer returns. Execution does
+// not resume at the panic site. Place the defer in a per-item wrapper only when
+// its caller can safely continue with the next item.
+//
+// A nil onPanic callback is allowed. If the callback panics, that new panic is
+// also contained and reported best-effort to stderr because the normal logging
+// path may be what failed.
+func RecoverPanic(onPanic func(Panic)) {
+	recoverPanic(recover(), onPanic, os.Stderr)
+}
+
+// recoverPanic handles a value returned by recover. Keeping the callback and
+// fallback handling separate makes the containment behavior testable without
+// replacing the process-wide stderr stream.
+func recoverPanic(r any, onPanic func(Panic), fallbackWriter io.Writer) {
+	if r == nil {
+		return
+	}
+
+	if onPanic == nil {
+		return
+	}
+
+	panicDetails := Panic{
+		Value: r,
+		Stack: TruncatePanicStack(debug.Stack()),
+	}
+
+	defer func() {
+		callbackPanic := recover()
+		if callbackPanic == nil {
+			return
+		}
+
+		reportCallbackPanic(
+			fallbackWriter, r, callbackPanic,
+			TruncatePanicStack(debug.Stack()),
+		)
+	}()
+
+	onPanic(panicDetails)
+}
+
+// reportCallbackPanic writes a last-resort report when the callback used to
+// contain a panic also panics. The report path must never propagate a panic.
+func reportCallbackPanic(writer io.Writer, originalPanic,
+	callbackPanic any, stack []byte) {
+
+	defer func() {
+		_ = recover()
+	}()
+
+	_, _ = fmt.Fprintf(
+		writer, "fn: panic handler panicked: %v "+
+			"(while containing %T: %v)\n%s\n", callbackPanic,
+		originalPanic, originalPanic, stack,
+	)
+}
+
+// PanicStack returns the stack trace of the calling goroutine, bounded to the
+// configured size.
+func PanicStack() []byte {
+	return TruncatePanicStack(debug.Stack())
+}
+
+// TruncatePanicStack caps a panic stack trace at a bounded size. Where it can,
+// it cuts on a line boundary so the last frame in the log stays readable rather
+// than ending mid-token, and it marks the cut so the trace doesn't look
+// complete.
+func TruncatePanicStack(stack []byte) []byte {
+	if len(stack) <= maxPanicStackSize {
+		return stack
+	}
+
+	suffix := []byte(panicStackTruncatedMsg)
+	maxStackLen := maxPanicStackSize - len(suffix)
+	searchStack := stack[:maxStackLen+1]
+	newLineIndex := bytes.LastIndexByte(searchStack, '\n')
+	if newLineIndex > 0 {
+		maxStackLen = newLineIndex
+	}
+
+	truncatedStack := make([]byte, 0, maxStackLen+len(suffix))
+	truncatedStack = append(truncatedStack, stack[:maxStackLen]...)
+	truncatedStack = append(truncatedStack, suffix...)
+
+	return truncatedStack
+}

--- a/fn/stack_test.go
+++ b/fn/stack_test.go
@@ -1,0 +1,296 @@
+package fn
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestLogRecoveredPanic asserts that recovered panics use one structured log
+// shape, preserve caller attributes, and handle failures during logging.
+func TestLogRecoveredPanic(t *testing.T) {
+	t.Parallel()
+
+	t.Run("structured record", func(t *testing.T) {
+		t.Parallel()
+
+		logger := &capturingPanicLogger{}
+		panicValue := panicTestValue{code: 7}
+		LogRecoveredPanic(
+			context.Background(), logger, Panic{
+				Value: panicValue,
+				Stack: []byte("bounded stack"),
+			}, slog.String("message_type", "CommitSig"),
+		)
+
+		require.Equal(
+			t, "Recovered panic", logger.msg,
+		)
+		require.ErrorIs(t, logger.err, errRecoveredPanic)
+
+		attrs := make(map[string]slog.Value, len(logger.attrs))
+		for _, value := range logger.attrs {
+			attr, ok := value.(slog.Attr)
+			require.True(t, ok)
+
+			attrs[attr.Key] = attr.Value
+		}
+
+		require.Len(t, attrs, 4)
+		require.Equal(t, "CommitSig", attrs["message_type"].String())
+		require.Equal(
+			t, "fn.panicTestValue", attrs["panic_type"].String(),
+		)
+		require.Equal(t, slog.KindAny, attrs["panic_value"].Kind())
+		require.Equal(t, panicValue, attrs["panic_value"].Any())
+		require.Equal(t, "bounded stack", attrs["stack"].String())
+	})
+
+	t.Run("logging panic is handled", func(t *testing.T) {
+		t.Parallel()
+
+		require.NotPanics(t, func() {
+			LogRecoveredPanic(
+				context.Background(), panickingPanicLogger{},
+				Panic{
+					Value: errors.New("boom"),
+				},
+			)
+		})
+	})
+
+	t.Run("stack can be logged at debug", func(t *testing.T) {
+		t.Parallel()
+
+		logger := &capturingPanicLogger{}
+		LogRecoveredPanicWithDebugStack(
+			context.Background(), logger, Panic{
+				Value: "boom",
+				Stack: []byte("bounded stack"),
+			}, slog.String("peer", "alice"),
+		)
+
+		errorAttrs := attrsByKey(t, logger.attrs)
+		require.NotContains(t, errorAttrs, "stack")
+		require.Equal(t, "alice", errorAttrs["peer"].String())
+
+		require.Equal(
+			t, "Recovered panic stack trace", logger.debugMsg,
+		)
+		debugAttrs := attrsByKey(t, logger.debugAttrs)
+		require.Equal(t, "alice", debugAttrs["peer"].String())
+		require.Equal(
+			t, "bounded stack", debugAttrs["stack"].String(),
+		)
+	})
+}
+
+// TestTruncatePanicStack asserts that panic stack traces are capped with a
+// readable truncation marker.
+func TestTruncatePanicStack(t *testing.T) {
+	t.Parallel()
+
+	shortStack := []byte("short stack")
+	require.Equal(t, shortStack, TruncatePanicStack(shortStack))
+
+	longStack := bytes.Repeat([]byte("stack frame\n"), maxPanicStackSize)
+	truncatedStack := TruncatePanicStack(longStack)
+
+	require.LessOrEqual(t, len(truncatedStack), maxPanicStackSize)
+	require.True(
+		t, bytes.HasSuffix(
+			truncatedStack, []byte(panicStackTruncatedMsg),
+		),
+	)
+}
+
+// TestRecoverPanic asserts that RecoverPanic stops a panic and reports it, that
+// it stays out of the way when nothing panicked, and that the stack it hands
+// back still names the function the panic actually came from.
+func TestRecoverPanic(t *testing.T) {
+	t.Parallel()
+
+	t.Run("recovers and reports", func(t *testing.T) {
+		t.Parallel()
+
+		var got Panic
+
+		func() {
+			defer RecoverPanic(func(p Panic) {
+				got = p
+			})
+
+			deepRecurse(0)
+		}()
+
+		require.Equal(t, "deep", got.Value)
+
+		// The trace has to name where the panic came from, not just the
+		// frame we caught it in, or it's of little use in a log.
+		require.Contains(
+			t, string(got.Stack), "deepRecurse",
+		)
+	})
+
+	t.Run("no panic means no callback", func(t *testing.T) {
+		t.Parallel()
+
+		called := false
+
+		func() {
+			defer RecoverPanic(func(p Panic) {
+				called = true
+			})
+		}()
+
+		require.False(t, called)
+	})
+
+	t.Run("named return can be set", func(t *testing.T) {
+		t.Parallel()
+
+		// The common use is turning a panic into an error, which relies
+		// on the callback being able to write the enclosing function's
+		// named return before it actually returns.
+		got := func() (err error) {
+			defer RecoverPanic(func(p Panic) {
+				err = fmt.Errorf("recovered panic: %v", p.Value)
+			})
+
+			panic("boom")
+		}()
+
+		require.ErrorContains(t, got, "boom")
+	})
+
+	t.Run("stack is bounded", func(t *testing.T) {
+		t.Parallel()
+
+		var got Panic
+
+		func() {
+			defer RecoverPanic(func(p Panic) {
+				got = p
+			})
+
+			deepRecurse(512)
+		}()
+
+		require.LessOrEqual(t, len(got.Stack), maxPanicStackSize)
+	})
+
+	t.Run("nil callback is contained", func(t *testing.T) {
+		t.Parallel()
+
+		require.NotPanics(t, func() {
+			func() {
+				defer RecoverPanic(nil)
+
+				panic("boom")
+			}()
+		})
+	})
+
+	t.Run("callback panic is contained", func(t *testing.T) {
+		t.Parallel()
+
+		var output bytes.Buffer
+		panickingCallback := func(Panic) {
+			panic("callback failed")
+		}
+
+		require.NotPanics(t, func() {
+			recoverPanic(
+				"original panic", panickingCallback, &output,
+			)
+		})
+		require.Contains(t, output.String(), "callback failed")
+		require.Contains(t, output.String(), "original panic")
+		require.Contains(t, output.String(), "TestRecoverPanic")
+
+		require.NotPanics(t, func() {
+			recoverPanic(
+				"original panic", panickingCallback,
+				panickingWriter{},
+			)
+		})
+	})
+}
+
+// deepRecurse panics from the bottom of a deep call stack, so that the trace is
+// long enough to need truncating.
+func deepRecurse(depth int) {
+	if depth == 0 {
+		panic("deep")
+	}
+
+	deepRecurse(depth - 1)
+}
+
+// capturingPanicLogger records the arguments passed to ErrorS.
+type capturingPanicLogger struct {
+	msg        string
+	err        error
+	attrs      []any
+	debugMsg   string
+	debugAttrs []any
+}
+
+// ErrorS records a structured error log call.
+func (l *capturingPanicLogger) ErrorS(_ context.Context, msg string, err error,
+	attrs ...any) {
+
+	l.msg = msg
+	l.err = err
+	l.attrs = attrs
+}
+
+// DebugS records a structured debug log call.
+func (l *capturingPanicLogger) DebugS(_ context.Context, msg string,
+	attrs ...any) {
+
+	l.debugMsg = msg
+	l.debugAttrs = attrs
+}
+
+// attrsByKey returns structured attributes keyed by name.
+func attrsByKey(t *testing.T, attrs []any) map[string]slog.Value {
+	t.Helper()
+
+	result := make(map[string]slog.Value, len(attrs))
+	for _, value := range attrs {
+		attr, ok := value.(slog.Attr)
+		require.True(t, ok)
+
+		result[attr.Key] = attr.Value
+	}
+
+	return result
+}
+
+// panickingPanicLogger panics whenever ErrorS is called.
+type panickingPanicLogger struct{}
+
+// ErrorS simulates a panic raised while reporting another panic.
+func (panickingPanicLogger) ErrorS(context.Context, string, error, ...any) {
+	panic("logger failed")
+}
+
+// panicTestValue is a non-string panic value used to verify that structured
+// logging preserves the original value.
+type panicTestValue struct {
+	code int
+}
+
+// panickingWriter simulates a failure in the stderr fallback path.
+type panickingWriter struct{}
+
+// Write panics when the fallback report is written.
+func (panickingWriter) Write([]byte) (int, error) {
+	panic("writer failed")
+}

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -171,14 +172,17 @@ type reservationWithCtx struct {
 	err     chan error
 }
 
-// isLocked checks the reservation's timestamp to determine whether it is
-// locked.
-func (r *reservationWithCtx) isLocked() bool {
+// isExpired reports whether the reservation has been idle for longer than the
+// timeout. A zero timestamp represents a locked reservation and never expires.
+func (r *reservationWithCtx) isExpired(timeout time.Duration) bool {
 	r.updateMtx.RLock()
 	defer r.updateMtx.RUnlock()
 
-	// The time zero value represents a locked reservation.
-	return r.lastUpdated.IsZero()
+	if r.lastUpdated.IsZero() {
+		return false
+	}
+
+	return time.Since(r.lastUpdated) > timeout
 }
 
 // updateTimestamp updates the reservation's timestamp with the current time.
@@ -5357,28 +5361,19 @@ func (f *Manager) handleErrorMsg(peer lnpeer.Peer, msg *lnwire.Error) {
 // funding flow for any reservations that have not been updated since the
 // ReservationTimeout and are not locked waiting for the funding transaction.
 func (f *Manager) pruneZombieReservations() {
-	zombieReservations := make(pendingChannels)
+	// This maintenance boundary does not advance a funding protocol state
+	// machine. If a panic happens before cancellation completes, the
+	// reservation remains indexed for a later sweep. After it is removed,
+	// cancellation is complete. A later notification failure cannot resume
+	// the flow. The locks reached below are released by deferred unlocks.
+	defer fn.RecoverPanic(func(pnc fn.Panic) {
+		fn.LogRecoveredPanic(
+			context.Background(), log, pnc,
+			slog.String("operation", "prune_zombie_reservations"),
+		)
+	})
 
-	f.resMtx.RLock()
-	for _, pendingReservations := range f.activeReservations {
-		for pendingChanID, resCtx := range pendingReservations {
-			if resCtx.isLocked() {
-				continue
-			}
-
-			// We don't want to expire PSBT funding reservations.
-			// These reservations are always initiated by us and the
-			// remote peer is likely going to cancel them after some
-			// idle time anyway. So no need for us to also prune
-			// them.
-			sinceLastUpdate := time.Since(resCtx.lastUpdated)
-			isExpired := sinceLastUpdate > f.cfg.ReservationTimeout
-			if !resCtx.reservation.IsPsbt() && isExpired {
-				zombieReservations[pendingChanID] = resCtx
-			}
-		}
-	}
-	f.resMtx.RUnlock()
+	zombieReservations := f.findZombieReservations()
 
 	for pendingChanID, resCtx := range zombieReservations {
 		err := fmt.Errorf("reservation timed out waiting for peer "+
@@ -5397,6 +5392,32 @@ func (f *Manager) pruneZombieReservations() {
 
 		f.failFundingFlow(resCtx.peer, cid, err)
 	}
+}
+
+// findZombieReservations returns the pending reservations that have expired.
+func (f *Manager) findZombieReservations() pendingChannels {
+	zombieReservations := make(pendingChannels)
+
+	f.resMtx.RLock()
+	defer f.resMtx.RUnlock()
+
+	for _, pendingReservations := range f.activeReservations {
+		for pendingChanID, resCtx := range pendingReservations {
+			// We don't want to expire PSBT funding reservations.
+			// These reservations are always initiated by us and the
+			// remote peer is likely going to cancel them after some
+			// idle time anyway. So no need for us to also prune
+			// them.
+			if !resCtx.reservation.IsPsbt() && resCtx.isExpired(
+				f.cfg.ReservationTimeout,
+			) {
+
+				zombieReservations[pendingChanID] = resCtx
+			}
+		}
+	}
+
+	return zombieReservations
 }
 
 // cancelReservationCtx does all needed work in order to securely cancel the

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -5447,3 +5447,61 @@ func TestChannelReadyUnknownChannelID(t *testing.T) {
 		t, alice, bob, 500000, 0, 1, updateChan, true, nil,
 	)
 }
+
+// TestPruneZombieReservationsPanicRecovery verifies that a malformed
+// reservation cannot terminate the coordinator or leave its mutex read-locked.
+func TestPruneZombieReservationsPanicRecovery(t *testing.T) {
+	t.Parallel()
+
+	manager := &Manager{
+		cfg: &Config{
+			ReservationTimeout: time.Second,
+		},
+		activeReservations: map[serializedPubKey]pendingChannels{
+			{1}: {
+				PendingChanID{1}: nil,
+			},
+		},
+	}
+
+	require.NotPanics(t, manager.pruneZombieReservations)
+	lockReleased := manager.resMtx.TryLock()
+	require.True(
+		t, lockReleased, "reservation lock was not released",
+	)
+	manager.resMtx.Unlock()
+}
+
+// TestReservationExpiryConcurrentUpdate verifies that the zombie sweep reads
+// the reservation timestamp under the same lock used by funding updates.
+func TestReservationExpiryConcurrentUpdate(t *testing.T) {
+	t.Parallel()
+
+	reservation := &reservationWithCtx{
+		lastUpdated: time.Now().Add(-time.Hour),
+	}
+	require.True(t, reservation.isExpired(time.Minute))
+
+	start := make(chan struct{})
+	done := make(chan struct{}, 2)
+	go func() {
+		<-start
+		for range 1000 {
+			reservation.updateTimestamp()
+		}
+		done <- struct{}{}
+	}()
+	go func() {
+		<-start
+		for range 1000 {
+			_ = reservation.isExpired(time.Minute)
+		}
+		done <- struct{}{}
+	}()
+
+	close(start)
+	<-done
+	<-done
+
+	require.False(t, reservation.isExpired(time.Minute))
+}

--- a/log.go
+++ b/log.go
@@ -51,6 +51,7 @@ import (
 	paymentsdb "github.com/lightningnetwork/lnd/payments/db"
 	"github.com/lightningnetwork/lnd/peer"
 	"github.com/lightningnetwork/lnd/peernotifier"
+	"github.com/lightningnetwork/lnd/pool"
 	"github.com/lightningnetwork/lnd/protofsm"
 	"github.com/lightningnetwork/lnd/routing"
 	"github.com/lightningnetwork/lnd/routing/blindedpath"
@@ -210,6 +211,7 @@ func SetupLoggers(root *build.SubLoggerManager, interceptor signal.Interceptor) 
 	AddSubLogger(root, graphdb.Subsystem, interceptor, graphdb.UseLogger)
 	AddSubLogger(root, chainio.Subsystem, interceptor, chainio.UseLogger)
 	AddSubLogger(root, msgmux.Subsystem, interceptor, msgmux.UseLogger)
+	AddSubLogger(root, pool.Subsystem, interceptor, pool.UseLogger)
 	AddSubLogger(root, sqldb.Subsystem, interceptor, sqldb.UseLogger)
 	AddSubLogger(
 		root, paymentsdb.Subsystem, interceptor, paymentsdb.UseLogger,

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -2245,13 +2245,20 @@ func newDiscMsgStream(p *Brontide) *msgStream {
 func (p *Brontide) readHandler() {
 	defer p.cg.WgDone()
 
-	// We'll stop the timer after a new messages is received, and also
+	// We'll stop the timer after a new message is received, and also
 	// reset it after we process the next message.
 	idleTimer := time.AfterFunc(idleTimeout, func() {
 		err := fmt.Errorf("peer %s no answer for %s -- disconnecting",
 			p, idleTimeout)
 		p.Disconnect(err)
 	})
+
+	// The timer belongs to this handler and must remain active while it
+	// reads messages. Defer its cleanup so every exit path, including panic
+	// recovery, disarms a timer that has not fired. This defer runs before
+	// WgDone, so an armed timer does not outlive the handler and request a
+	// redundant disconnect after teardown.
+	defer idleTimer.Stop()
 
 	// Initialize our negotiated gossip sync method before reading messages
 	// off the wire. When using gossip queries, this ensures a gossip
@@ -2262,8 +2269,43 @@ func (p *Brontide) readHandler() {
 	p.initGossipSync()
 
 	discStream := newDiscMsgStream(p)
+	p.runReadHandler(idleTimer, discStream)
+}
+
+// runReadHandler owns the discovery stream for the duration of the read loop.
+// The loop contains its own recovery boundary, so a recovered panic disconnects
+// the peer before this function stops the stream. This ordering lets a blocked
+// discovery delivery observe the peer quit signal and exit.
+func (p *Brontide) runReadHandler(idleTimer *time.Timer,
+	discStream *msgStream) {
+
 	discStream.Start()
 	defer discStream.Stop()
+
+	p.readHandlerLoop(idleTimer, discStream)
+
+	p.Disconnect(errors.New("read handler closed"))
+
+	p.log.Trace("readHandler for peer done")
+}
+
+// readHandlerLoop reads and dispatches peer messages until the peer exits. It
+// owns the recovery boundary so panic cleanup completes before the outer frame
+// stops the discovery stream.
+func (p *Brontide) readHandlerLoop(idleTimer *time.Timer,
+	discStream *msgStream) {
+
+	// Report any panic raised while reading or dispatching a message, then
+	// disconnect through the normal peer cleanup path.
+	defer fn.RecoverPanic(func(pnc fn.Panic) {
+		fn.LogRecoveredPanic(context.Background(), p.log, pnc)
+
+		// Only include the panic type in the cleanup error. Formatting
+		// the value could invoke a broken String or Error method and
+		// prevent the peer from being disconnected.
+		p.Disconnect(fmt.Errorf("panic in readHandler: %T", pnc.Value))
+	})
+
 out:
 	for atomic.LoadInt32(&p.disconnect) == 0 {
 		nextMsg, err := p.readNextMessage()
@@ -2513,10 +2555,6 @@ out:
 
 		idleTimer.Reset(idleTimeout)
 	}
-
-	p.Disconnect(errors.New("read handler closed"))
-
-	p.log.Trace("readHandler for peer done")
 }
 
 // handleCustomMessage handles the given custom message if a handler is
@@ -5284,6 +5322,7 @@ func (p *Brontide) StartTime() time.Time {
 // message is received from the remote peer. We'll use this message to advance
 // the chan closer state machine.
 func (p *Brontide) handleCloseMsg(msg *closeMsg) {
+
 	link := p.fetchLinkFromKeyAndCid(msg.cid)
 
 	// We'll now fetch the matching closing state machine in order to

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math/rand"
 	"net"
 	"strings"
@@ -147,6 +148,15 @@ type customMsg struct {
 type closeMsg struct {
 	cid lnwire.ChannelID
 	msg lnwire.Message
+}
+
+// legacyClosePanicState holds the error handler used to tear down a legacy
+// cooperative close after a recovered panic. The handler becomes available
+// only after the active closer has been fetched. closeFailed prevents recovery
+// from running that handler twice if it was itself the source of the panic.
+type legacyClosePanicState struct {
+	handleErr   func(error)
+	closeFailed atomic.Bool
 }
 
 // PendingUpdate describes the pending state of a closing channel.
@@ -4817,6 +4827,16 @@ func (p *Brontide) fetchLinkFromKeyAndCid(
 func (p *Brontide) finalizeChanClosure(chanCloser *chancloser.ChanCloser) {
 	closeReq := chanCloser.CloseRequest()
 
+	closingTx, err := chanCloser.ClosingTx()
+	if err != nil {
+		if closeReq != nil {
+			p.log.Error(err)
+			closeReq.Err <- err
+		}
+
+		return
+	}
+
 	// First, we'll clear all indexes related to the channel in question.
 	chanPoint := chanCloser.Channel().ChannelPoint()
 	p.WipeChannel(&chanPoint)
@@ -4841,19 +4861,14 @@ func (p *Brontide) finalizeChanClosure(chanCloser *chancloser.ChanCloser) {
 		errChan = closeReq.Err
 	}
 
-	closingTx, err := chanCloser.ClosingTx()
-	if err != nil {
-		if closeReq != nil {
-			p.log.Error(err)
-			closeReq.Err <- err
-		}
-	}
-
 	closingTxid := closingTx.TxHash()
 
 	// If this is a locally requested shutdown, update the caller with a
 	// new event detailing the current pending state of this request.
 	if closeReq != nil {
+		// TODO: This direct send relies on Updates having capacity for
+		// exactly two legacy close notifications. Make it cancellable
+		// before changing that producer or buffer invariant.
 		closeReq.Updates <- &PendingUpdate{
 			Txid: closingTxid[:],
 		}
@@ -5322,6 +5337,13 @@ func (p *Brontide) StartTime() time.Time {
 // message is received from the remote peer. We'll use this message to advance
 // the chan closer state machine.
 func (p *Brontide) handleCloseMsg(msg *closeMsg) {
+	// Install recovery around legacy close handling. Once the ordinary
+	// error handler is available, use it for recovered failures. The
+	// closeFailed flag prevents the handler from running twice.
+	panicState := &legacyClosePanicState{}
+	defer fn.RecoverPanic(p.legacyClosePanicHandler(
+		msg.cid, panicState,
+	))
 
 	link := p.fetchLinkFromKeyAndCid(msg.cid)
 
@@ -5359,7 +5381,12 @@ func (p *Brontide) handleCloseMsg(msg *closeMsg) {
 		chanCloser = c
 	})
 
-	handleErr := p.negotiateCloseErrHandler(msg.cid, chanCloser)
+	closeErrHandler := p.negotiateCloseErrHandler(msg.cid, chanCloser)
+	panicState.handleErr = func(err error) {
+		panicState.closeFailed.Store(true)
+		closeErrHandler(err)
+	}
+	handleErr := panicState.handleErr
 
 	// Next, we'll process the next message using the target state machine.
 	// We'll either continue negotiation, or halt.
@@ -5442,10 +5469,56 @@ func (p *Brontide) handleCloseMsg(msg *closeMsg) {
 		})
 
 	default:
+		// Only Shutdown and ClosingSigned messages are placed on
+		// chanCloseMsgs. Recovery deliberately contains an invariant
+		// violation. It limits the failure to this close and peer. The
+		// process continues.
 		panic("impossible closeMsg type")
 	}
 
 	p.maybeFinalizeChanClosure(chanCloser)
+}
+
+// legacyClosePanicHandler returns the callback used by a directly deferred
+// fn.RecoverPanic at each legacy close entry point owned by channelManager.
+// Once the ordinary close error handler is available, a recovered panic is
+// routed through it exactly once. Otherwise, recovery only disconnects the
+// peer.
+func (p *Brontide) legacyClosePanicHandler(cid lnwire.ChannelID,
+	state *legacyClosePanicState) func(fn.Panic) {
+
+	return func(pnc fn.Panic) {
+		fn.LogRecoveredPanic(
+			context.Background(), p.log, pnc,
+			slog.String("channel_id", cid.String()),
+		)
+
+		// Do not format the panic value while establishing containment.
+		// Its String or Error method may be the code that panicked.
+		err := fmt.Errorf("panic while handling close msg: %T",
+			pnc.Value)
+
+		// If we panicked before we were able to fetch the chan closer,
+		// or after the close was already failed, then we have no close
+		// left to fail, so we only disconnect.
+		if state.handleErr == nil || state.closeFailed.Load() {
+			p.Disconnect(err)
+			return
+		}
+
+		// If close failure handling also panics, report it and
+		// disconnect so channelManager can return to its loop.
+		defer fn.RecoverPanic(func(reportingPanic fn.Panic) {
+			fn.LogRecoveredPanic(
+				context.Background(), p.log, reportingPanic,
+				slog.String("channel_id", cid.String()),
+			)
+
+			p.Disconnect(err)
+		})
+
+		state.handleErr(err)
+	}
 }
 
 // handleChanFlushed is called once a link has drained the HTLCs from a channel
@@ -5455,6 +5528,11 @@ func (p *Brontide) handleCloseMsg(msg *closeMsg) {
 //
 // NOTE: MUST be called from the channelManager goroutine.
 func (p *Brontide) handleChanFlushed(cid lnwire.ChannelID) {
+	panicState := &legacyClosePanicState{}
+	defer fn.RecoverPanic(p.legacyClosePanicHandler(
+		cid, panicState,
+	))
+
 	// We deliberately don't go through fetchActiveChanCloser here, as that
 	// would build a fresh closer if the negotiation has already been torn
 	// down while we were waiting on the link.
@@ -5477,9 +5555,13 @@ func (p *Brontide) handleChanFlushed(cid lnwire.ChannelID) {
 		chanCloser = c
 	})
 
-	p.beginNegotiation(
-		chanCloser, p.negotiateCloseErrHandler(cid, chanCloser),
-	)
+	closeErrHandler := p.negotiateCloseErrHandler(cid, chanCloser)
+	panicState.handleErr = func(err error) {
+		panicState.closeFailed.Store(true)
+		closeErrHandler(err)
+	}
+
+	p.beginNegotiation(chanCloser, panicState.handleErr)
 }
 
 // beginNegotiation starts the fee negotiation phase of a legacy cooperative
@@ -5535,16 +5617,31 @@ func (p *Brontide) negotiateCloseErrHandler(cid lnwire.ChannelID,
 		err = fmt.Errorf("unable to process close msg: %w", err)
 		p.log.Error(err)
 
-		// As the negotiations failed, we'll reset the channel state
-		// machine to ensure we act to on-chain events as normal.
+		// Reset the in-memory closed flag after failed negotiation.
+		// This lets on-chain handling continue. ResetState leaves
+		// ChanStatusCoopBroadcasted intact. After a post-broadcast
+		// panic, restart and the chain arbitrator track the existing
+		// transaction.
 		chanCloser.Channel().ResetState()
-		if chanCloser.CloseRequest() != nil {
-			chanCloser.CloseRequest().Err <- err
-		}
 
+		// Remove the failed closer before notifying the caller.
+		// Notification is best effort. It must not block containment or
+		// peer disconnection.
+		closeReq := chanCloser.CloseRequest()
 		p.deleteActiveChanCloser(
 			cid, chanCloser.Channel().ChannelPoint(),
 		)
+		if closeReq != nil {
+			select {
+			case closeReq.Err <- err:
+			default:
+				p.log.Warnf(
+					"Close failure notification "+
+						"dropped for ChannelID(%v)",
+					cid,
+				)
+			}
+		}
 
 		p.Disconnect(err)
 	}

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -3954,6 +3954,24 @@ func ChooseAddr(addr lnwire.DeliveryAddress) fn.Option[lnwire.DeliveryAddress] {
 	return fn.Some(addr)
 }
 
+// sendFinalCloseUpdate notifies the close caller that its transaction has
+// confirmed. The caller may have stopped reading its bounded update channel,
+// so cancellation of either the request or peer must always release this send.
+func sendFinalCloseUpdate(closeReq *htlcswitch.ChanClose,
+	closingTxid chainhash.Hash, peerQuit <-chan struct{}) {
+
+	select {
+	case closeReq.Updates <- &ChannelCloseUpdate{
+		ClosingTxid: closingTxid[:],
+		Success:     true,
+	}:
+
+	case <-closeReq.Ctx.Done():
+
+	case <-peerQuit:
+	}
+}
+
 // observeRbfCloseUpdates observes the channel for any updates that may
 // indicate that a new txid has been broadcasted, or the channel fully closed
 // on chain.
@@ -4078,10 +4096,14 @@ func (p *Brontide) observeRbfCloseUpdates(chanCloser *chancloser.RbfChanCloser,
 				// update to the client.
 				closingTxid := closeState.ConfirmedTx.TxHash()
 				if closeReq != nil {
-					closeReq.Updates <- &ChannelCloseUpdate{
-						ClosingTxid: closingTxid[:],
-						Success:     true,
-					}
+					// Updates is bounded. The caller may no
+					// longer be reading. Stop waiting when
+					// the request or peer shuts down, so
+					// cleanup can proceed.
+					sendFinalCloseUpdate(
+						closeReq, closingTxid,
+						p.cg.Done(),
+					)
 				}
 				chanID := lnwire.NewChanIDFromOutPoint(
 					*closeReq.ChanPoint,

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chancloser"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -864,6 +865,288 @@ func TestPeerChannelClosureFeeNegotiationsInitiator(t *testing.T) {
 
 	// Alice should be waiting on a single confirmation for the coop close tx.
 	notifier.ConfChan <- &chainntnfs.TxConfirmation{}
+}
+
+// TestPeerChannelClosurePanicRecovery verifies that a panic while advancing a
+// legacy cooperative close reports the failure and disconnects the peer.
+func TestPeerChannelClosurePanicRecovery(t *testing.T) {
+	t.Parallel()
+
+	harness, err := createTestPeerWithChannel(t, noUpdate)
+	require.NoError(t, err, "unable to create test channels")
+
+	var (
+		alicePeer  = harness.peer
+		bobChan    = harness.channel
+		mockSwitch = harness.mockSwitch
+	)
+
+	chanPoint := bobChan.ChannelPoint()
+	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
+	mockLink := newMockUpdateHandler(chanID)
+	mockSwitch.links = append(mockSwitch.links, mockLink)
+
+	// Make the initiator send a shutdown request so the recovery path has
+	// an active chan closer and a local close request to fail.
+	updateChan := make(chan interface{}, 1)
+	errChan := make(chan error, 1)
+	closeCommand := &htlcswitch.ChanClose{
+		CloseType:      contractcourt.CloseRegular,
+		ChanPoint:      &chanPoint,
+		Updates:        updateChan,
+		TargetFeePerKw: 12500,
+		Err:            errChan,
+	}
+
+	alicePeer.localCloseChanReqs <- closeCommand
+
+	// Alice should now send a Shutdown request to Bob.
+	select {
+	case outMsg := <-alicePeer.outgoingQueue:
+		require.IsType(t, &lnwire.Shutdown{}, outMsg.msg)
+
+	case <-time.After(timeout):
+		t.Fatalf("did not receive shutdown request")
+	}
+
+	// The chan closer should now be tracked as active.
+	_, found := alicePeer.activeChanCloses.Load(chanID)
+	require.True(t, found, "chan closer not active")
+
+	// Deliver an unsupported close-related message to exercise recovery.
+	alicePeer.chanCloseMsgs <- &closeMsg{
+		cid: chanID,
+		msg: &lnwire.Warning{ChanID: chanID},
+	}
+
+	// The local close request should receive the recovered error.
+	select {
+	case err := <-errChan:
+		require.ErrorContains(t, err, "panic while handling close msg")
+
+	case <-time.After(timeout):
+		t.Fatalf("close request was not failed")
+	}
+
+	// The peer should also have been disconnected, and the chan closer
+	// removed so that we react to on-chain events as normal.
+	select {
+	case <-alicePeer.cg.Done():
+
+	case <-time.After(timeout):
+		t.Fatalf("peer was not disconnected")
+	}
+
+	_, found = alicePeer.activeChanCloses.Load(chanID)
+	require.False(t, found, "chan closer was not removed")
+
+	requirePeerGoroutinesExit(t, alicePeer)
+
+	// The failure path resets this channel while holding its mutex. Make
+	// sure recovery did not leave the mutex held after the peer exited.
+	aliceChan, found := alicePeer.activeChannels.Load(chanID)
+	require.True(t, found)
+	require.True(t, aliceChan.TryLock(), "channel mutex was not released")
+	aliceChan.Unlock()
+}
+
+// TestPeerClosePanicRecoveryFullErrChan verifies that a full caller error
+// channel cannot prevent recovered close failure from tearing down the closer
+// and peer.
+func TestPeerClosePanicRecoveryFullErrChan(t *testing.T) {
+	t.Parallel()
+
+	harness, err := createTestPeerWithChannel(t, noUpdate)
+	require.NoError(t, err, "unable to create test channels")
+
+	var (
+		alicePeer  = harness.peer
+		bobChan    = harness.channel
+		mockSwitch = harness.mockSwitch
+	)
+
+	chanPoint := bobChan.ChannelPoint()
+	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
+	mockSwitch.links = append(
+		mockSwitch.links, newMockUpdateHandler(chanID),
+	)
+
+	errChan := make(chan error, 1)
+	existingErr := fmt.Errorf("existing close error")
+	errChan <- existingErr
+	alicePeer.localCloseChanReqs <- &htlcswitch.ChanClose{
+		CloseType:      contractcourt.CloseRegular,
+		ChanPoint:      &chanPoint,
+		Updates:        make(chan interface{}, 1),
+		TargetFeePerKw: 12500,
+		Err:            errChan,
+	}
+
+	select {
+	case outMsg := <-alicePeer.outgoingQueue:
+		require.IsType(t, &lnwire.Shutdown{}, outMsg.msg)
+
+	case <-time.After(timeout):
+		t.Fatal("did not receive shutdown request")
+	}
+
+	_, found := alicePeer.activeChanCloses.Load(chanID)
+	require.True(t, found, "chan closer not active")
+
+	alicePeer.chanCloseMsgs <- &closeMsg{
+		cid: chanID,
+		msg: &lnwire.Warning{ChanID: chanID},
+	}
+
+	// Keep errChan full until disconnect. Reading it sooner could free the
+	// buffer before the failure handler reaches the send under test.
+	select {
+	case <-alicePeer.cg.Done():
+
+	case <-time.After(timeout):
+		t.Fatal("peer teardown blocked on full error channel")
+	}
+
+	_, found = alicePeer.activeChanCloses.Load(chanID)
+	require.False(t, found, "chan closer was not removed")
+	require.ErrorIs(t, <-errChan, existingErr)
+
+	requirePeerGoroutinesExit(t, alicePeer)
+}
+
+// TestFinalizeChanClosureUnfinished verifies that an unfinished legacy closer
+// returns its state error before removing any live peer state.
+func TestFinalizeChanClosureUnfinished(t *testing.T) {
+	t.Parallel()
+
+	harness, err := createTestPeerWithChannel(t, noUpdate)
+	require.NoError(t, err, "unable to create test channels")
+
+	alicePeer := harness.peer
+	chanPoint := harness.channel.ChannelPoint()
+	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
+	aliceChan, found := alicePeer.activeChannels.Load(chanID)
+	require.True(t, found)
+
+	closeReq := &htlcswitch.ChanClose{
+		ChanPoint: &chanPoint,
+		Updates:   make(chan interface{}, 2),
+		Err:       make(chan error, 1),
+		Ctx:       t.Context(),
+	}
+	deliveryAddr := &chancloser.DeliveryAddrWithKey{
+		DeliveryAddress: genScript(t, p2wshAddress),
+	}
+	closer, err := alicePeer.createChanCloser(
+		aliceChan, deliveryAddr, 12500, closeReq, lntypes.Local,
+	)
+	require.NoError(t, err)
+	alicePeer.activeChanCloses.Store(
+		chanID, makeNegotiateCloser(closer),
+	)
+
+	require.NotPanics(t, func() {
+		alicePeer.finalizeChanClosure(closer)
+	})
+	select {
+	case err := <-closeReq.Err:
+		require.ErrorIs(t, err, chancloser.ErrChanCloseNotFinished)
+	default:
+		t.Fatal("unfinished close did not report its state error")
+	}
+
+	_, found = alicePeer.activeChannels.Load(chanID)
+	require.True(t, found, "unfinished close removed active channel")
+	_, found = alicePeer.activeChanCloses.Load(chanID)
+	require.True(t, found, "unfinished close removed active closer")
+}
+
+// TestPeerClosePanicFailureReporting verifies recovery from a panic raised
+// while reporting a cooperative-close failure.
+func TestPeerClosePanicFailureReporting(t *testing.T) {
+	t.Parallel()
+
+	harness, err := createTestPeerWithChannel(t, noUpdate)
+	require.NoError(t, err, "unable to create test channels")
+
+	var (
+		alicePeer  = harness.peer
+		bobChan    = harness.channel
+		mockSwitch = harness.mockSwitch
+	)
+
+	chanPoint := bobChan.ChannelPoint()
+	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
+	mockSwitch.links = append(
+		mockSwitch.links, newMockUpdateHandler(chanID),
+	)
+
+	// Start a local close so the closer has an error channel. Closing that
+	// channel makes the ordinary failure path panic while reporting the
+	// original recovered panic.
+	errChan := make(chan error, 1)
+	alicePeer.localCloseChanReqs <- &htlcswitch.ChanClose{
+		CloseType:      contractcourt.CloseRegular,
+		ChanPoint:      &chanPoint,
+		Updates:        make(chan interface{}, 1),
+		TargetFeePerKw: 12500,
+		Err:            errChan,
+	}
+
+	select {
+	case outMsg := <-alicePeer.outgoingQueue:
+		require.IsType(t, &lnwire.Shutdown{}, outMsg.msg)
+	case <-time.After(timeout):
+		t.Fatal("did not receive shutdown request")
+	}
+	close(errChan)
+
+	alicePeer.chanCloseMsgs <- &closeMsg{
+		cid: chanID,
+		msg: &lnwire.Warning{ChanID: chanID},
+	}
+
+	select {
+	case <-alicePeer.cg.Done():
+	case <-time.After(timeout):
+		t.Fatal("peer was not disconnected after secondary panic")
+	}
+	_, found := alicePeer.activeChanCloses.Load(chanID)
+	require.False(t, found, "chan closer was not removed")
+
+	requirePeerGoroutinesExit(t, alicePeer)
+}
+
+// TestPeerFlushedClosePanicRecovery verifies recovery on the channel-flush
+// cooperative-close path.
+func TestPeerFlushedClosePanicRecovery(t *testing.T) {
+	t.Parallel()
+
+	harness, err := createTestPeerWithChannel(t, noUpdate)
+	require.NoError(t, err, "unable to create test channels")
+
+	alicePeer := harness.peer
+	chanID := lnwire.ChannelID{1}
+
+	// A nil legacy closer makes beginNegotiation panic and also exercises
+	// recovery from a failure-reporting panic.
+	alicePeer.activeChanCloses.Store(
+		chanID, makeNegotiateCloser(nil),
+	)
+
+	select {
+	case alicePeer.chanCloseFlushed <- chanID:
+	case <-time.After(timeout):
+		t.Fatal("channelManager did not accept flush notification")
+	}
+
+	select {
+	case <-alicePeer.cg.Done():
+	case <-time.After(timeout):
+		t.Fatal("peer was not disconnected after flush-path panic")
+	}
+
+	requirePeerGoroutinesExit(t, alicePeer)
 }
 
 // TestChooseDeliveryScript tests that chooseDeliveryScript correctly errors

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightningnetwork/lnd/chainntnfs"
@@ -1729,6 +1730,70 @@ func TestReadHandlerPanicDisconnectsBeforeStreamStop(t *testing.T) {
 	require.Equal(
 		t, int32(1), atomic.LoadInt32(&discStream.streamShutdown),
 	)
+}
+
+// TestCloseFinNotificationUnblocks asserts that a full client update channel
+// cannot hold peer teardown open after either the request or peer is canceled.
+func TestCloseFinNotificationUnblocks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		shutdownPeer bool
+	}{
+		{
+			name: "request canceled",
+		},
+		{
+			name:         "peer stopped",
+			shutdownPeer: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			updates := make(chan interface{}, 1)
+			updates <- struct{}{}
+			peerQuit := make(chan struct{})
+			closeReq := &htlcswitch.ChanClose{
+				Updates: updates,
+				Ctx:     ctx,
+			}
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+
+				sendFinalCloseUpdate(
+					closeReq, chainhash.Hash{}, peerQuit,
+				)
+			}()
+
+			select {
+			case <-done:
+				t.Fatal("notification returned while no exit " +
+					"condition was ready")
+			case <-time.After(50 * time.Millisecond):
+			}
+
+			if test.shutdownPeer {
+				close(peerQuit)
+			} else {
+				cancel()
+			}
+
+			select {
+			case <-done:
+			case <-time.After(timeout):
+				t.Fatal("final close notification blocked " +
+					"teardown")
+			}
+		})
+	}
 }
 
 // TestMessageSummaryPingIncludesNumPongBytes ensures the debug summary for a

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -2,7 +2,9 @@ package peer
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -21,6 +23,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chancloser"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/msgmux"
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/stretchr/testify/mock"
@@ -34,6 +37,64 @@ var (
 	// p2wshAddress is a valid pay to witness script hash address.
 	p2wshAddress = "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3"
 )
+
+// readHandlerPanicRouter panics in RouteMsg so the test can exercise
+// readHandler recovery.
+type readHandlerPanicRouter struct {
+	called     chan struct{}
+	panicValue any
+}
+
+// panickingStringer verifies that containment never depends on successfully
+// formatting the value supplied to panic.
+type panickingStringer struct{}
+
+// String simulates a panic raised while formatting another panic's value.
+func (panickingStringer) String() string {
+	panic("panic while formatting panic value")
+}
+
+// RegisterEndpoint implements msgmux.Router for the recovery test.
+func (r *readHandlerPanicRouter) RegisterEndpoint(msgmux.Endpoint) error {
+	return nil
+}
+
+// UnregisterEndpoint implements msgmux.Router for the recovery test.
+func (r *readHandlerPanicRouter) UnregisterEndpoint(
+	msgmux.EndpointName) error {
+
+	return nil
+}
+
+// RouteMsg signals delivery and raises the panic under test.
+func (r *readHandlerPanicRouter) RouteMsg(msgmux.PeerMsg) error {
+	r.called <- struct{}{}
+	panic(r.panicValue)
+}
+
+// Start implements msgmux.Router for the recovery test.
+func (r *readHandlerPanicRouter) Start(context.Context) {}
+
+// Stop implements msgmux.Router for the recovery test.
+func (r *readHandlerPanicRouter) Stop() {}
+
+// requirePeerGoroutinesExit verifies that recovered teardown does not leave a
+// peer goroutine blocked on a leaked lock or another shutdown dependency.
+func requirePeerGoroutinesExit(t *testing.T, peer *Brontide) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		peer.cg.WgWait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Fatal("peer goroutines did not exit")
+	}
+}
 
 // TestPeerChannelClosureShutdownResponseLinkRemoved tests the shutdown
 // response we get if the link for the channel can't be found in the
@@ -1263,6 +1324,128 @@ func TestPeerIgnoresPingWithoutPongReply(t *testing.T) {
 	pong, ok := msg.(*lnwire.Pong)
 	require.True(t, ok)
 	require.Len(t, pong.PongBytes, 1)
+}
+
+// TestReadHandlerPanicRecovery verifies that a dispatch panic disconnects the
+// peer and releases its wait-group entry.
+func TestReadHandlerPanicRecovery(t *testing.T) {
+	t.Parallel()
+
+	params := createTestPeer(t)
+	router := &readHandlerPanicRouter{
+		called:     make(chan struct{}, 1),
+		panicValue: panickingStringer{},
+	}
+
+	alicePeer := params.peer
+	alicePeer.msgRouter = fn.Some[msgmux.Router](router)
+	alicePeer.globalMsgRouter = true
+
+	startPeerDone := startPeer(t, params.mockConn, alicePeer)
+	_, err := fn.RecvOrTimeout(startPeerDone, 2*timeout)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	_, err = lnwire.WriteMessage(&buf, &lnwire.Ping{}, 0)
+	require.NoError(t, err)
+
+	select {
+	case params.mockConn.readMessages <- buf.Bytes():
+	case <-time.After(timeout):
+		t.Fatal("timeout sending ping to peer")
+	}
+
+	select {
+	case <-router.called:
+	case <-time.After(timeout):
+		t.Fatal("message router was not called")
+	}
+
+	select {
+	case <-alicePeer.cg.Done():
+	case <-time.After(timeout):
+		t.Fatal("peer was not disconnected after dispatch panic")
+	}
+
+	requirePeerGoroutinesExit(t, alicePeer)
+}
+
+// TestReadHandlerPanicDisconnectsBeforeStreamStop verifies that panic recovery
+// signals peer shutdown before waiting for the discovery stream to exit.
+func TestReadHandlerPanicDisconnectsBeforeStreamStop(t *testing.T) {
+	t.Parallel()
+
+	params := createTestPeer(t)
+	router := &readHandlerPanicRouter{
+		called:     make(chan struct{}, 1),
+		panicValue: "dispatch panic",
+	}
+
+	alicePeer := params.peer
+	alicePeer.msgRouter = fn.Some[msgmux.Router](router)
+	alicePeer.globalMsgRouter = true
+
+	// Keep the discovery consumer inside apply until peer shutdown. If the
+	// stream is stopped before recovery disconnects the peer, Stop waits
+	// forever for this callback and recovery can never run.
+	applyStarted := make(chan struct{})
+	discStream := newMsgStream(
+		alicePeer, "test discovery stream started",
+		"test discovery stream stopped", 1,
+		func(lnwire.Message) {
+			close(applyStarted)
+			<-alicePeer.cg.Done()
+		},
+	)
+
+	idleTimer := time.AfterFunc(time.Hour, func() {})
+	defer idleTimer.Stop()
+
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+
+		alicePeer.runReadHandler(idleTimer, discStream)
+	}()
+
+	discStream.AddMsg(&lnwire.ChannelUpdate1{})
+	select {
+	case <-applyStarted:
+	case <-time.After(timeout):
+		t.Fatal("discovery stream did not enter apply")
+	}
+
+	var buf bytes.Buffer
+	_, err := lnwire.WriteMessage(&buf, &lnwire.Ping{}, 0)
+	require.NoError(t, err)
+
+	select {
+	case params.mockConn.readMessages <- buf.Bytes():
+	case <-time.After(timeout):
+		t.Fatal("timeout sending ping to peer")
+	}
+
+	select {
+	case <-router.called:
+	case <-time.After(timeout):
+		t.Fatal("message router was not called")
+	}
+
+	select {
+	case <-readDone:
+	case <-time.After(timeout):
+		t.Fatal("read handler blocked stopping discovery stream")
+	}
+
+	select {
+	case <-alicePeer.cg.Done():
+	default:
+		t.Fatal("peer was not disconnected before stream shutdown")
+	}
+
+	require.Equal(
+		t, int32(1), atomic.LoadInt32(&discStream.streamShutdown),
+	)
 }
 
 // TestMessageSummaryPingIncludesNumPongBytes ensures the debug summary for a

--- a/pool/log.go
+++ b/pool/log.go
@@ -1,0 +1,31 @@
+package pool
+
+import (
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightningnetwork/lnd/build"
+)
+
+// Subsystem defines the logging code for this subsystem.
+const Subsystem = "POOL"
+
+// log is a logger that is initialized with no output filters. This means the
+// package will not perform any logging by default until the caller requests it.
+var log btclog.Logger
+
+// The default amount of logging is none.
+func init() {
+	UseLogger(build.NewSubLogger(Subsystem, nil))
+}
+
+// DisableLog disables all library log output. Logging output is disabled by
+// default until UseLogger is called.
+func DisableLog() {
+	UseLogger(btclog.Disabled)
+}
+
+// UseLogger uses a specified Logger to output package logging info. This
+// should be used in preference to SetLogWriter if the caller is also using
+// btclog.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/pool/worker.go
+++ b/pool/worker.go
@@ -1,14 +1,23 @@
 package pool
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
+
+	"github.com/lightningnetwork/lnd/fn/v2"
 )
 
 // ErrWorkerPoolExiting signals that a shutdown of the Worker has been
 // requested.
 var ErrWorkerPoolExiting = errors.New("worker pool exiting")
+
+// ErrWorkerTaskPanic signals that a submitted task panicked while being
+// executed by one of the pool's worker goroutines. The error returned to the
+// submitter wraps this sentinel error.
+var ErrWorkerTaskPanic = errors.New("worker task panicked")
 
 // DefaultWorkerTimeout is the default duration after which a worker goroutine
 // will exit to free up resources after having received no newly submitted
@@ -110,9 +119,14 @@ func (w *Worker) Stop() error {
 	return nil
 }
 
-// Submit accepts a function closure to the worker pool. The returned error will
-// be either the result of the closure's execution or an ErrWorkerPoolExiting if
-// a shutdown is requested.
+// Submit accepts a function closure to the worker pool. The returned error is
+// the result of the closure's execution, ErrWorkerPoolExiting if shutdown is
+// requested, or an error wrapping ErrWorkerTaskPanic if the closure panics.
+//
+// A panicking worker is retired, so its WorkerState is not reused. Effects that
+// the closure performed outside WorkerState are not rolled back. Callers must
+// treat those effects as having an unknown result and retire or reset their
+// owner before continuing.
 func (w *Worker) Submit(fn func(WorkerState) error) error {
 	req := &request{
 		fn:      fn,
@@ -188,7 +202,9 @@ func (w *Worker) spawnWorker(req *request) {
 	state := w.cfg.NewWorkerState()
 	defer state.Cleanup()
 
-	req.errChan <- req.fn(state)
+	if w.runTask(req, state) {
+		return
+	}
 
 	// We'll use a timer to implement the worker timeouts, as this reduces
 	// the number of total allocations that would otherwise be necessary
@@ -206,7 +222,10 @@ func (w *Worker) spawnWorker(req *request) {
 		// non-blocking case first so that under high load we can spare
 		// allocating a timeout.
 		case req := <-w.work:
-			req.errChan <- req.fn(state)
+			if w.runTask(req, state) {
+				return
+			}
+
 			continue
 
 		case <-w.quit:
@@ -229,7 +248,9 @@ func (w *Worker) spawnWorker(req *request) {
 
 		// Process any new requests that get submitted.
 		case req := <-w.work:
-			req.errChan <- req.fn(state)
+			if w.runTask(req, state) {
+				return
+			}
 
 			// Stop the timer, draining the timer's channel if a
 			// notification was already delivered.
@@ -247,4 +268,51 @@ func (w *Worker) spawnWorker(req *request) {
 			return
 		}
 	}
+}
+
+// runTask executes the task attached to the given request against the worker's
+// state, then hands the outcome back to the submitter.
+//
+// A recovered task panic is returned to the submitter as an ordinary error.
+// The returned boolean reports whether the caller should retire the worker
+// instead of reusing its state.
+//
+// NOTE: Exactly one value is always delivered on the request's error channel,
+// on every exit path. The channel is buffered with a size of one, so the send
+// never blocks.
+//
+//nolint:nonamedreturns // Recovery must report whether the worker is reusable.
+func (w *Worker) runTask(req *request, state WorkerState) (panicked bool) {
+	var err error
+
+	// Deliver the outcome of the task to the submitter, which is blocked
+	// waiting on this channel.
+	defer func() {
+		req.errChan <- err
+	}()
+
+	defer fn.RecoverPanic(func(p fn.Panic) {
+		panicked = true
+
+		fn.LogRecoveredPanic(context.Background(), log, p)
+
+		// Formatting the original value could call the same broken
+		// String or Error method that caused the panic. The structured
+		// report above records the value best-effort. This error can
+		// always be constructed, so the submitter observes the failure.
+		panicString, ok := p.Value.(string)
+		if ok {
+			err = fmt.Errorf(
+				"%w: %s", ErrWorkerTaskPanic, panicString,
+			)
+
+			return
+		}
+
+		err = fmt.Errorf("%w: %T", ErrWorkerTaskPanic, p.Value)
+	})
+
+	err = req.fn(state)
+
+	return false
 }

--- a/pool/worker_test.go
+++ b/pool/worker_test.go
@@ -20,6 +20,12 @@ type workerPoolTest struct {
 	numWorkers int
 }
 
+type panickingStringer struct{}
+
+func (panickingStringer) String() string {
+	panic("panic while formatting panic value")
+}
+
 // TestConcreteWorkerPools asserts the behavior of any concrete implementations
 // of worker pools provided by the pool package. Currently this tests the
 // pool.Read and pool.Write instances.
@@ -285,6 +291,161 @@ func stopGeneric(t *testing.T, p interface{}) {
 	}
 
 	require.NoError(t, err, "unable to stop worker pool")
+}
+
+// TestWorkerPoolPanicRecovery verifies that a task panic is returned as an
+// error and the pool retains all worker slots.
+func TestWorkerPoolPanicRecovery(t *testing.T) {
+	t.Parallel()
+
+	const (
+		gcInterval     = time.Second
+		expiryInterval = 250 * time.Millisecond
+		numWorkers     = 3
+
+		// The worker timeout is set well beyond the duration of the
+		// test, so that a worker only ever exits because we tore it
+		// down, and never because it went idle for too long.
+		workerTimeout = time.Minute
+	)
+
+	// panicTask is a task that panics rather than returning an error.
+	panicTask := func(*buffer.Read) error {
+		panic("panic in worker task")
+	}
+	panickingValueTask := func(*buffer.Read) error {
+		panic(panickingStringer{})
+	}
+
+	// newReadPool creates and starts a fresh pool.Read, which is the pool
+	// used to decode messages we read off the wire.
+	newReadPool := func(t *testing.T) *pool.Read {
+		bp := pool.NewReadBuffer(gcInterval, expiryInterval)
+		p := pool.NewRead(bp, numWorkers, workerTimeout)
+
+		require.NoError(t, p.Start())
+		t.Cleanup(func() {
+			require.NoError(t, p.Stop())
+		})
+
+		return p
+	}
+
+	// submitWithTimeout keeps a regression from parking the test before its
+	// cleanup can stop the pool and release the blocked submission.
+	submitWithTimeout := func(t *testing.T, p *pool.Read,
+		task func(*buffer.Read) error) error {
+
+		t.Helper()
+
+		errChan := make(chan error, 1)
+		go func() {
+			errChan <- p.Submit(task)
+		}()
+
+		select {
+		case err := <-errChan:
+			return err
+
+		case <-time.After(5 * time.Second):
+			t.Fatal("worker task submission never returned")
+
+			return nil
+		}
+	}
+
+	// saturate submits exactly numWorkers tasks that each block until all
+	// of them are running, meaning the pool must be able to allocate its
+	// full complement of workers for this to return. If any worker slot has
+	// been leaked, fewer tasks can run in parallel and this will time out.
+	saturate := func(t *testing.T, p *pool.Read) {
+		t.Helper()
+
+		var (
+			started = make(chan struct{}, numWorkers)
+			release = make(chan struct{})
+			errs    = make(chan error, numWorkers)
+		)
+		for i := 0; i < numWorkers; i++ {
+			go func() {
+				errs <- p.Submit(func(*buffer.Read) error {
+					started <- struct{}{}
+					<-release
+
+					return nil
+				})
+			}()
+		}
+
+		for i := 0; i < numWorkers; i++ {
+			select {
+			case <-started:
+			case <-time.After(5 * time.Second):
+				t.Fatalf("only %d of %d tasks are running in "+
+					"parallel, a worker slot was leaked",
+					i, numWorkers)
+			}
+		}
+
+		close(release)
+
+		for i := 0; i < numWorkers; i++ {
+			select {
+			case err := <-errs:
+				require.NoError(t, err)
+
+			case <-time.After(5 * time.Second):
+				t.Fatalf("task %d never completed", i)
+			}
+		}
+	}
+
+	// The first case covers a panic in the very first task handed to a
+	// newly spawned worker goroutine.
+	t.Run("first task on a new worker", func(t *testing.T) {
+		t.Parallel()
+
+		p := newReadPool(t)
+
+		err := submitWithTimeout(t, p, panicTask)
+		require.ErrorIs(t, err, pool.ErrWorkerTaskPanic)
+		require.ErrorContains(t, err, "panic in worker task")
+
+		saturate(t, p)
+	})
+
+	// The second case covers a panic in a task handed to a worker that has
+	// already processed a task and is sitting idle waiting for more work.
+	t.Run("task on an existing worker", func(t *testing.T) {
+		t.Parallel()
+
+		p := newReadPool(t)
+
+		// Saturating the pool leaves us with numWorkers idle workers,
+		// so the next task we submit is guaranteed to be handed to one
+		// of them rather than to a freshly spawned worker.
+		saturate(t, p)
+
+		err := submitWithTimeout(t, p, panicTask)
+		require.ErrorIs(t, err, pool.ErrWorkerTaskPanic)
+		require.ErrorContains(t, err, "panic in worker task")
+
+		saturate(t, p)
+	})
+
+	// A panic value is allowed to implement String or Error with arbitrary
+	// code. A second panic while formatting it must not turn the recovered
+	// task into an apparent success or prevent worker retirement.
+	t.Run("panic value formatting panics", func(t *testing.T) {
+		t.Parallel()
+
+		p := newReadPool(t)
+
+		err := submitWithTimeout(t, p, panickingValueTask)
+		require.ErrorIs(t, err, pool.ErrWorkerTaskPanic)
+
+		saturate(t, p)
+	})
 }
 
 func submitGeneric(p interface{}, sem <-chan struct{}) error {

--- a/rpcperms/interceptor.go
+++ b/rpcperms/interceptor.go
@@ -1,16 +1,16 @@
 package rpcperms
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"runtime/debug"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 
 	"github.com/btcsuite/btclog/v2"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/macaroons"
 	"github.com/lightningnetwork/lnd/monitoring"
@@ -642,41 +642,12 @@ func logRecoveredPanic(logger btclog.Logger, fullMethod string,
 		fullMethod = "<unknown>"
 	}
 
-	stack := truncatePanicStack(debug.Stack())
-
-	logger.Errorf("[%v]: recovered panic in RPC handler: %v\n%s",
-		fullMethod, panicValue, stack)
-}
-
-const (
-	// maxPanicStackSize is the maximum stack size logged for recovered RPC
-	// panics. This follows the existing 8 KiB recovered-panic stack bound
-	// convention while avoiding package coupling for a single constant.
-	maxPanicStackSize = 8192
-
-	panicStackTruncatedMsg = "\n... stack trace truncated ..."
-)
-
-// truncatePanicStack caps a panic stack trace while keeping the final logged
-// line readable when possible.
-func truncatePanicStack(stack []byte) []byte {
-	if len(stack) <= maxPanicStackSize {
-		return stack
-	}
-
-	suffix := []byte(panicStackTruncatedMsg)
-	maxStackLen := maxPanicStackSize - len(suffix)
-	searchStack := stack[:maxStackLen+1]
-	newLineIndex := bytes.LastIndexByte(searchStack, '\n')
-	if newLineIndex > 0 {
-		maxStackLen = newLineIndex
-	}
-
-	truncatedStack := make([]byte, 0, maxStackLen+len(suffix))
-	truncatedStack = append(truncatedStack, stack[:maxStackLen]...)
-	truncatedStack = append(truncatedStack, suffix...)
-
-	return truncatedStack
+	fn.LogRecoveredPanic(
+		context.Background(), logger, fn.Panic{
+			Value: panicValue,
+			Stack: fn.PanicStack(),
+		}, slog.String("rpc_method", fullMethod),
+	)
 }
 
 // panicRecoveryUnaryServerInterceptor recovers panics from unary RPC handlers

--- a/rpcperms/interceptor_test.go
+++ b/rpcperms/interceptor_test.go
@@ -1,7 +1,6 @@
 package rpcperms
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"testing"
@@ -109,21 +108,4 @@ type recordingServerStream struct {
 func (s *recordingServerStream) SendMsg(any) error {
 	s.numSent++
 	return nil
-}
-
-// TestTruncatePanicStack asserts that panic stack traces are capped with a
-// readable truncation marker.
-func TestTruncatePanicStack(t *testing.T) {
-	shortStack := []byte("short stack")
-	require.Equal(t, shortStack, truncatePanicStack(shortStack))
-
-	longStack := bytes.Repeat([]byte("stack frame\n"), maxPanicStackSize)
-	truncatedStack := truncatePanicStack(longStack)
-
-	require.LessOrEqual(t, len(truncatedStack), maxPanicStackSize)
-	require.True(
-		t, bytes.HasSuffix(
-			truncatedStack, []byte(panicStackTruncatedMsg),
-		),
-	)
 }

--- a/tools/linters/deferrecover.go
+++ b/tools/linters/deferrecover.go
@@ -1,0 +1,120 @@
+package linters
+
+import (
+	"go/ast"
+	"go/types"
+
+	"github.com/golangci/plugin-module-register/register"
+	"golang.org/x/tools/go/analysis"
+)
+
+const (
+	deferRecoverLinterName = "deferrecover"
+	fnPackagePath          = "github.com/lightningnetwork/lnd/fn/v2"
+)
+
+// NewDeferRecover creates a linter plugin that verifies RecoverPanic is
+// deferred directly.
+func NewDeferRecover(_ any) (register.LinterPlugin, error) {
+	return &DeferRecoverPlugin{}, nil
+}
+
+// DeferRecoverPlugin checks that calls to fn.RecoverPanic are direct defer
+// expressions.
+type DeferRecoverPlugin struct{}
+
+// BuildAnalyzers creates the analyzers for the deferrecover linter.
+//
+// NOTE: This is part of the register.LinterPlugin interface.
+func (d *DeferRecoverPlugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
+	return []*analysis.Analyzer{newDeferRecoverAnalyzer()}, nil
+}
+
+// GetLoadMode returns the load mode for the deferrecover linter.
+//
+// NOTE: This is part of the register.LinterPlugin interface.
+func (d *DeferRecoverPlugin) GetLoadMode() string {
+	return register.LoadModeTypesInfo
+}
+
+// newDeferRecoverAnalyzer constructs the analyzer used by the custom linter.
+func newDeferRecoverAnalyzer() *analysis.Analyzer {
+	return &analysis.Analyzer{
+		Name: deferRecoverLinterName,
+		Doc:  "Reports fn.RecoverPanic calls that are not deferred directly",
+		Run:  runDeferRecover,
+	}
+}
+
+// runDeferRecover reports RecoverPanic calls that are not direct defer
+// expressions.
+func runDeferRecover(pass *analysis.Pass) (any, error) {
+	for _, file := range pass.Files {
+		directDefers := make(map[*ast.CallExpr]struct{})
+		ast.Inspect(file, func(node ast.Node) bool {
+			deferStmt, ok := node.(*ast.DeferStmt)
+			if ok {
+				directDefers[deferStmt.Call] = struct{}{}
+			}
+
+			return true
+		})
+
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok || !isRecoverPanicCall(pass, call) {
+				return true
+			}
+
+			if _, ok := directDefers[call]; ok {
+				return true
+			}
+
+			pass.Reportf(
+				call.Pos(), "fn.RecoverPanic only works when "+
+					"deferred directly",
+			)
+
+			return true
+		})
+	}
+
+	return nil, nil
+}
+
+// isRecoverPanicCall reports whether call resolves to fn.RecoverPanic.
+func isRecoverPanicCall(pass *analysis.Pass, call *ast.CallExpr) bool {
+	var object types.Object
+
+	switch fn := unparen(call.Fun).(type) {
+	case *ast.Ident:
+		object = pass.TypesInfo.Uses[fn]
+
+	case *ast.SelectorExpr:
+		object = pass.TypesInfo.Uses[fn.Sel]
+	}
+
+	function, ok := object.(*types.Func)
+	if !ok || function.Pkg() == nil {
+		return false
+	}
+
+	return function.Pkg().Path() == fnPackagePath &&
+		function.Name() == "RecoverPanic"
+}
+
+// unparen removes any parentheses surrounding an expression.
+func unparen(expr ast.Expr) ast.Expr {
+	for {
+		paren, ok := expr.(*ast.ParenExpr)
+		if !ok {
+			return expr
+		}
+
+		expr = paren.X
+	}
+}
+
+func init() {
+	register.Plugin(deferRecoverLinterName, NewDeferRecover)
+}

--- a/tools/linters/deferrecover_test.go
+++ b/tools/linters/deferrecover_test.go
@@ -1,0 +1,17 @@
+package linters
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+// TestDeferRecover verifies direct-defer acceptance and misuse diagnostics.
+func TestDeferRecover(t *testing.T) {
+	t.Parallel()
+
+	analysistest.Run(
+		t, analysistest.TestData(), newDeferRecoverAnalyzer(),
+		"deferrecover",
+	)
+}

--- a/tools/linters/go.mod
+++ b/tools/linters/go.mod
@@ -11,5 +11,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/mod v0.23.0 // indirect
+	golang.org/x/sync v0.11.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/tools/linters/go.sum
+++ b/tools/linters/go.sum
@@ -2,10 +2,16 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golangci/plugin-module-register v0.1.1 h1:TCmesur25LnyJkpsVrupv1Cdzo+2f7zX0H6Jkw1Ol6c=
 github.com/golangci/plugin-module-register v0.1.1/go.mod h1:TTpqoB6KkwOJMV8u7+NyXMrkwwESJLOkfl9TxR1DGFc=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/mod v0.23.0 h1:Zb7khfcRGKk+kqfxFaP5tZqCnDZMjC5VtUBs87Hr6QM=
+golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
+golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/tools v0.30.0 h1:BgcpHewrV5AUp2G9MebG4XPFI1E2W41zU1SaqVA9vJY=
 golang.org/x/tools v0.30.0/go.mod h1:c347cR/OJfw5TI+GfX7RUPNMdDRRbjvYTS0jPyvsVtY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/tools/linters/testdata/src/deferrecover/deferrecover.go
+++ b/tools/linters/testdata/src/deferrecover/deferrecover.go
@@ -1,0 +1,41 @@
+// Package deferrecover contains valid and invalid RecoverPanic uses for the
+// deferrecover analyzer.
+package deferrecover
+
+import (
+	. "github.com/lightningnetwork/lnd/fn/v2"
+	panicfn "github.com/lightningnetwork/lnd/fn/v2"
+)
+
+// handlePanic is the callback shared by the analyzer test cases.
+func handlePanic(panicfn.Panic) {}
+
+// valid exercises the supported selector and dot-import forms.
+func valid() {
+	defer panicfn.RecoverPanic(handlePanic)
+	defer RecoverPanic(handlePanic)
+}
+
+// invalid exercises calls that are not deferred directly.
+func invalid() {
+	panicfn.RecoverPanic(handlePanic) // want "deferred directly"
+
+	defer func() {
+		panicfn.RecoverPanic(handlePanic) // want "deferred directly"
+	}()
+
+	go panicfn.RecoverPanic(handlePanic) // want "deferred directly"
+	RecoverPanic(handlePanic)            // want "deferred directly"
+}
+
+// unrelated provides a same-named method from a different type.
+type unrelated struct{}
+
+// RecoverPanic is intentionally unrelated to fn.RecoverPanic.
+func (unrelated) RecoverPanic(func(panicfn.Panic)) {}
+
+// unrelatedMethod verifies that same-named methods are ignored.
+func unrelatedMethod() {
+	var value unrelated
+	value.RecoverPanic(handlePanic)
+}

--- a/tools/linters/testdata/src/github.com/lightningnetwork/lnd/fn/v2/fn.go
+++ b/tools/linters/testdata/src/github.com/lightningnetwork/lnd/fn/v2/fn.go
@@ -1,0 +1,9 @@
+// Package fn provides the minimal API needed by the deferrecover analyzer
+// fixture.
+package fn
+
+// Panic represents a recovered panic in the analyzer fixture.
+type Panic struct{}
+
+// RecoverPanic represents the function checked by the analyzer fixture.
+func RecoverPanic(func(Panic)) {}


### PR DESCRIPTION
## Change Description

This PR introduces shared helpers for reporting unexpected panics and for
recovering at selected asynchronous boundaries. Recovery is used only where
the affected owner can be retired without resuming uncertain mutable state.
If recovery cleanup itself panics, that panic propagates.

The goal is to reduce the failure scope while preserving fail-stop behavior
for the affected peer, worker, or protocol instance.

## Safe Recovery Boundary Definition

A recovery boundary is considered safe when the affected execution unit and
its state are retired after a panic. It does not process another event.
Panic recovery in this PR uses that fail-stop model; funding reservation
maintenance has synchronized reads but no recovery boundary.

Attacker reachability is evaluated separately. It determines how important a
boundary may be for denial-of-service protection, but it does not prove that
recovering there is safe. A highly exposed state machine is still excluded if
its partial effects cannot be rolled back or quarantined.

## Boundary Evaluation Requirements

Every candidate site was evaluated individually against the same requirements:

1. Identify the trigger, trust boundary, owning goroutine, and exact function
   that returns after recovery.
2. Trace in-memory mutations, persistent writes, wallet or signer operations,
   messages, broadcasts, subscriptions, and launched goroutines that may have
   completed before the panic.
3. Prove that uncertain state is retired or quarantined and that cleanup
   failures still propagate rather than resuming a partial transition.
4. Trace every mutex, wait group, worker token, stream, and cleanup defer to
   ensure panic unwinding releases ownership correctly.
5. Trace teardown ordering and bounded channel operations so cleanup does not
   wait for a signal that only a later cleanup step can produce. Any remaining
   producer and buffer assumptions must be explicit.
6. Preserve recoverable persistent state when teardown occurs after an external
   effect such as broadcasting a cooperative-close transaction.
7. Exercise the boundary with fault injection, goroutine-exit checks, lock
   reacquisition checks, and race-detector coverage.

The analysis assumes a panic can occur at any instruction, including after an
external effect but before the corresponding in-memory bookkeeping completes.

## Recovery Boundaries Retained in This PR

| Boundary | Trigger | Containment outcome | Why recovery is safe |
|---|---|---|---|
| `peer.readNextMessageWithRecovery` | Peer wire read or decode | Reports the panic as a read error and disconnects the peer | Stateful message dispatch remains outside recovery. Peer quit is signaled before discovery-stream shutdown waits for its consumer. |
| `pool.Worker.runTask` | Submitted buffer-pool task | Converts the panic to an error and retires the worker state | Current production callers propagate the task failure into peer teardown. The panicking worker does not continue with its previous task state. |
| `peer.handleCloseMsg` | Remote legacy cooperative-close message | Fails and removes the legacy closer, resets in-memory state, disconnects the peer, and stops `channelManager` | An already broadcast transaction retains `ChanStatusCoopBroadcasted` for restart recovery. A panic during cleanup propagates. |
| `peer.handleChanFlushed` | Legacy close flush notification | Uses the same legacy-close failure and manager retirement path | The closer remains owned by `channelManager`; it does not receive another event after recovery. Cleanup panics propagate. |

The legacy close path checks that a final closing transaction exists before
removing live channel state. Its impossible-message assertion remains. If it
fires, recovery attempts close cleanup and retires the peer and manager only
when cleanup completes. A cleanup panic remains fatal. The disabled, flushed
link remains registered until the confirmation watcher has started; legacy
caller notifications are best effort when the Updates channel is full.

## Deliberately Excluded Boundaries

This PR excludes recovery where the same stateful component could continue
after an unknown subset of its effects completed. This includes actor mailbox
delivery, message-router endpoints, protocol state machines, the HTLC manager,
remote and local funding workflows, late funding messages, asynchronous
`ChannelReady` processing, local close initiation, and funding cancellation.

Those paths can persist state, consume mappings, reserve wallet inputs, create
signer state, send messages, register subscriptions, install channels, or
broadcast transactions before panicking. They require path-specific rollback,
quarantine, or transaction-like ownership before recovery can be enabled
safely. They will be handled in focused follow-up changes.

This boundary-specific policy remains enabled by default. It does not require
node operators to anticipate an unknown remotely triggerable crash or opt in to
protection before a vulnerability is disclosed.

## Additional Changes

- Recovered failures use structured error summaries. Peer-facing and pool
  boundaries log bounded stack traces at debug level to limit log amplification.
- `fn.RecoverPanic(nil)` propagates the original panic; a cleanup callback that
  panics also propagates its failure.
- Funding zombie reservation expiry reads its timestamp under the same lock
  used by updates. The sweep has no panic recovery boundary.
- Existing gossip and RPC recovery behavior is unchanged. Only its reporting is
  migrated to the shared helpers.
- The final RBF cooperative-close update is cancellable so an abandoned caller
  cannot hold observer teardown open.
- Legacy close updates are best effort when the caller's Updates buffer is
  full, so they cannot block channel-manager or watcher cleanup.
- A custom analyzer requires every `fn.RecoverPanic` call to be deferred
  directly so Go recovery semantics cannot be bypassed accidentally.

## Validation

- `peer`, `funding`, `pool`, `discovery`, and `rpcperms` package tests pass.
  Full `fn` and custom-linter module tests also pass.
- Focused peer, pool, and funding recovery tests pass under `-race -count=20`.
  The full `fn` module passes under `-race`.
- Tests verify peer goroutine exit, cooperative-close cleanup, lock
  reacquisition, funding reservation lock release, and synchronized reservation
  timestamp access.
- `make lint-native workers=4` passes with zero issues using Go 1.27.1 and a
  rebuilt custom linter.
