### PR TITLE
[v0.20.x-branch] Backport #11098: build: bump Go language to 1.25.13 and toolchain to 1.26.6

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -52,8 +52,8 @@ runs:
         # The key is used to create and later look up the cache. It's made of
         # four parts:
         # - The base part is made from the OS name, Go version and a
-        #   job-specified key prefix. Example: `linux-go-1.25.5-unit-test-`.
-        #   It ensures that a job running on Linux with Go 1.25 only looks for
+        #   job-specified key prefix. Example: `linux-go-1.26.6-unit-test-`.
+        #   It ensures that a job running on Linux with Go 1.26 only looks for
         #   caches from the same environment.
         # - The unique part is the `hashFiles('**/go.sum')`, which calculates a
         #   hash (a fingerprint) of the go.sum file. 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
           - name: amd64
             sys: darwin-amd64 freebsd-amd64 linux-amd64 netbsd-amd64 openbsd-amd64 windows-amd64
           - name: arm
-            sys: darwin-arm64 freebsd-arm linux-armv6 linux-armv7 linux-arm64 windows-arm
+            sys: darwin-arm64 freebsd-arm linux-armv6 linux-armv7 linux-arm64 windows-arm64
     steps:
       - name: Git checkout
         uses: actions/checkout@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ env:
 
   # If you change this please also update GO_VERSION in Makefile (then run
   # `make lint` to see where else it needs to be updated as well).
-  GO_VERSION: 1.25.5
+  GO_VERSION: 1.26.6
 
 jobs:
   static-checks:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ defaults:
 env:
   # If you change this please also update GO_VERSION in Makefile (then run
   # `make lint` to see where else it needs to be updated as well).
-  GO_VERSION: 1.25.5
+  GO_VERSION: 1.26.6
 
 jobs:
   ########################

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 run:
   # If you change this please also update GO_VERSION in Makefile (then run
   # `make lint` to see where else it needs to be updated as well).
-  go: "1.25.5"
+  go: "1.26.6"
 
   # Abort after 10 minutes.
   timeout: 10m

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # If you change this please also update GO_VERSION in Makefile (then run
 # `make lint` to see where else it needs to be updated as well).
-FROM golang:1.25.5-alpine as builder
+FROM golang:1.26.6-alpine as builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ACTIVE_GO_VERSION_MINOR := $(shell echo $(ACTIVE_GO_VERSION) | cut -d. -f2)
 # GO_VERSION is the Go version used for the release build, docker files, and
 # GitHub Actions. This is the reference version for the project. All other Go
 # versions are checked against this version.
-GO_VERSION = 1.25.5
+GO_VERSION = 1.26.6
 
 GOBUILD := $(GOCC) build -v
 GOINSTALL := $(GOCC) install -v

--- a/cert/go.mod
+++ b/cert/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/cert
 
-go 1.24.11
+go 1.25.13
 
 require github.com/stretchr/testify v1.8.2
 

--- a/clock/go.mod
+++ b/clock/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/clock
 
-go 1.24.11
+go 1.25.13
 
 require github.com/stretchr/testify v1.8.2
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,6 +1,6 @@
 # If you change this please also update GO_VERSION in Makefile (then run
 # `make lint` to see where else it needs to be updated as well).
-FROM golang:1.25.5-alpine AS builder
+FROM golang:1.26.6-alpine AS builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 

--- a/docker/btcd/Dockerfile
+++ b/docker/btcd/Dockerfile
@@ -1,6 +1,6 @@
 # If you change this please also update GO_VERSION in Makefile (then run
 # `make lint` to see where else it needs to be updated as well).
-FROM golang:1.25.5-alpine as builder
+FROM golang:1.26.6-alpine AS builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -93,7 +93,7 @@ following build dependencies are required:
 
 ### Installing Go
 
-`lnd` is written in Go, with a minimum version of `1.24.11` (or, in case this
+`lnd` is written in Go, with a minimum version of `1.25.13` (or, in case this
 document gets out of date, whatever the Go version in the main `go.mod` file
 requires). To install, run one of the following commands for your OS:
 
@@ -101,15 +101,15 @@ requires). To install, run one of the following commands for your OS:
   <summary>Linux (x86-64)</summary>
 
   ```
-  wget https://dl.google.com/go/go1.24.11.linux-amd64.tar.gz
-  echo "bceca00afaac856bc48b4cc33db7cd9eb383c81811379faed3bdbc80edb0af65  go1.24.11.linux-amd64.tar.gz" | sha256sum --check
+  wget https://dl.google.com/go/go1.25.13.linux-amd64.tar.gz
+  echo "39042a078ea9ceebe3ecda4a7188f0f5b96e14a071d27923ba7f40b456e85ae3  go1.25.13.linux-amd64.tar.gz" | sha256sum --check
   ```
 
-  The command above should output `go1.24.11.linux-amd64.tar.gz: OK`. If it
+  The command above should output `go1.25.13.linux-amd64.tar.gz: OK`. If it
   doesn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
   this version of Go. If it matches, then proceed to install Go:
   ```
-  sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.24.11.linux-amd64.tar.gz
+  sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.25.13.linux-amd64.tar.gz
   export PATH=$PATH:/usr/local/go/bin
   ```
 </details>
@@ -118,15 +118,15 @@ requires). To install, run one of the following commands for your OS:
   <summary>Linux (ARMv6)</summary>
 
   ```
-  wget https://dl.google.com/go/go1.24.11.linux-armv6l.tar.gz
-  echo "24d712a7e8ea2f429c05bc67287249e0291f2fe0ea6d6ff268f11b7343ad0f47  go1.24.11.linux-armv6l.tar.gz" | sha256sum --check
+  wget https://dl.google.com/go/go1.25.13.linux-armv6l.tar.gz
+  echo "f98ba3beb03a5c269d0115c7f8573483c139be88ce9989e53aff336826d13f5c  go1.25.13.linux-armv6l.tar.gz" | sha256sum --check
   ```
 
-  The command above should output `go1.24.11.linux-armv6l.tar.gz: OK`. If it
+  The command above should output `go1.25.13.linux-armv6l.tar.gz: OK`. If it
   isn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
   this version of Go. If it matches, then proceed to install Go:
   ```
-  sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.24.11.linux-armv6l.tar.gz
+  sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.25.13.linux-armv6l.tar.gz
   export PATH=$PATH:/usr/local/go/bin
   ```
 

--- a/fn/go.mod
+++ b/fn/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/fn/v2
 
-go 1.24.11
+go 1.25.13
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -213,9 +213,9 @@ replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 // allows us to specify that as an option.
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display
 
-// If you change this please also update docs/INSTALL.md and GO_VERSION in
-// Makefile (then run `make lint` to see where else it needs to be updated as
-// well).
-go 1.24.11
+// If you change this please also update docs/INSTALL.md and all other go.mod
+// files. The release build toolchain version is tracked separately by
+// GO_VERSION in Makefile.
+go 1.25.13
 
 retract v0.0.2

--- a/healthcheck/go.mod
+++ b/healthcheck/go.mod
@@ -24,4 +24,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.24.11
+go 1.25.13

--- a/kvdb/go.mod
+++ b/kvdb/go.mod
@@ -147,4 +147,4 @@ replace github.com/ulikunitz/xz => github.com/ulikunitz/xz v0.5.11
 // https://deps.dev/advisory/OSV/GO-2021-0053?from=%2Fgo%2Fgithub.com%252Fgogo%252Fprotobuf%2Fv1.3.1
 replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 
-go 1.24.11
+go 1.25.13

--- a/lnrpc/Dockerfile
+++ b/lnrpc/Dockerfile
@@ -1,6 +1,6 @@
 # If you change this please also update GO_VERSION in Makefile (then run
 # `make lint` to see where else it needs to be updated as well).
-FROM golang:1.25.5-bookworm
+FROM golang:1.26.6-bookworm
 
 RUN apt-get update && apt-get install -y \
   git \

--- a/lnrpc/gen_protos_docker.sh
+++ b/lnrpc/gen_protos_docker.sh
@@ -6,7 +6,7 @@ set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # golang docker image version used in this script.
-GO_IMAGE=docker.io/library/golang:1.25.5-alpine
+GO_IMAGE=docker.io/library/golang:1.26.6-alpine
 
 PROTOBUF_VERSION=$(docker run --rm -v $DIR/../:/lnd -w /lnd $GO_IMAGE \
 	go list -f '{{.Version}}' -m google.golang.org/protobuf)

--- a/make/builder.Dockerfile
+++ b/make/builder.Dockerfile
@@ -1,6 +1,6 @@
 # If you change this please also update GO_VERSION in Makefile (then run
 # `make lint` to see where else it needs to be updated as well).
-FROM golang:1.25.5-bookworm
+FROM golang:1.26.6-bookworm
 
 MAINTAINER Olaoluwa Osuntokun <laolu@lightning.engineering>
 

--- a/make/release_flags.mk
+++ b/make/release_flags.mk
@@ -26,7 +26,7 @@ netbsd-amd64 \
 openbsd-amd64 \
 windows-386 \
 windows-amd64 \
-windows-arm
+windows-arm64
 
 RELEASE_TAGS = autopilotrpc signrpc walletrpc chainrpc invoicesrpc watchtowerrpc neutrinorpc monitoring peersrpc kvdb_postgres kvdb_etcd kvdb_sqlite
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -103,7 +103,7 @@ following commands:
 
 ```
 RUN apt-get install -y wget \
-    && wget -c https://golang.org/dl/go1.17.6.linux-amd64.tar.gz -O - \
+    && wget -c https://dl.google.com/go/go1.26.6.linux-amd64.tar.gz -O - \
     | tar -xz -C /usr/local
 ENV GOPATH=/go
 ENV PATH=$PATH:/usr/local/go/bin:/go/bin

--- a/queue/go.mod
+++ b/queue/go.mod
@@ -4,4 +4,4 @@ require github.com/lightningnetwork/lnd/ticker v1.0.0
 
 replace github.com/lightningnetwork/lnd/ticker v1.0.0 => ../ticker
 
-go 1.24.11
+go 1.25.13

--- a/sqldb/go.mod
+++ b/sqldb/go.mod
@@ -75,4 +75,4 @@ require (
 	modernc.org/token v1.1.0 // indirect
 )
 
-go 1.24.11
+go 1.25.13

--- a/ticker/go.mod
+++ b/ticker/go.mod
@@ -1,3 +1,3 @@
 module github.com/lightningnetwork/lnd/ticker
 
-go 1.24.11
+go 1.25.13

--- a/tlv/go.mod
+++ b/tlv/go.mod
@@ -22,4 +22,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.24.11
+go 1.25.13

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.5
+FROM golang:1.26.6
 
 RUN apt-get update && apt-get install -y git
 ENV GOCACHE=/tmp/build/.cache

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/tools
 
-go 1.24.11
+go 1.25.13
 
 require (
 	github.com/btcsuite/btcd v0.24.2

--- a/tools/linters/go.mod
+++ b/tools/linters/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightningnetwork/lnd/tools/linters
 
-go 1.24.11
+go 1.25.13
 
 require (
 	github.com/golangci/plugin-module-register v0.1.1

--- a/tor/go.mod
+++ b/tor/go.mod
@@ -23,4 +23,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.24.11
+go 1.25.13


### PR DESCRIPTION
Backport of #11098

Opened manually rather than via the backport bot, since the change touches
`.github/` files.

---

- all tracked `go.mod` files move to `go 1.25.13`
- release/toolchain pins move to Go 1.26.6 across Makefile, CI, Dockerfiles, golangci-lint config, and protobuf generation
- install docs reference Go 1.25.13 with the official Linux amd64 and ARMv6 SHA256 checksums

### Behaviour change reviewers should be aware of

Unlike the v0.21.x backport (#11101), this branch was on `go 1.24.11`, so the
`go` directive crosses a Go minor. That directive is what selects the GODEBUG
compatibility baseline compiled into the binary, so five defaults flip. Verified
on the built binary:

```
before (go 1.24.11):
  DefaultGODEBUG=containermaxprocs=0,cryptocustomrand=1,decoratemappings=0,
                 tlssecpmlkem=0,tlssha1=1,updatemaxprocs=0,urlstrictcolons=0,
                 x509sha256skid=0

after  (go 1.25.13):
  DefaultGODEBUG=cryptocustomrand=1,tlssecpmlkem=0,urlstrictcolons=0
```

What each dropped pin means for lnd:

| Setting | Effect | Assessment |
|---|---|---|
| `containermaxprocs`, `updatemaxprocs` | GOMAXPROCS now derives from cgroup CPU limits, and tracks changes to them | The only operationally visible change. lnd never calls `runtime.GOMAXPROCS`; the five `runtime.NumCPU()` call sites (`rpcserver.go`, `autopilot/top_centrality.go`, `fn/slice.go`, sig pools) are unaffected, since `NumCPU` reads the affinity mask rather than the cgroup quota. Containerised nodes may see a different scheduler `P` count. |
| `x509sha256skid` | Newly generated certs get a SHA-256 derived Subject Key ID | `cert/selfsigned.go` omits `SubjectKeyId` with `IsCA: true`, so Go computes it. Cosmetic: the cert is self-signed and pinned by clients. Certs already on disk are untouched. |
| `tlssha1` | SHA-1 signature algorithms rejected in TLS 1.2 | Inert. `cert/tls.go` already pins four non-SHA-1 suites with `MinVersion: TLS1.2`. |
| `decoratemappings` | VMA naming on Linux | Observability only. |

All five remain overridable at runtime via the `GODEBUG` environment variable,
so an operator can restore the previous behaviour without a rebuild.

### Additional fix: windows-arm -> windows-arm64 release target

Go 1.26 drops the 32-bit windows/arm port, so cross-compiling the `windows-arm`
release target fails once the toolchain moves to 1.26.6. The release matrix in
`.github/workflows/main.yml` and the target list in `make/release_flags.mk` are
switched to `windows-arm64`.

This mirrors master's #10838 (commit `d3dad1690`), which bundled the same arm64
switch into an earlier Go toolchain bump. That change was never backported to
`v0.20.x`, so it is carried here alongside the toolchain bump that requires it.
Added as its own commit for clarity.

### Backport adaptations

Every hunk conflicted, since the branch was on `go 1.24.11` / toolchain
`1.25.5`. Conflicts were resolved by taking the incoming version numbers; four
places needed manual attention:

- **Three files do not exist on this branch** and are deliberately *not*
  introduced: `.github/workflows/govulncheck.yml`, `actor/go.mod`, and
  `sqldb/v2/go.mod`.

- **`queue/go.mod`** — this branch keeps its `go` directive at the end of the
  file, while master has it at the top. The three-way merge produced a file with
  *two* `go` directives and dropped the `require github.com/lightningnetwork/lnd/ticker`
  line. Rewritten so the only change is the version.

- **`kvdb/go.mod`** — the `go` directive sits after two `replace` directives
  (GHSA-25xm-hr59-7c27 and GO-2021-0053) that master no longer has in that
  position. The conflict region spanned them; restored explicitly.

- **`mobile/README.md`** — this branch still referenced `go1.17.6` via the old
  `golang.org/dl` URL. Master fixed that in an earlier bump that was never
  backported, so the line is brought up to date here rather than left stale.

### Testing

- `make check-go-version` — all Dockerfiles and YAML files report 1.26.6
- `GOTOOLCHAIN=go1.26.6 make build` — `lnd-debug` and `lncli-debug` build and report `0.20.3-beta`
- `GOTOOLCHAIN=go1.26.6 go build ./...` in all 11 submodules — clean
- `go mod edit -json` parses all 13 tracked `go.mod` files; each verified to contain exactly one `go` directive and to differ from the branch only in the version line
- `git diff --check` — clean
- no remaining `1.24.11` or `1.25.5` references in tracked files

