### PR TITLE
lnrpc+lncli: add reverse ordering to GetTransactions

### DIFF
--- a/cmd/commands/commands.go
+++ b/cmd/commands/commands.go
@@ -2287,6 +2287,12 @@ var listChainTxnsCommand = cli.Command{
 				"all transactions",
 			Value: 0,
 		},
+		cli.BoolFlag{
+			Name: "reverse",
+			Usage: "return transactions from oldest to newest " +
+				"(ascending block height) instead of the " +
+				"default newest to oldest",
+		},
 	},
 	Description: `
 	List all transactions an address of the wallet was involved in.
@@ -2337,6 +2343,7 @@ func listChainTxns(ctx *cli.Context) error {
 		MaxTransactions: uint32(ctx.Uint64("max_transactions")),
 		StartHeight:     startHeight,
 		EndHeight:       endHeight,
+		Reverse:         ctx.Bool("reverse"),
 	}
 
 	resp, err := client.GetTransactions(ctxc, req)

--- a/cmd/commands/commands.go
+++ b/cmd/commands/commands.go
@@ -2289,9 +2289,11 @@ var listChainTxnsCommand = cli.Command{
 		},
 		cli.BoolFlag{
 			Name: "reverse",
-			Usage: "return transactions from oldest to newest " +
-				"(ascending block height) instead of the " +
-				"default newest to oldest",
+			Usage: "order the returned transactions oldest to " +
+				"newest, with unconfirmed last, instead of " +
+				"the default newest to oldest; this only " +
+				"reorders the returned page, it does not " +
+				"change which transactions are returned",
 		},
 	},
 	Description: `

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -64,6 +64,12 @@
   the chain backend via bitcoind's `submitpackage`, allowing a zero-fee v3/TRUC
   parent to be accepted together with a fee-paying CPFP child.
 
+* `lnrpc.GetTransactions` now has a
+  [`reverse`](https://github.com/lightningnetwork/lnd/pull/11126) field that
+  returns transactions from oldest to newest (ascending block height) instead of
+  the default newest to oldest. This fixes a long-standing gap where the
+  response order could not be controlled.
+
 ## lncli Additions
 
 * The `estimateroutefee` command now supports [restricting fee estimates to
@@ -75,6 +81,11 @@
   [`wallet submitpackage`](https://github.com/lightningnetwork/lnd/pull/10900)
   command submits a package of hex-encoded transactions via the new
   `SubmitPackage` RPC.
+
+* The `listchaintxns` command now has a
+  [`--reverse`](https://github.com/lightningnetwork/lnd/pull/11126) flag that
+  lists transactions from oldest to newest (ascending block height) instead of
+  the default newest to oldest.
 
 # Improvements
 
@@ -167,3 +178,4 @@
 * Erick Cestari
 * Jared Tobin
 * Nishant Bansal
+* Vandit Singh

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -66,9 +66,10 @@
 
 * `lnrpc.GetTransactions` now has a
   [`reverse`](https://github.com/lightningnetwork/lnd/pull/11126) field that
-  returns transactions from oldest to newest (ascending block height) instead of
-  the default newest to oldest. This fixes a long-standing gap where the
-  response order could not be controlled.
+  orders the returned transactions oldest to newest, with unconfirmed last,
+  instead of the default newest to oldest. It reorders the returned page only
+  and does not change which transactions are returned. This fixes a
+  long-standing gap where the response order could not be controlled.
 
 ## lncli Additions
 
@@ -84,8 +85,8 @@
 
 * The `listchaintxns` command now has a
   [`--reverse`](https://github.com/lightningnetwork/lnd/pull/11126) flag that
-  lists transactions from oldest to newest (ascending block height) instead of
-  the default newest to oldest.
+  lists the returned transactions oldest to newest, with unconfirmed last,
+  instead of the default newest to oldest.
 
 # Improvements
 

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -2364,8 +2364,7 @@ func (x *Transaction) GetPreviousOutpoints() []*PreviousOutPoint {
 
 type GetTransactionsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// The height from which to list transactions, inclusive. If this value is
-	// greater than end_height, transactions will be read in reverse.
+	// The height from which to list transactions, inclusive.
 	StartHeight int32 `protobuf:"varint,1,opt,name=start_height,json=startHeight,proto3" json:"start_height,omitempty"`
 	// The height until which to list transactions, inclusive. To include
 	// unconfirmed transactions, this value should be set to -1, which will
@@ -2381,8 +2380,13 @@ type GetTransactionsRequest struct {
 	// The maximal number of transactions returned in the response to this query.
 	// This value should be set to 0 to return all transactions.
 	MaxTransactions uint32 `protobuf:"varint,5,opt,name=max_transactions,json=maxTransactions,proto3" json:"max_transactions,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// If set, transactions are returned from oldest to newest (ascending block
+	// height) instead of the default newest to oldest. The ordering of
+	// start_height and end_height does not affect the order of the returned
+	// transactions; use this field to control it.
+	Reverse       bool `protobuf:"varint,6,opt,name=reverse,proto3" json:"reverse,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetTransactionsRequest) Reset() {
@@ -2448,6 +2452,13 @@ func (x *GetTransactionsRequest) GetMaxTransactions() uint32 {
 		return x.MaxTransactions
 	}
 	return 0
+}
+
+func (x *GetTransactionsRequest) GetReverse() bool {
+	if x != nil {
+		return x.Reverse
+	}
+	return false
 }
 
 type TransactionDetails struct {
@@ -18602,14 +18613,15 @@ const file_lightning_proto_rawDesc = "" +
 	"raw_tx_hex\x18\t \x01(\tR\brawTxHex\x12\x14\n" +
 	"\x05label\x18\n" +
 	" \x01(\tR\x05label\x12F\n" +
-	"\x12previous_outpoints\x18\f \x03(\v2\x17.lnrpc.PreviousOutPointR\x11previousOutpoints\"\xc2\x01\n" +
+	"\x12previous_outpoints\x18\f \x03(\v2\x17.lnrpc.PreviousOutPointR\x11previousOutpoints\"\xdc\x01\n" +
 	"\x16GetTransactionsRequest\x12!\n" +
 	"\fstart_height\x18\x01 \x01(\x05R\vstartHeight\x12\x1d\n" +
 	"\n" +
 	"end_height\x18\x02 \x01(\x05R\tendHeight\x12\x18\n" +
 	"\aaccount\x18\x03 \x01(\tR\aaccount\x12!\n" +
 	"\findex_offset\x18\x04 \x01(\rR\vindexOffset\x12)\n" +
-	"\x10max_transactions\x18\x05 \x01(\rR\x0fmaxTransactions\"\x8c\x01\n" +
+	"\x10max_transactions\x18\x05 \x01(\rR\x0fmaxTransactions\x12\x18\n" +
+	"\areverse\x18\x06 \x01(\bR\areverse\"\x8c\x01\n" +
 	"\x12TransactionDetails\x126\n" +
 	"\ftransactions\x18\x01 \x03(\v2\x12.lnrpc.TransactionR\ftransactions\x12\x1d\n" +
 	"\n" +

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -2380,10 +2380,16 @@ type GetTransactionsRequest struct {
 	// The maximal number of transactions returned in the response to this query.
 	// This value should be set to 0 to return all transactions.
 	MaxTransactions uint32 `protobuf:"varint,5,opt,name=max_transactions,json=maxTransactions,proto3" json:"max_transactions,omitempty"`
-	// If set, transactions are returned from oldest to newest (ascending block
-	// height) instead of the default newest to oldest. The ordering of
-	// start_height and end_height does not affect the order of the returned
-	// transactions; use this field to control it.
+	// If set, the returned transactions are ordered oldest to newest, with
+	// unconfirmed transactions last, instead of the default newest to oldest
+	// (unconfirmed first). This only reorders the returned page; it does not
+	// change which transactions are returned. index_offset and max_transactions
+	// still select the same page, and the order of start_height and end_height
+	// does not affect it.
+	//
+	// Note this is not the same as the reversed field on ListPayments and
+	// ListInvoices, which paginates backwards from index_offset and leaves the
+	// returned order unchanged; reverse controls output order only.
 	Reverse       bool `protobuf:"varint,6,opt,name=reverse,proto3" json:"reverse,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -794,8 +794,7 @@ message Transaction {
 
 message GetTransactionsRequest {
     /*
-    The height from which to list transactions, inclusive. If this value is
-    greater than end_height, transactions will be read in reverse.
+    The height from which to list transactions, inclusive.
     */
     int32 start_height = 1;
 
@@ -822,6 +821,14 @@ message GetTransactionsRequest {
     This value should be set to 0 to return all transactions.
     */
     uint32 max_transactions = 5;
+
+    /*
+    If set, transactions are returned from oldest to newest (ascending block
+    height) instead of the default newest to oldest. The ordering of
+    start_height and end_height does not affect the order of the returned
+    transactions; use this field to control it.
+    */
+    bool reverse = 6;
 }
 
 message TransactionDetails {

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -823,10 +823,16 @@ message GetTransactionsRequest {
     uint32 max_transactions = 5;
 
     /*
-    If set, transactions are returned from oldest to newest (ascending block
-    height) instead of the default newest to oldest. The ordering of
-    start_height and end_height does not affect the order of the returned
-    transactions; use this field to control it.
+    If set, the returned transactions are ordered oldest to newest, with
+    unconfirmed transactions last, instead of the default newest to oldest
+    (unconfirmed first). This only reorders the returned page; it does not
+    change which transactions are returned. index_offset and max_transactions
+    still select the same page, and the order of start_height and end_height
+    does not affect it.
+
+    Note this is not the same as the reversed field on ListPayments and
+    ListInvoices, which paginates backwards from index_offset and leaves the
+    returned order unchanged; reverse controls output order only.
     */
     bool reverse = 6;
 }

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -2665,7 +2665,7 @@
         "parameters": [
           {
             "name": "start_height",
-            "description": "The height from which to list transactions, inclusive. If this value is\ngreater than end_height, transactions will be read in reverse.",
+            "description": "The height from which to list transactions, inclusive.",
             "in": "query",
             "required": false,
             "type": "integer",
@@ -2701,6 +2701,13 @@
             "required": false,
             "type": "integer",
             "format": "int64"
+          },
+          {
+            "name": "reverse",
+            "description": "If set, transactions are returned from oldest to newest (ascending block\nheight) instead of the default newest to oldest. The ordering of\nstart_height and end_height does not affect the order of the returned\ntransactions; use this field to control it.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "tags": [
@@ -2871,7 +2878,7 @@
         "parameters": [
           {
             "name": "start_height",
-            "description": "The height from which to list transactions, inclusive. If this value is\ngreater than end_height, transactions will be read in reverse.",
+            "description": "The height from which to list transactions, inclusive.",
             "in": "query",
             "required": false,
             "type": "integer",
@@ -2907,6 +2914,13 @@
             "required": false,
             "type": "integer",
             "format": "int64"
+          },
+          {
+            "name": "reverse",
+            "description": "If set, transactions are returned from oldest to newest (ascending block\nheight) instead of the default newest to oldest. The ordering of\nstart_height and end_height does not affect the order of the returned\ntransactions; use this field to control it.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "tags": [

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -2704,7 +2704,7 @@
           },
           {
             "name": "reverse",
-            "description": "If set, transactions are returned from oldest to newest (ascending block\nheight) instead of the default newest to oldest. The ordering of\nstart_height and end_height does not affect the order of the returned\ntransactions; use this field to control it.",
+            "description": "If set, the returned transactions are ordered oldest to newest, with\nunconfirmed transactions last, instead of the default newest to oldest\n(unconfirmed first). This only reorders the returned page; it does not\nchange which transactions are returned. index_offset and max_transactions\nstill select the same page, and the order of start_height and end_height\ndoes not affect it.\n\nNote this is not the same as the reversed field on ListPayments and\nListInvoices, which paginates backwards from index_offset and leaves the\nreturned order unchanged; reverse controls output order only.",
             "in": "query",
             "required": false,
             "type": "boolean"
@@ -2917,7 +2917,7 @@
           },
           {
             "name": "reverse",
-            "description": "If set, transactions are returned from oldest to newest (ascending block\nheight) instead of the default newest to oldest. The ordering of\nstart_height and end_height does not affect the order of the returned\ntransactions; use this field to control it.",
+            "description": "If set, the returned transactions are ordered oldest to newest, with\nunconfirmed transactions last, instead of the default newest to oldest\n(unconfirmed first). This only reorders the returned page; it does not\nchange which transactions are returned. index_offset and max_transactions\nstill select the same page, and the order of start_height and end_height\ndoes not affect it.\n\nNote this is not the same as the reversed field on ListPayments and\nListInvoices, which paginates backwards from index_offset and leaves the\nreturned order unchanged; reverse controls output order only.",
             "in": "query",
             "required": false,
             "type": "boolean"

--- a/lnrpc/rpc_utils.go
+++ b/lnrpc/rpc_utils.go
@@ -118,7 +118,7 @@ func RPCTransaction(tx *lnwallet.TransactionDetail) *Transaction {
 
 // RPCTransactionDetails returns a set of rpc transaction details.
 func RPCTransactionDetails(txns []*lnwallet.TransactionDetail, firstIdx,
-	lastIdx uint64) *TransactionDetails {
+	lastIdx uint64, reverse bool) *TransactionDetails {
 
 	txDetails := &TransactionDetails{
 		Transactions: make([]*Transaction, len(txns)),
@@ -135,7 +135,16 @@ func RPCTransactionDetails(txns []*lnwallet.TransactionDetail, firstIdx,
 	// follow the most recently set of confirmed transactions. If we sort
 	// by height, unconfirmed transactions will follow our oldest
 	// transactions, because they have lower block heights.
+	//
+	// When reverse is set, we flip the comparison so that transactions are
+	// returned from oldest to newest (ascending block height), with
+	// unconfirmed transactions last.
 	sort.Slice(txDetails.Transactions, func(i, j int) bool {
+		if reverse {
+			return txDetails.Transactions[i].NumConfirmations >
+				txDetails.Transactions[j].NumConfirmations
+		}
+
 		return txDetails.Transactions[i].NumConfirmations <
 			txDetails.Transactions[j].NumConfirmations
 	})

--- a/lnrpc/rpc_utils.go
+++ b/lnrpc/rpc_utils.go
@@ -131,15 +131,16 @@ func RPCTransactionDetails(txns []*lnwallet.TransactionDetail, firstIdx,
 	}
 
 	// Sort transactions by number of confirmations rather than height so
-	// that unconfirmed transactions (height =0; confirmations =-1) will
+	// that unconfirmed transactions (height 0, confirmations 0) will
 	// follow the most recently set of confirmed transactions. If we sort
 	// by height, unconfirmed transactions will follow our oldest
 	// transactions, because they have lower block heights.
 	//
 	// When reverse is set, we flip the comparison so that transactions are
-	// returned from oldest to newest (ascending block height), with
-	// unconfirmed transactions last.
-	sort.Slice(txDetails.Transactions, func(i, j int) bool {
+	// returned from oldest to newest, with unconfirmed transactions last.
+	// The sort is stable so transactions sharing a block keep their
+	// relative order and reverse is an exact mirror of the default.
+	sort.SliceStable(txDetails.Transactions, func(i, j int) bool {
 		if reverse {
 			return txDetails.Transactions[i].NumConfirmations >
 				txDetails.Transactions[j].NumConfirmations

--- a/lnrpc/rpc_utils_test.go
+++ b/lnrpc/rpc_utils_test.go
@@ -1,0 +1,44 @@
+package lnrpc
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRPCTransactionDetailsReverse checks that RPCTransactionDetails orders the
+// returned transactions newest to oldest by default, and oldest to newest when
+// reverse is set. Ordering is keyed off the number of confirmations so that
+// unconfirmed transactions stay adjacent to the most recent confirmed ones.
+func TestRPCTransactionDetailsReverse(t *testing.T) {
+	t.Parallel()
+
+	// Construct transactions across three block heights plus one
+	// unconfirmed transaction. A more recent transaction has fewer
+	// confirmations, and an unconfirmed transaction has zero.
+	txns := []*lnwallet.TransactionDetail{
+		{BlockHeight: 401, NumConfirmations: 3},
+		{BlockHeight: 402, NumConfirmations: 2},
+		{BlockHeight: 403, NumConfirmations: 1},
+		{BlockHeight: 0, NumConfirmations: 0},
+	}
+
+	// Default ordering is newest to oldest: the unconfirmed transaction
+	// first, then descending block height.
+	forward := RPCTransactionDetails(txns, 0, 0, false)
+	forwardHeights := make([]int32, len(forward.Transactions))
+	for i, tx := range forward.Transactions {
+		forwardHeights[i] = tx.BlockHeight
+	}
+	require.Equal(t, []int32{0, 403, 402, 401}, forwardHeights)
+
+	// With reverse set the ordering flips to oldest to newest, ascending
+	// block height, with the unconfirmed transaction last.
+	reverse := RPCTransactionDetails(txns, 0, 0, true)
+	reverseHeights := make([]int32, len(reverse.Transactions))
+	for i, tx := range reverse.Transactions {
+		reverseHeights[i] = tx.BlockHeight
+	}
+	require.Equal(t, []int32{401, 402, 403, 0}, reverseHeights)
+}

--- a/lnrpc/rpc_utils_test.go
+++ b/lnrpc/rpc_utils_test.go
@@ -42,3 +42,34 @@ func TestRPCTransactionDetailsReverse(t *testing.T) {
 	}
 	require.Equal(t, []int32{401, 402, 403, 0}, reverseHeights)
 }
+
+// TestRPCTransactionDetailsStableTie checks that transactions sharing a block
+// (equal confirmation counts) keep their input order in both directions, so
+// reverse is an exact mirror of the default ordering rather than an arbitrary
+// re-shuffle of the tied transactions.
+func TestRPCTransactionDetailsStableTie(t *testing.T) {
+	t.Parallel()
+
+	// Two transactions in the same block have equal confirmations. They
+	// are labelled so we can tell them apart in the output.
+	txns := []*lnwallet.TransactionDetail{
+		{BlockHeight: 500, NumConfirmations: 1, Label: "a"},
+		{BlockHeight: 500, NumConfirmations: 1, Label: "b"},
+	}
+
+	labels := func(d *TransactionDetails) []string {
+		got := make([]string, len(d.Transactions))
+		for i, tx := range d.Transactions {
+			got[i] = tx.Label
+		}
+		return got
+	}
+
+	// A stable sort keeps the tied transactions in their input order for
+	// both directions.
+	forward := RPCTransactionDetails(txns, 0, 0, false)
+	require.Equal(t, []string{"a", "b"}, labels(forward))
+
+	reverse := RPCTransactionDetails(txns, 0, 0, true)
+	require.Equal(t, []string{"a", "b"}, labels(reverse))
+}

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -1565,7 +1565,7 @@ func (w *WalletKit) ListSweeps(ctx context.Context,
 		return &ListSweepsResponse{
 			Sweeps: &ListSweepsResponse_TransactionDetails{
 				TransactionDetails: lnrpc.RPCTransactionDetails(
-					txDetails, firstIdx, lastIdx,
+					txDetails, firstIdx, lastIdx, false,
 				),
 			},
 		}, nil

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -416,12 +416,11 @@ type WalletController interface {
 		accountFilter string) ([]*Utxo, error)
 
 	// ListTransactionDetails returns a list of all transactions which are
-	// relevant to the wallet over [startHeight;endHeight]. If start height
-	// is greater than end height, the transactions will be retrieved in
-	// reverse order. To include unconfirmed transactions, endHeight should
-	// be set to the special value -1. This will return transactions from
-	// the tip of the chain until the start height (inclusive) and
-	// unconfirmed transactions. The account parameter serves as a filter to
+	// relevant to the wallet over [startHeight;endHeight]. To include
+	// unconfirmed transactions, endHeight should be set to the special
+	// value -1. This will return transactions from the tip of the chain
+	// until the start height (inclusive) and unconfirmed transactions. The
+	// account parameter serves as a filter to
 	// retrieve the transactions relevant to a specific account. When
 	// empty, transactions of all wallet accounts are returned.
 	ListTransactionDetails(startHeight, endHeight int32,

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -6199,7 +6199,9 @@ func (r *rpcServer) GetTransactions(ctx context.Context,
 		return nil, err
 	}
 
-	return lnrpc.RPCTransactionDetails(txns, firstIdx, lastIdx), nil
+	return lnrpc.RPCTransactionDetails(
+		txns, firstIdx, lastIdx, req.Reverse,
+	), nil
 }
 
 // DescribeGraph returns a description of the latest graph state from the PoV


### PR DESCRIPTION
Adds a `reverse` field to `GetTransactionsRequest` and a `--reverse` flag to `lncli listchaintxns`, so transactions can be listed oldest first. Fixes #7316.

**Root cause**

The wallet does not set the response order. `RPCTransactionDetails` (lnrpc/rpc_utils.go) re-sorts by confirmation count, so results are always newest first regardless of how `start_height`/`end_height` are ordered. #9558 also rejects `start_height > end_height` at the CLI, so the old swap-the-heights trick is gone. Reversing the slice in the wallet layer does nothing, because this sort runs after it, so the flag goes into the sort.

**Behaviour**

- `reverse` unset: unchanged, newest first.
- `reverse` set: oldest to newest, unconfirmed last.
- Field defaults to false, so existing clients are unaffected.

**Pagination**

`index_offset`/`max_transactions` are applied in the wallet layer before this sort, so `--reverse` sets display order, not which page you get. That split predates this change and is out of scope.

**Testing**

- `TestRPCTransactionDetailsReverse` covers both orderings and unconfirmed placement.
- On a simnet node: default returns `403,402,401`, `--reverse` returns `401,402,403`.
