### PR TITLE
discovery: page historical channel range queries

### DIFF
--- a/discovery/sync_manager.go
+++ b/discovery/sync_manager.go
@@ -8,8 +8,10 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/lightningnetwork/lnd/actor"
 	graphdb "github.com/lightningnetwork/lnd/graph/db"
 	"github.com/lightningnetwork/lnd/lnpeer"
+	"github.com/lightningnetwork/lnd/lnutils"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/ticker"
@@ -80,6 +82,20 @@ type staleSyncer struct {
 	// needed to ensure we always create a new syncer for a flappy peer
 	// after they disconnect if they happened to be an active syncer.
 	doneChan chan struct{}
+}
+
+// failedHistoricalSync is an internal message used to replace a peer that
+// could not complete the initial historical sync.
+type failedHistoricalSync struct {
+	// syncer is the syncer whose historical sync failed. We retain the
+	// instance so a delayed failure cannot match a new connection from the
+	// same peer.
+	syncer *GossipSyncer
+
+	// accepted is completed once the SyncManager has detached the failed
+	// attempt from its completion signal. Replacement selection happens
+	// after this acknowledgement so it cannot delay the failed syncer.
+	accepted actor.Promise[error]
 }
 
 // SyncManagerCfg contains all of the dependencies required for the SyncManager
@@ -186,6 +202,10 @@ type SyncManager struct {
 	// GossipSyncers for disconnected peers.
 	staleSyncers chan *staleSyncer
 
+	// failedHistoricalSyncs receives peers which could not complete a
+	// historical sync using the response they received.
+	failedHistoricalSyncs chan *failedHistoricalSync
+
 	// syncersMu guards the read and write access to the activeSyncers and
 	// inactiveSyncers maps below.
 	syncersMu sync.Mutex
@@ -248,10 +268,11 @@ func newSyncManager(cfg *SyncManagerCfg) *SyncManager {
 	)
 
 	return &SyncManager{
-		cfg:          *cfg,
-		rateLimiter:  rateLimiter,
-		newSyncers:   make(chan *newSyncer),
-		staleSyncers: make(chan *staleSyncer),
+		cfg:                   *cfg,
+		rateLimiter:           rateLimiter,
+		newSyncers:            make(chan *newSyncer),
+		staleSyncers:          make(chan *staleSyncer),
+		failedHistoricalSyncs: make(chan *failedHistoricalSync),
 		activeSyncers: make(
 			map[route.Vertex]*GossipSyncer, cfg.NumActiveSyncers,
 		),
@@ -320,6 +341,13 @@ func (m *SyncManager) syncerHandler() {
 		// attempted just because the initialHistoricalSyncer was
 		// disconnected.
 		initialHistoricalSyncSignal chan struct{}
+
+		// failedHistoricalSyncers contains peers which rejected a
+		// channel range reply since the previous scheduled historical
+		// sync. Keeping them out of immediate replacements and the next
+		// scheduled pick prevents a small set of bad peers from cycling
+		// indefinitely.
+		failedHistoricalSyncers = make(map[route.Vertex]struct{})
 	)
 
 	setInitialHistoricalSyncer := func(s *GossipSyncer) {
@@ -409,7 +437,11 @@ func (m *SyncManager) syncerHandler() {
 			// We'll force a historical sync with the first peer we
 			// connect to, to ensure we get as much of the graph as
 			// possible.
-			if !attemptHistoricalSync {
+			_, failedHistoricalSync :=
+				failedHistoricalSyncers[s.cfg.peerPub]
+			if !attemptHistoricalSync ||
+				(!isPinnedSyncer && failedHistoricalSync) {
+
 				continue
 			}
 
@@ -460,7 +492,7 @@ func (m *SyncManager) syncerHandler() {
 			log.Debug("Finding replacement for initial " +
 				"historical sync")
 
-			s := m.forceHistoricalSync()
+			s := m.forceHistoricalSync(failedHistoricalSyncers)
 			if s == nil {
 				log.Debug("No eligible replacement found " +
 					"for initial historical sync")
@@ -473,6 +505,46 @@ func (m *SyncManager) syncerHandler() {
 
 			setInitialHistoricalSyncer(s)
 
+		// The current historical syncer rejected its peer's response.
+		// Select another peer without tearing down the connection.
+		case failedSync := <-m.failedHistoricalSyncs:
+			failedHistoricalSyncers[failedSync.syncer.cfg.peerPub] =
+				struct{}{}
+
+			isInitialSyncer := initialHistoricalSyncer != nil &&
+				failedSync.syncer == initialHistoricalSyncer
+
+			// Detach the failed attempt before acknowledgement. The
+			// syncer can then return to chansSynced without its old
+			// signal being mistaken for a successful initial sync.
+			if isInitialSyncer {
+				initialHistoricalSyncer = nil
+				initialHistoricalSyncSignal = nil
+			}
+			completeGossipResult(failedSync.accepted, nil)
+
+			if isInitialSyncer && m.cfg.NumActiveSyncers > 0 {
+				log.Debug("Finding replacement for failed " +
+					"historical sync")
+
+				s := m.forceHistoricalSync(
+					failedHistoricalSyncers,
+				)
+				if s == nil {
+					msg := "No eligible " +
+						"replacement found for " +
+						"failed historical sync"
+					log.Debug(msg)
+				} else {
+					log.Debugf("Replaced failed "+
+						"historical GossipSyncer(%v) "+
+						"with GossipSyncer(%x)",
+						failedSync.syncer.cfg.peerPub,
+						s.cfg.peerPub)
+
+					setInitialHistoricalSyncer(s)
+				}
+			}
 		// Our initial historical sync signal has completed, so we'll
 		// nil all of the relevant fields as they're no longer needed.
 		case <-initialHistoricalSyncSignal:
@@ -531,7 +603,12 @@ func (m *SyncManager) syncerHandler() {
 
 			// If we don't have a syncer available we have nothing
 			// to do.
-			s := m.forceHistoricalSync()
+			s := m.forceHistoricalSync(failedHistoricalSyncers)
+
+			// Failed peers remain excluded from immediate
+			// replacements and one scheduled pick. Clear the set
+			// to keep this a bounded retry delay, not a ban.
+			clear(failedHistoricalSyncers)
 			if s == nil {
 				continue
 			}
@@ -673,6 +750,9 @@ func (m *SyncManager) createGossipSyncer(peer lnpeer.Peer) *GossipSyncer {
 
 			return m.sendMessages(ctx, sync, peer, nodeID, msgs...)
 		},
+		historicalSyncFailed: func(s *GossipSyncer, err error) {
+			m.reportHistoricalSyncFailure(s, err)
+		},
 		ignoreHistoricalFilters:  m.cfg.IgnoreHistoricalFilters,
 		bestHeight:               m.cfg.BestHeight,
 		markGraphSynced:          m.markGraphSynced,
@@ -692,6 +772,30 @@ func (m *SyncManager) createGossipSyncer(peer lnpeer.Peer) *GossipSyncer {
 		s.syncState(), s.SyncType(), peer.PubKey())
 
 	return s
+}
+
+// reportHistoricalSyncFailure asks the SyncManager to select another peer for
+// the initial historical sync.
+func (m *SyncManager) reportHistoricalSyncFailure(syncer *GossipSyncer,
+	err error) {
+
+	log.Debugf("GossipSyncer(%x) rejected historical sync response: %v",
+		syncer.cfg.peerPub, err)
+
+	accepted := actor.NewPromise[error]()
+	select {
+	case m.failedHistoricalSyncs <- &failedHistoricalSync{
+		syncer:   syncer,
+		accepted: accepted,
+	}:
+	case <-m.quit:
+		return
+	}
+
+	ctx, cancel := lnutils.ContextFromQuit(m.quit)
+	defer cancel()
+
+	_ = AwaitGossipResult(ctx, accepted.Future())
 }
 
 // removeGossipSyncer removes all internal references to the disconnected peer's
@@ -814,14 +918,21 @@ func (m *SyncManager) transitionPassiveSyncer(s *GossipSyncer) error {
 }
 
 // forceHistoricalSync chooses a syncer with a remote peer at random and forces
-// a historical sync with it.
-func (m *SyncManager) forceHistoricalSync() *GossipSyncer {
+// a historical sync with it. Peers in the excluded set are not considered.
+func (m *SyncManager) forceHistoricalSync(
+	excluded map[route.Vertex]struct{}) *GossipSyncer {
+
 	m.syncersMu.Lock()
 	defer m.syncersMu.Unlock()
 
 	// We'll sample from both sets of active and inactive syncers in the
 	// event that we don't have any inactive syncers.
-	return chooseRandomSyncer(m.gossipSyncers(), func(s *GossipSyncer) error {
+	syncers := m.gossipSyncers()
+	for peer := range excluded {
+		delete(syncers, peer)
+	}
+
+	return chooseRandomSyncer(syncers, func(s *GossipSyncer) error {
 		return s.historicalSync()
 	})
 }

--- a/discovery/sync_manager_test.go
+++ b/discovery/sync_manager_test.go
@@ -180,6 +180,230 @@ func TestSyncManagerNewActiveSyncerAfterDisconnect(t *testing.T) {
 	assertPassiveSyncerTransition(t, newActiveSyncer, newActiveSyncPeer)
 }
 
+// TestSyncManagerReplacesOversizedHistoricalSyncer ensures that a peer which
+// exceeds the channel range limit is kept connected while another peer takes
+// over the initial historical sync.
+func TestSyncManagerReplacesOversizedHistoricalSyncer(t *testing.T) {
+	t.Parallel()
+
+	syncMgr := newTestSyncManager(2)
+	syncMgr.Start()
+	defer syncMgr.Stop()
+
+	oversizedPeer := randPeer(t, syncMgr.quit)
+	require.NoError(t, syncMgr.InitSyncState(oversizedPeer))
+	oversizedSyncer := assertSyncerExistence(t, syncMgr, oversizedPeer)
+
+	var query *lnwire.QueryChannelRange
+	select {
+	case msg := <-oversizedPeer.sentMsgs:
+		var ok bool
+		query, ok = msg.(*lnwire.QueryChannelRange)
+		require.True(t, ok)
+
+	case <-time.After(time.Second):
+		t.Fatal("expected initial channel range query")
+	}
+
+	require.Eventually(t, func() bool {
+		return oversizedSyncer.syncState() == waitingQueryRangeReply
+	}, time.Second, 10*time.Millisecond)
+
+	replacementPeer := randPeer(t, syncMgr.quit)
+	require.NoError(t, syncMgr.InitSyncState(replacementPeer))
+	assertNoMsgSent(t, replacementPeer)
+
+	// Leave room for no more SCIDs, then send one additional SCID through
+	// the public message path.
+	oversizedSyncer.numChanRangeReplySCIDsRcvd = maxChanRangeReplySCIDs
+	err := oversizedSyncer.ProcessQueryMsg(&lnwire.ReplyChannelRange{
+		ChainHash:        query.ChainHash,
+		FirstBlockHeight: query.FirstBlockHeight,
+		NumBlocks:        query.NumBlocks,
+		EncodingType:     lnwire.EncodingSortedPlain,
+		ShortChanIDs: []lnwire.ShortChannelID{{
+			BlockHeight: query.FirstBlockHeight,
+		}},
+	}, nil)
+	require.NoError(t, err)
+
+	select {
+	case msg := <-replacementPeer.sentMsgs:
+		_, ok := msg.(*lnwire.QueryChannelRange)
+		require.True(t, ok)
+
+	case <-time.After(time.Second):
+		t.Fatal("expected replacement channel range query")
+	}
+
+	require.False(t, oversizedPeer.disconnected.Load())
+	require.Eventually(t, func() bool {
+		return oversizedSyncer.syncState() == chansSynced
+	}, time.Second, 10*time.Millisecond)
+
+	// The failed peer remains ineligible for the next scheduled pick. The
+	// replacement is still waiting for its reply, so the failed peer would
+	// otherwise be the only eligible candidate.
+	historicalTicker, isForce :=
+		syncMgr.cfg.HistoricalSyncTicker.(*ticker.Force)
+	require.True(t, isForce)
+	historicalTicker.Force <- time.Time{}
+	assertNoMsgSent(t, oversizedPeer)
+
+	_, ok := syncMgr.GossipSyncer(oversizedPeer.PubKey())
+	require.True(t, ok)
+	require.NoError(
+		t, oversizedSyncer.ProcessSyncTransition(
+			oversizedSyncer.SyncType(),
+		),
+	)
+}
+
+// TestSyncManagerAcksFailureBeforeReplacement ensures that a failed syncer
+// only waits for the manager to detach its completion signal, not for
+// replacement selection.
+func TestSyncManagerAcksFailureBeforeReplacement(t *testing.T) {
+	t.Parallel()
+
+	syncMgr := newTestSyncManager(2)
+	syncMgr.Start()
+	defer syncMgr.Stop()
+
+	failedPeer := randPeer(t, syncMgr.quit)
+	require.NoError(t, syncMgr.InitSyncState(failedPeer))
+	failedSyncer := assertSyncerExistence(t, syncMgr, failedPeer)
+
+	select {
+	case <-failedPeer.sentMsgs:
+	case <-time.After(time.Second):
+		t.Fatal("expected initial channel range query")
+	}
+
+	replacementPeer := randPeer(t, syncMgr.quit)
+	require.NoError(t, syncMgr.InitSyncState(replacementPeer))
+	assertNoMsgSent(t, replacementPeer)
+
+	// Hold the lock used by replacement selection. The failure report must
+	// still return because the manager acknowledges it before taking this
+	// lock to choose another peer.
+	syncMgr.syncersMu.Lock()
+	reported := make(chan struct{})
+	go func() {
+		syncMgr.reportHistoricalSyncFailure(
+			failedSyncer, errInvalidChanRangeReply,
+		)
+		close(reported)
+	}()
+
+	var acknowledged bool
+	select {
+	case <-reported:
+		acknowledged = true
+	case <-time.After(time.Second):
+	}
+	syncMgr.syncersMu.Unlock()
+
+	require.True(t, acknowledged, "failure report awaited replacement")
+}
+
+// TestSyncManagerRetainsFailureAcrossReconnect ensures that reconnecting does
+// not bypass the failed peer's bounded exclusion.
+func TestSyncManagerRetainsFailureAcrossReconnect(t *testing.T) {
+	t.Parallel()
+
+	syncMgr := newTestSyncManager(1)
+	syncMgr.Start()
+	defer syncMgr.Stop()
+
+	pubKey := randPubKey(t)
+	failedPeer := peerWithPubkey(pubKey, syncMgr.quit)
+	require.NoError(t, syncMgr.InitSyncState(failedPeer))
+	failedSyncer := assertSyncerExistence(t, syncMgr, failedPeer)
+
+	select {
+	case <-failedPeer.sentMsgs:
+	case <-time.After(time.Second):
+		t.Fatal("expected initial channel range query")
+	}
+
+	syncMgr.reportHistoricalSyncFailure(
+		failedSyncer, errInvalidChanRangeReply,
+	)
+	syncMgr.PruneSyncState(failedPeer.PubKey())
+
+	reconnectedPeer := peerWithPubkey(pubKey, syncMgr.quit)
+	require.NoError(t, syncMgr.InitSyncState(reconnectedPeer))
+	assertNoMsgSent(t, reconnectedPeer)
+
+	historicalTicker, isForce :=
+		syncMgr.cfg.HistoricalSyncTicker.(*ticker.Force)
+	require.True(t, isForce)
+
+	// The next scheduled attempt consumes the exclusion. A later attempt
+	// can retry the peer, so the exclusion does not become a ban.
+	historicalTicker.Force <- time.Time{}
+	assertNoMsgSent(t, reconnectedPeer)
+	historicalTicker.Force <- time.Time{}
+	assertMsgSent(t, reconnectedPeer, &lnwire.QueryChannelRange{
+		FirstBlockHeight: 0,
+		NumBlocks:        latestKnownHeight,
+		QueryOptions:     lnwire.NewTimestampQueryOption(),
+	})
+}
+
+// TestSyncManagerIgnoresStaleHistoricalSyncFailure ensures that a delayed
+// failure from an old connection cannot be applied to a new syncer for the
+// same peer.
+func TestSyncManagerIgnoresStaleHistoricalSyncFailure(t *testing.T) {
+	t.Parallel()
+
+	syncMgr := newTestSyncManager(2)
+	syncMgr.Start()
+	defer syncMgr.Stop()
+
+	pubKey := randPubKey(t)
+	oldPeer := peerWithPubkey(pubKey, syncMgr.quit)
+	require.NoError(t, syncMgr.InitSyncState(oldPeer))
+	oldSyncer := assertSyncerExistence(t, syncMgr, oldPeer)
+
+	select {
+	case <-oldPeer.sentMsgs:
+	case <-time.After(time.Second):
+		t.Fatal("expected initial channel range query")
+	}
+
+	syncMgr.PruneSyncState(oldPeer.PubKey())
+
+	newPeer := peerWithPubkey(pubKey, syncMgr.quit)
+	require.NoError(t, syncMgr.InitSyncState(newPeer))
+	newSyncer := assertSyncerExistence(t, syncMgr, newPeer)
+
+	select {
+	case <-newPeer.sentMsgs:
+	case <-time.After(time.Second):
+		t.Fatal("expected reconnected channel range query")
+	}
+
+	// Deliver an old instance's failure after a replacement with the same
+	// peer key becomes the tracked historical syncer.
+	syncMgr.reportHistoricalSyncFailure(oldSyncer, errInvalidChanRangeReply)
+
+	replacementPeer := randPeer(t, syncMgr.quit)
+	require.NoError(t, syncMgr.InitSyncState(replacementPeer))
+	syncMgr.PruneSyncState(newPeer.PubKey())
+
+	select {
+	case msg := <-replacementPeer.sentMsgs:
+		_, ok := msg.(*lnwire.QueryChannelRange)
+		require.True(t, ok)
+
+	case <-time.After(time.Second):
+		t.Fatal("expected replacement channel range query")
+	}
+
+	require.NotSame(t, oldSyncer, newSyncer)
+}
+
 // TestSyncManagerRotateActiveSyncerCandidate tests that we can successfully
 // rotate our active syncers after a certain interval.
 func TestSyncManagerRotateActiveSyncerCandidate(t *testing.T) {

--- a/discovery/syncer.go
+++ b/discovery/syncer.go
@@ -204,6 +204,15 @@ var (
 	// ErrGossipSyncerExiting signals that the syncer has been killed.
 	ErrGossipSyncerExiting = errors.New("gossip syncer exiting")
 
+	// errChanRangeReplyTooLarge is returned when a peer sends more channel
+	// IDs than we'll accept for a single channel range query.
+	errChanRangeReplyTooLarge = errors.New("channel range reply exceeds " +
+		"maximum number of short channel IDs")
+
+	// errInvalidChanRangeReply is returned when a peer's channel range
+	// response does not match the query which prompted it.
+	errInvalidChanRangeReply = errors.New("invalid channel range reply")
+
 	// ErrSyncTransitionTimeout is an error returned when we've timed out
 	// attempting to perform a sync transition.
 	ErrSyncTransitionTimeout = errors.New("timed out attempting to " +
@@ -258,6 +267,10 @@ type gossipSyncerCfg struct {
 	// The boolean indicates whether this method should be blocked or not
 	// while waiting for sends to be written to the wire.
 	sendMsg func(context.Context, bool, ...lnwire.Message) error
+
+	// historicalSyncFailed requests another peer for the initial historical
+	// sync when this peer's response cannot be used.
+	historicalSyncFailed func(*GossipSyncer, error)
 
 	// noSyncChannels will prevent the GossipSyncer from spawning a
 	// channelGraphSyncer, meaning we will not try to reconcile unknown
@@ -545,6 +558,30 @@ func (g *GossipSyncer) handleSyncingChans(ctx context.Context) error {
 	return nil
 }
 
+// handleChanRangeError recovers from a peer response which cannot be used and
+// returns true when the syncer can continue serving the peer.
+func (g *GossipSyncer) handleChanRangeError(err error) bool {
+	log.Errorf("Unable to process chan range query: %v", err)
+
+	if !errors.Is(err, errChanRangeReplyTooLarge) &&
+		!errors.Is(err, errInvalidChanRangeReply) {
+
+		return false
+	}
+
+	// The idle state keeps this syncer out of replacement selection and
+	// does not signal that its historical sync completed.
+	g.genHistoricalChanRangeQuery = false
+	g.setSyncState(syncerIdle)
+	if g.cfg.historicalSyncFailed != nil {
+		g.cfg.historicalSyncFailed(g, err)
+	}
+
+	g.setSyncState(chansSynced)
+
+	return true
+}
+
 // channelGraphSyncer is the main goroutine responsible for ensuring that we
 // properly channel graph state with the remote peer, and also that we only
 // send them messages which actually pass their defined update horizon.
@@ -595,9 +632,10 @@ func (g *GossipSyncer) channelGraphSyncer(ctx context.Context) {
 						ctx, queryReply,
 					)
 					if err != nil {
-						log.Errorf("Unable to "+
-							"process chan range "+
-							"query: %v", err)
+						if g.handleChanRangeError(err) {
+							continue
+						}
+
 						return
 					}
 					continue
@@ -932,11 +970,10 @@ func isLegacyReplyChannelRange(query *lnwire.QueryChannelRange,
 func (g *GossipSyncer) processChanRangeReply(ctx context.Context,
 	msg *lnwire.ReplyChannelRange) error {
 
-	// Any error here terminates the range sync, so we release whatever we
-	// accumulated to stop the peer from pinning it by deliberately forcing
-	// an error. Our caller exits the state machine on any error we return,
-	// and nothing prunes a syncer until its peer disconnects, so otherwise
-	// the buffer stays reachable from a syncer that will never run again.
+	// Any error abandons the current reply stream, so release everything we
+	// accumulated before returning it. Peer response errors may recover the
+	// syncer. Local errors terminate it. Neither path should retain an
+	// abandoned buffer.
 	err := g.bufferChanRangeReply(ctx, msg)
 	if err != nil {
 		g.resetChanRangeReplyState()
@@ -953,12 +990,10 @@ func (g *GossipSyncer) bufferChanRangeReply(_ context.Context,
 
 	// A reply only means anything in the context of the query that
 	// prompted it, and every check below reads that query. Today this is
-	// unreachable, as we only accept a reply in waitingQueryRangeReply and
-	// we always set the query before entering that state. It is worth
-	// guarding anyway: an error leaves the syncer sitting in
-	// waitingQueryRangeReply with the query cleared, so any future change
-	// that recovers the handler instead of tearing it down would turn this
-	// into a remote panic.
+	// unreachable because we only accept a reply in waitingQueryRangeReply,
+	// and we always set the query before entering that state. Guard it so a
+	// future state transition cannot turn an unexpected response into a
+	// remote panic.
 	if g.curQueryRangeMsg == nil {
 		return fmt.Errorf("received channel range reply without an " +
 			"active query")
@@ -979,9 +1014,12 @@ func (g *GossipSyncer) bufferChanRangeReply(_ context.Context,
 	if !isLegacyReplyChannelRange(g.curQueryRangeMsg, msg) {
 		// The first block should be within our original request.
 		if msg.FirstBlockHeight < g.curQueryRangeMsg.FirstBlockHeight {
-			return fmt.Errorf("reply includes channels for height "+
-				"%v prior to query %v", msg.FirstBlockHeight,
-				g.curQueryRangeMsg.FirstBlockHeight)
+			return fmt.Errorf("%w: reply includes channels for "+
+				"height %v prior to query %v",
+				errInvalidChanRangeReply,
+				msg.FirstBlockHeight,
+				g.curQueryRangeMsg.FirstBlockHeight,
+			)
 		}
 
 		// The last block should also be. We don't need to check the
@@ -990,9 +1028,12 @@ func (g *GossipSyncer) bufferChanRangeReply(_ context.Context,
 		replyLastHeight := msg.LastBlockHeight()
 		queryLastHeight := g.curQueryRangeMsg.LastBlockHeight()
 		if replyLastHeight > queryLastHeight {
-			return fmt.Errorf("reply includes channels for height "+
-				"%v after query %v", replyLastHeight,
-				queryLastHeight)
+			return fmt.Errorf(
+				"%w: reply includes channels for height %v "+
+					"after query %v",
+				errInvalidChanRangeReply,
+				replyLastHeight, queryLastHeight,
+			)
 		}
 
 		// If we've previously received a reply for this query, look at
@@ -1008,10 +1049,13 @@ func (g *GossipSyncer) bufferChanRangeReply(_ context.Context,
 			if msg.FirstBlockHeight != prevReplyLastHeight &&
 				msg.FirstBlockHeight != prevReplyLastHeight+1 {
 
-				return fmt.Errorf("first block of reply %v "+
-					"does not continue from last block of "+
-					"previous %v", msg.FirstBlockHeight,
-					prevReplyLastHeight)
+				return fmt.Errorf("%w: first block of reply "+
+					"%v does not continue from last "+
+					"block of previous %v",
+					errInvalidChanRangeReply,
+					msg.FirstBlockHeight,
+					prevReplyLastHeight,
+				)
 			}
 		}
 	}
@@ -1029,7 +1073,8 @@ func (g *GossipSyncer) bufferChanRangeReply(_ context.Context,
 
 	default:
 		return fmt.Errorf(
-			"unhandled encoding type %v", msg.EncodingType,
+			"%w: unhandled encoding type %v",
+			errInvalidChanRangeReply, msg.EncodingType,
 		)
 	}
 
@@ -1038,8 +1083,7 @@ func (g *GossipSyncer) bufferChanRangeReply(_ context.Context,
 		numReplySCIDs > maxChanRangeReplySCIDs-
 			g.numChanRangeReplySCIDsRcvd {
 
-		return fmt.Errorf("channel range reply exceeds maximum "+
-			"number of short channel IDs: max=%v",
+		return fmt.Errorf("%w: max=%v", errChanRangeReplyTooLarge,
 			maxChanRangeReplySCIDs)
 	}
 

--- a/discovery/syncer.go
+++ b/discovery/syncer.go
@@ -176,6 +176,10 @@ const (
 	// we'll process for a single QueryChannelRange request.
 	maxChanRangeReplySCIDs = 100_000
 
+	// historicalChanRangeQueryBlocks is the maximum number of blocks we'll
+	// request in one page of a historical channel range sync.
+	historicalChanRangeQueryBlocks = 50_000
+
 	// chanRangeQueryBuffer is the number of blocks back that we'll go when
 	// asking the remote peer for their any channels they know of beyond
 	// our highest known channel ID.
@@ -367,6 +371,12 @@ type GossipSyncer struct {
 	// historical sync. It can be unset if the syncer ever transitions from
 	// PassiveSync to ActiveSync.
 	genHistoricalChanRangeQuery bool
+
+	// historicalSyncNextStart is the first block to request in the next
+	// page of a historical channel range sync. historicalSyncEnd is the
+	// exclusive end height captured when the sync begins.
+	historicalSyncNextStart uint32
+	historicalSyncEnd       uint32
 
 	// gossipMsgs is a channel that all responses to our queries from the
 	// target peer will be sent over, these will be read by the
@@ -674,13 +684,8 @@ func (g *GossipSyncer) channelGraphSyncer(ctx context.Context) {
 			}
 
 			// If we're fully synchronized, then we can transition
-			// to our terminal state.
-			g.setSyncState(chansSynced)
-
-			// Ensure that the sync manager becomes aware that the
-			// historical sync completed so synced_to_graph is
-			// updated over rpc.
-			g.cfg.markGraphSynced()
+			// to the next historical page or our terminal state.
+			g.finishChanRangePage()
 
 		// In this state, we've just sent off a new query for channels
 		// that we don't yet know of. We'll remain in this state until
@@ -1186,6 +1191,10 @@ func (g *GossipSyncer) bufferChanRangeReply(_ context.Context,
 		return fmt.Errorf("unable to filter chan ids: %w", err)
 	}
 
+	// Record the next historical page before clearing the query which
+	// defines the page we just completed.
+	g.advanceHistoricalSync()
+
 	// As we've received the entirety of the reply, we no longer need to
 	// hold on to the set of buffered replies or the original query that
 	// prompted the replies, so we'll let that be garbage collected now.
@@ -1197,12 +1206,7 @@ func (g *GossipSyncer) bufferChanRangeReply(_ context.Context,
 		log.Infof("GossipSyncer(%x): remote peer has no new chans",
 			g.cfg.peerPub[:])
 
-		g.setSyncState(chansSynced)
-
-		// Ensure that the sync manager becomes aware that the
-		// historical sync completed so synced_to_graph is updated over
-		// rpc.
-		g.cfg.markGraphSynced()
+		g.finishChanRangePage()
 		return nil
 	}
 
@@ -1215,6 +1219,36 @@ func (g *GossipSyncer) bufferChanRangeReply(_ context.Context,
 		g.cfg.peerPub[:], len(newChans))
 
 	return nil
+}
+
+// advanceHistoricalSync records the first block of the next historical page.
+func (g *GossipSyncer) advanceHistoricalSync() {
+	if !g.genHistoricalChanRangeQuery || g.curQueryRangeMsg == nil {
+		return
+	}
+
+	query := g.curQueryRangeMsg
+	g.historicalSyncNextStart = query.FirstBlockHeight + query.NumBlocks
+}
+
+// finishChanRangePage advances a historical sync to its next page, or marks
+// the channel range sync complete when no pages remain.
+func (g *GossipSyncer) finishChanRangePage() {
+	if g.genHistoricalChanRangeQuery &&
+		g.historicalSyncNextStart < g.historicalSyncEnd {
+
+		g.setSyncState(syncingChans)
+		return
+	}
+
+	g.genHistoricalChanRangeQuery = false
+	g.historicalSyncNextStart = 0
+	g.historicalSyncEnd = 0
+	g.setSyncState(chansSynced)
+
+	// Ensure that the sync manager becomes aware that the historical sync
+	// completed so synced_to_graph is updated over rpc.
+	g.cfg.markGraphSynced()
 }
 
 // resetChanRangeReplyState releases all state accumulated while processing a
@@ -1243,15 +1277,31 @@ func (g *GossipSyncer) genChanRangeQuery(ctx context.Context,
 		return nil, err
 	}
 
+	bestHeight := g.cfg.bestHeight()
+
 	// Once we have the chan ID of the newest, we'll obtain the block height
 	// of the channel, then subtract our default horizon to ensure we don't
 	// miss any channels. By default, we go back 1 day from the newest
 	// channel, unless we're attempting a historical sync, where we'll
 	// actually start from the genesis block instead.
-	var startHeight uint32
+	var (
+		startHeight uint32
+		numBlocks   uint32
+	)
 	switch {
 	case historicalQuery:
-		fallthrough
+		if g.historicalSyncEnd == 0 {
+			g.historicalSyncEnd = bestHeight
+		}
+
+		startHeight = g.historicalSyncNextStart
+		if startHeight < g.historicalSyncEnd {
+			numBlocks = g.historicalSyncEnd - startHeight
+		}
+		if numBlocks > historicalChanRangeQueryBlocks {
+			numBlocks = historicalChanRangeQueryBlocks
+		}
+
 	case newestChan.BlockHeight <= chanRangeQueryBuffer:
 		startHeight = 0
 	default:
@@ -1261,8 +1311,9 @@ func (g *GossipSyncer) genChanRangeQuery(ctx context.Context,
 	// Determine the number of blocks to request based on our best height.
 	// We'll take into account any potential underflows and explicitly set
 	// numBlocks to its minimum value of 1 if so.
-	bestHeight := g.cfg.bestHeight()
-	numBlocks := bestHeight - startHeight
+	if !historicalQuery {
+		numBlocks = bestHeight - startHeight
+	}
 	if int64(numBlocks) < 1 {
 		numBlocks = 1
 	}
@@ -2029,6 +2080,8 @@ func (g *GossipSyncer) handleHistoricalSync(req *historicalSyncReq) {
 	// the remote peer to give us all of the channel IDs they know of
 	// starting from the genesis block.
 	g.genHistoricalChanRangeQuery = true
+	g.historicalSyncNextStart = 0
+	g.historicalSyncEnd = 0
 	g.setSyncState(syncingChans)
 	close(req.doneChan)
 }

--- a/discovery/syncer_test.go
+++ b/discovery/syncer_test.go
@@ -1405,6 +1405,137 @@ func TestGossipSyncerGenChanRangeQuery(t *testing.T) {
 	}
 }
 
+// TestGossipSyncerHistoricalChanRangePages tests that historical range queries
+// cover a fixed tip snapshot with contiguous, bounded pages.
+func TestGossipSyncerHistoricalChanRangePages(t *testing.T) {
+	t.Parallel()
+
+	const syncEnd = 2*historicalChanRangeQueryBlocks + 123
+	bestHeight := uint32(syncEnd)
+
+	_, syncer, chanSeries := newTestSyncer(
+		lnwire.ShortChannelID{}, defaultEncoding, defaultChunkSize,
+	)
+	syncer.cfg.bestHeight = func() uint32 {
+		return bestHeight
+	}
+
+	var syncedCount int
+	syncer.cfg.markGraphSynced = func() {
+		syncedCount++
+	}
+	syncer.genHistoricalChanRangeQuery = true
+
+	expectedPages := []struct {
+		start uint32
+		count uint32
+	}{
+		{start: 0, count: historicalChanRangeQueryBlocks},
+		{
+			start: historicalChanRangeQueryBlocks,
+			count: historicalChanRangeQueryBlocks,
+		},
+		{start: 2 * historicalChanRangeQueryBlocks, count: 123},
+	}
+
+	for i, expected := range expectedPages {
+		query, err := syncer.genChanRangeQuery(t.Context(), true)
+		require.NoError(t, err)
+		require.Equal(t, expected.start, query.FirstBlockHeight)
+		require.Equal(t, expected.count, query.NumBlocks)
+
+		go func() {
+			<-chanSeries.filterReq
+			chanSeries.filterResp <- nil
+		}()
+
+		reply := &lnwire.ReplyChannelRange{
+			ChainHash:        query.ChainHash,
+			FirstBlockHeight: query.FirstBlockHeight,
+			NumBlocks:        query.NumBlocks,
+			Complete:         1,
+			EncodingType:     lnwire.EncodingSortedPlain,
+		}
+		require.NoError(
+			t, syncer.processChanRangeReply(t.Context(), reply),
+		)
+
+		if i < len(expectedPages)-1 {
+			require.Equal(t, syncingChans, syncer.syncState())
+			require.Zero(t, syncedCount)
+			require.Nil(t, syncer.bufferedChanRangeReplies)
+			bestHeight += historicalChanRangeQueryBlocks
+
+			continue
+		}
+
+		require.Equal(t, chansSynced, syncer.syncState())
+		require.Equal(t, 1, syncedCount)
+		require.False(t, syncer.genHistoricalChanRangeQuery)
+	}
+}
+
+// TestGossipSyncerHistoricalPageQueriesChannels tests that a syncer finishes
+// querying unknown channels before it advances to the next historical page.
+func TestGossipSyncerHistoricalPageQueriesChannels(t *testing.T) {
+	t.Parallel()
+
+	msgChan, syncer, chanSeries := newTestSyncer(
+		lnwire.ShortChannelID{}, defaultEncoding, defaultChunkSize,
+	)
+	syncer.cfg.bestHeight = func() uint32 {
+		return historicalChanRangeQueryBlocks + 1
+	}
+
+	var syncedCount int
+	syncer.cfg.markGraphSynced = func() {
+		syncedCount++
+	}
+	syncer.genHistoricalChanRangeQuery = true
+
+	query, err := syncer.genChanRangeQuery(t.Context(), true)
+	require.NoError(t, err)
+
+	newChan := lnwire.ShortChannelID{BlockHeight: 42}
+	go func() {
+		<-chanSeries.filterReq
+		chanSeries.filterResp <- []lnwire.ShortChannelID{newChan}
+	}()
+
+	reply := &lnwire.ReplyChannelRange{
+		ChainHash:        query.ChainHash,
+		FirstBlockHeight: query.FirstBlockHeight,
+		NumBlocks:        query.NumBlocks,
+		Complete:         1,
+		EncodingType:     lnwire.EncodingSortedPlain,
+		ShortChanIDs:     []lnwire.ShortChannelID{newChan},
+	}
+	require.NoError(t, syncer.processChanRangeReply(t.Context(), reply))
+	require.Equal(t, queryNewChannels, syncer.syncState())
+	require.Zero(t, syncedCount)
+
+	done, err := syncer.synchronizeChanIDs(t.Context())
+	require.NoError(t, err)
+	require.False(t, done)
+	require.Equal(t, waitingQueryChanReply, syncer.syncState())
+
+	msgs := <-msgChan
+	require.Len(t, msgs, 1)
+	queryIDs, ok := msgs[0].(*lnwire.QueryShortChanIDs)
+	require.True(t, ok)
+	require.Equal(
+		t, []lnwire.ShortChannelID{newChan}, queryIDs.ShortChanIDs,
+	)
+
+	syncer.setSyncState(queryNewChannels)
+	done, err = syncer.synchronizeChanIDs(t.Context())
+	require.NoError(t, err)
+	require.True(t, done)
+	syncer.finishChanRangePage()
+	require.Equal(t, syncingChans, syncer.syncState())
+	require.Zero(t, syncedCount)
+}
+
 // TestGossipSyncerProcessChanRangeReply tests that we'll properly buffer
 // replied channel replies until we have the complete version.
 func TestGossipSyncerProcessChanRangeReply(t *testing.T) {

--- a/discovery/syncer_test.go
+++ b/discovery/syncer_test.go
@@ -2687,12 +2687,114 @@ func TestGossipSyncerMaxChannelRangeSCIDs(t *testing.T) {
 		lnwire.NewShortChanIDFromInt(uint64(len(scids))),
 	}
 	err = syncer.processChanRangeReply(ctx, reply)
+	require.ErrorIs(t, err, errChanRangeReplyTooLarge)
 	require.ErrorContains(
 		t, err, "exceeds maximum number of short channel IDs",
 	)
 	require.Empty(t, syncer.bufferedChanRangeReplies)
 	require.Zero(t, syncer.numChanRangeReplySCIDsRcvd)
 	require.Nil(t, syncer.curQueryRangeMsg)
+}
+
+// TestGossipSyncerRotatesOnRejectedChannelRange ensures that a rejected range
+// response requests another historical syncer without stopping this one.
+func TestGossipSyncerRotatesOnRejectedChannelRange(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		mutate      func(*GossipSyncer, *lnwire.ReplyChannelRange)
+		expectedErr error
+	}{
+		{
+			name: "SCID limit",
+			mutate: func(syncer *GossipSyncer,
+				reply *lnwire.ReplyChannelRange) {
+
+				syncer.numChanRangeReplySCIDsRcvd =
+					maxChanRangeReplySCIDs
+				reply.ShortChanIDs = []lnwire.ShortChannelID{{
+					BlockHeight: reply.FirstBlockHeight,
+				}}
+			},
+			expectedErr: errChanRangeReplyTooLarge,
+		},
+		{
+			name: "range before query",
+			mutate: func(_ *GossipSyncer,
+				reply *lnwire.ReplyChannelRange) {
+
+				reply.FirstBlockHeight--
+			},
+			expectedErr: errInvalidChanRangeReply,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			msgChan, syncer, _ := newTestSyncer(
+				lnwire.ShortChannelID{
+					BlockHeight: latestKnownHeight,
+				}, defaultEncoding, defaultChunkSize,
+			)
+			failureErr := make(chan error, 1)
+			syncer.cfg.historicalSyncFailed = func(_ *GossipSyncer,
+				err error) {
+
+				failureErr <- err
+			}
+
+			syncer.Start()
+			defer syncer.Stop()
+
+			var query *lnwire.QueryChannelRange
+			select {
+			case msgs := <-msgChan:
+				require.Len(t, msgs, 1)
+				var ok bool
+				query, ok = msgs[0].(*lnwire.QueryChannelRange)
+				require.True(t, ok)
+
+			case <-time.After(time.Second):
+				t.Fatal("expected channel range query")
+			}
+
+			require.Eventually(t, func() bool {
+				state := syncer.syncState()
+
+				return state == waitingQueryRangeReply
+			}, time.Second, 10*time.Millisecond)
+
+			reply := &lnwire.ReplyChannelRange{
+				ChainHash:        query.ChainHash,
+				FirstBlockHeight: query.FirstBlockHeight,
+				NumBlocks:        query.NumBlocks,
+				EncodingType:     lnwire.EncodingSortedPlain,
+			}
+			test.mutate(syncer, reply)
+			require.NoError(
+				t, syncer.ProcessQueryMsg(reply, nil),
+			)
+
+			select {
+			case err := <-failureErr:
+				require.ErrorIs(t, err, test.expectedErr)
+
+			case <-time.After(time.Second):
+				t.Fatal("expected historical sync failure")
+			}
+
+			require.Eventually(t, func() bool {
+				return syncer.syncState() == chansSynced
+			}, time.Second, 10*time.Millisecond)
+			syncType := syncer.SyncType()
+			require.NoError(
+				t, syncer.ProcessSyncTransition(syncType),
+			)
+		})
+	}
 }
 
 // TestGossipSyncerChanRangeReplyNoQuery ensures that a range reply which
@@ -2900,12 +3002,10 @@ func TestGossipSyncerStateHandlerErrors(t *testing.T) {
 				// racing the syncer's own goroutine.
 				assertRangeSyncAborted(t, s)
 
-				// NOTE: the syncer is left in
-				// waitingQueryRangeReply with no live handler.
-				// That matches how every other terminal error
-				// in this state machine behaves today.
+				// The peer remains connected and the syncer
+				// returns to its terminal state.
 				require.Equal(
-					t, waitingQueryRangeReply,
+					t, chansSynced,
 					s.syncState(),
 				)
 			},

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -94,6 +94,12 @@
 
 ## Performance Improvements
 
+* [Historical graph
+  synchronization](https://github.com/lightningnetwork/lnd/pull/11174) now
+  requests channel ranges in fixed-size block pages and releases each page
+  before continuing. This bounds temporary range state while processing long
+  chain histories.
+
 ## Deprecations
 
 # Technical and Architectural Updates

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -22,6 +22,12 @@
 
 # Bug Fixes
 
+* [Fixed historical graph
+  synchronization](https://github.com/lightningnetwork/lnd/pull/11173) so a
+  peer whose channel range response cannot be used is rotated out of the
+  current historical sync. The sync manager selects another peer without
+  disconnecting the first one or waiting for the historical sync interval.
+
 * Bitcoind outbound peer health checks [now use](https://github.com/lightningnetwork/lnd/pull/10686)
   `getnetworkinfo.connections_out` instead of `getpeerinfo`. The same PR also
   [clarifies](https://github.com/lightningnetwork/lnd/issues/10568) the ZMQ


### PR DESCRIPTION
In this PR, we process historical channel range synchronization in fixed 50,000-block pages. The syncer captures the end height once, filters and releases each page before requesting the next one, and completes the unknown-channel queries within a page before advancing. This preserves complete historical coverage while bounding temporary channel range state.

This PR is stacked on #11173. Once that PR lands, its two commits will fall out of this diff.

The tests cover contiguous page boundaries, a fixed tip snapshot, per-page cleanup, final graph synchronization, and the unknown-channel gate between pages.

Follow-up to #11172.