### PR TITLE
lnrpc: fix contradictory unit descriptions for fee_per_mil and fee_rate

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -82,6 +82,14 @@
 
 ## RPC Updates
 
+* [Corrected the unit descriptions](https://github.com/lightningnetwork/lnd/pull/11155)
+  of `fee_per_mil`, `fee_rate` and `inbound_fee_per_mil` in the
+  `ChannelFeeReport` message. `fee_per_mil` was documented as an absolute
+  amount while `fee_rate` was documented as that same value divided by one
+  million, which is not dimensionally consistent. They are now described as
+  the proportional fee in parts per million and as the equivalent fraction
+  of the amount forwarded. Documentation only; no behaviour change.
+
 ## lncli Updates
 
 ## Breaking Changes
@@ -167,3 +175,4 @@
 * Erick Cestari
 * Jared Tobin
 * Nishant Bansal
+* Porter

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -14906,16 +14906,19 @@ type ChannelFeeReport struct {
 	ChannelPoint string `protobuf:"bytes,1,opt,name=channel_point,json=channelPoint,proto3" json:"channel_point,omitempty"`
 	// The base fee charged regardless of the number of milli-satoshis sent.
 	BaseFeeMsat int64 `protobuf:"varint,2,opt,name=base_fee_msat,json=baseFeeMsat,proto3" json:"base_fee_msat,omitempty"`
-	// The amount charged per milli-satoshis transferred expressed in
-	// millionths of a satoshi.
+	// The proportional fee charged on the amount forwarded, expressed in
+	// parts per million: a value of N charges N milli-satoshis for every
+	// 1,000,000 milli-satoshis forwarded.
 	FeePerMil int64 `protobuf:"varint,3,opt,name=fee_per_mil,json=feePerMil,proto3" json:"fee_per_mil,omitempty"`
-	// The effective fee rate in milli-satoshis. Computed by dividing the
+	// The same proportional fee expressed as a fraction of the amount
+	// forwarded rather than in parts per million. Computed by dividing the
 	// fee_per_mil value by 1 million.
 	FeeRate float64 `protobuf:"fixed64,4,opt,name=fee_rate,json=feeRate,proto3" json:"fee_rate,omitempty"`
 	// The base fee charged regardless of the number of milli-satoshis sent.
 	InboundBaseFeeMsat int32 `protobuf:"varint,6,opt,name=inbound_base_fee_msat,json=inboundBaseFeeMsat,proto3" json:"inbound_base_fee_msat,omitempty"`
-	// The amount charged per milli-satoshis transferred expressed in
-	// millionths of a satoshi.
+	// The proportional fee charged on the amount forwarded, expressed in
+	// parts per million: a value of N charges N milli-satoshis for every
+	// 1,000,000 milli-satoshis forwarded.
 	InboundFeePerMil int32 `protobuf:"varint,7,opt,name=inbound_fee_per_mil,json=inboundFeePerMil,proto3" json:"inbound_fee_per_mil,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -4637,19 +4637,22 @@ message ChannelFeeReport {
     // The base fee charged regardless of the number of milli-satoshis sent.
     int64 base_fee_msat = 2;
 
-    // The amount charged per milli-satoshis transferred expressed in
-    // millionths of a satoshi.
+    // The proportional fee charged on the amount forwarded, expressed in
+    // parts per million: a value of N charges N milli-satoshis for every
+    // 1,000,000 milli-satoshis forwarded.
     int64 fee_per_mil = 3;
 
-    // The effective fee rate in milli-satoshis. Computed by dividing the
+    // The same proportional fee expressed as a fraction of the amount
+    // forwarded rather than in parts per million. Computed by dividing the
     // fee_per_mil value by 1 million.
     double fee_rate = 4;
 
     // The base fee charged regardless of the number of milli-satoshis sent.
     int32 inbound_base_fee_msat = 6;
 
-    // The amount charged per milli-satoshis transferred expressed in
-    // millionths of a satoshi.
+    // The proportional fee charged on the amount forwarded, expressed in
+    // parts per million: a value of N charges N milli-satoshis for every
+    // 1,000,000 milli-satoshis forwarded.
     int32 inbound_fee_per_mil = 7;
 }
 

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -4550,12 +4550,12 @@
         "fee_per_mil": {
           "type": "string",
           "format": "int64",
-          "description": "The amount charged per milli-satoshis transferred expressed in\nmillionths of a satoshi."
+          "description": "The proportional fee charged on the amount forwarded, expressed in\nparts per million: a value of N charges N milli-satoshis for every\n1,000,000 milli-satoshis forwarded."
         },
         "fee_rate": {
           "type": "number",
           "format": "double",
-          "description": "The effective fee rate in milli-satoshis. Computed by dividing the\nfee_per_mil value by 1 million."
+          "description": "The same proportional fee expressed as a fraction of the amount\nforwarded rather than in parts per million. Computed by dividing the\nfee_per_mil value by 1 million."
         },
         "inbound_base_fee_msat": {
           "type": "integer",
@@ -4565,7 +4565,7 @@
         "inbound_fee_per_mil": {
           "type": "integer",
           "format": "int32",
-          "description": "The amount charged per milli-satoshis transferred expressed in\nmillionths of a satoshi."
+          "description": "The proportional fee charged on the amount forwarded, expressed in\nparts per million: a value of N charges N milli-satoshis for every\n1,000,000 milli-satoshis forwarded."
         }
       }
     },


### PR DESCRIPTION
## Change Description

Fixes #4155.

The comments for `fee_per_mil` and `fee_rate` in `ChannelFeeReport` describe units that cannot both be right. `fee_per_mil` is documented as an absolute amount — "the amount charged per milli-satoshis transferred expressed in millionths of a satoshi" — while `fee_rate` is documented as "the effective fee rate in milli-satoshis... computed by dividing the fee_per_mil value by 1 million". An absolute amount divided by a million is not a rate, and a rate is not itself denominated in milli-satoshis.

Reading the code: `fee_per_mil` is set from `edgePolicy.FeeProportionalMillionths` and `fee_rate` is that value divided by `feeBase = 1000000` (`rpcserver.go`). The proportional fee is applied as `rate * amt_msat / 1000000` (`htlcswitch/link.go` `ExpectedFee`, and `ComputeFee` in `graph/db/models`). So the field is a parts-per-million share of the amount forwarded — a dimensionless ratio, not an amount — and `fee_rate` is the same ratio written as a plain fraction. The values returned by `lncli feereport` were always correct; only the prose was wrong.

The identical wording had since been copied onto `inbound_fee_per_mil`, which is populated from the equivalent inbound rate (`CalcFee` in `graph/db/models/inbound_fee.go`, also over 1e6), so this corrects that too.

### On the wording — this part is a proposal, please pick

The thread did not settle on a framing and I do not want to pre-empt that. @yyforyongyu wrote:

> The first is to fix the inaccuracies in the documentations, which is what this issue is about.

and derived the rate as nano-satoshis per milli-satoshi. @jhoenicke argued the opposite:

> I think stating it in nanosat per millisat confuses people even more. It's a fraction. Just say its in "per million"

Both are dimensionally valid; they differ only in presentation. I went with the plain per-million framing because it is already how this same quantity is described elsewhere in this file — `PolicyUpdateRequest.fee_rate_ppm` is "parts per million" — and in `lncli updatechanpolicy`. Consistency with existing wording seemed the least surprising choice for a docs fix, but I am happy to switch to the nanosat/millisat framing, or to any wording a maintainer prefers. Just say which and I will push it.

I deliberately did **not** act on two adjacent suggestions from the thread, as both are larger than a documentation fix and want their own discussion:

- Renaming `fee_per_mil` (@jhoenicke notes it can be misread as "per mille", i.e. per thousand). That is a breaking API change. The new comment says "parts per million" explicitly, which resolves the ambiguity in prose without touching the wire API.
- Introducing a `lnwire.NanoSatoshi` type (@yyforyongyu's second suggestion).

## Steps to Test

No behaviour change, so there is nothing to test at runtime. To verify the generated artefacts match the proto:

```
make rpc-check
```

## Pull Request Checklist

### Testing
- [x] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included. — n/a, documentation only.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions. — n/a, no code change.

### Code Style and Documentation
- [x] The change is not insubstantial. This is a wrong-unit description in the public RPC API that caused a user to file this issue after `lncli feereport` and `lnd -h` appeared to contradict each other. The issue was triaged and labelled `documentation` by a maintainer.
- [x] The change obeys the Code Documentation and Commenting guidelines, and lines wrap at 80.
- [x] Commits follow the Ideal Git Commit Structure.
- [x] Any new logging statements use an appropriate subsystem and logging level. — n/a.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file. — n/a.
- [x] There is a change description in the release notes.
