### PR TITLE
funding: cancel unregistered reservations

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -47,6 +47,11 @@
   the reported network statistics such as total network capacity, channel
   count and max out degree.
 
+* Funding responders now [cancel wallet
+  reservations](https://github.com/lightningnetwork/lnd/pull/11156) when
+  channel setup fails before manager registration, ensuring rejected channel
+  proposals do not retain reservation state.
+
 # New Features
 
 ## Functional Enhancements
@@ -166,4 +171,5 @@
 * Boris Nagaev
 * Erick Cestari
 * Jared Tobin
+* moscowchill
 * Nishant Bansal

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -1732,6 +1732,22 @@ func (f *Manager) fundeeProcessOpenChannel(peer lnpeer.Peer,
 		return
 	}
 
+	// Until the reservation is added to activeReservations, the regular
+	// funding flow cleanup cannot find it. Cancel it directly if any of the
+	// remaining setup steps fail before ownership is transferred to the
+	// funding manager.
+	cancelReservation := true
+	defer func() {
+		if !cancelReservation {
+			return
+		}
+
+		if err := reservation.Cancel(); err != nil {
+			log.Errorf("Unable to cancel unregistered reservation: %v",
+				err)
+		}
+	}()
+
 	log.Debugf("Initialized channel reservation: zeroConf=%v, psbt=%v, "+
 		"cannedShim=%v", reservation.IsZeroConf(),
 		reservation.IsPsbt(), reservation.IsCannedShim())
@@ -1918,6 +1934,7 @@ func (f *Manager) fundeeProcessOpenChannel(peer lnpeer.Peer,
 		peer:              peer,
 	}
 	f.activeReservations[peerIDKey][msg.PendingChannelID] = resCtx
+	cancelReservation = false
 	f.resMtx.Unlock()
 
 	// Update the timestamp once the fundingOpenMsg has been handled.

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -5130,6 +5130,58 @@ func TestFundingManagerRejectMissingChanType(t *testing.T) {
 	assertNumPendingReservations(t, bob, alicePubKey, 0)
 }
 
+// TestFundingManagerRejectInvalidConstraintsClearsReservation verifies that
+// rejecting an OpenChannel after wallet reservation initialization removes the
+// reservation from both the funding manager and wallet.
+func TestFundingManagerRejectInvalidConstraintsClearsReservation(t *testing.T) {
+	t.Parallel()
+
+	alice, bob := setupFundingManagers(t)
+	t.Cleanup(func() {
+		tearDownFundingManagers(t, alice, bob)
+	})
+
+	legacyType := lnwire.ChannelType(*lnwire.NewRawFeatureVector())
+	attempts := lncfg.DefaultMaxPendingChannels + 1
+	var openChannelReq *lnwire.OpenChannel
+	for i := 0; i < attempts; i++ {
+		openChannelReq = &lnwire.OpenChannel{
+			ChainHash:            *fundingNetParams.GenesisHash,
+			PendingChannelID:     [32]byte{byte(i + 1)},
+			FundingAmount:        btcutil.Amount(10_000_000),
+			DustLimit:            btcutil.Amount(1),
+			MaxValueInFlight:     lnwire.MilliSatoshi(100_000_000),
+			ChannelReserve:       btcutil.Amount(10_000),
+			HtlcMinimum:          lnwire.MilliSatoshi(1_000),
+			FeePerKiloWeight:     15_000,
+			CsvDelay:             144,
+			MaxAcceptedHTLCs:     483,
+			FundingKey:           alice.privKey.PubKey(),
+			RevocationPoint:      alice.privKey.PubKey(),
+			PaymentPoint:         alice.privKey.PubKey(),
+			DelayedPaymentPoint:  alice.privKey.PubKey(),
+			HtlcPoint:            alice.privKey.PubKey(),
+			FirstCommitmentPoint: alice.privKey.PubKey(),
+			ChannelType:          &legacyType,
+		}
+
+		bob.fundingMgr.ProcessFundingMsg(openChannelReq, alice)
+		assertFundingMsgSent(t, bob.msgChan, "Error")
+	}
+
+	// Process one final request that fails before wallet initialization. The
+	// funding manager handles messages serially, so receiving this error also
+	// confirms that cancellation for the preceding request has completed.
+	barrierReq := *openChannelReq
+	barrierReq.PendingChannelID = [32]byte{byte(attempts + 1)}
+	barrierReq.ChannelType = nil
+	bob.fundingMgr.ProcessFundingMsg(&barrierReq, alice)
+	assertFundingMsgSent(t, bob.msgChan, "Error")
+
+	assertNumPendingReservations(t, bob, alicePubKey, 0)
+	require.Empty(t, bob.fundingMgr.cfg.Wallet.ActiveReservations())
+}
+
 // TestFundingManagerAcceptChanType verifies that the fundee accepts an
 // OpenChannel message that includes the ChannelType field and echoes it back
 // in AcceptChannel, even when neither peer advertises the explicit channel


### PR DESCRIPTION
## Change Description

The fundee wallet records a channel reservation before all remaining setup steps have completed. If one of those steps fails before the reservation is added to `activeReservations`, the existing manager cleanup cannot find it.

This PR keeps direct ownership of the wallet reservation until manager registration succeeds. A deferred cleanup cancels the reservation on every earlier return, and the guard is disarmed when `activeReservations` takes ownership.

The regression test sends more invalid proposals than the default pending-channel limit and verifies that both manager and wallet reservation state return to zero.

## Steps to Test

```text
go test ./funding -run '^TestFundingManagerRejectInvalidConstraintsClearsReservation$' -count=10
go test -race ./funding -run '^TestFundingManagerRejectInvalidConstraintsClearsReservation$' -count=10
go test ./funding -count=1
```

## Pull Request Checklist

### Testing

- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative error paths are included.
- [x] The bug fix contains a test triggering the original cleanup gap.

### Code Style and Documentation

- [x] The change is substantial and focused.
- [x] The change follows the code documentation and 80-column guidelines.
- [x] The commit follows the ideal Git commit structure.
- [x] New logging uses an appropriate subsystem and level.
- [x] No lncli command is added.
- [x] A release-note entry is included.
