### PR TITLE
htlcswitch: reconcile resumed forward replays

### DIFF
--- a/docs/release-notes/release-notes-0.20.5.md
+++ b/docs/release-notes/release-notes-0.20.5.md
@@ -21,6 +21,12 @@
 
 # Bug Fixes
 
+* The [HTLC forward
+  interceptor](https://github.com/lightningnetwork/lnd/pull/11163) now
+  reconciles incoming-link replays after a forward is resumed. This prevents
+  the replay from being handled as a second interception while the original
+  outgoing HTLC remains active.
+
 # New Features
 
 ## Functional Enhancements

--- a/docs/release-notes/release-notes-0.21.4.md
+++ b/docs/release-notes/release-notes-0.21.4.md
@@ -21,6 +21,12 @@
 
 # Bug Fixes
 
+* The [HTLC forward
+  interceptor](https://github.com/lightningnetwork/lnd/pull/11163) now
+  reconciles incoming-link replays after a forward is resumed. This prevents
+  the replay from being handled as a second interception while the original
+  outgoing HTLC remains active.
+
 # New Features
 
 ## Functional Enhancements

--- a/htlcswitch/held_htlc_set_test.go
+++ b/htlcswitch/held_htlc_set_test.go
@@ -176,9 +176,9 @@ func TestHeldHtlcSetAddOffChainKeepsExisting(t *testing.T) {
 	second.AssertNotCalled(t, "Resume")
 }
 
-// TestInterceptableSwitchForwardOffChainAlreadyHeld verifies that normal
-// off-chain forwarding handles duplicates before adding them to the held set.
-func TestInterceptableSwitchForwardOffChainAlreadyHeld(t *testing.T) {
+// TestInterceptableSwitchAlreadyHeld verifies that interception handles held
+// duplicates before applying a new expiry decision.
+func TestInterceptableSwitchAlreadyHeld(t *testing.T) {
 	key := testCircuitKey()
 	fwd := newMockInterceptedForward(key, 100)
 	s := &InterceptableSwitch{
@@ -187,9 +187,11 @@ func TestInterceptableSwitchForwardOffChainAlreadyHeld(t *testing.T) {
 
 	require.NoError(t, s.heldHtlcSet.addOffChain(fwd))
 
-	handled, err := s.forwardOffChain(
-		newMockInterceptedForward(key, 100), true,
-	)
+	handled, err := s.interceptForward(&htlcPacket{
+		incomingChanID: key.ChanID,
+		incomingHTLCID: key.HtlcID,
+		htlc:           &lnwire.UpdateAddHTLC{},
+	}, true)
 	require.NoError(t, err)
 	require.True(t, handled)
 }

--- a/htlcswitch/interceptable_switch.go
+++ b/htlcswitch/interceptable_switch.go
@@ -102,6 +102,7 @@ type interceptedPackets struct {
 	packets  []*htlcPacket
 	linkQuit <-chan struct{}
 	isReplay bool
+	done     chan error
 }
 
 type onchainInterceptRequest struct {
@@ -307,6 +308,10 @@ func (s *InterceptableSwitch) run() error {
 
 		case packets := <-s.intercepted:
 			var notIntercepted []*htlcPacket
+			if packets.isReplay {
+				s.reconcileReplays(packets)
+			}
+
 			for _, p := range packets.packets {
 				intercepted, err := s.interceptForward(
 					p, packets.isReplay,
@@ -362,6 +367,52 @@ func (s *InterceptableSwitch) run() error {
 			return nil
 		}
 	}
+}
+
+// reconcileReplays forwards adds with known incoming circuits while the
+// incoming link remains paused. Packets that still require interception remain
+// in the batch for the event loop to process.
+func (s *InterceptableSwitch) reconcileReplays(packets *interceptedPackets) {
+	var err error
+	defer func() {
+		packets.done <- err
+	}()
+
+	var known []*htlcPacket
+	known, packets.packets = s.partitionReplays(packets.packets)
+	err = s.htlcSwitch.ForwardPackets(packets.linkQuit, known...)
+}
+
+// partitionReplays separates adds with known incoming circuits from packets
+// that still require interceptor processing.
+func (s *InterceptableSwitch) partitionReplays(
+	packets []*htlcPacket) ([]*htlcPacket, []*htlcPacket) {
+
+	var known, remaining []*htlcPacket
+	for _, packet := range packets {
+		if !s.isKnownReplay(packet) {
+			remaining = append(remaining, packet)
+			continue
+		}
+
+		known = append(known, packet)
+	}
+
+	return known, remaining
+}
+
+// isKnownReplay reports whether the packet is a remote add with an incoming
+// circuit that the switch can reconcile.
+func (s *InterceptableSwitch) isKnownReplay(packet *htlcPacket) bool {
+	if _, isAdd := packet.htlc.(*lnwire.UpdateAddHTLC); !isAdd {
+		return false
+	}
+
+	if packet.incomingChanID == hop.Source {
+		return false
+	}
+
+	return s.htlcSwitch.circuits.LookupCircuit(packet.inKey()) != nil
 }
 
 func (s *InterceptableSwitch) failExpiredHtlcs() {
@@ -445,9 +496,14 @@ func (s *InterceptableSwitch) Resolve(res *FwdResolution) error {
 // ForwardPackets attempts to forward the batch of htlcs to a connected
 // interceptor. If the interceptor signals the resume action, the htlcs are
 // forwarded to the switch. The link's quit signal should be provided to allow
-// cancellation of forwarding during link shutdown.
+// cancellation of forwarding during link shutdown. Replay calls return after
+// the switch has reconciled any circuits that already exist.
 func (s *InterceptableSwitch) ForwardPackets(linkQuit <-chan struct{},
 	isReplay bool, packets ...*htlcPacket) error {
+	var done chan error
+	if isReplay {
+		done = make(chan error, 1)
+	}
 
 	// Synchronize with the main event loop. This should be light in the
 	// case where there is no interceptor.
@@ -456,10 +512,28 @@ func (s *InterceptableSwitch) ForwardPackets(linkQuit <-chan struct{},
 		packets:  packets,
 		linkQuit: linkQuit,
 		isReplay: isReplay,
+		done:     done,
 	}:
 
 	case <-linkQuit:
 		log.Debugf("Forward cancelled because link quit")
+
+	case <-s.quit:
+		return errors.New("interceptable switch quit")
+	}
+
+	if !isReplay {
+		return nil
+	}
+
+	// Keep the incoming link paused until the switch reconciles any
+	// existing replay circuits.
+	select {
+	case err := <-done:
+		return err
+
+	case <-linkQuit:
+		log.Debugf("Replay reconciliation cancelled because link quit")
 
 	case <-s.quit:
 		return errors.New("interceptable switch quit")

--- a/htlcswitch/interceptable_switch.go
+++ b/htlcswitch/interceptable_switch.go
@@ -594,6 +594,13 @@ func (s *InterceptableSwitch) interceptForward(packet *htlcPacket,
 			return false, nil
 		}
 
+		// A held replay retains the original expiry decision and
+		// resolution handle. Do not fail a duplicate as the chain
+		// height advances.
+		if s.heldHtlcSet.exists(packet.inKey()) {
+			return true, nil
+		}
+
 		intercepted := &interceptedForward{
 			htlc:       htlc,
 			packet:     packet,
@@ -634,13 +641,6 @@ func (s *InterceptableSwitch) interceptForward(packet *htlcPacket,
 // interceptor if needed.
 func (s *InterceptableSwitch) forwardOffChain(
 	fwd InterceptedForward, isReplay bool) (bool, error) {
-
-	inKey := fwd.Packet().IncomingCircuit
-
-	// Ignore already held htlcs.
-	if s.heldHtlcSet.exists(inKey) {
-		return true, nil
-	}
 
 	// If there is no interceptor currently registered, configuration and packet
 	// replay status determine how the packet is handled.

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -4466,6 +4466,118 @@ func TestInterceptableSwitchReplayAfterResume(t *testing.T) {
 	assertNumCircuits(t, c.s, 0, 0)
 }
 
+// TestInterceptableSwitchHeldReplayNearExpiry verifies that a replay of a held
+// forward cannot fail upstream as the HTLC enters the interception cutoff.
+func TestInterceptableSwitchHeldReplayNearExpiry(t *testing.T) {
+	t.Parallel()
+
+	c := newInterceptableSwitchTestContext(t)
+	defer c.finish()
+
+	epochs := make(chan *chainntnfs.BlockEpoch)
+	notifier := &mock.ChainNotifier{
+		EpochChan: epochs,
+	}
+
+	interceptSwitch, err := NewInterceptableSwitch(
+		&InterceptableSwitchConfig{
+			Switch:             c.s,
+			CltvRejectDelta:    c.cltvRejectDelta,
+			CltvInterceptDelta: c.cltvInterceptDelta,
+			Notifier:           notifier,
+		},
+	)
+	require.NoError(t, err)
+	require.NoError(t, interceptSwitch.Start())
+	defer func() {
+		require.NoError(t, interceptSwitch.Stop())
+	}()
+
+	initialEpochSent := make(chan struct{})
+	go func() {
+		epochs <- &chainntnfs.BlockEpoch{Height: testStartingHeight}
+		close(initialEpochSent)
+	}()
+	<-initialEpochSent
+
+	c.forwardInterceptor.interceptedChan = make(chan InterceptedPacket, 1)
+	interceptSwitch.SetInterceptor(
+		c.forwardInterceptor.InterceptForwardHtlc,
+	)
+
+	linkQuit := make(chan struct{})
+	packet := c.createTestPacket()
+	packet.incomingTimeout = testStartingHeight + c.cltvInterceptDelta
+
+	// Retain the incoming-link form for replay after the block height moves
+	// inside the interception cutoff.
+	replay := *packet
+	add, isAdd := packet.htlc.(*lnwire.UpdateAddHTLC)
+	require.True(t, isAdd)
+	htlc := *add
+	replay.htlc = &htlc
+
+	require.NoError(t, interceptSwitch.ForwardPackets(
+		linkQuit, false, packet,
+	))
+	intercepted := c.forwardInterceptor.getIntercepted()
+
+	// Move one block forward. This is inside the interception cutoff but
+	// still two blocks before the original held forward's auto-fail height.
+	epochs <- &chainntnfs.BlockEpoch{Height: testStartingHeight + 1}
+	err = interceptSwitch.Resolve(&FwdResolution{
+		Key: models.CircuitKey{
+			ChanID: c.aliceChannelLink.ShortChanID(),
+			HtlcID: c.incomingHtlcID + 1,
+		},
+		Action: FwdActionResume,
+	})
+	require.ErrorIs(t, err, ErrFwdNotExists)
+
+	require.NoError(t, interceptSwitch.ForwardPackets(
+		linkQuit, true, &replay,
+	))
+
+	// Synchronize with the event loop after it handles the replay.
+	err = interceptSwitch.Resolve(&FwdResolution{
+		Key: models.CircuitKey{
+			ChanID: c.aliceChannelLink.ShortChanID(),
+			HtlcID: c.incomingHtlcID + 2,
+		},
+		Action: FwdActionResume,
+	})
+	require.ErrorIs(t, err, ErrFwdNotExists)
+
+	select {
+	case <-c.forwardInterceptor.interceptedChan:
+		t.Fatal("held replay was offered to the interceptor")
+	default:
+	}
+
+	assertOutgoingLinkReceive(t, c.aliceChannelLink, false)
+	assertOutgoingLinkReceive(t, c.bobChannelLink, false)
+	assertNumCircuits(t, c.s, 0, 0)
+
+	// The original resolution handle must remain usable and open exactly
+	// one outgoing circuit.
+	require.NoError(t, interceptSwitch.Resolve(&FwdResolution{
+		Key:    intercepted.IncomingCircuit,
+		Action: FwdActionResume,
+	}))
+	outgoing := assertOutgoingLinkReceive(t, c.bobChannelLink, true)
+	assertNumCircuits(t, c.s, 1, 1)
+
+	require.NoError(t, interceptSwitch.ForwardPackets(
+		linkQuit, false,
+		c.createSettlePacket(outgoing.outgoingHTLCID),
+	))
+
+	settle := assertOutgoingLinkReceive(t, c.aliceChannelLink, true)
+	_, ok := settle.htlc.(*lnwire.UpdateFulfillHTLC)
+	require.True(t, ok)
+	assertNumCircuits(t, c.s, 0, 0)
+}
+
 func TestInterceptableSwitchWatchDog(t *testing.T) {
 	t.Parallel()
 

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -3904,6 +3904,28 @@ func assertOutgoingLinkReceiveIntercepted(t *testing.T,
 	return nil
 }
 
+// commitBlockingCircuitMap blocks circuit commits until the test releases the
+// barrier.
+type commitBlockingCircuitMap struct {
+	CircuitMap
+
+	commitStarted chan struct{}
+	commitRelease chan struct{}
+}
+
+// CommitCircuits signals that a commit has started, then waits for the test to
+// release it.
+func (c *commitBlockingCircuitMap) CommitCircuits(
+	circuits ...*PaymentCircuit) (*CircuitFwdActions, error) {
+
+	close(c.commitStarted)
+	<-c.commitRelease
+
+	return c.CircuitMap.CommitCircuits(circuits...)
+}
+
+var _ CircuitMap = (*commitBlockingCircuitMap)(nil)
+
 type interceptableSwitchTestContext struct {
 	t *testing.T
 
@@ -4305,6 +4327,143 @@ func TestSwitchHoldForward(t *testing.T) {
 
 	default:
 	}
+}
+
+// TestInterceptableSwitchReplayAfterResume verifies that an incoming link
+// replay is reconciled by the switch after the interceptor has resumed the
+// original forward and the outgoing circuit has been opened.
+func TestInterceptableSwitchReplayAfterResume(t *testing.T) {
+	t.Parallel()
+
+	c := newInterceptableSwitchTestContext(t)
+	defer c.finish()
+
+	notifier := &mock.ChainNotifier{
+		EpochChan: make(chan *chainntnfs.BlockEpoch, 1),
+	}
+	notifier.EpochChan <- &chainntnfs.BlockEpoch{
+		Height: testStartingHeight,
+	}
+
+	interceptSwitch, err := NewInterceptableSwitch(
+		&InterceptableSwitchConfig{
+			Switch:             c.s,
+			CltvRejectDelta:    c.cltvRejectDelta,
+			CltvInterceptDelta: c.cltvInterceptDelta,
+			Notifier:           notifier,
+		},
+	)
+	require.NoError(t, err)
+	require.NoError(t, interceptSwitch.Start())
+	defer func() {
+		require.NoError(t, interceptSwitch.Stop())
+	}()
+
+	c.forwardInterceptor.interceptedChan = make(chan InterceptedPacket, 1)
+	interceptSwitch.SetInterceptor(
+		c.forwardInterceptor.InterceptForwardHtlc,
+	)
+
+	linkQuit := make(chan struct{})
+	packet := c.createTestPacket()
+
+	// Retain the incoming-link packet for replay after the outgoing link
+	// assigns its circuit key.
+	replay := *packet
+	add, isAdd := packet.htlc.(*lnwire.UpdateAddHTLC)
+	require.True(t, isAdd)
+	htlc := *add
+	replay.htlc = &htlc
+
+	require.NoError(t, interceptSwitch.ForwardPackets(
+		linkQuit, false, packet,
+	))
+
+	intercepted := c.forwardInterceptor.getIntercepted()
+	require.NoError(t, interceptSwitch.Resolve(&FwdResolution{
+		Key:    intercepted.IncomingCircuit,
+		Action: FwdActionResume,
+	}))
+
+	outgoing := assertOutgoingLinkReceive(t, c.bobChannelLink, true)
+	assertNumCircuits(t, c.s, 1, 1)
+
+	// Block the switch at circuit commit to verify that the incoming link
+	// remains paused across replay lookup and reconciliation.
+	commitStarted := make(chan struct{})
+	commitRelease := make(chan struct{})
+	c.s.circuits = &commitBlockingCircuitMap{
+		CircuitMap:    c.s.circuits,
+		commitStarted: commitStarted,
+		commitRelease: commitRelease,
+	}
+
+	// Replay the incoming add as processRemoteAdds does when the incoming
+	// link restarts before the return packet has been committed. The replay
+	// must not be offered to the interceptor again.
+	replayErr := make(chan error, 1)
+	go func() {
+		replayErr <- interceptSwitch.ForwardPackets(
+			linkQuit, true, &replay,
+		)
+	}()
+
+	select {
+	case <-commitStarted:
+	case <-time.After(time.Second):
+		close(commitRelease)
+		t.Fatal("replay did not reach circuit commit")
+	}
+
+	var (
+		forwardErr    error
+		returnedEarly bool
+	)
+	select {
+	case forwardErr = <-replayErr:
+		returnedEarly = true
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(commitRelease)
+	if !returnedEarly {
+		forwardErr = <-replayErr
+	}
+	require.NoError(t, forwardErr)
+	require.False(t, returnedEarly, "replay returned before circuit commit")
+
+	// Wait for the replay to finish processing by sending a request through
+	// the same event loop.
+	err = interceptSwitch.Resolve(&FwdResolution{
+		Key: models.CircuitKey{
+			ChanID: c.aliceChannelLink.ShortChanID(),
+			HtlcID: c.incomingHtlcID + 1,
+		},
+		Action: FwdActionResume,
+	})
+	require.ErrorIs(t, err, ErrFwdNotExists)
+
+	select {
+	case <-c.forwardInterceptor.interceptedChan:
+		require.Fail(t, "replay was offered to the interceptor")
+
+	default:
+	}
+
+	assertOutgoingLinkReceive(t, c.bobChannelLink, false)
+	assertNumCircuits(t, c.s, 1, 1)
+
+	// The outgoing settle must still traverse the original circuit and
+	// resolve the incoming HTLC.
+	require.NoError(t, interceptSwitch.ForwardPackets(
+		linkQuit, false,
+		c.createSettlePacket(outgoing.outgoingHTLCID),
+	))
+
+	settle := assertOutgoingLinkReceive(t, c.aliceChannelLink, true)
+	_, ok := settle.htlc.(*lnwire.UpdateFulfillHTLC)
+	require.True(t, ok)
+	assertNumCircuits(t, c.s, 0, 0)
 }
 
 func TestInterceptableSwitchWatchDog(t *testing.T) {

--- a/itest/list_exclude_test.go
+++ b/itest/list_exclude_test.go
@@ -46,7 +46,8 @@ var excludedTestsWindows = append(append([]string{
 
 	"coop close with htlcs",
 
-	"forward interceptor restart",
+	"forward interceptor restart before resume",
+	"forward interceptor restart after resume",
 	"forward interceptor dedup htlcs",
 	"invoice HTLC modifier basic",
 	"lookup htlc resolution",

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -456,8 +456,12 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testForwardInterceptorBasic,
 	},
 	{
-		Name:     "forward interceptor restart",
-		TestFunc: testForwardInterceptorRestart,
+		Name:     "forward interceptor restart before resume",
+		TestFunc: testForwardInterceptorRestartBeforeResume,
+	},
+	{
+		Name:     "forward interceptor restart after resume",
+		TestFunc: testForwardInterceptorRestartAfterResume,
 	},
 	{
 		Name:     "forward interceptor on chain settle after restart",

--- a/itest/lnd_forward_interceptor_test.go
+++ b/itest/lnd_forward_interceptor_test.go
@@ -343,16 +343,29 @@ func testForwardInterceptorBasic(ht *lntest.HarnessTest) {
 	}
 }
 
-// testForwardInterceptorRestart tests that the interceptor can read any wire
-// custom records provided by the sender of a payment as part of the
-// update_add_htlc message and that those records are persisted correctly and
-// re-sent on node restart.
-func testForwardInterceptorRestart(ht *lntest.HarnessTest) {
+// testForwardInterceptorRestartBeforeResume verifies that an unresolved HTLC
+// is re-intercepted with its custom records after a restart.
+func testForwardInterceptorRestartBeforeResume(ht *lntest.HarnessTest) {
+	testForwardInterceptorRestart(ht, false)
+}
+
+// testForwardInterceptorRestartAfterResume verifies that a resumed HTLC is
+// reconciled without a second interception after a restart.
+func testForwardInterceptorRestartAfterResume(ht *lntest.HarnessTest) {
+	testForwardInterceptorRestart(ht, true)
+}
+
+// testForwardInterceptorRestart verifies restart behavior before and after an
+// intercepted forward is resumed.
+func testForwardInterceptorRestart(
+	ht *lntest.HarnessTest, resumeBeforeRestart bool) {
+
 	const chanAmt = btcutil.Amount(300000)
 	p := lntest.OpenChannelParams{Amt: chanAmt}
 
-	// Initialize the test context with 4 connected nodes.
-	cfgs := [][]string{nil, nil, nil, nil}
+	// Require Bob's interceptor so a replay cannot pass through before the
+	// replacement stream registers.
+	cfgs := [][]string{nil, {"--requireinterceptor"}, nil, nil}
 
 	// Open and wait for channels.
 	chanPoints, nodes := ht.CreateSimpleNetwork(cfgs, p)
@@ -391,62 +404,113 @@ func testForwardInterceptorRestart(ht *lntest.HarnessTest) {
 		customRecords,
 	), packet.InWireCustomRecords)
 
-	// We accept the payment at Bob and resume it, so it gets to Carol.
-	// This means the HTLC should now be fully locked in on Alice's side and
-	// any restart of the node should cause the payment to be resumed and
-	// the data to be persisted across restarts.
-	err := bobInterceptor.Send(&routerrpc.ForwardHtlcInterceptResponse{
-		IncomingCircuitKey: packet.IncomingCircuitKey,
-		Action:             actionResume,
-	})
-	require.NoError(ht, err, "failed to send request")
+	var carolPacket *routerrpc.ForwardHtlcInterceptRequest
+	if resumeBeforeRestart {
+		// Resume at Bob and retain Carol's interception. This proves
+		// the outgoing HTLC is live before the incoming replay.
+		err := bobInterceptor.Send(
+			&routerrpc.ForwardHtlcInterceptResponse{
+				IncomingCircuitKey: packet.IncomingCircuitKey,
+				Action:             actionResume,
+			},
+		)
+		require.NoError(ht, err, "failed to send request")
 
-	// We don't resume the payment on Carol, so it should be held there.
+		carolPacket = ht.ReceiveHtlcInterceptor(carolInterceptor)
+	}
 
 	// The payment should now be in flight.
 	var preimage lntypes.Preimage
 	copy(preimage[:], invoice.RPreimage)
 	ht.AssertPaymentStatus(alice, preimage.Hash(), lnrpc.Payment_IN_FLIGHT)
 
-	// We don't resume the payment on Carol, so it should be held there.
-	// We now restart first Bob, then Alice, so we can make sure we've
-	// started the interceptor again on Bob before Alice resumes the
-	// payment.
-	cancelBobInterceptor()
+	// Restart first Bob, then Alice, so Bob's interceptor is registered
+	// before Alice replays the incoming add.
 	restartBob := ht.SuspendNode(bob)
+	cancelBobInterceptor()
 	restartAlice := ht.SuspendNode(alice)
 
 	require.NoError(ht, restartBob(), "failed to restart bob")
 	bobInterceptor, cancelBobInterceptor = bob.RPC.HtlcInterceptor()
 	defer cancelBobInterceptor()
 
+	var (
+		bobReplay  chan *routerrpc.ForwardHtlcInterceptRequest
+		bobRecvErr chan error
+	)
+	if resumeBeforeRestart {
+		bobReplay = make(
+			chan *routerrpc.ForwardHtlcInterceptRequest, 1,
+		)
+		bobRecvErr = make(chan error, 1)
+		go func() {
+			resp, err := bobInterceptor.Recv()
+			if err != nil {
+				bobRecvErr <- err
+				return
+			}
+
+			bobReplay <- resp
+		}()
+	}
+
+	// Subscribe while Alice is offline, so the Alice-Bob active event can
+	// only describe the recovery triggered by Alice's restart below.
+	bobChanSub := bob.RPC.SubscribeChannelEvents()
+
 	require.NoError(ht, restartAlice(), "failed to restart alice")
 
-	// Once restarted, we will wait until the reestabilishment of the links,
-	// Alice=>Bob and Bob=>Carol, finish before calling the interceptors. We
-	// check this by asserting that Carol is now aware of the two channels
-	// being active again.
-	ht.AssertChannelInGraph(carol, chanPoints[0])
-	ht.AssertChannelInGraph(carol, chanPoints[1])
+	// Wait for Bob to finish recovering the Alice-Bob link. Bob emits the
+	// active event only after resolving the forwarding packages. This
+	// includes reconciling the replay under test.
+	aliceBobChan := ht.OutPointFromChannelPoint(chanPoints[0])
+	for {
+		update := ht.ReceiveChannelEvent(bobChanSub)
+		if update.Type != lnrpc.ChannelEventUpdate_ACTIVE_CHANNEL {
+			continue
+		}
 
-	// We should get another notification about the held HTLC.
-	packet = ht.ReceiveHtlcInterceptor(bobInterceptor)
+		activeChan := ht.OutPointFromChannelPoint(
+			update.GetActiveChannel(),
+		)
+		if activeChan == aliceBobChan {
+			break
+		}
+	}
 
-	require.Len(ht, packet.InWireCustomRecords, 2)
-	require.Equal(ht, lntest.CustomRecordsWithUnaccountable(customRecords),
-		packet.InWireCustomRecords)
+	if !resumeBeforeRestart {
+		// The unresolved HTLC should be offered to Bob again with its
+		// custom records intact.
+		packet = ht.ReceiveHtlcInterceptor(bobInterceptor)
+		require.Len(ht, packet.InWireCustomRecords, 2)
+		require.Equal(
+			ht,
+			lntest.CustomRecordsWithUnaccountable(customRecords),
+			packet.InWireCustomRecords,
+		)
 
-	// And now we forward the payment at Carol, expecting only an
-	// accountability signal in our incoming custom records.
-	packet = ht.ReceiveHtlcInterceptor(carolInterceptor)
-	require.Len(ht, packet.InWireCustomRecords, 1)
-	err = carolInterceptor.Send(&routerrpc.ForwardHtlcInterceptResponse{
-		IncomingCircuitKey: packet.IncomingCircuitKey,
+		err := bobInterceptor.Send(
+			&routerrpc.ForwardHtlcInterceptResponse{
+				IncomingCircuitKey: packet.IncomingCircuitKey,
+				Action:             actionResume,
+			},
+		)
+		require.NoError(ht, err, "failed to send request")
+
+		carolPacket = ht.ReceiveHtlcInterceptor(carolInterceptor)
+	}
+
+	// Forward the payment at Carol, expecting only an accountability signal
+	// in the incoming custom records.
+	require.Len(ht, carolPacket.InWireCustomRecords, 1)
+	err := carolInterceptor.Send(&routerrpc.ForwardHtlcInterceptResponse{
+		IncomingCircuitKey: carolPacket.IncomingCircuitKey,
 		Action:             actionResume,
 	})
 	require.NoError(ht, err, "failed to send request")
 
-	// Assert that the payment was successful.
+	// Assert that the payment was successful and fully removed from the
+	// forwarding path.
 	ht.AssertPaymentStatus(
 		alice, preimage.Hash(), lnrpc.Payment_SUCCEEDED,
 		func(p *lnrpc.Payment) error {
@@ -482,6 +546,43 @@ func testForwardInterceptorRestart(ht *lntest.HarnessTest) {
 			return nil
 		},
 	)
+	ht.AssertNumActiveHtlcs(alice, 0)
+	ht.AssertNumActiveHtlcs(bob, 0)
+
+	if !resumeBeforeRestart {
+		return
+	}
+
+	// Bob must not receive the replay after it resumed the original HTLC.
+	select {
+	case replay := <-bobReplay:
+		require.Failf(
+			ht, "unexpected interception",
+			"received replay for circuit %v",
+			replay.IncomingCircuitKey,
+		)
+
+	case recvErr := <-bobRecvErr:
+		require.NoError(ht, recvErr, "bob interceptor closed early")
+
+	default:
+	}
+
+	cancelBobInterceptor()
+	select {
+	case replay := <-bobReplay:
+		require.Failf(
+			ht, "unexpected interception",
+			"received replay for circuit %v",
+			replay.IncomingCircuitKey,
+		)
+
+	case recvErr := <-bobRecvErr:
+		require.Equal(ht, codes.Canceled, status.Code(recvErr))
+
+	case <-time.After(defaultTimeout):
+		require.Fail(ht, "timeout waiting for interceptor cancellation")
+	}
 }
 
 // testForwardInterceptorOnChainSettleAfterRestart tests that an HTLC offered


### PR DESCRIPTION
## Change Description

In this PR, we make resumed forward-interceptor HTLCs idempotent across
incoming-link replays.

Once an interceptor resumes a forward, the switch commits its incoming circuit
and removes the packet from the held set. If the incoming link restarts before
the return packet is committed, it can replay the add. Treating that replay as a
new intercepted forward can fail the incoming HTLC while the original outgoing
HTLC remains live.

For replayed adds that already have a circuit, we now pass the add back through
the switch and wait for the circuit map to classify it before releasing the
incoming link. Fresh adds and unresolved replays still use the asynchronous
interceptor path, so a blocked interceptor callback doesn't stall the link.

We also check the held set before applying the current-height expiry cutoff. A
held replay keeps the original resolution handle and auto-fail height instead of
making a second expiry decision.

## Steps to Test

Run the focused forward-interceptor tests:

```bash
go test ./htlcswitch \
  -run '^(TestInterceptableSwitch|TestSwitchHoldForward)' -count=1
```

Run the package tests and vet with the development build tag:

```bash
go test -tags dev ./htlcswitch -count=1
go vet -tags dev ./htlcswitch
```

Run the two replay regressions under the race detector:

```bash
go test -race -tags dev ./htlcswitch \
  -run '^TestInterceptableSwitchReplayAfterResume$' -count=10
go test -race -tags dev ./htlcswitch \
  -run '^TestInterceptableSwitchHeldReplayNearExpiry$' -count=10
```

## Pull Request Checklist

### Testing

- [ ] The public PR passes all CI checks.
- [x] Tests covering the positive and negative paths are included.
- [x] The bug fix includes tests that trigger both replay regressions.

### Code Style and Documentation

- [x] The change is substantial.
- [x] The change follows the code documentation and commenting guidelines.
- [x] The commits follow the ideal Git commit structure.
- [x] New logging uses the existing HTLC switch subsystem and error level.
- [x] The change adds no `lncli` commands.
- [x] Add a release note or mark the public PR to skip the release-note check.
