### PR TITLE
walletrpc: add RemoveAccount RPC

### DIFF
--- a/cmd/commands/walletrpc_active.go
+++ b/cmd/commands/walletrpc_active.go
@@ -53,6 +53,7 @@ var (
 			createAccountCommand,
 			importAccountCommand,
 			importPubKeyCommand,
+			removeAccountCommand,
 		},
 	}
 
@@ -2452,6 +2453,82 @@ func importPubKey(ctx *cli.Context) error {
 		AddressType: addrType,
 	}
 	resp, err := walletClient.ImportPublicKey(ctxc, req)
+	if err != nil {
+		return err
+	}
+
+	printRespJSON(resp)
+	return nil
+}
+
+var removeAccountCommand = cli.Command{
+	Name:      "remove",
+	Usage:     "Remove a watch-only account imported via 'accounts import'.",
+	ArgsUsage: "name",
+	Description: `
+	Removes a watch-only account that was previously imported via
+	'accounts import', along with all addresses derived from it.
+
+	Only imported accounts can be removed; the wallet's reserved "default"
+	and "imported" accounts, and accounts owned by the wallet itself, are
+	refused.
+
+	Removal is allowed even if the account still holds a balance. The
+	wallet simply stops tracking the account's addresses: its balance and
+	UTXOs disappear from the wallet's view and later deposits to its
+	addresses are not detected. The funds themselves are not moved or
+	lost — whoever holds the account's keys retains full control, and
+	re-importing the same extended public key restores tracking.
+	`,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name: "address_type",
+			Usage: "(optional) only needed if the same name " +
+				"exists under more than one key scope, one " +
+				"of: p2wkh, np2wkh, np2wkh-p2wkh, p2tr",
+		},
+		cli.BoolFlag{
+			Name:  "yes",
+			Usage: "skip the confirmation prompt",
+		},
+	},
+	Action: actionDecorator(removeAccount),
+}
+
+func removeAccount(ctx *cli.Context) error {
+	ctxc := getContext()
+
+	// Display the command's help message if we do not have the expected
+	// number of arguments/flags.
+	if ctx.NArg() != 1 || ctx.NumFlags() > 2 {
+		return cli.ShowCommandHelp(ctx, "remove")
+	}
+	name := ctx.Args().First()
+
+	addrType, err := parseAddrType(ctx.String("address_type"))
+	if err != nil {
+		return err
+	}
+
+	if !ctx.Bool("yes") {
+		confirmed := promptForConfirmation(fmt.Sprintf("WARNING: "+
+			"removing account %q stops lnd from tracking its "+
+			"addresses and any balance they hold. The funds are "+
+			"not moved; re-importing the extended public key "+
+			"restores tracking. Proceed? (yes/no): ", name))
+		if !confirmed {
+			return errors.New("removal cancelled")
+		}
+	}
+
+	walletClient, cleanUp := getWalletClient(ctx)
+	defer cleanUp()
+
+	req := &walletrpc.RemoveAccountRequest{
+		Name:        name,
+		AddressType: addrType,
+	}
+	resp, err := walletClient.RemoveAccount(ctxc, req)
 	if err != nil {
 		return err
 	}

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -64,6 +64,15 @@
   the chain backend via bitcoind's `submitpackage`, allowing a zero-fee v3/TRUC
   parent to be accepted together with a fee-paying CPFP child.
 
+* A new
+  [`walletrpc.RemoveAccount`](https://github.com/lightningnetwork/lnd/issues/8654)
+  RPC removes a watch-only account that was previously imported via
+  `ImportAccount`, along with all addresses derived from it. Removal is
+  allowed even if the account still holds a balance: the wallet simply stops
+  tracking the account's addresses, while the funds remain under the control
+  of whoever holds the account's keys, and re-importing the same extended
+  public key restores tracking.
+
 ## lncli Additions
 
 * The `estimateroutefee` command now supports [restricting fee estimates to
@@ -75,6 +84,12 @@
   [`wallet submitpackage`](https://github.com/lightningnetwork/lnd/pull/10900)
   command submits a package of hex-encoded transactions via the new
   `SubmitPackage` RPC.
+
+* A new
+  [`wallet accounts remove`](https://github.com/lightningnetwork/lnd/issues/8654)
+  command removes a watch-only account imported via `wallet accounts import`
+  through the new `RemoveAccount` RPC, asking for confirmation first since the
+  wallet stops tracking the account's balance.
 
 # Improvements
 
@@ -158,4 +173,5 @@
 * bitromortac
 * Boris Nagaev
 * Erick Cestari
+* Evan Kaloudis
 * Jared Tobin

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -891,6 +891,10 @@ func init() {
 		walletImportAccountTestCases,
 	)
 	allTestCases = appendPrefixed(
+		"wallet remove account", allTestCases,
+		walletRemoveAccountTestCases,
+	)
+	allTestCases = appendPrefixed(
 		"funding", allTestCases, basicFundingTestCases,
 	)
 	allTestCases = appendPrefixed(

--- a/itest/lnd_wallet_remove_account_test.go
+++ b/itest/lnd_wallet_remove_account_test.go
@@ -1,0 +1,176 @@
+package itest
+
+import (
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
+	"github.com/lightningnetwork/lnd/lntest"
+	"github.com/lightningnetwork/lnd/lntest/node"
+	"github.com/stretchr/testify/require"
+)
+
+// walletRemoveAccountTestCases tests that a watch-only account imported via
+// ImportAccount can be removed again, and that the accounts the wallet relies
+// on are protected from removal.
+var walletRemoveAccountTestCases = []*lntest.TestCase{
+	{
+		Name:     "happy path",
+		TestFunc: testRemoveAccount,
+	},
+	{
+		Name:     "rejections",
+		TestFunc: testRemoveAccountRejections,
+	},
+}
+
+// testRemoveAccount covers the full life cycle of an imported account: import
+// Carol's account xpub into Dave's node, fund it, remove it while it still
+// holds a balance, and assert the wallet stops tracking it — across a restart
+// — until the same xpub is imported again.
+func testRemoveAccount(ht *lntest.HarnessTest) {
+	const utxoAmt int64 = btcutil.SatoshiPerBitcoin
+	addrType := walletrpc.AddressType_WITNESS_PUBKEY_HASH
+
+	// We'll start our test by having two nodes, Carol and Dave. Carol's
+	// default wallet account will be imported into Dave's node, funded,
+	// and then removed again.
+	carol := ht.NewNode("carol", nil)
+	dave := ht.NewNode("dave", nil)
+
+	listResp := carol.RPC.ListAccounts(&walletrpc.ListAccountsRequest{
+		Name:        "default",
+		AddressType: addrType,
+	})
+	require.Len(ht, listResp.Accounts, 1)
+	carolAccount := listResp.Accounts[0]
+
+	const importedAccount = "carol"
+	dave.RPC.ImportAccount(&walletrpc.ImportAccountRequest{
+		Name:              importedAccount,
+		ExtendedPublicKey: carolAccount.ExtendedPublicKey,
+		AddressType:       addrType,
+	})
+
+	// Fund the imported account and confirm the coins, so that the removal
+	// below provably happens on an account with a non-zero balance.
+	externalAddr := newExternalAddr(
+		ht, dave, carol, importedAccount, addrType,
+	)
+
+	alice := ht.NewNodeWithCoins("Alice", nil)
+	alice.RPC.SendCoins(&lnrpc.SendCoinsRequest{
+		Addr:       externalAddr,
+		Amount:     utxoAmt,
+		SatPerByte: 1,
+	})
+	ht.MineBlocksAndAssertNumTxes(1, 1)
+	ht.AssertWalletAccountBalance(dave, importedAccount, utxoAmt, 0)
+
+	// Remove the account. The response echoes what was removed.
+	removeResp := dave.RPC.RemoveAccount(&walletrpc.RemoveAccountRequest{
+		Name: importedAccount,
+	})
+	require.Equal(ht, importedAccount, removeResp.Account.Name)
+	require.True(ht, removeResp.Account.WatchOnly)
+
+	// The wallet must have dropped the account entirely: it no longer
+	// lists, its addresses are gone and its balance no longer counts
+	// towards the wallet's.
+	assertAccountGone(ht, dave, importedAccount)
+
+	// The removal must also survive a restart.
+	ht.RestartNode(dave)
+	assertAccountGone(ht, dave, importedAccount)
+
+	// Re-importing the same xpub under the same name must succeed again. A
+	// dry run first proves derivation restarts identically: the first
+	// external address is the one we funded above.
+	dryResp := dave.RPC.ImportAccount(&walletrpc.ImportAccountRequest{
+		Name:              importedAccount,
+		ExtendedPublicKey: carolAccount.ExtendedPublicKey,
+		AddressType:       addrType,
+		DryRun:            true,
+	})
+	require.NotEmpty(ht, dryResp.DryRunExternalAddrs)
+	require.Equal(ht, externalAddr, dryResp.DryRunExternalAddrs[0])
+
+	dave.RPC.ImportAccount(&walletrpc.ImportAccountRequest{
+		Name:              importedAccount,
+		ExtendedPublicKey: carolAccount.ExtendedPublicKey,
+		AddressType:       addrType,
+	})
+
+	// The deposit predates the re-import, and events are only detected
+	// from the import onwards, so the balance starts out at zero. This
+	// pins ImportAccount's documented no-rescan limitation for the
+	// remove-then-reimport cycle.
+	ht.AssertWalletAccountBalance(dave, importedAccount, 0, 0)
+}
+
+// assertAccountGone asserts that no trace of the given account is left in the
+// node's wallet: not in the account list, not in the address list and not in
+// the wallet's balance.
+func assertAccountGone(ht *lntest.HarnessTest, hn *node.HarnessNode,
+	account string) {
+
+	listResp := hn.RPC.ListAccounts(&walletrpc.ListAccountsRequest{})
+	for _, acct := range listResp.Accounts {
+		require.NotEqual(ht, account, acct.Name)
+	}
+
+	addrResp := hn.RPC.ListAddresses(&walletrpc.ListAddressesRequest{})
+	for _, acct := range addrResp.AccountWithAddresses {
+		require.NotEqual(ht, account, acct.Name)
+	}
+
+	balanceResp := hn.RPC.WalletBalance()
+	require.NotContains(ht, balanceResp.AccountBalance, account)
+	require.EqualValues(ht, 0, balanceResp.TotalBalance)
+}
+
+// testRemoveAccountRejections asserts the guard rails around RemoveAccount:
+// the wallet's reserved accounts and accounts it owns itself cannot be
+// removed, and a missing or unnamed account is reported as such.
+func testRemoveAccountRejections(ht *lntest.HarnessTest) {
+	alice := ht.NewNode("Alice", nil)
+
+	// An empty name is refused before anything is looked up.
+	err := alice.RPC.RemoveAccountAssertErr(
+		&walletrpc.RemoveAccountRequest{},
+	)
+	require.ErrorContains(ht, err, "account name is required")
+
+	// The wallet's own reserved accounts are refused by name.
+	for _, reserved := range []string{"default", "imported"} {
+		err := alice.RPC.RemoveAccountAssertErr(
+			&walletrpc.RemoveAccountRequest{Name: reserved},
+		)
+		require.ErrorContains(ht, err, "reserved by the wallet")
+	}
+
+	// A name that does not resolve to any account is reported missing.
+	err = alice.RPC.RemoveAccountAssertErr(
+		&walletrpc.RemoveAccountRequest{Name: "does-not-exist"},
+	)
+	require.ErrorContains(ht, err, "not found")
+
+	// An account the wallet derived from its own master key is not an
+	// imported one and must be refused, and must still be intact
+	// afterwards.
+	const ownedAccount = "owned"
+	alice.RPC.XCreateAccount(&walletrpc.XCreateAccountRequest{
+		Name:              ownedAccount,
+		AddressType:       walletrpc.AddressType_TAPROOT_PUBKEY,
+		IKnowWhatIAmDoing: true,
+	})
+
+	err = alice.RPC.RemoveAccountAssertErr(
+		&walletrpc.RemoveAccountRequest{Name: ownedAccount},
+	)
+	require.ErrorContains(ht, err, "not a watch-only imported account")
+
+	listResp := alice.RPC.ListAccounts(&walletrpc.ListAccountsRequest{
+		Name: ownedAccount,
+	})
+	require.Len(ht, listResp.Accounts, 1)
+}

--- a/lnrpc/walletrpc/remove_account_test.go
+++ b/lnrpc/walletrpc/remove_account_test.go
@@ -1,0 +1,72 @@
+//go:build walletrpc
+// +build walletrpc
+
+package walletrpc
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/stretchr/testify/require"
+)
+
+// TestKeyScopeFromAddrType asserts the mapping from the RPC address types onto
+// the key scopes accounts live in. RemoveAccount and ListAccounts both resolve
+// accounts through this mapping, so a wrong entry would make a caller operate
+// on a different scope than the one they named.
+func TestKeyScopeFromAddrType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		addrType      AddressType
+		expectedScope *waddrmgr.KeyScope
+		expectedErr   string
+	}{{
+		name:          "unknown means no scope filter",
+		addrType:      AddressType_UNKNOWN,
+		expectedScope: nil,
+	}, {
+		name:          "witness pubkey hash",
+		addrType:      AddressType_WITNESS_PUBKEY_HASH,
+		expectedScope: &waddrmgr.KeyScopeBIP0084,
+	}, {
+		name:          "nested witness pubkey hash",
+		addrType:      AddressType_NESTED_WITNESS_PUBKEY_HASH,
+		expectedScope: &waddrmgr.KeyScopeBIP0049Plus,
+	}, {
+		name:          "hybrid nested witness pubkey hash",
+		addrType:      AddressType_HYBRID_NESTED_WITNESS_PUBKEY_HASH,
+		expectedScope: &waddrmgr.KeyScopeBIP0049Plus,
+	}, {
+		name:          "taproot pubkey",
+		addrType:      AddressType_TAPROOT_PUBKEY,
+		expectedScope: &waddrmgr.KeyScopeBIP0086,
+	}, {
+		name:        "unhandled type rejected",
+		addrType:    AddressType(999),
+		expectedErr: "unhandled address type",
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			scope, err := keyScopeFromAddrType(test.addrType)
+
+			if test.expectedErr != "" {
+				require.ErrorContains(t, err, test.expectedErr)
+				return
+			}
+
+			require.NoError(t, err)
+			if test.expectedScope == nil {
+				require.Nil(t, scope)
+				return
+			}
+
+			require.NotNil(t, scope)
+			require.Equal(t, *test.expectedScope, *scope)
+		})
+	}
+}

--- a/lnrpc/walletrpc/walletkit.pb.go
+++ b/lnrpc/walletrpc/walletkit.pb.go
@@ -2044,6 +2044,109 @@ func (x *ImportAccountResponse) GetDryRunInternalAddrs() []string {
 	return nil
 }
 
+type RemoveAccountRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The name of the account to remove.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// An optional address type used to resolve which key scope the account lives
+	// in. Account names are normally unique across all key scopes, so this can
+	// usually be left unset; it is only required if the same name exists under
+	// more than one key scope, which is possible on wallets created before
+	// uniqueness was enforced.
+	AddressType   AddressType `protobuf:"varint,2,opt,name=address_type,json=addressType,proto3,enum=walletrpc.AddressType" json:"address_type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RemoveAccountRequest) Reset() {
+	*x = RemoveAccountRequest{}
+	mi := &file_walletrpc_walletkit_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RemoveAccountRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RemoveAccountRequest) ProtoMessage() {}
+
+func (x *RemoveAccountRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_walletrpc_walletkit_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RemoveAccountRequest.ProtoReflect.Descriptor instead.
+func (*RemoveAccountRequest) Descriptor() ([]byte, []int) {
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *RemoveAccountRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *RemoveAccountRequest) GetAddressType() AddressType {
+	if x != nil {
+		return x.AddressType
+	}
+	return AddressType_UNKNOWN
+}
+
+type RemoveAccountResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The properties of the account that was removed.
+	Account       *Account `protobuf:"bytes,1,opt,name=account,proto3" json:"account,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RemoveAccountResponse) Reset() {
+	*x = RemoveAccountResponse{}
+	mi := &file_walletrpc_walletkit_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RemoveAccountResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RemoveAccountResponse) ProtoMessage() {}
+
+func (x *RemoveAccountResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_walletrpc_walletkit_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RemoveAccountResponse.ProtoReflect.Descriptor instead.
+func (*RemoveAccountResponse) Descriptor() ([]byte, []int) {
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *RemoveAccountResponse) GetAccount() *Account {
+	if x != nil {
+		return x.Account
+	}
+	return nil
+}
+
 type ImportPublicKeyRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// A compressed public key represented as raw bytes.
@@ -2056,7 +2159,7 @@ type ImportPublicKeyRequest struct {
 
 func (x *ImportPublicKeyRequest) Reset() {
 	*x = ImportPublicKeyRequest{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[27]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2068,7 +2171,7 @@ func (x *ImportPublicKeyRequest) String() string {
 func (*ImportPublicKeyRequest) ProtoMessage() {}
 
 func (x *ImportPublicKeyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[27]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2081,7 +2184,7 @@ func (x *ImportPublicKeyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImportPublicKeyRequest.ProtoReflect.Descriptor instead.
 func (*ImportPublicKeyRequest) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{27}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ImportPublicKeyRequest) GetPublicKey() []byte {
@@ -2108,7 +2211,7 @@ type ImportPublicKeyResponse struct {
 
 func (x *ImportPublicKeyResponse) Reset() {
 	*x = ImportPublicKeyResponse{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[28]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2120,7 +2223,7 @@ func (x *ImportPublicKeyResponse) String() string {
 func (*ImportPublicKeyResponse) ProtoMessage() {}
 
 func (x *ImportPublicKeyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[28]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2133,7 +2236,7 @@ func (x *ImportPublicKeyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImportPublicKeyResponse.ProtoReflect.Descriptor instead.
 func (*ImportPublicKeyResponse) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{28}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ImportPublicKeyResponse) GetStatus() string {
@@ -2160,7 +2263,7 @@ type ImportTapscriptRequest struct {
 
 func (x *ImportTapscriptRequest) Reset() {
 	*x = ImportTapscriptRequest{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[29]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2172,7 +2275,7 @@ func (x *ImportTapscriptRequest) String() string {
 func (*ImportTapscriptRequest) ProtoMessage() {}
 
 func (x *ImportTapscriptRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[29]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2185,7 +2288,7 @@ func (x *ImportTapscriptRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImportTapscriptRequest.ProtoReflect.Descriptor instead.
 func (*ImportTapscriptRequest) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{29}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ImportTapscriptRequest) GetInternalPublicKey() []byte {
@@ -2288,7 +2391,7 @@ type TapscriptFullTree struct {
 
 func (x *TapscriptFullTree) Reset() {
 	*x = TapscriptFullTree{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[30]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2300,7 +2403,7 @@ func (x *TapscriptFullTree) String() string {
 func (*TapscriptFullTree) ProtoMessage() {}
 
 func (x *TapscriptFullTree) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[30]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2313,7 +2416,7 @@ func (x *TapscriptFullTree) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TapscriptFullTree.ProtoReflect.Descriptor instead.
 func (*TapscriptFullTree) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{30}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *TapscriptFullTree) GetAllLeaves() []*TapLeaf {
@@ -2335,7 +2438,7 @@ type TapLeaf struct {
 
 func (x *TapLeaf) Reset() {
 	*x = TapLeaf{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[31]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2347,7 +2450,7 @@ func (x *TapLeaf) String() string {
 func (*TapLeaf) ProtoMessage() {}
 
 func (x *TapLeaf) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[31]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2360,7 +2463,7 @@ func (x *TapLeaf) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TapLeaf.ProtoReflect.Descriptor instead.
 func (*TapLeaf) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{31}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *TapLeaf) GetLeafVersion() uint32 {
@@ -2392,7 +2495,7 @@ type TapscriptPartialReveal struct {
 
 func (x *TapscriptPartialReveal) Reset() {
 	*x = TapscriptPartialReveal{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[32]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2404,7 +2507,7 @@ func (x *TapscriptPartialReveal) String() string {
 func (*TapscriptPartialReveal) ProtoMessage() {}
 
 func (x *TapscriptPartialReveal) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[32]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2417,7 +2520,7 @@ func (x *TapscriptPartialReveal) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TapscriptPartialReveal.ProtoReflect.Descriptor instead.
 func (*TapscriptPartialReveal) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{32}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *TapscriptPartialReveal) GetRevealedLeaf() *TapLeaf {
@@ -2445,7 +2548,7 @@ type ImportTapscriptResponse struct {
 
 func (x *ImportTapscriptResponse) Reset() {
 	*x = ImportTapscriptResponse{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[33]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2457,7 +2560,7 @@ func (x *ImportTapscriptResponse) String() string {
 func (*ImportTapscriptResponse) ProtoMessage() {}
 
 func (x *ImportTapscriptResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[33]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2470,7 +2573,7 @@ func (x *ImportTapscriptResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImportTapscriptResponse.ProtoReflect.Descriptor instead.
 func (*ImportTapscriptResponse) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{33}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *ImportTapscriptResponse) GetP2TrAddress() string {
@@ -2494,7 +2597,7 @@ type Transaction struct {
 
 func (x *Transaction) Reset() {
 	*x = Transaction{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[34]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2506,7 +2609,7 @@ func (x *Transaction) String() string {
 func (*Transaction) ProtoMessage() {}
 
 func (x *Transaction) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[34]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2519,7 +2622,7 @@ func (x *Transaction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Transaction.ProtoReflect.Descriptor instead.
 func (*Transaction) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{34}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *Transaction) GetTxHex() []byte {
@@ -2550,7 +2653,7 @@ type PublishResponse struct {
 
 func (x *PublishResponse) Reset() {
 	*x = PublishResponse{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[35]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2562,7 +2665,7 @@ func (x *PublishResponse) String() string {
 func (*PublishResponse) ProtoMessage() {}
 
 func (x *PublishResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[35]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2575,7 +2678,7 @@ func (x *PublishResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PublishResponse.ProtoReflect.Descriptor instead.
 func (*PublishResponse) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{35}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *PublishResponse) GetPublishError() string {
@@ -2601,7 +2704,7 @@ type SubmitPackageRequest struct {
 
 func (x *SubmitPackageRequest) Reset() {
 	*x = SubmitPackageRequest{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[36]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2613,7 +2716,7 @@ func (x *SubmitPackageRequest) String() string {
 func (*SubmitPackageRequest) ProtoMessage() {}
 
 func (x *SubmitPackageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[36]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2626,7 +2729,7 @@ func (x *SubmitPackageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitPackageRequest.ProtoReflect.Descriptor instead.
 func (*SubmitPackageRequest) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{36}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *SubmitPackageRequest) GetRawTxs() [][]byte {
@@ -2659,7 +2762,7 @@ type SubmitPackageTxResult struct {
 
 func (x *SubmitPackageTxResult) Reset() {
 	*x = SubmitPackageTxResult{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[37]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2671,7 +2774,7 @@ func (x *SubmitPackageTxResult) String() string {
 func (*SubmitPackageTxResult) ProtoMessage() {}
 
 func (x *SubmitPackageTxResult) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[37]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2684,7 +2787,7 @@ func (x *SubmitPackageTxResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitPackageTxResult.ProtoReflect.Descriptor instead.
 func (*SubmitPackageTxResult) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{37}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *SubmitPackageTxResult) GetTxid() string {
@@ -2722,7 +2825,7 @@ type SubmitPackageResponse struct {
 
 func (x *SubmitPackageResponse) Reset() {
 	*x = SubmitPackageResponse{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[38]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2734,7 +2837,7 @@ func (x *SubmitPackageResponse) String() string {
 func (*SubmitPackageResponse) ProtoMessage() {}
 
 func (x *SubmitPackageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[38]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2747,7 +2850,7 @@ func (x *SubmitPackageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitPackageResponse.ProtoReflect.Descriptor instead.
 func (*SubmitPackageResponse) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{38}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *SubmitPackageResponse) GetPackageMsg() string {
@@ -2781,7 +2884,7 @@ type RemoveTransactionResponse struct {
 
 func (x *RemoveTransactionResponse) Reset() {
 	*x = RemoveTransactionResponse{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[39]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2793,7 +2896,7 @@ func (x *RemoveTransactionResponse) String() string {
 func (*RemoveTransactionResponse) ProtoMessage() {}
 
 func (x *RemoveTransactionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[39]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2806,7 +2909,7 @@ func (x *RemoveTransactionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveTransactionResponse.ProtoReflect.Descriptor instead.
 func (*RemoveTransactionResponse) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{39}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *RemoveTransactionResponse) GetStatus() string {
@@ -2838,7 +2941,7 @@ type SendOutputsRequest struct {
 
 func (x *SendOutputsRequest) Reset() {
 	*x = SendOutputsRequest{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[40]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2850,7 +2953,7 @@ func (x *SendOutputsRequest) String() string {
 func (*SendOutputsRequest) ProtoMessage() {}
 
 func (x *SendOutputsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[40]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2863,7 +2966,7 @@ func (x *SendOutputsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendOutputsRequest.ProtoReflect.Descriptor instead.
 func (*SendOutputsRequest) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{40}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *SendOutputsRequest) GetSatPerKw() int64 {
@@ -2918,7 +3021,7 @@ type SendOutputsResponse struct {
 
 func (x *SendOutputsResponse) Reset() {
 	*x = SendOutputsResponse{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[41]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2930,7 +3033,7 @@ func (x *SendOutputsResponse) String() string {
 func (*SendOutputsResponse) ProtoMessage() {}
 
 func (x *SendOutputsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[41]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2943,7 +3046,7 @@ func (x *SendOutputsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendOutputsResponse.ProtoReflect.Descriptor instead.
 func (*SendOutputsResponse) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{41}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *SendOutputsResponse) GetRawTx() []byte {
@@ -2963,7 +3066,7 @@ type EstimateFeeRequest struct {
 
 func (x *EstimateFeeRequest) Reset() {
 	*x = EstimateFeeRequest{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[42]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2975,7 +3078,7 @@ func (x *EstimateFeeRequest) String() string {
 func (*EstimateFeeRequest) ProtoMessage() {}
 
 func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[42]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2988,7 +3091,7 @@ func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeRequest.ProtoReflect.Descriptor instead.
 func (*EstimateFeeRequest) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{42}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *EstimateFeeRequest) GetConfTarget() int32 {
@@ -3011,7 +3114,7 @@ type EstimateFeeResponse struct {
 
 func (x *EstimateFeeResponse) Reset() {
 	*x = EstimateFeeResponse{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[43]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3023,7 +3126,7 @@ func (x *EstimateFeeResponse) String() string {
 func (*EstimateFeeResponse) ProtoMessage() {}
 
 func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[43]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3036,7 +3139,7 @@ func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeResponse.ProtoReflect.Descriptor instead.
 func (*EstimateFeeResponse) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{43}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *EstimateFeeResponse) GetSatPerKw() int64 {
@@ -3116,7 +3219,7 @@ type PendingSweep struct {
 
 func (x *PendingSweep) Reset() {
 	*x = PendingSweep{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[44]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3128,7 +3231,7 @@ func (x *PendingSweep) String() string {
 func (*PendingSweep) ProtoMessage() {}
 
 func (x *PendingSweep) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[44]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3141,7 +3244,7 @@ func (x *PendingSweep) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PendingSweep.ProtoReflect.Descriptor instead.
 func (*PendingSweep) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{44}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *PendingSweep) GetOutpoint() *lnrpc.OutPoint {
@@ -3262,7 +3365,7 @@ type PendingSweepsRequest struct {
 
 func (x *PendingSweepsRequest) Reset() {
 	*x = PendingSweepsRequest{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[45]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3274,7 +3377,7 @@ func (x *PendingSweepsRequest) String() string {
 func (*PendingSweepsRequest) ProtoMessage() {}
 
 func (x *PendingSweepsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[45]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3287,7 +3390,7 @@ func (x *PendingSweepsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PendingSweepsRequest.ProtoReflect.Descriptor instead.
 func (*PendingSweepsRequest) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{45}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{47}
 }
 
 type PendingSweepsResponse struct {
@@ -3300,7 +3403,7 @@ type PendingSweepsResponse struct {
 
 func (x *PendingSweepsResponse) Reset() {
 	*x = PendingSweepsResponse{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[46]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3312,7 +3415,7 @@ func (x *PendingSweepsResponse) String() string {
 func (*PendingSweepsResponse) ProtoMessage() {}
 
 func (x *PendingSweepsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[46]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3325,7 +3428,7 @@ func (x *PendingSweepsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PendingSweepsResponse.ProtoReflect.Descriptor instead.
 func (*PendingSweepsResponse) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{46}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *PendingSweepsResponse) GetPendingSweeps() []*PendingSweep {
@@ -3380,7 +3483,7 @@ type BumpFeeRequest struct {
 
 func (x *BumpFeeRequest) Reset() {
 	*x = BumpFeeRequest{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[47]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3392,7 +3495,7 @@ func (x *BumpFeeRequest) String() string {
 func (*BumpFeeRequest) ProtoMessage() {}
 
 func (x *BumpFeeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[47]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3405,7 +3508,7 @@ func (x *BumpFeeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BumpFeeRequest.ProtoReflect.Descriptor instead.
 func (*BumpFeeRequest) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{47}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *BumpFeeRequest) GetOutpoint() *lnrpc.OutPoint {
@@ -3476,7 +3579,7 @@ type BumpFeeResponse struct {
 
 func (x *BumpFeeResponse) Reset() {
 	*x = BumpFeeResponse{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[48]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3488,7 +3591,7 @@ func (x *BumpFeeResponse) String() string {
 func (*BumpFeeResponse) ProtoMessage() {}
 
 func (x *BumpFeeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[48]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3501,7 +3604,7 @@ func (x *BumpFeeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BumpFeeResponse.ProtoReflect.Descriptor instead.
 func (*BumpFeeResponse) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{48}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *BumpFeeResponse) GetStatus() string {
@@ -3545,7 +3648,7 @@ type BumpForceCloseFeeRequest struct {
 
 func (x *BumpForceCloseFeeRequest) Reset() {
 	*x = BumpForceCloseFeeRequest{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[49]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3557,7 +3660,7 @@ func (x *BumpForceCloseFeeRequest) String() string {
 func (*BumpForceCloseFeeRequest) ProtoMessage() {}
 
 func (x *BumpForceCloseFeeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[49]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3570,7 +3673,7 @@ func (x *BumpForceCloseFeeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BumpForceCloseFeeRequest.ProtoReflect.Descriptor instead.
 func (*BumpForceCloseFeeRequest) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{49}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *BumpForceCloseFeeRequest) GetChanPoint() *lnrpc.ChannelPoint {
@@ -3625,7 +3728,7 @@ type BumpForceCloseFeeResponse struct {
 
 func (x *BumpForceCloseFeeResponse) Reset() {
 	*x = BumpForceCloseFeeResponse{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[50]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3637,7 +3740,7 @@ func (x *BumpForceCloseFeeResponse) String() string {
 func (*BumpForceCloseFeeResponse) ProtoMessage() {}
 
 func (x *BumpForceCloseFeeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[50]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3650,7 +3753,7 @@ func (x *BumpForceCloseFeeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BumpForceCloseFeeResponse.ProtoReflect.Descriptor instead.
 func (*BumpForceCloseFeeResponse) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{50}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *BumpForceCloseFeeResponse) GetStatus() string {
@@ -3676,7 +3779,7 @@ type ListSweepsRequest struct {
 
 func (x *ListSweepsRequest) Reset() {
 	*x = ListSweepsRequest{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[51]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3688,7 +3791,7 @@ func (x *ListSweepsRequest) String() string {
 func (*ListSweepsRequest) ProtoMessage() {}
 
 func (x *ListSweepsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[51]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3701,7 +3804,7 @@ func (x *ListSweepsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSweepsRequest.ProtoReflect.Descriptor instead.
 func (*ListSweepsRequest) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{51}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *ListSweepsRequest) GetVerbose() bool {
@@ -3731,7 +3834,7 @@ type ListSweepsResponse struct {
 
 func (x *ListSweepsResponse) Reset() {
 	*x = ListSweepsResponse{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[52]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3743,7 +3846,7 @@ func (x *ListSweepsResponse) String() string {
 func (*ListSweepsResponse) ProtoMessage() {}
 
 func (x *ListSweepsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[52]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3756,7 +3859,7 @@ func (x *ListSweepsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSweepsResponse.ProtoReflect.Descriptor instead.
 func (*ListSweepsResponse) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{52}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *ListSweepsResponse) GetSweeps() isListSweepsResponse_Sweeps {
@@ -3815,7 +3918,7 @@ type LabelTransactionRequest struct {
 
 func (x *LabelTransactionRequest) Reset() {
 	*x = LabelTransactionRequest{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[53]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3827,7 +3930,7 @@ func (x *LabelTransactionRequest) String() string {
 func (*LabelTransactionRequest) ProtoMessage() {}
 
 func (x *LabelTransactionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[53]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3840,7 +3943,7 @@ func (x *LabelTransactionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LabelTransactionRequest.ProtoReflect.Descriptor instead.
 func (*LabelTransactionRequest) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{53}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *LabelTransactionRequest) GetTxid() []byte {
@@ -3874,7 +3977,7 @@ type LabelTransactionResponse struct {
 
 func (x *LabelTransactionResponse) Reset() {
 	*x = LabelTransactionResponse{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[54]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3886,7 +3989,7 @@ func (x *LabelTransactionResponse) String() string {
 func (*LabelTransactionResponse) ProtoMessage() {}
 
 func (x *LabelTransactionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[54]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3899,7 +4002,7 @@ func (x *LabelTransactionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LabelTransactionResponse.ProtoReflect.Descriptor instead.
 func (*LabelTransactionResponse) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{54}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *LabelTransactionResponse) GetStatus() string {
@@ -3954,7 +4057,7 @@ type FundPsbtRequest struct {
 
 func (x *FundPsbtRequest) Reset() {
 	*x = FundPsbtRequest{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[55]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3966,7 +4069,7 @@ func (x *FundPsbtRequest) String() string {
 func (*FundPsbtRequest) ProtoMessage() {}
 
 func (x *FundPsbtRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[55]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3979,7 +4082,7 @@ func (x *FundPsbtRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FundPsbtRequest.ProtoReflect.Descriptor instead.
 func (*FundPsbtRequest) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{55}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *FundPsbtRequest) GetTemplate() isFundPsbtRequest_Template {
@@ -4196,7 +4299,7 @@ type FundPsbtResponse struct {
 
 func (x *FundPsbtResponse) Reset() {
 	*x = FundPsbtResponse{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[56]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4208,7 +4311,7 @@ func (x *FundPsbtResponse) String() string {
 func (*FundPsbtResponse) ProtoMessage() {}
 
 func (x *FundPsbtResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[56]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4221,7 +4324,7 @@ func (x *FundPsbtResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FundPsbtResponse.ProtoReflect.Descriptor instead.
 func (*FundPsbtResponse) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{56}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *FundPsbtResponse) GetFundedPsbt() []byte {
@@ -4263,7 +4366,7 @@ type TxTemplate struct {
 
 func (x *TxTemplate) Reset() {
 	*x = TxTemplate{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[57]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4275,7 +4378,7 @@ func (x *TxTemplate) String() string {
 func (*TxTemplate) ProtoMessage() {}
 
 func (x *TxTemplate) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[57]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4288,7 +4391,7 @@ func (x *TxTemplate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TxTemplate.ProtoReflect.Descriptor instead.
 func (*TxTemplate) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{57}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *TxTemplate) GetInputs() []*lnrpc.OutPoint {
@@ -4328,7 +4431,7 @@ type PsbtCoinSelect struct {
 
 func (x *PsbtCoinSelect) Reset() {
 	*x = PsbtCoinSelect{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[58]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4340,7 +4443,7 @@ func (x *PsbtCoinSelect) String() string {
 func (*PsbtCoinSelect) ProtoMessage() {}
 
 func (x *PsbtCoinSelect) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[58]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4353,7 +4456,7 @@ func (x *PsbtCoinSelect) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PsbtCoinSelect.ProtoReflect.Descriptor instead.
 func (*PsbtCoinSelect) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{58}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *PsbtCoinSelect) GetPsbt() []byte {
@@ -4429,7 +4532,7 @@ type UtxoLease struct {
 
 func (x *UtxoLease) Reset() {
 	*x = UtxoLease{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[59]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4441,7 +4544,7 @@ func (x *UtxoLease) String() string {
 func (*UtxoLease) ProtoMessage() {}
 
 func (x *UtxoLease) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[59]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4454,7 +4557,7 @@ func (x *UtxoLease) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UtxoLease.ProtoReflect.Descriptor instead.
 func (*UtxoLease) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{59}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *UtxoLease) GetId() []byte {
@@ -4503,7 +4606,7 @@ type SignPsbtRequest struct {
 
 func (x *SignPsbtRequest) Reset() {
 	*x = SignPsbtRequest{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[60]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4515,7 +4618,7 @@ func (x *SignPsbtRequest) String() string {
 func (*SignPsbtRequest) ProtoMessage() {}
 
 func (x *SignPsbtRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[60]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4528,7 +4631,7 @@ func (x *SignPsbtRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignPsbtRequest.ProtoReflect.Descriptor instead.
 func (*SignPsbtRequest) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{60}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *SignPsbtRequest) GetFundedPsbt() []byte {
@@ -4550,7 +4653,7 @@ type SignPsbtResponse struct {
 
 func (x *SignPsbtResponse) Reset() {
 	*x = SignPsbtResponse{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[61]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4562,7 +4665,7 @@ func (x *SignPsbtResponse) String() string {
 func (*SignPsbtResponse) ProtoMessage() {}
 
 func (x *SignPsbtResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[61]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4575,7 +4678,7 @@ func (x *SignPsbtResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignPsbtResponse.ProtoReflect.Descriptor instead.
 func (*SignPsbtResponse) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{61}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *SignPsbtResponse) GetSignedPsbt() []byte {
@@ -4607,7 +4710,7 @@ type FinalizePsbtRequest struct {
 
 func (x *FinalizePsbtRequest) Reset() {
 	*x = FinalizePsbtRequest{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[62]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4619,7 +4722,7 @@ func (x *FinalizePsbtRequest) String() string {
 func (*FinalizePsbtRequest) ProtoMessage() {}
 
 func (x *FinalizePsbtRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[62]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4632,7 +4735,7 @@ func (x *FinalizePsbtRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FinalizePsbtRequest.ProtoReflect.Descriptor instead.
 func (*FinalizePsbtRequest) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{62}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *FinalizePsbtRequest) GetFundedPsbt() []byte {
@@ -4661,7 +4764,7 @@ type FinalizePsbtResponse struct {
 
 func (x *FinalizePsbtResponse) Reset() {
 	*x = FinalizePsbtResponse{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[63]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4673,7 +4776,7 @@ func (x *FinalizePsbtResponse) String() string {
 func (*FinalizePsbtResponse) ProtoMessage() {}
 
 func (x *FinalizePsbtResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[63]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4686,7 +4789,7 @@ func (x *FinalizePsbtResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FinalizePsbtResponse.ProtoReflect.Descriptor instead.
 func (*FinalizePsbtResponse) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{63}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *FinalizePsbtResponse) GetSignedPsbt() []byte {
@@ -4711,7 +4814,7 @@ type ListLeasesRequest struct {
 
 func (x *ListLeasesRequest) Reset() {
 	*x = ListLeasesRequest{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[64]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4723,7 +4826,7 @@ func (x *ListLeasesRequest) String() string {
 func (*ListLeasesRequest) ProtoMessage() {}
 
 func (x *ListLeasesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[64]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4736,7 +4839,7 @@ func (x *ListLeasesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListLeasesRequest.ProtoReflect.Descriptor instead.
 func (*ListLeasesRequest) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{64}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{66}
 }
 
 type ListLeasesResponse struct {
@@ -4749,7 +4852,7 @@ type ListLeasesResponse struct {
 
 func (x *ListLeasesResponse) Reset() {
 	*x = ListLeasesResponse{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[65]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4761,7 +4864,7 @@ func (x *ListLeasesResponse) String() string {
 func (*ListLeasesResponse) ProtoMessage() {}
 
 func (x *ListLeasesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[65]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4774,7 +4877,7 @@ func (x *ListLeasesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListLeasesResponse.ProtoReflect.Descriptor instead.
 func (*ListLeasesResponse) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{65}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *ListLeasesResponse) GetLockedUtxos() []*UtxoLease {
@@ -4796,7 +4899,7 @@ type ListSweepsResponse_TransactionIDs struct {
 
 func (x *ListSweepsResponse_TransactionIDs) Reset() {
 	*x = ListSweepsResponse_TransactionIDs{}
-	mi := &file_walletrpc_walletkit_proto_msgTypes[67]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4808,7 +4911,7 @@ func (x *ListSweepsResponse_TransactionIDs) String() string {
 func (*ListSweepsResponse_TransactionIDs) ProtoMessage() {}
 
 func (x *ListSweepsResponse_TransactionIDs) ProtoReflect() protoreflect.Message {
-	mi := &file_walletrpc_walletkit_proto_msgTypes[67]
+	mi := &file_walletrpc_walletkit_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4821,7 +4924,7 @@ func (x *ListSweepsResponse_TransactionIDs) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use ListSweepsResponse_TransactionIDs.ProtoReflect.Descriptor instead.
 func (*ListSweepsResponse_TransactionIDs) Descriptor() ([]byte, []int) {
-	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{52, 0}
+	return file_walletrpc_walletkit_proto_rawDescGZIP(), []int{54, 0}
 }
 
 func (x *ListSweepsResponse_TransactionIDs) GetTransactionIds() []string {
@@ -4932,7 +5035,12 @@ const file_walletrpc_walletkit_proto_rawDesc = "" +
 	"\x15ImportAccountResponse\x12,\n" +
 	"\aaccount\x18\x01 \x01(\v2\x12.walletrpc.AccountR\aaccount\x123\n" +
 	"\x16dry_run_external_addrs\x18\x02 \x03(\tR\x13dryRunExternalAddrs\x123\n" +
-	"\x16dry_run_internal_addrs\x18\x03 \x03(\tR\x13dryRunInternalAddrs\"r\n" +
+	"\x16dry_run_internal_addrs\x18\x03 \x03(\tR\x13dryRunInternalAddrs\"e\n" +
+	"\x14RemoveAccountRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x129\n" +
+	"\faddress_type\x18\x02 \x01(\x0e2\x16.walletrpc.AddressTypeR\vaddressType\"E\n" +
+	"\x15RemoveAccountResponse\x12,\n" +
+	"\aaccount\x18\x01 \x01(\v2\x12.walletrpc.AccountR\aaccount\"r\n" +
 	"\x16ImportPublicKeyRequest\x12\x1d\n" +
 	"\n" +
 	"public_key\x18\x01 \x01(\fR\tpublicKey\x129\n" +
@@ -5180,7 +5288,7 @@ const file_walletrpc_walletkit_proto_rawDesc = "" +
 	"\x1fTAPROOT_COMMITMENT_REVOKE_FINAL\x10**V\n" +
 	"\x11ChangeAddressType\x12#\n" +
 	"\x1fCHANGE_ADDRESS_TYPE_UNSPECIFIED\x10\x00\x12\x1c\n" +
-	"\x18CHANGE_ADDRESS_TYPE_P2TR\x10\x012\x81\x13\n" +
+	"\x18CHANGE_ADDRESS_TYPE_P2TR\x10\x012\xd5\x13\n" +
 	"\tWalletKit\x12L\n" +
 	"\vListUnspent\x12\x1d.walletrpc.ListUnspentRequest\x1a\x1e.walletrpc.ListUnspentResponse\x12L\n" +
 	"\vLeaseOutput\x12\x1d.walletrpc.LeaseOutputRequest\x1a\x1e.walletrpc.LeaseOutputResponse\x12R\n" +
@@ -5197,7 +5305,8 @@ const file_walletrpc_walletkit_proto_rawDesc = "" +
 	"\rListAddresses\x12\x1f.walletrpc.ListAddressesRequest\x1a .walletrpc.ListAddressesResponse\x12d\n" +
 	"\x13SignMessageWithAddr\x12%.walletrpc.SignMessageWithAddrRequest\x1a&.walletrpc.SignMessageWithAddrResponse\x12j\n" +
 	"\x15VerifyMessageWithAddr\x12'.walletrpc.VerifyMessageWithAddrRequest\x1a(.walletrpc.VerifyMessageWithAddrResponse\x12R\n" +
-	"\rImportAccount\x12\x1f.walletrpc.ImportAccountRequest\x1a .walletrpc.ImportAccountResponse\x12X\n" +
+	"\rImportAccount\x12\x1f.walletrpc.ImportAccountRequest\x1a .walletrpc.ImportAccountResponse\x12R\n" +
+	"\rRemoveAccount\x12\x1f.walletrpc.RemoveAccountRequest\x1a .walletrpc.RemoveAccountResponse\x12X\n" +
 	"\x0fImportPublicKey\x12!.walletrpc.ImportPublicKeyRequest\x1a\".walletrpc.ImportPublicKeyResponse\x12X\n" +
 	"\x0fImportTapscript\x12!.walletrpc.ImportTapscriptRequest\x1a\".walletrpc.ImportTapscriptResponse\x12H\n" +
 	"\x12PublishTransaction\x12\x16.walletrpc.Transaction\x1a\x1a.walletrpc.PublishResponse\x12R\n" +
@@ -5228,7 +5337,7 @@ func file_walletrpc_walletkit_proto_rawDescGZIP() []byte {
 }
 
 var file_walletrpc_walletkit_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_walletrpc_walletkit_proto_msgTypes = make([]protoimpl.MessageInfo, 69)
+var file_walletrpc_walletkit_proto_msgTypes = make([]protoimpl.MessageInfo, 71)
 var file_walletrpc_walletkit_proto_goTypes = []any{
 	(AddressType)(0),                          // 0: walletrpc.AddressType
 	(WitnessType)(0),                          // 1: walletrpc.WitnessType
@@ -5260,62 +5369,64 @@ var file_walletrpc_walletkit_proto_goTypes = []any{
 	(*VerifyMessageWithAddrResponse)(nil),     // 27: walletrpc.VerifyMessageWithAddrResponse
 	(*ImportAccountRequest)(nil),              // 28: walletrpc.ImportAccountRequest
 	(*ImportAccountResponse)(nil),             // 29: walletrpc.ImportAccountResponse
-	(*ImportPublicKeyRequest)(nil),            // 30: walletrpc.ImportPublicKeyRequest
-	(*ImportPublicKeyResponse)(nil),           // 31: walletrpc.ImportPublicKeyResponse
-	(*ImportTapscriptRequest)(nil),            // 32: walletrpc.ImportTapscriptRequest
-	(*TapscriptFullTree)(nil),                 // 33: walletrpc.TapscriptFullTree
-	(*TapLeaf)(nil),                           // 34: walletrpc.TapLeaf
-	(*TapscriptPartialReveal)(nil),            // 35: walletrpc.TapscriptPartialReveal
-	(*ImportTapscriptResponse)(nil),           // 36: walletrpc.ImportTapscriptResponse
-	(*Transaction)(nil),                       // 37: walletrpc.Transaction
-	(*PublishResponse)(nil),                   // 38: walletrpc.PublishResponse
-	(*SubmitPackageRequest)(nil),              // 39: walletrpc.SubmitPackageRequest
-	(*SubmitPackageTxResult)(nil),             // 40: walletrpc.SubmitPackageTxResult
-	(*SubmitPackageResponse)(nil),             // 41: walletrpc.SubmitPackageResponse
-	(*RemoveTransactionResponse)(nil),         // 42: walletrpc.RemoveTransactionResponse
-	(*SendOutputsRequest)(nil),                // 43: walletrpc.SendOutputsRequest
-	(*SendOutputsResponse)(nil),               // 44: walletrpc.SendOutputsResponse
-	(*EstimateFeeRequest)(nil),                // 45: walletrpc.EstimateFeeRequest
-	(*EstimateFeeResponse)(nil),               // 46: walletrpc.EstimateFeeResponse
-	(*PendingSweep)(nil),                      // 47: walletrpc.PendingSweep
-	(*PendingSweepsRequest)(nil),              // 48: walletrpc.PendingSweepsRequest
-	(*PendingSweepsResponse)(nil),             // 49: walletrpc.PendingSweepsResponse
-	(*BumpFeeRequest)(nil),                    // 50: walletrpc.BumpFeeRequest
-	(*BumpFeeResponse)(nil),                   // 51: walletrpc.BumpFeeResponse
-	(*BumpForceCloseFeeRequest)(nil),          // 52: walletrpc.BumpForceCloseFeeRequest
-	(*BumpForceCloseFeeResponse)(nil),         // 53: walletrpc.BumpForceCloseFeeResponse
-	(*ListSweepsRequest)(nil),                 // 54: walletrpc.ListSweepsRequest
-	(*ListSweepsResponse)(nil),                // 55: walletrpc.ListSweepsResponse
-	(*LabelTransactionRequest)(nil),           // 56: walletrpc.LabelTransactionRequest
-	(*LabelTransactionResponse)(nil),          // 57: walletrpc.LabelTransactionResponse
-	(*FundPsbtRequest)(nil),                   // 58: walletrpc.FundPsbtRequest
-	(*FundPsbtResponse)(nil),                  // 59: walletrpc.FundPsbtResponse
-	(*TxTemplate)(nil),                        // 60: walletrpc.TxTemplate
-	(*PsbtCoinSelect)(nil),                    // 61: walletrpc.PsbtCoinSelect
-	(*UtxoLease)(nil),                         // 62: walletrpc.UtxoLease
-	(*SignPsbtRequest)(nil),                   // 63: walletrpc.SignPsbtRequest
-	(*SignPsbtResponse)(nil),                  // 64: walletrpc.SignPsbtResponse
-	(*FinalizePsbtRequest)(nil),               // 65: walletrpc.FinalizePsbtRequest
-	(*FinalizePsbtResponse)(nil),              // 66: walletrpc.FinalizePsbtResponse
-	(*ListLeasesRequest)(nil),                 // 67: walletrpc.ListLeasesRequest
-	(*ListLeasesResponse)(nil),                // 68: walletrpc.ListLeasesResponse
-	nil,                                       // 69: walletrpc.SubmitPackageResponse.TxResultsEntry
-	(*ListSweepsResponse_TransactionIDs)(nil), // 70: walletrpc.ListSweepsResponse.TransactionIDs
-	nil,                              // 71: walletrpc.TxTemplate.OutputsEntry
-	(*lnrpc.Utxo)(nil),               // 72: lnrpc.Utxo
-	(*lnrpc.OutPoint)(nil),           // 73: lnrpc.OutPoint
-	(*signrpc.TxOut)(nil),            // 74: signrpc.TxOut
-	(lnrpc.CoinSelectionStrategy)(0), // 75: lnrpc.CoinSelectionStrategy
-	(*lnrpc.ChannelPoint)(nil),       // 76: lnrpc.ChannelPoint
-	(*lnrpc.TransactionDetails)(nil), // 77: lnrpc.TransactionDetails
-	(*signrpc.KeyLocator)(nil),       // 78: signrpc.KeyLocator
-	(*signrpc.KeyDescriptor)(nil),    // 79: signrpc.KeyDescriptor
-	(*lnrpc.Transaction)(nil),        // 80: lnrpc.Transaction
+	(*RemoveAccountRequest)(nil),              // 30: walletrpc.RemoveAccountRequest
+	(*RemoveAccountResponse)(nil),             // 31: walletrpc.RemoveAccountResponse
+	(*ImportPublicKeyRequest)(nil),            // 32: walletrpc.ImportPublicKeyRequest
+	(*ImportPublicKeyResponse)(nil),           // 33: walletrpc.ImportPublicKeyResponse
+	(*ImportTapscriptRequest)(nil),            // 34: walletrpc.ImportTapscriptRequest
+	(*TapscriptFullTree)(nil),                 // 35: walletrpc.TapscriptFullTree
+	(*TapLeaf)(nil),                           // 36: walletrpc.TapLeaf
+	(*TapscriptPartialReveal)(nil),            // 37: walletrpc.TapscriptPartialReveal
+	(*ImportTapscriptResponse)(nil),           // 38: walletrpc.ImportTapscriptResponse
+	(*Transaction)(nil),                       // 39: walletrpc.Transaction
+	(*PublishResponse)(nil),                   // 40: walletrpc.PublishResponse
+	(*SubmitPackageRequest)(nil),              // 41: walletrpc.SubmitPackageRequest
+	(*SubmitPackageTxResult)(nil),             // 42: walletrpc.SubmitPackageTxResult
+	(*SubmitPackageResponse)(nil),             // 43: walletrpc.SubmitPackageResponse
+	(*RemoveTransactionResponse)(nil),         // 44: walletrpc.RemoveTransactionResponse
+	(*SendOutputsRequest)(nil),                // 45: walletrpc.SendOutputsRequest
+	(*SendOutputsResponse)(nil),               // 46: walletrpc.SendOutputsResponse
+	(*EstimateFeeRequest)(nil),                // 47: walletrpc.EstimateFeeRequest
+	(*EstimateFeeResponse)(nil),               // 48: walletrpc.EstimateFeeResponse
+	(*PendingSweep)(nil),                      // 49: walletrpc.PendingSweep
+	(*PendingSweepsRequest)(nil),              // 50: walletrpc.PendingSweepsRequest
+	(*PendingSweepsResponse)(nil),             // 51: walletrpc.PendingSweepsResponse
+	(*BumpFeeRequest)(nil),                    // 52: walletrpc.BumpFeeRequest
+	(*BumpFeeResponse)(nil),                   // 53: walletrpc.BumpFeeResponse
+	(*BumpForceCloseFeeRequest)(nil),          // 54: walletrpc.BumpForceCloseFeeRequest
+	(*BumpForceCloseFeeResponse)(nil),         // 55: walletrpc.BumpForceCloseFeeResponse
+	(*ListSweepsRequest)(nil),                 // 56: walletrpc.ListSweepsRequest
+	(*ListSweepsResponse)(nil),                // 57: walletrpc.ListSweepsResponse
+	(*LabelTransactionRequest)(nil),           // 58: walletrpc.LabelTransactionRequest
+	(*LabelTransactionResponse)(nil),          // 59: walletrpc.LabelTransactionResponse
+	(*FundPsbtRequest)(nil),                   // 60: walletrpc.FundPsbtRequest
+	(*FundPsbtResponse)(nil),                  // 61: walletrpc.FundPsbtResponse
+	(*TxTemplate)(nil),                        // 62: walletrpc.TxTemplate
+	(*PsbtCoinSelect)(nil),                    // 63: walletrpc.PsbtCoinSelect
+	(*UtxoLease)(nil),                         // 64: walletrpc.UtxoLease
+	(*SignPsbtRequest)(nil),                   // 65: walletrpc.SignPsbtRequest
+	(*SignPsbtResponse)(nil),                  // 66: walletrpc.SignPsbtResponse
+	(*FinalizePsbtRequest)(nil),               // 67: walletrpc.FinalizePsbtRequest
+	(*FinalizePsbtResponse)(nil),              // 68: walletrpc.FinalizePsbtResponse
+	(*ListLeasesRequest)(nil),                 // 69: walletrpc.ListLeasesRequest
+	(*ListLeasesResponse)(nil),                // 70: walletrpc.ListLeasesResponse
+	nil,                                       // 71: walletrpc.SubmitPackageResponse.TxResultsEntry
+	(*ListSweepsResponse_TransactionIDs)(nil), // 72: walletrpc.ListSweepsResponse.TransactionIDs
+	nil,                              // 73: walletrpc.TxTemplate.OutputsEntry
+	(*lnrpc.Utxo)(nil),               // 74: lnrpc.Utxo
+	(*lnrpc.OutPoint)(nil),           // 75: lnrpc.OutPoint
+	(*signrpc.TxOut)(nil),            // 76: signrpc.TxOut
+	(lnrpc.CoinSelectionStrategy)(0), // 77: lnrpc.CoinSelectionStrategy
+	(*lnrpc.ChannelPoint)(nil),       // 78: lnrpc.ChannelPoint
+	(*lnrpc.TransactionDetails)(nil), // 79: lnrpc.TransactionDetails
+	(*signrpc.KeyLocator)(nil),       // 80: signrpc.KeyLocator
+	(*signrpc.KeyDescriptor)(nil),    // 81: signrpc.KeyDescriptor
+	(*lnrpc.Transaction)(nil),        // 82: lnrpc.Transaction
 }
 var file_walletrpc_walletkit_proto_depIdxs = []int32{
-	72, // 0: walletrpc.ListUnspentResponse.utxos:type_name -> lnrpc.Utxo
-	73, // 1: walletrpc.LeaseOutputRequest.outpoint:type_name -> lnrpc.OutPoint
-	73, // 2: walletrpc.ReleaseOutputRequest.outpoint:type_name -> lnrpc.OutPoint
+	74, // 0: walletrpc.ListUnspentResponse.utxos:type_name -> lnrpc.Utxo
+	75, // 1: walletrpc.LeaseOutputRequest.outpoint:type_name -> lnrpc.OutPoint
+	75, // 2: walletrpc.ReleaseOutputRequest.outpoint:type_name -> lnrpc.OutPoint
 	0,  // 3: walletrpc.AddrRequest.type:type_name -> walletrpc.AddressType
 	0,  // 4: walletrpc.Account.address_type:type_name -> walletrpc.AddressType
 	0,  // 5: walletrpc.AccountWithAddresses.address_type:type_name -> walletrpc.AddressType
@@ -5327,96 +5438,100 @@ var file_walletrpc_walletkit_proto_depIdxs = []int32{
 	14, // 11: walletrpc.ListAddressesResponse.account_with_addresses:type_name -> walletrpc.AccountWithAddresses
 	0,  // 12: walletrpc.ImportAccountRequest.address_type:type_name -> walletrpc.AddressType
 	12, // 13: walletrpc.ImportAccountResponse.account:type_name -> walletrpc.Account
-	0,  // 14: walletrpc.ImportPublicKeyRequest.address_type:type_name -> walletrpc.AddressType
-	33, // 15: walletrpc.ImportTapscriptRequest.full_tree:type_name -> walletrpc.TapscriptFullTree
-	35, // 16: walletrpc.ImportTapscriptRequest.partial_reveal:type_name -> walletrpc.TapscriptPartialReveal
-	34, // 17: walletrpc.TapscriptFullTree.all_leaves:type_name -> walletrpc.TapLeaf
-	34, // 18: walletrpc.TapscriptPartialReveal.revealed_leaf:type_name -> walletrpc.TapLeaf
-	69, // 19: walletrpc.SubmitPackageResponse.tx_results:type_name -> walletrpc.SubmitPackageResponse.TxResultsEntry
-	74, // 20: walletrpc.SendOutputsRequest.outputs:type_name -> signrpc.TxOut
-	75, // 21: walletrpc.SendOutputsRequest.coin_selection_strategy:type_name -> lnrpc.CoinSelectionStrategy
-	73, // 22: walletrpc.PendingSweep.outpoint:type_name -> lnrpc.OutPoint
-	1,  // 23: walletrpc.PendingSweep.witness_type:type_name -> walletrpc.WitnessType
-	47, // 24: walletrpc.PendingSweepsResponse.pending_sweeps:type_name -> walletrpc.PendingSweep
-	73, // 25: walletrpc.BumpFeeRequest.outpoint:type_name -> lnrpc.OutPoint
-	76, // 26: walletrpc.BumpForceCloseFeeRequest.chan_point:type_name -> lnrpc.ChannelPoint
-	77, // 27: walletrpc.ListSweepsResponse.transaction_details:type_name -> lnrpc.TransactionDetails
-	70, // 28: walletrpc.ListSweepsResponse.transaction_ids:type_name -> walletrpc.ListSweepsResponse.TransactionIDs
-	60, // 29: walletrpc.FundPsbtRequest.raw:type_name -> walletrpc.TxTemplate
-	61, // 30: walletrpc.FundPsbtRequest.coin_select:type_name -> walletrpc.PsbtCoinSelect
-	2,  // 31: walletrpc.FundPsbtRequest.change_type:type_name -> walletrpc.ChangeAddressType
-	75, // 32: walletrpc.FundPsbtRequest.coin_selection_strategy:type_name -> lnrpc.CoinSelectionStrategy
-	62, // 33: walletrpc.FundPsbtResponse.locked_utxos:type_name -> walletrpc.UtxoLease
-	73, // 34: walletrpc.TxTemplate.inputs:type_name -> lnrpc.OutPoint
-	71, // 35: walletrpc.TxTemplate.outputs:type_name -> walletrpc.TxTemplate.OutputsEntry
-	73, // 36: walletrpc.UtxoLease.outpoint:type_name -> lnrpc.OutPoint
-	62, // 37: walletrpc.ListLeasesResponse.locked_utxos:type_name -> walletrpc.UtxoLease
-	40, // 38: walletrpc.SubmitPackageResponse.TxResultsEntry.value:type_name -> walletrpc.SubmitPackageTxResult
-	3,  // 39: walletrpc.WalletKit.ListUnspent:input_type -> walletrpc.ListUnspentRequest
-	5,  // 40: walletrpc.WalletKit.LeaseOutput:input_type -> walletrpc.LeaseOutputRequest
-	7,  // 41: walletrpc.WalletKit.ReleaseOutput:input_type -> walletrpc.ReleaseOutputRequest
-	67, // 42: walletrpc.WalletKit.ListLeases:input_type -> walletrpc.ListLeasesRequest
-	9,  // 43: walletrpc.WalletKit.DeriveNextKey:input_type -> walletrpc.KeyReq
-	78, // 44: walletrpc.WalletKit.DeriveKey:input_type -> signrpc.KeyLocator
-	10, // 45: walletrpc.WalletKit.NextAddr:input_type -> walletrpc.AddrRequest
-	23, // 46: walletrpc.WalletKit.GetTransaction:input_type -> walletrpc.GetTransactionRequest
-	15, // 47: walletrpc.WalletKit.ListAccounts:input_type -> walletrpc.ListAccountsRequest
-	17, // 48: walletrpc.WalletKit.XCreateAccount:input_type -> walletrpc.XCreateAccountRequest
-	19, // 49: walletrpc.WalletKit.RequiredReserve:input_type -> walletrpc.RequiredReserveRequest
-	21, // 50: walletrpc.WalletKit.ListAddresses:input_type -> walletrpc.ListAddressesRequest
-	24, // 51: walletrpc.WalletKit.SignMessageWithAddr:input_type -> walletrpc.SignMessageWithAddrRequest
-	26, // 52: walletrpc.WalletKit.VerifyMessageWithAddr:input_type -> walletrpc.VerifyMessageWithAddrRequest
-	28, // 53: walletrpc.WalletKit.ImportAccount:input_type -> walletrpc.ImportAccountRequest
-	30, // 54: walletrpc.WalletKit.ImportPublicKey:input_type -> walletrpc.ImportPublicKeyRequest
-	32, // 55: walletrpc.WalletKit.ImportTapscript:input_type -> walletrpc.ImportTapscriptRequest
-	37, // 56: walletrpc.WalletKit.PublishTransaction:input_type -> walletrpc.Transaction
-	39, // 57: walletrpc.WalletKit.SubmitPackage:input_type -> walletrpc.SubmitPackageRequest
-	23, // 58: walletrpc.WalletKit.RemoveTransaction:input_type -> walletrpc.GetTransactionRequest
-	43, // 59: walletrpc.WalletKit.SendOutputs:input_type -> walletrpc.SendOutputsRequest
-	45, // 60: walletrpc.WalletKit.EstimateFee:input_type -> walletrpc.EstimateFeeRequest
-	48, // 61: walletrpc.WalletKit.PendingSweeps:input_type -> walletrpc.PendingSweepsRequest
-	50, // 62: walletrpc.WalletKit.BumpFee:input_type -> walletrpc.BumpFeeRequest
-	52, // 63: walletrpc.WalletKit.BumpForceCloseFee:input_type -> walletrpc.BumpForceCloseFeeRequest
-	54, // 64: walletrpc.WalletKit.ListSweeps:input_type -> walletrpc.ListSweepsRequest
-	56, // 65: walletrpc.WalletKit.LabelTransaction:input_type -> walletrpc.LabelTransactionRequest
-	58, // 66: walletrpc.WalletKit.FundPsbt:input_type -> walletrpc.FundPsbtRequest
-	63, // 67: walletrpc.WalletKit.SignPsbt:input_type -> walletrpc.SignPsbtRequest
-	65, // 68: walletrpc.WalletKit.FinalizePsbt:input_type -> walletrpc.FinalizePsbtRequest
-	4,  // 69: walletrpc.WalletKit.ListUnspent:output_type -> walletrpc.ListUnspentResponse
-	6,  // 70: walletrpc.WalletKit.LeaseOutput:output_type -> walletrpc.LeaseOutputResponse
-	8,  // 71: walletrpc.WalletKit.ReleaseOutput:output_type -> walletrpc.ReleaseOutputResponse
-	68, // 72: walletrpc.WalletKit.ListLeases:output_type -> walletrpc.ListLeasesResponse
-	79, // 73: walletrpc.WalletKit.DeriveNextKey:output_type -> signrpc.KeyDescriptor
-	79, // 74: walletrpc.WalletKit.DeriveKey:output_type -> signrpc.KeyDescriptor
-	11, // 75: walletrpc.WalletKit.NextAddr:output_type -> walletrpc.AddrResponse
-	80, // 76: walletrpc.WalletKit.GetTransaction:output_type -> lnrpc.Transaction
-	16, // 77: walletrpc.WalletKit.ListAccounts:output_type -> walletrpc.ListAccountsResponse
-	18, // 78: walletrpc.WalletKit.XCreateAccount:output_type -> walletrpc.XCreateAccountResponse
-	20, // 79: walletrpc.WalletKit.RequiredReserve:output_type -> walletrpc.RequiredReserveResponse
-	22, // 80: walletrpc.WalletKit.ListAddresses:output_type -> walletrpc.ListAddressesResponse
-	25, // 81: walletrpc.WalletKit.SignMessageWithAddr:output_type -> walletrpc.SignMessageWithAddrResponse
-	27, // 82: walletrpc.WalletKit.VerifyMessageWithAddr:output_type -> walletrpc.VerifyMessageWithAddrResponse
-	29, // 83: walletrpc.WalletKit.ImportAccount:output_type -> walletrpc.ImportAccountResponse
-	31, // 84: walletrpc.WalletKit.ImportPublicKey:output_type -> walletrpc.ImportPublicKeyResponse
-	36, // 85: walletrpc.WalletKit.ImportTapscript:output_type -> walletrpc.ImportTapscriptResponse
-	38, // 86: walletrpc.WalletKit.PublishTransaction:output_type -> walletrpc.PublishResponse
-	41, // 87: walletrpc.WalletKit.SubmitPackage:output_type -> walletrpc.SubmitPackageResponse
-	42, // 88: walletrpc.WalletKit.RemoveTransaction:output_type -> walletrpc.RemoveTransactionResponse
-	44, // 89: walletrpc.WalletKit.SendOutputs:output_type -> walletrpc.SendOutputsResponse
-	46, // 90: walletrpc.WalletKit.EstimateFee:output_type -> walletrpc.EstimateFeeResponse
-	49, // 91: walletrpc.WalletKit.PendingSweeps:output_type -> walletrpc.PendingSweepsResponse
-	51, // 92: walletrpc.WalletKit.BumpFee:output_type -> walletrpc.BumpFeeResponse
-	53, // 93: walletrpc.WalletKit.BumpForceCloseFee:output_type -> walletrpc.BumpForceCloseFeeResponse
-	55, // 94: walletrpc.WalletKit.ListSweeps:output_type -> walletrpc.ListSweepsResponse
-	57, // 95: walletrpc.WalletKit.LabelTransaction:output_type -> walletrpc.LabelTransactionResponse
-	59, // 96: walletrpc.WalletKit.FundPsbt:output_type -> walletrpc.FundPsbtResponse
-	64, // 97: walletrpc.WalletKit.SignPsbt:output_type -> walletrpc.SignPsbtResponse
-	66, // 98: walletrpc.WalletKit.FinalizePsbt:output_type -> walletrpc.FinalizePsbtResponse
-	69, // [69:99] is the sub-list for method output_type
-	39, // [39:69] is the sub-list for method input_type
-	39, // [39:39] is the sub-list for extension type_name
-	39, // [39:39] is the sub-list for extension extendee
-	0,  // [0:39] is the sub-list for field type_name
+	0,  // 14: walletrpc.RemoveAccountRequest.address_type:type_name -> walletrpc.AddressType
+	12, // 15: walletrpc.RemoveAccountResponse.account:type_name -> walletrpc.Account
+	0,  // 16: walletrpc.ImportPublicKeyRequest.address_type:type_name -> walletrpc.AddressType
+	35, // 17: walletrpc.ImportTapscriptRequest.full_tree:type_name -> walletrpc.TapscriptFullTree
+	37, // 18: walletrpc.ImportTapscriptRequest.partial_reveal:type_name -> walletrpc.TapscriptPartialReveal
+	36, // 19: walletrpc.TapscriptFullTree.all_leaves:type_name -> walletrpc.TapLeaf
+	36, // 20: walletrpc.TapscriptPartialReveal.revealed_leaf:type_name -> walletrpc.TapLeaf
+	71, // 21: walletrpc.SubmitPackageResponse.tx_results:type_name -> walletrpc.SubmitPackageResponse.TxResultsEntry
+	76, // 22: walletrpc.SendOutputsRequest.outputs:type_name -> signrpc.TxOut
+	77, // 23: walletrpc.SendOutputsRequest.coin_selection_strategy:type_name -> lnrpc.CoinSelectionStrategy
+	75, // 24: walletrpc.PendingSweep.outpoint:type_name -> lnrpc.OutPoint
+	1,  // 25: walletrpc.PendingSweep.witness_type:type_name -> walletrpc.WitnessType
+	49, // 26: walletrpc.PendingSweepsResponse.pending_sweeps:type_name -> walletrpc.PendingSweep
+	75, // 27: walletrpc.BumpFeeRequest.outpoint:type_name -> lnrpc.OutPoint
+	78, // 28: walletrpc.BumpForceCloseFeeRequest.chan_point:type_name -> lnrpc.ChannelPoint
+	79, // 29: walletrpc.ListSweepsResponse.transaction_details:type_name -> lnrpc.TransactionDetails
+	72, // 30: walletrpc.ListSweepsResponse.transaction_ids:type_name -> walletrpc.ListSweepsResponse.TransactionIDs
+	62, // 31: walletrpc.FundPsbtRequest.raw:type_name -> walletrpc.TxTemplate
+	63, // 32: walletrpc.FundPsbtRequest.coin_select:type_name -> walletrpc.PsbtCoinSelect
+	2,  // 33: walletrpc.FundPsbtRequest.change_type:type_name -> walletrpc.ChangeAddressType
+	77, // 34: walletrpc.FundPsbtRequest.coin_selection_strategy:type_name -> lnrpc.CoinSelectionStrategy
+	64, // 35: walletrpc.FundPsbtResponse.locked_utxos:type_name -> walletrpc.UtxoLease
+	75, // 36: walletrpc.TxTemplate.inputs:type_name -> lnrpc.OutPoint
+	73, // 37: walletrpc.TxTemplate.outputs:type_name -> walletrpc.TxTemplate.OutputsEntry
+	75, // 38: walletrpc.UtxoLease.outpoint:type_name -> lnrpc.OutPoint
+	64, // 39: walletrpc.ListLeasesResponse.locked_utxos:type_name -> walletrpc.UtxoLease
+	42, // 40: walletrpc.SubmitPackageResponse.TxResultsEntry.value:type_name -> walletrpc.SubmitPackageTxResult
+	3,  // 41: walletrpc.WalletKit.ListUnspent:input_type -> walletrpc.ListUnspentRequest
+	5,  // 42: walletrpc.WalletKit.LeaseOutput:input_type -> walletrpc.LeaseOutputRequest
+	7,  // 43: walletrpc.WalletKit.ReleaseOutput:input_type -> walletrpc.ReleaseOutputRequest
+	69, // 44: walletrpc.WalletKit.ListLeases:input_type -> walletrpc.ListLeasesRequest
+	9,  // 45: walletrpc.WalletKit.DeriveNextKey:input_type -> walletrpc.KeyReq
+	80, // 46: walletrpc.WalletKit.DeriveKey:input_type -> signrpc.KeyLocator
+	10, // 47: walletrpc.WalletKit.NextAddr:input_type -> walletrpc.AddrRequest
+	23, // 48: walletrpc.WalletKit.GetTransaction:input_type -> walletrpc.GetTransactionRequest
+	15, // 49: walletrpc.WalletKit.ListAccounts:input_type -> walletrpc.ListAccountsRequest
+	17, // 50: walletrpc.WalletKit.XCreateAccount:input_type -> walletrpc.XCreateAccountRequest
+	19, // 51: walletrpc.WalletKit.RequiredReserve:input_type -> walletrpc.RequiredReserveRequest
+	21, // 52: walletrpc.WalletKit.ListAddresses:input_type -> walletrpc.ListAddressesRequest
+	24, // 53: walletrpc.WalletKit.SignMessageWithAddr:input_type -> walletrpc.SignMessageWithAddrRequest
+	26, // 54: walletrpc.WalletKit.VerifyMessageWithAddr:input_type -> walletrpc.VerifyMessageWithAddrRequest
+	28, // 55: walletrpc.WalletKit.ImportAccount:input_type -> walletrpc.ImportAccountRequest
+	30, // 56: walletrpc.WalletKit.RemoveAccount:input_type -> walletrpc.RemoveAccountRequest
+	32, // 57: walletrpc.WalletKit.ImportPublicKey:input_type -> walletrpc.ImportPublicKeyRequest
+	34, // 58: walletrpc.WalletKit.ImportTapscript:input_type -> walletrpc.ImportTapscriptRequest
+	39, // 59: walletrpc.WalletKit.PublishTransaction:input_type -> walletrpc.Transaction
+	41, // 60: walletrpc.WalletKit.SubmitPackage:input_type -> walletrpc.SubmitPackageRequest
+	23, // 61: walletrpc.WalletKit.RemoveTransaction:input_type -> walletrpc.GetTransactionRequest
+	45, // 62: walletrpc.WalletKit.SendOutputs:input_type -> walletrpc.SendOutputsRequest
+	47, // 63: walletrpc.WalletKit.EstimateFee:input_type -> walletrpc.EstimateFeeRequest
+	50, // 64: walletrpc.WalletKit.PendingSweeps:input_type -> walletrpc.PendingSweepsRequest
+	52, // 65: walletrpc.WalletKit.BumpFee:input_type -> walletrpc.BumpFeeRequest
+	54, // 66: walletrpc.WalletKit.BumpForceCloseFee:input_type -> walletrpc.BumpForceCloseFeeRequest
+	56, // 67: walletrpc.WalletKit.ListSweeps:input_type -> walletrpc.ListSweepsRequest
+	58, // 68: walletrpc.WalletKit.LabelTransaction:input_type -> walletrpc.LabelTransactionRequest
+	60, // 69: walletrpc.WalletKit.FundPsbt:input_type -> walletrpc.FundPsbtRequest
+	65, // 70: walletrpc.WalletKit.SignPsbt:input_type -> walletrpc.SignPsbtRequest
+	67, // 71: walletrpc.WalletKit.FinalizePsbt:input_type -> walletrpc.FinalizePsbtRequest
+	4,  // 72: walletrpc.WalletKit.ListUnspent:output_type -> walletrpc.ListUnspentResponse
+	6,  // 73: walletrpc.WalletKit.LeaseOutput:output_type -> walletrpc.LeaseOutputResponse
+	8,  // 74: walletrpc.WalletKit.ReleaseOutput:output_type -> walletrpc.ReleaseOutputResponse
+	70, // 75: walletrpc.WalletKit.ListLeases:output_type -> walletrpc.ListLeasesResponse
+	81, // 76: walletrpc.WalletKit.DeriveNextKey:output_type -> signrpc.KeyDescriptor
+	81, // 77: walletrpc.WalletKit.DeriveKey:output_type -> signrpc.KeyDescriptor
+	11, // 78: walletrpc.WalletKit.NextAddr:output_type -> walletrpc.AddrResponse
+	82, // 79: walletrpc.WalletKit.GetTransaction:output_type -> lnrpc.Transaction
+	16, // 80: walletrpc.WalletKit.ListAccounts:output_type -> walletrpc.ListAccountsResponse
+	18, // 81: walletrpc.WalletKit.XCreateAccount:output_type -> walletrpc.XCreateAccountResponse
+	20, // 82: walletrpc.WalletKit.RequiredReserve:output_type -> walletrpc.RequiredReserveResponse
+	22, // 83: walletrpc.WalletKit.ListAddresses:output_type -> walletrpc.ListAddressesResponse
+	25, // 84: walletrpc.WalletKit.SignMessageWithAddr:output_type -> walletrpc.SignMessageWithAddrResponse
+	27, // 85: walletrpc.WalletKit.VerifyMessageWithAddr:output_type -> walletrpc.VerifyMessageWithAddrResponse
+	29, // 86: walletrpc.WalletKit.ImportAccount:output_type -> walletrpc.ImportAccountResponse
+	31, // 87: walletrpc.WalletKit.RemoveAccount:output_type -> walletrpc.RemoveAccountResponse
+	33, // 88: walletrpc.WalletKit.ImportPublicKey:output_type -> walletrpc.ImportPublicKeyResponse
+	38, // 89: walletrpc.WalletKit.ImportTapscript:output_type -> walletrpc.ImportTapscriptResponse
+	40, // 90: walletrpc.WalletKit.PublishTransaction:output_type -> walletrpc.PublishResponse
+	43, // 91: walletrpc.WalletKit.SubmitPackage:output_type -> walletrpc.SubmitPackageResponse
+	44, // 92: walletrpc.WalletKit.RemoveTransaction:output_type -> walletrpc.RemoveTransactionResponse
+	46, // 93: walletrpc.WalletKit.SendOutputs:output_type -> walletrpc.SendOutputsResponse
+	48, // 94: walletrpc.WalletKit.EstimateFee:output_type -> walletrpc.EstimateFeeResponse
+	51, // 95: walletrpc.WalletKit.PendingSweeps:output_type -> walletrpc.PendingSweepsResponse
+	53, // 96: walletrpc.WalletKit.BumpFee:output_type -> walletrpc.BumpFeeResponse
+	55, // 97: walletrpc.WalletKit.BumpForceCloseFee:output_type -> walletrpc.BumpForceCloseFeeResponse
+	57, // 98: walletrpc.WalletKit.ListSweeps:output_type -> walletrpc.ListSweepsResponse
+	59, // 99: walletrpc.WalletKit.LabelTransaction:output_type -> walletrpc.LabelTransactionResponse
+	61, // 100: walletrpc.WalletKit.FundPsbt:output_type -> walletrpc.FundPsbtResponse
+	66, // 101: walletrpc.WalletKit.SignPsbt:output_type -> walletrpc.SignPsbtResponse
+	68, // 102: walletrpc.WalletKit.FinalizePsbt:output_type -> walletrpc.FinalizePsbtResponse
+	72, // [72:103] is the sub-list for method output_type
+	41, // [41:72] is the sub-list for method input_type
+	41, // [41:41] is the sub-list for extension type_name
+	41, // [41:41] is the sub-list for extension extendee
+	0,  // [0:41] is the sub-list for field type_name
 }
 
 func init() { file_walletrpc_walletkit_proto_init() }
@@ -5424,18 +5539,18 @@ func file_walletrpc_walletkit_proto_init() {
 	if File_walletrpc_walletkit_proto != nil {
 		return
 	}
-	file_walletrpc_walletkit_proto_msgTypes[29].OneofWrappers = []any{
+	file_walletrpc_walletkit_proto_msgTypes[31].OneofWrappers = []any{
 		(*ImportTapscriptRequest_FullTree)(nil),
 		(*ImportTapscriptRequest_PartialReveal)(nil),
 		(*ImportTapscriptRequest_RootHashOnly)(nil),
 		(*ImportTapscriptRequest_FullKeyOnly)(nil),
 	}
-	file_walletrpc_walletkit_proto_msgTypes[36].OneofWrappers = []any{}
-	file_walletrpc_walletkit_proto_msgTypes[52].OneofWrappers = []any{
+	file_walletrpc_walletkit_proto_msgTypes[38].OneofWrappers = []any{}
+	file_walletrpc_walletkit_proto_msgTypes[54].OneofWrappers = []any{
 		(*ListSweepsResponse_TransactionDetails)(nil),
 		(*ListSweepsResponse_TransactionIds)(nil),
 	}
-	file_walletrpc_walletkit_proto_msgTypes[55].OneofWrappers = []any{
+	file_walletrpc_walletkit_proto_msgTypes[57].OneofWrappers = []any{
 		(*FundPsbtRequest_Psbt)(nil),
 		(*FundPsbtRequest_Raw)(nil),
 		(*FundPsbtRequest_CoinSelect)(nil),
@@ -5443,7 +5558,7 @@ func file_walletrpc_walletkit_proto_init() {
 		(*FundPsbtRequest_SatPerVbyte)(nil),
 		(*FundPsbtRequest_SatPerKw)(nil),
 	}
-	file_walletrpc_walletkit_proto_msgTypes[58].OneofWrappers = []any{
+	file_walletrpc_walletkit_proto_msgTypes[60].OneofWrappers = []any{
 		(*PsbtCoinSelect_ExistingOutputIndex)(nil),
 		(*PsbtCoinSelect_Add)(nil),
 	}
@@ -5453,7 +5568,7 @@ func file_walletrpc_walletkit_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_walletrpc_walletkit_proto_rawDesc), len(file_walletrpc_walletkit_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   69,
+			NumMessages:   71,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/lnrpc/walletrpc/walletkit.pb.gw.go
+++ b/lnrpc/walletrpc/walletkit.pb.gw.go
@@ -534,6 +534,40 @@ func local_request_WalletKit_ImportAccount_0(ctx context.Context, marshaler runt
 
 }
 
+func request_WalletKit_RemoveAccount_0(ctx context.Context, marshaler runtime.Marshaler, client WalletKitClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq RemoveAccountRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.RemoveAccount(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_WalletKit_RemoveAccount_0(ctx context.Context, marshaler runtime.Marshaler, server WalletKitServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq RemoveAccountRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.RemoveAccount(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 func request_WalletKit_ImportPublicKey_0(ctx context.Context, marshaler runtime.Marshaler, client WalletKitClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq ImportPublicKeyRequest
 	var metadata runtime.ServerMetadata
@@ -1429,6 +1463,31 @@ func RegisterWalletKitHandlerServer(ctx context.Context, mux *runtime.ServeMux, 
 
 	})
 
+	mux.Handle("POST", pattern_WalletKit_RemoveAccount_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/walletrpc.WalletKit/RemoveAccount", runtime.WithHTTPPathPattern("/v2/wallet/accounts/remove"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_WalletKit_RemoveAccount_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_WalletKit_RemoveAccount_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	mux.Handle("POST", pattern_WalletKit_ImportPublicKey_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2175,6 +2234,28 @@ func RegisterWalletKitHandlerClient(ctx context.Context, mux *runtime.ServeMux, 
 
 	})
 
+	mux.Handle("POST", pattern_WalletKit_RemoveAccount_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/walletrpc.WalletKit/RemoveAccount", runtime.WithHTTPPathPattern("/v2/wallet/accounts/remove"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_WalletKit_RemoveAccount_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_WalletKit_RemoveAccount_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	mux.Handle("POST", pattern_WalletKit_ImportPublicKey_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2539,6 +2620,8 @@ var (
 
 	pattern_WalletKit_ImportAccount_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v2", "wallet", "accounts", "import"}, ""))
 
+	pattern_WalletKit_RemoveAccount_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v2", "wallet", "accounts", "remove"}, ""))
+
 	pattern_WalletKit_ImportPublicKey_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v2", "wallet", "key", "import"}, ""))
 
 	pattern_WalletKit_ImportTapscript_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v2", "wallet", "tapscript", "import"}, ""))
@@ -2600,6 +2683,8 @@ var (
 	forward_WalletKit_VerifyMessageWithAddr_0 = runtime.ForwardResponseMessage
 
 	forward_WalletKit_ImportAccount_0 = runtime.ForwardResponseMessage
+
+	forward_WalletKit_RemoveAccount_0 = runtime.ForwardResponseMessage
 
 	forward_WalletKit_ImportPublicKey_0 = runtime.ForwardResponseMessage
 

--- a/lnrpc/walletrpc/walletkit.pb.json.go
+++ b/lnrpc/walletrpc/walletkit.pb.json.go
@@ -397,6 +397,31 @@ func RegisterWalletKitJSONCallbacks(registry map[string]func(ctx context.Context
 		callback(string(respBytes), nil)
 	}
 
+	registry["walletrpc.WalletKit.RemoveAccount"] = func(ctx context.Context,
+		conn *grpc.ClientConn, reqJSON string, callback func(string, error)) {
+
+		req := &RemoveAccountRequest{}
+		err := marshaler.Unmarshal([]byte(reqJSON), req)
+		if err != nil {
+			callback("", err)
+			return
+		}
+
+		client := NewWalletKitClient(conn)
+		resp, err := client.RemoveAccount(ctx, req)
+		if err != nil {
+			callback("", err)
+			return
+		}
+
+		respBytes, err := marshaler.Marshal(resp)
+		if err != nil {
+			callback("", err)
+			return
+		}
+		callback(string(respBytes), nil)
+	}
+
 	registry["walletrpc.WalletKit.ImportPublicKey"] = func(ctx context.Context,
 		conn *grpc.ClientConn, reqJSON string, callback func(string, error)) {
 

--- a/lnrpc/walletrpc/walletkit.proto
+++ b/lnrpc/walletrpc/walletkit.proto
@@ -227,6 +227,24 @@ service WalletKit {
     */
     rpc ImportAccount (ImportAccountRequest) returns (ImportAccountResponse);
 
+    /* lncli: `wallet accounts remove`
+    RemoveAccount removes a watch-only account that was previously imported
+    via ImportAccount, along with all addresses derived from it.
+
+    Only accounts imported through ImportAccount can be removed; the wallet's
+    reserved "default" and "imported" accounts, and accounts owned by the
+    wallet itself, are refused.
+
+    NOTE: Removal is allowed even if the account still holds a balance. The
+    wallet simply stops tracking the account's addresses: its balance and
+    UTXOs disappear from the wallet's view and later deposits to its addresses
+    are not detected. The funds themselves are not moved or lost — whoever
+    holds the account's keys retains full control, and re-importing the same
+    extended public key (followed by a rescan once supported) restores
+    tracking.
+    */
+    rpc RemoveAccount (RemoveAccountRequest) returns (RemoveAccountResponse);
+
     /* lncli: `wallet accounts import-pubkey`
     ImportPublicKey imports a public key as watch-only into the wallet. The
     public key is converted into a simple address of the given type and that
@@ -796,6 +814,24 @@ message ImportAccountResponse {
     returned if a dry run was specified within the request.
     */
     repeated string dry_run_internal_addrs = 3;
+}
+
+message RemoveAccountRequest {
+    // The name of the account to remove.
+    string name = 1;
+
+    /*
+    An optional address type used to resolve which key scope the account lives
+    in. Account names are normally unique across all key scopes, so this can
+    usually be left unset; it is only required if the same name exists under
+    more than one key scope, which is possible on wallets created before
+    uniqueness was enforced.
+    */
+    AddressType address_type = 2;
+}
+message RemoveAccountResponse {
+    // The properties of the account that was removed.
+    Account account = 1;
 }
 
 message ImportPublicKeyRequest {

--- a/lnrpc/walletrpc/walletkit.swagger.json
+++ b/lnrpc/walletrpc/walletkit.swagger.json
@@ -164,6 +164,40 @@
         ]
       }
     },
+    "/v2/wallet/accounts/remove": {
+      "post": {
+        "summary": "lncli: `wallet accounts remove`\nRemoveAccount removes a watch-only account that was previously imported\nvia ImportAccount, along with all addresses derived from it.",
+        "description": "Only accounts imported through ImportAccount can be removed; the wallet's\nreserved \"default\" and \"imported\" accounts, and accounts owned by the\nwallet itself, are refused.\n\nNOTE: Removal is allowed even if the account still holds a balance. The\nwallet simply stops tracking the account's addresses: its balance and\nUTXOs disappear from the wallet's view and later deposits to its addresses\nare not detected. The funds themselves are not moved or lost — whoever\nholds the account's keys retains full control, and re-importing the same\nextended public key (followed by a rescan once supported) restores\ntracking.",
+        "operationId": "WalletKit_RemoveAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/walletrpcRemoveAccountResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/walletrpcRemoveAccountRequest"
+            }
+          }
+        ],
+        "tags": [
+          "WalletKit"
+        ]
+      }
+    },
     "/v2/wallet/address/next": {
       "post": {
         "summary": "NextAddr returns the next unused address within the wallet.",
@@ -2129,6 +2163,28 @@
         "status": {
           "type": "string",
           "description": "The status of the release operation."
+        }
+      }
+    },
+    "walletrpcRemoveAccountRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the account to remove."
+        },
+        "address_type": {
+          "$ref": "#/definitions/walletrpcAddressType",
+          "description": "An optional address type used to resolve which key scope the account lives\nin. Account names are normally unique across all key scopes, so this can\nusually be left unset; it is only required if the same name exists under\nmore than one key scope, which is possible on wallets created before\nuniqueness was enforced."
+        }
+      }
+    },
+    "walletrpcRemoveAccountResponse": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/walletrpcAccount",
+          "description": "The properties of the account that was removed."
         }
       }
     },

--- a/lnrpc/walletrpc/walletkit.yaml
+++ b/lnrpc/walletrpc/walletkit.yaml
@@ -73,6 +73,9 @@ http:
     - selector: walletrpc.WalletKit.ImportAccount
       post: "/v2/wallet/accounts/import"
       body: "*"
+    - selector: walletrpc.WalletKit.RemoveAccount
+      post: "/v2/wallet/accounts/remove"
+      body: "*"
     - selector: walletrpc.WalletKit.SignMessageWithAddr
       post: "/v2/wallet/address/signmessage"
       body: "*"

--- a/lnrpc/walletrpc/walletkit_grpc.pb.go
+++ b/lnrpc/walletrpc/walletkit_grpc.pb.go
@@ -182,6 +182,22 @@ type WalletKitClient interface {
 	// detected by lnd if they happen after the import. Rescans to detect past
 	// events will be supported later on.
 	ImportAccount(ctx context.Context, in *ImportAccountRequest, opts ...grpc.CallOption) (*ImportAccountResponse, error)
+	// lncli: `wallet accounts remove`
+	// RemoveAccount removes a watch-only account that was previously imported
+	// via ImportAccount, along with all addresses derived from it.
+	//
+	// Only accounts imported through ImportAccount can be removed; the wallet's
+	// reserved "default" and "imported" accounts, and accounts owned by the
+	// wallet itself, are refused.
+	//
+	// NOTE: Removal is allowed even if the account still holds a balance. The
+	// wallet simply stops tracking the account's addresses: its balance and
+	// UTXOs disappear from the wallet's view and later deposits to its addresses
+	// are not detected. The funds themselves are not moved or lost — whoever
+	// holds the account's keys retains full control, and re-importing the same
+	// extended public key (followed by a rescan once supported) restores
+	// tracking.
+	RemoveAccount(ctx context.Context, in *RemoveAccountRequest, opts ...grpc.CallOption) (*RemoveAccountResponse, error)
 	// lncli: `wallet accounts import-pubkey`
 	// ImportPublicKey imports a public key as watch-only into the wallet. The
 	// public key is converted into a simple address of the given type and that
@@ -492,6 +508,15 @@ func (c *walletKitClient) ImportAccount(ctx context.Context, in *ImportAccountRe
 	return out, nil
 }
 
+func (c *walletKitClient) RemoveAccount(ctx context.Context, in *RemoveAccountRequest, opts ...grpc.CallOption) (*RemoveAccountResponse, error) {
+	out := new(RemoveAccountResponse)
+	err := c.cc.Invoke(ctx, "/walletrpc.WalletKit/RemoveAccount", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *walletKitClient) ImportPublicKey(ctx context.Context, in *ImportPublicKeyRequest, opts ...grpc.CallOption) (*ImportPublicKeyResponse, error) {
 	out := new(ImportPublicKeyResponse)
 	err := c.cc.Invoke(ctx, "/walletrpc.WalletKit/ImportPublicKey", in, out, opts...)
@@ -793,6 +818,22 @@ type WalletKitServer interface {
 	// detected by lnd if they happen after the import. Rescans to detect past
 	// events will be supported later on.
 	ImportAccount(context.Context, *ImportAccountRequest) (*ImportAccountResponse, error)
+	// lncli: `wallet accounts remove`
+	// RemoveAccount removes a watch-only account that was previously imported
+	// via ImportAccount, along with all addresses derived from it.
+	//
+	// Only accounts imported through ImportAccount can be removed; the wallet's
+	// reserved "default" and "imported" accounts, and accounts owned by the
+	// wallet itself, are refused.
+	//
+	// NOTE: Removal is allowed even if the account still holds a balance. The
+	// wallet simply stops tracking the account's addresses: its balance and
+	// UTXOs disappear from the wallet's view and later deposits to its addresses
+	// are not detected. The funds themselves are not moved or lost — whoever
+	// holds the account's keys retains full control, and re-importing the same
+	// extended public key (followed by a rescan once supported) restores
+	// tracking.
+	RemoveAccount(context.Context, *RemoveAccountRequest) (*RemoveAccountResponse, error)
 	// lncli: `wallet accounts import-pubkey`
 	// ImportPublicKey imports a public key as watch-only into the wallet. The
 	// public key is converted into a simple address of the given type and that
@@ -1009,6 +1050,9 @@ func (UnimplementedWalletKitServer) VerifyMessageWithAddr(context.Context, *Veri
 }
 func (UnimplementedWalletKitServer) ImportAccount(context.Context, *ImportAccountRequest) (*ImportAccountResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ImportAccount not implemented")
+}
+func (UnimplementedWalletKitServer) RemoveAccount(context.Context, *RemoveAccountRequest) (*RemoveAccountResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RemoveAccount not implemented")
 }
 func (UnimplementedWalletKitServer) ImportPublicKey(context.Context, *ImportPublicKeyRequest) (*ImportPublicKeyResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ImportPublicKey not implemented")
@@ -1334,6 +1378,24 @@ func _WalletKit_ImportAccount_Handler(srv interface{}, ctx context.Context, dec 
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(WalletKitServer).ImportAccount(ctx, req.(*ImportAccountRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _WalletKit_RemoveAccount_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RemoveAccountRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WalletKitServer).RemoveAccount(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/walletrpc.WalletKit/RemoveAccount",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WalletKitServer).RemoveAccount(ctx, req.(*RemoveAccountRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1674,6 +1736,10 @@ var WalletKit_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ImportAccount",
 			Handler:    _WalletKit_ImportAccount_Handler,
+		},
+		{
+			MethodName: "RemoveAccount",
+			Handler:    _WalletKit_RemoveAccount_Handler,
 		},
 		{
 			MethodName: "ImportPublicKey",

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -184,6 +184,10 @@ var (
 			Entity: "onchain",
 			Action: "write",
 		}},
+		"/walletrpc.WalletKit/RemoveAccount": {{
+			Entity: "onchain",
+			Action: "write",
+		}},
 		"/walletrpc.WalletKit/ImportPublicKey": {{
 			Entity: "onchain",
 			Action: "write",
@@ -2642,32 +2646,39 @@ func marshalWalletAddressList(w *WalletKit, account *waddrmgr.AccountProperties,
 // ListAccounts retrieves all accounts belonging to the wallet by default. A
 // name and key scope filter can be provided to filter through all of the wallet
 // accounts and return only those matching.
-func (w *WalletKit) ListAccounts(ctx context.Context,
-	req *ListAccountsRequest) (*ListAccountsResponse, error) {
-
-	// Map the supported address types into their corresponding key scope.
-	var keyScopeFilter *waddrmgr.KeyScope
-	switch req.AddressType {
+// keyScopeFromAddrType maps an RPC address type onto the key scope its
+// accounts live in. AddressType_UNKNOWN maps to nil, meaning no scope filter.
+func keyScopeFromAddrType(addrType AddressType) (*waddrmgr.KeyScope, error) {
+	switch addrType {
 	case AddressType_UNKNOWN:
-		break
+		return nil, nil
 
 	case AddressType_WITNESS_PUBKEY_HASH:
 		keyScope := waddrmgr.KeyScopeBIP0084
-		keyScopeFilter = &keyScope
+		return &keyScope, nil
 
 	case AddressType_NESTED_WITNESS_PUBKEY_HASH,
 		AddressType_HYBRID_NESTED_WITNESS_PUBKEY_HASH:
 
 		keyScope := waddrmgr.KeyScopeBIP0049Plus
-		keyScopeFilter = &keyScope
+		return &keyScope, nil
 
 	case AddressType_TAPROOT_PUBKEY:
 		keyScope := waddrmgr.KeyScopeBIP0086
-		keyScopeFilter = &keyScope
+		return &keyScope, nil
 
 	default:
-		return nil, fmt.Errorf("unhandled address type %v",
-			req.AddressType)
+		return nil, fmt.Errorf("unhandled address type %v", addrType)
+	}
+}
+
+func (w *WalletKit) ListAccounts(ctx context.Context,
+	req *ListAccountsRequest) (*ListAccountsResponse, error) {
+
+	// Map the supported address types into their corresponding key scope.
+	keyScopeFilter, err := keyScopeFromAddrType(req.AddressType)
+	if err != nil {
+		return nil, err
 	}
 
 	accounts, err := w.cfg.Wallet.ListAccounts(req.Name, keyScopeFilter)
@@ -3141,6 +3152,37 @@ func (w *WalletKit) ImportAccount(_ context.Context,
 	}
 
 	return resp, nil
+}
+
+// RemoveAccount removes a watch-only account that was previously imported via
+// ImportAccount, along with all addresses derived from it. The wallet stops
+// tracking the account's addresses: its balance and UTXOs disappear from the
+// wallet's view and later deposits to its addresses are not detected. The
+// funds themselves are not moved or lost — whoever holds the account's keys
+// retains full control, and re-importing the same extended public key restores
+// tracking.
+func (w *WalletKit) RemoveAccount(_ context.Context,
+	req *RemoveAccountRequest) (*RemoveAccountResponse, error) {
+
+	// The address type is only needed to pick between several key scopes
+	// holding the same name, which can only happen on wallets that predate
+	// the cross-scope uniqueness check, so it is usually left unset.
+	keyScope, err := keyScopeFromAddrType(req.AddressType)
+	if err != nil {
+		return nil, err
+	}
+
+	accountProps, err := w.cfg.Wallet.RemoveAccount(req.Name, keyScope)
+	if err != nil {
+		return nil, err
+	}
+
+	rpcAccount, err := marshalWalletAccount(w.internalScope(), accountProps)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RemoveAccountResponse{Account: rpcAccount}, nil
 }
 
 // ImportPublicKey imports a single derived public key into the wallet. The

--- a/lntest/mock/walletcontroller.go
+++ b/lntest/mock/walletcontroller.go
@@ -139,6 +139,13 @@ func (w *WalletController) ImportAccount(string, *hdkeychain.ExtendedKey,
 	return nil, nil, nil, nil
 }
 
+// RemoveAccount currently returns a dummy value.
+func (w *WalletController) RemoveAccount(string,
+	*waddrmgr.KeyScope) (*waddrmgr.AccountProperties, error) {
+
+	return nil, nil
+}
+
 // ImportPublicKey currently returns a dummy value.
 func (w *WalletController) ImportPublicKey(*btcec.PublicKey,
 	waddrmgr.AddressType) error {

--- a/lntest/rpc/wallet_kit.go
+++ b/lntest/rpc/wallet_kit.go
@@ -357,6 +357,33 @@ func (h *HarnessRPC) ImportAccountAssertErr(
 	return err
 }
 
+// RemoveAccount makes a RPC call to the node's WalletKitClient and asserts.
+func (h *HarnessRPC) RemoveAccount(
+	req *walletrpc.RemoveAccountRequest) *walletrpc.RemoveAccountResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.WalletKit.RemoveAccount(ctxt, req)
+	h.NoError(err, "RemoveAccount")
+
+	return resp
+}
+
+// RemoveAccountAssertErr makes the RemoveAccount RPC call and asserts an error
+// is returned. It then returns the error.
+func (h *HarnessRPC) RemoveAccountAssertErr(
+	req *walletrpc.RemoveAccountRequest) error {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	_, err := h.WalletKit.RemoveAccount(ctxt, req)
+	require.Error(h, err)
+
+	return err
+}
+
 // ImportPublicKey makes a RPC call to the node's WalletKitClient and asserts.
 //
 //nolint:ll

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -99,15 +99,15 @@ type BtcWallet struct {
 
 	chainKeyScope waddrmgr.KeyScope
 
-	// accountMtx serialises the calls that add a named account, meaning
-	// CreateAccount and ImportAccount. Both do the same check-then-act
-	// against the same invariant — a name must exist in at most one key
-	// scope — and both need two database transactions to do it, since
-	// btcwallet exposes no way to check and create in one. Without a lock
-	// covering both, two concurrent calls (in either combination) can pass
-	// their duplicate checks and then each create the name under a
-	// different scope, which is precisely the ambiguity the checks exist
-	// to prevent.
+	// accountMtx serialises the calls that add or remove a named account,
+	// meaning CreateAccount, ImportAccount and RemoveAccount. All do a
+	// check-then-act against the same invariant — a name must exist in at
+	// most one key scope — and all need two database transactions to do
+	// it, since btcwallet exposes no way to check and mutate in one.
+	// Without a lock covering them, two concurrent calls (in any
+	// combination) can pass their checks and then each mutate the
+	// namespace, which is precisely the ambiguity the checks exist to
+	// prevent.
 	accountMtx sync.Mutex
 
 	blockCache *blockcache.BlockCache
@@ -831,6 +831,15 @@ type accountCreator interface {
 	NextAccount(scope waddrmgr.KeyScope, name string) (uint32, error)
 }
 
+// accountRemover is the subset of btcwallet's wallet API needed to remove a
+// watch-only imported account. It is declared here because btcwallet's
+// base.Interface does not include RemoveAccount yet.
+type accountRemover interface {
+	// RemoveAccount removes the account with the given name from the given
+	// key scope, along with all addresses derived from it.
+	RemoveAccount(scope waddrmgr.KeyScope, name string) error
+}
+
 // CreateAccount creates a new account within the given key scope, deriving the
 // account's keys from the wallet's master key.
 //
@@ -1000,6 +1009,94 @@ func (b *BtcWallet) ImportAccount(name string, accountPubKey *hdkeychain.Extende
 	}
 
 	return accountProps, externalAddrs, internalAddrs, nil
+}
+
+// RemoveAccount removes a watch-only account that was previously registered
+// via ImportAccount, along with all addresses derived from it. A nil key scope
+// resolves the name across all default key scopes; if the same name exists in
+// more than one scope, a scope must be provided to disambiguate.
+//
+// The wallet stops tracking the account's addresses: any balance held on them
+// disappears from the wallet's view and future deposits to them are not
+// detected. The funds themselves are unaffected — the holder of the account's
+// extended keys retains full control, and re-importing the same extended
+// public key (plus a rescan) restores tracking.
+//
+// In a remote-signing setup this only affects the watch-only node the account
+// was imported into; the signer never learned about the account.
+//
+// This is a part of the WalletController interface.
+func (b *BtcWallet) RemoveAccount(name string,
+	keyScope *waddrmgr.KeyScope) (*waddrmgr.AccountProperties, error) {
+
+	if name == "" {
+		return nil, errors.New("account name is required")
+	}
+
+	// The wallet creates both of these accounts itself, in every key
+	// scope, and relies on them being present.
+	if name == lnwallet.DefaultAccountName ||
+		name == waddrmgr.ImportedAddrAccountName {
+
+		return nil, fmt.Errorf("account name %v is reserved by the "+
+			"wallet", name)
+	}
+
+	// This reads and then mutates the account namespace, and btcwallet
+	// cannot do that in one database transaction, so hold the same lock
+	// CreateAccount and ImportAccount take; see the field's documentation.
+	b.accountMtx.Lock()
+	defer b.accountMtx.Unlock()
+
+	// Resolve the name to the account's properties, either within the
+	// requested scope or across all default scopes. A missing account
+	// surfaces here as ErrAccountNotFound.
+	accounts, err := b.ListAccounts(name, keyScope)
+	if err != nil {
+		return nil, err
+	}
+
+	// A name can only resolve in several scopes on wallets that predate
+	// the cross-scope uniqueness check in CreateAccount/ImportAccount. We
+	// never guess which one was meant.
+	if len(accounts) > 1 {
+		return nil, fmt.Errorf("account %v exists in multiple key "+
+			"scopes; specify an address type to disambiguate",
+			name)
+	}
+	props := accounts[0]
+
+	// The scope lnd derives its own keys from is never removable, and an
+	// account the wallet can sign for was created by CreateAccount rather
+	// than imported, so removing it would orphan keys derived from the
+	// wallet's own master key.
+	if props.KeyScope == b.chainKeyScope {
+		return nil, fmt.Errorf("account %v is part of lnd's internal "+
+			"key scope and cannot be removed", name)
+	}
+	if !props.IsWatchOnly {
+		return nil, fmt.Errorf("account %v is not a watch-only "+
+			"imported account; only accounts imported via "+
+			"ImportAccount can be removed", name)
+	}
+
+	// btcwallet's base.Interface does not expose RemoveAccount yet. Assert
+	// for the capability instead of widening the interface, so lnd doesn't
+	// need to carry a forked btcwallet; see CreateAccount for the full
+	// rationale. This assertion can be dropped once RemoveAccount is part
+	// of base.Interface upstream.
+	remover, ok := b.wallet.(accountRemover)
+	if !ok {
+		return nil, fmt.Errorf("wallet of type %T does not support "+
+			"removing accounts", b.wallet)
+	}
+
+	if err := remover.RemoveAccount(props.KeyScope, name); err != nil {
+		return nil, fmt.Errorf("unable to remove account %v: %w",
+			name, err)
+	}
+
+	return props, nil
 }
 
 // ImportPublicKey imports a single derived public key into the wallet. The

--- a/lnwallet/btcwallet/remove_account_test.go
+++ b/lnwallet/btcwallet/remove_account_test.go
@@ -1,0 +1,244 @@
+package btcwallet
+
+import (
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	base "github.com/btcsuite/btcwallet/wallet"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/stretchr/testify/require"
+)
+
+// removeAccountWallet is a minimal fake of btcwallet's base.Interface covering
+// only the calls RemoveAccount makes. The embedded interface is deliberately
+// left nil so that any additional call this test does not expect panics loudly
+// rather than silently returning a zero value.
+type removeAccountWallet struct {
+	base.Interface
+
+	// existing maps a key scope to the account names that already exist in
+	// it, which drives the name-resolution lookups.
+	existing map[waddrmgr.KeyScope][]string
+
+	// notWatchOnly holds the names of accounts the wallet owns itself.
+	// Every other account resolves as watch-only, mirroring an account
+	// registered through ImportAccount.
+	notWatchOnly map[string]bool
+
+	// removedScope and removedName record the arguments of the
+	// RemoveAccount call so the test can assert the resolved scope was
+	// forwarded unchanged.
+	removedScope waddrmgr.KeyScope
+	removedName  string
+
+	// removeAccountErr, when set, is returned by RemoveAccount.
+	removeAccountErr error
+}
+
+// AccountPropertiesByName reports whether the named account exists in the
+// given scope, mirroring waddrmgr's not-found error so that the caller's
+// waddrmgr.IsError check behaves as it does against a real wallet.
+func (w *removeAccountWallet) AccountPropertiesByName(scope waddrmgr.KeyScope,
+	name string) (*waddrmgr.AccountProperties, error) {
+
+	if slices.Contains(w.existing[scope], name) {
+		return &waddrmgr.AccountProperties{
+			AccountName: name,
+			KeyScope:    scope,
+			IsWatchOnly: !w.notWatchOnly[name],
+		}, nil
+	}
+
+	return nil, newAccountNotFoundError(name)
+}
+
+// RemoveAccount records the requested scope and name.
+func (w *removeAccountWallet) RemoveAccount(scope waddrmgr.KeyScope,
+	name string) error {
+
+	if w.removeAccountErr != nil {
+		return w.removeAccountErr
+	}
+
+	w.removedScope = scope
+	w.removedName = name
+
+	return nil
+}
+
+// TestRemoveAccount asserts the guard rails around removing an imported
+// account: only watch-only, non-reserved accounts outside lnd's internal key
+// scope can be removed, an ambiguous name is refused rather than guessed at,
+// and the scope the name resolves to is what the removal is forwarded with.
+func TestRemoveAccount(t *testing.T) {
+	t.Parallel()
+
+	const accountName = "external"
+
+	chainScope := waddrmgr.KeyScope{
+		Purpose: keychain.BIP0043Purpose,
+		Coin:    0,
+	}
+
+	tests := []struct {
+		name          string
+		accountName   string
+		keyScope      *waddrmgr.KeyScope
+		existing      map[waddrmgr.KeyScope][]string
+		notWatchOnly  map[string]bool
+		expectedScope waddrmgr.KeyScope
+		expectedErr   string
+	}{{
+		name:        "resolved across scopes and removed",
+		accountName: accountName,
+		existing: map[waddrmgr.KeyScope][]string{
+			waddrmgr.KeyScopeBIP0084: {accountName},
+		},
+		expectedScope: waddrmgr.KeyScopeBIP0084,
+	}, {
+		name:        "removed within explicit scope",
+		accountName: accountName,
+		keyScope:    &waddrmgr.KeyScopeBIP0086,
+		existing: map[waddrmgr.KeyScope][]string{
+			waddrmgr.KeyScopeBIP0086: {accountName},
+		},
+		expectedScope: waddrmgr.KeyScopeBIP0086,
+	}, {
+		name:        "empty name rejected",
+		accountName: "",
+		expectedErr: "account name is required",
+	}, {
+		name:        "default account name reserved",
+		accountName: lnwallet.DefaultAccountName,
+		expectedErr: "reserved by the wallet",
+	}, {
+		name:        "imported account name reserved",
+		accountName: waddrmgr.ImportedAddrAccountName,
+		expectedErr: "reserved by the wallet",
+	}, {
+		name:        "missing account not found",
+		accountName: accountName,
+		expectedErr: "not found",
+	}, {
+		// A name resolving in several scopes is only possible on
+		// wallets that predate the cross-scope uniqueness check, and
+		// the caller has to say which one they mean.
+		name:        "ambiguous name rejected",
+		accountName: accountName,
+		existing: map[waddrmgr.KeyScope][]string{
+			waddrmgr.KeyScopeBIP0084: {accountName},
+			waddrmgr.KeyScopeBIP0086: {accountName},
+		},
+		expectedErr: "multiple key scopes",
+	}, {
+		name:        "wallet-owned account rejected",
+		accountName: accountName,
+		existing: map[waddrmgr.KeyScope][]string{
+			waddrmgr.KeyScopeBIP0086: {accountName},
+		},
+		notWatchOnly: map[string]bool{accountName: true},
+		expectedErr:  "not a watch-only imported account",
+	}, {
+		name:        "internal key scope rejected",
+		accountName: accountName,
+		keyScope:    &chainScope,
+		existing: map[waddrmgr.KeyScope][]string{
+			chainScope: {accountName},
+		},
+		expectedErr: "internal key scope",
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			fake := &removeAccountWallet{
+				existing:     test.existing,
+				notWatchOnly: test.notWatchOnly,
+			}
+			w := &BtcWallet{
+				wallet:        fake,
+				chainKeyScope: chainScope,
+			}
+
+			props, err := w.RemoveAccount(
+				test.accountName, test.keyScope,
+			)
+
+			if test.expectedErr != "" {
+				require.ErrorContains(t, err, test.expectedErr)
+				require.Nil(t, props)
+
+				// A rejected request must not have reached the
+				// wallet.
+				require.Empty(t, fake.removedName)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.accountName, props.AccountName)
+			require.True(t, props.IsWatchOnly)
+			require.Equal(t, test.expectedScope, props.KeyScope)
+			require.Equal(t, test.expectedScope, fake.removedScope)
+			require.Equal(t, test.accountName, fake.removedName)
+		})
+	}
+}
+
+// TestRemoveAccountUnsupportedWallet asserts that a wallet backend without
+// removal support is reported as such instead of panicking. This pins the
+// behaviour lnd has while its btcwallet dependency predates RemoveAccount.
+func TestRemoveAccountUnsupportedWallet(t *testing.T) {
+	t.Parallel()
+
+	w := &BtcWallet{wallet: &lookupOnlyRemoveWallet{}}
+
+	// An explicit scope keeps resolution to a single lookup, so that the
+	// capability check is the guard that fails.
+	_, err := w.RemoveAccount("external", &waddrmgr.KeyScopeBIP0084)
+	require.ErrorContains(t, err, "does not support removing accounts")
+}
+
+// TestRemoveAccountWalletError asserts that a failure from the underlying
+// wallet is surfaced with the account name attached.
+func TestRemoveAccountWalletError(t *testing.T) {
+	t.Parallel()
+
+	walletErr := errors.New("db failure")
+	fake := &removeAccountWallet{
+		existing: map[waddrmgr.KeyScope][]string{
+			waddrmgr.KeyScopeBIP0084: {"external"},
+		},
+		removeAccountErr: walletErr,
+	}
+	w := &BtcWallet{wallet: fake}
+
+	_, err := w.RemoveAccount("external", nil)
+	require.ErrorIs(t, err, walletErr)
+	require.ErrorContains(t, err, "external")
+}
+
+// lookupOnlyRemoveWallet answers the name-resolution lookups but deliberately
+// does not implement RemoveAccount, standing in for a wallet backend that
+// cannot remove accounts.
+type lookupOnlyRemoveWallet struct {
+	base.Interface
+}
+
+// AccountPropertiesByName always reports the account as present and
+// watch-only, so that resolution succeeds and the capability check is what
+// fails.
+func (w *lookupOnlyRemoveWallet) AccountPropertiesByName(
+	scope waddrmgr.KeyScope, name string) (*waddrmgr.AccountProperties,
+	error) {
+
+	return &waddrmgr.AccountProperties{
+		AccountName: name,
+		KeyScope:    scope,
+		IsWatchOnly: true,
+	}, nil
+}

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -351,6 +351,25 @@ type WalletController interface {
 		dryRun bool) (*waddrmgr.AccountProperties, []address.Address,
 		[]address.Address, error)
 
+	// RemoveAccount removes a watch-only account that was previously
+	// registered via ImportAccount, along with all addresses derived from
+	// it. A nil key scope resolves the name across all default key scopes;
+	// if the same name exists in more than one scope, a scope must be
+	// provided to disambiguate.
+	//
+	// The wallet stops tracking the account's addresses: any balance held
+	// on them disappears from the wallet's view and future deposits to
+	// them are not detected. The funds themselves are unaffected — the
+	// holder of the account's extended keys retains full control, and
+	// re-importing the same extended public key (plus a rescan) restores
+	// tracking.
+	//
+	// The wallet's reserved accounts ("default" and "imported") and
+	// accounts fully owned by the wallet (non-watch-only, i.e. created via
+	// CreateAccount) cannot be removed.
+	RemoveAccount(name string,
+		keyScope *waddrmgr.KeyScope) (*waddrmgr.AccountProperties, error)
+
 	// ImportPublicKey imports a single derived public key into the wallet.
 	// The address type can usually be inferred from the key's version, but
 	// in the case of legacy versions (xpub, tpub), an address type must be

--- a/lnwallet/mock.go
+++ b/lnwallet/mock.go
@@ -149,6 +149,13 @@ func (w *mockWalletController) ImportAccount(string, *hdkeychain.ExtendedKey,
 	return nil, nil, nil, nil
 }
 
+// RemoveAccount currently returns a dummy value.
+func (w *mockWalletController) RemoveAccount(string,
+	*waddrmgr.KeyScope) (*waddrmgr.AccountProperties, error) {
+
+	return nil, nil
+}
+
 // ImportPublicKey currently returns a dummy value.
 func (w *mockWalletController) ImportPublicKey(*btcec.PublicKey,
 	waddrmgr.AddressType) error {


### PR DESCRIPTION
## Change Description

Adds a `WalletKit.RemoveAccount` RPC (and `lncli wallet accounts remove`) that
deletes a watch-only account previously registered via `ImportAccount`, along
with all addresses derived from it. Fixes #8654.

The wallet stops tracking the account's addresses; the funds themselves are
unaffected and re-importing the same extended public key (plus a rescan)
restores tracking. Since removal silently drops the account's balance and
UTXOs from the wallet's view, the lncli command asks for confirmation unless
`--yes` is given.

Guard rails on the wallet side:

- The wallet's reserved accounts (`default`, `imported`), lnd's internal key
  scope, and accounts owned by the wallet itself (created via
  `XCreateAccount`) are refused — only watch-only imported accounts can be
  removed.
- A name that resolves in more than one key scope — possible only on wallets
  that predate the cross-scope uniqueness check — must be disambiguated with
  an explicit address type, which maps to a key scope the same way
  `ListAccounts` resolves it (the mapping is extracted into a shared helper).
- The `accountMtx` introduced for `XCreateAccount` now also serialises
  removal, since all three account mutations (`CreateAccount`,
  `ImportAccount`, `RemoveAccount`) do a check-then-act against the same
  name-uniqueness invariant across two database transactions.

### Upstream dependency

The underlying removal is implemented in btcsuite/btcwallet#1352
(`wallet.RemoveAccount`, atomically removing the waddrmgr account and its
wtxmgr credits). Until that merges and lnd bumps its btcwallet dependency,
`BtcWallet.RemoveAccount` asserts for the capability at runtime (the
`accountRemover` interface, same pattern as `accountCreator` for
`XCreateAccount`) and reports the wallet as unsupported. This keeps the PR
compilable and reviewable against the current dependency, but the happy-path
itest fails until the bump — hence **draft** until #1352 lands and the go.mod
bump commit is added here.

## Steps to Test

Unit tests (pass today):

```sh
go test ./lnwallet/btcwallet/... ./lnrpc/walletrpc/...
```

Integration tests:

```sh
make itest icase=wallet_remove_account
```

The rejections case (reserved accounts, default account, unknown account,
wallet-owned account) passes today. The happy path (import Carol's xpub into
Dave's node, fund it, remove with a non-zero balance, assert no trace across
restart, re-import the same xpub) requires the btcwallet dependency; it has
been verified end-to-end against btcsuite/btcwallet#1352 via local replace
directives.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks. *(happy-path itest blocked on
  btcsuite/btcwallet#1352 — see above)*
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.
