### PR TITLE
multi: bound peer message subscriptions

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -47,6 +47,11 @@
   the reported network statistics such as total network capacity, channel
   count and max out degree.
 
+* Custom-message and onion-message RPC streams now [evict slow
+  subscribers](https://github.com/lightningnetwork/lnd/pull/11159) when their
+  per-client queue fills, preventing stalled clients from retaining unbounded
+  peer messages.
+
 # New Features
 
 ## Functional Enhancements
@@ -166,4 +171,5 @@
 * Boris Nagaev
 * Erick Cestari
 * Jared Tobin
+* moscowchill
 * Nishant Bansal

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -82,6 +82,7 @@ import (
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/rpcperms"
 	"github.com/lightningnetwork/lnd/signal"
+	"github.com/lightningnetwork/lnd/subscribe"
 	"github.com/lightningnetwork/lnd/sweep"
 	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/lightningnetwork/lnd/watchtower"
@@ -8714,6 +8715,20 @@ func (r *rpcServer) SendCustomMessage(ctx context.Context,
 	}, nil
 }
 
+// subscriptionClientError maps a server-initiated subscription shutdown to
+// the error returned by its RPC stream.
+func subscriptionClientError(client *subscribe.Client) error {
+	err := client.Err()
+	if errors.Is(err, subscribe.ErrSlowConsumer) {
+		return status.Error(codes.ResourceExhausted, err.Error())
+	}
+	if err != nil {
+		return err
+	}
+
+	return errors.New("shutdown")
+}
+
 // SubscribeCustomMessages subscribes to a stream of incoming custom peer
 // messages.
 func (r *rpcServer) SubscribeCustomMessages(
@@ -8727,9 +8742,17 @@ func (r *rpcServer) SubscribeCustomMessages(
 	defer client.Cancel()
 
 	for {
+		// Prefer a server-side eviction over another queued update once the
+		// client has been removed for falling behind.
 		select {
 		case <-client.Quit():
-			return errors.New("shutdown")
+			return subscriptionClientError(client)
+		default:
+		}
+
+		select {
+		case <-client.Quit():
+			return subscriptionClientError(client)
 
 		case <-server.Context().Done():
 			return server.Context().Err()
@@ -8793,9 +8816,17 @@ func (r *rpcServer) SubscribeOnionMessages(
 	defer client.Cancel()
 
 	for {
+		// Prefer a server-side eviction over another queued update once the
+		// client has been removed for falling behind.
 		select {
 		case <-client.Quit():
-			return errors.New("shutdown")
+			return subscriptionClientError(client)
+		default:
+		}
+
+		select {
+		case <-client.Quit():
+			return subscriptionClientError(client)
 
 		case <-server.Context().Done():
 			return server.Context().Err()

--- a/rpcserver_test.go
+++ b/rpcserver_test.go
@@ -1,6 +1,7 @@
 package lnd
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -8,9 +9,14 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/signal"
+	"github.com/lightningnetwork/lnd/subscribe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -74,6 +80,138 @@ func TestAuxDataParser(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, []byte{0x00, 0x00}, resp.CustomChannelData)
+}
+
+// TestSlowSubscriptionClientError verifies that an evicted subscription is
+// translated into an explicit gRPC slow-consumer error.
+func TestSlowSubscriptionClientError(t *testing.T) {
+	t.Parallel()
+
+	server := subscribe.NewServerWithQueueSize(1)
+	require.NoError(t, server.Start())
+	t.Cleanup(func() {
+		require.NoError(t, server.Stop())
+	})
+
+	client, err := server.Subscribe()
+	require.NoError(t, err)
+
+	// The first update fills the queue and the second evicts the client.
+	require.NoError(t, server.SendUpdate(1))
+	require.NoError(t, server.SendUpdate(2))
+
+	select {
+	case <-client.Quit():
+	case <-time.After(time.Second):
+		t.Fatal("slow client was not evicted")
+	}
+
+	err = subscriptionClientError(client)
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+	require.ErrorContains(t, err, subscribe.ErrSlowConsumer.Error())
+}
+
+// blockingCustomMessageStream models a custom-message RPC whose transport is
+// unable to accept the first response.
+type blockingCustomMessageStream struct {
+	grpc.ServerStream
+
+	ctx         context.Context
+	sendStarted chan struct{}
+	sendRelease chan struct{}
+}
+
+// Context returns the lifetime of the test stream.
+func (s *blockingCustomMessageStream) Context() context.Context {
+	return s.ctx
+}
+
+// Send blocks until the test releases the simulated transport.
+func (s *blockingCustomMessageStream) Send(*lnrpc.CustomMessage) error {
+	close(s.sendStarted)
+
+	select {
+	case <-s.sendRelease:
+		return nil
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	}
+}
+
+// TestSubscribeCustomMessagesSlowClient verifies that the custom-message RPC
+// returns ResourceExhausted after its bounded subscription evicts it.
+func TestSubscribeCustomMessagesSlowClient(t *testing.T) {
+	t.Parallel()
+
+	const queueSize = 10
+
+	messageServer := subscribe.NewServerWithQueueSize(queueSize)
+	require.NoError(t, messageServer.Start())
+	t.Cleanup(func() {
+		require.NoError(t, messageServer.Stop())
+	})
+
+	rpc := &rpcServer{
+		server: &server{
+			customMessageServer: messageServer,
+		},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	stream := &blockingCustomMessageStream{
+		ctx:         ctx,
+		sendStarted: make(chan struct{}),
+		sendRelease: make(chan struct{}),
+	}
+	rpcResult := make(chan error, 1)
+	go func() {
+		rpcResult <- rpc.SubscribeCustomMessages(
+			&lnrpc.SubscribeCustomMessagesRequest{}, stream,
+		)
+	}()
+
+	update := &CustomMessage{
+		Msg: &lnwire.Custom{
+			Type: 32_769,
+			Data: []byte{1},
+		},
+	}
+
+	// Dispatch until the RPC subscription is active and its first Send is
+	// blocked in the simulated transport.
+	deadline := time.After(5 * time.Second)
+sendFirstUpdate:
+	for {
+		require.NoError(t, messageServer.SendUpdate(update))
+
+		select {
+		case <-stream.sendStarted:
+			break sendFirstUpdate
+		case <-deadline:
+			t.Fatal("custom-message RPC did not start sending")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	// One update fills the queue, the next evicts the client, and the last
+	// acts as a barrier proving that eviction has completed.
+	for i := 0; i < queueSize+2; i++ {
+		require.NoError(t, messageServer.SendUpdate(update))
+	}
+
+	close(stream.sendRelease)
+
+	select {
+	case err := <-rpcResult:
+		require.Equal(t, codes.ResourceExhausted, status.Code(err))
+		require.ErrorContains(
+			t, err, subscribe.ErrSlowConsumer.Error(),
+		)
+	case <-time.After(time.Second):
+		t.Fatal("custom-message RPC did not return after eviction")
+	}
 }
 
 // TestStopDaemonBeforeRPCStartup makes sure StopDaemon can be called during

--- a/server.go
+++ b/server.go
@@ -115,6 +115,12 @@ const (
 	// multiAddrConnectionStagger is the number of seconds to wait between
 	// attempting to a peer with each of its advertised addresses.
 	multiAddrConnectionStagger = 10 * time.Second
+
+	// rpcMessageSubscriptionQueueSize is the maximum number of pending peer
+	// messages retained for each custom-message or onion-message RPC client.
+	// At the maximum Lightning message size, this limits one active client to
+	// less than 6.3 MiB of queued message payloads.
+	rpcMessageSubscriptionQueueSize = 100
 )
 
 var (
@@ -846,9 +852,13 @@ func newServer(ctx context.Context, cfg *Config, listenAddrs []net.Addr,
 
 		invoiceHtlcModifier: invoiceHtlcModifier,
 
-		customMessageServer: subscribe.NewServer(),
+		customMessageServer: subscribe.NewServerWithQueueSize(
+			rpcMessageSubscriptionQueueSize,
+		),
 
-		onionMessageServer: subscribe.NewServer(),
+		onionMessageServer: subscribe.NewServerWithQueueSize(
+			rpcMessageSubscriptionQueueSize,
+		),
 
 		actorSystem: actor.NewActorSystem(),
 

--- a/subscribe/subscribe.go
+++ b/subscribe/subscribe.go
@@ -8,9 +8,15 @@ import (
 	"github.com/lightningnetwork/lnd/queue"
 )
 
-// ErrServerShuttingDown is an error returned in case the server is in the
-// process of shutting down.
-var ErrServerShuttingDown = errors.New("subscription server shutting down")
+var (
+	// ErrServerShuttingDown is an error returned in case the server is in
+	// the process of shutting down.
+	ErrServerShuttingDown = errors.New("subscription server shutting down")
+
+	// ErrSlowConsumer is recorded on a bounded subscription client when it
+	// cannot keep up with the updates sent by the server.
+	ErrSlowConsumer = errors.New("subscription client is too slow")
+)
 
 // Client is used to get notified about updates the caller has subscribed to,
 type Client struct {
@@ -18,13 +24,27 @@ type Client struct {
 	// subscribe for updates from the server.
 	cancel func()
 
+	// updates is used by servers created with NewServer and preserves the
+	// historical unbounded queue behavior.
 	updates *queue.ConcurrentQueue
-	quit    chan struct{}
+
+	// boundedUpdates is used by servers that opt into a fixed per-client
+	// queue size.
+	boundedUpdates *queue.BackpressureQueue[interface{}]
+
+	errMtx sync.RWMutex
+	err    error
+
+	quit chan struct{}
 }
 
 // Updates returns a read-only channel where the updates the client has
 // subscribed to will be delivered.
 func (c *Client) Updates() <-chan interface{} {
+	if c.boundedUpdates != nil {
+		return c.boundedUpdates.ReceiveChan()
+	}
+
 	return c.updates.ChanOut()
 }
 
@@ -40,6 +60,23 @@ func (c *Client) Cancel() {
 	c.cancel()
 }
 
+// Err returns the reason the server stopped the subscription. A nil error
+// means that the client canceled the subscription or the server shut down.
+func (c *Client) Err() error {
+	c.errMtx.RLock()
+	defer c.errMtx.RUnlock()
+
+	return c.err
+}
+
+// setErr records the reason the server stopped the subscription.
+func (c *Client) setErr(err error) {
+	c.errMtx.Lock()
+	defer c.errMtx.Unlock()
+
+	c.err = err
+}
+
 // Server is a struct that manages a set of subscriptions and their
 // corresponding clients. Any update will be delivered to all active clients.
 type Server struct {
@@ -52,6 +89,10 @@ type Server struct {
 	clientUpdates chan *clientUpdate
 
 	updates chan interface{}
+
+	// clientQueueSize is the maximum number of pending updates retained for
+	// each client. A zero value preserves the historical unbounded queue.
+	clientQueueSize int
 
 	quit chan struct{}
 	wg   sync.WaitGroup
@@ -78,11 +119,29 @@ type clientUpdate struct {
 
 // NewServer returns a new Server.
 func NewServer() *Server {
+	return newServer(0)
+}
+
+// NewServerWithQueueSize returns a Server with a fixed pending-update limit
+// for each client. A client is evicted with ErrSlowConsumer when a new update
+// would exceed queueSize. The queue size must be positive.
+func NewServerWithQueueSize(queueSize int) *Server {
+	if queueSize <= 0 {
+		panic("subscribe: queue size must be positive")
+	}
+
+	return newServer(queueSize)
+}
+
+// newServer creates a subscription server with the requested client queue
+// size. A queue size of zero selects the historical unbounded queue.
+func newServer(queueSize int) *Server {
 	return &Server{
-		clients:       make(map[uint64]*Client),
-		clientUpdates: make(chan *clientUpdate),
-		updates:       make(chan interface{}),
-		quit:          make(chan struct{}),
+		clients:         make(map[uint64]*Client),
+		clientUpdates:   make(chan *clientUpdate),
+		updates:         make(chan interface{}),
+		clientQueueSize: queueSize,
+		quit:            make(chan struct{}),
 	}
 }
 
@@ -122,8 +181,7 @@ func (s *Server) Subscribe() (*Client, error) {
 	// populated to send the cancellation intent to the
 	// subscriptionHandler.
 	client := &Client{
-		updates: queue.NewConcurrentQueue(20),
-		quit:    make(chan struct{}),
+		quit: make(chan struct{}),
 		cancel: func() {
 			select {
 			case s.clientUpdates <- &clientUpdate{
@@ -134,6 +192,17 @@ func (s *Server) Subscribe() (*Client, error) {
 				return
 			}
 		},
+	}
+
+	if s.clientQueueSize == 0 {
+		client.updates = queue.NewConcurrentQueue(20)
+	} else {
+		client.boundedUpdates = queue.NewBackpressureQueue(
+			s.clientQueueSize,
+			func(_ int, _ interface{}) bool {
+				return false
+			},
+		)
 	}
 
 	select {
@@ -147,6 +216,37 @@ func (s *Server) Subscribe() (*Client, error) {
 	}
 
 	return client, nil
+}
+
+// removeClient stops and removes a client. The reason is recorded before Quit
+// is closed so callers observing Quit can retrieve it through Err.
+func (s *Server) removeClient(clientID uint64, reason error) {
+	client, ok := s.clients[clientID]
+	if !ok {
+		return
+	}
+
+	if client.updates != nil {
+		client.updates.Stop()
+	}
+
+	// A bounded client's RPC sender can still be blocked in transport flow
+	// control after eviction. Drain pending items now so the blocked handler
+	// cannot retain the entire queue until the transport becomes writable.
+	if client.boundedUpdates != nil {
+	drainLoop:
+		for {
+			select {
+			case <-client.boundedUpdates.ReceiveChan():
+			default:
+				break drainLoop
+			}
+		}
+	}
+
+	client.setErr(reason)
+	close(client.quit)
+	delete(s.clients, clientID)
 }
 
 // SendUpdate is called to send the passed update to all currently active
@@ -181,12 +281,7 @@ func (s *Server) subscriptionHandler() {
 			// underlying queue, and remove the client from the set
 			// of active subscription clients.
 			if update.cancel {
-				client, ok := s.clients[update.clientID]
-				if ok {
-					client.updates.Stop()
-					close(client.quit)
-					delete(s.clients, clientID)
-				}
+				s.removeClient(clientID, nil)
 
 				continue
 			}
@@ -195,12 +290,24 @@ func (s *Server) subscriptionHandler() {
 			// queue and add the client to our set of subscription
 			// clients. It will be notified about any new updates
 			// the server receives.
-			update.client.updates.Start()
+			if update.client.updates != nil {
+				update.client.updates.Start()
+			}
 			s.clients[update.clientID] = update.client
 
 		// A new update was received, forward it to all active clients.
 		case upd := <-s.updates:
-			for _, client := range s.clients {
+			for clientID, client := range s.clients {
+				if client.boundedUpdates != nil {
+					if !client.boundedUpdates.TryEnqueue(upd) {
+						s.removeClient(
+							clientID, ErrSlowConsumer,
+						)
+					}
+
+					continue
+				}
+
 				select {
 				case client.updates.ChanIn() <- upd:
 				case <-client.quit:
@@ -212,9 +319,8 @@ func (s *Server) subscriptionHandler() {
 		// In case the server is shutting down, stop the clients and
 		// close the quit channels to notify them.
 		case <-s.quit:
-			for _, client := range s.clients {
-				client.updates.Stop()
-				close(client.quit)
+			for clientID := range s.clients {
+				s.removeClient(clientID, nil)
 			}
 			return
 		}

--- a/subscribe/subscribe_test.go
+++ b/subscribe/subscribe_test.go
@@ -1,6 +1,7 @@
 package subscribe_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -107,4 +108,83 @@ func TestSubscribe(t *testing.T) {
 
 	}
 
+}
+
+// TestBoundedServerEvictsSlowClient verifies that a bounded server evicts a
+// stalled client without delaying or reordering updates for a healthy client.
+func TestBoundedServerEvictsSlowClient(t *testing.T) {
+	t.Parallel()
+
+	const (
+		queueSize  = 3
+		numUpdates = 10
+	)
+
+	server := subscribe.NewServerWithQueueSize(queueSize)
+	if err := server.Start(); err != nil {
+		t.Fatalf("unable to start server: %v", err)
+	}
+	defer func() {
+		if err := server.Stop(); err != nil {
+			t.Errorf("unable to stop server: %v", err)
+		}
+	}()
+
+	slowClient, err := server.Subscribe()
+	if err != nil {
+		t.Fatalf("unable to subscribe slow client: %v", err)
+	}
+
+	fastClient, err := server.Subscribe()
+	if err != nil {
+		t.Fatalf("unable to subscribe fast client: %v", err)
+	}
+
+	for i := 0; i < numUpdates; i++ {
+		if err := server.SendUpdate(i); err != nil {
+			t.Fatalf("unable to send update %v: %v", i, err)
+		}
+
+		select {
+		case update := <-fastClient.Updates():
+			value, ok := update.(int)
+			if !ok {
+				t.Fatalf("unexpected update type %T", update)
+			}
+			if value != i {
+				t.Fatalf("expected fast client update %v, got %v",
+					i, value)
+			}
+
+		case <-time.After(time.Second):
+			t.Fatalf("fast client did not receive update %v", i)
+		}
+	}
+
+	select {
+	case <-slowClient.Quit():
+	case <-time.After(time.Second):
+		t.Fatal("slow client was not evicted")
+	}
+
+	if !errors.Is(slowClient.Err(), subscribe.ErrSlowConsumer) {
+		t.Fatalf("expected slow-consumer error, got %v", slowClient.Err())
+	}
+	if queued := len(slowClient.Updates()); queued != 0 {
+		t.Fatalf("evicted client retained %v queued updates", queued)
+	}
+
+	select {
+	case <-fastClient.Quit():
+		t.Fatalf("fast client was unexpectedly evicted: %v",
+			fastClient.Err())
+	default:
+	}
+
+	fastClient.Cancel()
+	select {
+	case <-fastClient.Quit():
+	case <-time.After(time.Second):
+		t.Fatal("fast client did not stop after cancellation")
+	}
 }


### PR DESCRIPTION
## Change Description

Custom-message and onion-message RPC subscribers currently use an unbounded per-client queue. If a stream stops accepting responses while peer messages continue to arrive, its queue retains those messages without a memory limit.

This PR adds an opt-in bounded mode to the subscription server and uses it for both peer-message RPCs. Each client may retain 100 pending messages, which limits maximum-sized queued payloads to less than 6.3 MiB. A client that exceeds the limit is removed and its queued references are drained immediately; healthy clients continue receiving ordered updates without producer blocking.

Slow-consumer eviction is reported as gRPC `ResourceExhausted` once the stream can make transport progress. Existing users of `subscribe.NewServer()` keep their current queue behavior.

## Steps to Test

```text
go test ./subscribe -count=20
go test . -count=1
go test -race ./subscribe -count=1
go test -race . -run '^(TestSlowSubscriptionClientError|TestSubscribeCustomMessagesSlowClient)$' -count=10
```

## Pull Request Checklist

### Testing

- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative error paths are included.
- [x] The bug fix contains a blocked-stream regression test.

### Code Style and Documentation

- [x] The change is substantial and focused.
- [x] The change follows the code documentation and 80-column guidelines.
- [x] The commit follows the ideal Git commit structure.
- [x] New logging uses an appropriate subsystem and level.
- [x] No lncli command is added.
- [x] A release-note entry is included.
