### PR TITLE
lncli: show subcommands in `lncli help <command>`

### DIFF
--- a/cmd/commands/cmd_help.go
+++ b/cmd/commands/cmd_help.go
@@ -1,0 +1,54 @@
+package commands
+
+import (
+	"flag"
+
+	"github.com/urfave/cli"
+)
+
+// helpCommand replaces the help command that the cli library registers by
+// default. That default implementation always renders a command with the flat
+// command help template, which has no section for subcommands. So
+// "lncli help wallet" only prints the name and usage of the wallet command,
+// while "lncli wallet --help" also lists every command below it. We therefore
+// hand a command that has subcommands to its own help output, so both ways of
+// asking for help print the same thing.
+//
+// NOTE: The cli library only registers the global help flag if the application
+// doesn't declare a command called "help" itself. Because we do, cli.HelpFlag
+// is added to the application's flags by hand, see main.go.
+var helpCommand = cli.Command{
+	Name:      "help",
+	Aliases:   []string{"h"},
+	Usage:     "Shows a list of commands or help for one command",
+	ArgsUsage: "[command]",
+	Action:    helpCommandAction,
+}
+
+// helpCommandAction prints the help of the command named by the first
+// argument, or the help of the application itself if there is no argument.
+func helpCommandAction(ctx *cli.Context) error {
+	args := ctx.Args()
+	if !args.Present() {
+		return cli.ShowAppHelp(ctx)
+	}
+
+	// A command that has no subcommands is rendered correctly by the
+	// library itself. So is a name that doesn't resolve to a command at
+	// all, in which case we want the library's "no help topic" error.
+	name := args.First()
+	command := ctx.App.Command(name)
+	if command == nil || len(command.Subcommands) == 0 {
+		return cli.ShowCommandHelp(ctx, name)
+	}
+
+	// Run the command with the help flag as its only argument. The library
+	// prints the subcommand help and returns before any action is
+	// executed, which is what "lncli <command> --help" does as well.
+	set := flag.NewFlagSet(name, flag.ContinueOnError)
+	if err := set.Parse([]string{name, "--help"}); err != nil {
+		return err
+	}
+
+	return command.Run(cli.NewContext(ctx.App, set, ctx))
+}

--- a/cmd/commands/cmd_help_test.go
+++ b/cmd/commands/cmd_help_test.go
@@ -1,0 +1,109 @@
+package commands
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli"
+)
+
+// newHelpTestApp returns an application that is wired up the same way lncli
+// is: a command that has subcommands, a command that has none, our own help
+// command and the help flag that comes with it.
+func newHelpTestApp(w io.Writer) *cli.App {
+	app := cli.NewApp()
+	app.Name = "lncli"
+	app.HelpName = "lncli"
+	app.Version = "1.0.0"
+	app.Writer = w
+	app.Flags = []cli.Flag{cli.HelpFlag}
+	app.Commands = []cli.Command{
+		{
+			Name:     "wallet",
+			Usage:    "Interact with the wallet.",
+			Category: "Wallet",
+			Subcommands: []cli.Command{
+				{
+					Name:  "accounts",
+					Usage: "Interact with wallet accounts.",
+				},
+				{
+					Name:  "labeltx",
+					Usage: "Adds a label to a transaction.",
+				},
+			},
+		},
+		{
+			Name:  "sendcoins",
+			Usage: "Send bitcoin on-chain to an address.",
+		},
+		helpCommand,
+	}
+
+	return app
+}
+
+// runHelpTestApp runs the given arguments against a fresh test application and
+// returns everything it printed.
+func runHelpTestApp(t *testing.T, args ...string) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	app := newHelpTestApp(&buf)
+	require.NoError(t, app.Run(append([]string{"lncli"}, args...)))
+
+	return buf.String()
+}
+
+// TestHelpCommandWithSubCommands makes sure that asking for the help of a
+// command that has subcommands lists them, and that it prints exactly what the
+// command's own help flag prints.
+func TestHelpCommandWithSubCommands(t *testing.T) {
+	t.Parallel()
+
+	help := runHelpTestApp(t, "help", "wallet")
+	require.Contains(t, help, "lncli wallet - Interact with the wallet.")
+	require.Contains(t, help, "COMMANDS:")
+	require.Contains(t, help, "accounts")
+	require.Contains(t, help, "labeltx")
+
+	require.Equal(t, runHelpTestApp(t, "wallet", "--help"), help)
+}
+
+// TestHelpCommandWithoutSubCommands makes sure the help of a command that has
+// no subcommands is left alone.
+func TestHelpCommandWithoutSubCommands(t *testing.T) {
+	t.Parallel()
+
+	help := runHelpTestApp(t, "help", "sendcoins")
+	require.Contains(
+		t, help, "lncli sendcoins - Send bitcoin on-chain to an "+
+			"address.",
+	)
+	require.NotContains(t, help, "COMMANDS:")
+}
+
+// TestHelpCommandWithoutArguments makes sure that the help command without an
+// argument still shows the help of the application itself.
+func TestHelpCommandWithoutArguments(t *testing.T) {
+	t.Parallel()
+
+	help := runHelpTestApp(t, "help")
+	require.Contains(t, help, "COMMANDS:")
+	require.Contains(t, help, "wallet")
+	require.Contains(t, help, "sendcoins")
+}
+
+// TestHelpFlag makes sure the global help flag keeps working next to our own
+// help command. The cli library stops adding that flag as soon as the
+// application declares a command called "help", so it has to be registered by
+// hand.
+func TestHelpFlag(t *testing.T) {
+	t.Parallel()
+
+	help := runHelpTestApp(t, "--help")
+	require.Contains(t, help, "GLOBAL OPTIONS:")
+	require.Contains(t, help, "--help, -h")
+}

--- a/cmd/commands/main.go
+++ b/cmd/commands/main.go
@@ -445,6 +445,12 @@ func Main() {
 				"authentication",
 			Hidden: true,
 		},
+
+		// The cli library only registers the help flag by itself if the
+		// application doesn't declare a command called "help". Because
+		// we declare our own (see cmd_help.go), we have to add the flag
+		// here.
+		cli.HelpFlag,
 	}
 	app.Commands = []cli.Command{
 		createCommand,
@@ -531,6 +537,10 @@ func Main() {
 	app.Commands = append(app.Commands, devCommands()...)
 	app.Commands = append(app.Commands, peersCommands()...)
 	app.Commands = append(app.Commands, chainCommands()...)
+
+	// The help command goes last, which is where the cli library would put
+	// its own version of it as well.
+	app.Commands = append(app.Commands, helpCommand)
 
 	if err := app.Run(os.Args); err != nil {
 		fatal(err)

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -41,6 +41,12 @@
   exclude such inputs from sweeping even though their input set could
   comfortably pay its fees.
 
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/11157) where
+  `lncli help <command>` left out the subcommands of a command that has them,
+  so `lncli help wallet` showed nothing about `lncli wallet accounts` and its
+  siblings. `lncli help <command>` now prints the same help as
+  `lncli <command> --help`.
+
 * [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/10963) in
   `GetNetworkInfo` where encountering an already-seen channel skipped the
   rest of that node's channels instead of just that channel, undercounting
@@ -164,6 +170,7 @@
 
 * bitromortac
 * Boris Nagaev
+* Chris Allott
 * Erick Cestari
 * Jared Tobin
 * Nishant Bansal


### PR DESCRIPTION
## Change Description

Fixes #7975.

`lncli help wallet` printed only the name, usage and category of the `wallet`
command, while `lncli wallet --help` also listed everything below it:

```
NAME:
   lncli wallet - Interact with the wallet.

USAGE:
   lncli wallet [arguments...]

CATEGORY:
   Wallet
```

The cli library's `help` command always renders through `cli.ShowCommandHelp`,
which uses the flat `CommandHelpTemplate`. That template has no section for
subcommands. The `--help` flag takes a different path: a command that has
subcommands is turned into its own sub-application, which is rendered with
`SubcommandHelpTemplate` and does list them.

This replaces the library's `help` command with one that hands a command that
has subcommands to that same sub-application path, so both ways of asking print
the same thing. Commands without subcommands, and names that don't resolve to a
command at all, keep going through `cli.ShowCommandHelp` unchanged.

The library only registers the global help flag if the application doesn't
declare a command called `help` itself, so `cli.HelpFlag` is now added to
`app.Flags` by hand. `lncli --help` and `lncli -h` are unaffected.

After:

```
NAME:
   lncli wallet - Interact with the wallet.

USAGE:
   lncli wallet command [command options] [arguments...]

COMMANDS:
   estimatefeerate    Estimates the on-chain fee rate to achieve a confirmation target.
   pendingsweeps      List all outputs that are pending to be swept within lnd.
   bumpfee            Bumps the fee of an arbitrary input/transaction.
   ...
   addresses          Interact with wallet addresses.

OPTIONS:
   --help, -h  show help
```

## Steps to Test

Build `lncli` and compare the two ways of asking for help:

```
lncli help wallet
lncli wallet --help
```

The output is now identical. The same holds for the other commands that have
subcommands (`profile`, `wtclient`, `peers`, `chain`). `lncli help sendcoins`,
`lncli help`, `lncli --help` and `lncli help <unknown>` (still exit code 3) are
unchanged.

Unit tests:

```
go test ./cmd/commands/ -run TestHelp -v
```

## Pull Request Checklist

### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.
