### PR TITLE
tor: restore all managed onion services

### DIFF
--- a/tor/cmd_info.go
+++ b/tor/cmd_info.go
@@ -3,6 +3,7 @@ package tor
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -21,57 +22,100 @@ var (
 	ErrNoServiceFound = errors.New("no active service found")
 )
 
-// CheckOnionService checks that the onion service created by the controller
-// is active. It queries the Tor daemon using the endpoint "onions/current" to
-// get the current onion service and checks that service ID matches the
-// activeServiceID.
+// CheckOnionService checks that all onion services created by the controller
+// are active. It queries the Tor daemon using the endpoint "onions/current" to
+// get the current onion services and checks that their exact set matches every
+// active service tracked by the controller.
 func (c *Controller) CheckOnionService() error {
-	// Check that we have a hidden service created.
-	if c.activeServiceID == "" {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	expectedIDs, expectedSet := c.trackedServiceIDs()
+	if len(expectedIDs) == 0 {
 		return ErrServiceNotCreated
 	}
 
 	// Fetch the onion services that live in current control connection.
 	cmd := "GETINFO onions/current"
-	code, reply, err := c.sendCommand(cmd)
+	code, reply, err := c.sendCommandLocked(cmd)
 
 	// Exit early if we got an error or Tor daemon didn't respond success.
 	// TODO(yy): unify the usage of err and code so we could rely on a
 	// single source to change our state.
 	if err != nil || code != success {
-		log.Debugf("query service:%v got err:%v, reply:%v",
-			c.activeServiceID, err, reply)
+		log.Debugf("query services got err:%v, reply:%v", err, reply)
 
 		return fmt.Errorf("%w: %v", err, reply)
 	}
 
-	// Parse the reply, which should have the following format,
-	//      onions/current=serviceID
-	// After parsing, we get a map as,
-	// 	[onion/current: serviceID]
-	//
-	// NOTE: our current tor controller does NOT support multiple onion
-	// services to be created at the same time, thus we expect the reply to
-	// only contain one serviceID. If multiple serviceIDs are returned, we
-	// would expected the reply to have the following format,
-	//      onions/current=serviceID1, serviceID2, serviceID3,...
-	// Thus a new parser is need to parse that reply.
+	// Parse the comma-separated service IDs from onions/current.
 	resp := parseTorReply(reply)
 	serviceID, ok := resp["onions/current"]
 	if !ok {
 		return ErrNoServiceFound
 	}
 
-	// Check that our active service is indeed the service acknowledged by
-	// Tor daemon. The controller is only aware of a single service but the
-	// Tor daemon might have multiple services registered (for example for
-	// the watchtower as well as the node p2p connections). So we just want
-	// to check that our current controller's ID is contained in the list of
-	// registered services.
-	if !strings.Contains(serviceID, c.activeServiceID) {
-		return fmt.Errorf("%w: controller has: %v, Tor daemon has: %v",
-			ErrServiceIDMismatch, c.activeServiceID, serviceID)
+	if serviceID == "" {
+		return ErrNoServiceFound
+	}
+
+	actualIDs := strings.Split(serviceID, ",")
+	actualSet := make(map[string]struct{}, len(actualIDs))
+	for _, actualID := range actualIDs {
+		if actualID == "" {
+			return serviceIDMismatch(expectedIDs, actualIDs)
+		}
+		if _, duplicate := actualSet[actualID]; duplicate {
+			return serviceIDMismatch(expectedIDs, actualIDs)
+		}
+
+		actualSet[actualID] = struct{}{}
+		if _, expected := expectedSet[actualID]; !expected {
+			return serviceIDMismatch(expectedIDs, actualIDs)
+		}
+	}
+
+	if len(actualSet) != len(expectedSet) {
+		return serviceIDMismatch(expectedIDs, actualIDs)
 	}
 
 	return nil
+}
+
+// trackedServiceIDs returns every registered identity in deterministic order.
+// The active set fallback supports controllers constructed before registration
+// tracking and tests that exercise the control response parser directly.
+func (c *Controller) trackedServiceIDs() ([]string, map[string]struct{}) {
+	expectedIDs := make([]string, 0, len(c.registrations))
+	expectedSet := make(map[string]struct{}, len(c.registrations))
+	for _, registration := range c.registrations {
+		serviceID := registration.serviceID
+		if _, duplicate := expectedSet[serviceID]; duplicate {
+			continue
+		}
+
+		expectedIDs = append(expectedIDs, serviceID)
+		expectedSet[serviceID] = struct{}{}
+	}
+
+	if len(expectedIDs) != 0 {
+		return expectedIDs, expectedSet
+	}
+
+	var remaining []string
+	for serviceID := range c.activeServiceIDs {
+		remaining = append(remaining, serviceID)
+	}
+	sort.Strings(remaining)
+	for _, serviceID := range remaining {
+		expectedSet[serviceID] = struct{}{}
+	}
+
+	return remaining, expectedSet
+}
+
+// serviceIDMismatch constructs a deterministic service set mismatch error.
+func serviceIDMismatch(expectedIDs, actualIDs []string) error {
+	return fmt.Errorf("%w: controller has: %v, Tor daemon has: %v",
+		ErrServiceIDMismatch, expectedIDs, actualIDs)
 }

--- a/tor/cmd_info_test.go
+++ b/tor/cmd_info_test.go
@@ -29,7 +29,12 @@ func TestCheckOnionServiceSucceed(t *testing.T) {
 	server := proxy.serverConn
 
 	// Assign a fake service ID to the controller.
-	c := &Controller{conn: proxy.clientConn, activeServiceID: "fakeID"}
+	c := &Controller{
+		conn: proxy.clientConn,
+		activeServiceIDs: map[string]struct{}{
+			"fakeID": {},
+		},
+	}
 
 	// Test a successful response.
 	serverResp := "250-onions/current=fakeID\n250 OK\n"
@@ -51,7 +56,12 @@ func TestCheckOnionServiceFailOnServiceIDNotMatch(t *testing.T) {
 	server := proxy.serverConn
 
 	// Assign a fake service ID to the controller.
-	c := &Controller{conn: proxy.clientConn, activeServiceID: "fakeID"}
+	c := &Controller{
+		conn: proxy.clientConn,
+		activeServiceIDs: map[string]struct{}{
+			"fakeID": {},
+		},
+	}
 
 	// Mock a response with a different serviceID.
 	serverResp := "250-onions/current=unmatchedID\n250 OK\n"
@@ -64,7 +74,7 @@ func TestCheckOnionServiceFailOnServiceIDNotMatch(t *testing.T) {
 	require.ErrorIs(t, c.CheckOnionService(), ErrServiceIDMismatch)
 }
 
-func TestCheckOnionServiceSucceedOnMultipleServices(t *testing.T) {
+func TestCheckOnionServiceExactMultipleServices(t *testing.T) {
 	t.Parallel()
 
 	// Create mock server and client connection.
@@ -72,19 +82,81 @@ func TestCheckOnionServiceSucceedOnMultipleServices(t *testing.T) {
 	t.Cleanup(proxy.cleanUp)
 	server := proxy.serverConn
 
-	// Assign a fake service ID to the controller.
-	c := &Controller{conn: proxy.clientConn, activeServiceID: "fakeID"}
+	// Assign two fake service IDs to the controller.
+	c := &Controller{
+		conn: proxy.clientConn,
+		registrations: []onionServiceRegistration{
+			{serviceID: "service1"},
+			{serviceID: "service2"},
+		},
+		activeServiceIDs: map[string]struct{}{
+			"service1": {},
+			"service2": {},
+		},
+	}
 
-	// Mock a response with a different serviceID.
-	serverResp := "250-onions/current=service1,fakeID,service2\n250 OK\n"
+	// Reordering the exact service set is accepted.
+	serverResp := "250-onions/current=service2,service1\n250 OK\n"
 
 	// Let the server mocks a given response.
 	_, err := server.Write([]byte(serverResp))
 	require.NoError(t, err, "server failed to write")
 
-	// No error is expected, the controller's ID is contained within the
-	// list of active services.
+	// No error is expected because every tracked service is present and
+	// there are no unexpected services.
 	require.NoError(t, c.CheckOnionService())
+}
+
+func TestCheckOnionServiceRejectsInexactSets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		response string
+	}{
+		{
+			name:     "missing service",
+			response: "service1",
+		},
+		{
+			name:     "partial service name",
+			response: "service1,service",
+		},
+		{
+			name:     "unexpected service",
+			response: "service1,service2,service3",
+		},
+		{
+			name:     "duplicate service",
+			response: "service1,service1",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			proxy := createTestProxy(t)
+			t.Cleanup(proxy.cleanUp)
+			c := &Controller{
+				conn: proxy.clientConn,
+				activeServiceIDs: map[string]struct{}{
+					"service1": {},
+					"service2": {},
+				},
+			}
+
+			_, err := proxy.serverConn.Write([]byte(
+				"250-onions/current=" + test.response +
+					"\n250 OK\n",
+			))
+			require.NoError(t, err)
+			require.ErrorIs(
+				t, c.CheckOnionService(), ErrServiceIDMismatch,
+			)
+		})
+	}
 }
 
 func TestCheckOnionServiceFailOnClosedConnection(t *testing.T) {
@@ -96,7 +168,12 @@ func TestCheckOnionServiceFailOnClosedConnection(t *testing.T) {
 	server := proxy.serverConn
 
 	// Assign a fake service ID to the controller.
-	c := &Controller{conn: proxy.clientConn, activeServiceID: "fakeID"}
+	c := &Controller{
+		conn: proxy.clientConn,
+		activeServiceIDs: map[string]struct{}{
+			"fakeID": {},
+		},
+	}
 
 	// Close the connection from the server side.
 	require.NoError(t, server.Close(), "server failed to close conn")

--- a/tor/cmd_onion.go
+++ b/tor/cmd_onion.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 )
 
 var (
@@ -241,6 +242,14 @@ func (c *Controller) prepareAddOnion(cfg AddOnionConfig) (string, string,
 		return "", "", err
 	}
 
+	return c.prepareAddOnionWithKey(cfg, keyParam), keyParam, nil
+}
+
+// prepareAddOnionWithKey constructs an ADD_ONION command using a known private
+// key and the original port mapping.
+func (c *Controller) prepareAddOnionWithKey(cfg AddOnionConfig,
+	keyParam string) string {
+
 	// Now, we'll create a mapping from the virtual port to each target
 	// port. If no target ports were specified, we'll use the virtual port
 	// to provide a one-to-one mapping.
@@ -268,9 +277,7 @@ func (c *Controller) prepareAddOnion(cfg AddOnionConfig) (string, string,
 
 	// Send the command to create the onion service to the Tor server and
 	// await its response.
-	cmd := fmt.Sprintf("ADD_ONION %s %s", keyParam, portParam)
-
-	return cmd, keyParam, nil
+	return fmt.Sprintf("ADD_ONION %s %s", keyParam, portParam)
 }
 
 // AddOnion creates an ephemeral onion service and returns its onion address.
@@ -283,23 +290,58 @@ func (c *Controller) prepareAddOnion(cfg AddOnionConfig) (string, string,
 // to survive beyond current controller connection, use the "Detach" flag when
 // creating new service via `ADD_ONION`.
 func (c *Controller) AddOnion(cfg AddOnionConfig) (*OnionAddr, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	// Before sending the request to create an onion service to the Tor
 	// server, we'll make sure that it supports V3 onion services.
 	if err := supportsV3(c.version); err != nil {
 		return nil, err
 	}
 
-	// Construct the cmd command.
-	cmd, keyParam, err := c.prepareAddOnion(cfg)
+	addr, keyParam, err := c.addOnionLocked(cfg, "", true)
 	if err != nil {
 		return nil, err
 	}
 
-	// Send the command to create the onion service to the Tor server and
-	// await its response.
-	_, reply, err := c.sendCommand(cmd)
+	serviceID := strings.TrimSuffix(addr.OnionService, OnionSuffix)
+	if c.activeServiceIDs == nil {
+		c.activeServiceIDs = make(map[string]struct{})
+	}
+	c.activeServiceIDs[serviceID] = struct{}{}
+
+	// Copy the target ports so callers cannot mutate the recorded mapping.
+	cfg.TargetPorts = append([]int(nil), cfg.TargetPorts...)
+	c.registrations = append(c.registrations, onionServiceRegistration{
+		serviceID: serviceID,
+		keyParam:  keyParam,
+		config:    cfg,
+	})
+	log.Debugf("serviceID:%s added to tor controller", serviceID)
+
+	return addr, nil
+}
+
+// addOnionLocked creates an onion service while the controller mutex is held.
+// If keyParam is empty, the configured store is consulted. If persistKey is
+// false, the store is not written during restoration.
+func (c *Controller) addOnionLocked(cfg AddOnionConfig, keyParam string,
+	persistKey bool) (*OnionAddr, string, error) {
+
+	var cmd string
+	if keyParam == "" {
+		var err error
+		cmd, keyParam, err = c.prepareAddOnion(cfg)
+		if err != nil {
+			return nil, "", err
+		}
+	} else {
+		cmd = c.prepareAddOnionWithKey(cfg, keyParam)
+	}
+
+	_, reply, err := c.sendCommandLocked(cmd)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	// If successful, the reply from the server should be of the following
@@ -319,7 +361,7 @@ func (c *Controller) AddOnion(cfg AddOnionConfig) (*OnionAddr, error) {
 	replyParams := parseTorReply(reply)
 	serviceID, ok := replyParams["ServiceID"]
 	if !ok {
-		return nil, errors.New("service id not found in reply")
+		return nil, "", errors.New("service id not found in reply")
 	}
 
 	// If a new onion service was created, use the new private key for
@@ -333,16 +375,16 @@ func (c *Controller) AddOnion(cfg AddOnionConfig) (*OnionAddr, error) {
 	// we'll store its private key to disk in the event that it needs to
 	// be recreated later on. We write the private key to disk every time
 	// in case the user toggles the --tor.encryptkey flag.
-	if cfg.Store != nil {
+	if persistKey && cfg.Store != nil {
 		err := cfg.Store.StorePrivateKey([]byte(keyParam))
 		if err != nil {
-			return nil, fmt.Errorf("unable to write private key "+
-				"to file: %v", err)
+			storeErr := fmt.Errorf("unable to write private key "+
+				"to file: %w", err)
+			deleteErr := c.delOnionLocked(serviceID)
+
+			return nil, "", errors.Join(storeErr, deleteErr)
 		}
 	}
-
-	c.activeServiceID = serviceID
-	log.Debugf("serviceID:%s added to tor controller", serviceID)
 
 	// Finally, we'll return the onion address composed of the service ID,
 	// along with the onion suffix, and the port this onion service can be
@@ -351,7 +393,55 @@ func (c *Controller) AddOnion(cfg AddOnionConfig) (*OnionAddr, error) {
 		OnionService: serviceID + ".onion",
 		Port:         cfg.VirtualPort,
 		PrivateKey:   keyParam,
-	}, nil
+	}, keyParam, nil
+}
+
+// RestoreOnionServices re-registers every recorded onion service using its
+// persisted key and original port mapping. The returned identities must match
+// the original registrations exactly.
+func (c *Controller) RestoreOnionServices() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.started != 1 {
+		return errTCNotStarted
+	}
+	if c.stopped != 0 {
+		return errTCStopped
+	}
+	if len(c.registrations) == 0 {
+		return ErrServiceNotCreated
+	}
+	if len(c.activeServiceIDs) != 0 {
+		return errors.New("onion services must be inactive before restore")
+	}
+	if c.activeServiceIDs == nil {
+		c.activeServiceIDs = make(map[string]struct{})
+	}
+
+	for _, registration := range c.registrations {
+		addr, _, err := c.addOnionLocked(
+			registration.config, registration.keyParam, false,
+		)
+		if err != nil {
+			return fmt.Errorf("restore onion service %s: %w",
+				registration.serviceID, err)
+		}
+
+		serviceID := strings.TrimSuffix(addr.OnionService, OnionSuffix)
+		if serviceID != registration.serviceID {
+			mismatchErr := fmt.Errorf("%w: expected %s, got %s",
+				ErrServiceIDMismatch, registration.serviceID,
+				serviceID)
+			deleteErr := c.delOnionLocked(serviceID)
+
+			return errors.Join(mismatchErr, deleteErr)
+		}
+
+		c.activeServiceIDs[serviceID] = struct{}{}
+	}
+
+	return nil
 }
 
 // DelOnion tells the Tor daemon to remove an onion service, which satisfies
@@ -360,13 +450,39 @@ func (c *Controller) AddOnion(cfg AddOnionConfig) (*OnionAddr, error) {
 //     "DEL_ONION" command.
 //   - the onion service was created using the "Detach" flag.
 func (c *Controller) DelOnion(serviceID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	err := c.delOnionLocked(serviceID)
+	if err != nil {
+		return err
+	}
+
+	delete(c.activeServiceIDs, serviceID)
+	for i := range c.registrations {
+		if c.registrations[i].serviceID != serviceID {
+			continue
+		}
+
+		c.registrations = append(
+			c.registrations[:i], c.registrations[i+1:]...,
+		)
+
+		break
+	}
+
+	return nil
+}
+
+// delOnionLocked removes an onion service while the controller mutex is held.
+func (c *Controller) delOnionLocked(serviceID string) error {
 	log.Debugf("removing serviceID:%s from tor controller", serviceID)
 
 	cmd := fmt.Sprintf("DEL_ONION %s", serviceID)
 
 	// Send the command to create the onion service to the Tor server and
 	// await its response.
-	code, _, err := c.sendCommand(cmd)
+	code, _, err := c.sendCommandLocked(cmd)
 
 	// Tor replies with "250 OK" on success, or a 512 if there are an
 	// invalid number of arguments, or a 552 if it doesn't recognize the

--- a/tor/controller.go
+++ b/tor/controller.go
@@ -8,12 +8,13 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"net"
 	"net/textproto"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
-	"sync/atomic"
+	"sync"
 )
 
 const (
@@ -103,12 +104,14 @@ var (
 //   - place under sub-package?
 //   - support async replies from the server
 type Controller struct {
-	// started is used atomically in order to prevent multiple calls to
-	// Start.
+	// mu serializes lifecycle changes, control commands, onion service
+	// registration and restoration, and shutdown.
+	mu sync.Mutex
+
+	// started prevents multiple calls to Start.
 	started int32
 
-	// stopped is used atomically in order to prevent multiple calls to
-	// Stop.
+	// stopped prevents multiple calls to Stop.
 	stopped int32
 
 	// conn is the underlying connection between the controller and the
@@ -133,8 +136,21 @@ type Controller struct {
 	// runs on another host, otherwise the service will not be reachable.
 	targetIPAddress string
 
-	// activeServiceID is the Onion ServiceID created by ADD_ONION.
-	activeServiceID string
+	// registrations contains every successfully registered onion service in
+	// creation order so the complete set can be restored deterministically.
+	registrations []onionServiceRegistration
+
+	// activeServiceIDs contains the services active on the current control
+	// connection.
+	activeServiceIDs map[string]struct{}
+}
+
+// onionServiceRegistration contains the stable identity and original port
+// mapping needed to restore an lnd-managed onion service.
+type onionServiceRegistration struct {
+	serviceID string
+	keyParam  string
+	config    AddOnionConfig
 }
 
 // NewController returns a new Tor controller that will be able to interact with
@@ -143,9 +159,10 @@ func NewController(controlAddr string, targetIPAddress string,
 	password string) *Controller {
 
 	return &Controller{
-		controlAddr:     controlAddr,
-		targetIPAddress: targetIPAddress,
-		password:        password,
+		controlAddr:      controlAddr,
+		targetIPAddress:  targetIPAddress,
+		password:         password,
+		activeServiceIDs: make(map[string]struct{}),
 	}
 }
 
@@ -153,7 +170,10 @@ func NewController(controlAddr string, targetIPAddress string,
 // and a Tor server. Once done, the controller will be able to send commands
 // and expect responses.
 func (c *Controller) Start() error {
-	if !atomic.CompareAndSwapInt32(&c.started, 0, 1) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.started != 0 {
 		return nil
 	}
 
@@ -165,47 +185,66 @@ func (c *Controller) Start() error {
 	}
 
 	c.conn = conn
+	if err := c.authenticate(); err != nil {
+		_ = c.conn.Close()
+		c.conn = nil
 
-	return c.authenticate()
+		return err
+	}
+
+	c.started = 1
+
+	return nil
 }
 
 // Stop closes the connection between the controller and the Tor server.
 func (c *Controller) Stop() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.stopped != 0 {
+		return nil
+	}
 	if c.conn == nil {
 		return fmt.Errorf("no connection available to the tor server")
 	}
-
-	if !atomic.CompareAndSwapInt32(&c.stopped, 0, 1) {
-		return nil
-	}
+	c.stopped = 1
 
 	log.Info("Stopping tor controller")
 
-	var delOnionErr error
-
-	// Remove the onion service if one was created successfully.
-	if c.activeServiceID != "" {
-		if err := c.DelOnion(c.activeServiceID); err != nil {
-			log.Errorf("DEL_ONION got error: %v", err)
-			delOnionErr = err
+	var cleanupErrs []error
+	for _, registration := range c.registrations {
+		serviceID := registration.serviceID
+		if _, ok := c.activeServiceIDs[serviceID]; !ok {
+			continue
 		}
+
+		if err := c.delOnionLocked(serviceID); err != nil {
+			log.Errorf("DEL_ONION %s got error: %v", serviceID, err)
+			cleanupErrs = append(cleanupErrs, fmt.Errorf(
+				"delete onion service %s: %w", serviceID, err,
+			))
+
+			continue
+		}
+
+		delete(c.activeServiceIDs, serviceID)
 	}
 
-	closeErr := c.conn.Close()
-	if delOnionErr == nil || closeErr == nil {
-		// Reset service ID. If DEL_ONION failed but the control
-		// connection closed successfully, the ephemeral service is
-		// removed by Tor along with the connection.
-		c.activeServiceID = ""
+	if err := c.conn.Close(); err != nil {
+		cleanupErrs = append(cleanupErrs, err)
+	} else {
+		clear(c.activeServiceIDs)
 	}
+	c.conn = nil
 
-	return errors.Join(delOnionErr, closeErr)
+	return errors.Join(cleanupErrs...)
 }
 
 // Reconnect makes a new socket connection between the tor controller and
 // daemon. It will attempt to close the old connection, make a new connection
-// and authenticate, and finally reset the activeServiceID that the controller
-// is aware of.
+// and authenticate, and finally reset the active service set. Recorded service
+// registrations remain available to RestoreOnionServices.
 //
 // NOTE: Any old onion services will be removed once this function is called.
 // In the case of a Tor daemon restart, previously created onion services will
@@ -213,6 +252,9 @@ func (c *Controller) Stop() error {
 // because the control connection is reset, all the onion services belonging to
 // the old connection will be removed.
 func (c *Controller) Reconnect() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	// Require the tor controller to be running when we want to reconnect.
 	// This means the started flag must be 1 and the stopped flag must be
 	// 0.
@@ -233,6 +275,8 @@ func (c *Controller) Reconnect() error {
 			log.Debugf("closing old conn got err: %v", err)
 		}
 	}
+	c.conn = nil
+	clear(c.activeServiceIDs)
 
 	// Make a new connection and authenticate.
 	conn, err := textproto.Dial("tcp", c.controlAddr)
@@ -244,14 +288,11 @@ func (c *Controller) Reconnect() error {
 
 	// Authenticate the connection between the controller and Tor daemon.
 	if err := c.authenticate(); err != nil {
+		_ = c.conn.Close()
+		c.conn = nil
+
 		return err
 	}
-
-	// Reset the activeServiceID. This value would only be set if a
-	// previous onion service was created. Because the old connection has
-	// been closed at this point, the old onion service is no longer
-	// active.
-	c.activeServiceID = ""
 
 	return nil
 }
@@ -259,6 +300,18 @@ func (c *Controller) Reconnect() error {
 // sendCommand sends a command to the Tor server and returns its response, as a
 // single space-delimited string, and code.
 func (c *Controller) sendCommand(command string) (int, string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.sendCommandLocked(command)
+}
+
+// sendCommandLocked sends a command while the controller mutex is held.
+func (c *Controller) sendCommandLocked(command string) (int, string, error) {
+	if c.conn == nil {
+		return 0, "", net.ErrClosed
+	}
+
 	id, err := c.conn.Cmd("%v", command)
 	if err != nil {
 		return 0, "", err
@@ -489,7 +542,7 @@ func (c *Controller) authenticate() error {
 // authenticateViaNull authenticates the controller with the Tor server using
 // the NULL authentication method.
 func (c *Controller) authenticateViaNull() error {
-	_, _, err := c.sendCommand("AUTHENTICATE")
+	_, _, err := c.sendCommandLocked("AUTHENTICATE")
 	return err
 }
 
@@ -497,7 +550,7 @@ func (c *Controller) authenticateViaNull() error {
 // server using the HASHEDPASSWORD authentication method.
 func (c *Controller) authenticateViaHashedPassword() error {
 	cmd := fmt.Sprintf("AUTHENTICATE \"%s\"", c.password)
-	_, _, err := c.sendCommand(cmd)
+	_, _, err := c.sendCommandLocked(cmd)
 	return err
 }
 
@@ -524,7 +577,7 @@ func (c *Controller) authenticateViaSafeCookie(info protocolInfo) error {
 	}
 
 	cmd := fmt.Sprintf("AUTHCHALLENGE SAFECOOKIE %x", clientNonce)
-	_, reply, err := c.sendCommand(cmd)
+	_, reply, err := c.sendCommandLocked(cmd)
 	if err != nil {
 		return err
 	}
@@ -591,7 +644,7 @@ func (c *Controller) authenticateViaSafeCookie(info protocolInfo) error {
 	}
 
 	cmd = fmt.Sprintf("AUTHENTICATE %x", clientHash)
-	if _, _, err := c.sendCommand(cmd); err != nil {
+	if _, _, err := c.sendCommandLocked(cmd); err != nil {
 		return err
 	}
 
@@ -691,7 +744,7 @@ func (i protocolInfo) supportsAuthMethod(method string) bool {
 // response.
 func (c *Controller) protocolInfo() (protocolInfo, error) {
 	cmd := fmt.Sprintf("PROTOCOLINFO %d", ProtocolInfoVersion)
-	_, reply, err := c.sendCommand(cmd)
+	_, reply, err := c.sendCommandLocked(cmd)
 	if err != nil {
 		return nil, err
 	}

--- a/tor/controller_test.go
+++ b/tor/controller_test.go
@@ -360,8 +360,13 @@ func TestStopClosesConnectionOnDelOnionError(t *testing.T) {
 
 	const serviceID = "fakeID"
 	c := &Controller{
-		conn:            proxy.clientConn,
-		activeServiceID: serviceID,
+		conn: proxy.clientConn,
+		registrations: []onionServiceRegistration{
+			{serviceID: serviceID},
+		},
+		activeServiceIDs: map[string]struct{}{
+			serviceID: {},
+		},
 	}
 
 	serverErr := make(chan error, 1)
@@ -394,7 +399,7 @@ func TestStopClosesConnectionOnDelOnionError(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid arguments")
 	require.NoError(t, <-serverErr)
-	require.Empty(t, c.activeServiceID)
+	require.Empty(t, c.activeServiceIDs)
 
 	assertControlConnClosed(t, proxy.serverConn)
 }
@@ -410,15 +415,20 @@ func TestStopReturnsDelOnionAndCloseErrors(t *testing.T) {
 		closeErr:  closeErr,
 	}
 	c := &Controller{
-		conn:            textproto.NewConn(conn),
-		activeServiceID: serviceID,
+		conn: textproto.NewConn(conn),
+		registrations: []onionServiceRegistration{
+			{serviceID: serviceID},
+		},
+		activeServiceIDs: map[string]struct{}{
+			serviceID: {},
+		},
 	}
 
 	err := c.Stop()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid arguments")
 	require.ErrorIs(t, err, closeErr)
-	require.Equal(t, serviceID, c.activeServiceID)
+	require.Contains(t, c.activeServiceIDs, serviceID)
 	require.Equal(t, "DEL_ONION fakeID\r\n", conn.commands.String())
 }
 

--- a/tor/recovery_test.go
+++ b/tor/recovery_test.go
@@ -1,0 +1,358 @@
+package tor
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"net"
+	"net/textproto"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type controlStep struct {
+	command  string
+	response string
+}
+
+// runControlScript serves a fixed sequence of Tor control commands.
+func runControlScript(conn net.Conn, steps []controlStep) <-chan error {
+	result := make(chan error, 1)
+	go func() {
+		defer conn.Close()
+
+		reader := bufio.NewReader(conn)
+		for _, step := range steps {
+			command, err := reader.ReadString('\n')
+			if err != nil {
+				result <- err
+
+				return
+			}
+			if strings.TrimSpace(command) != step.command {
+				result <- fmt.Errorf("expected command %q, got %q",
+					step.command, strings.TrimSpace(command))
+
+				return
+			}
+
+			if _, err := conn.Write([]byte(step.response)); err != nil {
+				result <- err
+
+				return
+			}
+		}
+
+		result <- nil
+	}()
+
+	return result
+}
+
+type memoryOnionStore struct {
+	mu     sync.Mutex
+	key    []byte
+	writes int
+}
+
+func (s *memoryOnionStore) StorePrivateKey(key []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.key = append([]byte(nil), key...)
+	s.writes++
+
+	return nil
+}
+
+func (s *memoryOnionStore) PrivateKey() ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.key == nil {
+		return nil, ErrNoPrivateKey
+	}
+
+	return append([]byte(nil), s.key...), nil
+}
+
+func (s *memoryOnionStore) DeletePrivateKey() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.key = nil
+
+	return nil
+}
+
+func (s *memoryOnionStore) writeCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.writes
+}
+
+func TestRestoreMultipleOnionServices(t *testing.T) {
+	client, server := net.Pipe()
+	initialResult := runControlScript(server, []controlStep{
+		{
+			command: "ADD_ONION NEW:ED25519-V3 Port=9735,1001 " +
+				"Port=9735,1002",
+			response: "250-ServiceID=node-service\r\n" +
+				"250-PrivateKey=ED25519-V3:node-key\r\n" +
+				"250 OK\r\n",
+		},
+		{
+			command: "ADD_ONION NEW:ED25519-V3 Port=9911,2001",
+			response: "250-ServiceID=tower-service\r\n" +
+				"250-PrivateKey=ED25519-V3:tower-key\r\n" +
+				"250 OK\r\n",
+		},
+	})
+
+	c := &Controller{
+		conn:             textproto.NewConn(client),
+		version:          "0.4.8.0",
+		started:          1,
+		activeServiceIDs: make(map[string]struct{}),
+	}
+	nodeStore := &memoryOnionStore{}
+	towerStore := &memoryOnionStore{}
+	nodeCfg := AddOnionConfig{
+		VirtualPort: 9735,
+		TargetPorts: []int{1001, 1002},
+		Store:       nodeStore,
+	}
+	towerCfg := AddOnionConfig{
+		VirtualPort: 9911,
+		TargetPorts: []int{2001},
+		Store:       towerStore,
+	}
+
+	nodeAddr, err := c.AddOnion(nodeCfg)
+	require.NoError(t, err)
+	towerAddr, err := c.AddOnion(towerCfg)
+	require.NoError(t, err)
+	require.Equal(t, "node-service.onion:9735", nodeAddr.String())
+	require.Equal(t, "tower-service.onion:9911", towerAddr.String())
+	require.NoError(t, <-initialResult)
+	require.Equal(t, 1, nodeStore.writeCount())
+	require.Equal(t, 1, towerStore.writeCount())
+
+	// Mutating the caller's target slice must not change the recorded port
+	// mapping used during restoration.
+	nodeCfg.TargetPorts[0] = 9999
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	c.controlAddr = listener.Addr().String()
+	restoreResult := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			restoreResult <- err
+
+			return
+		}
+
+		result := runControlScript(conn, []controlStep{
+			{
+				command: "PROTOCOLINFO 1",
+				response: "250-PROTOCOLINFO 1\r\n" +
+					"250-AUTH METHODS=NULL\r\n" +
+					"250-VERSION Tor=\"0.4.8.0\"\r\n" +
+					"250 OK\r\n",
+			},
+			{command: "AUTHENTICATE", response: "250 OK\r\n"},
+			{
+				command: "ADD_ONION ED25519-V3:node-key " +
+					"Port=9735,1001 Port=9735,1002",
+				response: "250-ServiceID=node-service\r\n" +
+					"250 OK\r\n",
+			},
+			{
+				command: "ADD_ONION ED25519-V3:tower-key " +
+					"Port=9911,2001",
+				response: "250-ServiceID=tower-service\r\n" +
+					"250 OK\r\n",
+			},
+			{
+				command: "GETINFO onions/current",
+				response: "250-onions/current=tower-service," +
+					"node-service\r\n250 OK\r\n",
+			},
+			{command: "DEL_ONION node-service", response: "250 OK\r\n"},
+			{command: "DEL_ONION tower-service", response: "250 OK\r\n"},
+		})
+		restoreResult <- <-result
+	}()
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+
+	require.NoError(t, c.Reconnect())
+	require.Empty(t, c.activeServiceIDs)
+	require.NoError(t, c.RestoreOnionServices())
+	require.Len(t, c.activeServiceIDs, 2)
+	require.NoError(t, c.CheckOnionService())
+	require.NoError(t, c.Stop())
+	require.NoError(t, <-restoreResult)
+	require.Equal(t, 1, nodeStore.writeCount())
+	require.Equal(t, 1, towerStore.writeCount())
+}
+
+func TestPartialRestoreCanRetryAfterReconnect(t *testing.T) {
+	client, server := net.Pipe()
+	partialResult := runControlScript(server, []controlStep{
+		{
+			command:  "ADD_ONION ED25519-V3:key-one Port=9735,1001",
+			response: "250-ServiceID=service-one\r\n250 OK\r\n",
+		},
+		{
+			command:  "ADD_ONION ED25519-V3:key-two Port=9911,2001",
+			response: "551 restore failed\r\n",
+		},
+		{
+			command: "GETINFO onions/current",
+			response: "250-onions/current=service-one\r\n" +
+				"250 OK\r\n",
+		},
+	})
+	c := &Controller{
+		conn:    textproto.NewConn(client),
+		started: 1,
+		registrations: []onionServiceRegistration{
+			{
+				serviceID: "service-one",
+				keyParam:  "ED25519-V3:key-one",
+				config: AddOnionConfig{
+					VirtualPort: 9735,
+					TargetPorts: []int{1001},
+				},
+			},
+			{
+				serviceID: "service-two",
+				keyParam:  "ED25519-V3:key-two",
+				config: AddOnionConfig{
+					VirtualPort: 9911,
+					TargetPorts: []int{2001},
+				},
+			},
+		},
+		activeServiceIDs: make(map[string]struct{}),
+	}
+
+	err := c.RestoreOnionServices()
+	require.ErrorContains(t, err, "restore onion service service-two")
+	require.Contains(t, c.activeServiceIDs, "service-one")
+	require.ErrorIs(t, c.CheckOnionService(), ErrServiceIDMismatch)
+	require.NoError(t, <-partialResult)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	c.controlAddr = listener.Addr().String()
+	retryResult := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			retryResult <- err
+
+			return
+		}
+
+		result := runControlScript(conn, []controlStep{
+			{
+				command: "PROTOCOLINFO 1",
+				response: "250-PROTOCOLINFO 1\r\n" +
+					"250-AUTH METHODS=NULL\r\n250 OK\r\n",
+			},
+			{command: "AUTHENTICATE", response: "250 OK\r\n"},
+			{
+				command: "ADD_ONION ED25519-V3:key-one " +
+					"Port=9735,1001",
+				response: "250-ServiceID=service-one\r\n250 OK\r\n",
+			},
+			{
+				command: "ADD_ONION ED25519-V3:key-two " +
+					"Port=9911,2001",
+				response: "250-ServiceID=service-two\r\n250 OK\r\n",
+			},
+			{command: "DEL_ONION service-one", response: "250 OK\r\n"},
+			{command: "DEL_ONION service-two", response: "250 OK\r\n"},
+		})
+		retryResult <- <-result
+	}()
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+
+	require.NoError(t, c.Reconnect())
+	require.Empty(t, c.activeServiceIDs)
+	require.NoError(t, c.RestoreOnionServices())
+	require.Len(t, c.activeServiceIDs, 2)
+	require.NoError(t, c.Stop())
+	require.NoError(t, <-retryResult)
+}
+
+func TestRestoreRejectsChangedIdentity(t *testing.T) {
+	client, server := net.Pipe()
+	result := runControlScript(server, []controlStep{
+		{
+			command:  "ADD_ONION ED25519-V3:key Port=9735,1001",
+			response: "250-ServiceID=changed-service\r\n250 OK\r\n",
+		},
+		{
+			command:  "DEL_ONION changed-service",
+			response: "250 OK\r\n",
+		},
+	})
+	c := &Controller{
+		conn:    textproto.NewConn(client),
+		started: 1,
+		registrations: []onionServiceRegistration{{
+			serviceID: "original-service",
+			keyParam:  "ED25519-V3:key",
+			config: AddOnionConfig{
+				VirtualPort: 9735,
+				TargetPorts: []int{1001},
+			},
+		}},
+		activeServiceIDs: make(map[string]struct{}),
+	}
+
+	err := c.RestoreOnionServices()
+	require.ErrorIs(t, err, ErrServiceIDMismatch)
+	require.Empty(t, c.activeServiceIDs)
+	require.NoError(t, <-result)
+}
+
+func TestStopDeletesAllServicesAndJoinsErrors(t *testing.T) {
+	closeErr := errors.New("close failed")
+	conn := &closeErrorConn{
+		responses: strings.NewReader(
+			"512 Bad arguments\r\n512 Bad arguments\r\n",
+		),
+		closeErr: closeErr,
+	}
+	c := &Controller{
+		conn: textproto.NewConn(conn),
+		registrations: []onionServiceRegistration{
+			{serviceID: "service-one"},
+			{serviceID: "service-two"},
+		},
+		activeServiceIDs: map[string]struct{}{
+			"service-one": {},
+			"service-two": {},
+		},
+	}
+
+	err := c.Stop()
+	require.ErrorIs(t, err, closeErr)
+	require.ErrorContains(t, err, "delete onion service service-one")
+	require.ErrorContains(t, err, "delete onion service service-two")
+	require.Equal(t, "DEL_ONION service-one\r\n"+
+		"DEL_ONION service-two\r\n", conn.commands.String())
+}


### PR DESCRIPTION
## Change Description

The Tor controller currently stores only one active onion service ID. When lnd
creates both its node and watchtower onion services through the same controller,
the second registration replaces the first in the controller state. Recovery
and shutdown can therefore verify, recreate, or remove only one of the managed
services.

This change makes the controller track every successful onion service
registration in creation order, including the stable service ID, private key,
and original port mapping. It adds `RestoreOnionServices` to replay the complete
set after reconnecting while verifying that every restored identity matches the
original registration.

It also:

- validates the exact comma-separated set returned by `GETINFO onions/current`;
- serializes lifecycle and control operations;
- permits a clean retry after a partial restoration; and
- removes all active managed services deterministically on shutdown while
  preserving all cleanup errors.

A follow-up lnd/healthcheck integration will use the released Tor module method
to restore both node and watchtower services. Because `tor` is a separately
versioned module, that integration must wait for this change to merge and for a
new `tor` tag to be published.

## Steps to Test

```bash
cd tor
go test ./...
go test -race ./...
go vet ./...
```

The complete repository checks were also run locally:

```bash
make unit-module
make unit
make lint
```

## Pull Request Checklist

### Testing
- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not insubstantial.
- [x] The change obeys the code documentation and commenting guidelines, and
  lines wrap at 80.
- [x] Commits follow the Ideal Git Commit Structure.
- [x] New logging statements use an appropriate subsystem and logging level.
- [x] No new lncli commands are introduced.
- [ ] The user-facing release note is intentionally included in the stacked
  lnd integration, which cannot be submitted until this module is released.
