### PR TITLE
graph/db: fix legacy feature decoding in SQL migration

### DIFF
--- a/docs/release-notes/release-notes-0.21.4.md
+++ b/docs/release-notes/release-notes-0.21.4.md
@@ -27,6 +27,11 @@
   the replay from being handled as a second interception while the original
   outgoing HTLC remains active.
 
+* [Fixed native SQL graph migration](https://github.com/lightningnetwork/lnd/pull/11179)
+  failing with `unable to decode features: EOF` for legacy channel records
+  with empty features. The migration now uses the regular graph reader's
+  existing feature-format compatibility handling.
+
 # New Features
 
 ## Functional Enhancements
@@ -75,3 +80,5 @@
 # Contributors (Alphabetical Order)
 
 * Andras Banki-Horvath
+* Olaoluwa Osuntokun
+* Ziggie

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -22,10 +22,6 @@
 
 # Bug Fixes
 
-* Fixed native SQL graph migration failing with `unable to decode features:
-  EOF` for legacy channel records with empty features. The migration now uses
-  the regular graph reader's existing feature-format compatibility handling.
-
 * Bitcoind outbound peer health checks [now use](https://github.com/lightningnetwork/lnd/pull/10686)
   `getnetworkinfo.connections_out` instead of `getpeerinfo`. The same PR also
   [clarifies](https://github.com/lightningnetwork/lnd/issues/10568) the ZMQ

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -22,6 +22,10 @@
 
 # Bug Fixes
 
+* Fixed native SQL graph migration failing with `unable to decode features:
+  EOF` for legacy channel records with empty features. The migration now uses
+  the regular graph reader's existing feature-format compatibility handling.
+
 * Bitcoind outbound peer health checks [now use](https://github.com/lightningnetwork/lnd/pull/10686)
   `getnetworkinfo.connections_out` instead of `getpeerinfo`. The same PR also
   [clarifies](https://github.com/lightningnetwork/lnd/issues/10568) the ZMQ

--- a/graph/db/migration1/kv_store.go
+++ b/graph/db/migration1/kv_store.go
@@ -1676,6 +1676,78 @@ func fetchChanEdgeInfo(edgeIndex kvdb.RBucket,
 	return deserializeChanEdgeInfo(edgeInfoReader)
 }
 
+// deserializeChanEdgeFeatures deserializes channel edge features from bytes,
+// handling both the legacy format (raw feature bits) and the current format
+// (2-byte length prefix followed by feature bits).
+//
+// Legacy format (pre-v0.20): VarBytes containing raw feature bits directly.
+// Current format (v0.20+): VarBytes containing a 2-byte big-endian length
+// followed by the feature bits.
+//
+// The format is detected by checking if the first 2 bytes, interpreted as a
+// big-endian uint16 length, equals len(featureBytes)-2. Since this length
+// check alone could have false positives (e.g., a 258-byte legacy vector
+// starting with 0x01, 0x00), we additionally verify by decoding and
+// re-encoding the payload to confirm it produces the exact same bytes
+// (canonical encoding check).
+func deserializeChanEdgeFeatures(featureBytes []byte) (*lnwire.FeatureVector,
+	error) {
+
+	features := lnwire.NewRawFeatureVector()
+
+	// Empty features are valid in both formats.
+	if len(featureBytes) == 0 {
+		return lnwire.NewFeatureVector(features, lnwire.Features), nil
+	}
+
+	// Check if this looks like the new format with a 2-byte length prefix.
+	// In the new format, the first 2 bytes encode the length of the
+	// remaining feature bytes.
+	if len(featureBytes) >= 2 {
+		encodedLen := binary.BigEndian.Uint16(featureBytes[:2])
+		if int(encodedLen) == len(featureBytes)-2 {
+			// This looks like it could be the new format. To be
+			// certain, we decode and re-encode to verify canonical
+			// encoding, as a legacy feature vector could
+			// accidentally match the length check (e.g., a 258-byte
+			// legacy vector starting with 0x01, 0x00 would have
+			// 256 == 258 - 2).
+			payload := featureBytes[2:]
+			tempFeatures := lnwire.NewRawFeatureVector()
+			err := tempFeatures.DecodeBase256(
+				bytes.NewReader(payload), int(encodedLen),
+			)
+
+			var checkBuf bytes.Buffer
+			if err == nil {
+				err = tempFeatures.EncodeBase256(&checkBuf)
+			}
+
+			// If there were no errors and the re-encoded payload
+			// matches the original, we are confident it's the new
+			// format.
+			isCanonical := bytes.Equal(checkBuf.Bytes(), payload)
+			if err == nil && isCanonical {
+				return lnwire.NewFeatureVector(
+					tempFeatures, lnwire.Features,
+				), nil
+			}
+		}
+	}
+
+	// Legacy format: the bytes are raw feature bits without a length
+	// prefix.
+	err := features.DecodeBase256(
+		bytes.NewReader(featureBytes), len(featureBytes),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode features "+
+			"(legacy format): %w", err)
+	}
+
+	return lnwire.NewFeatureVector(features, lnwire.Features), nil
+}
+
 func deserializeChanEdgeInfo(r io.Reader) (*models.ChannelEdgeInfo, error) {
 	var (
 		err      error
@@ -1700,13 +1772,10 @@ func deserializeChanEdgeInfo(r io.Reader) (*models.ChannelEdgeInfo, error) {
 		return nil, err
 	}
 
-	features := lnwire.NewRawFeatureVector()
-	err = features.Decode(bytes.NewReader(featureBytes))
+	edgeInfo.Features, err = deserializeChanEdgeFeatures(featureBytes)
 	if err != nil {
-		return nil, fmt.Errorf("unable to decode "+
-			"features: %w", err)
+		return nil, err
 	}
-	edgeInfo.Features = lnwire.NewFeatureVector(features, lnwire.Features)
 
 	proof := &models.ChannelAuthProof{}
 

--- a/graph/db/migration1/sql_migration_features_test.go
+++ b/graph/db/migration1/sql_migration_features_test.go
@@ -1,0 +1,148 @@
+//go:build test_db_postgres || test_db_sqlite
+
+package migration1
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightningnetwork/lnd/graph/db/migration1/models"
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/sqldb"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMigrateGraphToSQLFeatureEncodings checks that legacy channel records
+// migrate alongside records containing length-prefixed features. The legacy
+// records are written directly because the current KV writer adds the prefix.
+func TestMigrateGraphToSQLFeatureEncodings(t *testing.T) {
+	t.Parallel()
+
+	dbFixture := NewTestDBFixture(t)
+	tests := []struct {
+		name string
+		bits []lnwire.FeatureBit
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name: "single byte",
+			bits: []lnwire.FeatureBit{7},
+		},
+		{
+			name: "multiple bytes",
+			bits: []lnwire.FeatureBit{0, 15},
+		},
+		{
+			// The legacy payload starts with 0x01, 0x00 and is
+			// 258 bytes long, so a length check alone would mistake
+			// it for a length-prefixed vector of 256 zero bytes.
+			name: "legacy length prefix collision",
+			bits: []lnwire.FeatureBit{2056},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := t.Context()
+			kv := setUpKVStore(t)
+			store := NewTestDBWithFixture(t, dbFixture)
+			sql, ok := store.(*SQLStore)
+			require.True(t, ok)
+			features := lnwire.NewFeatureVector(
+				lnwire.NewRawFeatureVector(test.bits...),
+				lnwire.Features,
+			)
+
+			// Create two channels with the same features and both
+			// policies. Only the first channel will be rewritten in
+			// the legacy format, leaving a mix of encodings.
+			var legacyChannel *models.ChannelEdgeInfo
+			for i := range 2 {
+				channel := makeTestChannel(
+					t, func(c *models.ChannelEdgeInfo) {
+						c.ChannelID = uint64(i + 1)
+						c.Features = features
+					},
+				)
+				err := kv.AddChannelEdge(ctx, channel)
+				require.NoError(t, err)
+
+				for _, isNode1 := range []bool{true, false} {
+					toNode := channel.NodeKey1Bytes
+					if isNode1 {
+						toNode = channel.NodeKey2Bytes
+					}
+					policy := makeTestPolicy(
+						channel.ChannelID, toNode,
+						isNode1,
+					)
+					_, _, err := kv.UpdateEdgePolicy(
+						ctx, policy,
+					)
+					require.NoError(t, err)
+				}
+
+				if i == 0 {
+					legacyChannel = channel
+				}
+			}
+
+			// Capture the expected state before rewriting features.
+			// This does not depend on legacy decoding working.
+			expected := fetchAllChannelsAndPolicies(t, kv)
+			err := kvdb.Update(kv.db, func(tx kvdb.RwTx) error {
+				index := tx.ReadWriteBucket(edgeBucket).
+					NestedReadWriteBucket(edgeIndexBucket)
+				var key [8]byte
+				byteOrder.PutUint64(
+					key[:], legacyChannel.ChannelID,
+				)
+				record := index.Get(key[:])
+				require.NotEmpty(t, record)
+
+				// Four public keys precede the feature VarBytes
+				// field. Keep all other record bytes intact.
+				const keysLen = 4 * 33
+				reader := bytes.NewReader(record[keysLen:])
+				_, err := wire.ReadVarBytes(
+					reader, 0, 900, "features",
+				)
+				if err != nil {
+					return err
+				}
+				tail := record[len(record)-reader.Len():]
+
+				var featureBuf, rewritten bytes.Buffer
+				err = features.EncodeBase256(&featureBuf)
+				if err != nil {
+					return err
+				}
+				rewritten.Write(record[:keysLen])
+				err = wire.WriteVarBytes(
+					&rewritten, 0, featureBuf.Bytes(),
+				)
+				if err != nil {
+					return err
+				}
+				rewritten.Write(tail)
+				return index.Put(key[:], rewritten.Bytes())
+			}, func() {})
+			require.NoError(t, err)
+
+			err = sql.db.ExecTx(ctx, sqldb.WriteTxOpt(),
+				func(tx SQLQueries) error {
+					return MigrateGraphToSQL(
+						ctx, sql.cfg, kv.db, tx,
+					)
+				}, sqldb.NoOpReset,
+			)
+			require.NoError(t, err)
+			actual := fetchAllChannelsAndPolicies(t, sql)
+			require.Equal(t, expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
## Change Description

Native SQL graph migration can abort with `could not migrate channels and policies: could not migrate channels and policies: unable to decode features: EOF` when it encounters an older channel record with an empty feature payload.

#10529 added backward-compatible feature decoding to the regular graph reader, but the frozen reader in `graph/db/migration1` still unconditionally calls `RawFeatureVector.Decode`, which expects a two-byte length prefix. Apply the existing graph reader helper to the migration copy so these legacy records can migrate alongside length-prefixed records.

The regression test writes legacy feature payloads directly into the KV edge index and migrates them together with current-format channels. It compares the resulting channels and both policies against state captured before rewriting the feature field. Cases cover empty, single-byte and multi-byte vectors, plus the existing helper's noncanonical length-collision fallback.

## Steps to Test

```sh
go test -tags='test_db_sqlite kvdb_sqlite' ./graph/db/migration1 -run '^TestMigrateGraphToSQLFeatureEncodings$' -count=1
go test -tags='test_db_sqlite kvdb_sqlite' ./graph/db/migration1 -count=1
```

The empty legacy case reproduces the reported nested EOF before the fix. The regression cases and the full SQLite migration suite pass with the fix.

## Pull Request Checklist

- [ ] All CI checks pass.
- [x] Regression coverage reproduces the original failure.
- [x] Existing migration tests pass locally with SQLite.
- [x] Go formatting and whitespace checks pass.
- [x] Release notes describe the change.
