### PR TITLE
chainntnfs: add spend depth notifications

### DIFF
--- a/chainntnfs/bitcoindnotify/bitcoind.go
+++ b/chainntnfs/bitcoindnotify/bitcoind.go
@@ -717,13 +717,16 @@ func (b *BitcoindNotifier) notifyBlockEpochClient(epochClient *blockEpochRegistr
 // Once a spend of has been detected, the details of the spending event will be
 // sent across the 'Spend' channel.
 func (b *BitcoindNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	pkScript []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	pkScript []byte, heightHint uint32,
+	opts ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
 	// Register the conf notification with the TxNotifier. A non-nil value
 	// for `dispatch` will be returned if we are required to perform a
 	// manual scan for the confirmation. Otherwise the notifier will begin
 	// watching at tip for the transaction to confirm.
-	ntfn, err := b.txNotifier.RegisterSpend(outpoint, pkScript, heightHint)
+	ntfn, err := b.txNotifier.RegisterSpend(
+		outpoint, pkScript, heightHint, opts...,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/chainntnfs/btcdnotify/btcd.go
+++ b/chainntnfs/btcdnotify/btcd.go
@@ -787,13 +787,16 @@ func (b *BtcdNotifier) notifyBlockEpochClient(epochClient *blockEpochRegistratio
 // Once a spend of has been detected, the details of the spending event will be
 // sent across the 'Spend' channel.
 func (b *BtcdNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	pkScript []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	pkScript []byte, heightHint uint32,
+	opts ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
 	// Register the conf notification with the TxNotifier. A non-nil value
 	// for `dispatch` will be returned if we are required to perform a
 	// manual scan for the confirmation. Otherwise the notifier will begin
 	// watching at tip for the transaction to confirm.
-	ntfn, err := b.txNotifier.RegisterSpend(outpoint, pkScript, heightHint)
+	ntfn, err := b.txNotifier.RegisterSpend(
+		outpoint, pkScript, heightHint, opts...,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/chainntnfs/interface.go
+++ b/chainntnfs/interface.go
@@ -95,6 +95,53 @@ func WithIncludeBlock() NotifierOption {
 	}
 }
 
+// SpendOptions is the caller-selected policy for a spend notification.
+type SpendOptions struct {
+	// NumConfs is the number of confirmations required before the spend is
+	// delivered as mature.
+	NumConfs uint32
+}
+
+// DefaultSpendOptions preserves the historical one-confirmation spend
+// notification behavior for callers that do not supply an option.
+func DefaultSpendOptions() *SpendOptions {
+	return &SpendOptions{NumConfs: 1}
+}
+
+// SpendOption changes one aspect of a spend notification policy.
+type SpendOption func(*SpendOptions)
+
+// WithSpendNumConfs requests delivery only after the spending transaction has
+// reached numConfs confirmations. Registration rejects values outside the
+// notifier's supported reorg window.
+func WithSpendNumConfs(numConfs uint32) SpendOption {
+	return func(o *SpendOptions) {
+		// Store the requested depth here so every notifier backend
+		// applies the same maturity policy through TxNotifier.
+		o.NumConfs = numConfs
+	}
+}
+
+// ParseSpendOptions applies caller options to the compatibility default and
+// rejects values no notifier is allowed to support. A concrete TxNotifier
+// performs its possibly smaller reorg-window check during registration.
+func ParseSpendOptions(optFuncs ...SpendOption) (*SpendOptions, error) {
+	opts := DefaultSpendOptions()
+	for _, optFunc := range optFuncs {
+		// Apply options in call order so the last value follows the
+		// established functional-option convention.
+		optFunc(opts)
+	}
+
+	if opts.NumConfs == 0 || opts.NumConfs > MaxNumConfs {
+		// Reject unsupported depths before a backend installs watches
+		// or mutates registration state.
+		return nil, ErrNumConfsOutOfRange
+	}
+
+	return opts, nil
+}
+
 // ChainNotifier represents a trusted source to receive notifications concerning
 // targeted events on the Bitcoin blockchain. The interface specification is
 // intentionally general in order to support a wide array of chain notification
@@ -143,13 +190,14 @@ type ChainNotifier interface {
 	// light clients. It denotes the earliest height in the blockchain in
 	// which the target output could have been spent.
 	//
-	// NOTE: The notification should only be triggered when the spending
-	// transaction receives a single confirmation.
+	// By default, the notification is triggered when the spending
+	// transaction receives one confirmation. A SpendOption can request a
+	// deeper notification within the notifier's supported reorg window.
 	//
 	// NOTE: Dispatching notifications to multiple clients subscribed to a
 	// spend of the same outpoint MUST be supported.
 	RegisterSpendNtfn(outpoint *wire.OutPoint, pkScript []byte,
-		heightHint uint32) (*SpendEvent, error)
+		heightHint uint32, opts ...SpendOption) (*SpendEvent, error)
 
 	// RegisterBlockEpochNtfn registers an intent to be notified of each
 	// new block connected to the tip of the main chain. The returned

--- a/chainntnfs/mocks.go
+++ b/chainntnfs/mocks.go
@@ -77,9 +77,18 @@ func (m *MockChainNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash,
 // RegisterSpendNtfn registers an intent to be notified once the target
 // outpoint is successfully spent within a transaction.
 func (m *MockChainNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	pkScript []byte, heightHint uint32) (*SpendEvent, error) {
+	pkScript []byte, heightHint uint32,
+	opts ...SpendOption) (*SpendEvent, error) {
 
-	args := m.Called(outpoint, pkScript, heightHint)
+	// Preserve existing three-argument expectations, while exposing the
+	// option slice when a test needs to verify a requested spend depth.
+	callArgs := []interface{}{outpoint, pkScript, heightHint}
+	if len(opts) != 0 {
+		// Keep all options in one argument. This lets mock expectations
+		// compare the exact policy passed through an adapter.
+		callArgs = append(callArgs, opts)
+	}
+	args := m.Called(callArgs...)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/chainntnfs/neutrinonotify/neutrino.go
+++ b/chainntnfs/neutrinonotify/neutrino.go
@@ -761,13 +761,16 @@ func (n *NeutrinoNotifier) notifyBlockEpochClient(epochClient *blockEpochRegistr
 // Once a spend of has been detected, the details of the spending event will be
 // sent across the 'Spend' channel.
 func (n *NeutrinoNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	pkScript []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	pkScript []byte, heightHint uint32,
+	opts ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
 	// Register the conf notification with the TxNotifier. A non-nil value
 	// for `dispatch` will be returned if we are required to perform a
 	// manual scan for the confirmation. Otherwise the notifier will begin
 	// watching at tip for the transaction to confirm.
-	ntfn, err := n.txNotifier.RegisterSpend(outpoint, pkScript, heightHint)
+	ntfn, err := n.txNotifier.RegisterSpend(
+		outpoint, pkScript, heightHint, opts...,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/chainntnfs/test/test_interface.go
+++ b/chainntnfs/test/test_interface.go
@@ -406,6 +406,129 @@ func testSpendNotificationDepth(
 	require.Equal(t, spendHeight, atThree.SpendingHeight)
 }
 
+// testHistoricalSpendNotificationDepth proves each backend applies explicit
+// maturity to a spend found by its historical dispatch path.
+func testHistoricalSpendNotificationDepth(
+	miner *rpctest.Harness, notifier chainntnfs.TestChainNotifier,
+	scriptDispatch bool, t *testing.T) {
+
+	// Arrange a spend and an epoch client before mining so the depth-aware
+	// registration can begin only after the transaction is historical.
+	const numConfs = uint32(3)
+	outpoint, output, privKey := chainntnfs.CreateSpendableOutput(t, miner)
+	tipHash, heightHint, err := miner.Client.GetBestBlock()
+	require.NoError(t, err, "unable to get current height")
+	spendingTx := chainntnfs.CreateSpendTx(t, outpoint, output, privKey)
+	spenderHash, err := miner.Client.SendRawTransaction(spendingTx, true)
+	require.NoError(t, err, "unable to broadcast spend")
+	require.NoError(
+		t, chainntnfs.WaitForMempoolTx(miner, spenderHash),
+		"spend was not relayed to miner",
+	)
+	epochClient, err := notifier.RegisterBlockEpochNtfn(nil)
+	require.NoError(t, err, "unable to register for block epochs")
+	t.Cleanup(epochClient.Cancel)
+	// Drain the registration-time tip event so the Act phase synchronizes
+	// exclusively with blocks mined after the historical setup completes.
+	waitForNotifierEpoch(t, epochClient, tipHash)
+
+	// Act by mining the spend first, registering from the earlier hint, and
+	// advancing through its remaining depth. An extra block before the
+	// second registration exercises cached delivery strictly after, rather
+	// than exactly at, the maturity boundary.
+	blockHashes, err := miner.Client.Generate(1)
+	require.NoError(t, err, "unable to mine historical spend")
+	waitForNotifierEpoch(t, epochClient, blockHashes[0])
+	_, spendHeight, err := miner.Client.GetBestBlock()
+	require.NoError(t, err, "unable to get historical spend height")
+	var spendClient *chainntnfs.SpendEvent
+	if scriptDispatch {
+		// Register the historical script-only path here so this test
+		// visibly applies the option to the subject API.
+		spendClient, err = notifier.RegisterSpendNtfn(
+			nil, output.PkScript, uint32(heightHint),
+			chainntnfs.WithSpendNumConfs(numConfs),
+		)
+	} else {
+		// Register the historical outpoint path with the same option
+		// so every backend dispatch mode is exercised directly.
+		spendClient, err = notifier.RegisterSpendNtfn(
+			outpoint, output.PkScript, uint32(heightHint),
+			chainntnfs.WithSpendNumConfs(numConfs),
+		)
+	}
+	require.NoError(t, err, "unable to register historical spend")
+	t.Cleanup(spendClient.Cancel)
+
+	blockHashes, err = miner.Client.Generate(1)
+	require.NoError(t, err, "unable to mine pre-maturity block")
+	waitForNotifierEpoch(t, epochClient, blockHashes[0])
+	beforeMaturity, beforeMaturityOK := pollSpendNotification(
+		spendClient.Spend,
+	)
+
+	blockHashes, err = miner.Client.Generate(1)
+	require.NoError(t, err, "unable to mine historical maturity")
+	waitForNotifierEpoch(t, epochClient, blockHashes[0])
+	var matureSpend *chainntnfs.SpendDetail
+	select {
+	case matureSpend = <-spendClient.Spend:
+		// Retain asynchronous delivery so semantic checks remain in the
+		// dedicated Assert phase below.
+
+	case <-time.After(30 * time.Second):
+		t.Fatalf("historical spend did not mature")
+	}
+
+	blockHashes, err = miner.Client.Generate(1)
+	require.NoError(t, err, "unable to mine past historical maturity")
+	waitForNotifierEpoch(t, epochClient, blockHashes[0])
+
+	var cachedClient *chainntnfs.SpendEvent
+	if scriptDispatch {
+		// Repeat the script-only subject call after maturity to prove
+		// cached delivery retains the explicit depth contract.
+		cachedClient, err = notifier.RegisterSpendNtfn(
+			nil, output.PkScript, uint32(heightHint),
+			chainntnfs.WithSpendNumConfs(numConfs),
+		)
+	} else {
+		// Repeat the outpoint subject call after maturity so cached
+		// delivery is covered without hiding the registration option.
+		cachedClient, err = notifier.RegisterSpendNtfn(
+			outpoint, output.PkScript, uint32(heightHint),
+			chainntnfs.WithSpendNumConfs(numConfs),
+		)
+	}
+	require.NoError(t, err, "unable to register cached mature spend")
+	t.Cleanup(cachedClient.Cancel)
+	var cachedSpend *chainntnfs.SpendDetail
+	select {
+	case cachedSpend = <-cachedClient.Spend:
+		// Historical dispatch is asynchronous, so retain its result
+		// after bounded delivery for comparison in the Assert phase.
+
+	case <-time.After(30 * time.Second):
+		t.Fatalf("cached historical spend was not delivered")
+	}
+
+	// Assert the historical candidate remains hidden at depth two, then is
+	// delivered to both the pending client and a post-maturity
+	// registration.
+	require.False(t, beforeMaturityOK)
+	require.Nil(t, beforeMaturity)
+	require.NotNil(t, matureSpend)
+	require.Equal(t, *outpoint, *matureSpend.SpentOutPoint)
+	require.Equal(t, *spenderHash, *matureSpend.SpenderTxHash)
+	require.Zero(t, matureSpend.SpenderInputIndex)
+	require.Equal(t, spendHeight, matureSpend.SpendingHeight)
+	require.NotNil(t, cachedSpend)
+	require.Equal(t, *outpoint, *cachedSpend.SpentOutPoint)
+	require.Equal(t, *spenderHash, *cachedSpend.SpenderTxHash)
+	require.Zero(t, cachedSpend.SpenderInputIndex)
+	require.Equal(t, spendHeight, cachedSpend.SpendingHeight)
+}
+
 func testSpendNotification(miner *rpctest.Harness,
 	notifier chainntnfs.TestChainNotifier, scriptDispatch bool, t *testing.T) {
 
@@ -1975,6 +2098,10 @@ var txNtfnTests = []txNtfnTestCase{
 	{
 		name: "historical spend dispatch",
 		test: testSpendBeforeNtfnRegistration,
+	},
+	{
+		name: "historical spend depth dispatch",
+		test: testHistoricalSpendNotificationDepth,
 	},
 	{
 		name: "reorg spend",

--- a/chainntnfs/test/test_interface.go
+++ b/chainntnfs/test/test_interface.go
@@ -273,6 +273,139 @@ func checkNotificationFields(ntfn *chainntnfs.SpendDetail,
 	}
 }
 
+// waitForNotifierEpoch ignores stale epochs until the exact block arrives.
+func waitForNotifierEpoch(t *testing.T,
+	epochClient *chainntnfs.BlockEpochEvent,
+	expectedHash *chainhash.Hash) {
+
+	t.Helper()
+
+	// A bounded wait turns backend synchronization failures into a focused
+	// test error instead of allowing later spend assertions to race.
+	timeout := time.After(30 * time.Second)
+	for {
+		select {
+		case epoch, ok := <-epochClient.Epochs:
+			if !ok {
+				t.Fatalf("epoch channel closed before " +
+					"synchronization")
+			}
+			if epoch.Hash.IsEqual(expectedHash) {
+				return
+			}
+
+		case <-timeout:
+			t.Fatalf(
+				"notifier did not report "+
+					"block %v", expectedHash,
+			)
+		}
+	}
+}
+
+// pollSpendNotification records whether a backend has delivered a spend
+// without delaying the maturity-boundary assertions.
+func pollSpendNotification(spend <-chan *chainntnfs.SpendDetail) (
+	*chainntnfs.SpendDetail, bool) {
+
+	// Non-blocking observation distinguishes an immature registration from
+	// one dispatched by the just-synchronized block.
+	select {
+	case details := <-spend:
+		return details, true
+
+	default:
+		return nil, false
+	}
+}
+
+// testSpendNotificationDepth proves each backend forwards an explicit spend
+// depth for a transaction discovered after registration.
+func testSpendNotificationDepth(
+	miner *rpctest.Harness, notifier chainntnfs.TestChainNotifier,
+	scriptDispatch bool, t *testing.T) {
+
+	// Arrange a spendable output, a synchronized epoch client, and a depth-
+	// three notification before broadcasting the spending transaction.
+	const numConfs = uint32(3)
+	outpoint, output, privKey := chainntnfs.CreateSpendableOutput(t, miner)
+	tipHash, heightHint, err := miner.Client.GetBestBlock()
+	require.NoError(t, err, "unable to get current height")
+	epochClient, err := notifier.RegisterBlockEpochNtfn(nil)
+	require.NoError(t, err, "unable to register for block epochs")
+	t.Cleanup(epochClient.Cancel)
+
+	// A nil best block produces one immediate tip event. Drain it during
+	// Arrange so each later wait corresponds to a newly generated block.
+	waitForNotifierEpoch(t, epochClient, tipHash)
+	var spendClient *chainntnfs.SpendEvent
+	if scriptDispatch {
+		// Register the script-only path here so the subject API and the
+		// exact depth option remain visible in this backend test.
+		spendClient, err = notifier.RegisterSpendNtfn(
+			nil, output.PkScript, uint32(heightHint),
+			chainntnfs.WithSpendNumConfs(numConfs),
+		)
+	} else {
+		// Register the outpoint path with the same explicit option so
+		// both backend dispatch modes prove the public contract.
+		spendClient, err = notifier.RegisterSpendNtfn(
+			outpoint, output.PkScript, uint32(heightHint),
+			chainntnfs.WithSpendNumConfs(numConfs),
+		)
+	}
+	require.NoError(t, err, "unable to register depth-aware spend")
+	t.Cleanup(spendClient.Cancel)
+	spendingTx := chainntnfs.CreateSpendTx(t, outpoint, output, privKey)
+	spenderHash, err := miner.Client.SendRawTransaction(spendingTx, true)
+	require.NoError(t, err, "unable to broadcast spend")
+	require.NoError(
+		t, chainntnfs.WaitForMempoolTx(miner, spenderHash),
+		"spend was not relayed to miner",
+	)
+
+	// Act by mining the inclusion block and two successors, synchronizing
+	// after each one, and recording delivery at every depth boundary.
+	blockHashes, err := miner.Client.Generate(1)
+	require.NoError(t, err, "unable to mine spend inclusion")
+	waitForNotifierEpoch(t, epochClient, blockHashes[0])
+	atOne, atOneOK := pollSpendNotification(spendClient.Spend)
+	_, spendHeight, err := miner.Client.GetBestBlock()
+	require.NoError(t, err, "unable to get spend height")
+
+	blockHashes, err = miner.Client.Generate(1)
+	require.NoError(t, err, "unable to mine second confirmation")
+	waitForNotifierEpoch(t, epochClient, blockHashes[0])
+	atTwo, atTwoOK := pollSpendNotification(spendClient.Spend)
+
+	blockHashes, err = miner.Client.Generate(1)
+	require.NoError(t, err, "unable to mine maturity confirmation")
+	waitForNotifierEpoch(t, epochClient, blockHashes[0])
+	var atThree *chainntnfs.SpendDetail
+	// Block epochs and spend results use independent delivery channels.
+	// Allow a bounded asynchronous handoff after maturity processing.
+	select {
+	case atThree = <-spendClient.Spend:
+		// Retain the result so Assert can verify its transaction and
+		// block metadata.
+
+	case <-time.After(30 * time.Second):
+		t.Fatalf("live spend did not mature")
+	}
+
+	// Assert no backend delivers before the requested depth and every
+	// backend supplies the canonical spend exactly at three confirmations.
+	require.False(t, atOneOK)
+	require.Nil(t, atOne)
+	require.False(t, atTwoOK)
+	require.Nil(t, atTwo)
+	require.NotNil(t, atThree)
+	require.Equal(t, *outpoint, *atThree.SpentOutPoint)
+	require.Equal(t, *spenderHash, *atThree.SpenderTxHash)
+	require.Zero(t, atThree.SpenderInputIndex)
+	require.Equal(t, spendHeight, atThree.SpendingHeight)
+}
+
 func testSpendNotification(miner *rpctest.Harness,
 	notifier chainntnfs.TestChainNotifier, scriptDispatch bool, t *testing.T) {
 
@@ -1834,6 +1967,10 @@ var txNtfnTests = []txNtfnTestCase{
 	{
 		name: "spend ntfn",
 		test: testSpendNotification,
+	},
+	{
+		name: "spend depth ntfn",
+		test: testSpendNotificationDepth,
 	},
 	{
 		name: "historical spend dispatch",

--- a/chainntnfs/txnotifier.go
+++ b/chainntnfs/txnotifier.go
@@ -530,6 +530,12 @@ type TxNotifier struct {
 	// being reorged out of the chain.
 	spendsByHeight map[uint32]map[SpendRequest]struct{}
 
+	// ntfnsBySpendConfirmHeight indexes individual spend clients by the
+	// height at which their shared candidate reaches the requested depth.
+	// Keeping this index separate lets clients use independent depths while
+	// retaining one inclusion record for reorg handling.
+	ntfnsBySpendConfirmHeight map[uint32]map[*SpendNtfn]struct{}
+
 	// confirmHintCache is a cache used to maintain the latest height hints
 	// for transactions/output scripts. Each height hint represents the
 	// earliest height at which they scripts could have been confirmed
@@ -564,9 +570,12 @@ func NewTxNotifier(startHeight uint32, reorgSafetyLimit uint32,
 		ntfnsByConfirmHeight: make(map[uint32]map[*ConfNtfn]struct{}),
 		spendNotifications:   make(map[SpendRequest]*spendNtfnSet),
 		spendsByHeight:       make(map[uint32]map[SpendRequest]struct{}),
-		confirmHintCache:     confirmHintCache,
-		spendHintCache:       spendHintCache,
-		quit:                 make(chan struct{}),
+		ntfnsBySpendConfirmHeight: make(
+			map[uint32]map[*SpendNtfn]struct{},
+		),
+		confirmHintCache: confirmHintCache,
+		spendHintCache:   spendHintCache,
+		quit:             make(chan struct{}),
 	}
 }
 
@@ -1138,7 +1147,7 @@ func (n *TxNotifier) RegisterSpend(
 			"registration since rescan has finished",
 			ntfn.SpendRequest)
 
-		err := n.dispatchSpendDetails(ntfn, spendSet.details)
+		err := n.scheduleSpendNtfn(ntfn, spendSet.details, false)
 		if err != nil {
 			return nil, err
 		}
@@ -1227,6 +1236,8 @@ func (n *TxNotifier) CancelSpend(spendRequest SpendRequest, spendID uint64) {
 
 	Log.Debugf("Canceling spend notification: spend_id=%d, %v", spendID,
 		spendRequest)
+
+	n.removeSpendMaturity(ntfn)
 
 	// We'll close all the notification channels to let the client know
 	// their cancel request has been fulfilled.
@@ -1396,13 +1407,78 @@ func (n *TxNotifier) updateSpendDetails(spendRequest SpendRequest,
 
 	spendSet.details = details
 	for _, ntfn := range spendSet.ntfns {
-		err := n.dispatchSpendDetails(ntfn, spendSet.details)
+		err := n.scheduleSpendNtfn(ntfn, spendSet.details, false)
 		if err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// scheduleSpendNtfn records a canonical spend candidate for one client and
+// either queues it at the requested maturity height or dispatches an already
+// mature historical candidate. A tip candidate waits for NotifyHeight even at
+// depth one so ConnectTip and notification delivery remain separate phases.
+//
+// NOTE: This must be called with the TxNotifier's lock held.
+func (n *TxNotifier) scheduleSpendNtfn(ntfn *SpendNtfn,
+	details *SpendDetail, waitForNotify bool) error {
+
+	// A missing candidate has nothing to schedule, while a delivered client
+	// must not receive the shared candidate a second time.
+	if details == nil || ntfn.dispatched {
+		return nil
+	}
+
+	spendHeight := uint32(details.SpendingHeight)
+	spendConfirmHeight := spendHeight + ntfn.NumConfirmations - 1
+
+	// Historical candidates at or behind the processed tip are already
+	// mature. A live tip candidate at the current height waits until the
+	// caller completes block processing through NotifyHeight.
+	if spendConfirmHeight < n.currentHeight ||
+		(spendConfirmHeight == n.currentHeight && !waitForNotify) {
+
+		return n.dispatchSpendDetails(ntfn, details)
+	}
+
+	ntfnSet, ok := n.ntfnsBySpendConfirmHeight[spendConfirmHeight]
+	if !ok {
+		// Allocate one bucket per maturity height so NotifyHeight can
+		// dispatch clients without scanning unrelated spend requests.
+		ntfnSet = make(map[*SpendNtfn]struct{})
+		n.ntfnsBySpendConfirmHeight[spendConfirmHeight] = ntfnSet
+	}
+	ntfnSet[ntfn] = struct{}{}
+
+	return nil
+}
+
+// removeSpendMaturity removes a pending client from its candidate's maturity
+// index. It is safe to call for an already-dispatched or candidate-free client
+// because deleting a missing map entry is a no-op.
+//
+// NOTE: This must be called with the TxNotifier's lock held.
+func (n *TxNotifier) removeSpendMaturity(ntfn *SpendNtfn) {
+	spendSet := n.spendNotifications[ntfn.SpendRequest]
+
+	// A canceled request without a candidate was never entered in the
+	// maturity index, so cleanup is complete without computing a height.
+	if spendSet == nil || spendSet.details == nil {
+		return
+	}
+
+	spendHeight := uint32(spendSet.details.SpendingHeight)
+	spendConfirmHeight := spendHeight + ntfn.NumConfirmations - 1
+	ntfnSet := n.ntfnsBySpendConfirmHeight[spendConfirmHeight]
+	delete(ntfnSet, ntfn)
+
+	if len(ntfnSet) == 0 {
+		// Drop empty height buckets to keep the index bounded by active
+		// spend clients rather than previously observed chain heights.
+		delete(n.ntfnsBySpendConfirmHeight, spendConfirmHeight)
+	}
 }
 
 // dispatchSpendDetails dispatches a spend notification to the client.
@@ -1527,6 +1603,18 @@ func (n *TxNotifier) ConnectTip(block *btcutil.Block,
 		for spendRequest := range n.spendsByHeight[matureBlockHeight] {
 			spendSet := n.spendNotifications[spendRequest]
 			for _, ntfn := range spendSet.ntfns {
+				// NotifyHeight normally dispatches this
+				// notification at its maturity height. Schedule
+				// it defensively if pruning is reached before
+				// that height is processed.
+				err := n.scheduleSpendNtfn(
+					ntfn, spendSet.details, false,
+				)
+				if err != nil {
+					return err
+				}
+				n.removeSpendMaturity(ntfn)
+
 				select {
 				case ntfn.Event.Done <- struct{}{}:
 				case <-n.quit:
@@ -1739,6 +1827,13 @@ func (n *TxNotifier) handleSpendDetailsAtTip(spendRequest SpendRequest,
 		case <-ntfn.Event.Reorg:
 		default:
 		}
+
+		// Queue tip candidates even at depth one so callers cannot
+		// observe them until NotifyHeight completes the block.
+		if err := n.scheduleSpendNtfn(ntfn, details, true); err != nil {
+			Log.Errorf("Unable to schedule spend for %v: %v",
+				spendRequest, err)
+		}
 	}
 
 	// We'll note the spending height of the request in order to correctly
@@ -1834,17 +1929,25 @@ func (n *TxNotifier) NotifyHeight(height uint32) error {
 	}
 	delete(n.ntfnsByConfirmHeight, height)
 
-	// Finally, we'll dispatch spend notifications for all the requests that
-	// were spent at this new block height.
-	for spendRequest := range n.spendsByHeight[height] {
-		spendSet := n.spendNotifications[spendRequest]
-		for _, ntfn := range spendSet.ntfns {
-			err := n.dispatchSpendDetails(ntfn, spendSet.details)
-			if err != nil {
-				return err
-			}
+	// Finally, we'll dispatch spend notifications whose individual maturity
+	// height has been reached. Their shared inclusion index remains intact
+	// until the candidate is reorg safe.
+	for ntfn := range n.ntfnsBySpendConfirmHeight[height] {
+		spendSet := n.spendNotifications[ntfn.SpendRequest]
+		if spendSet == nil {
+			// Cancellation can remove a registration before its
+			// queued height. Skip stale index entries.
+			continue
+		}
+
+		// Deliver the canonical details only after this client's own
+		// maturity height has been reached.
+		err := n.dispatchSpendDetails(ntfn, spendSet.details)
+		if err != nil {
+			return err
 		}
 	}
+	delete(n.ntfnsBySpendConfirmHeight, height)
 
 	return nil
 }
@@ -1929,10 +2032,17 @@ func (n *TxNotifier) DisconnectTip(blockHeight uint32) error {
 	// requests whose spending transaction was included at the height being
 	// disconnected.
 	for op := range n.spendsByHeight[blockHeight] {
+		spendSet := n.spendNotifications[op]
+
+		// Remove each queued maturity before clearing its shared
+		// candidate so a replacement cannot trigger a stale delivery.
+		for _, ntfn := range spendSet.ntfns {
+			n.removeSpendMaturity(ntfn)
+		}
+
 		// Since the spending transaction is being reorged out of the
 		// chain, we'll need to clear out the spending details of the
 		// request.
-		spendSet := n.spendNotifications[op]
 		spendSet.details = nil
 
 		// For all requests which have had a spend notification

--- a/chainntnfs/txnotifier.go
+++ b/chainntnfs/txnotifier.go
@@ -1406,6 +1406,7 @@ func (n *TxNotifier) updateSpendDetails(spendRequest SpendRequest,
 		"request %v", details.SpendingHeight, spendRequest)
 
 	spendSet.details = details
+	n.trackSpendByHeight(spendRequest, details)
 	for _, ntfn := range spendSet.ntfns {
 		err := n.scheduleSpendNtfn(ntfn, spendSet.details, false)
 		if err != nil {
@@ -1414,6 +1415,31 @@ func (n *TxNotifier) updateSpendDetails(spendRequest SpendRequest,
 	}
 
 	return nil
+}
+
+// trackSpendByHeight indexes shared candidate ownership independently of the
+// current client count, ensuring cancellation cannot hide cached details from
+// the disconnect path that must clear them after a reorg.
+//
+// NOTE: This must be called with the TxNotifier's lock held.
+func (n *TxNotifier) trackSpendByHeight(spendRequest SpendRequest,
+	details *SpendDetail) {
+
+	// Candidates beyond the notifier's reorg window no longer need reverse
+	// indexing because a supported DisconnectTip cannot reach their block.
+	spendHeight := uint32(details.SpendingHeight)
+	if spendHeight+n.reorgSafetyLimit <= n.currentHeight {
+		return
+	}
+
+	spendSet, ok := n.spendsByHeight[spendHeight]
+	if !ok {
+		// Allocate one bucket per inclusion height so every cached
+		// request is invalidated when the block disconnects.
+		spendSet = make(map[SpendRequest]struct{})
+		n.spendsByHeight[spendHeight] = spendSet
+	}
+	spendSet[spendRequest] = struct{}{}
 }
 
 // scheduleSpendNtfn records a canonical spend candidate for one client and
@@ -1503,19 +1529,6 @@ func (n *TxNotifier) dispatchSpendDetails(ntfn *SpendNtfn, details *SpendDetail)
 		ntfn.dispatched = true
 	case <-n.quit:
 		return ErrTxNotifierExiting
-	}
-
-	spendHeight := uint32(details.SpendingHeight)
-
-	// We also add to spendsByHeight to notify on chain reorgs.
-	reorgSafeHeight := spendHeight + n.reorgSafetyLimit
-	if reorgSafeHeight > n.currentHeight {
-		txSet, exists := n.spendsByHeight[spendHeight]
-		if !exists {
-			txSet = make(map[SpendRequest]struct{})
-			n.spendsByHeight[spendHeight] = txSet
-		}
-		txSet[ntfn.SpendRequest] = struct{}{}
 	}
 
 	return nil
@@ -1817,6 +1830,7 @@ func (n *TxNotifier) handleSpendDetailsAtTip(spendRequest SpendRequest,
 	spendSet := n.spendNotifications[spendRequest]
 	spendSet.rescanStatus = rescanComplete
 	spendSet.details = details
+	n.trackSpendByHeight(spendRequest, details)
 
 	for _, ntfn := range spendSet.ntfns {
 		// In the event that this notification was aware that the
@@ -1836,19 +1850,8 @@ func (n *TxNotifier) handleSpendDetailsAtTip(spendRequest SpendRequest,
 		}
 	}
 
-	// We'll note the spending height of the request in order to correctly
-	// handle dispatching notifications when the spending transactions gets
-	// reorged out of the chain.
-	spendHeight := uint32(details.SpendingHeight)
-	opSet, exists := n.spendsByHeight[spendHeight]
-	if !exists {
-		opSet = make(map[SpendRequest]struct{})
-		n.spendsByHeight[spendHeight] = opSet
-	}
-	opSet[spendRequest] = struct{}{}
-
 	Log.Debugf("Spend request %v spent at tip=%d", spendRequest,
-		spendHeight)
+		details.SpendingHeight)
 }
 
 // NotifyHeight dispatches confirmation and spend notifications to the clients

--- a/chainntnfs/txnotifier.go
+++ b/chainntnfs/txnotifier.go
@@ -432,6 +432,10 @@ type SpendNtfn struct {
 	// an entry for it.
 	HeightHint uint32
 
+	// NumConfirmations is the depth at which the spend becomes safe to
+	// deliver.
+	NumConfirmations uint32
+
 	// dispatched signals whether a spend notification has been dispatched
 	// to the client.
 	dispatched bool
@@ -1019,7 +1023,8 @@ func (n *TxNotifier) dispatchConfDetails(
 // newSpendNtfn validates all of the parameters required to successfully create
 // and register a spend notification.
 func (n *TxNotifier) newSpendNtfn(outpoint *wire.OutPoint,
-	pkScript []byte, heightHint uint32) (*SpendNtfn, error) {
+	pkScript []byte, heightHint uint32,
+	opts *SpendOptions) (*SpendNtfn, error) {
 
 	// An accompanying output script must always be provided.
 	if len(pkScript) == 0 {
@@ -1032,6 +1037,13 @@ func (n *TxNotifier) newSpendNtfn(outpoint *wire.OutPoint,
 		return nil, ErrNoHeightHint
 	}
 
+	// Keep the requested maturity inside this notifier's retained reorg
+	// history so the candidate cannot be pruned before delivery. Production
+	// notifiers retain ReorgSafetyLimit, currently 144 blocks.
+	if opts.NumConfs > n.reorgSafetyLimit {
+		return nil, ErrNumConfsOutOfRange
+	}
+
 	// Ensure the output script is of a supported type.
 	spendRequest, err := NewSpendRequest(outpoint, pkScript)
 	if err != nil {
@@ -1040,8 +1052,9 @@ func (n *TxNotifier) newSpendNtfn(outpoint *wire.OutPoint,
 
 	spendID := atomic.AddUint64(&n.spendClientCounter, 1)
 	return &SpendNtfn{
-		SpendID:      spendID,
-		SpendRequest: spendRequest,
+		SpendID:          spendID,
+		SpendRequest:     spendRequest,
+		NumConfirmations: opts.NumConfs,
 		Event: NewSpendEvent(func() {
 			n.CancelSpend(spendRequest, spendID)
 		}),
@@ -1057,8 +1070,9 @@ func (n *TxNotifier) newSpendNtfn(outpoint *wire.OutPoint,
 // before the notifier's current tip, the spend details must be provided with
 // the UpdateSpendDetails method, otherwise we will wait for the outpoint/output
 // script to be spent at tip, even though it already has.
-func (n *TxNotifier) RegisterSpend(outpoint *wire.OutPoint, pkScript []byte,
-	heightHint uint32) (*SpendRegistration, error) {
+func (n *TxNotifier) RegisterSpend(
+	outpoint *wire.OutPoint, pkScript []byte, heightHint uint32,
+	optFuncs ...SpendOption) (*SpendRegistration, error) {
 
 	select {
 	case <-n.quit:
@@ -1066,8 +1080,15 @@ func (n *TxNotifier) RegisterSpend(outpoint *wire.OutPoint, pkScript []byte,
 	default:
 	}
 
-	// We'll start by performing a series of validation checks.
-	ntfn, err := n.newSpendNtfn(outpoint, pkScript, heightHint)
+	// Parse the globally valid policy before creating any client state.
+	opts, err := ParseSpendOptions(optFuncs...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Apply request and notifier-specific validation before touching caches
+	// or registration maps.
+	ntfn, err := n.newSpendNtfn(outpoint, pkScript, heightHint, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/chainntnfs/txnotifier.go
+++ b/chainntnfs/txnotifier.go
@@ -1828,6 +1828,17 @@ func (n *TxNotifier) handleSpendDetailsAtTip(spendRequest SpendRequest,
 
 	// TODO(wilmer): cancel pending historical rescans if any?
 	spendSet := n.spendNotifications[spendRequest]
+
+	// A script-only request can match several outpoints that reuse one
+	// script. Preserve the first candidate until it disconnects or ages out
+	// so queued clients cannot be retargeted to a less mature replacement.
+	if spendSet.details != nil {
+		Log.Warnf("Ignoring output script reuse for %s at height %d.",
+			spendRequest, details.SpendingHeight)
+
+		return
+	}
+
 	spendSet.rescanStatus = rescanComplete
 	spendSet.details = details
 	n.trackSpendByHeight(spendRequest, details)

--- a/chainntnfs/txnotifier_test.go
+++ b/chainntnfs/txnotifier_test.go
@@ -126,6 +126,285 @@ func newMockHintCache() *mockHintCache {
 	}
 }
 
+// createSpendTestTx builds a distinct transaction that spends outpoint. The
+// version differentiates replacement transactions without changing which
+// registered request TxNotifier matches.
+func createSpendTestTx(outpoint wire.OutPoint, version int32) *wire.MsgTx {
+	spendTx := wire.NewMsgTx(version)
+
+	// Include witness and signature data so the transaction resembles
+	// spend forms covered by existing notifier regression tests.
+	spendTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: outpoint,
+		Witness:          testWitness,
+		SignatureScript:  testSigScript,
+	})
+
+	return spendTx
+}
+
+// pollSpendTest performs a non-blocking observation of a spend channel. It
+// lets tests record delivery at each height and defer all conclusions to a
+// distinct Assert phase.
+func pollSpendTest(spend <-chan *chainntnfs.SpendDetail) (
+	*chainntnfs.SpendDetail, bool) {
+
+	// A non-blocking select distinguishes an eligible notification from a
+	// client that must remain pending at its configured depth.
+	select {
+	case details := <-spend:
+		return details, true
+
+	default:
+		return nil, false
+	}
+}
+
+// TestTxNotifierSpendDepth verifies that clients sharing a spend candidate
+// are delivered independently at the compatibility default and explicit
+// confirmation depths.
+func TestTxNotifierSpendDepth(t *testing.T) {
+	t.Parallel()
+
+	// Arrange a notifier at height 10, two clients for the same outpoint,
+	// and one spend entering the next block. The default client requests no
+	// option, while the second explicitly requires three confirmations.
+	const startHeight = uint32(10)
+	hintCache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, hintCache, hintCache,
+	)
+	outpoint := wire.OutPoint{Index: 1}
+	defaultNtfn, err := n.RegisterSpend(
+		&outpoint, testRawScript, startHeight+1,
+	)
+	require.NoError(t, err)
+	t.Cleanup(defaultNtfn.Event.Cancel)
+
+	deepNtfn, err := n.RegisterSpend(
+		&outpoint, testRawScript, startHeight+1,
+		chainntnfs.WithSpendNumConfs(3),
+	)
+	require.NoError(t, err)
+	t.Cleanup(deepNtfn.Event.Cancel)
+	spendTx := createSpendTestTx(outpoint, 2)
+
+	// Act by processing the inclusion block and two successors. Observe
+	// both client channels after each height so the Assert phase can prove
+	// the exact delivery boundary instead of merely eventual delivery.
+	require.NoError(t, n.ConnectTip(btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{spendTx},
+	}), 11))
+	require.NoError(t, n.NotifyHeight(11))
+	defaultAtOne, defaultAtOneOK := pollSpendTest(defaultNtfn.Event.Spend)
+	deepAtOne, deepAtOneOK := pollSpendTest(deepNtfn.Event.Spend)
+
+	require.NoError(t, n.ConnectTip(
+		btcutil.NewBlock(&wire.MsgBlock{}), 12,
+	))
+	require.NoError(t, n.NotifyHeight(12))
+	deepAtTwo, deepAtTwoOK := pollSpendTest(deepNtfn.Event.Spend)
+
+	require.NoError(t, n.ConnectTip(
+		btcutil.NewBlock(&wire.MsgBlock{}), 13,
+	))
+	require.NoError(t, n.NotifyHeight(13))
+	deepAtThree, deepAtThreeOK := pollSpendTest(deepNtfn.Event.Spend)
+
+	// Assert the legacy client receives the canonical spend at one
+	// confirmation, while the explicit client stays silent through depth
+	// two and receives the same candidate exactly at depth three.
+	require.True(t, defaultAtOneOK)
+	require.NotNil(t, defaultAtOne)
+	require.Equal(t, int32(11), defaultAtOne.SpendingHeight)
+	require.False(t, deepAtOneOK)
+	require.Nil(t, deepAtOne)
+	require.False(t, deepAtTwoOK)
+	require.Nil(t, deepAtTwo)
+	require.True(t, deepAtThreeOK)
+	require.NotNil(t, deepAtThree)
+	require.Equal(t, spendTx.TxHash(), *deepAtThree.SpenderTxHash)
+}
+
+// TestTxNotifierHistoricalSpendDepth verifies that cached spend details obey
+// each newly registered client's depth rather than inheriting the first
+// client's delivery state.
+func TestTxNotifierHistoricalSpendDepth(t *testing.T) {
+	t.Parallel()
+
+	// Arrange a notifier one block before a three-confirmation candidate
+	// matures. Register the deep client before supplying historical details
+	// so a later default client must reuse the same cached candidate.
+	const startHeight = uint32(12)
+	hintCache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, hintCache, hintCache,
+	)
+	outpoint := wire.OutPoint{Index: 2}
+	spendTx := createSpendTestTx(outpoint, 2)
+	spendHash := spendTx.TxHash()
+	spendDetails := &chainntnfs.SpendDetail{
+		SpentOutPoint:     &outpoint,
+		SpenderTxHash:     &spendHash,
+		SpendingTx:        spendTx,
+		SpenderInputIndex: 0,
+		SpendingHeight:    11,
+	}
+	deepNtfn, err := n.RegisterSpend(
+		&outpoint, testRawScript, 1,
+		chainntnfs.WithSpendNumConfs(3),
+	)
+	require.NoError(t, err)
+	t.Cleanup(deepNtfn.Event.Cancel)
+
+	// Act by caching the historical inclusion, registering a default-depth
+	// client against that cache, and then advancing to the deep client's
+	// maturity height. Record both pre- and post-maturity observations.
+	require.NoError(t, n.UpdateSpendDetails(
+		deepNtfn.HistoricalDispatch.SpendRequest, spendDetails,
+	))
+	deepBefore, deepBeforeOK := pollSpendTest(deepNtfn.Event.Spend)
+
+	defaultNtfn, err := n.RegisterSpend(&outpoint, testRawScript, 1)
+	require.NoError(t, err)
+	t.Cleanup(defaultNtfn.Event.Cancel)
+	defaultCached, defaultCachedOK := pollSpendTest(
+		defaultNtfn.Event.Spend,
+	)
+
+	require.NoError(t, n.ConnectTip(
+		btcutil.NewBlock(&wire.MsgBlock{}), 13,
+	))
+	require.NoError(t, n.NotifyHeight(13))
+	deepMature, deepMatureOK := pollSpendTest(deepNtfn.Event.Spend)
+
+	// Assert the depth-three client remains queued at height 12, the cached
+	// default client receives the already mature spend immediately, and the
+	// queued client receives identical details when height 13 is processed.
+	require.False(t, deepBeforeOK)
+	require.Nil(t, deepBefore)
+	require.True(t, defaultCachedOK)
+	require.Equal(t, spendHash, *defaultCached.SpenderTxHash)
+	require.True(t, deepMatureOK)
+	require.Equal(t, spendHash, *deepMature.SpenderTxHash)
+}
+
+// TestTxNotifierSpendDepthReorg verifies that a candidate disconnected before
+// maturity is discarded and a replacement candidate can satisfy the same
+// registration at the requested depth.
+func TestTxNotifierSpendDepthReorg(t *testing.T) {
+	t.Parallel()
+
+	// Arrange a three-confirmation client and two transactions. Both spend
+	// the same outpoint, while the second represents the replacement after
+	// the first inclusion is disconnected.
+	const startHeight = uint32(10)
+	hintCache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, hintCache, hintCache,
+	)
+	outpoint := wire.OutPoint{Index: 3}
+	ntfn, err := n.RegisterSpend(
+		&outpoint, testRawScript, startHeight+1,
+		chainntnfs.WithSpendNumConfs(3),
+	)
+	require.NoError(t, err)
+	t.Cleanup(ntfn.Event.Cancel)
+	originalTx := createSpendTestTx(outpoint, 2)
+	replacementTx := createSpendTestTx(outpoint, 3)
+
+	// Act by advancing the original candidate to depth two, disconnecting
+	// both blocks so its inclusion leaves the canonical chain, and then
+	// mining the replacement candidate through depth three.
+	require.NoError(t, n.ConnectTip(btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{originalTx},
+	}), 11))
+	require.NoError(t, n.NotifyHeight(11))
+	require.NoError(t, n.ConnectTip(
+		btcutil.NewBlock(&wire.MsgBlock{}), 12,
+	))
+	require.NoError(t, n.NotifyHeight(12))
+	originalBeforeReorg, originalBeforeReorgOK := pollSpendTest(
+		ntfn.Event.Spend,
+	)
+
+	require.NoError(t, n.DisconnectTip(12))
+	require.NoError(t, n.DisconnectTip(11))
+	afterReorg, afterReorgOK := pollSpendTest(ntfn.Event.Spend)
+
+	require.NoError(t, n.ConnectTip(btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{replacementTx},
+	}), 11))
+	require.NoError(t, n.NotifyHeight(11))
+	require.NoError(t, n.ConnectTip(
+		btcutil.NewBlock(&wire.MsgBlock{}), 12,
+	))
+	require.NoError(t, n.NotifyHeight(12))
+	require.NoError(t, n.ConnectTip(
+		btcutil.NewBlock(&wire.MsgBlock{}), 13,
+	))
+	require.NoError(t, n.NotifyHeight(13))
+	replacementMature, replacementMatureOK := pollSpendTest(
+		ntfn.Event.Spend,
+	)
+
+	// Assert the original candidate never escaped before or during the
+	// reorg, and only the replacement transaction is delivered once its own
+	// three-confirmation boundary is reached.
+	require.False(t, originalBeforeReorgOK)
+	require.Nil(t, originalBeforeReorg)
+	require.False(t, afterReorgOK)
+	require.Nil(t, afterReorg)
+	require.True(t, replacementMatureOK)
+	require.Equal(
+		t, replacementTx.TxHash(), *replacementMature.SpenderTxHash,
+	)
+}
+
+// TestTxNotifierSpendDepthCancel verifies cancellation removes a queued
+// maturity entry before its height is processed.
+func TestTxNotifierSpendDepthCancel(t *testing.T) {
+	t.Parallel()
+
+	// Arrange a deep client with a spend candidate at one confirmation so
+	// cancellation occurs while the client is present in both the shared
+	// inclusion index and its client-specific maturity bucket.
+	const startHeight = uint32(10)
+	hintCache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, hintCache, hintCache,
+	)
+	outpoint := wire.OutPoint{Index: 4}
+	ntfn, err := n.RegisterSpend(
+		&outpoint, testRawScript, startHeight+1,
+		chainntnfs.WithSpendNumConfs(3),
+	)
+	require.NoError(t, err)
+	spendTx := createSpendTestTx(outpoint, 2)
+
+	// Act by queueing the candidate, canceling the only client, and then
+	// processing the two blocks that would otherwise trigger delivery.
+	require.NoError(t, n.ConnectTip(btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{spendTx},
+	}), 11))
+	require.NoError(t, n.NotifyHeight(11))
+	ntfn.Event.Cancel()
+	require.NoError(t, n.ConnectTip(
+		btcutil.NewBlock(&wire.MsgBlock{}), 12,
+	))
+	require.NoError(t, n.NotifyHeight(12))
+	require.NoError(t, n.ConnectTip(
+		btcutil.NewBlock(&wire.MsgBlock{}), 13,
+	))
+	require.NoError(t, n.NotifyHeight(13))
+	_, spendOpen := <-ntfn.Event.Spend
+
+	// Assert cancellation closed the client channel and processing the old
+	// maturity height succeeded, proving no stale delivery attempted to use
+	// the removed registration.
+	require.False(t, spendOpen)
+}
+
 // TestTxNotifierRegistrationValidation ensures that we are not able to register
 // requests with invalid parameters.
 func TestTxNotifierRegistrationValidation(t *testing.T) {

--- a/chainntnfs/txnotifier_test.go
+++ b/chainntnfs/txnotifier_test.go
@@ -405,6 +405,168 @@ func TestTxNotifierSpendDepthCancel(t *testing.T) {
 	require.False(t, spendOpen)
 }
 
+// TestTxNotifierScriptSpendCandidateOwnership verifies a script notification
+// keeps its first canonical spend while that candidate is awaiting maturity.
+func TestTxNotifierScriptSpendCandidateOwnership(t *testing.T) {
+	t.Parallel()
+
+	// Arrange two depth-three clients for one script and two distinct
+	// outpoints that reuse it in consecutive blocks. The second client lets
+	// cancellation expose a stale first-candidate maturity entry.
+	const startHeight = uint32(10)
+	hintCache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, hintCache, hintCache,
+	)
+	firstClient, err := n.RegisterSpend(
+		nil, testRawScript, startHeight+1,
+		chainntnfs.WithSpendNumConfs(3),
+	)
+	require.NoError(t, err)
+	t.Cleanup(firstClient.Event.Cancel)
+	secondClient, err := n.RegisterSpend(
+		nil, testRawScript, startHeight+1,
+		chainntnfs.WithSpendNumConfs(3),
+	)
+	require.NoError(t, err)
+	firstOutpoint := wire.OutPoint{Hash: chainhash.Hash{1}, Index: 1}
+	secondOutpoint := wire.OutPoint{Hash: chainhash.Hash{2}, Index: 2}
+	firstSpend := createSpendTestTx(firstOutpoint, 2)
+	secondSpend := createSpendTestTx(secondOutpoint, 3)
+
+	// Act by queueing the first candidate, processing a later same-script
+	// spend, canceling one client, and advancing to the original maturity
+	// height. A stale bucket would either deliver the immature replacement
+	// or attempt to send it through the canceled client's closed channel.
+	require.NoError(t, n.ConnectTip(btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{firstSpend},
+	}), 11))
+	require.NoError(t, n.NotifyHeight(11))
+	require.NoError(t, n.ConnectTip(btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{secondSpend},
+	}), 12))
+	require.NoError(t, n.NotifyHeight(12))
+	secondClient.Event.Cancel()
+	require.NoError(t, n.ConnectTip(
+		btcutil.NewBlock(&wire.MsgBlock{}), 13,
+	))
+	require.NoError(t, n.NotifyHeight(13))
+	delivered, deliveredOK := pollSpendTest(firstClient.Event.Spend)
+	_, canceledOpen := <-secondClient.Event.Spend
+
+	// Assert only the first candidate is delivered at its own depth and
+	// the canceled client stays closed. Reaching the height without a panic
+	// also proves cancellation removed the immutable maturity entry.
+	require.True(t, deliveredOK)
+	require.NotNil(t, delivered)
+	require.Equal(t, firstSpend.TxHash(), *delivered.SpenderTxHash)
+	require.False(t, canceledOpen)
+}
+
+// TestTxNotifierCanceledSpendReorg checks that a spend discovered after its
+// last client cancels cannot remain cached across a block disconnection.
+func TestTxNotifierCanceledSpendReorg(t *testing.T) {
+	t.Parallel()
+
+	// Arrange a notifier with one request whose only client cancels before
+	// the original spend. Distinct transaction versions let the assertions
+	// distinguish stale delivery from the canonical replacement.
+	const startHeight = uint32(10)
+	hintCache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, hintCache, hintCache,
+	)
+	outpoint := wire.OutPoint{Index: 8}
+	canceledNtfn, err := n.RegisterSpend(
+		&outpoint, testRawScript, startHeight+1,
+	)
+	require.NoError(t, err)
+	canceledNtfn.Event.Cancel()
+	originalTx := createSpendTestTx(outpoint, 2)
+	replacementTx := createSpendTestTx(outpoint, 3)
+
+	// Act by discovering the original spend with no active clients, then
+	// disconnect its block and register a fresh client. Process an empty
+	// block to expose stale candidates, reorg it, and connect the actual
+	// replacement spend at the same height.
+	require.NoError(t, n.ConnectTip(btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{originalTx},
+	}), 11))
+	require.NoError(t, n.NotifyHeight(11))
+	require.NoError(t, n.DisconnectTip(11))
+
+	freshNtfn, err := n.RegisterSpend(
+		&outpoint, testRawScript, startHeight+1,
+	)
+	require.NoError(t, err)
+	t.Cleanup(freshNtfn.Event.Cancel)
+	require.NoError(t, n.ConnectTip(
+		btcutil.NewBlock(&wire.MsgBlock{}), 11,
+	))
+	require.NoError(t, n.NotifyHeight(11))
+	staleSpend, staleSpendOK := pollSpendTest(freshNtfn.Event.Spend)
+
+	require.NoError(t, n.DisconnectTip(11))
+	require.NoError(t, n.ConnectTip(btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{replacementTx},
+	}), 11))
+	require.NoError(t, n.NotifyHeight(11))
+	replacementSpend, replacementSpendOK := pollSpendTest(
+		freshNtfn.Event.Spend,
+	)
+
+	// Assert the empty block cannot deliver the disconnected transaction.
+	// The registration must stay live for only the canonical replacement,
+	// proving request-level reorg tracking survives client turnover.
+	require.False(t, staleSpendOK)
+	require.Nil(t, staleSpend)
+	require.True(t, replacementSpendOK)
+	require.NotNil(t, replacementSpend)
+	require.Equal(
+		t, replacementTx.TxHash(), *replacementSpend.SpenderTxHash,
+	)
+}
+
+// TestTxNotifierSpendDepthValidation verifies invalid depth requests fail
+// before a spend registration is created.
+func TestTxNotifierSpendDepthValidation(t *testing.T) {
+	t.Parallel()
+
+	// Arrange one standard notifier for global boundary checks and one with
+	// a smaller retained reorg window for its stricter backend boundary.
+	hintCache := newMockHintCache()
+	standard := chainntnfs.NewTxNotifier(
+		10, chainntnfs.ReorgSafetyLimit, hintCache, hintCache,
+	)
+	narrow := chainntnfs.NewTxNotifier(10, 2, hintCache, hintCache)
+	outpoint := wire.OutPoint{Index: 5}
+
+	// Act by requesting zero confirmations, more than the global maximum,
+	// and a globally valid depth that exceeds the narrow notifier's reorg
+	// window. Capture registrations to verify failure is mutation-free.
+	zeroReg, zeroErr := standard.RegisterSpend(
+		&outpoint, testRawScript, 1,
+		chainntnfs.WithSpendNumConfs(0),
+	)
+	globalReg, globalErr := standard.RegisterSpend(
+		&outpoint, testRawScript, 1,
+		chainntnfs.WithSpendNumConfs(chainntnfs.MaxNumConfs+1),
+	)
+	narrowReg, narrowErr := narrow.RegisterSpend(
+		&outpoint, testRawScript, 1,
+		chainntnfs.WithSpendNumConfs(3),
+	)
+
+	// Assert both validation layers return the shared public sentinel and
+	// none exposes a partially registered client to the caller.
+	require.ErrorIs(t, zeroErr, chainntnfs.ErrNumConfsOutOfRange)
+	require.Nil(t, zeroReg)
+	require.ErrorIs(t, globalErr, chainntnfs.ErrNumConfsOutOfRange)
+	require.Nil(t, globalReg)
+	require.ErrorIs(t, narrowErr, chainntnfs.ErrNumConfsOutOfRange)
+	require.Nil(t, narrowReg)
+}
+
 // TestTxNotifierRegistrationValidation ensures that we are not able to register
 // requests with invalid parameters.
 func TestTxNotifierRegistrationValidation(t *testing.T) {

--- a/chainreg/no_chain_backend.go
+++ b/chainreg/no_chain_backend.go
@@ -66,7 +66,7 @@ func (n *NoChainBackend) RegisterConfirmationsNtfn(*chainhash.Hash, []byte,
 }
 
 func (n *NoChainBackend) RegisterSpendNtfn(*wire.OutPoint, []byte,
-	uint32) (*chainntnfs.SpendEvent, error) {
+	uint32, ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
 	return nil, errNotImplemented
 }

--- a/contractcourt/chain_watcher_test_harness.go
+++ b/contractcourt/chain_watcher_test_harness.go
@@ -88,7 +88,8 @@ type mockConfirmationEvent struct {
 
 // RegisterSpendNtfn creates a new mock spend event.
 func (m *mockChainNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	pkScript []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	pkScript []byte, heightHint uint32,
+	_ ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
 	// The base mock already has SpendChan, use that.
 	spendEvent := &chainntnfs.SpendEvent{

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -455,7 +455,8 @@ func (m *mockNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash,
 }
 
 func (m *mockNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint, _ []byte,
-	_ uint32) (*chainntnfs.SpendEvent, error) {
+	_ uint32, _ ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
+
 	return nil, nil
 }
 

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -232,7 +232,9 @@ func (m *mockNotifier) Stop() error {
 }
 
 func (m *mockNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint, _ []byte,
-	heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	heightHint uint32, _ ...chainntnfs.SpendOption) (
+	*chainntnfs.SpendEvent, error) {
+
 	return &chainntnfs.SpendEvent{
 		Spend:  make(chan *chainntnfs.SpendDetail),
 		Cancel: func() {},

--- a/lntest/mock/chainnotifier.go
+++ b/lntest/mock/chainnotifier.go
@@ -40,7 +40,8 @@ func (c *ChainNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash,
 // RegisterSpendNtfn returns a SpendEvent that contains a channel that the spend
 // details will go over.
 func (c *ChainNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	pkScript []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	pkScript []byte, heightHint uint32,
+	_ ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
 	return &chainntnfs.SpendEvent{
 		Spend:  c.SpendChan,

--- a/lntest/mock/spendnotifier.go
+++ b/lntest/mock/spendnotifier.go
@@ -31,7 +31,8 @@ func MakeMockSpendNotifier() *SpendNotifier {
 
 // RegisterSpendNtfn registers a spend notification for a specified outpoint.
 func (s *SpendNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	_ []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	_ []byte, heightHint uint32,
+	_ ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
 	s.mtx.Lock()
 	defer s.mtx.Unlock()

--- a/lnwallet/chancloser/mock.go
+++ b/lnwallet/chancloser/mock.go
@@ -73,9 +73,18 @@ func (d *dummyAdapters) RegisterConfirmationsNtfn(txid *chainhash.Hash,
 }
 
 func (d *dummyAdapters) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	pkScript []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	pkScript []byte, heightHint uint32,
+	opts ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
-	args := d.Called(outpoint, pkScript, heightHint)
+	// Preserve existing three-argument expectations, while exposing the
+	// option slice when a focused test verifies the requested spend depth.
+	callArgs := []interface{}{outpoint, pkScript, heightHint}
+	if len(opts) != 0 {
+		// Keep options grouped so the mock can compare the same
+		// variadic boundary used by the production interface.
+		callArgs = append(callArgs, opts)
+	}
+	args := d.Called(callArgs...)
 
 	err := args.Error(0)
 

--- a/lnwallet/mock.go
+++ b/lnwallet/mock.go
@@ -370,7 +370,8 @@ func (c *mockChainNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash,
 // RegisterSpendNtfn returns a SpendEvent that contains a channel that the spend
 // details will go over.
 func (c *mockChainNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	pkScript []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	pkScript []byte, heightHint uint32,
+	_ ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
 	return &chainntnfs.SpendEvent{
 		Spend:  c.SpendChan,

--- a/peer/daemon_adapters.go
+++ b/peer/daemon_adapters.go
@@ -129,10 +129,11 @@ func (l *LndDaemonAdapters) RegisterConfirmationsNtfn(txid *chainhash.Hash,
 // RegisterSpendNtfn registers an intent to be notified once the target
 // outpoint is successfully spent within a transaction.
 func (l *LndDaemonAdapters) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	pkScript []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	pkScript []byte, heightHint uint32,
+	opts ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
 	return l.cfg.ChainNotifier.RegisterSpendNtfn(
-		outpoint, pkScript, heightHint,
+		outpoint, pkScript, heightHint, opts...,
 	)
 }
 

--- a/protofsm/state_machine.go
+++ b/protofsm/state_machine.go
@@ -113,7 +113,8 @@ type DaemonAdapters interface {
 	// the outpoint creates must also be specified. This allows this
 	// interface to be implemented by BIP 158-like filtering.
 	RegisterSpendNtfn(outpoint *wire.OutPoint, pkScript []byte,
-		heightHint uint32) (*chainntnfs.SpendEvent, error)
+		heightHint uint32, opts ...chainntnfs.SpendOption) (
+		*chainntnfs.SpendEvent, error)
 }
 
 // stateQuery is used by outside callers to query the internal state of the

--- a/protofsm/state_machine_test.go
+++ b/protofsm/state_machine_test.go
@@ -395,9 +395,18 @@ func (d *dummyAdapters) RegisterConfirmationsNtfn(txid *chainhash.Hash,
 }
 
 func (d *dummyAdapters) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	pkScript []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	pkScript []byte, heightHint uint32,
+	opts ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
-	args := d.Called(outpoint, pkScript, heightHint)
+	// Preserve existing three-argument expectations, while exposing the
+	// option slice when a focused test verifies the requested spend depth.
+	callArgs := []interface{}{outpoint, pkScript, heightHint}
+	if len(opts) != 0 {
+		// Keep options grouped so the mock can compare the same
+		// variadic boundary used by the production interface.
+		callArgs = append(callArgs, opts)
+	}
+	args := d.Called(callArgs...)
 
 	err := args.Error(0)
 

--- a/sweep/test_utils.go
+++ b/sweep/test_utils.go
@@ -209,7 +209,8 @@ func (m *MockNotifier) Stop() error {
 
 // RegisterSpendNtfn registers for spend notifications.
 func (m *MockNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	_ []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	_ []byte, heightHint uint32,
+	_ ...chainntnfs.SpendOption) (*chainntnfs.SpendEvent, error) {
 
 	log.Debugf("RegisterSpendNtfn for outpoint %v", outpoint)
 


### PR DESCRIPTION
## Summary

Add caller-selected confirmation depth to spend notifications while preserving the existing one-confirmation default.

## Change Description

Spend registrations now carry their requested maturity through TxNotifier scheduling and reorg handling. Backend-neutral coverage exercises future and historical registrations, maturity boundaries, reorgs, and cancellation.

## Notes

This is PR 1 of 3 for the resolution-lifecycle update and depends only on master. After this PR merges, the sweep lifecycle layer will be rebased onto the updated master and opened as PR 2. PR #11054 remains draft as PR 3 until both prerequisite layers merge.