### PR TITLE
build: bump Go language to 1.25.13 and toolchain to 1.26.6

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -52,7 +52,7 @@ runs:
         # The key is used to create and later look up the cache. It's made of
         # four parts:
         # - The base part is made from the OS name, Go version and a
-        #   job-specified key prefix. Example: `linux-go-1.26.4-unit-test-`.
+        #   job-specified key prefix. Example: `linux-go-1.26.6-unit-test-`.
         #   It ensures that a job running on Linux with Go 1.26 only looks for
         #   caches from the same environment.
         # - The unique part is the `hashFiles('**/go.sum')`, which calculates a

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -40,7 +40,7 @@ defaults:
 env:
   # If you change this please also update GO_VERSION in Makefile (then run
   # `make lint` to see where else it needs to be updated as well).
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.6
 
 jobs:
   govulncheck:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ env:
 
   # If you change this please also update GO_VERSION in Makefile (then run
   # `make lint` to see where else it needs to be updated as well).
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.6
 
 jobs:
   static-checks:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ defaults:
 env:
   # If you change this please also update GO_VERSION in Makefile (then run
   # `make lint` to see where else it needs to be updated as well).
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.6
 
 jobs:
   ########################

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@ version: "2"
 run:
   # If you change this please also update GO_VERSION in Makefile (then run
   # `make lint` to see where else it needs to be updated as well).
-  go: "1.26.4"
+  go: "1.26.6"
 
   # Abort after 10 minutes.
   timeout: 10m

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # If you change this please also update GO_VERSION in Makefile (then run
 # `make lint` to see where else it needs to be updated as well).
-FROM golang:1.26.4-alpine as builder
+FROM golang:1.26.6-alpine as builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ACTIVE_GO_VERSION_MINOR := $(shell echo $(ACTIVE_GO_VERSION) | cut -d. -f2)
 # GO_VERSION is the Go version used for the release build, docker files, and
 # GitHub Actions. This is the reference version for the project. All other Go
 # versions are checked against this version.
-GO_VERSION = 1.26.4
+GO_VERSION = 1.26.6
 
 GOBUILD := $(GOCC) build -v
 GOINSTALL := $(GOCC) install -v

--- a/actor/go.mod
+++ b/actor/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/actor
 
-go 1.25.11
+go 1.25.13
 
 require (
 	github.com/btcsuite/btclog/v2 v2.0.1-0.20250602222548-9967d19bb084

--- a/cert/go.mod
+++ b/cert/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/cert
 
-go 1.25.11
+go 1.25.13
 
 require github.com/stretchr/testify v1.8.2
 

--- a/clock/go.mod
+++ b/clock/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/clock
 
-go 1.25.11
+go 1.25.13
 
 require github.com/stretchr/testify v1.8.2
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,6 +1,6 @@
 # If you change this please also update GO_VERSION in Makefile (then run
 # `make lint` to see where else it needs to be updated as well).
-FROM golang:1.26.4-alpine AS builder
+FROM golang:1.26.6-alpine AS builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 

--- a/docker/btcd/Dockerfile
+++ b/docker/btcd/Dockerfile
@@ -1,6 +1,6 @@
 # If you change this please also update GO_VERSION in Makefile (then run
 # `make lint` to see where else it needs to be updated as well).
-FROM golang:1.26.4-alpine AS builder
+FROM golang:1.26.6-alpine AS builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -93,7 +93,7 @@ following build dependencies are required:
 
 ### Installing Go
 
-`lnd` is written in Go, with a minimum version of `1.25.11` (or, in case this
+`lnd` is written in Go, with a minimum version of `1.25.13` (or, in case this
 document gets out of date, whatever the Go version in the main `go.mod` file
 requires). To install, run one of the following commands for your OS:
 
@@ -101,15 +101,15 @@ requires). To install, run one of the following commands for your OS:
   <summary>Linux (x86-64)</summary>
 
   ```
-  wget https://dl.google.com/go/go1.25.11.linux-amd64.tar.gz
-  echo "34f14304e856893f4ba30c2cacfe93906e9de7915c5f6aaaf3a81cdccd7ba30b  go1.25.11.linux-amd64.tar.gz" | sha256sum --check
+  wget https://dl.google.com/go/go1.25.13.linux-amd64.tar.gz
+  echo "39042a078ea9ceebe3ecda4a7188f0f5b96e14a071d27923ba7f40b456e85ae3  go1.25.13.linux-amd64.tar.gz" | sha256sum --check
   ```
 
-  The command above should output `go1.25.11.linux-amd64.tar.gz: OK`. If it
+  The command above should output `go1.25.13.linux-amd64.tar.gz: OK`. If it
   doesn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
   this version of Go. If it matches, then proceed to install Go:
   ```
-  sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.25.11.linux-amd64.tar.gz
+  sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.25.13.linux-amd64.tar.gz
   export PATH=$PATH:/usr/local/go/bin
   ```
 </details>
@@ -118,15 +118,15 @@ requires). To install, run one of the following commands for your OS:
   <summary>Linux (ARMv6)</summary>
 
   ```
-  wget https://dl.google.com/go/go1.25.11.linux-armv6l.tar.gz
-  echo "492d69badee59cae12e9a36282dfce94041bd4aac88fdddea575a7d99a2bd05d  go1.25.11.linux-armv6l.tar.gz" | sha256sum --check
+  wget https://dl.google.com/go/go1.25.13.linux-armv6l.tar.gz
+  echo "f98ba3beb03a5c269d0115c7f8573483c139be88ce9989e53aff336826d13f5c  go1.25.13.linux-armv6l.tar.gz" | sha256sum --check
   ```
 
-  The command above should output `go1.25.11.linux-armv6l.tar.gz: OK`. If it
+  The command above should output `go1.25.13.linux-armv6l.tar.gz: OK`. If it
   isn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
   this version of Go. If it matches, then proceed to install Go:
   ```
-  sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.25.11.linux-armv6l.tar.gz
+  sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.25.13.linux-armv6l.tar.gz
   export PATH=$PATH:/usr/local/go/bin
   ```
 

--- a/fn/go.mod
+++ b/fn/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/fn/v2
 
-go 1.25.11
+go 1.25.13
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -217,7 +217,7 @@ replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-d
 // If you change this please also update docs/INSTALL.md and all other go.mod
 // files. The release build toolchain version is tracked separately by
 // GO_VERSION in Makefile.
-go 1.25.11
+go 1.25.13
 
 retract v0.0.2
 

--- a/healthcheck/go.mod
+++ b/healthcheck/go.mod
@@ -23,4 +23,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.25.11
+go 1.25.13

--- a/kvdb/go.mod
+++ b/kvdb/go.mod
@@ -143,4 +143,4 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
-go 1.25.11
+go 1.25.13

--- a/lnrpc/Dockerfile
+++ b/lnrpc/Dockerfile
@@ -1,6 +1,6 @@
 # If you change this please also update GO_VERSION in Makefile (then run
 # `make lint` to see where else it needs to be updated as well).
-FROM golang:1.26.4-bookworm
+FROM golang:1.26.6-bookworm
 
 RUN apt-get update && apt-get install -y \
   git \

--- a/lnrpc/gen_protos_docker.sh
+++ b/lnrpc/gen_protos_docker.sh
@@ -6,7 +6,7 @@ set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # golang docker image version used in this script.
-GO_IMAGE=docker.io/library/golang:1.26.4-alpine
+GO_IMAGE=docker.io/library/golang:1.26.6-alpine
 
 PROTOBUF_VERSION=$(docker run --rm -v $DIR/../:/lnd -w /lnd $GO_IMAGE \
 	go list -f '{{.Version}}' -m google.golang.org/protobuf)

--- a/make/builder.Dockerfile
+++ b/make/builder.Dockerfile
@@ -1,6 +1,6 @@
 # If you change this please also update GO_VERSION in Makefile (then run
 # `make lint` to see where else it needs to be updated as well).
-FROM golang:1.26.4-bookworm
+FROM golang:1.26.6-bookworm
 
 MAINTAINER Olaoluwa Osuntokun <laolu@lightning.engineering>
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -103,7 +103,7 @@ following commands:
 
 ```
 RUN apt-get install -y wget \
-    && wget -c https://dl.google.com/go/go1.26.4.linux-amd64.tar.gz -O - \
+    && wget -c https://dl.google.com/go/go1.26.6.linux-amd64.tar.gz -O - \
     | tar -xz -C /usr/local
 ENV GOPATH=/go
 ENV PATH=$PATH:/usr/local/go/bin:/go/bin

--- a/queue/go.mod
+++ b/queue/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/queue
 
-go 1.25.11
+go 1.25.13
 
 require (
 	github.com/lightningnetwork/lnd/fn/v2 v2.0.8

--- a/sqldb/go.mod
+++ b/sqldb/go.mod
@@ -71,4 +71,4 @@ require (
 	modernc.org/token v1.1.0 // indirect
 )
 
-go 1.25.11
+go 1.25.13

--- a/sqldb/v2/go.mod
+++ b/sqldb/v2/go.mod
@@ -70,4 +70,4 @@ require (
 // did not yet make it into the upstream repository.
 replace github.com/golang-migrate/migrate/v4 => github.com/lightninglabs/migrate/v4 v4.18.2-9023d66a-fork-pr-2.0.20251211093704-71c1eef09789
 
-go 1.25.11
+go 1.25.13

--- a/ticker/go.mod
+++ b/ticker/go.mod
@@ -1,3 +1,3 @@
 module github.com/lightningnetwork/lnd/ticker
 
-go 1.25.11
+go 1.25.13

--- a/tlv/go.mod
+++ b/tlv/go.mod
@@ -22,4 +22,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.25.11
+go 1.25.13

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4
+FROM golang:1.26.6
 
 RUN apt-get update && apt-get install -y git
 ENV GOCACHE=/tmp/build/.cache

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/tools
 
-go 1.25.11
+go 1.25.13
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0 // indirect

--- a/tools/linters/go.mod
+++ b/tools/linters/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/tools/linters
 
-go 1.25.11
+go 1.25.13
 
 require (
 	github.com/golangci/plugin-module-register v0.1.1

--- a/tor/go.mod
+++ b/tor/go.mod
@@ -25,4 +25,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.25.11
+go 1.25.13


### PR DESCRIPTION
This updates the Go language/minimum version and build toolchain pins separately:

- all tracked `go.mod` files now use `go 1.25.13`
- release/toolchain pins move to Go 1.26.6 across Makefile, CI, Dockerfiles, golangci-lint config, and protobuf generation
- install docs now reference Go 1.25.13 with official Linux amd64 and ARMv6 SHA256 checksums

Verification:

- `git diff --check`
- `make check-go-version`
- `GOTOOLCHAIN=go1.26.6 go version`
- parsed all nested module files with `GOTOOLCHAIN=go1.26.6 go mod edit -json`
- checked tracked files for stale `1.25.11`, `go1.25.11`, `1.26.4`, and `go1.26.4` references
