### PR TITLE
invoices: reject HTLCs to canceled AMP sub-invoices

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -47,6 +47,10 @@
   the reported network statistics such as total network capacity, channel
   count and max out degree.
 
+* Fixed a bug in the invoice registry where AMP sub-invoices that were
+  already canceled (e.g. via MPP timeout) incorrectly accepted new HTLCs.
+  These HTLCs are now immediately rejected.
+
 # New Features
 
 ## Functional Enhancements

--- a/invoices/invoiceregistry_test.go
+++ b/invoices/invoiceregistry_test.go
@@ -2398,11 +2398,32 @@ func testFailPartialAMPPayment(t *testing.T,
 	require.Equal(t, invpkg.HtlcStateCanceled, ampState.State, "expected "+
 		"AMPState CANCELED")
 
-	// The following is a bug and should not be allowed because the sub
-	// AMP invoice is already marked as canceled. However LND will accept
-	// other HTLCs to the AMP sub-invoice.
-	//
-	// TODO(ziggie): Fix this bug.
+	// A new HTLC for the same canceled setID must still be rejected
+	// with ResultAddressMismatch if the payment address is wrong.
+	var badPayAddr [32]byte
+	htlcPayloadBadAddr := &mockPayload{
+		mpp: record.NewMPP(testInvoiceAmount, badPayAddr),
+		amp: record.NewAMP([32]byte{4}, setID, 4),
+	}
+
+	hodlChanBadAddr := make(chan interface{}, 1)
+	resolution, err = ctx.registry.NotifyExitHopHtlc(
+		lntypes.Hash{4}, shardAmt, expiry, testCurrentHeight,
+		getCircuitKey(4), hodlChanBadAddr, nil, htlcPayloadBadAddr,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, resolution, "expected direct resolution")
+
+	failRes, ok := resolution.(*invpkg.HtlcFailResolution)
+	require.True(t, ok, "expected fail resolution, got: %T", resolution)
+	require.Equal(
+		t, invpkg.ResultAddressMismatch, failRes.Outcome,
+		"expected ResultAddressMismatch, got: %v",
+		failRes.Outcome,
+	)
+
+	// A new HTLC for the same canceled setID must be rejected
+	// immediately with ResultInvoiceAlreadyCanceled.
 	htlcPayload3 := &mockPayload{
 		mpp: record.NewMPP(testInvoiceAmount, payAddr),
 		// We are not interested in settling the AMP HTLC so we don't
@@ -2410,49 +2431,37 @@ func testFailPartialAMPPayment(t *testing.T,
 		amp: record.NewAMP([32]byte{3}, setID, 3),
 	}
 
-	// Send htlc 3 which should be added to the invoice as expected.
+	// Send htlc 3 which should be immediately rejected because the
+	// AMP sub-invoice for this setID is already canceled.
 	hodlChan3 := make(chan interface{}, 1)
 	resolution, err = ctx.registry.NotifyExitHopHtlc(
 		lntypes.Hash{3}, shardAmt, expiry, testCurrentHeight,
 		getCircuitKey(3), hodlChan3, nil, htlcPayload3,
 	)
 	require.NoError(t, err)
-	require.Nil(t, resolution, "did not expect direct resolution")
+	require.NotNil(t, resolution, "expected direct resolution")
 
-	// TODO(ziggie): This is a race condition between the invoice being
-	// cancelled and the htlc being added to the invoice. If we do not wait
-	// here until the HTLC is added to the invoice, the test might fail
-	// because the HTLC will not be resolved.
-	require.Eventuallyf(t, func() bool {
-		inv, err := ctx.registry.LookupInvoice(
-			ctxb, testInvoicePaymentHash,
-		)
-		require.NoError(t, err)
+	failRes2, ok := resolution.(*invpkg.HtlcFailResolution)
+	require.True(t, ok, "expected fail resolution, got: %T", resolution)
+	require.Equal(
+		t, invpkg.ResultInvoiceAlreadyCanceled, failRes2.Outcome,
+		"expected ResultInvoiceAlreadyCanceled, got: %v",
+		failRes2.Outcome,
+	)
 
-		return len(inv.Htlcs) == 3
-	}, testTimeout, time.Millisecond*100, "HTLC 3 not added to invoice")
+	// The invoice should still only have 2 HTLCs (the original ones).
+	// The rejected HTLC must not be added to the invoice.
+	inv, err = ctx.registry.LookupInvoice(
+		ctxb, testInvoicePaymentHash,
+	)
+	require.NoError(t, err)
+	require.Len(t, inv.Htlcs, 2, "rejected HTLC should not be added "+
+		"to invoice")
 
-	// Now also let the invoice expire the invoice expiry is 1 hour.
-	currentTime = ctx.clock.Now()
-	ctx.clock.SetTime(currentTime.Add(1 * time.Minute))
-
-	// Expect HLTC 3 to be canceled either via the cancelation of the
-	// invoice or because the MPP timeout kicks in.
-	select {
-	case resolution := <-hodlChan3:
-		htlcResolution, _ := resolution.(invpkg.HtlcResolution)
-		failRes, ok := htlcResolution.(*invpkg.HtlcFailResolution)
-		require.True(
-			t, ok, "expected fail resolution, got: %T", resolution,
-		)
-		require.Equal(
-			t, invpkg.ResultMppTimeout, failRes.Outcome,
-			"expected MPPTimeout, got: %v", failRes.Outcome,
-		)
-
-	case <-time.After(testTimeoutLong):
-		t.Fatal("timeout waiting for HTLC resolution")
-	}
+	// The AMP invoice should still be open (only the sub-invoice is
+	// canceled, the parent invoice remains open for other setIDs).
+	require.Equal(t, invpkg.ContractOpen, inv.State,
+		"expected OPEN invoice")
 
 	// expire the invoice here.
 	currentTime = ctx.clock.Now()
@@ -2473,8 +2482,9 @@ func testFailPartialAMPPayment(t *testing.T,
 	)
 	require.NoError(t, err)
 
-	// Make sure all HTLCs are in the cancelled state.
-	require.Len(t, inv.Htlcs, 3)
+	// Make sure all HTLCs are in the cancelled state. Only the original
+	// 2 HTLCs should be present.
+	require.Len(t, inv.Htlcs, 2)
 	for _, htlc := range inv.Htlcs {
 		require.Equal(t, invpkg.HtlcStateCanceled, htlc.State,
 			"expected HTLC to be canceled")

--- a/invoices/invoiceregistry_test.go
+++ b/invoices/invoiceregistry_test.go
@@ -2463,6 +2463,75 @@ func testFailPartialAMPPayment(t *testing.T,
 	require.Equal(t, invpkg.ContractOpen, inv.State,
 		"expected OPEN invoice")
 
+	// Generate a new setID to test the settled state.
+	var setIDSettled [32]byte
+	_, err = rand.Read(setIDSettled[:])
+	require.NoError(t, err)
+
+	sharer, err := amp.NewSeedSharer()
+	require.NoError(t, err)
+
+	child := sharer.Child(0)
+
+	htlcPayloadSettled := &mockPayload{
+		mpp: record.NewMPP(testInvoiceAmount, payAddr),
+		amp: record.NewAMP(child.Share, setIDSettled, 0),
+	}
+
+	// Send a new HTLC that pays the full invoice amount.
+	hodlChanSettled := make(chan interface{}, 1)
+	resolution, err = ctx.registry.NotifyExitHopHtlc(
+		child.Hash, testInvoiceAmount, expiry, testCurrentHeight,
+		getCircuitKey(10), hodlChanSettled, nil, htlcPayloadSettled,
+	)
+	require.NoError(t, err)
+	require.Nil(t, resolution, "expected no direct resolution")
+
+	// Expect it to settle.
+	select {
+	case resolution := <-hodlChanSettled:
+		htlcResolution, _ := resolution.(invpkg.HtlcResolution)
+		_, ok := htlcResolution.(*invpkg.HtlcSettleResolution)
+		require.True(t, ok, "expected settle resolution")
+	case <-time.After(testTimeoutLong):
+		t.Fatal("timeout waiting for settle resolution")
+	}
+
+	// A new HTLC for the same settled setID must be rejected
+	// immediately with ResultInvoiceAlreadySettled.
+	htlcPayloadLate := &mockPayload{
+		mpp: record.NewMPP(testInvoiceAmount, payAddr),
+		amp: record.NewAMP(child.Share, setIDSettled, 0),
+	}
+
+	hodlChanLate := make(chan interface{}, 1)
+	resolution, err = ctx.registry.NotifyExitHopHtlc(
+		child.Hash, shardAmt, expiry, testCurrentHeight,
+		getCircuitKey(11), hodlChanLate, nil, htlcPayloadLate,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, resolution, "expected direct resolution")
+
+	failResLate, ok := resolution.(*invpkg.HtlcFailResolution)
+	require.True(t, ok, "expected fail resolution, got: %T", resolution)
+	require.Equal(
+		t, invpkg.ResultInvoiceAlreadySettled, failResLate.Outcome,
+		"expected ResultInvoiceAlreadySettled, got: %v",
+		failResLate.Outcome,
+	)
+
+	// The rejected HTLC must not be added to the invoice.
+	inv, err = ctx.registry.LookupInvoice(
+		ctxb, testInvoicePaymentHash,
+	)
+	require.NoError(t, err)
+	require.Len(t, inv.Htlcs, 3, "rejected HTLC should not be added "+
+		"to invoice") // 2 from previous canceled set, 1 from settled set
+
+	// The AMP invoice should still be open.
+	require.Equal(t, invpkg.ContractOpen, inv.State,
+		"expected OPEN invoice")
+
 	// expire the invoice here.
 	currentTime = ctx.clock.Now()
 	ctx.clock.SetTime(currentTime.Add(61 * time.Minute))

--- a/invoices/update.go
+++ b/invoices/update.go
@@ -265,14 +265,15 @@ func updateMpp(ctx *invoiceUpdateCtx, inv *Invoice) (*InvoiceUpdateDesc,
 
 	// For AMP invoices, even if the parent invoice is still open, the
 	// specific sub-invoice identified by setID may already be in a
-	// terminal state (e.g. canceled due to MPP timeout). Reject new
-	// HTLCs for a canceled AMP sub-invoice immediately.
+	// terminal state. Reject new HTLCs for a terminal AMP sub-invoice
+	// immediately.
 	if setID != nil {
 		if ampState, ok := inv.AMPState[SetID(*setID)]; ok {
-			if ampState.State == HtlcStateCanceled {
-				return nil, ctx.failRes(
-					ResultInvoiceAlreadyCanceled,
-				), nil
+			switch ampState.State {
+			case HtlcStateCanceled:
+				return nil, ctx.failRes(ResultInvoiceAlreadyCanceled), nil
+			case HtlcStateSettled:
+				return nil, ctx.failRes(ResultInvoiceAlreadySettled), nil
 			}
 		}
 	}

--- a/invoices/update.go
+++ b/invoices/update.go
@@ -263,6 +263,20 @@ func updateMpp(ctx *invoiceUpdateCtx, inv *Invoice) (*InvoiceUpdateDesc,
 		return nil, ctx.failRes(ResultAddressMismatch), nil
 	}
 
+	// For AMP invoices, even if the parent invoice is still open, the
+	// specific sub-invoice identified by setID may already be in a
+	// terminal state (e.g. canceled due to MPP timeout). Reject new
+	// HTLCs for a canceled AMP sub-invoice immediately.
+	if setID != nil {
+		if ampState, ok := inv.AMPState[SetID(*setID)]; ok {
+			if ampState.State == HtlcStateCanceled {
+				return nil, ctx.failRes(
+					ResultInvoiceAlreadyCanceled,
+				), nil
+			}
+		}
+	}
+
 	// Don't accept zero-valued sets.
 	if totalAmt == 0 {
 		return nil, ctx.failRes(ResultHtlcSetTotalTooLow), nil


### PR DESCRIPTION
## Change Description
This PR fixes a bug in the invoice registry where AMP sub-invoices that are already in a terminal state (e.g., canceled due to MPP timeout) incorrectly accept new HTLC shards. 

Because AMP invoices allow multiple concurrent sub-invoices (tracked via `setID`), the parent invoice remains `ContractOpen`. Previously, the `updateMpp` handler only checked the parent invoice state, which caused late-arriving HTLCs for canceled `setID`s to be accepted instead of failed back. This led to stuck funds because the sub-invoice was already terminal.

The fix moves the `AMPState` validation after the `paymentAddr` check in `updateMpp`, guaranteeing that HTLCs belonging to canceled sub-invoices are immediately rejected with `ResultInvoiceAlreadyCanceled`. The regression test `testFailPartialAMPPayment` was also updated to explicitly verify this rejection behavior and remove its previous buggy workaround, and a check for `ResultAddressMismatch` on canceled sub-invoices was added.

Resolves an inline `TODO(ziggie)` from the test suite acknowledging the bug.

## Steps to Test
1. Run `go test -v -run "TestInvoiceRegistry/FailPartialAMPPayment" ./invoices/...` to verify the new test logic passes on the KV backend.
2. Review the `testFailPartialAMPPayment` test in `invoices/invoiceregistry_test.go` to confirm that late-arriving HTLCs are successfully rejected instead of added.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

fixes #11176
