### PR TITLE
docs: move coop close limbo fix to v0.21.3 notes

### DIFF
--- a/docs/release-notes/release-notes-0.21.3.md
+++ b/docs/release-notes/release-notes-0.21.3.md
@@ -21,6 +21,14 @@
 
 # Bug Fixes
 
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/10782)
+  that could be encountered during co-op closes whereby
+  `ChanStatusCoopBroadcasted` was set before a close transaction
+  actually existed. As a side effect, channels in shutdown
+  negotiation now remain in `ListChannels` (as inactive) until
+  the close transaction is actually broadcast, and
+  `WaitingCloseChannel.ClosingTx` is never empty.
+
 * Peer connections [now rate limit inbound ping replies and bound outgoing
   message queue growth](https://github.com/lightningnetwork/lnd/pull/11090),
   preventing peer-controlled resource exhaustion.
@@ -128,6 +136,7 @@
 # Contributors (Alphabetical Order)
 
 * Elle Mouton
+* Jared Tobin
 * LNBiG
 * Yong Yu
 * Ziggie

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -27,14 +27,6 @@
   [clarifies](https://github.com/lightningnetwork/lnd/issues/10568) the ZMQ
   port-mismatch warnings so they no longer suggest that the connection failed.
 
-* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/10782)
-  that could be encountered during co-op closes whereby
-  `ChanStatusCoopBroadcasted` was set before a close transaction
-  actually existed. As a side effect, channels in shutdown
-  negotiation now remain in `ListChannels` (as inactive) until
-  the close transaction is actually broadcast, and
-  `WaitingCloseChannel.ClosingTx` is never empty.
-
 * [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/10890)
   where `ListChannels` reported 100% `uptime` for channels whose peer
   was offline. The channel fitness store assumed a peer was online when


### PR DESCRIPTION
## Change

Move the release note for #10782 from the v0.22.0 notes to the v0.21.3 notes,
keeping its wording and original PR link unchanged.

## Rationale

The fix is being backported to v0.21.x in #11135, so it should be documented
in the v0.21.3 release notes rather than first appearing under v0.22.0.

## Verification

- `git diff --check`
- Confirmed the #10782 release-note link appears exactly once, under v0.21.3
