### PR TITLE
[v0.20.x-branch] Backport #10249: enforce strict TLV length checks

### DIFF
--- a/docs/release-notes/release-notes-0.20.4.md
+++ b/docs/release-notes/release-notes-0.20.4.md
@@ -21,6 +21,12 @@
 
 # Bug Fixes
 
+* TLV decoders [now reject malformed records with incorrect
+  lengths](https://github.com/lightningnetwork/lnd/pull/10249). Fixed-size
+  records such as the inbound fee, Musig2 nonce and short channel ID are
+  validated against their declared length, so a record whose length does not
+  match is no longer silently accepted and re-encoded differently.
+
 * Channel funding attempts [now return
   cleanly](https://github.com/lightningnetwork/lnd/pull/11035) when their
   pending wallet reservation is no longer present.
@@ -89,6 +95,7 @@
 
 # Contributors (Alphabetical Order)
 
+* Erick Cestari
 * LNBiG
 * Yong Yu
 * Ziggie

--- a/lnwire/musig2.go
+++ b/lnwire/musig2.go
@@ -51,7 +51,7 @@ func nonceTypeEncoder(w io.Writer, val interface{}, _ *[8]byte) error {
 func nonceTypeDecoder(r io.Reader, val interface{}, _ *[8]byte,
 	l uint64) error {
 
-	if v, ok := val.(*Musig2Nonce); ok {
+	if v, ok := val.(*Musig2Nonce); ok && l == musig2.PubNonceSize {
 		_, err := io.ReadFull(r, v[:])
 		return err
 	}

--- a/lnwire/musig2_test.go
+++ b/lnwire/musig2_test.go
@@ -1,0 +1,62 @@
+package lnwire
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/stretchr/testify/require"
+)
+
+// makeNonce creates a test Musig2Nonce with sequential byte values for testing
+// TLV encoding/decoding.
+func makeNonce() Musig2Nonce {
+	var n Musig2Nonce
+	for i := range n {
+		n[i] = byte(i)
+	}
+
+	return n
+}
+
+// TestMusig2NonceEncodeDecode tests that we're able to properly encode and
+// decode Musig2Nonce within TLV streams.
+func TestMusig2NonceEncodeDecode(t *testing.T) {
+	t.Parallel()
+
+	nonce := makeNonce()
+
+	var extraData ExtraOpaqueData
+	require.NoError(t, extraData.PackRecords(&nonce))
+
+	var extractedNonce Musig2Nonce
+	_, err := extraData.ExtractRecords(&extractedNonce)
+	require.NoError(t, err)
+
+	require.Equal(t, nonce, extractedNonce)
+}
+
+// TestMusig2NonceTypeDecodeInvalidLength ensures that decoding a Musig2Nonce
+// TLV with an invalid length (anything other than 66 bytes) fails with an
+// error.
+func TestMusig2NonceTypeDecodeInvalidLength(t *testing.T) {
+	t.Parallel()
+
+	nonce := makeNonce()
+
+	var extraData ExtraOpaqueData
+	require.NoError(t, extraData.PackRecords(&nonce))
+
+	// Corrupt the TLV length field to simulate malformed input.
+	// Byte 1 contains the varint size encoding. Since 66 bytes fits into
+	// a single varint byte, we can directly modify extraData[1].
+	extraData[1] = musig2.PubNonceSize + 1
+
+	var out Musig2Nonce
+	_, err := extraData.ExtractRecords(&out)
+	require.Error(t, err)
+
+	extraData[1] = musig2.PubNonceSize - 1
+
+	_, err = extraData.ExtractRecords(&out)
+	require.Error(t, err)
+}

--- a/lnwire/short_channel_id.go
+++ b/lnwire/short_channel_id.go
@@ -92,7 +92,8 @@ func DShortChannelID(r io.Reader, val interface{}, buf *[8]byte,
 
 	if v, ok := val.(*ShortChannelID); ok {
 		var scid uint64
-		err := tlv.DUint64(r, &scid, buf, 8)
+		// tlv.DUint64 forces the length to be 8 bytes.
+		err := tlv.DUint64(r, &scid, buf, l)
 		if err != nil {
 			return err
 		}

--- a/lnwire/short_channel_id_test.go
+++ b/lnwire/short_channel_id_test.go
@@ -62,3 +62,28 @@ func TestScidTypeEncodeDecode(t *testing.T) {
 	require.Contains(t, tlvs, AliasScidRecordType)
 	require.Equal(t, aliasScid, aliasScid2)
 }
+
+// TestScidTypeDecodeInvalidLength ensures that decoding a ShortChannelID TLV
+// with an invalid length (anything other than 8 bytes) fails with an error.
+func TestScidTypeDecodeInvalidLength(t *testing.T) {
+	t.Parallel()
+
+	aliasScid := ShortChannelID{
+		BlockHeight: 1, TxIndex: 1, TxPosition: 1,
+	}
+
+	var extraData ExtraOpaqueData
+	require.NoError(t, extraData.PackRecords(&aliasScid))
+
+	// Corrupt the TLV length field to simulate malformed input.
+	extraData[1] = 8 + 1
+
+	var out ShortChannelID
+	_, err := extraData.ExtractRecords(&out)
+	require.Error(t, err)
+
+	extraData[1] = 8 - 1
+
+	_, err = extraData.ExtractRecords(&out)
+	require.Error(t, err)
+}

--- a/lnwire/typed_fee.go
+++ b/lnwire/typed_fee.go
@@ -41,7 +41,7 @@ func feeEncoder(w io.Writer, val interface{}, buf *[8]byte) error {
 // feeDecoder is a custom TLV decoder for the fee record.
 func feeDecoder(r io.Reader, val interface{}, buf *[8]byte, l uint64) error {
 	v, ok := val.(*Fee)
-	if !ok {
+	if !ok || l != 8 {
 		return tlv.NewTypeForDecodingErr(val, "lnwire.Fee", l, 8)
 	}
 

--- a/lnwire/typed_fee_test.go
+++ b/lnwire/typed_fee_test.go
@@ -38,3 +38,28 @@ func testTypedFee(t *testing.T, fee Fee) { //nolint: thelper
 
 	require.Equal(t, fee, extractedFee)
 }
+
+// TestTypedFeeTypeDecodeInvalidLength ensures that decoding a Fee TLV
+// with an invalid length (anything other than 8 bytes) fails with an error.
+func TestTypedFeeTypeDecodeInvalidLength(t *testing.T) {
+	t.Parallel()
+
+	fee := Fee{
+		BaseFee: 1, FeeRate: 1,
+	}
+
+	var extraData ExtraOpaqueData
+	require.NoError(t, extraData.PackRecords(&fee))
+
+	// Corrupt the TLV length field to simulate malformed input.
+	extraData[3] = 8 + 1
+
+	var out Fee
+	_, err := extraData.ExtractRecords(&out)
+	require.Error(t, err)
+
+	extraData[3] = 8 - 1
+
+	_, err = extraData.ExtractRecords(&out)
+	require.Error(t, err)
+}

--- a/routing/route/route.go
+++ b/routing/route/route.go
@@ -112,7 +112,7 @@ func encodeVertex(w io.Writer, val interface{}, _ *[8]byte) error {
 }
 
 func decodeVertex(r io.Reader, val interface{}, _ *[8]byte, l uint64) error {
-	if b, ok := val.(*Vertex); ok {
+	if b, ok := val.(*Vertex); ok && l == VertexSize {
 		_, err := io.ReadFull(r, b[:])
 		return err
 	}

--- a/tlv/primitive.go
+++ b/tlv/primitive.go
@@ -257,7 +257,7 @@ func EBytes33(w io.Writer, val interface{}, _ *[8]byte) error {
 // DBytes33 is a Decoder for 33-byte arrays. An error is returned if val is not
 // a *[33]byte.
 func DBytes33(r io.Reader, val interface{}, _ *[8]byte, l uint64) error {
-	if b, ok := val.(*[33]byte); ok {
+	if b, ok := val.(*[33]byte); ok && l == 33 {
 		_, err := io.ReadFull(r, b[:])
 		return err
 	}


### PR DESCRIPTION
Backport of #10249 (`multi: enforce strict TLV length checks`) to
`v0.20.x-branch`.

### Why

`v0.20.x` is missing the strict length validation in the fixed-size TLV
decoders. The `tlv` stream delegates that check to each decoder:

```go
// We know of this record type, proceed to decode the value.
// This method asserts that length bytes are read in the
// process, and returns an error if the number of bytes is not
// exactly length.
case ok:
        err := rec.decoder(r, rec.value, &s.buf, length)
```

`feeDecoder` ignores the `l` argument, so an inbound-fee record that declares a
length larger than the bytes actually present is silently accepted. It only
consumes 8 bytes, the stream then hits a clean EOF, and decoding succeeds with
`ExtraOpaqueData` retaining the bogus length. Re-encoding rebuilds the record
canonically, so the message does not round-trip.

This is latent on `v0.20.x` today: the old `ChannelUpdate1.Encode` wrote the
merged extra data back into the message, so the round-trip fuzz assertion
compared the encoder's output against itself and never observed the mismatch.

It stops being latent under #11130, which backports #11090. That PR makes the
extra-data canonicalization non-mutating, which removes the rewrite that was
hiding the discrepancy, and five fuzz seeds start failing `unit-race` and
`unit-cover`:

```
--- FAIL: FuzzFailAmountBelowMinimum/4662b612b4d7be63
--- FAIL: FuzzFailAmountBelowMinimum/9fd80ba0c3e2ab94
--- FAIL: FuzzFailIncorrectCltvExpiry/de22154e6461560a
--- FAIL: FuzzFailExpiryTooSoon/30069949c12a8569
--- FAIL: FuzzFailExpiryTooSoon/3325a74843c4d3d6
```

With this fix the malformed record is rejected at decode, so the harness skips
those inputs, which is exactly how `master` behaves.

### Notes

* The upstream release-notes commit targets `release-notes-0.21.0.md` and
  conflicts here, so it is replaced with an equivalent entry in
  `release-notes-0.20.4.md`.
* `tlv/primitive.go` is included for fidelity with upstream, but `tlv` is a
  separate module and `go.mod` pins `lnd/tlv v1.3.2` with no `replace`, so that
  hunk has no effect on the build until `tlv` is released and bumped. The
  effective changes here are in `lnwire/` and `routing/route/`.

### Testing

Verified with the `lightninglabs/lnd-fuzz` corpus rsync'd in, both standalone
and with the #11130 stack rebased on top: builds clean, and `-race` passes for
`lnwire`, `netann`, `peer`, `routing/route`, plus the `queue` and `tlv`
submodules.
