### PR TITLE
aezeed: validate seed creation birthdays

### DIFF
--- a/aezeed/cipherseed.go
+++ b/aezeed/cipherseed.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/binary"
+	"fmt"
 	"hash/crc32"
 	"io"
+	"math"
 	"time"
 
 	"github.com/Yawning/aez"
@@ -202,9 +204,18 @@ type CipherSeed struct {
 // New generates a new CipherSeed instance from an optional source of entropy.
 // If the entropy isn't provided, then a set of random bytes will be used in
 // place. The final fixed argument should be the time at which the seed was
-// created, followed by optional seed option modifiers.
+// created, followed by optional seed option modifiers. Creation times before
+// Bitcoin's genesis block or beyond the unsigned 16-bit day range are rejected.
 func New(internalVersion uint8, entropy *[EntropySize]byte,
 	now time.Time, modifiers ...SeedOptionModifier) (*CipherSeed, error) {
+
+	// Validate before narrowing or generating randomness: a wrapped day
+	// count could silently move the wallet's recovery scan past its funds.
+	birthday := now.Sub(BitcoinGenesisDate) / (24 * time.Hour)
+	if now.Before(BitcoinGenesisDate) || birthday > math.MaxUint16 {
+		return nil, fmt.Errorf("seed creation time %v is outside "+
+			"the representable birthday range", now)
+	}
 
 	opts := DefaultOptions()
 	for _, modifier := range modifiers {
@@ -224,14 +235,9 @@ func New(internalVersion uint8, entropy *[EntropySize]byte,
 		copy(seed[:], entropy[:])
 	}
 
-	// To compute our "birthday", we'll first use the current time, then
-	// subtract that from the Bitcoin Genesis Date. We'll then convert that
-	// value to days.
-	birthday := uint16(now.Sub(BitcoinGenesisDate) / (time.Hour * 24))
-
 	c := &CipherSeed{
 		InternalVersion: internalVersion,
-		Birthday:        birthday,
+		Birthday:        uint16(birthday),
 		Entropy:         seed,
 	}
 

--- a/aezeed/cipherseed_test.go
+++ b/aezeed/cipherseed_test.go
@@ -2,6 +2,7 @@ package aezeed
 
 import (
 	"bytes"
+	"math"
 	"math/rand"
 	"testing"
 	"testing/quick"
@@ -100,6 +101,62 @@ func TestAezeedVersion0TestVectors(t *testing.T) {
 		// expected value.
 		require.Equal(t, v.expectedMnemonic[:], mnemonic[:])
 		require.Equal(t, v.expectedBirthday, cipherSeed.Birthday)
+	}
+}
+
+// TestCipherSeedBirthdayRange checks that dates cannot wrap the encoded scan
+// boundary while the final representable birthday remains usable.
+func TestCipherSeedBirthdayRange(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: exercise both negative offsets and the upper boundary with
+	// fixed entropy, so only the caller's creation time varies.
+	lastDay := BitcoinGenesisDate.Add(math.MaxUint16 * 24 * time.Hour)
+	testCases := []struct {
+		name         string
+		birthday     time.Time
+		wantErr      bool
+		wantBirthday uint16
+	}{
+		{
+			name:     "beforeGenesis",
+			birthday: BitcoinGenesisDate.Add(-24 * time.Hour),
+			wantErr:  true,
+		},
+		{
+			name:     "justBeforeGenesis",
+			birthday: BitcoinGenesisDate.Add(-time.Nanosecond),
+			wantErr:  true,
+		},
+		{
+			name:         "lastRepresentableDay",
+			birthday:     lastDay,
+			wantBirthday: math.MaxUint16,
+		},
+		{
+			name:     "afterLastDay",
+			birthday: lastDay.Add(24 * time.Hour),
+			wantErr:  true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Act: call the public constructor to exercise date
+			// validation before conversion to an unsigned day.
+			seed, err := New(0, &testEntropy, testCase.birthday)
+
+			// Assert: invalid dates must not produce a seed; the
+			// last valid day must retain its exact encoded value.
+			if testCase.wantErr {
+				require.Error(t, err)
+				require.Nil(t, seed)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, testCase.wantBirthday, seed.Birthday)
+		})
 	}
 }
 
@@ -370,15 +427,14 @@ func TestMnemonicEncoding(t *testing.T) {
 func TestEncipherDecipher(t *testing.T) {
 	t.Parallel()
 
-	// mainScenario is the main driver of our property based test. We'll
-	// ensure that given a random seed tuple (internal version, entropy,
-	// and birthday) we're able to convert that to a valid cipher seed.
-	// Additionally, we should be able to decipher the final mnemonic, and
-	// recover the original cipher seed.
+	// Arrange: generate representable birthday offsets so this round-trip
+	// property exercises valid seed tuples rather than invalid Unix times.
 	mainScenario := func(version uint8, entropy [EntropySize]byte,
-		nowInt int64, pass [20]byte) bool {
+		birthday uint16, pass [20]byte) bool {
 
-		now := time.Unix(nowInt, 0)
+		now := BitcoinGenesisDate.Add(
+			time.Duration(birthday) * 24 * time.Hour,
+		)
 
 		cipherSeed, err := New(version, &entropy, now)
 		if err != nil {
@@ -386,6 +442,8 @@ func TestEncipherDecipher(t *testing.T) {
 			return false
 		}
 
+		// Act: encode and recover using the same password, exercising
+		// the public mnemonic path for each generated valid seed.
 		mnemonic, err := cipherSeed.ToMnemonic(pass[:])
 		if err != nil {
 			t.Fatalf("unable to generate mnemonic: %v", err)
@@ -398,6 +456,8 @@ func TestEncipherDecipher(t *testing.T) {
 			return false
 		}
 
+		// Assert: all seed fields must survive recovery, including the
+		// birthday that determines where the wallet starts scanning.
 		if cipherSeed.InternalVersion != cipherSeed2.InternalVersion {
 			t.Fatalf("mismatched versions: expected %v, got %v",
 				cipherSeed.InternalVersion, cipherSeed2.InternalVersion)

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -22,6 +22,11 @@
 
 # Bug Fixes
 
+* [Validate aezeed creation dates](https://github.com/lightningnetwork/lnd/pull/11180)
+  before storing the birthday as an unsigned 16-bit day count. Dates before
+  Bitcoin's genesis or beyond the representable range are rejected instead
+  of wrapping into an incorrect birthday.
+
 * Bitcoind outbound peer health checks [now use](https://github.com/lightningnetwork/lnd/pull/10686)
   `getnetworkinfo.connections_out` instead of `getpeerinfo`. The same PR also
   [clarifies](https://github.com/lightningnetwork/lnd/issues/10568) the ZMQ


### PR DESCRIPTION
## Summary

Prevent invalid seed creation dates from wrapping into incorrect aezeed birthdays.

## Change Description

Validate creation dates before converting the elapsed day count to uint16. Reject dates before Bitcoin's genesis and beyond the representable range.

Add birthday-boundary regression tests, constrain the existing round-trip property test to valid birthdays, and document the validation in the release notes. Package tests, formatting, and targeted lint pass.
