### PR TITLE
tor: add configurable clearnet SOCKS proxy

### DIFF
--- a/tor/bypass.go
+++ b/tor/bypass.go
@@ -1,0 +1,186 @@
+package tor
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+var defaultNoProxyTargets = []string{
+	"localhost",
+	"127.0.0.0/8",
+	"::1/128",
+}
+
+var defaultBypassMatcher = func() *bypassMatcher {
+	matcher, err := newBypassMatcher(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	return matcher
+}()
+
+// bypassMatcher determines whether a destination should be connected to
+// directly instead of through a proxy.
+type bypassMatcher struct {
+	hosts    map[string]struct{}
+	zones    []string
+	ips      []net.IP
+	networks []*net.IPNet
+}
+
+// newBypassMatcher validates the configured bypass targets and constructs a
+// matcher. The loopback defaults are always included.
+func newBypassMatcher(targets []string) (*bypassMatcher, error) {
+	m := &bypassMatcher{
+		hosts: make(map[string]struct{}),
+	}
+
+	allTargets := make([]string, 0, len(defaultNoProxyTargets)+len(targets))
+	allTargets = append(allTargets, defaultNoProxyTargets...)
+	allTargets = append(allTargets, targets...)
+
+	seen := make(map[string]struct{}, len(allTargets))
+	for _, target := range allTargets {
+		if err := m.addTarget(target, seen); err != nil {
+			return nil, err
+		}
+	}
+
+	return m, nil
+}
+
+// addTarget validates and adds one exact host, wildcard DNS zone, IP address,
+// or CIDR network.
+func (m *bypassMatcher) addTarget(target string,
+	seen map[string]struct{}) error {
+
+	if target == "" || strings.TrimSpace(target) != target {
+		return fmt.Errorf("invalid proxy bypass target %q", target)
+	}
+
+	if strings.ContainsAny(target, "/") {
+		_, network, err := net.ParseCIDR(target)
+		if err != nil {
+			return fmt.Errorf("invalid proxy bypass CIDR %q: %w",
+				target, err)
+		}
+
+		key := "cidr:" + network.String()
+		if _, ok := seen[key]; ok {
+			return nil
+		}
+
+		seen[key] = struct{}{}
+		m.networks = append(m.networks, network)
+
+		return nil
+	}
+
+	if ip := net.ParseIP(target); ip != nil {
+		key := "ip:" + ip.String()
+		if _, ok := seen[key]; ok {
+			return nil
+		}
+
+		seen[key] = struct{}{}
+		m.ips = append(m.ips, ip)
+
+		return nil
+	}
+
+	zone := strings.HasPrefix(target, "*.")
+	host := target
+	if zone {
+		host = strings.TrimPrefix(target, "*.")
+	}
+	if err := validateProxyHost(host); err != nil {
+		return fmt.Errorf("invalid proxy bypass target %q: %w",
+			target, err)
+	}
+
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+	if zone {
+		key := "zone:" + host
+		if _, ok := seen[key]; ok {
+			return nil
+		}
+
+		seen[key] = struct{}{}
+		m.zones = append(m.zones, host)
+
+		return nil
+	}
+
+	key := "host:" + host
+	if _, ok := seen[key]; ok {
+		return nil
+	}
+
+	seen[key] = struct{}{}
+	m.hosts[host] = struct{}{}
+
+	return nil
+}
+
+// validateProxyHost validates a DNS host without performing a lookup.
+func validateProxyHost(host string) error {
+	if host == "" || len(host) > 253 {
+		return fmt.Errorf("invalid host length")
+	}
+	if strings.ContainsAny(host, ":*[]") {
+		return fmt.Errorf("host must not contain a port or wildcard")
+	}
+
+	host = strings.TrimSuffix(host, ".")
+	for _, label := range strings.Split(host, ".") {
+		if label == "" || len(label) > 63 || label[0] == '-' ||
+			label[len(label)-1] == '-' {
+
+			return fmt.Errorf("invalid DNS label %q", label)
+		}
+
+		for _, char := range label {
+			valid := char >= 'a' && char <= 'z' ||
+				char >= 'A' && char <= 'Z' ||
+				char >= '0' && char <= '9' || char == '-'
+			if !valid {
+				return fmt.Errorf("invalid character %q", char)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Match reports whether the host matches a configured bypass target.
+func (m *bypassMatcher) Match(host string) bool {
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+	if _, ok := m.hosts[host]; ok {
+		return true
+	}
+
+	if ip := net.ParseIP(host); ip != nil {
+		for _, exactIP := range m.ips {
+			if exactIP.Equal(ip) {
+				return true
+			}
+		}
+		for _, network := range m.networks {
+			if network.Contains(ip) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	for _, zone := range m.zones {
+		if len(host) > len(zone) && strings.HasSuffix(host, "."+zone) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/tor/net.go
+++ b/tor/net.go
@@ -3,8 +3,12 @@ package tor
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
+	"strconv"
 	"time"
+
+	"golang.org/x/net/proxy"
 )
 
 // TODO: this interface and its implementations should ideally be moved
@@ -40,15 +44,142 @@ type Net interface {
 	ResolveTCPAddr(network, address string) (*net.TCPAddr, error)
 }
 
-// ClearNet is an implementation of the Net interface that defines behaviour
-// for regular network connections.
-type ClearNet struct{}
+// ClearNetConfig contains the options for clearnet connections. Its zero value
+// selects direct connections with the default loopback bypass targets.
+type ClearNetConfig struct {
+	// SOCKS is the optional host:port of a SOCKS5 proxy.
+	SOCKS string
 
-// Dial on the regular network uses net.Dial
+	// Username and Password are the optional SOCKS5 credentials. A username
+	// is required when a password is set.
+	Username string
+	Password string
+
+	// NoProxyTargets contains additional destinations that should bypass
+	// the SOCKS5 proxy. Entries can be exact hosts, wildcard zones such as
+	// *.example.com, IP addresses, or CIDR networks.
+	NoProxyTargets []string
+}
+
+// ClearNet is an implementation of the Net interface that defines behavior
+// for regular network connections, optionally through a SOCKS5 proxy.
+type ClearNet struct {
+	socksAddr string
+	auth      *proxy.Auth
+	bypass    *bypassMatcher
+}
+
+// NewClearNet validates the configuration and returns a clearnet network. A
+// configured SOCKS5 proxy is fail-closed: dialing errors are returned without
+// falling back to a direct connection.
+func NewClearNet(cfg ClearNetConfig) (*ClearNet, error) {
+	bypass, err := newBypassMatcher(cfg.NoProxyTargets)
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.SOCKS == "" {
+		if cfg.Username != "" || cfg.Password != "" {
+			return nil, errors.New("SOCKS credentials require a proxy")
+		}
+
+		return &ClearNet{bypass: bypass}, nil
+	}
+
+	if err := validateSOCKSEndpoint(cfg.SOCKS); err != nil {
+		return nil, err
+	}
+	if cfg.Username == "" && cfg.Password != "" {
+		return nil, errors.New("SOCKS password requires a username")
+	}
+	if len(cfg.Username) > 255 || len(cfg.Password) > 255 {
+		return nil, errors.New("SOCKS credentials exceed 255 bytes")
+	}
+
+	var auth *proxy.Auth
+	if cfg.Username != "" {
+		auth = &proxy.Auth{
+			User:     cfg.Username,
+			Password: cfg.Password,
+		}
+	}
+
+	return &ClearNet{
+		socksAddr: cfg.SOCKS,
+		auth:      auth,
+		bypass:    bypass,
+	}, nil
+}
+
+// validateSOCKSEndpoint validates a SOCKS5 proxy endpoint without resolving
+// its hostname.
+func validateSOCKSEndpoint(endpoint string) error {
+	host, port, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		return fmt.Errorf("invalid SOCKS5 proxy endpoint %q: %w",
+			endpoint, err)
+	}
+	if host == "" {
+		return fmt.Errorf("invalid SOCKS5 proxy endpoint %q: empty host",
+			endpoint)
+	}
+	if net.ParseIP(host) == nil {
+		if err := validateProxyHost(host); err != nil {
+			return fmt.Errorf("invalid SOCKS5 proxy endpoint %q: %w",
+				endpoint, err)
+		}
+	}
+
+	portNum, err := strconv.ParseUint(port, 10, 16)
+	if err != nil || portNum == 0 {
+		return fmt.Errorf("invalid SOCKS5 proxy endpoint %q: invalid port",
+			endpoint)
+	}
+
+	return nil
+}
+
+// proxyBypass returns the configured matcher or the loopback defaults for a
+// zero-value ClearNet.
+func (r *ClearNet) proxyBypass() *bypassMatcher {
+	if r.bypass != nil {
+		return r.bypass
+	}
+
+	return defaultBypassMatcher
+}
+
+// Dial connects directly or through the configured SOCKS5 proxy.
 func (r *ClearNet) Dial(
 	network, address string, timeout time.Duration) (net.Conn, error) {
 
-	return net.DialTimeout(network, address, timeout)
+	direct := &net.Dialer{Timeout: timeout}
+	if r.socksAddr == "" {
+		return direct.Dial(network, address)
+	}
+
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+	if r.proxyBypass().Match(host) {
+		return direct.Dial(network, address)
+	}
+
+	switch network {
+	case "tcp", "tcp4", "tcp6":
+	default:
+		return nil, errors.New("cannot dial non-tcp network via SOCKS5")
+	}
+
+	dialer, err := proxy.SOCKS5(
+		"tcp", r.socksAddr, r.auth, direct,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create SOCKS5 dialer: %w", err)
+	}
+
+	return dialer.Dial(network, address)
 }
 
 // LookupHost for regular network uses the net.LookupHost function
@@ -93,6 +224,76 @@ type ProxyNet struct {
 	// connections to non-onion service targets. If enabled, the node IP
 	// address will be revealed while communicating with such targets.
 	SkipProxyForClearNetTargets bool
+
+	// ClearNet is the network used for non-onion destinations when Tor is
+	// skipped. If unset, direct clearnet is used for compatibility.
+	ClearNet Net
+
+	// NoProxyTargets contains validated destinations that should bypass Tor
+	// and use ClearNet instead.
+	NoProxyTargets []string
+
+	bypass *bypassMatcher
+}
+
+// ProxyNetConfig contains the options for Tor connections and their clearnet
+// routing policy.
+type ProxyNetConfig struct {
+	// SOCKS is the host:port of Tor's SOCKS5 proxy.
+	SOCKS string
+
+	// DNS is the host:port of the TCP DNS server used for SRV queries.
+	DNS string
+
+	// StreamIsolation randomizes Tor SOCKS5 credentials per connection.
+	StreamIsolation bool
+
+	// SkipProxyForClearNetTargets sends every non-onion destination through
+	// ClearNet.
+	SkipProxyForClearNetTargets bool
+
+	// ClearNet handles destinations that bypass Tor.
+	ClearNet Net
+
+	// NoProxyTargets contains additional destinations that bypass Tor.
+	NoProxyTargets []string
+}
+
+// NewProxyNet validates the proxy bypass targets and constructs a Tor network.
+func NewProxyNet(cfg ProxyNetConfig) (*ProxyNet, error) {
+	bypass, err := newBypassMatcher(cfg.NoProxyTargets)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ProxyNet{
+		SOCKS:                       cfg.SOCKS,
+		DNS:                         cfg.DNS,
+		StreamIsolation:             cfg.StreamIsolation,
+		SkipProxyForClearNetTargets: cfg.SkipProxyForClearNetTargets,
+		ClearNet:                    cfg.ClearNet,
+		NoProxyTargets:              cfg.NoProxyTargets,
+		bypass:                      bypass,
+	}, nil
+}
+
+// clearNet returns the selected clearnet network.
+func (p *ProxyNet) clearNet() Net {
+	if p.ClearNet != nil {
+		return p.ClearNet
+	}
+
+	return &ClearNet{}
+}
+
+// proxyBypass returns a validated matcher. Callers that accept user input
+// should use NewProxyNet to surface validation errors during startup.
+func (p *ProxyNet) proxyBypass() (*bypassMatcher, error) {
+	if p.bypass != nil {
+		return p.bypass, nil
+	}
+
+	return newBypassMatcher(p.NoProxyTargets)
 }
 
 // Dial uses the Tor Dial function in order to establish connections through
@@ -105,10 +306,25 @@ func (p *ProxyNet) Dial(network, address string,
 	default:
 		return nil, errors.New("cannot dial non-tcp network via Tor")
 	}
-	return Dial(
-		address, p.SOCKS, p.StreamIsolation,
-		p.SkipProxyForClearNetTargets, timeout,
-	)
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+
+	// Onion services must always use Tor. For clearnet destinations, use
+	// the selected clearnet network only when proxy skipping is enabled or
+	// the destination explicitly matches a bypass rule.
+	bypass, err := p.proxyBypass()
+	if err != nil {
+		return nil, err
+	}
+	if !IsOnionHost(host) && (p.SkipProxyForClearNetTargets ||
+		bypass.Match(host)) {
+
+		return p.clearNet().Dial(network, address, timeout)
+	}
+
+	return Dial(address, p.SOCKS, p.StreamIsolation, false, timeout)
 }
 
 // LookupHost uses the Tor LookupHost function in order to resolve hosts over
@@ -122,9 +338,11 @@ func (p *ProxyNet) LookupHost(host string) ([]string, error) {
 func (p *ProxyNet) LookupSRV(service, proto,
 	name string, timeout time.Duration) (string, []*net.SRV, error) {
 
+	// SRV queries must always reach tor.dns over Tor, even if clearnet
+	// proxy skipping is active or the DNS server matches a bypass rule.
 	return LookupSRV(
 		service, proto, name, p.SOCKS, p.DNS, p.StreamIsolation,
-		p.SkipProxyForClearNetTargets, timeout,
+		false, timeout,
 	)
 }
 

--- a/tor/net_test.go
+++ b/tor/net_test.go
@@ -1,0 +1,567 @@
+package tor
+
+import (
+	"bufio"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+type socksRequest struct {
+	command  byte
+	host     string
+	port     uint16
+	username string
+	password string
+}
+
+type socksServer struct {
+	listener    net.Listener
+	requireAuth bool
+	forward     bool
+
+	requests chan socksRequest
+	quit     chan struct{}
+	wg       sync.WaitGroup
+}
+
+func newSOCKSServer(t *testing.T, requireAuth, forward bool) *socksServer {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := &socksServer{
+		listener:    listener,
+		requireAuth: requireAuth,
+		forward:     forward,
+		requests:    make(chan socksRequest, 20),
+		quit:        make(chan struct{}),
+	}
+	server.wg.Add(1)
+	go server.serve()
+	t.Cleanup(func() {
+		close(server.quit)
+		require.NoError(t, server.listener.Close())
+		server.wg.Wait()
+	})
+
+	return server
+}
+
+func (s *socksServer) addr() string {
+	return s.listener.Addr().String()
+}
+
+func (s *socksServer) serve() {
+	defer s.wg.Done()
+
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			select {
+			case <-s.quit:
+				return
+			default:
+				continue
+			}
+		}
+
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			_ = s.handle(conn)
+		}()
+	}
+}
+
+func (s *socksServer) handle(conn net.Conn) error {
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+	header := make([]byte, 2)
+	if _, err := io.ReadFull(reader, header); err != nil {
+		return err
+	}
+	methods := make([]byte, int(header[1]))
+	if _, err := io.ReadFull(reader, methods); err != nil {
+		return err
+	}
+
+	method := byte(0)
+	if s.requireAuth {
+		method = 2
+	}
+	if _, err := conn.Write([]byte{5, method}); err != nil {
+		return err
+	}
+
+	var request socksRequest
+	if s.requireAuth {
+		credentials, err := readSOCKSCredentials(reader)
+		if err != nil {
+			return err
+		}
+		request.username = credentials.username
+		request.password = credentials.password
+		if _, err := conn.Write([]byte{1, 0}); err != nil {
+			return err
+		}
+	}
+
+	requestHeader := make([]byte, 4)
+	if _, err := io.ReadFull(reader, requestHeader); err != nil {
+		return err
+	}
+	request.command = requestHeader[1]
+
+	host, err := readSOCKSHost(reader, requestHeader[3])
+	if err != nil {
+		return err
+	}
+	request.host = host
+
+	port := make([]byte, 2)
+	if _, err := io.ReadFull(reader, port); err != nil {
+		return err
+	}
+	request.port = binary.BigEndian.Uint16(port)
+	s.requests <- request
+
+	if request.command == 0xf0 {
+		_, err := conn.Write([]byte{5, 0, 0, 1, 192, 0, 2, 1})
+
+		return err
+	}
+
+	if !s.forward {
+		_, err := conn.Write([]byte{5, 0, 0, 1, 127, 0, 0, 1, 0, 0})
+		if err != nil {
+			return err
+		}
+
+		_, _ = io.Copy(io.Discard, reader)
+
+		return nil
+	}
+
+	upstream, err := net.Dial(
+		"tcp", net.JoinHostPort(request.host, fmt.Sprint(request.port)),
+	)
+	if err != nil {
+		_, _ = conn.Write([]byte{5, 5, 0, 1, 0, 0, 0, 0, 0, 0})
+
+		return err
+	}
+	defer upstream.Close()
+
+	if _, err := conn.Write([]byte{5, 0, 0, 1, 127, 0, 0, 1, 0, 0}); err != nil {
+
+		return err
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(upstream, reader)
+		_ = upstream.(*net.TCPConn).CloseWrite()
+		close(done)
+	}()
+	_, _ = io.Copy(conn, upstream)
+	<-done
+
+	return nil
+}
+
+func readSOCKSCredentials(reader *bufio.Reader) (socksRequest, error) {
+	header := make([]byte, 2)
+	if _, err := io.ReadFull(reader, header); err != nil {
+		return socksRequest{}, err
+	}
+
+	username := make([]byte, int(header[1]))
+	if _, err := io.ReadFull(reader, username); err != nil {
+		return socksRequest{}, err
+	}
+	passwordLen, err := reader.ReadByte()
+	if err != nil {
+		return socksRequest{}, err
+	}
+	password := make([]byte, int(passwordLen))
+	if _, err := io.ReadFull(reader, password); err != nil {
+		return socksRequest{}, err
+	}
+
+	return socksRequest{
+		username: string(username),
+		password: string(password),
+	}, nil
+}
+
+func readSOCKSHost(reader *bufio.Reader, addressType byte) (string, error) {
+	switch addressType {
+	case 1:
+		ip := make([]byte, net.IPv4len)
+		_, err := io.ReadFull(reader, ip)
+
+		return net.IP(ip).String(), err
+
+	case 3:
+		length, err := reader.ReadByte()
+		if err != nil {
+			return "", err
+		}
+		host := make([]byte, int(length))
+		_, err = io.ReadFull(reader, host)
+
+		return string(host), err
+
+	case 4:
+		ip := make([]byte, net.IPv6len)
+		_, err := io.ReadFull(reader, ip)
+
+		return net.IP(ip).String(), err
+
+	default:
+		return "", fmt.Errorf("unknown SOCKS address type %d", addressType)
+	}
+}
+
+func receiveSOCKSRequest(t *testing.T, server *socksServer) socksRequest {
+	t.Helper()
+
+	select {
+	case request := <-server.requests:
+		return request
+
+	case <-time.After(time.Second):
+		t.Fatal("SOCKS request not received")
+
+		return socksRequest{}
+	}
+}
+
+func TestNewClearNetValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  ClearNetConfig
+	}{
+		{
+			name: "missing proxy for credentials",
+			cfg:  ClearNetConfig{Username: "alice"},
+		},
+		{
+			name: "missing username",
+			cfg: ClearNetConfig{
+				SOCKS:    "127.0.0.1:9050",
+				Password: "secret",
+			},
+		},
+		{
+			name: "missing port",
+			cfg:  ClearNetConfig{SOCKS: "127.0.0.1"},
+		},
+		{
+			name: "invalid port",
+			cfg:  ClearNetConfig{SOCKS: "127.0.0.1:70000"},
+		},
+		{
+			name: "invalid CIDR",
+			cfg: ClearNetConfig{
+				NoProxyTargets: []string{"192.0.2.0/99"},
+			},
+		},
+		{
+			name: "invalid wildcard",
+			cfg: ClearNetConfig{
+				NoProxyTargets: []string{"foo.*.example.com"},
+			},
+		},
+		{
+			name: "target with port",
+			cfg: ClearNetConfig{
+				NoProxyTargets: []string{"example.com:443"},
+			},
+		},
+		{
+			name: "empty target",
+			cfg: ClearNetConfig{
+				NoProxyTargets: []string{""},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := NewClearNet(test.cfg)
+			require.Error(t, err)
+		})
+	}
+
+	_, err := NewClearNet(ClearNetConfig{
+		SOCKS:          "[2001:db8::1]:9050",
+		Username:       "alice",
+		Password:       "secret",
+		NoProxyTargets: []string{"example.com", "*.example.org"},
+	})
+	require.NoError(t, err)
+}
+
+func TestBypassMatcher(t *testing.T) {
+	t.Parallel()
+
+	matcher, err := newBypassMatcher([]string{
+		"example.com", "*.example.org", "192.0.2.10",
+		"198.51.100.0/24", "2001:db8::/32", "example.com",
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		host  string
+		match bool
+	}{
+		{host: "localhost", match: true},
+		{host: "127.1.2.3", match: true},
+		{host: "::1", match: true},
+		{host: "example.com", match: true},
+		{host: "EXAMPLE.COM.", match: true},
+		{host: "sub.example.org", match: true},
+		{host: "example.org", match: false},
+		{host: "notexample.org", match: false},
+		{host: "192.0.2.10", match: true},
+		{host: "192.0.2.11", match: false},
+		{host: "198.51.100.200", match: true},
+		{host: "2001:db8::42", match: true},
+		{host: "203.0.113.1", match: false},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.host, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, test.match, matcher.Match(test.host))
+		})
+	}
+}
+
+func TestClearNetRoutingAndAuthentication(t *testing.T) {
+	proxyServer := newSOCKSServer(t, true, false)
+	clearNet, err := NewClearNet(ClearNetConfig{
+		SOCKS:    proxyServer.addr(),
+		Username: "user:name",
+		Password: "p@ssword",
+	})
+	require.NoError(t, err)
+
+	conn, err := clearNet.Dial("tcp", "198.51.100.1:9735", time.Second)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	request := receiveSOCKSRequest(t, proxyServer)
+	require.Equal(t, "198.51.100.1", request.host)
+	require.Equal(t, uint16(9735), request.port)
+	require.Equal(t, "user:name", request.username)
+	require.Equal(t, "p@ssword", request.password)
+
+	conn, err = clearNet.Dial("tcp6", "[2001:db8::1]:443", time.Second)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+	require.Equal(t, "2001:db8::1",
+		receiveSOCKSRequest(t, proxyServer).host)
+}
+
+func TestClearNetDefaultBypass(t *testing.T) {
+	proxyServer := newSOCKSServer(t, false, false)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, listener.Close())
+	})
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err == nil {
+			accepted <- conn
+		}
+	}()
+
+	clearNet, err := NewClearNet(ClearNetConfig{SOCKS: proxyServer.addr()})
+	require.NoError(t, err)
+	conn, err := clearNet.Dial("tcp", listener.Addr().String(), time.Second)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	select {
+	case serverConn := <-accepted:
+		require.NoError(t, serverConn.Close())
+	case <-time.After(time.Second):
+		t.Fatal("direct loopback connection not received")
+	}
+
+	select {
+	case request := <-proxyServer.requests:
+		t.Fatalf("loopback unexpectedly proxied: %+v", request)
+	default:
+	}
+}
+
+func TestClearNetProxyFailureIsFailClosed(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	proxyAddr := listener.Addr().String()
+	require.NoError(t, listener.Close())
+
+	clearNet, err := NewClearNet(ClearNetConfig{SOCKS: proxyAddr})
+	require.NoError(t, err)
+	conn, err := clearNet.Dial("tcp", "198.51.100.1:9735", 50*time.Millisecond)
+	require.Error(t, err)
+	require.Nil(t, conn)
+}
+
+func TestProxyNetHybridRoutingAndIsolation(t *testing.T) {
+	torProxy := newSOCKSServer(t, true, false)
+	clearProxy := newSOCKSServer(t, true, false)
+	clearNet, err := NewClearNet(ClearNetConfig{
+		SOCKS:    clearProxy.addr(),
+		Username: "clear-user",
+		Password: "clear-password",
+	})
+	require.NoError(t, err)
+	torNet, err := NewProxyNet(ProxyNetConfig{
+		SOCKS:                       torProxy.addr(),
+		DNS:                         "127.0.0.1:53",
+		StreamIsolation:             true,
+		SkipProxyForClearNetTargets: true,
+		ClearNet:                    clearNet,
+	})
+	require.NoError(t, err)
+
+	onionHost := strings.Repeat("a", 56) + ".onion"
+	conn, err := torNet.Dial(
+		"onion", net.JoinHostPort(onionHost, "9735"), time.Second,
+	)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	conn, err = torNet.Dial("tcp", "198.51.100.1:9735", time.Second)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	torRequest := receiveSOCKSRequest(t, torProxy)
+	clearRequest := receiveSOCKSRequest(t, clearProxy)
+	require.Equal(t, onionHost, torRequest.host)
+	require.Len(t, torRequest.username, 16)
+	require.Len(t, torRequest.password, 16)
+	require.Equal(t, "clear-user", clearRequest.username)
+	require.Equal(t, "clear-password", clearRequest.password)
+	require.NotEqual(t, torRequest.username, clearRequest.username)
+}
+
+func TestProxyNetTorBypassTarget(t *testing.T) {
+	torProxy := newSOCKSServer(t, false, false)
+	clearProxy := newSOCKSServer(t, false, false)
+	clearNet, err := NewClearNet(ClearNetConfig{SOCKS: clearProxy.addr()})
+	require.NoError(t, err)
+	torNet, err := NewProxyNet(ProxyNetConfig{
+		SOCKS:          torProxy.addr(),
+		DNS:            "127.0.0.1:53",
+		ClearNet:       clearNet,
+		NoProxyTargets: []string{"198.51.100.0/24"},
+	})
+	require.NoError(t, err)
+
+	for _, address := range []string{
+		"198.51.100.20:9735", "203.0.113.20:9735",
+	} {
+		conn, err := torNet.Dial("tcp", address, time.Second)
+		require.NoError(t, err)
+		require.NoError(t, conn.Close())
+	}
+
+	require.Equal(t, "198.51.100.20",
+		receiveSOCKSRequest(t, clearProxy).host)
+	require.Equal(t, "203.0.113.20",
+		receiveSOCKSRequest(t, torProxy).host)
+}
+
+func TestProxyNetLookupsUseTor(t *testing.T) {
+	torProxy := newSOCKSServer(t, false, true)
+
+	dnsListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	dnsServer := &dns.Server{
+		Listener: dnsListener,
+		Net:      "tcp",
+		Handler: dns.HandlerFunc(func(w dns.ResponseWriter, request *dns.Msg) {
+			response := new(dns.Msg)
+			response.SetReply(request)
+			response.Answer = []dns.RR{&dns.SRV{
+				Hdr: dns.RR_Header{
+					Name:   "_nodes._tcp.example.com.",
+					Rrtype: dns.TypeSRV,
+					Class:  dns.ClassINET,
+					Ttl:    60,
+				},
+				Port:   9735,
+				Target: "node.example.com.",
+			}}
+			require.NoError(t, w.WriteMsg(response))
+		}),
+	}
+	go func() {
+		_ = dnsServer.ActivateAndServe()
+	}()
+	t.Cleanup(func() {
+		require.NoError(t, dnsServer.Shutdown())
+	})
+
+	torNet, err := NewProxyNet(ProxyNetConfig{
+		SOCKS:                       torProxy.addr(),
+		DNS:                         dnsListener.Addr().String(),
+		SkipProxyForClearNetTargets: true,
+		ClearNet:                    &ClearNet{},
+		NoProxyTargets:              []string{"127.0.0.0/8"},
+	})
+	require.NoError(t, err)
+
+	ips, err := torNet.LookupHost("example.com")
+	require.NoError(t, err)
+	require.Equal(t, []string{"192.0.2.1"}, ips)
+	require.Equal(t, byte(0xf0),
+		receiveSOCKSRequest(t, torProxy).command)
+
+	_, records, err := torNet.LookupSRV(
+		"nodes", "tcp", "example.com", time.Second,
+	)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	require.Equal(t, uint16(9735), records[0].Port)
+
+	dnsRequest := receiveSOCKSRequest(t, torProxy)
+	require.Equal(t, byte(1), dnsRequest.command)
+	require.Equal(t, "127.0.0.1", dnsRequest.host)
+
+	// The legacy exported function retains its proxy-skip argument for API
+	// compatibility, but SRV resolution must ignore it and still use Tor.
+	_, records, err = LookupSRV(
+		"nodes", "tcp", "example.com", torProxy.addr(),
+		dnsListener.Addr().String(), false, true, time.Second,
+	)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	require.Equal(t, "127.0.0.1",
+		receiveSOCKSRequest(t, torProxy).host)
+}

--- a/tor/tor.go
+++ b/tor/tor.go
@@ -149,13 +149,12 @@ func LookupHost(host, socksAddr string) ([]string, error) {
 // proxy by connecting directly to a DNS server and querying it. The DNS server
 // must have TCP resolution enabled for the given port.
 func LookupSRV(service, proto, name, socksAddr,
-	dnsServer string, streamIsolation bool, skipProxyForClearNetTargets bool,
+	dnsServer string, streamIsolation bool, _ bool,
 	timeout time.Duration) (string, []*net.SRV, error) {
 
 	// Connect to the DNS server we'll be using to query SRV records.
 	conn, err := dialProxy(
-		dnsServer, socksAddr, streamIsolation,
-		skipProxyForClearNetTargets, timeout,
+		dnsServer, socksAddr, streamIsolation, false, timeout,
 	)
 	if err != nil {
 		return "", nil, err


### PR DESCRIPTION
## Change Description

This is the separately versioned Tor-module prerequisite for the dual-proxy
routing requested in #10106. It builds on the flexible proxy configuration from
#5651 and retains its authorship credit, while leaving the public `Net`
interface unchanged.

The change adds a clearnet network implementation that can use an authenticated
SOCKS5 proxy with validated, opt-in bypass rules. The combined proxy network
supports the intended routing modes while preserving Tor-specific behavior:

- onion connections always use Tor;
- Tor remains the default for clearnet while active unless explicitly skipped;
- a configured clearnet proxy fails closed instead of silently dialing direct;
- stream-isolation credentials are generated only for Tor streams; and
- hostname and SRV resolution continue through Tor while Tor routing is active.

The matching lnd configuration, credential redaction, tests, documentation, and
release note are published on a stacked branch for review/cherry-picking into
#5651. No competing root integration PR will be opened while coordination with
that PR's author is pending. Once this module change is merged and tagged, #5651
can consume the released version without a local module replacement.

This PR is independent of the controller recovery work in #11099 and changes a
disjoint set of Tor-module files. If both are merged before the next Tor module
tag, the tag can include both prerequisites.

## Steps to Test

```bash
cd tor
go test ./...
go test -race ./...
go vet ./...
```

The stacked integration was also checked with:

```bash
go test . ./lncfg/... ./watchtower/...
make unit-module
make lint
```

## Pull Request Checklist

### Testing
- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not insubstantial.
- [x] The change obeys the code documentation and commenting guidelines, and
  lines wrap at 80.
- [x] Commits follow the Ideal Git Commit Structure.
- [x] New logging statements use an appropriate subsystem and logging level.
- [x] No new lncli commands are introduced.
- [ ] The user-facing release note is intentionally included in the stacked
  lnd integration, which cannot be submitted until this module is released.
