### PR TITLE
lnwallet: reply to funding requests with a promise instead of channels

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -101,6 +101,17 @@
   later in the reservation flow as a funder-balance-dust error; they now
   surface a clearer, spec-aligned error string up front.
 
+* The fundee now [rejects absurdly high channel
+  feerates](https://github.com/lightningnetwork/lnd/pull/11151), covering the
+  two BOLT-02 checks that bound the commitment feerate an initiator can impose.
+  An incoming `open_channel` is failed if its `feerate_per_kw` exceeds ten times
+  our own estimate (never below 100 sat/vbyte, so a low or stale estimate can't
+  turn away sane channels), or if the resulting `to_local` and `to_remote`
+  amounts would both land at or under their channel reserve. Because all
+  channels are single funder, an initiator proposing such a feerate mostly
+  burns its own capacity; the checks stop it from also spending one of our
+  pending channel slots on a channel that could never be used.
+
 * [Require an explicit `channel_type` during channel
   funding](https://github.com/lightningnetwork/lnd/pull/11064). It is now always
   set in `open_channel` and echoed back in `accept_channel`, and an

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -158,6 +158,13 @@
 
 ## Code Health
 
+* [Promises for the wallet's funding
+  workflow](https://github.com/lightningnetwork/lnd/pull/11152): the
+  internal requests the `LightningWallet` message handler serves no longer
+  carry their own reply channels. Each request now hands back an
+  `actor.Future`, which removes the paired error and result channels that
+  callers had to drain in the right order.
+
 ## Tooling and Documentation
 
 * [`dev.Dockerfile` now uses](https://github.com/lightningnetwork/lnd/pull/10903)

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -108,7 +108,24 @@ const (
 	// can have. After this point, pending channel opens will start to be
 	// rejected.
 	pendingChansLimit = 50
+
+	// maxCommitFeeRateMultiplier is the multiple of our own commitment fee
+	// rate estimate that we'll tolerate as the initial fee rate of a
+	// channel opened by a remote peer. BOLT-02 requires that we fail a
+	// channel whose feerate_per_kw we consider "unreasonably large", but
+	// leaves the threshold up to each implementation. Both CLN and Eclair
+	// settle on 10x their own estimate, so we do the same.
+	maxCommitFeeRateMultiplier = 10
 )
+
+// minCommitFeeRateCap is the floor we place on the maximum commitment fee rate
+// we'll accept from a channel initiator. Our fee estimator can report a very
+// low rate on a quiet chain, or fall back to the relay fee entirely, and we
+// don't want that to make us reject a channel opened at a rate that's high
+// relative to our estimate yet perfectly sane in absolute terms. At 100
+// sat/vbyte a commitment transaction confirms under any realistic mempool
+// condition, so we never treat anything at or below it as unreasonable.
+var minCommitFeeRateCap = chainfee.SatPerKVByte(100 * 1000).FeePerKWeight()
 
 var (
 	// ErrFundingManagerShuttingDown is an error returned when attempting to
@@ -1429,6 +1446,34 @@ func (f *Manager) ProcessFundingMsg(msg lnwire.Message, peer lnpeer.Peer) {
 	}
 }
 
+// maxRemoteCommitFeeRate returns the highest commitment fee rate we're willing
+// to accept from the initiator of an inbound channel. The bound scales with our
+// own view of the current network fee rate, but never drops below
+// minCommitFeeRateCap, so a low or stale estimate can't make us turn away
+// channels opened at an absolutely reasonable rate.
+func (f *Manager) maxRemoteCommitFeeRate() chainfee.SatPerKWeight {
+	// We use the same conf target we'd use for a channel we open
+	// ourselves, so that the bound tracks the rate we consider necessary
+	// for a timely unilateral close.
+	ourFeeRate, err := f.cfg.FeeEstimator.EstimateFeePerKW(3)
+	if err != nil {
+		// A fee estimate isn't essential here: without one we simply
+		// fall back to the absolute bound rather than failing an
+		// otherwise valid channel.
+		log.Warnf("Unable to estimate commitment fee rate, using "+
+			"static bound of %v: %v", minCommitFeeRateCap, err)
+
+		return minCommitFeeRateCap
+	}
+
+	maxFeeRate := ourFeeRate * maxCommitFeeRateMultiplier
+	if maxFeeRate < minCommitFeeRateCap {
+		return minCommitFeeRateCap
+	}
+
+	return maxFeeRate
+}
+
 // fundeeProcessOpenChannel creates an initial 'ChannelReservation' within the
 // wallet, then responds to the source peer with an accept channel message
 // progressing the funding workflow.
@@ -1487,6 +1532,23 @@ func (f *Manager) fundeeProcessOpenChannel(peer lnpeer.Peer,
 		f.failFundingFlow(
 			peer, cid,
 			lnwallet.ErrChanTooSmall(amt, f.cfg.MinChanSize),
+		)
+
+		return
+	}
+
+	// Enforce BOLT-02: the receiver MUST fail the channel if it considers
+	// feerate_per_kw unreasonably large. The initiator pays the commitment
+	// fee out of its own balance, so an absurd rate burns most of the
+	// channel capacity before either party can use it.
+	commitFeeRate := chainfee.SatPerKWeight(msg.FeePerKiloWeight)
+	maxCommitFeeRate := f.maxRemoteCommitFeeRate()
+	if commitFeeRate > maxCommitFeeRate {
+		f.failFundingFlow(
+			peer, cid,
+			lnwallet.ErrCommitFeeRateTooLarge(
+				commitFeeRate, maxCommitFeeRate,
+			),
 		)
 
 		return

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -3970,6 +3970,63 @@ func TestFundingManagerPushAmountAtCapacity(t *testing.T) {
 	}
 }
 
+// TestFundingManagerBalancesBelowReserve asserts that the fundee rejects an
+// incoming OpenChannel when neither party would hold more than its channel
+// reserve on the initial commitment transaction. Such a channel can never be
+// used, as neither side could add an HTLC without dipping below its reserve.
+func TestFundingManagerBalancesBelowReserve(t *testing.T) {
+	t.Parallel()
+
+	alice, bob := setupFundingManagers(t)
+	t.Cleanup(func() {
+		tearDownFundingManagers(t, alice, bob)
+	})
+
+	// Have Bob demand that Alice keeps the entire channel capacity in
+	// reserve. Alice pushes nothing to Bob, so Bob starts out at zero
+	// while Alice sits at (capacity - fees), which is below the reserve we
+	// just made unsatisfiable. That puts both sides at or under their
+	// respective reserves.
+	bob.fundingMgr.cfg.RequiredRemoteChanReserve = func(chanAmt,
+		_ btcutil.Amount) btcutil.Amount {
+
+		return chanAmt
+	}
+
+	const localAmt = btcutil.Amount(500000)
+	updateChan := make(chan *lnrpc.OpenStatusUpdate)
+	errChan := make(chan error, 1)
+	initReq := &InitFundingMsg{
+		Peer:            bob,
+		TargetPubkey:    bob.privKey.PubKey(),
+		ChainHash:       *fundingNetParams.GenesisHash,
+		LocalFundingAmt: localAmt,
+		FundingFeePerKw: 1000,
+		Private:         true,
+		Updates:         updateChan,
+		Err:             errChan,
+	}
+	alice.fundingMgr.InitFundingWorkflow(initReq)
+
+	aliceMsg := assertFundingMsgSent(t, alice.msgChan, "OpenChannel")
+	openChanMsg, ok := aliceMsg.(*lnwire.OpenChannel)
+	require.True(
+		t, ok, "expected *lnwire.OpenChannel, got %T", aliceMsg,
+	)
+
+	bob.fundingMgr.ProcessFundingMsg(openChanMsg, alice)
+
+	// Bob must refuse the channel rather than answer with an
+	// AcceptChannel.
+	bobMsg := assertFundingMsgSent(t, bob.msgChan, "Error")
+	errMsg, ok := bobMsg.(*lnwire.Error)
+	require.True(t, ok, "expected *lnwire.Error, got %T", bobMsg)
+	require.Contains(
+		t, string(errMsg.Data),
+		"both initial balances are below their channel reserve",
+	)
+}
+
 // TestFundingManagerRejectPublicTaprootInitiator checks that a public taproot
 // channel request is rejected by the initiator before an OpenChannel message is
 // sent to the peer.

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -3970,6 +3970,68 @@ func TestFundingManagerPushAmountAtCapacity(t *testing.T) {
 	}
 }
 
+// TestFundingManagerCommitFeeRateTooLarge asserts that the fundee rejects an
+// incoming OpenChannel whose feerate_per_kw exceeds the bound we derive from
+// our own fee estimate, as required by BOLT-02. The boundary itself must still
+// be accepted.
+func TestFundingManagerCommitFeeRateTooLarge(t *testing.T) {
+	t.Parallel()
+
+	alice, bob := setupFundingManagers(t)
+	t.Cleanup(func() {
+		tearDownFundingManagers(t, alice, bob)
+	})
+
+	// The fee rate check happens before any of the heavier funding work, so
+	// we only need to populate the fields Bob inspects up to that point.
+	const fundingAmt = btcutil.Amount(500000)
+	maxFeeRate := bob.fundingMgr.maxRemoteCommitFeeRate()
+
+	newOpenChanMsg := func(
+		feeRate chainfee.SatPerKWeight) *lnwire.OpenChannel {
+
+		return &lnwire.OpenChannel{
+			ChainHash:        *fundingNetParams.GenesisHash,
+			PendingChannelID: [32]byte{0x01},
+			FundingAmount:    fundingAmt,
+			FeePerKiloWeight: uint32(feeRate),
+		}
+	}
+
+	// A fee rate one satoshi per kw above the bound must be rejected with
+	// the spec-aligned error.
+	tooLarge := maxFeeRate + 1
+	bob.fundingMgr.ProcessFundingMsg(newOpenChanMsg(tooLarge), alice)
+
+	msg := assertFundingMsgSent(t, bob.msgChan, "Error")
+	errMsg, ok := msg.(*lnwire.Error)
+	require.True(t, ok, "expected *lnwire.Error, got %T", msg)
+
+	expected := lnwallet.ErrCommitFeeRateTooLarge(tooLarge, maxFeeRate)
+	require.Equal(t, expected.Error(), string(errMsg.Data))
+
+	// The bound itself is still acceptable, so the flow must not fail with
+	// the fee rate error. It may well fail later for unrelated reasons, as
+	// the message we hand Bob is deliberately incomplete.
+	bob.fundingMgr.ProcessFundingMsg(newOpenChanMsg(maxFeeRate), alice)
+
+	forbidden := lnwallet.ErrCommitFeeRateTooLarge(
+		maxFeeRate, maxFeeRate,
+	).Error()
+
+	select {
+	case msg := <-bob.msgChan:
+		errMsg, ok := msg.(*lnwire.Error)
+		if !ok {
+			return
+		}
+		require.NotEqual(t, forbidden, string(errMsg.Data),
+			"fundee rejected a fee rate exactly at the bound")
+
+	case <-time.After(time.Second):
+	}
+}
+
 // TestFundingManagerBalancesBelowReserve asserts that the fundee rejects an
 // incoming OpenChannel when neither party would hold more than its channel
 // reserve on the initial commitment transaction. Such a channel can never be

--- a/lnwallet/errors.go
+++ b/lnwallet/errors.go
@@ -97,6 +97,21 @@ func ErrPushAmountTooLarge(pushAmt lnwire.MilliSatoshi,
 	}
 }
 
+// ErrBalancesBelowReserve returns an error indicating that neither party would
+// hold more than its channel reserve on the initial commitment transaction,
+// leaving the channel unusable. BOLT-02 requires that we fail such a channel.
+func ErrBalancesBelowReserve(localBalance, localReserve, remoteBalance,
+	remoteReserve btcutil.Amount) ReservationError {
+
+	return ReservationError{
+		fmt.Errorf("both initial balances are below their channel "+
+			"reserve: local balance %v sat with reserve %v sat, "+
+			"remote balance %v sat with reserve %v sat",
+			int64(localBalance), int64(localReserve),
+			int64(remoteBalance), int64(remoteReserve)),
+	}
+}
+
 // ErrMinHtlcTooLarge returns an error indicating that the MinHTLC value the
 // remote required is too large to be accepted.
 func ErrMinHtlcTooLarge(minHtlc,

--- a/lnwallet/errors.go
+++ b/lnwallet/errors.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
 
@@ -94,6 +95,18 @@ func ErrPushAmountTooLarge(pushAmt lnwire.MilliSatoshi,
 	return ReservationError{
 		fmt.Errorf("push amount %v exceeds funding amount %v",
 			pushAmt, lnwire.NewMSatFromSatoshis(fundingAmt)),
+	}
+}
+
+// ErrCommitFeeRateTooLarge returns an error indicating that the commitment fee
+// rate proposed by the channel initiator is unreasonably large, as described by
+// BOLT-02.
+func ErrCommitFeeRateTooLarge(feeRate,
+	maxFeeRate chainfee.SatPerKWeight) ReservationError {
+
+	return ReservationError{
+		fmt.Errorf("commitment fee rate of %v is unreasonably large, "+
+			"max is %v", feeRate, maxFeeRate),
 	}
 }
 

--- a/lnwallet/reservation.go
+++ b/lnwallet/reservation.go
@@ -11,6 +11,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightningnetwork/lnd/actor"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/chanstate"
 	"github.com/lightningnetwork/lnd/fn/v2"
@@ -693,16 +694,18 @@ func (r *ChannelReservation) OurContribution() *ChannelContribution {
 // transaction belonging to the wallet are available. Additionally, the wallet
 // will generate a signature to the counterparty's version of the commitment
 // transaction.
-func (r *ChannelReservation) ProcessContribution(theirContribution *ChannelContribution) error {
-	errChan := make(chan error, 1)
+func (r *ChannelReservation) ProcessContribution(
+	theirContribution *ChannelContribution) error {
+
+	promise := actor.NewPromise[error]()
 
 	r.wallet.msgChan <- &addContributionMsg{
+		errRequest:       errRequest{resp: promise},
 		pendingFundingID: r.reservationID,
 		contribution:     theirContribution,
-		err:              errChan,
 	}
 
-	return <-errChan
+	return awaitWalletResult(promise.Future())
 }
 
 // IsPsbt returns true if there is a PSBT funding intent mapped to this
@@ -725,15 +728,15 @@ func (r *ChannelReservation) IsCannedShim() bool {
 func (r *ChannelReservation) ProcessPsbt(
 	auxFundingDesc fn.Option[AuxFundingDesc]) error {
 
-	errChan := make(chan error, 1)
+	promise := actor.NewPromise[error]()
 
 	r.wallet.msgChan <- &continueContributionMsg{
+		errRequest:       errRequest{resp: promise},
 		auxFundingDesc:   auxFundingDesc,
 		pendingFundingID: r.reservationID,
-		err:              errChan,
 	}
 
-	return <-errChan
+	return awaitWalletResult(promise.Future())
 }
 
 // RemoteCanceled informs the PSBT funding state machine that the remote peer
@@ -750,16 +753,18 @@ func (r *ChannelReservation) RemoteCanceled() {
 // to this pending single funder channel. Internally, no further action is
 // taken other than recording the initiator's contribution to the single funder
 // channel.
-func (r *ChannelReservation) ProcessSingleContribution(theirContribution *ChannelContribution) error {
-	errChan := make(chan error, 1)
+func (r *ChannelReservation) ProcessSingleContribution(
+	theirContribution *ChannelContribution) error {
+
+	promise := actor.NewPromise[error]()
 
 	r.wallet.msgChan <- &addSingleContributionMsg{
+		errRequest:       errRequest{resp: promise},
 		pendingFundingID: r.reservationID,
 		contribution:     theirContribution,
-		err:              errChan,
 	}
 
-	return <-errChan
+	return awaitWalletResult(promise.Future())
 }
 
 // TheirContribution returns the counterparty's pending contribution to the
@@ -807,18 +812,16 @@ func (r *ChannelReservation) CompleteReservation(fundingInputScripts []*input.Sc
 	commitmentSig input.Signature) (*chanstate.OpenChannel, error) {
 
 	// TODO(roasbeef): add flag for watch or not?
-	errChan := make(chan error, 1)
-	completeChan := make(chan *chanstate.OpenChannel, 1)
+	promise := actor.NewPromise[fn.Result[*chanstate.OpenChannel]]()
 
 	r.wallet.msgChan <- &addCounterPartySigsMsg{
+		openChanRequest:          openChanRequest{resp: promise},
 		pendingFundingID:         r.reservationID,
 		theirFundingInputScripts: fundingInputScripts,
 		theirCommitmentSig:       commitmentSig,
-		completeChan:             completeChan,
-		err:                      errChan,
 	}
 
-	return <-completeChan, <-errChan
+	return awaitWalletResult(promise.Future()).Unpack()
 }
 
 // CompleteReservationSingle finalizes the pending single funder channel
@@ -835,19 +838,17 @@ func (r *ChannelReservation) CompleteReservationSingle(
 	auxFundingDesc fn.Option[AuxFundingDesc]) (*chanstate.OpenChannel,
 	error) {
 
-	errChan := make(chan error, 1)
-	completeChan := make(chan *chanstate.OpenChannel, 1)
+	promise := actor.NewPromise[fn.Result[*chanstate.OpenChannel]]()
 
 	r.wallet.msgChan <- &addSingleFunderSigsMsg{
+		openChanRequest:    openChanRequest{resp: promise},
 		pendingFundingID:   r.reservationID,
 		fundingOutpoint:    fundingPoint,
 		theirCommitmentSig: commitSig,
-		completeChan:       completeChan,
 		auxFundingDesc:     auxFundingDesc,
-		err:                errChan,
 	}
 
-	return <-completeChan, <-errChan
+	return awaitWalletResult(promise.Future()).Unpack()
 }
 
 // TheirSignatures returns the counterparty's signatures to all inputs to the
@@ -920,13 +921,13 @@ func (r *ChannelReservation) LeaseExpiry() uint32 {
 // channel are returned to the free pool, allowing subsequent reservations to
 // utilize the now freed resources.
 func (r *ChannelReservation) Cancel() error {
-	errChan := make(chan error, 1)
+	promise := actor.NewPromise[error]()
 	r.wallet.msgChan <- &fundingReserveCancelMsg{
+		errRequest:       errRequest{resp: promise},
 		pendingFundingID: r.reservationID,
-		err:              errChan,
 	}
 
-	return <-errChan
+	return awaitWalletResult(promise.Future())
 }
 
 // ChanState the current open channel state.

--- a/lnwallet/reservation.go
+++ b/lnwallet/reservation.go
@@ -647,6 +647,32 @@ func (r *ChannelReservation) validateReserveBounds() bool {
 	return minChanReserve >= maxDustLimit
 }
 
+// validateInitialBalances checks that at least one side of the initial
+// commitment transaction holds more than the channel reserve it is required to
+// maintain. BOLT#02 mandates that the receiver of open_channel fail the channel
+// if both to_local and to_remote are less than or equal to the channel reserve:
+// in that case neither party can ever add an HTLC without dipping below its
+// reserve, so the channel is dead on arrival. This function should be called
+// with the lock held.
+func (r *ChannelReservation) validateInitialBalances() error {
+	// The reserve stored in our contribution is the one the remote party
+	// requires us to maintain, while the one in their contribution is what
+	// we require of them.
+	commit := r.partialState.LocalCommitment
+	ourBalance := commit.LocalBalance.ToSatoshis()
+	ourReserve := r.ourContribution.ChanReserve
+	theirBalance := commit.RemoteBalance.ToSatoshis()
+	theirReserve := r.theirContribution.ChanReserve
+
+	if ourBalance <= ourReserve && theirBalance <= theirReserve {
+		return ErrBalancesBelowReserve(
+			ourBalance, ourReserve, theirBalance, theirReserve,
+		)
+	}
+
+	return nil
+}
+
 // OurContribution returns the wallet's fully populated contribution to the
 // pending payment channel. See 'ChannelContribution' for further details
 // regarding the contents of a contribution.

--- a/lnwallet/reservation_test.go
+++ b/lnwallet/reservation_test.go
@@ -1,0 +1,159 @@
+package lnwallet
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/chanstate"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateInitialBalances checks that a reservation is only rejected when
+// both sides of the initial commitment transaction start out at or below their
+// respective channel reserves, which is what BOLT#02 mandates the receiver of
+// open_channel to fail on.
+func TestValidateInitialBalances(t *testing.T) {
+	t.Parallel()
+
+	const reserve = btcutil.Amount(10000)
+
+	// chanCfg builds the minimal channel config validateInitialBalances
+	// reads: the reserve the party it belongs to must maintain.
+	chanCfg := func(reserve btcutil.Amount) *channeldb.ChannelConfig {
+		bounds := channeldb.ChannelStateBounds{
+			ChanReserve: reserve,
+		}
+
+		return &channeldb.ChannelConfig{
+			ChannelStateBounds: bounds,
+		}
+	}
+
+	tests := []struct {
+		name         string
+		ourBalance   btcutil.Amount
+		ourReserve   btcutil.Amount
+		theirBalance btcutil.Amount
+		theirReserve btcutil.Amount
+		expectErr    bool
+	}{
+		{
+			// The common case for a fundee: we start at zero with
+			// no push, but the initiator holds nearly the full
+			// capacity.
+			name:         "only initiator above reserve",
+			ourBalance:   0,
+			ourReserve:   reserve,
+			theirBalance: 1000000,
+			theirReserve: reserve,
+		},
+		{
+			// The mirror image, which is what a full push looks
+			// like.
+			name:         "only fundee above reserve",
+			ourBalance:   1000000,
+			ourReserve:   reserve,
+			theirBalance: 0,
+			theirReserve: reserve,
+		},
+		{
+			name:         "both above reserve",
+			ourBalance:   500000,
+			ourReserve:   reserve,
+			theirBalance: 500000,
+			theirReserve: reserve,
+		},
+		{
+			// An absurd commitment fee rate burns the capacity
+			// before either party can use the channel.
+			name:         "both below reserve",
+			ourBalance:   0,
+			ourReserve:   reserve,
+			theirBalance: 9000,
+			theirReserve: reserve,
+			expectErr:    true,
+		},
+		{
+			// The spec fails on "less than or equal to", so a
+			// balance sitting exactly at the reserve doesn't save
+			// the channel: no HTLC could be added without dipping
+			// below it.
+			name:         "both exactly at reserve",
+			ourBalance:   reserve,
+			ourReserve:   reserve,
+			theirBalance: reserve,
+			theirReserve: reserve,
+			expectErr:    true,
+		},
+		{
+			// A single satoshi above the reserve is enough for the
+			// channel to be considered usable.
+			name:         "one satoshi above reserve",
+			ourBalance:   reserve,
+			ourReserve:   reserve,
+			theirBalance: reserve + 1,
+			theirReserve: reserve,
+		},
+		{
+			// Both reserves may legitimately be zero, in which
+			// case a channel with any balance at all is fine.
+			name:         "zero reserves with balance",
+			ourBalance:   0,
+			ourReserve:   0,
+			theirBalance: 1,
+			theirReserve: 0,
+		},
+		{
+			// With zero reserves and no funds anywhere, the
+			// channel is still useless.
+			name:         "zero reserves without balance",
+			ourBalance:   0,
+			ourReserve:   0,
+			theirBalance: 0,
+			theirReserve: 0,
+			expectErr:    true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			commit := channeldb.ChannelCommitment{
+				LocalBalance: lnwire.NewMSatFromSatoshis(
+					test.ourBalance,
+				),
+				RemoteBalance: lnwire.NewMSatFromSatoshis(
+					test.theirBalance,
+				),
+			}
+
+			res := &ChannelReservation{
+				ourContribution: &ChannelContribution{
+					ChannelConfig: chanCfg(test.ourReserve),
+				},
+				theirContribution: &ChannelContribution{
+					ChannelConfig: chanCfg(
+						test.theirReserve,
+					),
+				},
+				partialState: &chanstate.OpenChannel{
+					LocalCommitment: commit,
+				},
+			}
+
+			err := res.validateInitialBalances()
+			if !test.expectErr {
+				require.NoError(t, err)
+				return
+			}
+
+			require.ErrorContains(
+				t, err, "both initial balances are below "+
+					"their channel reserve",
+			)
+		})
+	}
+}

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -2095,6 +2095,14 @@ func (l *LightningWallet) handleSingleContribution(req *addSingleContributionMsg
 		return
 	}
 
+	// Now that both reserves are known, make sure the channel the initiator
+	// is proposing could actually be used: at least one side must start out
+	// above its reserve.
+	if err := pendingReservation.validateInitialBalances(); err != nil {
+		req.err <- err
+		return
+	}
+
 	// Initialize an empty sha-chain for them, tracking the current pending
 	// revocation hash (we don't yet know the preimage so we can't add it
 	// to the chain).

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -22,6 +22,7 @@ import (
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/wallet"
+	"github.com/lightningnetwork/lnd/actor"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/chanstate"
 	"github.com/lightningnetwork/lnd/fn/v2"
@@ -245,29 +246,34 @@ type InitFundingReserveMsg struct {
 	// be used to create the combined key for musig2 based channels.
 	TapscriptRoot fn.Option[chainhash.Hash]
 
-	// err is a channel in which all errors will be sent across. Will be
-	// nil if this initial set is successful.
-	//
-	// NOTE: In order to avoid deadlocks, this channel MUST be buffered.
-	err chan error
+	// resp is the promise the outcome of this request is delivered over.
+	// In the case of a successful reservation initiation it carries a
+	// ChannelReservation with our contributions filled in, otherwise it
+	// carries the error that caused the initiation to fail.
+	resp actor.Promise[fn.Result[*ChannelReservation]]
+}
 
-	// resp is channel in which a ChannelReservation with our contributions
-	// filled in will be sent across this channel in the case of a
-	// successfully reservation initiation. In the case of an error, this
-	// will read a nil pointer.
-	//
-	// NOTE: In order to avoid deadlocks, this channel MUST be buffered.
-	resp chan *ChannelReservation
+// fail resolves the request's promise with the passed error, signaling that
+// the reservation could not be created.
+func (r *InitFundingReserveMsg) fail(err error) {
+	completeWalletResult(r.resp, fn.Err[*ChannelReservation](err))
+}
+
+// succeed resolves the request's promise with the newly created channel
+// reservation.
+func (r *InitFundingReserveMsg) succeed(res *ChannelReservation) {
+	completeWalletResult(r.resp, fn.Ok(res))
 }
 
 // fundingReserveCancelMsg is a message reserved for cancelling an existing
 // channel reservation identified by its reservation ID. Cancelling a reservation
 // frees its locked outputs up, for inclusion within further reservations.
 type fundingReserveCancelMsg struct {
-	pendingFundingID uint64
+	// errRequest carries the promise the outcome of this request is
+	// delivered over.
+	errRequest
 
-	// NOTE: In order to avoid deadlocks, this channel MUST be buffered.
-	err chan error // Buffered
+	pendingFundingID uint64
 }
 
 // addContributionMsg represents a message executing the second phase of the
@@ -278,26 +284,28 @@ type fundingReserveCancelMsg struct {
 // finally generate signatures for all our inputs to the funding transaction,
 // and for the remote node's version of the commitment transaction.
 type addContributionMsg struct {
+	// errRequest carries the promise the outcome of this request is
+	// delivered over.
+	errRequest
+
 	pendingFundingID uint64
 
 	contribution *ChannelContribution
-
-	// NOTE: In order to avoid deadlocks, this channel MUST be buffered.
-	err chan error
 }
 
 // continueContributionMsg represents a message that signals that the
 // interrupted funding process involving a PSBT can now be continued because the
 // finalized transaction is now available.
 type continueContributionMsg struct {
+	// errRequest carries the promise the outcome of this request is
+	// delivered over.
+	errRequest
+
 	pendingFundingID uint64
 
 	// auxFundingDesc is an optional descriptor that contains information
 	// about the custom channel funding flow.
 	auxFundingDesc fn.Option[AuxFundingDesc]
-
-	// NOTE: In order to avoid deadlocks, this channel MUST be buffered.
-	err chan error
 }
 
 // addSingleContributionMsg represents a message executing the second phase of
@@ -306,12 +314,13 @@ type continueContributionMsg struct {
 // sent when on the responding side to a single funder workflow, no further
 // action apart from storing the provided contribution is carried out.
 type addSingleContributionMsg struct {
+	// errRequest carries the promise the outcome of this request is
+	// delivered over.
+	errRequest
+
 	pendingFundingID uint64
 
 	contribution *ChannelContribution
-
-	// NOTE: In order to avoid deadlocks, this channel MUST be buffered.
-	err chan error
 }
 
 // addCounterPartySigsMsg represents the final message required to complete,
@@ -323,6 +332,10 @@ type addSingleContributionMsg struct {
 // configurable number of confirmations, the channel is officially considered
 // 'open'.
 type addCounterPartySigsMsg struct {
+	// openChanRequest carries the promise the completed channel, or the
+	// error that prevented it from being created, is delivered over.
+	openChanRequest
+
 	pendingFundingID uint64
 
 	// Should be order of sorted inputs that are theirs. Sorting is done
@@ -333,13 +346,6 @@ type addCounterPartySigsMsg struct {
 	// This should be 1/2 of the signatures needed to successfully spend our
 	// version of the commitment transaction.
 	theirCommitmentSig input.Signature
-
-	// This channel is used to return the completed channel after the wallet
-	// has completed all of its stages in the funding process.
-	completeChan chan *chanstate.OpenChannel
-
-	// NOTE: In order to avoid deadlocks, this channel MUST be buffered.
-	err chan error
 }
 
 // addSingleFunderSigsMsg represents the next-to-last message required to
@@ -349,6 +355,10 @@ type addCounterPartySigsMsg struct {
 // is processed we (the responder) are able to construct both commitment
 // transactions, signing the remote party's version.
 type addSingleFunderSigsMsg struct {
+	// openChanRequest carries the promise the completed channel, or the
+	// error that prevented it from being created, is delivered over.
+	openChanRequest
+
 	pendingFundingID uint64
 
 	// auxFundingDesc is an optional descriptor that contains information
@@ -362,13 +372,6 @@ type addSingleFunderSigsMsg struct {
 	// theirCommitmentSig are the 1/2 of the signatures needed to
 	// successfully spend our version of the commitment transaction.
 	theirCommitmentSig input.Signature
-
-	// This channel is used to return the completed channel after the wallet
-	// has completed all of its stages in the funding process.
-	completeChan chan *chanstate.OpenChannel
-
-	// NOTE: In order to avoid deadlocks, this channel MUST be buffered.
-	err chan error
 }
 
 // CheckReservedValueTxReq is the request struct used to call
@@ -710,8 +713,8 @@ out:
 func (l *LightningWallet) InitChannelReservation(
 	req *InitFundingReserveMsg) (*ChannelReservation, error) {
 
-	req.resp = make(chan *ChannelReservation, 1)
-	req.err = make(chan error, 1)
+	promise := actor.NewPromise[fn.Result[*ChannelReservation]]()
+	req.resp = promise
 
 	select {
 	case l.msgChan <- req:
@@ -719,7 +722,7 @@ func (l *LightningWallet) InitChannelReservation(
 		return nil, errors.New("wallet shutting down")
 	}
 
-	return <-req.resp, <-req.err
+	return awaitWalletResult(promise.Future()).Unpack()
 }
 
 // RegisterFundingIntent allows a caller to signal to the wallet that if a
@@ -881,20 +884,16 @@ func (l *LightningWallet) handleFundingReserveRequest(req *InitFundingReserveMsg
 
 	// It isn't possible to create a channel with zero funds committed.
 	if noFundsCommitted {
-		err := ErrZeroCapacity()
-		req.err <- err
-		req.resp <- nil
+		req.fail(ErrZeroCapacity())
 		return
 	}
 
 	// If the funding request is for a different chain than the one the
 	// wallet is aware of, then we'll reject the request.
 	if !bytes.Equal(l.Cfg.NetParams.GenesisHash[:], req.ChainHash[:]) {
-		err := ErrChainMismatch(
+		req.fail(ErrChainMismatch(
 			l.Cfg.NetParams.GenesisHash, req.ChainHash,
-		)
-		req.err <- err
-		req.resp <- nil
+		))
 		return
 	}
 
@@ -964,8 +963,7 @@ func (l *LightningWallet) handleFundingReserveRequest(req *InitFundingReserveMsg
 		if req.FundUpToMaxAmt > 0 && req.MinFundAmt > 0 {
 			numAnchorChans, err = l.CurrentNumAnchorChans()
 			if err != nil {
-				req.err <- err
-				req.resp <- nil
+				req.fail(err)
 				return
 			}
 
@@ -1004,8 +1002,7 @@ func (l *LightningWallet) handleFundingReserveRequest(req *InitFundingReserveMsg
 			fundingReq,
 		)
 		if err != nil {
-			req.err <- err
-			req.resp <- nil
+			req.fail(err)
 			return
 		}
 
@@ -1014,8 +1011,7 @@ func (l *LightningWallet) handleFundingReserveRequest(req *InitFundingReserveMsg
 		// example.
 		err = l.RegisterFundingIntent(req.PendingChanID, fundingIntent)
 		if err != nil {
-			req.err <- err
-			req.resp <- nil
+			req.fail(err)
 			return
 		}
 
@@ -1029,8 +1025,7 @@ func (l *LightningWallet) handleFundingReserveRequest(req *InitFundingReserveMsg
 	// At this point there _has_ to be a funding intent, otherwise something
 	// went really wrong.
 	if fundingIntent == nil {
-		req.err <- fmt.Errorf("no funding intent present")
-		req.resp <- nil
+		req.fail(fmt.Errorf("no funding intent present"))
 		return
 	}
 
@@ -1068,8 +1063,7 @@ func (l *LightningWallet) handleFundingReserveRequest(req *InitFundingReserveMsg
 		if err != nil {
 			fundingIntent.Cancel()
 
-			req.err <- err
-			req.resp <- nil
+			req.fail(err)
 			return
 		}
 	}
@@ -1086,8 +1080,7 @@ func (l *LightningWallet) handleFundingReserveRequest(req *InitFundingReserveMsg
 	if err != nil {
 		fundingIntent.Cancel()
 
-		req.err <- err
-		req.resp <- nil
+		req.fail(err)
 		return
 	}
 
@@ -1097,8 +1090,7 @@ func (l *LightningWallet) handleFundingReserveRequest(req *InitFundingReserveMsg
 	if err != nil {
 		fundingIntent.Cancel()
 
-		req.err <- err
-		req.resp <- nil
+		req.fail(err)
 		return
 	}
 
@@ -1112,8 +1104,7 @@ func (l *LightningWallet) handleFundingReserveRequest(req *InitFundingReserveMsg
 	// Funding reservation request successfully handled. The funding inputs
 	// will be marked as unavailable until the reservation is either
 	// completed, or canceled.
-	req.resp <- reservation
-	req.err <- nil
+	req.succeed(reservation)
 
 	walletLog.Debugf("Successfully handled funding reservation with "+
 		"pendingChanID: %x, reservationID: %v",
@@ -1476,7 +1467,8 @@ func (l *LightningWallet) handleFundingCancelRequest(req *fundingReserveCancelMs
 	pendingReservation, ok := l.fundingLimbo[req.pendingFundingID]
 	if !ok {
 		// TODO(roasbeef): make new error, "unknown funding state" or something
-		req.err <- fmt.Errorf("attempted to cancel non-existent funding state")
+		req.complete(fmt.Errorf("attempted to cancel non-existent " +
+			"funding state"))
 		return
 	}
 
@@ -1507,7 +1499,7 @@ func (l *LightningWallet) handleFundingCancelRequest(req *fundingReserveCancelMs
 	}
 	l.intentMtx.Unlock()
 
-	req.err <- nil
+	req.complete(nil)
 }
 
 // createCommitOpts is a struct that holds the options for creating a new
@@ -1605,7 +1597,8 @@ func (l *LightningWallet) handleContributionMsg(req *addContributionMsg) {
 	pendingReservation, ok := l.fundingLimbo[req.pendingFundingID]
 	l.limboMtx.Unlock()
 	if !ok {
-		req.err <- fmt.Errorf("attempted to update non-existent funding state")
+		req.complete(fmt.Errorf("attempted to update non-existent " +
+			"funding state"))
 		return
 	}
 
@@ -1618,7 +1611,7 @@ func (l *LightningWallet) handleContributionMsg(req *addContributionMsg) {
 	if len(shutdown) > 0 {
 		// Validate the shutdown script.
 		if !ValidateUpfrontShutdown(shutdown, &l.Cfg.NetParams) {
-			req.err <- fmt.Errorf("invalid shutdown script")
+			req.complete(fmt.Errorf("invalid shutdown script"))
 			return
 		}
 	}
@@ -1631,7 +1624,7 @@ func (l *LightningWallet) handleContributionMsg(req *addContributionMsg) {
 	// Perform bounds-checking on both ChannelReserve and DustLimit
 	// parameters.
 	if !pendingReservation.validateReserveBounds() {
-		req.err <- fmt.Errorf("invalid reserve and dust bounds")
+		req.complete(fmt.Errorf("invalid reserve and dust bounds"))
 		return
 	}
 
@@ -1650,8 +1643,8 @@ func (l *LightningWallet) handleContributionMsg(req *addContributionMsg) {
 	case *chanfunding.ShimIntent:
 		chanPoint, err = fundingIntent.ChanPoint()
 		if err != nil {
-			req.err <- fmt.Errorf("unable to obtain chan point: %w",
-				err)
+			req.complete(fmt.Errorf("unable to obtain chan "+
+				"point: %w", err))
 			return
 		}
 
@@ -1664,8 +1657,8 @@ func (l *LightningWallet) handleContributionMsg(req *addContributionMsg) {
 	// containing the eventual funding transaction.
 	case *chanfunding.PsbtIntent:
 		if fundingIntent.PendingPsbt != nil {
-			req.err <- fmt.Errorf("PSBT funding already in" +
-				"progress")
+			req.complete(fmt.Errorf("PSBT funding already in" +
+				"progress"))
 			return
 		}
 
@@ -1692,9 +1685,9 @@ func (l *LightningWallet) handleContributionMsg(req *addContributionMsg) {
 		)
 
 		// Exit early because we can't continue the funding flow yet.
-		req.err <- &PsbtFundingRequired{
+		req.complete(&PsbtFundingRequired{
 			Intent: fundingIntent,
-		}
+		})
 		return
 
 	case *chanfunding.FullIntent:
@@ -1713,14 +1706,14 @@ func (l *LightningWallet) handleContributionMsg(req *addContributionMsg) {
 			theirContribution.ChangeOutputs,
 		)
 		if err != nil {
-			req.err <- fmt.Errorf("unable to construct funding "+
-				"tx: %v", err)
+			req.complete(fmt.Errorf("unable to construct funding "+
+				"tx: %v", err))
 			return
 		}
 		chanPoint, err = fundingIntent.ChanPoint()
 		if err != nil {
-			req.err <- fmt.Errorf("unable to obtain chan "+
-				"point: %v", err)
+			req.complete(fmt.Errorf("unable to obtain chan "+
+				"point: %v", err))
 			return
 		}
 
@@ -1755,8 +1748,8 @@ func (l *LightningWallet) handleContributionMsg(req *addContributionMsg) {
 	// If we landed here and didn't exit early, it means we already have
 	// the channel point ready. We can jump directly to the next step.
 	l.handleChanPointReady(&continueContributionMsg{
+		errRequest:       req.errRequest,
 		pendingFundingID: req.pendingFundingID,
-		err:              req.err,
 	})
 }
 
@@ -1855,8 +1848,8 @@ func (l *LightningWallet) handleChanPointReady(req *continueContributionMsg) {
 	pendingReservation, ok := l.fundingLimbo[req.pendingFundingID]
 	l.limboMtx.Unlock()
 	if !ok {
-		req.err <- fmt.Errorf("attempted to update non-existent " +
-			"funding state")
+		req.complete(fmt.Errorf("attempted to update non-existent " +
+			"funding state"))
 		return
 	}
 
@@ -1895,14 +1888,14 @@ func (l *LightningWallet) handleChanPointReady(req *continueContributionMsg) {
 		// funding outpoint in stone for this channel.
 		fundingTx, err := psbtIntent.CompileFundingTx()
 		if err != nil {
-			req.err <- fmt.Errorf("unable to construct funding "+
-				"tx: %v", err)
+			req.complete(fmt.Errorf("unable to construct funding "+
+				"tx: %v", err))
 			return
 		}
 		chanPointPtr, err := psbtIntent.ChanPoint()
 		if err != nil {
-			req.err <- fmt.Errorf("unable to obtain chan "+
-				"point: %v", err)
+			req.complete(fmt.Errorf("unable to obtain chan "+
+				"point: %v", err))
 			return
 		}
 
@@ -1975,7 +1968,7 @@ func (l *LightningWallet) handleChanPointReady(req *continueContributionMsg) {
 		WithAuxLeaves(localAuxLeaves, remoteAuxLeaves),
 	)
 	if err != nil {
-		req.err <- err
+		req.complete(err)
 		return
 	}
 
@@ -2006,7 +1999,7 @@ func (l *LightningWallet) handleChanPointReady(req *continueContributionMsg) {
 	}
 	err = initStateHints(ourCommitTx, theirCommitTx, stateObfuscator)
 	if err != nil {
-		req.err <- err
+		req.complete(err)
 		return
 	}
 
@@ -2032,8 +2025,8 @@ func (l *LightningWallet) handleChanPointReady(req *continueContributionMsg) {
 	fundingIntent := pendingReservation.fundingIntent
 	fundingWitnessScript, fundingOutput, err := fundingIntent.FundingOutput()
 	if err != nil {
-		req.err <- fmt.Errorf("unable to obtain funding "+
-			"output: %w", err)
+		req.complete(fmt.Errorf("unable to obtain funding "+
+			"output: %w", err))
 		return
 	}
 
@@ -2044,13 +2037,13 @@ func (l *LightningWallet) handleChanPointReady(req *continueContributionMsg) {
 		fundingWitnessScript,
 	)
 	if err != nil {
-		req.err <- err
+		req.complete(err)
 		return
 	}
 
 	pendingReservation.ourCommitmentSig = sigTheirCommit
 
-	req.err <- nil
+	req.complete(nil)
 }
 
 // handleSingleContribution is called as the second step to a single funder
@@ -2062,7 +2055,8 @@ func (l *LightningWallet) handleSingleContribution(req *addSingleContributionMsg
 	pendingReservation, ok := l.fundingLimbo[req.pendingFundingID]
 	l.limboMtx.Unlock()
 	if !ok {
-		req.err <- fmt.Errorf("attempted to update non-existent funding state")
+		req.complete(fmt.Errorf("attempted to update non-existent " +
+			"funding state"))
 		return
 	}
 
@@ -2076,7 +2070,7 @@ func (l *LightningWallet) handleSingleContribution(req *addSingleContributionMsg
 	if len(shutdown) > 0 {
 		// Validate the shutdown script.
 		if !ValidateUpfrontShutdown(shutdown, &l.Cfg.NetParams) {
-			req.err <- fmt.Errorf("invalid shutdown script")
+			req.complete(fmt.Errorf("invalid shutdown script"))
 			return
 		}
 	}
@@ -2091,7 +2085,7 @@ func (l *LightningWallet) handleSingleContribution(req *addSingleContributionMsg
 	// parameters. The ChannelReserve may have been changed by the
 	// ChannelAcceptor RPC, so this is necessary.
 	if !pendingReservation.validateReserveBounds() {
-		req.err <- fmt.Errorf("invalid reserve and dust bounds")
+		req.complete(fmt.Errorf("invalid reserve and dust bounds"))
 		return
 	}
 
@@ -2099,7 +2093,7 @@ func (l *LightningWallet) handleSingleContribution(req *addSingleContributionMsg
 	// is proposing could actually be used: at least one side must start out
 	// above its reserve.
 	if err := pendingReservation.validateInitialBalances(); err != nil {
-		req.err <- err
+		req.complete(err)
 		return
 	}
 
@@ -2114,7 +2108,7 @@ func (l *LightningWallet) handleSingleContribution(req *addSingleContributionMsg
 	// process is complete.
 	chanState.RemoteCurrentRevocation = theirContribution.FirstCommitmentPoint
 
-	req.err <- nil
+	req.complete(nil)
 }
 
 // verifyFundingInputs attempts to verify all remote inputs to the funding
@@ -2278,8 +2272,8 @@ func (l *LightningWallet) handleFundingCounterPartySigs(msg *addCounterPartySigs
 	res, ok := l.fundingLimbo[msg.pendingFundingID]
 	l.limboMtx.RUnlock()
 	if !ok {
-		msg.err <- fmt.Errorf("attempted to update non-existent funding state")
-		msg.completeChan <- nil
+		msg.fail(fmt.Errorf("attempted to update non-existent " +
+			"funding state"))
 		return
 	}
 
@@ -2299,8 +2293,7 @@ func (l *LightningWallet) handleFundingCounterPartySigs(msg *addCounterPartySigs
 	if res.partialState.ChanType.HasFundingTx() {
 		err := l.verifyFundingInputs(fundingTx, inputScripts)
 		if err != nil {
-			msg.err <- err
-			msg.completeChan <- nil
+			msg.fail(err)
 			return
 		}
 	}
@@ -2312,9 +2305,8 @@ func (l *LightningWallet) handleFundingCounterPartySigs(msg *addCounterPartySigs
 
 	err := l.verifyCommitSig(res, msg.theirCommitmentSig, commitTx)
 	if err != nil {
-		msg.err <- fmt.Errorf("counterparty's commitment signature is "+
-			"invalid: %w", err)
-		msg.completeChan <- nil
+		msg.fail(fmt.Errorf("counterparty's commitment signature is "+
+			"invalid: %w", err))
 		return
 	}
 
@@ -2335,8 +2327,7 @@ func (l *LightningWallet) handleFundingCounterPartySigs(msg *addCounterPartySigs
 	// of the current height for record keeping purposes.
 	_, bestHeight, err := l.Cfg.ChainIO.GetBestBlock()
 	if err != nil {
-		msg.err <- err
-		msg.completeChan <- nil
+		msg.fail(err)
 		return
 	}
 
@@ -2364,13 +2355,11 @@ func (l *LightningWallet) handleFundingCounterPartySigs(msg *addCounterPartySigs
 	nodeAddr := res.nodeAddr
 	err = res.partialState.SyncPending(nodeAddr, uint32(bestHeight))
 	if err != nil {
-		msg.err <- err
-		msg.completeChan <- nil
+		msg.fail(err)
 		return
 	}
 
-	msg.completeChan <- res.partialState
-	msg.err <- nil
+	msg.succeed(res.partialState)
 }
 
 // handleSingleFunderSigs is called once the remote peer who initiated the
@@ -2383,8 +2372,8 @@ func (l *LightningWallet) handleSingleFunderSigs(req *addSingleFunderSigsMsg) {
 	pendingReservation, ok := l.fundingLimbo[req.pendingFundingID]
 	l.limboMtx.RUnlock()
 	if !ok {
-		req.err <- fmt.Errorf("attempted to update non-existent funding state")
-		req.completeChan <- nil
+		req.fail(fmt.Errorf("attempted to update non-existent " +
+			"funding state"))
 		return
 	}
 
@@ -2446,8 +2435,7 @@ func (l *LightningWallet) handleSingleFunderSigs(req *addSingleFunderSigsMsg) {
 		WithAuxLeaves(localAuxLeaves, remoteAuxLeaves),
 	)
 	if err != nil {
-		req.err <- err
-		req.completeChan <- nil
+		req.fail(err)
 		return
 	}
 
@@ -2460,8 +2448,7 @@ func (l *LightningWallet) handleSingleFunderSigs(req *addSingleFunderSigsMsg) {
 	)
 	err = initStateHints(ourCommitTx, theirCommitTx, stateObfuscator)
 	if err != nil {
-		req.err <- err
-		req.completeChan <- nil
+		req.fail(err)
 		return
 	}
 
@@ -2484,8 +2471,7 @@ func (l *LightningWallet) handleSingleFunderSigs(req *addSingleFunderSigsMsg) {
 		pendingReservation, req.theirCommitmentSig, ourCommitTx,
 	)
 	if err != nil {
-		req.err <- err
-		req.completeChan <- nil
+		req.fail(err)
 		return
 	}
 
@@ -2514,8 +2500,7 @@ func (l *LightningWallet) handleSingleFunderSigs(req *addSingleFunderSigsMsg) {
 		)
 	}
 	if err != nil {
-		req.err <- err
-		req.completeChan <- nil
+		req.fail(err)
 		return
 	}
 
@@ -2527,8 +2512,7 @@ func (l *LightningWallet) handleSingleFunderSigs(req *addSingleFunderSigsMsg) {
 		fundingWitnessScript,
 	)
 	if err != nil {
-		req.err <- err
-		req.completeChan <- nil
+		req.fail(err)
 		return
 	}
 
@@ -2536,8 +2520,7 @@ func (l *LightningWallet) handleSingleFunderSigs(req *addSingleFunderSigsMsg) {
 
 	_, bestHeight, err := l.Cfg.ChainIO.GetBestBlock()
 	if err != nil {
-		req.err <- err
-		req.completeChan <- nil
+		req.fail(err)
 		return
 	}
 
@@ -2557,13 +2540,11 @@ func (l *LightningWallet) handleSingleFunderSigs(req *addSingleFunderSigsMsg) {
 
 	err = chanState.SyncPending(pendingReservation.nodeAddr, uint32(bestHeight))
 	if err != nil {
-		req.err <- err
-		req.completeChan <- nil
+		req.fail(err)
 		return
 	}
 
-	req.completeChan <- chanState
-	req.err <- nil
+	req.succeed(chanState)
 
 	l.limboMtx.Lock()
 	delete(l.fundingLimbo, req.pendingFundingID)

--- a/lnwallet/wallet_result.go
+++ b/lnwallet/wallet_result.go
@@ -1,0 +1,65 @@
+package lnwallet
+
+import (
+	"context"
+
+	"github.com/lightningnetwork/lnd/actor"
+	"github.com/lightningnetwork/lnd/chanstate"
+	"github.com/lightningnetwork/lnd/fn/v2"
+)
+
+// errRequest is embedded within the wallet requests whose only result is an
+// error. It holds the promise that error is delivered over.
+type errRequest struct {
+	// resp is the promise the outcome of the request is delivered over.
+	resp actor.Promise[error]
+}
+
+// complete resolves the request's promise with the passed error. A nil error
+// signals that the request was handled successfully.
+func (e *errRequest) complete(err error) {
+	completeWalletResult(e.resp, err)
+}
+
+// openChanRequest is embedded within the two requests that finalize a funding
+// workflow. It holds the promise their result is delivered over.
+type openChanRequest struct {
+	// resp is the promise the result of the request is delivered over.
+	resp actor.Promise[fn.Result[*chanstate.OpenChannel]]
+}
+
+// fail resolves the request's promise with the passed error, signaling that
+// the funding workflow could not be completed.
+func (o *openChanRequest) fail(err error) {
+	completeWalletResult(o.resp, fn.Err[*chanstate.OpenChannel](err))
+}
+
+// succeed resolves the request's promise with the finalized channel state.
+func (o *openChanRequest) succeed(channel *chanstate.OpenChannel) {
+	completeWalletResult(o.resp, fn.Ok(channel))
+}
+
+// completeWalletResult resolves a wallet request promise with the provided
+// value. This function is safe to call multiple times; only the first call
+// takes effect.
+func completeWalletResult[T any](p actor.Promise[T], val T) {
+	if p == nil {
+		return
+	}
+
+	actor.CompleteWith(p, val)
+}
+
+// awaitWalletResult blocks until the passed future is resolved by the wallet's
+// request handler, returning the value it was resolved with. A background
+// context is used so the wait is never cut short, preserving the semantics of
+// the plain channel receive this replaced.
+func awaitWalletResult[T any](f actor.Future[T]) T {
+	// Every promise the wallet hands out is completed with a value rather
+	// than being failed, so the only error AwaitFuture can report here is
+	// a cancelled context. As the context above is never cancelled, that
+	// error is always nil.
+	val, _ := actor.AwaitFuture[T](context.Background(), f)
+
+	return val
+}

--- a/lnwallet/wallet_test.go
+++ b/lnwallet/wallet_test.go
@@ -3,7 +3,9 @@ package lnwallet
 import (
 	"testing"
 
+	"github.com/lightningnetwork/lnd/actor"
 	"github.com/lightningnetwork/lnd/chanstate"
+	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,19 +17,71 @@ func TestHandleFundingCounterPartySigsMissingReservation(t *testing.T) {
 	wallet := &LightningWallet{
 		fundingLimbo: make(map[uint64]*ChannelReservation),
 	}
-	completeChan := make(chan *chanstate.OpenChannel, 1)
-	errChan := make(chan error, 1)
+	promise := actor.NewPromise[fn.Result[*chanstate.OpenChannel]]()
 
 	wallet.handleFundingCounterPartySigs(&addCounterPartySigsMsg{
+		openChanRequest:  openChanRequest{resp: promise},
 		pendingFundingID: 1,
-		completeChan:     completeChan,
-		err:              errChan,
 	})
 
-	require.Len(t, completeChan, 1)
-	require.Nil(t, <-completeChan)
-	require.Len(t, errChan, 1)
-	require.ErrorContains(t, <-errChan, "non-existent funding state")
+	channel, err := awaitWalletResult(promise.Future()).Unpack()
+	require.Nil(t, channel)
+	require.ErrorContains(t, err, "non-existent funding state")
+}
+
+// TestReservationErrorTypePreserved asserts that the promises the wallet
+// answers its requests with hand concrete error types back to callers
+// untouched. funding.Manager.failFundingFlow type switches on
+// lnwallet.ReservationError to decide whether an error may be forwarded to the
+// remote peer, so any wrapping along the way would silently change that
+// decision.
+func TestReservationErrorTypePreserved(t *testing.T) {
+	t.Parallel()
+
+	// forwarded runs the same type switch failFundingFlow does, returning
+	// the error text the remote peer would be told about.
+	forwarded := func(err error) string {
+		// NOTE: failFundingFlow uses a plain type switch rather than
+		// errors.As, so we deliberately mirror that here. Switching
+		// this to errors.As would let a wrapped error slip past the
+		// test while still breaking the real decision.
+		//
+		//nolint:errorlint
+		switch e := err.(type) {
+		case ReservationError:
+			return e.Error()
+		default:
+			t.Fatalf("error is %T, not a ReservationError", err)
+			return ""
+		}
+	}
+
+	// The reservation initiation path answers with a result carrying the
+	// new reservation.
+	wallet := &LightningWallet{}
+	initPromise := actor.NewPromise[fn.Result[*ChannelReservation]]()
+	wallet.handleFundingReserveRequest(&InitFundingReserveMsg{
+		resp: initPromise,
+	})
+
+	reservation, initErr := awaitWalletResult(
+		initPromise.Future(),
+	).Unpack()
+	require.Nil(t, reservation)
+	require.Equal(t, ErrZeroCapacity().Error(), forwarded(initErr))
+
+	// The single contribution path, which is where the initial balance
+	// check lives, answers with a bare error instead.
+	balanceErr := ErrBalancesBelowReserve(0, 1, 0, 1)
+	req := &addSingleContributionMsg{
+		errRequest: errRequest{resp: actor.NewPromise[error]()},
+	}
+	req.complete(balanceErr)
+
+	require.Equal(
+		t, balanceErr.Error(),
+		forwarded(awaitWalletResult(req.resp.Future())),
+	)
 }
 
 // TestRegisterFundingIntent checks RegisterFundingIntent behaves as expected.


### PR DESCRIPTION
Builds on #11151, and is based on that branch so the diff here stays to just
the three commits that are new. Land #11151 first.

In this PR, we get the reply channels out of the internal requests the
`LightningWallet` message handler serves. Each of those requests used to carry
its own `err chan error`, and two of them carried a second channel for the value
they answer with, which left every caller draining a pair of channels in the
right order. We hand back an `actor.Future` instead, following the pattern the
gossiper already uses for `ProcessRemoteAnnouncement` (see
`discovery/gossip_result.go`).

The two requests that answer with a value alongside their error use
`actor.Promise[fn.Result[T]]`, so there's no bespoke result struct anywhere:
`fn.Result` already is the value-or-error type, and callers just `Unpack()` it
back into the `(T, error)` pair they had before. The requests whose only answer
is an error keep an `actor.Promise[error]` behind a small embedded `errRequest`,
same as the gossiper.

## On error types

One thing worth calling out for review, since it's the part that would break
silently. `funding.Manager.failFundingFlow` decides whether an error is safe to
forward to the remote peer with a plain type switch on
`lnwallet.ReservationError`, not `errors.As`. So anything that wraps an error on
its way out of the wallet would quietly turn every reservation error into a
generic one on the wire. `fn.Result.Unpack` returns the stored error verbatim,
so the concrete type survives, and `TestReservationErrorTypePreserved` in
`lnwallet/wallet_test.go` pins that down by running failFundingFlow's exact type
switch over both promise shapes.

## Behavior

This is a pure refactor. Every check, error string, and early-return ordering in
the request handler is unchanged, and the awaits use `context.Background()` so a
caller blocks for exactly as long as the bare channel receive did.
