### PR TITLE
contractcourt: fix stuck dust HTLC after confirmation

### DIFF
--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1310,16 +1310,30 @@ func (c *ChannelArbitrator) stateStep(
 
 			// We fail the upstream HTLCs for all remote pending
 			// outgoing HTLCs as soon as the commitment is
-			// confirmed. The upstream HTLCs for outgoing dust
-			// HTLCs have already been resolved before we reach
-			// this point.
+			// confirmed.
+			//
+			// We also fail the upstream HTLCs for all outgoing
+			// dust HTLCs here. Most of them have already been
+			// resolved before we reached this point, but an HTLC
+			// which is only dust on the commitment that ended up
+			// confirming could not be classified as dust before,
+			// so this is the first point at which we know that it
+			// has no output to resolve on chain. Sending a
+			// duplicate resolution message is safe, as the switch
+			// processes them idempotently.
 			getIdx := func(htlc channeldb.HTLC) uint64 {
 				return htlc.HtlcIndex
 			}
 			remoteDangling := fn.NewSet(fn.Map(
 				htlcActions[HtlcFailDanglingAction], getIdx,
 			)...)
-			err := c.abandonForwards(remoteDangling)
+			confirmedDust := fn.NewSet(fn.Map(
+				htlcActions[HtlcFailDustAction], getIdx,
+			)...)
+
+			err := c.abandonForwards(
+				remoteDangling.Union(confirmedDust),
+			)
 			if err != nil {
 				return StateError, closeTx, err
 			}
@@ -1738,8 +1752,10 @@ const (
 	// HtlcFailDanglingAction indicates that we should fail the upstream
 	// HTLC for an outgoing HTLC immediately after the commitment
 	// transaction has confirmed because it has no corresponding output on
-	// the commitment transaction. This category does NOT include any dust
-	// HTLCs which are mapped in the "HtlcFailDustAction" category.
+	// the commitment transaction. This category also includes HTLCs which
+	// are dust on our local commitment but have an output on a live
+	// remote commitment, and therefore cannot be failed safely before a
+	// commitment confirms.
 	HtlcFailDanglingAction = 7
 )
 
@@ -2073,17 +2089,76 @@ func (c *ChannelArbitrator) checkLocalChainActions(
 		return nil, err
 	}
 
+	// Collect the indexes of all outgoing HTLCs which have an output on
+	// any of the remote commitments. Both dust classifiers below must use
+	// the same view of the remote commitments.
+	liveOnRemote := fn.NewSet[uint64]()
+	for htlcSetKey, htlcs := range activeHTLCs {
+		if !htlcSetKey.IsRemote {
+			continue
+		}
+
+		for _, htlc := range htlcs.outgoingHTLCs {
+			if htlc.OutputIndex >= 0 {
+				liveOnRemote.Add(htlc.HtlcIndex)
+			}
+		}
+	}
+
 	// Next, we'll examine the remote commitment (and maybe a dangling one)
 	// to see if the set difference of our HTLCs is non-empty. If so, then
 	// we may need to cancel back some HTLCs if we decide go to chain.
 	remoteDanglingActions := c.checkRemoteDanglingActions(
-		height, activeHTLCs, commitsConfirmed,
+		height, activeHTLCs, liveOnRemote, commitsConfirmed,
 	)
 
 	// Finally, we'll merge the two set of chain actions.
 	localCommitActions.Merge(remoteDanglingActions)
 
+	// The condition is a defensive guard, it keeps the commitment which
+	// confirmed authoritative for the HTLCs on it.
+	if !commitsConfirmed {
+		c.deferDustHTLCsLiveOnRemote(localCommitActions, liveOnRemote)
+	}
+
 	return localCommitActions, nil
+}
+
+// deferDustHTLCsLiveOnRemote moves all outgoing HTLCs which are dust on our
+// local commitment, but still have an output on one of the remote commitments,
+// from the dust to the dangling chain action.
+//
+// NOTE: This must only be called as long as no commitment confirmed. Once one
+// did, its dust classification is the only one that matters.
+func (c *ChannelArbitrator) deferDustHTLCsLiveOnRemote(actions ChainActionMap,
+	liveOnRemote fn.Set[uint64]) {
+
+	var dustHTLCs []channeldb.HTLC
+	for _, htlc := range actions[HtlcFailDustAction] {
+		if !liveOnRemote.Contains(htlc.HtlcIndex) {
+			dustHTLCs = append(dustHTLCs, htlc)
+
+			continue
+		}
+
+		log.Infof("ChannelArbitrator(%v): defer dust htlc=%x, it has "+
+			"an output on a remote commitment", c.cfg.ChanPoint,
+			htlc.RHash[:])
+
+		actions[HtlcFailDanglingAction] = append(
+			actions[HtlcFailDanglingAction], htlc,
+		)
+	}
+
+	// Only keep the action around if there are dust HTLCs left, as an
+	// empty action would make us believe that we have to act on it.
+	if dustHTLCs == nil {
+		delete(actions, HtlcFailDustAction)
+
+		return
+	}
+
+	actions[HtlcFailDustAction] = dustHTLCs
 }
 
 // checkRemoteDanglingActions examines the set of remote commitments for any
@@ -2092,7 +2167,7 @@ func (c *ChannelArbitrator) checkLocalChainActions(
 // cancel immediately.
 func (c *ChannelArbitrator) checkRemoteDanglingActions(
 	height uint32, activeHTLCs map[HtlcSetKey]htlcSet,
-	commitsConfirmed bool) ChainActionMap {
+	liveOnRemote fn.Set[uint64], commitsConfirmed bool) ChainActionMap {
 
 	var (
 		pendingRemoteHTLCs []channeldb.HTLC
@@ -2164,7 +2239,7 @@ func (c *ChannelArbitrator) checkRemoteDanglingActions(
 		// gain or lose those dust amounts but there is no other way
 		// than cancelling the incoming back because we will never learn
 		// the preimage.
-		if htlc.OutputIndex < 0 {
+		if !liveOnRemote.Contains(htlc.HtlcIndex) {
 			log.Infof("ChannelArbitrator(%v): fail dangling dust "+
 				"htlc=%x from local/remote commitments diff",
 				c.cfg.ChanPoint, htlc.RHash[:])

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -1038,6 +1038,23 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 		StateWaitingFullResolution,
 	)
 
+	// Now that the commitment confirmed we cancel the upstream HTLCs of
+	// all outgoing dust HTLCs on it back once more. The outgoing dust HTLC
+	// was already failed before the confirmation, so this is a duplicate,
+	// which the switch processes idempotently. We have to fail dust HTLCs
+	// here as well because an HTLC which is only dust on the commitment
+	// that ends up confirming cannot be detected any earlier.
+	select {
+	case msgs := <-chanArbCtx.resolutions:
+		require.Len(t, msgs, 1)
+		require.EqualValues(
+			t, outgoingDustHtlc.HtlcIndex, msgs[0].HtlcIndex,
+		)
+
+	case <-time.After(defaultTimeout):
+		t.Fatalf("resolution msgs not sent")
+	}
+
 	// We'll grab the old notifier here as our resolvers are still holding
 	// a reference to this instance, and a new one will be created when we
 	// restart the channel arb below.
@@ -2073,6 +2090,458 @@ func TestChannelArbitratorDanglingCommitForceClose(t *testing.T) {
 			chanArbCtx.receiveBlockbeat(6)
 		})
 	}
+}
+
+// TestChannelArbitratorDustOnConfirmedCommit tests that the upstream HTLC of
+// an outgoing HTLC which is only dust on the commitment that ends up
+// confirming is still canceled back. Here the HTLC has an output on our local
+// commitment, but is trimmed on the remote one, so it cannot be classified as
+// dust before the remote commitment confirms.
+func TestChannelArbitratorDustOnConfirmedCommit(t *testing.T) {
+	t.Parallel()
+
+	arbLog := &mockArbitratorLog{
+		state:     StateDefault,
+		newStates: make(chan ArbitratorState, 5),
+		resolvers: make(map[ContractResolver]struct{}),
+	}
+
+	chanArbCtx, err := createTestChannelArbitrator(t, arbLog)
+	require.NoError(t, err)
+
+	chanArb := chanArbCtx.chanArb
+	require.NoError(t, chanArb.Start(nil, newBeatFromHeight(0)))
+	t.Cleanup(chanArbCtx.CleanUp)
+
+	chanArb.UpdateContractSignals(&ContractSignals{
+		ShortChanID: lnwire.ShortChannelID{},
+	})
+
+	// The HTLC has an output on our local commitment, but it is trimmed on
+	// the commitment of the remote party.
+	const htlcIndex = 99
+	liveHTLC := channeldb.HTLC{
+		Incoming:      false,
+		Amt:           10000,
+		HtlcIndex:     htlcIndex,
+		RefundTimeout: 10,
+		OutputIndex:   0,
+	}
+	dustHTLC := liveHTLC
+	dustHTLC.OutputIndex = -1
+	broadcastHeight := liveHTLC.RefundTimeout -
+		chanArb.cfg.OutgoingBroadcastDelta
+
+	chanArb.notifyContractUpdate(&ContractUpdate{
+		HtlcKey: LocalHtlcSet,
+		Htlcs:   []channeldb.HTLC{liveHTLC},
+	})
+	chanArb.notifyContractUpdate(&ContractUpdate{
+		HtlcKey: RemoteHtlcSet,
+		Htlcs:   []channeldb.HTLC{dustHTLC},
+	})
+
+	// Mine up to the broadcast cut off of the HTLC, which makes the
+	// arbitrator go on chain to time the HTLC out.
+	beat := newBeatFromHeight(int32(broadcastHeight))
+	chanArbCtx.chanArb.BlockbeatChan <- beat
+
+	chanArbCtx.AssertStateTransitions(
+		StateBroadcastCommit,
+		StateCommitmentBroadcasted,
+	)
+
+	// The HTLC is not dust on our local commitment, so it must not be
+	// canceled back before we know which commitment confirmed.
+	select {
+	case msgs := <-chanArbCtx.resolutions:
+		t.Fatalf("htlc canceled back before confirmation: %v", msgs)
+
+	case <-time.After(time.Second):
+	}
+
+	// Now the commitment of the remote party confirms, the one on which
+	// the HTLC is dust. There is no output to resolve on chain, so the
+	// incoming HTLC has to be failed back now.
+	closeTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: wire.OutPoint{},
+			Witness:          [][]byte{{0x9}},
+		}},
+	}
+
+	//nolint:ll
+	uniCloseInfo := &LocalUnilateralCloseInfo{
+		SpendDetail: &chainntnfs.SpendDetail{
+			SpendingHeight: int32(broadcastHeight),
+		},
+		LocalForceCloseSummary: &lnwallet.LocalForceCloseSummary{
+			CloseTx: closeTx,
+			ContractResolutions: fn.Some(lnwallet.ContractResolutions{
+				HtlcResolutions: &lnwallet.HtlcResolutions{},
+			}),
+		},
+		ChannelCloseSummary: &channeldb.ChannelCloseSummary{},
+		CommitSet: CommitSet{
+			ConfCommitKey: fn.Some(RemoteHtlcSet),
+			HtlcSets: map[HtlcSetKey][]channeldb.HTLC{
+				LocalHtlcSet:  {liveHTLC},
+				RemoteHtlcSet: {dustHTLC},
+			},
+		},
+	}
+
+	chanArb.cfg.ChainEvents.LocalUnilateralClosure <- uniCloseInfo
+
+	chanArbCtx.AssertStateTransitions(
+		StateContractClosed,
+		StateWaitingFullResolution,
+	)
+
+	select {
+	case msgs := <-chanArbCtx.resolutions:
+		require.Len(t, msgs, 1)
+		require.EqualValues(t, htlcIndex, msgs[0].HtlcIndex)
+
+	case <-time.After(defaultTimeout):
+		t.Fatalf("resolution msgs not sent")
+	}
+
+	chanArbCtx.receiveBlockbeat(int(broadcastHeight + 1))
+}
+
+// TestCheckRemoteDanglingActionsDustDivergence tests that a dangling outgoing
+// HTLC which is dust on one of the remote commitments but has an output on the
+// other one is handled consistently.
+func TestCheckRemoteDanglingActionsDustDivergence(t *testing.T) {
+	t.Parallel()
+
+	const (
+		heightHint = 100
+		htlcIndex  = 3
+	)
+
+	// The HTLC is close enough to its expiry that we would go on chain for
+	// it, which is what makes checkRemoteDanglingActions consider it in the
+	// first place.
+	newHTLC := func(outputIndex int32) channeldb.HTLC {
+		return channeldb.HTLC{
+			HtlcIndex:     htlcIndex,
+			RefundTimeout: heightHint,
+			OutputIndex:   outputIndex,
+			Amt:           lnwire.NewMSatFromSatoshis(1000),
+		}
+	}
+
+	// dustHTLC has been trimmed on the commitment it is part of, while
+	// liveHTLC has an actual output on it.
+	dustHTLC := newHTLC(-1)
+	liveHTLC := newHTLC(0)
+
+	tests := []struct {
+		name         string
+		remote       channeldb.HTLC
+		pending      channeldb.HTLC
+		expectAction ChainAction
+	}{
+		{
+			name:         "dust on both commitments",
+			remote:       dustHTLC,
+			pending:      dustHTLC,
+			expectAction: HtlcFailDustAction,
+		},
+		{
+			name:         "live on both commitments",
+			remote:       liveHTLC,
+			pending:      newHTLC(1),
+			expectAction: HtlcFailDanglingAction,
+		},
+		{
+			name:         "dust on the pending commitment only",
+			remote:       liveHTLC,
+			pending:      dustHTLC,
+			expectAction: HtlcFailDanglingAction,
+		},
+		{
+			name:         "dust on the remote commitment only",
+			remote:       dustHTLC,
+			pending:      liveHTLC,
+			expectAction: HtlcFailDanglingAction,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			chanArbCtx, err := createTestChannelArbitrator(
+				t, &mockArbitratorLog{state: StateDefault},
+			)
+			require.NoError(t, err)
+
+			chanArb := chanArbCtx.chanArb
+
+			activeHTLCs := map[HtlcSetKey]htlcSet{
+				LocalHtlcSet: newHtlcSet(nil),
+				RemoteHtlcSet: newHtlcSet(
+					[]channeldb.HTLC{test.remote},
+				),
+				RemotePendingHtlcSet: newHtlcSet(
+					[]channeldb.HTLC{test.pending},
+				),
+			}
+
+			liveOnRemote := fn.NewSet[uint64]()
+			if test.remote.OutputIndex >= 0 {
+				liveOnRemote.Add(test.remote.HtlcIndex)
+			}
+			if test.pending.OutputIndex >= 0 {
+				liveOnRemote.Add(test.pending.HtlcIndex)
+			}
+
+			actions := chanArb.checkRemoteDanglingActions(
+				heightHint, activeHTLCs, liveOnRemote,
+				false,
+			)
+
+			require.Len(t, actions, 1)
+			require.Len(t, actions[test.expectAction], 1)
+			require.Equal(
+				t, uint64(htlcIndex),
+				actions[test.expectAction][0].HtlcIndex,
+			)
+		})
+	}
+}
+
+// TestChannelArbitratorDustPendingCommitConfirms tests that the upstream HTLC
+// of a dangling outgoing HTLC which is only dust on the remote pending
+// commitment is still canceled back once that commitment confirms.
+func TestChannelArbitratorDustPendingCommitConfirms(t *testing.T) {
+	t.Parallel()
+
+	arbLog := &mockArbitratorLog{
+		state:     StateDefault,
+		newStates: make(chan ArbitratorState, 5),
+		resolvers: make(map[ContractResolver]struct{}),
+	}
+
+	chanArbCtx, err := createTestChannelArbitrator(t, arbLog)
+	require.NoError(t, err)
+
+	chanArb := chanArbCtx.chanArb
+	require.NoError(t, chanArb.Start(nil, newBeatFromHeight(0)))
+	t.Cleanup(chanArbCtx.CleanUp)
+
+	chanArb.UpdateContractSignals(&ContractSignals{
+		ShortChanID: lnwire.ShortChannelID{},
+	})
+
+	// The HTLC only exists on the remote commitments. It has an output on
+	// the remote commitment, but a fee update trimmed it on the remote
+	// pending commitment.
+	const htlcIndex = 99
+	liveHTLC := channeldb.HTLC{
+		Incoming:      false,
+		Amt:           10000,
+		HtlcIndex:     htlcIndex,
+		RefundTimeout: 10,
+		OutputIndex:   0,
+	}
+	dustHTLC := liveHTLC
+	dustHTLC.OutputIndex = -1
+	broadcastHeight := liveHTLC.RefundTimeout -
+		chanArb.cfg.OutgoingBroadcastDelta
+
+	chanArb.notifyContractUpdate(&ContractUpdate{
+		HtlcKey: RemoteHtlcSet,
+		Htlcs:   []channeldb.HTLC{liveHTLC},
+	})
+	chanArb.notifyContractUpdate(&ContractUpdate{
+		HtlcKey: RemotePendingHtlcSet,
+		Htlcs:   []channeldb.HTLC{dustHTLC},
+	})
+
+	// Mine up to the broadcast cut off of the HTLC, which makes the
+	// arbitrator go on chain to cancel the incoming HTLC back.
+	beat := newBeatFromHeight(int32(broadcastHeight))
+	chanArbCtx.chanArb.BlockbeatChan <- beat
+
+	chanArbCtx.AssertStateTransitions(
+		StateBroadcastCommit,
+		StateCommitmentBroadcasted,
+	)
+
+	select {
+	case msgs := <-chanArbCtx.resolutions:
+		t.Fatalf("htlc canceled back before confirmation: %v", msgs)
+	case <-time.After(time.Second):
+	}
+
+	// Now the remote pending commitment confirms, the one on which the
+	// HTLC is dust. The incoming HTLC has to be failed back now.
+	closeTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: wire.OutPoint{},
+			Witness:          [][]byte{{0x9}},
+		}},
+	}
+
+	//nolint:ll
+	uniCloseInfo := &LocalUnilateralCloseInfo{
+		SpendDetail: &chainntnfs.SpendDetail{
+			SpendingHeight: int32(broadcastHeight),
+		},
+		LocalForceCloseSummary: &lnwallet.LocalForceCloseSummary{
+			CloseTx: closeTx,
+			ContractResolutions: fn.Some(lnwallet.ContractResolutions{
+				HtlcResolutions: &lnwallet.HtlcResolutions{},
+			}),
+		},
+		ChannelCloseSummary: &channeldb.ChannelCloseSummary{},
+		CommitSet: CommitSet{
+			ConfCommitKey: fn.Some(RemotePendingHtlcSet),
+			HtlcSets: map[HtlcSetKey][]channeldb.HTLC{
+				RemoteHtlcSet:        {liveHTLC},
+				RemotePendingHtlcSet: {dustHTLC},
+			},
+		},
+	}
+
+	chanArb.cfg.ChainEvents.LocalUnilateralClosure <- uniCloseInfo
+
+	chanArbCtx.AssertStateTransitions(
+		StateContractClosed,
+		StateWaitingFullResolution,
+	)
+
+	select {
+	case msgs := <-chanArbCtx.resolutions:
+		require.Len(t, msgs, 1)
+		require.EqualValues(t, htlcIndex, msgs[0].HtlcIndex)
+
+	case <-time.After(defaultTimeout):
+		t.Fatalf("resolution msgs not sent")
+	}
+
+	chanArbCtx.receiveBlockbeat(int(broadcastHeight + 1))
+}
+
+// TestChannelArbitratorDustOnLocalLiveOnRemote tests that an outgoing HTLC
+// which is dust on our local commitment, but still has an output on a remote
+// commitment, is not canceled back before a commitment confirmed.
+func TestChannelArbitratorDustOnLocalLiveOnRemote(t *testing.T) {
+	t.Parallel()
+
+	arbLog := &mockArbitratorLog{
+		state:     StateDefault,
+		newStates: make(chan ArbitratorState, 5),
+		resolvers: make(map[ContractResolver]struct{}),
+	}
+
+	chanArbCtx, err := createTestChannelArbitrator(t, arbLog)
+	require.NoError(t, err)
+
+	chanArb := chanArbCtx.chanArb
+	require.NoError(t, chanArb.Start(nil, newBeatFromHeight(0)))
+	t.Cleanup(chanArbCtx.CleanUp)
+
+	chanArb.UpdateContractSignals(&ContractSignals{
+		ShortChanID: lnwire.ShortChannelID{},
+	})
+
+	// The HTLC is trimmed on our local commitment, but it has an output on
+	// the commitment of the remote party, for example because we lowered
+	// the fee rate and the remote party revoked its old commitment but has
+	// not sent the corresponding commitment signature yet.
+	const htlcIndex = 99
+	dustHTLC := channeldb.HTLC{
+		Incoming:      false,
+		Amt:           10000,
+		HtlcIndex:     htlcIndex,
+		RefundTimeout: 10,
+		OutputIndex:   -1,
+	}
+	liveHTLC := dustHTLC
+	liveHTLC.OutputIndex = 0
+	broadcastHeight := dustHTLC.RefundTimeout -
+		chanArb.cfg.OutgoingBroadcastDelta
+
+	chanArb.notifyContractUpdate(&ContractUpdate{
+		HtlcKey: LocalHtlcSet,
+		Htlcs:   []channeldb.HTLC{dustHTLC},
+	})
+	chanArb.notifyContractUpdate(&ContractUpdate{
+		HtlcKey: RemoteHtlcSet,
+		Htlcs:   []channeldb.HTLC{liveHTLC},
+	})
+
+	// Mine up to the broadcast cut off of the HTLC, which makes the
+	// arbitrator go on chain.
+	beat := newBeatFromHeight(int32(broadcastHeight))
+	chanArbCtx.chanArb.BlockbeatChan <- beat
+
+	chanArbCtx.AssertStateTransitions(
+		StateBroadcastCommit,
+		StateCommitmentBroadcasted,
+	)
+
+	// The HTLC must not be canceled back although it is dust on our local
+	// commitment.
+	select {
+	case msgs := <-chanArbCtx.resolutions:
+		t.Fatalf("dust htlc canceled back: %v", msgs)
+
+	case <-time.After(time.Second):
+	}
+
+	// Now our local commitment confirms, on which the HTLC is dust.
+	// The incoming HTLC has to be failed back now.
+	closeTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: wire.OutPoint{},
+			Witness:          [][]byte{{0x9}},
+		}},
+	}
+
+	//nolint:ll
+	uniCloseInfo := &LocalUnilateralCloseInfo{
+		SpendDetail: &chainntnfs.SpendDetail{
+			SpendingHeight: int32(broadcastHeight),
+		},
+		LocalForceCloseSummary: &lnwallet.LocalForceCloseSummary{
+			CloseTx: closeTx,
+			ContractResolutions: fn.Some(lnwallet.ContractResolutions{
+				HtlcResolutions: &lnwallet.HtlcResolutions{},
+			}),
+		},
+		ChannelCloseSummary: &channeldb.ChannelCloseSummary{},
+		CommitSet: CommitSet{
+			ConfCommitKey: fn.Some(LocalHtlcSet),
+			HtlcSets: map[HtlcSetKey][]channeldb.HTLC{
+				LocalHtlcSet:  {dustHTLC},
+				RemoteHtlcSet: {liveHTLC},
+			},
+		},
+	}
+
+	chanArb.cfg.ChainEvents.LocalUnilateralClosure <- uniCloseInfo
+
+	chanArbCtx.AssertStateTransitions(
+		StateContractClosed,
+		StateWaitingFullResolution,
+	)
+
+	select {
+	case msgs := <-chanArbCtx.resolutions:
+		require.Len(t, msgs, 1)
+		require.EqualValues(t, htlcIndex, msgs[0].HtlcIndex)
+
+	case <-time.After(defaultTimeout):
+		t.Fatalf("resolution msgs not sent")
+	}
+
+	chanArbCtx.receiveBlockbeat(int(broadcastHeight + 1))
 }
 
 // TestChannelArbitratorPendingExpiredHTLC tests that if we have pending htlc

--- a/docs/release-notes/release-notes-0.20.4.md
+++ b/docs/release-notes/release-notes-0.20.4.md
@@ -62,6 +62,9 @@
   transaction confirmed stayed in the `channelReadySent` opening state forever,
   never added to the graph and never announced. Only a restart recovered.
 
+* [Fixed an issue](https://github.com/lightningnetwork/lnd/pull/11140) where the
+  incoming side of a forwarded dust HTLC could remain stuck.
+
 # New Features
 
 ## Functional Enhancements
@@ -98,6 +101,7 @@
 
 # Contributors (Alphabetical Order)
 
+* Boris Nagaev
 * LNBiG
 * Yong Yu
 * Ziggie

--- a/docs/release-notes/release-notes-0.21.3.md
+++ b/docs/release-notes/release-notes-0.21.3.md
@@ -66,6 +66,9 @@
   by including extra outputs in initial fee estimation, preventing underpriced
   taproot/custom channel cooperative closes from failing mempool acceptance.
 
+* [Fixed an issue](https://github.com/lightningnetwork/lnd/pull/11140) where the
+  incoming side of a forwarded dust HTLC could remain stuck.
+
 # New Features
 
 ## Functional Enhancements
@@ -127,6 +130,7 @@
 
 # Contributors (Alphabetical Order)
 
+* Boris Nagaev
 * Elle Mouton
 * LNBiG
 * Yong Yu


### PR DESCRIPTION
## Change Description

When we forward a payment we hold two HTLCs that must resolve together: the incoming one (someone pays us) and the outgoing one (we pay the next hop). If the outgoing HTLC dies, we have to deal with the incoming one back upstream. Otherwise the incoming HTLC is stuck and hangs until its own channel force closes near the timeout.

For an outgoing HTLC that is dust there is no output to resolve on chain, so we process the incoming one back. This can happen at two points: before any commitment confirms, and again in StateContractClosed once one did.

Whether an HTLC is dust is not fixed though, it depends on the fee rate and the dust limit of the commitment it sits on. So an HTLC can have an output on our local commitment, yet be trimmed to dust on the remote one. If we did not see it as dust before, and the remote commitment is the one that confirms, neither point handled the incoming HTLC back: `StateContractClosed` only handled the dangling action and assumed all dust HTLCs were already resolved. The incoming HTLC was left stuck.

StateContractClosed now also processes the incoming HTLCs of the dust action. For an HTLC that was already handled before the confirmation this sends a duplicate resolution message, which is safe as the switch processes them idempotently.

## Steps to Test

```
go test ./contractcourt/
```

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
