### PR TITLE
invoices: migrate legacy AMP invoice HTLCs

### DIFF
--- a/docs/release-notes/release-notes-0.20.4.md
+++ b/docs/release-notes/release-notes-0.20.4.md
@@ -39,6 +39,12 @@
   incoming HTLC resolver could treat a foreign commitment spend as its own
   success transaction and offer a phantom input to the sweeper.
 
+* Native SQL invoice migration [now correctly associates legacy AMP invoice
+  HTLCs](https://github.com/lightningnetwork/lnd/pull/11106) with their AMP
+  sub-invoices. Previously, the HTLC rows were inserted without those
+  associations, causing verification to fail and the migration transaction to
+  roll back.
+
 # New Features
 
 ## Functional Enhancements

--- a/docs/release-notes/release-notes-0.21.3.md
+++ b/docs/release-notes/release-notes-0.21.3.md
@@ -39,6 +39,12 @@
   incoming HTLC resolver could treat a foreign commitment spend as its own
   success transaction and offer a phantom input to the sweeper.
 
+* Native SQL invoice migration [now correctly associates legacy AMP invoice
+  HTLCs](https://github.com/lightningnetwork/lnd/pull/11106) with their AMP
+  sub-invoices. Previously, the HTLC rows were inserted without those
+  associations, causing verification to fail and the migration transaction to
+  roll back.
+
 # New Features
 
 ## Functional Enhancements

--- a/invoices/sql_migration.go
+++ b/invoices/sql_migration.go
@@ -158,6 +158,103 @@ func toInsertMigratedInvoiceParams(
 	}
 }
 
+// reconstructLegacyAMPState reconstructs the AMP state for invoices created
+// before reusable AMP invoices were introduced. Those invoices store their
+// HTLCs inline and don't have an AMPState record. The SQL schema requires the
+// AMP state to associate each HTLC with its sub-invoice, so we construct the
+// equivalent modern representation before migrating it.
+func reconstructLegacyAMPState(invoice *Invoice) error {
+	// Return early unless this is a legacy AMP invoice with inline HTLCs
+	// and no AMP state to reconstruct.
+	if !invoice.IsAMP() || len(invoice.AMPState) != 0 ||
+		len(invoice.Htlcs) == 0 {
+
+		return nil
+	}
+
+	ampState := make(AMPInvoiceState)
+	for circuitKey, htlc := range invoice.Htlcs {
+		if htlc.AMP == nil {
+			return fmt.Errorf("legacy AMP invoice contains "+
+				"non-AMP HTLC %v", circuitKey)
+		}
+
+		setID := htlc.AMP.Record.SetID()
+		setState, setExists := ampState[setID]
+		if !setExists {
+			setState = InvoiceStateAMP{
+				State: HtlcStateAccepted,
+				InvoiceKeys: make(
+					map[models.CircuitKey]struct{},
+				),
+			}
+		}
+
+		setState.InvoiceKeys[circuitKey] = struct{}{}
+		if htlc.State != HtlcStateCanceled {
+			setState.AmtPaid += htlc.Amt
+		}
+
+		// Legacy sets can retain HTLCs with different states. A
+		// canceled shard remains stored if replacement shards with
+		// the same set ID later complete the payment. Mark the set
+		// settled if any HTLC settled. Otherwise, mark it accepted
+		// while any HTLC remains accepted. Mark it canceled only when
+		// all HTLCs are canceled. This is only the sub-invoice state;
+		// the parent is validated below.
+		switch htlc.State {
+		case HtlcStateSettled:
+			setState.State = HtlcStateSettled
+
+		case HtlcStateCanceled:
+			if !setExists {
+				setState.State = HtlcStateCanceled
+			}
+
+		case HtlcStateAccepted:
+			if setState.State != HtlcStateSettled {
+				setState.State = HtlcStateAccepted
+			}
+
+		default:
+			return fmt.Errorf("legacy AMP invoice contains "+
+				"HTLC %v with unknown state %v", circuitKey,
+				htlc.State)
+		}
+
+		ampState[setID] = setState
+	}
+
+	// Legacy AMP invoices record settlement only on the parent invoice. A
+	// settled AMP parent with parent-level settle metadata also
+	// distinguishes this representation from reusable AMP invoices, whose
+	// parents remain open and whose settlement events belong to their
+	// sub-invoices. Count settled sets for validation, but don't synthesize
+	// a second settlement event on the reconstructed sub-invoice.
+	var settledSets int
+	for _, state := range ampState {
+		if state.State != HtlcStateSettled {
+			continue
+		}
+
+		settledSets++
+	}
+
+	switch {
+	case invoice.State == ContractSettled && settledSets != 1:
+		return fmt.Errorf("settled legacy AMP invoice has %d settled "+
+			"HTLC sets", settledSets)
+
+	case invoice.State != ContractSettled && settledSets != 0:
+		return fmt.Errorf("legacy AMP invoice in state %v has %d "+
+			"settled HTLC sets", invoice.State, settledSets)
+	}
+
+	invoice.AMPState = ampState
+
+	return nil
+}
+
 // MigrateSingleInvoice migrates a single invoice to the new SQL schema. Note
 // that perfect equality between the old and new schemas is not achievable, as
 // the invoice's add index cannot be mapped directly to its ID due to SQL’s
@@ -165,6 +262,12 @@ func toInsertMigratedInvoiceParams(
 // serve as the add index in the new schema.
 func MigrateSingleInvoice(ctx context.Context, tx SQLInvoiceQueries,
 	invoice *Invoice, paymentHash lntypes.Hash) error {
+
+	err := reconstructLegacyAMPState(invoice)
+	if err != nil {
+		return fmt.Errorf("unable to reconstruct legacy AMP state for "+
+			"invoice(add_index=%v): %w", invoice.AddIndex, err)
+	}
 
 	insertInvoiceParams, err := makeInsertInvoiceParams(
 		invoice, paymentHash,
@@ -488,7 +591,9 @@ func MigrateInvoicesToSQL(ctx context.Context, db kvdb.Backend,
 func migrateInvoices(ctx context.Context, tx *sqlc.Queries,
 	invoices []Invoice) error {
 
-	for i, invoice := range invoices {
+	for i := range invoices {
+		invoice := &invoices[i]
+
 		var paymentHash lntypes.Hash
 		if invoice.Terms.PaymentPreimage != nil {
 			paymentHash = invoice.Terms.PaymentPreimage.Hash()
@@ -511,7 +616,7 @@ func migrateInvoices(ctx context.Context, tx *sqlc.Queries,
 			copy(paymentHash[:], paymentHashBytes)
 		}
 
-		err := MigrateSingleInvoice(ctx, tx, &invoices[i], paymentHash)
+		err := MigrateSingleInvoice(ctx, tx, invoice, paymentHash)
 		if err != nil {
 			return fmt.Errorf("unable to migrate invoice(%v): %w",
 				paymentHash, err)
@@ -534,13 +639,15 @@ func migrateInvoices(ctx context.Context, tx *sqlc.Queries,
 		// however in PostgreSQL it has microsecond precision while in
 		// SQLite it has nanosecond precision if using TEXT storage
 		// class.
-		OverrideInvoiceTimeZone(&invoice)
+		OverrideInvoiceTimeZone(invoice)
 		OverrideInvoiceTimeZone(migratedInvoice)
 
 		// Override the add index before checking for equality.
 		migratedInvoice.AddIndex = invoice.AddIndex
 
-		err = sqldb.CompareRecords(invoice, *migratedInvoice, "invoice")
+		err = sqldb.CompareRecords(
+			*invoice, *migratedInvoice, "invoice",
+		)
 		if err != nil {
 			return err
 		}

--- a/invoices/sql_migration_test.go
+++ b/invoices/sql_migration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
 	"github.com/lightningnetwork/lnd/sqldb"
+	"github.com/lightningnetwork/lnd/sqldb/sqlc"
 	"github.com/stretchr/testify/require"
 	"pgregory.net/rapid"
 )
@@ -249,6 +250,289 @@ func generateAMPHtlcsRapid(t *rapid.T, invoice *Invoice) {
 		}
 
 		invoice.AMPState[setID] = ampState
+	}
+}
+
+// TestMigrateLegacyAMPInvoice tests migration of an AMP invoice created before
+// reusable AMP invoices were introduced. These invoices store AMP HTLCs inline
+// and don't contain the AMPState metadata used by the SQL schema.
+func TestMigrateLegacyAMPInvoice(t *testing.T) {
+	// Create a shared Postgres instance so we don't spawn a new container
+	// for each test case.
+	pgFixture := sqldb.NewTestPgFixture(
+		t, sqldb.DefaultPostgresFixtureLifetime,
+	)
+	t.Cleanup(func() {
+		pgFixture.TearDown(t)
+	})
+
+	tests := []struct {
+		name   string
+		sqlite bool
+	}{
+		{
+			name:   "SQLite",
+			sqlite: true,
+		},
+		{
+			name: "Postgres",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var db *sqldb.BaseDB
+			if test.sqlite {
+				db = sqldb.NewTestSqliteDB(t).BaseDB
+			} else {
+				db = sqldb.NewTestPostgresDB(
+					t, pgFixture,
+				).BaseDB
+			}
+
+			testMigrateLegacyAMPInvoice(t, db)
+		})
+	}
+}
+
+// testMigrateLegacyAMPInvoice verifies that a legacy AMP invoice and its
+// inline HTLCs are migrated correctly to the given SQL backend.
+func testMigrateLegacyAMPInvoice(t *testing.T, db *sqldb.BaseDB) {
+	invoiceExecutor := sqldb.NewTransactionExecutor(
+		db, func(tx *sql.Tx) SQLInvoiceQueries {
+			return db.WithTx(tx)
+		},
+	)
+	genericExecutor := sqldb.NewTransactionExecutor(
+		db, func(tx *sql.Tx) *sqlc.Queries {
+			return db.WithTx(tx)
+		},
+	)
+	store := NewSQLStore(
+		invoiceExecutor, clock.NewTestClock(time.Unix(1, 0)),
+	)
+
+	features := lnwire.EmptyFeatureVector()
+	features.Set(lnwire.AMPRequired)
+
+	var (
+		invoicePreimage  = lntypes.Preimage{1}
+		settledPreimage  = lntypes.Preimage{2}
+		canceledPreimage = lntypes.Preimage{3}
+		settledHash      = settledPreimage.Hash()
+		canceledHash     = canceledPreimage.Hash()
+		settledSetID     = SetID{4}
+		canceledSetID    = SetID{5}
+		createdAt        = time.Unix(1_630_000_000, 0)
+		settledAt        = createdAt.Add(time.Minute)
+		settledKey       = models.CircuitKey{
+			ChanID: lnwire.NewShortChanIDFromInt(1),
+			HtlcID: 1,
+		}
+		canceledKey = models.CircuitKey{
+			ChanID: lnwire.NewShortChanIDFromInt(2),
+			HtlcID: 2,
+		}
+	)
+
+	legacyInvoice := Invoice{
+		Memo:           []byte("legacy AMP invoice"),
+		PaymentRequest: []byte("legacy AMP payment request"),
+		CreationDate:   createdAt,
+		SettleDate:     settledAt,
+		Terms: ContractTerm{
+			FinalCltvDelta:  40,
+			Expiry:          time.Hour,
+			PaymentPreimage: &invoicePreimage,
+			Value:           600,
+			PaymentAddr:     [32]byte{6},
+			Features:        features,
+		},
+		AddIndex:    23,
+		SettleIndex: 209,
+		State:       ContractSettled,
+		AmtPaid:     600,
+		Htlcs: map[models.CircuitKey]*InvoiceHTLC{
+			settledKey: {
+				Amt:          600,
+				MppTotalAmt:  600,
+				AcceptHeight: 100,
+				AcceptTime:   createdAt.Add(30 * time.Second),
+				ResolveTime:  settledAt,
+				Expiry:       200,
+				State:        HtlcStateSettled,
+				CustomRecords: record.CustomSet{
+					65536: []byte("legacy custom record"),
+				},
+				AMP: &InvoiceHtlcAMPData{
+					Record: *record.NewAMP(
+						[32]byte{7}, settledSetID,
+						4_138_590_185,
+					),
+					Hash:     settledHash,
+					Preimage: &settledPreimage,
+				},
+			},
+			canceledKey: {
+				Amt:           400,
+				MppTotalAmt:   1_000,
+				AcceptHeight:  101,
+				AcceptTime:    createdAt.Add(40 * time.Second),
+				ResolveTime:   settledAt,
+				Expiry:        201,
+				State:         HtlcStateCanceled,
+				CustomRecords: make(record.CustomSet),
+				AMP: &InvoiceHtlcAMPData{
+					Record: *record.NewAMP(
+						[32]byte{8}, canceledSetID, 1,
+					),
+					Hash: canceledHash,
+				},
+			},
+		},
+		AMPState: make(AMPInvoiceState),
+	}
+
+	ctx := t.Context()
+	err := genericExecutor.ExecTx(
+		ctx, sqldb.WriteTxOpt(), func(tx *sqlc.Queries) error {
+			invoices := []Invoice{legacyInvoice}
+
+			return migrateInvoices(ctx, tx, invoices)
+		}, sqldb.NoOpReset,
+	)
+	require.NoError(t, err)
+
+	migratedInvoice, err := store.LookupInvoice(
+		ctx, InvoiceRefByHash(invoicePreimage.Hash()),
+	)
+	require.NoError(t, err)
+
+	expectedInvoice := legacyInvoice
+	require.NoError(t, reconstructLegacyAMPState(&expectedInvoice))
+	migratedInvoice.AddIndex = expectedInvoice.AddIndex
+	OverrideInvoiceTimeZone(&expectedInvoice)
+	OverrideInvoiceTimeZone(&migratedInvoice)
+	require.Equal(t, expectedInvoice, migratedInvoice)
+
+	// The parent-level settlement event identifies the migrated invoice as
+	// legacy. The reconstructed settled sub-invoice describes which AMP set
+	// succeeded, but intentionally has no second settlement event.
+	require.Equal(t, ContractSettled, migratedInvoice.State)
+	require.Equal(
+		t, expectedInvoice.SettleIndex, migratedInvoice.SettleIndex,
+	)
+	require.Equal(
+		t, expectedInvoice.SettleDate, migratedInvoice.SettleDate,
+	)
+	require.Len(t, migratedInvoice.AMPState, 2)
+	require.Zero(
+		t, migratedInvoice.AMPState[settledSetID].SettleIndex,
+	)
+	require.True(
+		t, migratedInvoice.AMPState[settledSetID].SettleDate.IsZero(),
+	)
+	require.Zero(
+		t, migratedInvoice.AMPState[canceledSetID].SettleIndex,
+	)
+	require.True(
+		t, migratedInvoice.AMPState[canceledSetID].SettleDate.IsZero(),
+	)
+
+	settledInvoices, err := store.InvoicesSettledSince(
+		ctx, expectedInvoice.SettleIndex-1,
+	)
+	require.NoError(t, err)
+	require.Len(t, settledInvoices, 1)
+	require.Equal(
+		t, expectedInvoice.SettleIndex,
+		settledInvoices[0].SettleIndex,
+	)
+}
+
+// TestReconstructLegacyAMPStateMixedHTLCStates verifies that a legacy AMP
+// set's reconstructed state reflects whether it can still settle, regardless
+// of the individual HTLC states retained in the legacy record.
+func TestReconstructLegacyAMPStateMixedHTLCStates(t *testing.T) {
+	tests := []struct {
+		name          string
+		invoiceState  ContractState
+		htlcStates    []HtlcState
+		expectedState HtlcState
+		expectedAmt   lnwire.MilliSatoshi
+	}{
+		{
+			name:         "accepted and canceled",
+			invoiceState: ContractOpen,
+			htlcStates: []HtlcState{
+				HtlcStateAccepted, HtlcStateCanceled,
+			},
+			expectedState: HtlcStateAccepted,
+			expectedAmt:   1,
+		},
+		{
+			name:         "settled and canceled",
+			invoiceState: ContractSettled,
+			htlcStates: []HtlcState{
+				HtlcStateSettled, HtlcStateCanceled,
+			},
+			expectedState: HtlcStateSettled,
+			expectedAmt:   1,
+		},
+		{
+			name:         "all canceled",
+			invoiceState: ContractOpen,
+			htlcStates: []HtlcState{
+				HtlcStateCanceled, HtlcStateCanceled,
+			},
+			expectedState: HtlcStateCanceled,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			features := lnwire.EmptyFeatureVector()
+			features.Set(lnwire.AMPRequired)
+
+			setID := SetID{1}
+			invoice := Invoice{
+				State: test.invoiceState,
+				Terms: ContractTerm{
+					Features: features,
+				},
+				Htlcs: make(
+					map[models.CircuitKey]*InvoiceHTLC,
+				),
+				AMPState: make(AMPInvoiceState),
+			}
+
+			for i, state := range test.htlcStates {
+				key := models.CircuitKey{HtlcID: uint64(i)}
+				invoice.Htlcs[key] = &InvoiceHTLC{
+					Amt:   1,
+					State: state,
+					AMP: &InvoiceHtlcAMPData{
+						Record: *record.NewAMP(
+							[32]byte{2}, setID,
+							uint32(i),
+						),
+					},
+				}
+			}
+
+			require.NoError(t, reconstructLegacyAMPState(&invoice))
+			require.Len(t, invoice.AMPState, 1)
+			state := invoice.AMPState[setID]
+			require.Equal(
+				t, test.expectedState, state.State,
+			)
+			require.Equal(
+				t, test.expectedAmt, state.AmtPaid,
+			)
+			require.Len(
+				t, state.InvoiceKeys, len(test.htlcStates),
+			)
+		})
 	}
 }
 


### PR DESCRIPTION
## Change Description

Legacy AMP invoices created before reusable AMP invoices store their HTLCs
inline and don't contain `AMPState` metadata.

The KV-to-SQL migration inserted the generic HTLC rows for these invoices, but
without `AMPState` it did not create AMP sub-invoices or associate the HTLCs
with them. SQL read-back therefore returned an empty HTLC map, and strict
migration verification aborted startup.

Reconstruct the modern AMP sub-invoice state from each inline HTLC's set ID
before insertion. This preserves the HTLC associations, AMP metadata, custom
records, amounts, and settlement metadata while keeping the compatibility
handling isolated to the migration.

The migration fails closed if the legacy data is structurally inconsistent.
Release notes are included for v0.21.3 and v0.20.4.

## Steps to Test

```bash
make lint
go vet ./invoices
go test ./invoices -run '^TestMigrateLegacyAMPInvoice$' -count=20
```

The regression test migrates a settled legacy AMP invoice with a canceled
competing set, AMP metadata, a large child index, and custom records, then
verifies complete SQL read-back equality.

