### PR TITLE
build: Serialize rotating log writes through pipe

### DIFF
--- a/build/logrotator.go
+++ b/build/logrotator.go
@@ -2,10 +2,12 @@ package build
 
 import (
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/jrick/logrotate/rotator"
 	"github.com/klauspost/compress/zstd"
@@ -18,6 +20,10 @@ type RotatingLogWriter struct {
 	pipe *io.PipeWriter
 
 	rotator *rotator.Rotator
+	runErr  chan error
+
+	closeOnce sync.Once
+	closeErr  error
 }
 
 // NewRotatingLogWriter creates a new file rotating log writer.
@@ -34,25 +40,13 @@ func NewRotatingLogWriter() *RotatingLogWriter {
 func (r *RotatingLogWriter) InitLogRotator(cfg *FileLoggerConfig,
 	logFile string) error {
 
-	logDir, _ := filepath.Split(logFile)
-	err := os.MkdirAll(logDir, 0700)
-	if err != nil {
-		return fmt.Errorf("failed to create log directory: %w", err)
-	}
-
-	r.rotator, err = rotator.New(
-		logFile, int64(cfg.MaxLogFileSize*1024), false, cfg.MaxLogFiles,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create file rotator: %w", err)
-	}
-
-	// Reject unknown compressors.
+	// Reject unknown compressors before opening the log file.
 	if !SupportedLogCompressor(cfg.Compressor) {
 		return fmt.Errorf("unknown log compressor: %v", cfg.Compressor)
 	}
 
 	var c rotator.Compressor
+	var err error
 	switch cfg.Compressor {
 	case Gzip:
 		c = gzip.NewWriter(nil)
@@ -65,20 +59,35 @@ func (r *RotatingLogWriter) InitLogRotator(cfg *FileLoggerConfig,
 		}
 	}
 
+	logDir, _ := filepath.Split(logFile)
+	err = os.MkdirAll(logDir, 0700)
+	if err != nil {
+		return fmt.Errorf("failed to create log directory: %w", err)
+	}
+
+	r.rotator, err = rotator.New(
+		logFile, int64(cfg.MaxLogFileSize*1024), false, cfg.MaxLogFiles,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create file rotator: %w", err)
+	}
+
 	// Apply the compressor and its file suffix to the log rotator.
 	r.rotator.SetCompressor(c, logCompressors[cfg.Compressor])
 
-	// Run rotator as a goroutine now but make sure we catch any errors
-	// that happen in case something with the rotation goes wrong during
-	// runtime (like running out of disk space or not being allowed to
-	// create a new logfile for whatever reason).
+	// Run the rotator from a single goroutine so parallel callers are
+	// serialized by the pipe before they access the rotator.
 	pr, pw := io.Pipe()
+	r.runErr = make(chan error, 1)
 	go func() {
 		err := r.rotator.Run(pr)
-		if err != nil {
-			_, _ = fmt.Fprintf(os.Stderr,
-				"failed to run file rotator: %v\n", err)
+		if errors.Is(err, io.EOF) {
+			err = nil
 		}
+
+		// Propagate runtime rotation errors to blocked and future writers.
+		_ = pr.CloseWithError(err)
+		r.runErr <- err
 	}()
 
 	r.pipe = pw
@@ -88,8 +97,8 @@ func (r *RotatingLogWriter) InitLogRotator(cfg *FileLoggerConfig,
 
 // Write writes the byte slice to the log rotator, if present.
 func (r *RotatingLogWriter) Write(b []byte) (int, error) {
-	if r.rotator != nil {
-		return r.rotator.Write(b)
+	if r.pipe != nil {
+		return r.pipe.Write(b)
 	}
 
 	return len(b), nil
@@ -97,9 +106,21 @@ func (r *RotatingLogWriter) Write(b []byte) (int, error) {
 
 // Close closes the underlying log rotator if it has already been created.
 func (r *RotatingLogWriter) Close() error {
-	if r.rotator != nil {
-		return r.rotator.Close()
-	}
+	r.closeOnce.Do(func() {
+		if r.pipe == nil {
+			if r.rotator != nil {
+				r.closeErr = r.rotator.Close()
+			}
 
-	return nil
+			return
+		}
+
+		pipeErr := r.pipe.Close()
+		runErr := <-r.runErr
+		rotatorErr := r.rotator.Close()
+
+		r.closeErr = errors.Join(pipeErr, runErr, rotatorErr)
+	})
+
+	return r.closeErr
 }

--- a/build/logrotator_test.go
+++ b/build/logrotator_test.go
@@ -1,0 +1,62 @@
+package build
+
+import (
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRotatingLogWriterConcurrentWrites verifies parallel callers are
+// serialized through the rotator's pipe.
+func TestRotatingLogWriterConcurrentWrites(t *testing.T) {
+	t.Parallel()
+
+	const testLogFileSize = 1000 * 1024
+
+	logPath := filepath.Join(t.TempDir(), "lnd.log")
+	logConfig := DefaultLogConfig().File
+	logConfig.MaxLogFileSize = 1
+
+	logWriter := NewRotatingLogWriter()
+	require.NoError(t, logWriter.InitLogRotator(logConfig, logPath))
+
+	logLine := []byte(strings.Repeat("a", testLogFileSize/2-1) + "\n")
+	start := make(chan struct{})
+	writeErrs := make(chan error, 2)
+	for range 2 {
+		go func() {
+			<-start
+			_, err := logWriter.Write(logLine)
+			writeErrs <- err
+		}()
+	}
+	close(start)
+
+	for range 2 {
+		require.NoError(t, <-writeErrs)
+	}
+	require.NoError(t, logWriter.Close())
+	require.NoError(t, logWriter.Close())
+
+	backupFiles, err := filepath.Glob(logPath + ".*")
+	require.NoError(t, err)
+	require.Equal(t, []string{logPath + ".1.gz"}, backupFiles)
+
+	backupFile, err := os.Open(backupFiles[0])
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, backupFile.Close())
+	})
+
+	gzipReader, err := gzip.NewReader(backupFile)
+	require.NoError(t, err)
+	backupBytes, err := io.ReadAll(gzipReader)
+	require.NoError(t, err)
+	require.NoError(t, gzipReader.Close())
+	require.Len(t, backupBytes, testLogFileSize)
+}


### PR DESCRIPTION
## Overview

The rotating log writer starts a goroutine that consumes an `io.Pipe`, but
its `Write` method currently bypasses the pipe and writes to the underlying
rotator directly. Since subsystem loggers share this writer, concurrent log
calls can race over the rotator's file and size state. The direct write can
also race with the reader goroutine during startup.

This PR routes writes through the existing pipe. The reader goroutine becomes
the sole owner of the rotator, while `io.Pipe` serializes concurrent writers.
Shutdown now closes the pipe, waits for the reader, closes the rotator, and
returns any errors from those stages. Repeated `Close` calls are idempotent.

## Testing

- `go test -race ./build`
- `go test -race ./build -run TestRotatingLogWriterConcurrentWrites -count=20`
- `make fmt-check`
- `go vet ./build`

The regression test writes concurrently across the rotation threshold, waits
for shutdown, and decompresses the resulting gzip backup through EOF.
