### PR TITLE
contractcourt: validate HTLC resolver spends

### DIFF
--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -990,6 +990,10 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 		Hash:  closeTx.TxHash(),
 		Index: 0,
 	}
+	htlcSpendTx := &wire.MsgTx{TxIn: []*wire.TxIn{{
+		PreviousOutPoint: htlcOp,
+	}}}
+	htlcSpendTxid := htlcSpendTx.TxHash()
 
 	// Set up the outgoing resolution. Populate SignedTimeoutTx because our
 	// commitment transaction got confirmed.
@@ -1116,9 +1120,9 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 	// Notify resolver that the HTLC output of the commitment has been
 	// spent.
 	oldNotifier.SpendChan <- &chainntnfs.SpendDetail{
-		SpendingTx:    closeTx,
-		SpentOutPoint: &wire.OutPoint{},
-		SpenderTxHash: &closeTxid,
+		SpendingTx:    htlcSpendTx,
+		SpentOutPoint: &htlcOp,
+		SpenderTxHash: &htlcSpendTxid,
 	}
 
 	// Finally, we should also receive a resolution message instructing the

--- a/contractcourt/htlc_outgoing_contest_resolver.go
+++ b/contractcourt/htlc_outgoing_contest_resolver.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/lnwallet"
@@ -73,9 +74,9 @@ func (h *htlcOutgoingContestResolver) Launch() error {
 //  1. The HTLC expires. In this case, we'll sweep the funds and send a clean
 //     up cancel message to outside sub-systems.
 //
-//  2. The remote party sweeps this HTLC on-chain, in which case we'll add the
-//     pre-image to our global cache, then send a clean up settle message
-//     backwards.
+//  2. The output is spent on-chain. An authenticated success adds the
+//     preimage to our cache and settles backwards, while another valid spend
+//     is handed to the timeout resolver.
 //
 // When either of these two things happens, we'll create a new resolver which
 // is able to handle the final resolution of the contract. We're only the pivot
@@ -111,14 +112,14 @@ func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 
 	// We'll quickly check to see if the output has already been spent.
 	select {
-	// If the output has already been spent, then we can stop early and
-	// sweep the pre-image from the output.
+	// If the output has already been spent, authenticate the spend before
+	// cleaning up or handing its timeout work to the inner resolver.
 	case commitSpend, ok := <-spendNtfn.Spend:
 		if !ok {
 			return nil, errResolverShuttingDown
 		}
 
-		return nil, h.claimCleanUp(commitSpend)
+		return h.resolveSpend(commitSpend)
 
 	// If it hasn't, then we'll watch for both the expiration, and the
 	// sweeping out this output.
@@ -179,16 +180,31 @@ func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 				return nil, errResolverShuttingDown
 			}
 
-			// The only way this output can be spent by the remote
-			// party is by revealing the preimage. So we'll perform
-			// our duties to clean up the contract once it has been
-			// claimed.
-			return nil, h.claimCleanUp(commitSpend)
+			// Only an authenticated success spend can reveal the
+			// preimage. Other valid spends belong to the timeout
+			// resolver's existing non-preimage path.
+			return h.resolveSpend(commitSpend)
 
 		case <-h.quit:
 			return nil, errResolverShuttingDown
 		}
 	}
+}
+
+// resolveSpend authenticates a commitment spend before choosing the resolver
+// that owns its remaining work.
+func (h *htlcOutgoingContestResolver) resolveSpend(
+	commitSpend *chainntnfs.SpendDetail) (ContractResolver, error) {
+
+	hasPreimage, err := h.htlcTimeoutResolver.isPreimageSpend(commitSpend)
+	if err != nil {
+		return nil, err
+	}
+	if !hasPreimage {
+		return h.htlcTimeoutResolver, nil
+	}
+
+	return nil, h.claimCleanUp(commitSpend)
 }
 
 // report returns a report on the resolution state of the contract.

--- a/contractcourt/htlc_outgoing_contest_resolver_test.go
+++ b/contractcourt/htlc_outgoing_contest_resolver_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
@@ -13,6 +15,7 @@ import (
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnmock"
 	"github.com/lightningnetwork/lnd/lntest/mock"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/stretchr/testify/require"
@@ -82,8 +85,11 @@ func TestHtlcOutgoingResolverRemoteClaim(t *testing.T) {
 	spendTx := &wire.MsgTx{
 		TxIn: []*wire.TxIn{
 			{
+				PreviousOutPoint: ctx.resolver.htlcResolution.
+					ClaimOutpoint,
 				Witness: [][]byte{
 					{0}, {1}, {2}, preimage[:],
+					{txscript.OP_TRUE},
 				},
 			},
 		},
@@ -91,7 +97,7 @@ func TestHtlcOutgoingResolverRemoteClaim(t *testing.T) {
 
 	spendHash := spendTx.TxHash()
 
-	ctx.notifier.SpendChan <- &chainntnfs.SpendDetail{
+	ctx.spendChan <- &chainntnfs.SpendDetail{
 		SpendingTx:    spendTx,
 		SpenderTxHash: &spendHash,
 	}
@@ -116,6 +122,193 @@ func TestHtlcOutgoingResolverRemoteClaim(t *testing.T) {
 
 	// Assert that the resolver finishes without error.
 	ctx.waitForResult(false)
+}
+
+// TestHtlcOutgoingResolverTaprootSpend tests both contest spend notification
+// sites with authenticated and non-preimage Taproot paths.
+func TestHtlcOutgoingResolverTaprootSpend(t *testing.T) {
+	// Arrange: Build cached and live success, alternate, and malformed
+	// spends of the authoritative Taproot HTLC output.
+	// Act: Launch resolution and deliver each spend through the buffered
+	// mock event while recording the output that the resolver watches.
+	// Assert: Only authenticated success resolves and reveals a preimage;
+	// other paths transition safely and malformed proofs return an error.
+	tests := []struct {
+		name      string
+		cached    bool
+		spendPath string
+	}{
+		{"cached success", true, "success"},
+		{"cached auxiliary", true, "auxiliary"},
+		{"cached key", true, "key"},
+		{"cached malformed", true, "malformed"},
+		{"loop success", false, "success"},
+		{"loop auxiliary", false, "auxiliary"},
+		{"loop key", false, "key"},
+		{"loop malformed", false, "malformed"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := newOutgoingResolverTestContext(t)
+			fixture := newOutgoingTaprootFixture(t, test.spendPath)
+			ctx.resolver.htlcResolution = fixture.resolution
+			ctx.resolver.initReport()
+			initialReport := ctx.resolver.currentReport
+
+			if test.cached {
+				ctx.spendChan <- fixture.spend
+				ctx.startResolve()
+			} else {
+				ctx.resolve()
+				ctx.spendChan <- fixture.spend
+			}
+
+			registration := <-ctx.registered
+			require.Equal(
+				t, fixture.outpoint, registration.outpoint,
+			)
+			require.Equal(
+				t, fixture.pkScript, registration.pkScript,
+			)
+
+			result := <-ctx.resolverResultChan
+			switch test.spendPath {
+			case "success":
+				require.NoError(t, result.err)
+				require.Nil(t, result.nextResolver)
+				require.True(t, ctx.resolver.IsResolved())
+				require.Len(t, ctx.preimageDB.newPreimages, 1)
+				require.Len(t, ctx.resolutionChan, 1)
+				require.Len(t, ctx.checkpointChan, 1)
+
+			case "malformed":
+				require.Error(t, result.err)
+				require.NotErrorIs(
+					t, result.err, errPreimageMismatch,
+				)
+				require.Nil(t, result.nextResolver)
+
+			default:
+				require.NoError(t, result.err)
+				require.Same(
+					t, ctx.resolver.htlcTimeoutResolver,
+					result.nextResolver,
+				)
+			}
+
+			if test.spendPath != "success" {
+				require.False(t, ctx.resolver.IsResolved())
+				require.Empty(t, ctx.preimageDB.newPreimages)
+				require.Empty(t, ctx.resolutionChan)
+				require.Empty(t, ctx.checkpointChan)
+				require.Empty(
+					t, ctx.htlcNotifier.finalHtlcEvents,
+				)
+				require.Equal(
+					t, initialReport,
+					ctx.resolver.currentReport,
+				)
+			}
+		})
+	}
+}
+
+// outgoingTaprootFixture pairs a commitment resolution with its candidate
+// spend so contest tests exercise the same authenticated tree and outpoint.
+type outgoingTaprootFixture struct {
+	resolution lnwallet.OutgoingHtlcResolution
+	spend      *chainntnfs.SpendDetail
+	outpoint   wire.OutPoint
+	pkScript   []byte
+}
+
+// newOutgoingTaprootFixture creates a realistic remote-commitment Taproot
+// spend and the resolution data needed to authenticate it.
+func newOutgoingTaprootFixture(t *testing.T,
+	spendPath string) *outgoingTaprootFixture {
+
+	t.Helper()
+	_, senderKey := btcec.PrivKeyFromBytes([]byte{1})
+	_, receiverKey := btcec.PrivKeyFromBytes([]byte{2})
+	_, revokeKey := btcec.PrivKeyFromBytes([]byte{3})
+	successLeaf, err := input.ReceiverHtlcTapLeafSuccess(
+		receiverKey, senderKey, testResHash[:],
+	)
+	require.NoError(t, err)
+	auxLeaf := txscript.NewTapLeaf(0xc2, successLeaf.Script)
+	tree, err := input.ReceiverHTLCScriptTaproot(
+		outgoingContestHtlcExpiry, senderKey, receiverKey, revokeKey,
+		testResHash[:], lntypes.Remote, fn.Some(auxLeaf),
+	)
+	require.NoError(t, err)
+
+	controlBytes := func(path input.ScriptPath) []byte {
+		control, err := tree.CtrlBlockForPath(path)
+		require.NoError(t, err)
+		serialized, err := control.ToBytes()
+		require.NoError(t, err)
+
+		return serialized
+	}
+	timeoutControl := controlBytes(input.ScriptPathTimeout)
+	script, control := tree.SuccessTapLeaf.Script,
+		controlBytes(input.ScriptPathSuccess)
+	preimage := testResPreimage[:]
+	switch spendPath {
+	case "auxiliary":
+		auxIndex := tree.TapScriptTree().
+			LeafProofIndex[auxLeaf.TapHash()]
+		auxProof := tree.TapScriptTree().LeafMerkleProofs[auxIndex]
+		auxControl := auxProof.ToControlBlock(revokeKey)
+		control, err = auxControl.ToBytes()
+		require.NoError(t, err)
+		script = auxLeaf.Script
+		preimage = make([]byte, lntypes.HashSize)
+
+	case "key":
+		script, control = nil, nil
+
+	case "malformed":
+		control = []byte{1}
+	}
+
+	outpoint := wire.OutPoint{Index: 9}
+	witness := wire.TxWitness{
+		dummyBytes, dummyBytes, preimage, script, control,
+	}
+	if spendPath == "key" {
+		witness = wire.TxWitness{dummyBytes}
+	}
+	spendingTx := &wire.MsgTx{TxIn: []*wire.TxIn{{
+		PreviousOutPoint: outpoint,
+		Witness:          witness,
+	}}}
+	spendingHash := spendingTx.TxHash()
+	pkScript := tree.PkScript()
+
+	return &outgoingTaprootFixture{
+		resolution: lnwallet.OutgoingHtlcResolution{
+			ClaimOutpoint: outpoint,
+			Expiry:        outgoingContestHtlcExpiry,
+			SweepSignDesc: input.SignDescriptor{
+				Output: &wire.TxOut{
+					Value:    int64(testHtlcAmount),
+					PkScript: pkScript,
+				},
+				WitnessScript: tree.TimeoutTapLeaf.Script,
+				ControlBlock:  timeoutControl,
+			},
+		},
+		spend: &chainntnfs.SpendDetail{
+			SpentOutPoint:     &outpoint,
+			SpendingTx:        spendingTx,
+			SpenderTxHash:     &spendingHash,
+			SpenderInputIndex: 0,
+		},
+		outpoint: outpoint,
+		pkScript: pkScript,
+	}
 }
 
 type resolveResult struct {
@@ -155,31 +348,34 @@ func TestHtlcOutgoingResolverSupplementDeadline(t *testing.T) {
 
 type outgoingResolverTestContext struct {
 	resolver           *htlcOutgoingContestResolver
-	notifier           *mock.ChainNotifier
+	notifier           *chainntnfs.MockChainNotifier
+	spendChan          chan *chainntnfs.SpendDetail
+	epochChan          chan *chainntnfs.BlockEpoch
+	registered         chan spendRegistration
 	preimageDB         *mockWitnessBeacon
+	htlcNotifier       *mockHTLCNotifier
 	resolverResultChan chan resolveResult
 	resolutionChan     chan ResolutionMsg
+	checkpointChan     chan struct{}
 	t                  *testing.T
 }
 
 func newOutgoingResolverTestContext(t *testing.T) *outgoingResolverTestContext {
-	notifier := &mock.ChainNotifier{
-		EpochChan: make(chan *chainntnfs.BlockEpoch),
-		SpendChan: make(chan *chainntnfs.SpendDetail),
-		ConfChan:  make(chan *chainntnfs.TxConfirmation),
-	}
+	notifier, spendChan, epochChan, registered := newSpendMockNotifier()
 
 	checkPointChan := make(chan struct{}, 1)
 	resolutionChan := make(chan ResolutionMsg, 1)
 
 	preimageDB := newMockWitnessBeacon()
+	htlcNotifier := &mockHTLCNotifier{}
 
 	onionProcessor := &mockOnionProcessor{}
 
 	chainCfg := ChannelArbitratorConfig{
 		ChainArbitratorConfig: ChainArbitratorConfig{
-			Notifier:   notifier,
-			PreimageDB: preimageDB,
+			Notifier:     notifier,
+			PreimageDB:   preimageDB,
+			HtlcNotifier: htlcNotifier,
 			DeliverResolutionMsg: func(msgs ...ResolutionMsg) error {
 				if len(msgs) != 1 {
 					return fmt.Errorf("expected 1 "+
@@ -235,22 +431,32 @@ func newOutgoingResolverTestContext(t *testing.T) *outgoingResolverTestContext {
 		},
 	}
 	resolver.initLogger("htlcOutgoingContestResolver")
+	resolver.initReport()
 
 	return &outgoingResolverTestContext{
 		resolver:       resolver,
 		notifier:       notifier,
+		spendChan:      spendChan,
+		epochChan:      epochChan,
+		registered:     registered,
 		preimageDB:     preimageDB,
+		htlcNotifier:   htlcNotifier,
 		resolutionChan: resolutionChan,
+		checkpointChan: checkPointChan,
 		t:              t,
 	}
 }
 
-func (i *outgoingResolverTestContext) resolve() {
-	// Start resolver.
+// startResolve starts the contest resolver without sending an initial epoch
+// and returns every launch or resolution error to the owning test goroutine.
+func (i *outgoingResolverTestContext) startResolve() {
 	i.resolverResultChan = make(chan resolveResult, 1)
 	go func() {
 		err := i.resolver.Launch()
-		require.NoError(i.t, err)
+		if err != nil {
+			i.resolverResultChan <- resolveResult{err: err}
+			return
+		}
 
 		nextResolver, err := i.resolver.Resolve()
 		i.resolverResultChan <- resolveResult{
@@ -258,13 +464,20 @@ func (i *outgoingResolverTestContext) resolve() {
 			err:          err,
 		}
 	}()
+}
+
+// resolve starts the contest resolver and sends its initial block epoch.
+func (i *outgoingResolverTestContext) resolve() {
+	i.startResolve()
 
 	// Notify initial block height.
 	i.notifyEpoch(testInitialBlockHeight)
 }
 
+// notifyEpoch delivers a block height through the explicit mock event so the
+// resolver observes it through the production notifier subscription.
 func (i *outgoingResolverTestContext) notifyEpoch(height int32) {
-	i.notifier.EpochChan <- &chainntnfs.BlockEpoch{
+	i.epochChan <- &chainntnfs.BlockEpoch{
 		Height: height,
 	}
 }

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -175,7 +175,9 @@ func (h *htlcSuccessResolver) resolveRemoteCommitOutput() error {
 	if err != nil {
 		return err
 	}
-	spendingInput, err := h.validatedSpendInput(sweepTxDetails)
+	spendingInput, err := validatedSpendInput(
+		sweepTxDetails, h.htlcResolution.ClaimOutpoint,
+	)
 	if err != nil {
 		return err
 	}
@@ -600,19 +602,19 @@ func (h *htlcSuccessResolver) isTaprootFinal() bool {
 	return h.chanType.IsTaprootFinal()
 }
 
-// validatedSpendInput returns the transaction input reported to spend this
-// resolver's HTLC outpoint after validating the notifier data.
-func (h *htlcSuccessResolver) validatedSpendInput(
-	spend *chainntnfs.SpendDetail) (*wire.TxIn, error) {
+// validatedSpendInput returns the selected transaction input after validating
+// the untrusted notifier data against the outpoint registered for the spend.
+func validatedSpendInput(spend *chainntnfs.SpendDetail,
+	expectedOutpoint wire.OutPoint) (*wire.TxIn, error) {
 
 	switch {
 	case spend == nil:
 		return nil, fmt.Errorf("%w: missing spend detail for %v",
-			errInvalidSpendDetails, h.outpoint())
+			errInvalidSpendDetails, expectedOutpoint)
 
 	case spend.SpendingTx == nil:
 		return nil, fmt.Errorf("%w: missing spending tx for %v",
-			errInvalidSpendDetails, h.outpoint())
+			errInvalidSpendDetails, expectedOutpoint)
 
 	case spend.SpenderInputIndex >= uint32(len(spend.SpendingTx.TxIn)):
 		return nil, fmt.Errorf("%w: spender input index %d out of "+
@@ -625,10 +627,10 @@ func (h *htlcSuccessResolver) validatedSpendInput(
 		return nil, fmt.Errorf("%w: spender input %d is nil",
 			errInvalidSpendDetails, spend.SpenderInputIndex)
 	}
-	if spendingInput.PreviousOutPoint != h.outpoint() {
+	if spendingInput.PreviousOutPoint != expectedOutpoint {
 		return nil, fmt.Errorf("%w: input %v, expected %v",
 			errInvalidSpendDetails, spendingInput.PreviousOutPoint,
-			h.outpoint())
+			expectedOutpoint)
 	}
 
 	return spendingInput, nil
@@ -818,7 +820,9 @@ func (h *htlcSuccessResolver) sweepSuccessTxOutput() error {
 	if err != nil {
 		return err
 	}
-	_, err = h.validatedSpendInput(commitSpend)
+	expectedOutpoint :=
+		h.htlcResolution.SignedSuccessTx.TxIn[0].PreviousOutPoint
+	_, err = validatedSpendInput(commitSpend, expectedOutpoint)
 	if err != nil {
 		return err
 	}
@@ -974,7 +978,7 @@ func (h *htlcSuccessResolver) resolveSuccessTx() error {
 	if err != nil {
 		return err
 	}
-	_, err = h.validatedSpendInput(commitSpend)
+	_, err = validatedSpendInput(commitSpend, outpoint)
 	if err != nil {
 		return err
 	}
@@ -1016,7 +1020,8 @@ func (h *htlcSuccessResolver) resolveSuccessTx() error {
 }
 
 // resolveSuccessTxOutput waits for the spend of the output from the 2nd-level
-// success tx.
+// success tx. It validates the selected input before mutating resolver state
+// and derives the spend ID from the transaction rather than notifier metadata.
 func (h *htlcSuccessResolver) resolveSuccessTxOutput(op wire.OutPoint) error {
 	// To wrap this up, we'll wait until the second-level transaction has
 	// been spent, then fully resolve the contract.
@@ -1031,13 +1036,18 @@ func (h *htlcSuccessResolver) resolveSuccessTxOutput(op wire.OutPoint) error {
 	if err != nil {
 		return err
 	}
+	_, err = validatedSpendInput(spend, op)
+	if err != nil {
+		return err
+	}
+	spendTxID := spend.SpendingTx.TxHash()
 
 	h.reportLock.Lock()
 	h.currentReport.RecoveredBalance = h.currentReport.LimboBalance
 	h.currentReport.LimboBalance = 0
 	h.reportLock.Unlock()
 
-	return h.checkpointClaim(op, spend.SpenderTxHash)
+	return h.checkpointClaim(op, &spendTxID)
 }
 
 // Launch creates an input based on the details of the incoming htlc resolution

--- a/contractcourt/htlc_success_resolver_test.go
+++ b/contractcourt/htlc_success_resolver_test.go
@@ -261,11 +261,6 @@ func TestHtlcSuccessSingleStage(t *testing.T) {
 // notified HTLC input.
 func TestHtlcSuccessValidatedSpendInput(t *testing.T) {
 	claim := wire.OutPoint{Index: 2}
-	resolver := &htlcSuccessResolver{
-		htlcResolution: lnwallet.IncomingHtlcResolution{
-			ClaimOutpoint: claim,
-		},
-	}
 	spendInput := &wire.TxIn{PreviousOutPoint: claim}
 	validSpend := &chainntnfs.SpendDetail{
 		SpendingTx: &wire.MsgTx{
@@ -274,7 +269,7 @@ func TestHtlcSuccessValidatedSpendInput(t *testing.T) {
 		SpenderInputIndex: 1,
 	}
 
-	input, err := resolver.validatedSpendInput(validSpend)
+	input, err := validatedSpendInput(validSpend, claim)
 	require.NoError(t, err)
 	require.Same(t, spendInput, input)
 
@@ -322,9 +317,160 @@ func TestHtlcSuccessValidatedSpendInput(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			_, err := resolver.validatedSpendInput(testCase.spend)
+			_, err := validatedSpendInput(testCase.spend, claim)
 			require.ErrorIs(t, err, errInvalidSpendDetails)
 			require.ErrorContains(t, err, testCase.errText)
+		})
+	}
+}
+
+// TestHtlcSuccessFinalSpendValidation tests that final success resolution
+// validates notifier spend data before mutating or checkpointing state.
+//
+//nolint:ll
+func TestHtlcSuccessFinalSpendValidation(t *testing.T) {
+	expectedOutpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{1},
+		Index: 3,
+	}
+
+	testCases := []struct {
+		name   string
+		mutate func(*chainntnfs.SpendDetail) *chainntnfs.SpendDetail
+		valid  bool
+	}{
+		{
+			name: "missing spend detail",
+			mutate: func(
+				*chainntnfs.SpendDetail) *chainntnfs.SpendDetail {
+
+				return nil
+			},
+		},
+		{
+			name: "missing spending tx",
+			mutate: func(
+				spend *chainntnfs.SpendDetail) *chainntnfs.SpendDetail {
+
+				spend.SpendingTx = nil
+				return spend
+			},
+		},
+		{
+			name: "input index out of range",
+			mutate: func(
+				spend *chainntnfs.SpendDetail) *chainntnfs.SpendDetail {
+
+				spend.SpenderInputIndex = 1
+				return spend
+			},
+		},
+		{
+			name: "nil spender input",
+			mutate: func(
+				spend *chainntnfs.SpendDetail) *chainntnfs.SpendDetail {
+
+				spend.SpendingTx.TxIn[0] = nil
+				return spend
+			},
+		},
+		{
+			name: "unexpected input outpoint",
+			mutate: func(spend *chainntnfs.SpendDetail) *chainntnfs.SpendDetail {
+				spend.SpendingTx.TxIn[0].PreviousOutPoint.Index++
+				return spend
+			},
+		},
+		{
+			name: "missing notifier spend hash",
+			mutate: func(spend *chainntnfs.SpendDetail) *chainntnfs.SpendDetail {
+				spend.SpenderTxHash = nil
+				return spend
+			},
+			valid: true,
+		},
+		{
+			name: "inconsistent notifier spend hash",
+			mutate: func(spend *chainntnfs.SpendDetail) *chainntnfs.SpendDetail {
+				wrongHash := chainhash.Hash{0xff}
+				spend.SpenderTxHash = &wrongHash
+				return spend
+			},
+			valid: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Arrange a resolver with observable persistence and report
+			// state, then alter one notifier field.
+			commitOutpoint := wire.OutPoint{Index: 2}
+			resolution := newSuccessTestResolution(commitOutpoint)
+			ctx := newHtlcResolverTestContext(t, func(
+				htlc channeldb.HTLC,
+				cfg ResolverConfig) ContractResolver {
+
+				return newSuccessResolver(
+					resolution, 0, htlc, 0, cfg,
+				)
+			})
+			resolver := requireSuccessResolver(t, ctx.resolver)
+			resolver.currentReport.LimboBalance = 34
+			resolver.currentReport.RecoveredBalance = 21
+			originalReport := resolver.currentReport
+
+			checkpointCalls := 0
+			var reports []*channeldb.ResolverReport
+			ctx.checkpoint = func(_ ContractResolver,
+				gotReports ...*channeldb.ResolverReport) error {
+
+				checkpointCalls++
+				reports = gotReports
+				return nil
+			}
+
+			spendingTx := &wire.MsgTx{
+				TxIn: []*wire.TxIn{{
+					PreviousOutPoint: expectedOutpoint,
+				}},
+				TxOut: []*wire.TxOut{{Value: 1}},
+			}
+			spend := newSpendDetail(
+				expectedOutpoint, spendingTx, 0,
+			)
+			ctx.notifier.SpendChan <- testCase.mutate(spend)
+
+			// Act on the final second-level spend notification.
+			err := resolver.resolveSuccessTxOutput(expectedOutpoint)
+
+			// Assert malformed data has no durable or in-memory side
+			// effects, while valid data uses the transaction's hash.
+			if !testCase.valid {
+				require.ErrorIs(t, err, errInvalidSpendDetails)
+				require.Equal(t, originalReport,
+					resolver.currentReport)
+				require.Zero(t, checkpointCalls)
+				require.False(t, ctx.finalHtlcOutcomeStored)
+				require.Empty(t,
+					ctx.htlcNotifier.finalHtlcEvents)
+				require.False(t, resolver.IsResolved())
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, originalReport.LimboBalance,
+				resolver.currentReport.RecoveredBalance)
+			require.Zero(t, resolver.currentReport.LimboBalance)
+			require.Equal(t, 1, checkpointCalls)
+			require.Len(t, reports, 2)
+			expectedSpendHash := spendingTx.TxHash()
+			require.Equal(t, &expectedSpendHash,
+				reports[0].SpendTxID)
+			require.True(t, ctx.finalHtlcOutcomeStored)
+			require.True(t, ctx.finalHtlcSettled)
+			require.Len(t, ctx.htlcNotifier.finalHtlcEvents, 1)
+			require.True(t, resolver.IsResolved())
 		})
 	}
 }
@@ -929,7 +1075,9 @@ func TestHtlcSuccessSecondStageResolution(t *testing.T) {
 	}
 
 	sweepTx := &wire.MsgTx{
-		TxIn:  []*wire.TxIn{{}},
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: htlcOutpoint,
+		}},
 		TxOut: []*wire.TxOut{{}},
 	}
 	sweepHash := sweepTx.TxHash()

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -134,6 +134,96 @@ func (h *htlcTimeoutResolver) taprootHtlcCommitmentScript() ([]byte, error) {
 	return output.PkScript, nil
 }
 
+// taprootSuccessHashes identifies the canonical success path without using a
+// candidate spend's script or keys. HTLC trees order sender leaves as
+// {success, timeout} and receiver leaves as {timeout, success}, with an
+// optional auxiliary leaf appended third. Btcd pairs the first two leaves, so
+// the independently hashed timeout leaf authenticates their shared edge. The
+// hash-keyed LeafProofIndex can select a duplicate auxiliary occurrence;
+// therefore a verified stored proof supplies only an optional success hash.
+type taprootSuccessHashes struct {
+	timeoutLeafHash    chainhash.Hash
+	storedProofSibling fn.Option[chainhash.Hash]
+}
+
+// canonicalTaprootSuccessHashes derives success identities from the trusted
+// timeout resolution. The timeout leaf hash remains authoritative even when a
+// stored proof is unavailable or was selected for a duplicate leaf.
+func (h *htlcTimeoutResolver) canonicalTaprootSuccessHashes() (
+	taprootSuccessHashes, error) {
+
+	timeoutScript, controlBytes, err := h.taprootTimeoutProof()
+	if err != nil {
+		return taprootSuccessHashes{}, err
+	}
+
+	identities := taprootSuccessHashes{
+		timeoutLeafHash: txscript.NewBaseTapLeaf(
+			timeoutScript,
+		).TapHash(),
+	}
+
+	commitScript, err := h.taprootHtlcCommitmentScript()
+	if err != nil {
+		return identities, nil
+	}
+	_, witnessProgram, err := txscript.ExtractWitnessProgramInfo(
+		commitScript,
+	)
+	if err != nil || len(witnessProgram) != 32 {
+		return identities, nil
+	}
+
+	controlBlock, err := txscript.ParseControlBlock(controlBytes)
+	if err != nil {
+		return identities, nil
+	}
+	if err := txscript.VerifyTaprootLeafCommitment(
+		controlBlock, witnessProgram, timeoutScript,
+	); err != nil {
+		return identities, nil
+	}
+
+	if len(controlBlock.InclusionProof) < chainhash.HashSize {
+		return identities, nil
+	}
+
+	var sibling chainhash.Hash
+	copy(sibling[:], controlBlock.InclusionProof[:chainhash.HashSize])
+	identities.storedProofSibling = fn.Some(sibling)
+
+	return identities, nil
+}
+
+// taprootTimeoutProof returns the trusted timeout script and its stored
+// control block. Missing or truncated trusted resolution data is an error;
+// malformed proof bytes are handled as an unavailable optional identity by
+// canonicalTaprootSuccessHashes.
+func (h *htlcTimeoutResolver) taprootTimeoutProof() ([]byte, []byte, error) {
+	if h.htlcResolution.SignedTimeoutTx == nil {
+		script := h.htlcResolution.SweepSignDesc.WitnessScript
+		if len(script) == 0 {
+			return nil, nil, errors.New(
+				"missing remote timeout script",
+			)
+		}
+
+		return script, h.htlcResolution.SweepSignDesc.ControlBlock, nil
+	}
+
+	timeoutTx := h.htlcResolution.SignedTimeoutTx
+	if len(timeoutTx.TxIn) == 0 || timeoutTx.TxIn[0] == nil {
+		return nil, nil, errors.New("missing local timeout input")
+	}
+
+	witness := timeoutTx.TxIn[0].Witness
+	if len(witness) < 2 || len(witness[len(witness)-2]) == 0 {
+		return nil, nil, errors.New("missing local timeout script")
+	}
+
+	return witness[len(witness)-2], witness[len(witness)-1], nil
+}
+
 // outpoint returns the outpoint of the HTLC output we're attempting to sweep.
 func (h *htlcTimeoutResolver) outpoint() wire.OutPoint {
 	// The primary key for this resolver will be the outpoint of the HTLC

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -612,6 +612,26 @@ func isPreimageSpend(isTaproot bool, spend *chainntnfs.SpendDetail,
 	}
 }
 
+// isPreimageSpend classifies a validated spend as success, non-success, or
+// malformed. Only true authorizes claim cleanup; false leaves the spend to the
+// existing timeout path, while an error must propagate before cleanup.
+func (h *htlcTimeoutResolver) isPreimageSpend(
+	spend *chainntnfs.SpendDetail) (bool, error) {
+
+	if h.isTaproot() {
+		return h.isTaprootPreimageSpend(spend)
+	}
+
+	_, err := validatedSpendInput(spend, h.outpoint())
+	if err != nil {
+		return false, err
+	}
+
+	return isPreimageSpend(
+		false, spend, !h.isRemoteCommitOutput(),
+	), nil
+}
+
 // checkSizeAndIndex checks that the witness is of the expected size and that
 // the witness element at the specified index is of the expected size.
 func checkSizeAndIndex(witness wire.TxWitness, size, index int) bool {
@@ -1123,12 +1143,15 @@ func (h *htlcTimeoutResolver) consumeSpendEvents(resultChan chan *spendResult,
 			log.Debugf("Found mempool spend of HTLC output %s "+
 				"in tx=%s", op, spendDetail.SpenderTxHash)
 
-			// Check whether the spend reveals the preimage, if not
-			// continue the loop.
-			hasPreimage := isPreimageSpend(
-				h.isTaproot(), spendDetail,
-				!h.isRemoteCommitOutput(),
-			)
+			// Authenticated success leaves; non-success stays under
+			// observation, while malformed data propagates.
+			hasPreimage, err := h.isPreimageSpend(spendDetail)
+			if err != nil {
+				result.err = err
+				resultChan <- result
+
+				return
+			}
 			if !hasPreimage {
 				log.Debugf("HTLC output %s spent doesn't "+
 					"reveal preimage", op)
@@ -1191,10 +1214,13 @@ func (h *htlcTimeoutResolver) waitHtlcSpendAndCheckPreimage() (
 		return nil, err
 	}
 
-	// If the spend reveals the pre-image, then we'll enter the clean up
-	// workflow to pass the preimage back to the incoming link, add it to
-	// the witness cache, and exit.
-	if isPreimageSpend(h.isTaproot(), spend, !h.isRemoteCommitOutput()) {
+	// Only authenticated success authorizes cleanup; non-success keeps the
+	// timeout path and malformed data returns before cleanup.
+	hasPreimage, err := h.isPreimageSpend(spend)
+	if err != nil {
+		return nil, err
+	}
+	if hasPreimage {
 		return nil, h.claimCleanUp(spend)
 	}
 
@@ -1376,10 +1402,13 @@ func (h *htlcTimeoutResolver) resolveRemoteCommitOutput() error {
 		return err
 	}
 
-	// If the spend reveals the preimage, then we'll enter the clean up
-	// workflow to pass the preimage back to the incoming link, add it to
-	// the witness cache, and exit.
-	if isPreimageSpend(h.isTaproot(), spend, !h.isRemoteCommitOutput()) {
+	// Only authenticated success authorizes cleanup; non-success keeps the
+	// timeout path and malformed data returns before cleanup.
+	hasPreimage, err := h.isPreimageSpend(spend)
+	if err != nil {
+		return err
+	}
+	if hasPreimage {
 		return h.claimCleanUp(spend)
 	}
 
@@ -1414,10 +1443,13 @@ func (h *htlcTimeoutResolver) resolveTimeoutTx() error {
 		return err
 	}
 
-	// If the spend reveals the preimage, then we'll enter the clean up
-	// workflow to pass the preimage back to the incoming link, add it to
-	// the witness cache, and exit.
-	if isPreimageSpend(h.isTaproot(), spend, !h.isRemoteCommitOutput()) {
+	// Only authenticated success authorizes cleanup; non-success keeps the
+	// timeout path and malformed data returns before cleanup.
+	hasPreimage, err := h.isPreimageSpend(spend)
+	if err != nil {
+		return err
+	}
+	if hasPreimage {
 		return h.claimCleanUp(spend)
 	}
 

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -491,10 +491,8 @@ func (h *htlcTimeoutResolver) chainDetailsToWatch() (*wire.OutPoint, []byte, err
 	}
 
 	// If SignedTimeoutTx is not nil, this is the local party's commitment,
-	// and we'll need to grab watch the output that our timeout transaction
-	// points to. We can directly grab the outpoint, then also extract the
-	// witness script (the last element of the witness stack) to
-	// re-construct the pkScript we need to watch.
+	// and we'll need to watch the output that our timeout transaction points
+	// to. The outpoint can be read directly from the transaction input.
 	//
 	//nolint:ll
 	outPointToWatch := h.htlcResolution.SignedTimeoutTx.TxIn[0].PreviousOutPoint
@@ -505,34 +503,10 @@ func (h *htlcTimeoutResolver) chainDetailsToWatch() (*wire.OutPoint, []byte, err
 		err           error
 	)
 	switch {
-	// For taproot channels, then final witness element is the control
-	// block, and the one before it the witness script. We can use both of
-	// these together to reconstruct the taproot output key, then map that
-	// into a v1 witness program.
+	// A control block can select the wrong duplicate leaf, so Taproot watch
+	// registration must use the independently stored commitment output.
 	case h.isTaproot():
-		// First, we'll parse the control block into something we can
-		// use.
-		ctrlBlockBytes := witness[len(witness)-1]
-		ctrlBlock, err := txscript.ParseControlBlock(ctrlBlockBytes)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		// With the control block, we'll grab the witness script, then
-		// use that to derive the tapscript root.
-		witnessScript := witness[len(witness)-2]
-		tapscriptRoot := ctrlBlock.RootHash(witnessScript)
-
-		// Once we have the root, then we can derive the output key
-		// from the internal key, then turn that into a witness
-		// program.
-		outputKey := txscript.ComputeTaprootOutputKey(
-			ctrlBlock.InternalKey, tapscriptRoot,
-		)
-		scriptToWatch, err = txscript.PayToTaprootScript(outputKey)
-		if err != nil {
-			return nil, nil, err
-		}
+		scriptToWatch, err = h.taprootHtlcCommitmentScript()
 
 	// For regular channels, the witness script is the last element on the
 	// stack. We can then use this to re-derive the output that we're

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -224,6 +224,88 @@ func (h *htlcTimeoutResolver) taprootTimeoutProof() ([]byte, []byte, error) {
 	return witness[len(witness)-2], witness[len(witness)-1], nil
 }
 
+// isTaprootPreimageSpend authenticates success against the authoritative
+// commitment output. False identifies valid non-success; errors identify
+// malformed notifier data or invalid commitment proofs.
+func (h *htlcTimeoutResolver) isTaprootPreimageSpend(
+	spend *chainntnfs.SpendDetail) (bool, error) {
+
+	spendingInput, err := validatedSpendInput(spend, h.outpoint())
+	if err != nil {
+		return false, err
+	}
+	witness := input.StripTaprootAnnex(spendingInput.Witness)
+	if len(witness) == 1 {
+		return false, nil
+	}
+	if len(witness) < 2 {
+		return false, errors.New("truncated tapscript witness")
+	}
+	revealedScript := witness[len(witness)-2]
+	controlBlock, err := txscript.ParseControlBlock(witness[len(witness)-1])
+	if err != nil {
+		return false, fmt.Errorf("parse taproot control block: %w", err)
+	}
+	commitScript, err := h.taprootHtlcCommitmentScript()
+	if err != nil {
+		return false, err
+	}
+	version, witnessProgram, err := txscript.ExtractWitnessProgramInfo(
+		commitScript,
+	)
+	if err != nil || version != 1 || len(witnessProgram) != 32 {
+		return false, errors.New("invalid taproot commitment script")
+	}
+	if err := txscript.VerifyTaprootLeafCommitment(
+		controlBlock, witnessProgram, revealedScript,
+	); err != nil {
+		return false, fmt.Errorf("verify taproot leaf: %w", err)
+	}
+	if controlBlock.LeafVersion != txscript.BaseLeafVersion {
+		return false, nil
+	}
+	identities, err := h.canonicalTaprootSuccessHashes()
+	if err != nil {
+		return false, err
+	}
+	// The canonical success leaf is paired with the independently hashed
+	// timeout leaf. This remains true when a duplicate timeout leaf makes
+	// the stored timeout proof unavailable.
+	isSuccess := false
+	if len(controlBlock.InclusionProof) >= chainhash.HashSize {
+		var sibling chainhash.Hash
+		copy(sibling[:], controlBlock.InclusionProof[:32])
+		isSuccess = sibling == identities.timeoutLeafHash
+	}
+	// A verified timeout proof names the canonical success leaf by hash.
+	// This also authenticates an indistinguishable duplicate success leaf
+	// without using candidate-supplied keys.
+	candidateHash := txscript.NewBaseTapLeaf(revealedScript).TapHash()
+	identities.storedProofSibling.WhenSome(func(sibling chainhash.Hash) {
+		isSuccess = isSuccess || candidateHash == sibling
+	})
+	if !isSuccess {
+		return false, nil
+	}
+	preimageIndex := taprootRemotePreimageIndex
+	witnessSize := remoteTaprootWitnessSuccessSize
+	if h.htlcResolution.SignedTimeoutTx != nil {
+		preimageIndex = localPreimageIndex
+		witnessSize = localTaprootWitnessSuccessSize
+	}
+	if !checkSizeAndIndex(witness, witnessSize, preimageIndex) {
+		return false, errors.New("invalid taproot success witness")
+	}
+	var preimage lntypes.Preimage
+	copy(preimage[:], witness[preimageIndex])
+	if !preimage.Matches(h.htlc.RHash) {
+		return false, fmt.Errorf("%w: preimage %v, htlc hash %v",
+			errPreimageMismatch, preimage, h.htlc.RHash)
+	}
+
+	return true, nil
+}
+
 // outpoint returns the outpoint of the HTLC output we're attempting to sweep.
 func (h *htlcTimeoutResolver) outpoint() wire.OutPoint {
 	// The primary key for this resolver will be the outpoint of the HTLC

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -106,6 +106,34 @@ func (h *htlcTimeoutResolver) isTaprootFinal() bool {
 	return h.chanType.IsTaprootFinal()
 }
 
+// taprootHtlcCommitmentScript returns the authoritative script of the HTLC
+// output on the commitment transaction. These stored commitment outputs, and
+// never a script reconstructed from a control-block proof, define the program
+// against which tapscript spends must be verified.
+func (h *htlcTimeoutResolver) taprootHtlcCommitmentScript() ([]byte, error) {
+	var output *wire.TxOut
+	if h.htlcResolution.SignedTimeoutTx != nil {
+		if h.htlcResolution.SignDetails == nil {
+			return nil, errors.New(
+				"missing local HTLC sign details",
+			)
+		}
+
+		output = h.htlcResolution.SignDetails.SignDesc.Output
+	} else {
+		output = h.htlcResolution.SweepSignDesc.Output
+	}
+
+	if output == nil {
+		return nil, errors.New("missing commitment HTLC output")
+	}
+	if len(output.PkScript) == 0 {
+		return nil, errors.New("missing commitment HTLC script")
+	}
+
+	return output.PkScript, nil
+}
+
 // outpoint returns the outpoint of the HTLC output we're attempting to sweep.
 func (h *htlcTimeoutResolver) outpoint() wire.OutPoint {
 	// The primary key for this resolver will be the outpoint of the HTLC

--- a/contractcourt/htlc_timeout_resolver_test.go
+++ b/contractcourt/htlc_timeout_resolver_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
@@ -1734,3 +1735,245 @@ func TestClaimCleanUpPreimageMismatch(t *testing.T) {
 	// preimage.
 	require.False(t, resolver.IsResolved())
 }
+
+// taprootHtlcVariant selects a realistic auxiliary-leaf topology for a test.
+// Each value exercises a distinct proof-identity or tree-layout boundary.
+type taprootHtlcVariant uint8
+
+const (
+	// taprootHtlcNoAux isolates the canonical two-leaf HTLC tree.
+	taprootHtlcNoAux taprootHtlcVariant = iota
+	// taprootHtlcUnrelatedAux adds a distinct committed third leaf.
+	taprootHtlcUnrelatedAux
+	// taprootHtlcDuplicateTimeout exposes timeout-proof hash ambiguity.
+	taprootHtlcDuplicateTimeout
+	// taprootHtlcDuplicateSuccess exposes indistinguishable success leaves.
+	taprootHtlcDuplicateSuccess
+)
+
+// taprootHtlcFixture binds an actual HTLC tree to its resolver-owned data.
+// This lets tests compare candidate proofs with the authoritative output.
+type taprootHtlcFixture struct {
+	resolver          *htlcTimeoutResolver
+	tree              *input.HtlcScriptTree
+	commitmentScript  []byte
+	watchedOutpoint   wire.OutPoint
+	timeoutScript     []byte
+	timeoutControl    []byte
+	successScript     []byte
+	successControl    []byte
+	localCommit       bool
+	revocationKey     *btcec.PublicKey
+	timeoutProofIndex int
+}
+
+// newTaprootHtlcFixture creates an actual sender or receiver HTLC tree and
+// resolution data matching the commitment side under test.
+func newTaprootHtlcFixture(t *testing.T, localCommit bool,
+	variant taprootHtlcVariant) *taprootHtlcFixture {
+
+	t.Helper()
+	_, senderKey := btcec.PrivKeyFromBytes(bytes.Repeat([]byte{2}, 32))
+	_, receiverKey := btcec.PrivKeyFromBytes(bytes.Repeat([]byte{3}, 32))
+	_, revocationKey := btcec.PrivKeyFromBytes(bytes.Repeat([]byte{4}, 32))
+	buildTree := func(aux input.AuxTapLeaf) *input.HtlcScriptTree {
+		var (
+			tree *input.HtlcScriptTree
+			err  error
+		)
+		if localCommit {
+			tree, err = input.SenderHTLCScriptTaproot(
+				senderKey, receiverKey, revocationKey,
+				testResHash[:], lntypes.Local, aux,
+			)
+		} else {
+			tree, err = input.ReceiverHTLCScriptTaproot(
+				500, senderKey, receiverKey, revocationKey,
+				testResHash[:], lntypes.Remote, aux,
+			)
+		}
+		require.NoError(t, err)
+
+		return tree
+	}
+	baseTree := buildTree(input.NoneTapLeaf())
+	auxLeaf := input.NoneTapLeaf()
+	switch variant {
+	case taprootHtlcUnrelatedAux:
+		auxLeaf = fn.Some(txscript.NewBaseTapLeaf([]byte{
+			txscript.OP_TRUE,
+		}))
+	case taprootHtlcDuplicateTimeout:
+		auxLeaf = fn.Some(baseTree.TimeoutTapLeaf)
+	case taprootHtlcDuplicateSuccess:
+		auxLeaf = fn.Some(baseTree.SuccessTapLeaf)
+	}
+	tree := buildTree(auxLeaf)
+	commitmentScript, err := input.PayToTaprootScript(tree.TaprootKey)
+	require.NoError(t, err)
+	timeoutControl, err := tree.CtrlBlockForPath(input.ScriptPathTimeout)
+	require.NoError(t, err)
+	timeoutControlBytes, err := timeoutControl.ToBytes()
+	require.NoError(t, err)
+	successIndex := 1
+	timeoutIndex := 0
+	if localCommit {
+		successIndex = 0
+		timeoutIndex = 1
+	}
+	successControl := tree.TapscriptTree.LeafMerkleProofs[successIndex].
+		ToControlBlock(revocationKey)
+	successControlBytes, err := successControl.ToBytes()
+	require.NoError(t, err)
+
+	watchedOutpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{byte(variant + 1)},
+		Index: uint32(timeoutIndex),
+	}
+	resolution := lnwallet.OutgoingHtlcResolution{
+		ClaimOutpoint: watchedOutpoint,
+		SweepSignDesc: input.SignDescriptor{
+			Output:        &wire.TxOut{PkScript: commitmentScript},
+			WitnessScript: tree.TimeoutTapLeaf.Script,
+			ControlBlock:  timeoutControlBytes,
+		},
+	}
+	if localCommit {
+		secondLevelScript, err := input.PayToTaprootScript(senderKey)
+		require.NoError(t, err)
+		resolution.SignedTimeoutTx = &wire.MsgTx{
+			TxIn: []*wire.TxIn{{
+				PreviousOutPoint: watchedOutpoint,
+				Witness: wire.TxWitness{
+					dummyBytes, dummyBytes,
+					tree.TimeoutTapLeaf.Script,
+					timeoutControlBytes,
+				},
+			}},
+		}
+		resolution.SignDetails = &input.SignDetails{
+			SignDesc: input.SignDescriptor{
+				Output: &wire.TxOut{PkScript: commitmentScript},
+			},
+		}
+		// A local SweepSignDesc describes the second-level output, not
+		// the commitment HTLC output selected by the helper.
+		resolution.SweepSignDesc.Output = &wire.TxOut{
+			PkScript: secondLevelScript,
+		}
+	}
+
+	return &taprootHtlcFixture{
+		resolver: &htlcTimeoutResolver{
+			htlcResolution: resolution,
+		},
+		tree:              tree,
+		commitmentScript:  commitmentScript,
+		watchedOutpoint:   watchedOutpoint,
+		timeoutScript:     tree.TimeoutTapLeaf.Script,
+		timeoutControl:    timeoutControlBytes,
+		successScript:     tree.SuccessTapLeaf.Script,
+		successControl:    successControlBytes,
+		localCommit:       localCommit,
+		revocationKey:     revocationKey,
+		timeoutProofIndex: timeoutIndex,
+	}
+}
+
+// TestTaprootHtlcCommitmentScript tests that commitment scripts come from
+// authoritative resolution outputs for both commitment sides.
+func TestTaprootHtlcCommitmentScript(t *testing.T) {
+	// Arrange canonical, auxiliary, and duplicate-leaf trees so both
+	// commitment sides and every authoritative data source are covered.
+	variants := []taprootHtlcVariant{
+		taprootHtlcNoAux, taprootHtlcUnrelatedAux,
+		taprootHtlcDuplicateTimeout, taprootHtlcDuplicateSuccess,
+	}
+	for _, localCommit := range []bool{true, false} {
+		for _, variant := range variants {
+			// Act by reading the stored commitment output rather
+			// than rebuilding a program from candidate proof data.
+			fixture := newTaprootHtlcFixture(
+				t, localCommit, variant,
+			)
+			name := fmt.Sprintf("local=%v/variant=%v",
+				localCommit, variant)
+			t.Run(name, func(t *testing.T) {
+				script, err := fixture.resolver.
+					taprootHtlcCommitmentScript()
+				// Assert the program is returned and state
+				// remains unchanged; error cases follow below.
+				require.NoError(t, err)
+				require.Equal(
+					t, fixture.commitmentScript, script,
+				)
+				require.False(t, fixture.resolver.IsResolved())
+			})
+		}
+	}
+
+	local := newTaprootHtlcFixture(t, true, taprootHtlcNoAux)
+	remote := newTaprootHtlcFixture(t, false, taprootHtlcNoAux)
+	testCases := []struct {
+		name     string
+		resolver *htlcTimeoutResolver
+	}{
+		{
+			name: "missing local sign details",
+			resolver: func() *htlcTimeoutResolver {
+				local.resolver.htlcResolution.SignDetails = nil
+				return local.resolver
+			}(),
+		},
+		{
+			name: "missing remote output",
+			resolver: func() *htlcTimeoutResolver {
+				remote.resolver.htlcResolution.SweepSignDesc.
+					Output = nil
+				return remote.resolver
+			}(),
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			script, err := testCase.resolver.
+				taprootHtlcCommitmentScript()
+
+			require.Error(t, err)
+			require.Nil(t, script)
+			require.False(t, testCase.resolver.IsResolved())
+		})
+	}
+
+	for _, localCommit := range []bool{true, false} {
+		for _, missingOutput := range []bool{true, false} {
+			fixture := newTaprootHtlcFixture(
+				t, localCommit, taprootHtlcNoAux,
+			)
+			switch {
+			case localCommit && missingOutput:
+				fixture.resolver.htlcResolution.SignDetails.
+					SignDesc.Output = nil
+
+			case localCommit:
+				output := fixture.resolver.htlcResolution.
+					SignDetails.SignDesc.Output
+				output.PkScript = nil
+
+			case missingOutput:
+				fixture.resolver.htlcResolution.
+					SweepSignDesc.Output = nil
+
+			default:
+				fixture.resolver.htlcResolution.
+					SweepSignDesc.Output.PkScript = nil
+			}
+
+			_, err := fixture.resolver.taprootHtlcCommitmentScript()
+			require.Error(t, err)
+		}
+	}
+}
+
+// setTaprootTimeoutControl replaces the stored timeout proof on either
+// commitment side of a fixture.

--- a/contractcourt/htlc_timeout_resolver_test.go
+++ b/contractcourt/htlc_timeout_resolver_test.go
@@ -99,7 +99,7 @@ func genHtlcTimeoutTestCases() []htlcTimeoutTestCase {
 	fakePreimageBytes := testResPreimage[:]
 
 	var (
-		htlcOutpoint wire.OutPoint
+		htlcOutpoint = testChanPoint2
 		fakePreimage lntypes.Preimage
 	)
 	fakeSignDesc := &input.SignDescriptor{
@@ -438,6 +438,9 @@ func testHtlcTimeoutResolver(t *testing.T, testCase htlcTimeoutTestCase) {
 	if err != nil {
 		t.Fatalf("unable to generate tx: %v", err)
 	}
+	if testCase.remoteCommit {
+		spendingTx.TxIn[0].PreviousOutPoint = testChanPoint2
+	}
 	spendTxHash := spendingTx.TxHash()
 
 	select {
@@ -570,7 +573,9 @@ func TestHtlcTimeoutSingleStage(t *testing.T) {
 	commitOutpoint := wire.OutPoint{Index: 3}
 
 	sweepTx := &wire.MsgTx{
-		TxIn:  []*wire.TxIn{{}},
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: commitOutpoint,
+		}},
 		TxOut: []*wire.TxOut{{}},
 	}
 
@@ -794,7 +799,9 @@ func TestHtlcTimeoutSingleStageRemoteSpend(t *testing.T) {
 	htlcOutpoint := wire.OutPoint{Index: 3}
 
 	spendTx := &wire.MsgTx{
-		TxIn:  []*wire.TxIn{{}},
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: commitOutpoint,
+		}},
 		TxOut: []*wire.TxOut{{}},
 	}
 
@@ -1297,6 +1304,7 @@ func TestHtlcTimeoutSecondStageSweeperRemoteSpend(t *testing.T) {
 		TxIn:  []*wire.TxIn{{}},
 		TxOut: []*wire.TxOut{{}},
 	}
+	spendTx.TxIn[0].PreviousOutPoint = commitOutpoint
 
 	fakePreimageBytes := testResPreimage[:]
 	var fakePreimage lntypes.Preimage
@@ -2398,5 +2406,186 @@ func TestHtlcOutgoingResolverTaprootRegistration(t *testing.T) {
 		require.ErrorIs(t, resolved.err, errResolverShuttingDown)
 		require.Nil(t, resolved.nextResolver)
 		require.False(t, resolver.IsResolved())
+	}
+}
+
+// taprootSpendForPath creates a notifier spend for a realistic fixture path.
+func taprootSpendForPath(t *testing.T, fixture *taprootHtlcFixture,
+	path string) *chainntnfs.SpendDetail {
+
+	t.Helper()
+	script, control := fixture.successScript, fixture.successControl
+	preimage := testResPreimage[:]
+	if path == "auxiliary" {
+		proof := fixture.tree.TapscriptTree.LeafMerkleProofs[2]
+		block := proof.ToControlBlock(fixture.revocationKey)
+		var err error
+		control, err = block.ToBytes()
+		require.NoError(t, err)
+		script = proof.Script
+	}
+	if path == "wrong" {
+		preimage = bytes.Repeat([]byte{9}, lntypes.HashSize)
+	}
+	witness := wire.TxWitness{
+		dummyBytes, dummyBytes, preimage, script, control,
+	}
+	if fixture.localCommit {
+		witness = wire.TxWitness{dummyBytes, preimage, script, control}
+	}
+	if path == "key" {
+		witness = wire.TxWitness{dummyBytes}
+	}
+	tx := &wire.MsgTx{TxIn: []*wire.TxIn{{
+		PreviousOutPoint: fixture.watchedOutpoint,
+		Witness:          witness,
+	}}}
+	txHash := tx.TxHash()
+
+	return &chainntnfs.SpendDetail{
+		SpentOutPoint:     &fixture.watchedOutpoint,
+		SpendingTx:        tx,
+		SpenderTxHash:     &txHash,
+		SpenderInputIndex: 0,
+	}
+}
+
+// TestHtlcTimeoutTaprootSpendPath tests every Taproot spend decision point.
+//
+//nolint:ll
+func TestHtlcTimeoutTaprootSpendPath(t *testing.T) {
+	// Arrange: Combine every resolver entry point with authenticated success,
+	// benign alternate paths, and dishonest preimage witnesses.
+	// Act: Deliver each spend through the same explicit notifier event or the
+	// paired mempool/block streams used by the production decision path.
+	// Assert: Only valid success paths reveal and persist a preimage, while
+	// every other path preserves the resolver state appropriate to its site.
+	testCases := []struct {
+		name  string
+		site  string
+		path  string
+		local bool
+	}{
+		{"confirmed success", "confirmed", "success", false},
+		{"confirmed auxiliary", "confirmed", "auxiliary", true},
+		{"mempool success", "mempool", "success", false},
+		{"mempool wrong preimage", "mempool", "wrong", false},
+		{"mempool key path", "mempool", "key", true},
+		{"remote success", "remote", "success", false},
+		{"remote auxiliary", "remote", "auxiliary", false},
+		{"local success", "local", "success", true},
+		{"local wrong preimage", "local", "wrong", true},
+		{"local key path", "local", "key", true},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			variant := taprootHtlcNoAux
+			if testCase.path == "auxiliary" {
+				variant = taprootHtlcUnrelatedAux
+			}
+			fixture := newTaprootHtlcFixture(
+				t, testCase.local, variant,
+			)
+			spend := taprootSpendForPath(t, fixture, testCase.path)
+			notifier, spendChan, _, _ := newSpendMockNotifier()
+			beacon := newMockWitnessBeacon()
+			resolutionChan := make(chan ResolutionMsg, 1)
+			checkpointChan := make(chan struct{}, 1)
+			chainCfg := ChannelArbitratorConfig{
+				ChainArbitratorConfig: ChainArbitratorConfig{
+					Notifier:   notifier,
+					PreimageDB: beacon,
+					DeliverResolutionMsg: func(...ResolutionMsg) error {
+						resolutionChan <- ResolutionMsg{}
+						return nil
+					},
+				},
+			}
+			fixture.resolver.contractResolverKit = *newContractResolverKit(
+				ResolverConfig{
+					ChannelArbitratorConfig: chainCfg,
+					Checkpoint: func(ContractResolver,
+						...*channeldb.ResolverReport) error {
+
+						checkpointChan <- struct{}{}
+						return nil
+					},
+				},
+			)
+			fixture.resolver.initLogger("htlcTimeoutResolver")
+			fixture.resolver.currentReport = ContractReport{LimboBalance: 1}
+			initialReport := fixture.resolver.currentReport
+			var (
+				returnedSpend *chainntnfs.SpendDetail
+				err           error
+			)
+			switch testCase.site {
+			case "confirmed":
+				spendChan <- spend
+				returnedSpend, err = fixture.resolver.
+					waitHtlcSpendAndCheckPreimage()
+			case "mempool":
+				block := make(chan *chainntnfs.SpendDetail)
+				mempool := make(chan *chainntnfs.SpendDetail)
+				result := make(chan *spendResult, 1)
+				go fixture.resolver.consumeSpendEvents(
+					result, block, mempool,
+				)
+				mempool <- spend
+				if testCase.path == "key" {
+					close(block)
+				}
+				spendResult := <-result
+				returnedSpend, err = spendResult.spend, spendResult.err
+				close(fixture.resolver.quit)
+			case "remote":
+				spendChan <- spend
+				err = fixture.resolver.resolveRemoteCommitOutput()
+			case "local":
+				spendChan <- spend
+				close(spendChan)
+				err = fixture.resolver.resolveTimeoutTx()
+			}
+			switch testCase.path {
+			case "success":
+				require.NoError(t, err)
+				if testCase.site == "mempool" {
+					require.Same(t, spend, returnedSpend)
+					break
+				}
+				require.Nil(t, returnedSpend)
+				require.Len(t, beacon.newPreimages, 1)
+				require.Len(t, resolutionChan, 1)
+				require.Len(t, checkpointChan, 1)
+				require.True(t, fixture.resolver.IsResolved())
+
+			case "wrong":
+				require.ErrorIs(t, err, errPreimageMismatch)
+
+			case "auxiliary":
+				require.NoError(t, err)
+				if testCase.site == "confirmed" {
+					require.Same(t, spend, returnedSpend)
+				}
+
+			case "key":
+				require.ErrorIs(t, err, errResolverShuttingDown)
+			}
+
+			if testCase.path != "success" {
+				require.Empty(t, beacon.newPreimages)
+				require.Equal(t, initialReport,
+					fixture.resolver.currentReport)
+				if testCase.site == "remote" {
+					require.True(t, fixture.resolver.IsResolved())
+					require.Len(t, resolutionChan, 1)
+					require.Len(t, checkpointChan, 1)
+				} else {
+					require.False(t, fixture.resolver.IsResolved())
+					require.Empty(t, resolutionChan)
+					require.Empty(t, checkpointChan)
+				}
+			}
+		})
 	}
 }

--- a/contractcourt/htlc_timeout_resolver_test.go
+++ b/contractcourt/htlc_timeout_resolver_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
+	testifymock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -2230,5 +2231,172 @@ func TestTaprootPreimageSpend(t *testing.T) {
 			require.Equal(t, testCase.want, result)
 			require.False(t, fixture.resolver.IsResolved())
 		})
+	}
+}
+
+// spendRegistration preserves the output identity passed to the notifier.
+// Tests use this copy to verify the resolver watched authoritative data.
+type spendRegistration struct {
+	outpoint wire.OutPoint
+	pkScript []byte
+}
+
+// newSpendMockNotifier configures the standard testify-backed notifier mock.
+// Its explicit events let tests drive chain activity and inspect registrations.
+func newSpendMockNotifier() (*chainntnfs.MockChainNotifier,
+	chan *chainntnfs.SpendDetail, chan *chainntnfs.BlockEpoch,
+	chan spendRegistration) {
+
+	spendChan := make(chan *chainntnfs.SpendDetail, 1)
+	epochChan := make(chan *chainntnfs.BlockEpoch, 1)
+	// Two slots let a timeout resolver register both commitment and
+	// second-level outputs when a test only needs to drive its events.
+	registered := make(chan spendRegistration, 2)
+	notifier := &chainntnfs.MockChainNotifier{}
+	notifier.On(
+		"RegisterSpendNtfn", testifymock.Anything,
+		testifymock.Anything, testifymock.Anything,
+	).Run(func(args testifymock.Arguments) {
+		outpoint, ok := args.Get(0).(*wire.OutPoint)
+		if !ok {
+			panic("mock spend outpoint has unexpected type")
+		}
+		pkScript, ok := args.Get(1).([]byte)
+		if !ok {
+			panic("mock spend script has unexpected type")
+		}
+		registered <- spendRegistration{
+			outpoint: *outpoint,
+			pkScript: append([]byte(nil), pkScript...),
+		}
+	}).Return(&chainntnfs.SpendEvent{
+		Spend: spendChan,
+		Cancel: func() {
+		},
+	}, nil)
+	notifier.On(
+		"RegisterBlockEpochNtfn", testifymock.Anything,
+	).Return(&chainntnfs.BlockEpochEvent{
+		Epochs: epochChan,
+		Cancel: func() {
+		},
+	}, nil)
+
+	return notifier, spendChan, epochChan, registered
+}
+
+// TestTaprootChainDetailsToWatch tests that local Taproot spend watches use
+// the authoritative commitment output even when the timeout proof is unsafe.
+func TestTaprootChainDetailsToWatch(t *testing.T) {
+	// Arrange: Build valid and malformed local timeout proofs backed by an
+	// authoritative commitment output, plus one missing-output failure.
+	// Act: Derive each watch target and start the spend wait through the
+	// testify-backed notifier so its exact registration can be observed.
+	// Assert: Every usable resolution watches the stored output; missing
+	// authoritative data fails without resolving the contract.
+	testCases := []struct {
+		name      string
+		variant   taprootHtlcVariant
+		malformed bool
+	}{
+		{"duplicate timeout", taprootHtlcDuplicateTimeout, false},
+		{"malformed proof", taprootHtlcNoAux, true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newTaprootHtlcFixture(
+				t, true, testCase.variant,
+			)
+			if testCase.malformed {
+				setTaprootTimeoutControl(fixture, []byte{1})
+			}
+
+			outpoint, script, err := fixture.resolver.
+				chainDetailsToWatch()
+			require.NoError(t, err)
+			require.Equal(t, fixture.watchedOutpoint, *outpoint)
+			require.Equal(t, fixture.commitmentScript, script)
+
+			notifier, _, _, registered := newSpendMockNotifier()
+			chainCfg := ChannelArbitratorConfig{
+				ChainArbitratorConfig: ChainArbitratorConfig{
+					Notifier: notifier,
+				},
+			}
+			resolverCfg := ResolverConfig{
+				ChannelArbitratorConfig: chainCfg,
+			}
+			fixture.resolver.contractResolverKit =
+				*newContractResolverKit(resolverCfg)
+			result := make(chan error, 1)
+			go func() {
+				_, err := fixture.resolver.watchHtlcSpend()
+				result <- err
+			}()
+
+			registration := <-registered
+			require.Equal(t, fixture.watchedOutpoint,
+				registration.outpoint)
+			require.Equal(t, fixture.commitmentScript,
+				registration.pkScript)
+			close(fixture.resolver.quit)
+			require.ErrorIs(t, <-result, errResolverShuttingDown)
+			require.False(t, fixture.resolver.IsResolved())
+		})
+	}
+
+	fixture := newTaprootHtlcFixture(t, true, taprootHtlcNoAux)
+	fixture.resolver.htlcResolution.SignDetails = nil
+	_, _, err := fixture.resolver.chainDetailsToWatch()
+	require.Error(t, err)
+}
+
+// TestHtlcOutgoingResolverTaprootRegistration tests that contest resolution
+// registers the authoritative local commitment output before waiting.
+func TestHtlcOutgoingResolverTaprootRegistration(t *testing.T) {
+	// Arrange: Create duplicate-timeout trees with valid and malformed
+	// proofs while keeping the commitment output authoritative.
+	// Act: Run resolution through the testify notifier and capture its
+	// registration before stopping the asynchronous wait.
+	// Assert: Resolution always registers the exact HTLC output, then exits
+	// unresolved with the expected shutdown result and no successor.
+	for _, malformed := range []bool{false, true} {
+		fixture := newTaprootHtlcFixture(
+			t, true, taprootHtlcDuplicateTimeout,
+		)
+		if malformed {
+			setTaprootTimeoutControl(fixture, []byte{1})
+		}
+		notifier, _, _, registered := newSpendMockNotifier()
+		chainCfg := ChannelArbitratorConfig{
+			ChainArbitratorConfig: ChainArbitratorConfig{
+				Notifier: notifier,
+			},
+		}
+		fixture.resolver.contractResolverKit = *newContractResolverKit(
+			ResolverConfig{
+				ChannelArbitratorConfig: chainCfg,
+			},
+		)
+		resolver := &htlcOutgoingContestResolver{
+			htlcTimeoutResolver: fixture.resolver,
+		}
+		result := make(chan resolveResult, 1)
+		go func() {
+			next, err := resolver.Resolve()
+			result <- resolveResult{nextResolver: next, err: err}
+		}()
+
+		registration := <-registered
+		require.Equal(t, fixture.watchedOutpoint, registration.outpoint)
+		require.Equal(
+			t, fixture.commitmentScript, registration.pkScript,
+		)
+		close(resolver.quit)
+		resolved := <-result
+		require.ErrorIs(t, resolved.err, errResolverShuttingDown)
+		require.Nil(t, resolved.nextResolver)
+		require.False(t, resolver.IsResolved())
 	}
 }

--- a/contractcourt/htlc_timeout_resolver_test.go
+++ b/contractcourt/htlc_timeout_resolver_test.go
@@ -1977,3 +1977,122 @@ func TestTaprootHtlcCommitmentScript(t *testing.T) {
 
 // setTaprootTimeoutControl replaces the stored timeout proof on either
 // commitment side of a fixture.
+func setTaprootTimeoutControl(fixture *taprootHtlcFixture, control []byte) {
+	resolution := &fixture.resolver.htlcResolution
+	if fixture.localCommit {
+		witness := resolution.SignedTimeoutTx.TxIn[0].Witness
+		witness[len(witness)-1] = control
+		return
+	}
+
+	resolution.SweepSignDesc.ControlBlock = control
+}
+
+// TestCanonicalTaprootSuccessHashes tests independent timeout hashing and the
+// optional identity obtained from a verified stored proof.
+func TestCanonicalTaprootSuccessHashes(t *testing.T) {
+	// Arrange: Cover both commitment owners and every supported auxiliary
+	// leaf topology, then corrupt the stored proof in controlled ways.
+	// Act: Ask the resolver to derive identities from each authoritative
+	// commitment, including the deliberately damaged proof variants.
+	// Assert: Valid trees expose only unambiguous identities, while absent
+	// or unauthenticated proofs never contribute a success-leaf sibling.
+	variants := []taprootHtlcVariant{
+		taprootHtlcNoAux, taprootHtlcUnrelatedAux,
+		taprootHtlcDuplicateTimeout, taprootHtlcDuplicateSuccess,
+	}
+	for _, localCommit := range []bool{true, false} {
+		for _, variant := range variants {
+			fixture := newTaprootHtlcFixture(
+				t, localCommit, variant,
+			)
+			name := fmt.Sprintf("local=%v/variant=%v",
+				localCommit, variant)
+			t.Run(name, func(t *testing.T) {
+				identities, err := fixture.resolver.
+					canonicalTaprootSuccessHashes()
+				require.NoError(t, err)
+				require.Equal(t,
+					txscript.NewBaseTapLeaf(
+						fixture.timeoutScript,
+					).TapHash(),
+					identities.timeoutLeafHash,
+				)
+				if variant == taprootHtlcDuplicateTimeout {
+					sibling := identities.storedProofSibling
+					missing := sibling.IsNone()
+					require.True(t, missing)
+
+					return
+				}
+				require.Equal(t,
+					fixture.tree.SuccessTapLeaf.TapHash(),
+					identities.storedProofSibling.
+						UnwrapOrFail(t),
+				)
+			})
+		}
+	}
+	for _, localCommit := range []bool{true, false} {
+		for _, mutation := range []string{
+			"malformed proof", "siblingless proof",
+			"different commitment",
+		} {
+			fixture := newTaprootHtlcFixture(
+				t, localCommit, taprootHtlcUnrelatedAux,
+			)
+			switch mutation {
+			case "malformed proof":
+				setTaprootTimeoutControl(fixture, []byte{1})
+			case "siblingless proof":
+				control, err := txscript.ParseControlBlock(
+					fixture.timeoutControl,
+				)
+				require.NoError(t, err)
+				control.InclusionProof = nil
+				controlBytes, err := control.ToBytes()
+				require.NoError(t, err)
+				setTaprootTimeoutControl(fixture, controlBytes)
+
+			case "different commitment":
+				other := newTaprootHtlcFixture(
+					t, localCommit, taprootHtlcNoAux,
+				)
+				resolution := &fixture.resolver.htlcResolution
+				if localCommit {
+					resolution.SignDetails.
+						SignDesc.Output.PkScript =
+						other.commitmentScript
+				} else {
+					resolution.SweepSignDesc.Output.
+						PkScript =
+						other.commitmentScript
+				}
+			}
+			t.Run(fmt.Sprintf("local=%v/%s", localCommit,
+				mutation), func(t *testing.T) {
+				identities, err := fixture.resolver.
+					canonicalTaprootSuccessHashes()
+				require.NoError(t, err)
+				require.True(t,
+					identities.storedProofSibling.IsNone())
+			})
+		}
+	}
+
+	for _, localCommit := range []bool{true, false} {
+		fixture := newTaprootHtlcFixture(
+			t, localCommit, taprootHtlcNoAux,
+		)
+		if localCommit {
+			fixture.resolver.htlcResolution.SignedTimeoutTx.
+				TxIn[0].Witness = nil
+		} else {
+			fixture.resolver.htlcResolution.SweepSignDesc.
+				WitnessScript = nil
+		}
+
+		_, err := fixture.resolver.canonicalTaprootSuccessHashes()
+		require.Error(t, err)
+	}
+}

--- a/contractcourt/htlc_timeout_resolver_test.go
+++ b/contractcourt/htlc_timeout_resolver_test.go
@@ -1749,6 +1749,9 @@ const (
 	taprootHtlcDuplicateTimeout
 	// taprootHtlcDuplicateSuccess exposes indistinguishable success leaves.
 	taprootHtlcDuplicateSuccess
+	// taprootHtlcDifferentVersionSuccess reuses the success script under a
+	// distinct leaf version so authentication cannot match by script alone.
+	taprootHtlcDifferentVersionSuccess
 )
 
 // taprootHtlcFixture binds an actual HTLC tree to its resolver-owned data.
@@ -1807,6 +1810,12 @@ func newTaprootHtlcFixture(t *testing.T, localCommit bool,
 		auxLeaf = fn.Some(baseTree.TimeoutTapLeaf)
 	case taprootHtlcDuplicateSuccess:
 		auxLeaf = fn.Some(baseTree.SuccessTapLeaf)
+
+	case taprootHtlcDifferentVersionSuccess:
+		auxLeaf = fn.Some(txscript.NewTapLeaf(
+			txscript.TapscriptLeafVersion(0xc2),
+			baseTree.SuccessTapLeaf.Script,
+		))
 	}
 	tree := buildTree(auxLeaf)
 	commitmentScript, err := input.PayToTaprootScript(tree.TaprootKey)
@@ -1866,6 +1875,7 @@ func newTaprootHtlcFixture(t *testing.T, localCommit bool,
 	return &taprootHtlcFixture{
 		resolver: &htlcTimeoutResolver{
 			htlcResolution: resolution,
+			htlc:           channeldb.HTLC{RHash: testResHash},
 		},
 		tree:              tree,
 		commitmentScript:  commitmentScript,
@@ -2094,5 +2104,131 @@ func TestCanonicalTaprootSuccessHashes(t *testing.T) {
 
 		_, err := fixture.resolver.canonicalTaprootSuccessHashes()
 		require.Error(t, err)
+	}
+}
+
+// TestTaprootPreimageSpend authenticates committed success candidates.
+//
+//nolint:ll
+func TestTaprootPreimageSpend(t *testing.T) {
+	// Arrange: Build cases spanning valid success proofs, other committed
+	// paths, malformed witnesses, mismatched preimages, and wrong inputs.
+	testCases := []struct {
+		name    string
+		local   bool
+		variant taprootHtlcVariant
+		path    string
+		annex   bool
+		want    bool
+		wantErr string
+	}{
+		{name: "local success", local: true, want: true},
+		{name: "local success with annex", local: true, annex: true, want: true},
+		{name: "remote success", want: true},
+		{name: "remote success with annex", annex: true, want: true},
+		{name: "unrelated auxiliary", local: true,
+			variant: taprootHtlcUnrelatedAux, path: "aux"},
+		{name: "different leaf version", variant: taprootHtlcDifferentVersionSuccess, path: "aux"},
+		{name: "timeout leaf", local: true, path: "timeout"},
+		{name: "local duplicate timeout", local: true,
+			variant: taprootHtlcDuplicateTimeout, want: true},
+		{name: "remote duplicate timeout",
+			variant: taprootHtlcDuplicateTimeout, want: true},
+		{name: "local duplicate success", local: true,
+			variant: taprootHtlcDuplicateSuccess, path: "duplicate", want: true},
+		{name: "remote duplicate success", variant: taprootHtlcDuplicateSuccess,
+			path: "duplicate", want: true},
+		{name: "key path", local: true, path: "key"},
+		{name: "key path with annex", local: true, path: "key", annex: true},
+		{name: "empty witness", path: "empty", wantErr: "malformed"},
+		{name: "corrupt control", local: true, path: "corrupt",
+			wantErr: "malformed"},
+		{name: "short preimage", local: true, path: "short",
+			wantErr: "malformed"},
+		{name: "wrong preimage", path: "wrong", wantErr: "mismatch"},
+		{name: "wrong outpoint", local: true, path: "outpoint",
+			wantErr: "spend"},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newTaprootHtlcFixture(t, testCase.local, testCase.variant)
+			script, control := fixture.successScript, fixture.successControl
+			switch testCase.path {
+			case "aux":
+				proof := fixture.tree.TapscriptTree.LeafMerkleProofs[2]
+				block := proof.ToControlBlock(fixture.revocationKey)
+				script = proof.Script
+				controlBytes, err := block.ToBytes()
+				require.NoError(t, err)
+				control = controlBytes
+			case "timeout":
+				script, control = fixture.timeoutScript, fixture.timeoutControl
+			case "duplicate":
+				branch := txscript.NewTapBranch(
+					fixture.tree.SuccessTapLeaf,
+					fixture.tree.TimeoutTapLeaf,
+				).TapHash()
+				proof := txscript.TapscriptProof{
+					TapLeaf:        fixture.tree.SuccessTapLeaf,
+					RootNode:       fixture.tree.TapscriptTree.RootNode,
+					InclusionProof: branch[:],
+				}
+				block := proof.ToControlBlock(fixture.revocationKey)
+				controlBytes, err := block.ToBytes()
+				require.NoError(t, err)
+				control = controlBytes
+			case "corrupt":
+				control = append([]byte(nil), control...)
+				control[len(control)-1] ^= 1
+			}
+			preimage := testResPreimage[:]
+			if testCase.path == "wrong" {
+				preimage = bytes.Repeat([]byte{9}, lntypes.HashSize)
+			}
+			witness := wire.TxWitness{
+				dummyBytes, dummyBytes, preimage, script, control,
+			}
+			if testCase.local {
+				witness = wire.TxWitness{dummyBytes, preimage, script, control}
+			}
+			switch testCase.path {
+			case "key":
+				witness = wire.TxWitness{dummyBytes}
+			case "empty":
+				witness = nil
+			case "short":
+				witness[localPreimageIndex] = preimage[:31]
+			}
+			if testCase.annex {
+				witness = append(witness, []byte{txscript.TaprootAnnexTag})
+			}
+			outpoint := fixture.watchedOutpoint
+			if testCase.path == "outpoint" {
+				outpoint.Index++
+			}
+			spend := &chainntnfs.SpendDetail{
+				SpendingTx: &wire.MsgTx{TxIn: []*wire.TxIn{{
+					PreviousOutPoint: outpoint, Witness: witness,
+				}}},
+			}
+			// Act: Classify the fully assembled spend against the resolver's
+			// authoritative outpoint, output key, leaf version, and script.
+			result, err := fixture.resolver.isTaprootPreimageSpend(spend)
+			// Assert: Each case distinguishes authenticated success claims
+			// from benign other paths and malformed or dishonest candidates.
+			switch testCase.wantErr {
+			case "mismatch":
+				require.ErrorIs(t, err, errPreimageMismatch)
+			case "spend":
+				require.ErrorIs(t, err, errInvalidSpendDetails)
+			case "malformed":
+				require.Error(t, err)
+				require.NotErrorIs(t, err, errPreimageMismatch)
+			default:
+				require.NoError(t, err)
+			}
+			require.Equal(t, testCase.want, result)
+			require.False(t, fixture.resolver.IsResolved())
+		})
 	}
 }

--- a/docs/release-notes/release-notes-0.20.4.md
+++ b/docs/release-notes/release-notes-0.20.4.md
@@ -37,7 +37,9 @@
 
 * [Fixed an issue](https://github.com/lightningnetwork/lnd/pull/10869) where an
   incoming HTLC resolver could treat a foreign commitment spend as its own
-  success transaction and offer a phantom input to the sweeper.
+  success transaction and offer a phantom input to the sweeper. A
+  [follow-up](https://github.com/lightningnetwork/lnd/pull/11113) validates
+  final success-spend notifier data and authenticates Taproot preimage paths.
 
 * Native SQL invoice migration [now correctly associates legacy AMP invoice
   HTLCs](https://github.com/lightningnetwork/lnd/pull/11106) with their AMP

--- a/docs/release-notes/release-notes-0.21.3.md
+++ b/docs/release-notes/release-notes-0.21.3.md
@@ -37,7 +37,9 @@
 
 * [Fixed an issue](https://github.com/lightningnetwork/lnd/pull/10869) where an
   incoming HTLC resolver could treat a foreign commitment spend as its own
-  success transaction and offer a phantom input to the sweeper.
+  success transaction and offer a phantom input to the sweeper. A
+  [follow-up](https://github.com/lightningnetwork/lnd/pull/11113) validates
+  final success-spend notifier data and authenticates Taproot preimage paths.
 
 * Native SQL invoice migration [now correctly associates legacy AMP invoice
   HTLCs](https://github.com/lightningnetwork/lnd/pull/11106) with their AMP


### PR DESCRIPTION
## Summary

Follow up on #10869 by closing the remaining resolver spend-validation gaps
identified while addressing #10840.

## Change Description

- Validate notifier-selected inputs against the resolver's watched outpoint
  before recording a successful claim.
- Derive the claim transaction ID from the validated spending transaction.
- Authenticate Taproot success scripts, leaf versions, and control proofs
  against the authoritative HTLC output before accepting a preimage.
- Preserve timeout handling for valid auxiliary and key-path spends.
