### PR TITLE
chainntnfs: extend scans for earlier height hints

### DIFF
--- a/chainntnfs/confirmation_registration_order_test.go
+++ b/chainntnfs/confirmation_registration_order_test.go
@@ -1,0 +1,658 @@
+package chainntnfs_test
+
+import (
+	"crypto/sha256"
+	"sort"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// TestConfirmationRegistrationOrder ensures that all subscribers receive a
+// historical confirmation regardless of their registration order.
+func TestConfirmationRegistrationOrder(t *testing.T) {
+	testCases := []struct {
+		name                string
+		completeBeforeEarly bool
+		prefixFirst         bool
+		restartBeforePrefix bool
+	}{
+		{
+			name:                "narrow scan already complete",
+			completeBeforeEarly: true,
+		},
+		{
+			name: "narrow scan completes first",
+		},
+		{
+			name:        "prefix scan completes first",
+			prefixFirst: true,
+		},
+		{
+			name:                "prefix survives restart",
+			completeBeforeEarly: true,
+			restartBeforePrefix: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testConfirmationRegistrationOrder(
+				t, testCase.completeBeforeEarly,
+				testCase.prefixFirst,
+				testCase.restartBeforePrefix,
+			)
+		})
+	}
+}
+
+func testConfirmationRegistrationOrder(t *testing.T, completeBeforeEarly,
+	prefixFirst, restartBeforePrefix bool) {
+
+	const (
+		minedHeight   = uint32(100)
+		restartHeight = uint32(103)
+	)
+
+	program := sha256.Sum256([]byte("confirmation-registration-order"))
+	script := append([]byte{0x51, 0x20}, program[:]...)
+	tx := wire.NewMsgTx(2)
+	tx.AddTxOut(&wire.TxOut{Value: 1000, PkScript: script})
+	txid := tx.TxHash()
+	block := btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{tx},
+	})
+
+	cache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		minedHeight-1, chainntnfs.ReorgSafetyLimit, cache, cache,
+	)
+
+	initial, err := n.RegisterConf(
+		&txid, script, 1, minedHeight-1,
+	)
+	require.NoError(t, err)
+	require.NoError(t, n.UpdateConfDetails(
+		initial.HistoricalDispatch.ConfRequest, nil,
+	))
+	require.NoError(t, n.ConnectTip(block, minedHeight))
+	require.NoError(t, n.NotifyHeight(minedHeight))
+	n.TearDown()
+
+	n = chainntnfs.NewTxNotifier(
+		restartHeight, chainntnfs.ReorgSafetyLimit, cache, cache,
+	)
+	t.Cleanup(func() {
+		n.TearDown()
+	})
+
+	late, err := n.RegisterConf(&txid, script, 6, restartHeight)
+	require.NoError(t, err)
+	require.NotNil(t, late.HistoricalDispatch)
+
+	scan := func(registration *chainntnfs.ConfRegistration) {
+		dispatch := registration.HistoricalDispatch
+		require.NotNil(t, dispatch)
+
+		var details *chainntnfs.TxConfirmation
+		if dispatch.StartHeight <= minedHeight &&
+			minedHeight <= dispatch.EndHeight {
+
+			details = &chainntnfs.TxConfirmation{
+				BlockHash:   block.Hash(),
+				BlockHeight: minedHeight,
+				Tx:          tx,
+			}
+		}
+
+		require.NoError(t, n.UpdateConfDetails(
+			dispatch.ConfRequest, details,
+		))
+	}
+
+	if completeBeforeEarly {
+		scan(late)
+		hint, err := cache.QueryConfirmHint(
+			late.HistoricalDispatch.ConfRequest,
+		)
+		require.NoError(t, err)
+		require.Equal(t, restartHeight, hint)
+	}
+
+	early, err := n.RegisterConf(&txid, script, 3, minedHeight)
+	require.NoError(t, err)
+	require.NotNil(t, early.HistoricalDispatch)
+	require.Equal(t, minedHeight, early.HistoricalDispatch.StartHeight)
+	require.Equal(t, restartHeight-1, early.HistoricalDispatch.EndHeight)
+
+	// The earlier range must be durable as soon as it is accepted. If
+	// the notifier restarts before the prefix completes, the cache must
+	// cause the replacement subscription to scan that range again.
+	switch {
+	case restartBeforePrefix:
+		hint, err := cache.QueryConfirmHint(
+			early.HistoricalDispatch.ConfRequest,
+		)
+		require.NoError(t, err)
+		require.Equal(t, minedHeight, hint)
+
+		n.TearDown()
+		n = chainntnfs.NewTxNotifier(
+			restartHeight, chainntnfs.ReorgSafetyLimit,
+			cache, cache,
+		)
+
+		early, err = n.RegisterConf(&txid, script, 3, minedHeight)
+		require.NoError(t, err)
+		require.NotNil(t, early.HistoricalDispatch)
+		require.Equal(
+			t, minedHeight, early.HistoricalDispatch.StartHeight,
+		)
+		require.Equal(
+			t, restartHeight, early.HistoricalDispatch.EndHeight,
+		)
+
+		late, err = n.RegisterConf(&txid, script, 6, restartHeight)
+		require.NoError(t, err)
+		require.Nil(t, late.HistoricalDispatch)
+		scan(early)
+	case prefixFirst:
+		scan(early)
+		scan(late)
+
+	default:
+		if !completeBeforeEarly {
+			scan(late)
+			hint, err := cache.QueryConfirmHint(
+				late.HistoricalDispatch.ConfRequest,
+			)
+			require.NoError(t, err)
+			require.Equal(t, minedHeight, hint)
+		}
+		scan(early)
+	}
+
+	hint, err := cache.QueryConfirmHint(
+		early.HistoricalDispatch.ConfRequest,
+	)
+	require.NoError(t, err)
+	require.Equal(t, minedHeight, hint)
+
+	for height := restartHeight + 1; height <= minedHeight+10; height++ {
+		require.NoError(t, n.ConnectTip(
+			btcutil.NewBlock(&wire.MsgBlock{}), height,
+		))
+		require.NoError(t, n.NotifyHeight(height))
+	}
+
+	select {
+	case details := <-early.Event.Confirmed:
+		require.Equal(t, minedHeight, details.BlockHeight)
+	default:
+		t.Fatal("early subscriber missed historical confirmation")
+	}
+
+	select {
+	case details := <-late.Event.Confirmed:
+		require.Equal(t, minedHeight, details.BlockHeight)
+	default:
+		t.Fatal("late subscriber missed historical confirmation")
+	}
+}
+
+// TestConfirmationRegistrationOrderProperty asserts that subscriber and scan
+// completion order cannot change the historical range covered for a request.
+func TestConfirmationRegistrationOrderProperty(t *testing.T) {
+	program := sha256.Sum256([]byte("confirmation-order-property"))
+	script := append([]byte{0x51, 0x20}, program[:]...)
+	tx := wire.NewMsgTx(2)
+	tx.AddTxOut(&wire.TxOut{Value: 1000, PkScript: script})
+	txid := tx.TxHash()
+	block := btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{tx},
+	})
+
+	rapid.Check(t, func(t *rapid.T) {
+		tipHeight := rapid.Uint32Range(3, 1000).Draw(
+			t, "tip_height",
+		)
+		minHint := rapid.Uint32Range(1, tipHeight-1).Draw(
+			t, "min_hint",
+		)
+		numSubscribers := rapid.IntRange(2, 6).Draw(
+			t, "num_subscribers",
+		)
+		minHintIndex := rapid.IntRange(1, numSubscribers-1).Draw(
+			t, "min_hint_index",
+		)
+
+		// Place the minimum after the first subscriber. Other hints can
+		// create additional descending prefixes or duplicates.
+		hints := make([]uint32, numSubscribers)
+		for i := range hints {
+			if i == minHintIndex {
+				hints[i] = minHint
+				continue
+			}
+
+			hints[i] = rapid.Uint32Range(minHint+1, tipHeight).Draw(
+				t, "height_hint_"+string(rune('a'+i)),
+			)
+		}
+
+		minedHeight := rapid.Uint32Range(minHint, tipHeight).Draw(
+			t, "mined_height",
+		)
+
+		cache := newMockHintCache()
+		n := chainntnfs.NewTxNotifier(
+			tipHeight, chainntnfs.ReorgSafetyLimit, cache, cache,
+		)
+		defer n.TearDown()
+
+		events := make([]*chainntnfs.ConfirmationEvent, 0, len(hints))
+		dispatches := make(
+			[]*chainntnfs.HistoricalConfDispatch, 0, len(hints),
+		)
+		for _, hint := range hints {
+			registration, err := n.RegisterConf(
+				&txid, script, 1, hint,
+			)
+			require.NoError(t, err)
+			events = append(events, registration.Event)
+
+			if registration.HistoricalDispatch != nil {
+				dispatches = append(
+					dispatches,
+					registration.HistoricalDispatch,
+				)
+			}
+		}
+
+		// The dispatched ranges must be a gapless, non-overlapping
+		// partition of every block promised by the earliest subscriber.
+		sort.Slice(dispatches, func(i, j int) bool {
+			return dispatches[i].StartHeight <
+				dispatches[j].StartHeight
+		})
+		require.NotEmpty(t, dispatches)
+		require.Equal(t, minHint, dispatches[0].StartHeight)
+		require.Equal(
+			t, tipHeight, dispatches[len(dispatches)-1].EndHeight,
+		)
+		for i := 1; i < len(dispatches); i++ {
+			require.Equal(
+				t, dispatches[i-1].EndHeight+1,
+				dispatches[i].StartHeight,
+			)
+		}
+
+		completionOrder := rapid.Permutation(dispatches).Draw(
+			t, "completion_order",
+		)
+		found := false
+		for _, dispatch := range completionOrder {
+			var details *chainntnfs.TxConfirmation
+			if dispatch.StartHeight <= minedHeight &&
+				minedHeight <= dispatch.EndHeight {
+
+				details = &chainntnfs.TxConfirmation{
+					BlockHash:   block.Hash(),
+					BlockHeight: minedHeight,
+					Tx:          tx,
+				}
+				found = true
+			}
+
+			require.NoError(t, n.UpdateConfDetails(
+				dispatch.ConfRequest, details,
+			))
+
+			// An empty partial result cannot discard a prefix whose
+			// completion is still outstanding.
+			if !found {
+				hint, err := cache.QueryConfirmHint(
+					dispatch.ConfRequest,
+				)
+				require.NoError(t, err)
+				require.Equal(t, minHint, hint)
+			}
+		}
+
+		for _, event := range events {
+			select {
+			case details := <-event.Confirmed:
+				require.Equal(
+					t, minedHeight, details.BlockHeight,
+				)
+			default:
+				t.Fatal("subscriber missed confirmation")
+			}
+
+			select {
+			case <-event.Confirmed:
+				t.Fatal("subscriber received duplicate")
+			default:
+			}
+		}
+	})
+}
+
+type confirmationLifecycleScenario struct {
+	tipHeight         uint32
+	hints             []uint32
+	numConfs          []uint32
+	cancelIndex       int
+	cancelAfterConf   bool
+	scanInterruptions int
+	preMineBlocks     uint32
+	reincludeDelay    uint32
+}
+
+func genLifecycleScenarios() *rapid.Generator[confirmationLifecycleScenario] {
+	return rapid.Custom(func(t *rapid.T) confirmationLifecycleScenario {
+		tipHeight := rapid.Uint32Range(3, 1000).Draw(t, "tip_height")
+		minHint := rapid.Uint32Range(1, tipHeight-1).Draw(t, "min_hint")
+		numSubscribers := rapid.IntRange(2, 6).Draw(
+			t, "num_subscribers",
+		)
+		minHintIndex := rapid.IntRange(1, numSubscribers-1).Draw(
+			t, "min_hint_index",
+		)
+
+		hints := make([]uint32, numSubscribers)
+		numConfs := make([]uint32, numSubscribers)
+		for i := range hints {
+			if i == minHintIndex {
+				hints[i] = minHint
+			} else {
+				hints[i] = rapid.Uint32Range(
+					minHint+1, tipHeight,
+				).Draw(t, "height_hint_"+string(rune('a'+i)))
+			}
+
+			numConfs[i] = rapid.Uint32Range(1, 4).Draw(
+				t, "num_confs_"+string(rune('a'+i)),
+			)
+		}
+
+		return confirmationLifecycleScenario{
+			tipHeight: tipHeight,
+			hints:     hints,
+			numConfs:  numConfs,
+			cancelIndex: rapid.IntRange(1, numSubscribers-1).Draw(
+				t, "cancel_index",
+			),
+			cancelAfterConf: rapid.Bool().Draw(
+				t, "cancel_after_confirmation",
+			),
+			scanInterruptions: rapid.IntRange(0, 2).Draw(
+				t, "scan_interruptions",
+			),
+			preMineBlocks: rapid.Uint32Range(0, 2).Draw(
+				t, "pre_mine_blocks",
+			),
+			reincludeDelay: rapid.Uint32Range(0, 2).Draw(
+				t, "reinclude_delay",
+			),
+		}
+	})
+}
+
+// TestConfirmationLifecycleProperty asserts that restart, cancellation, tip
+// movement, and reorgs preserve the confirmation contract for every active
+// subscriber. Historical scan errors are not passed to TxNotifier. At this
+// boundary, an interrupted scan is a dispatch that never calls
+// UpdateConfDetails, followed by a restart and re-registration.
+func TestConfirmationLifecycleProperty(t *testing.T) {
+	program := sha256.Sum256([]byte("confirmation-lifecycle-property"))
+	script := append([]byte{0x51, 0x20}, program[:]...)
+	tx := wire.NewMsgTx(2)
+	tx.AddTxOut(&wire.TxOut{Value: 1000, PkScript: script})
+	txid := tx.TxHash()
+	txBlock := btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{tx},
+	})
+	emptyBlock := btcutil.NewBlock(&wire.MsgBlock{})
+
+	rapid.Check(t, func(t *rapid.T) {
+		scenario := genLifecycleScenarios().Draw(t, "scenario")
+		cache := newMockHintCache()
+		active := make([]bool, len(scenario.hints))
+		for i := range active {
+			active[i] = true
+		}
+
+		var (
+			n      *chainntnfs.TxNotifier
+			events = make(
+				[]*chainntnfs.ConfirmationEvent, len(active),
+			)
+		)
+		numAttempts := scenario.scanInterruptions + 1
+		for attempt := range numAttempts {
+			n = chainntnfs.NewTxNotifier(
+				scenario.tipHeight, chainntnfs.ReorgSafetyLimit,
+				cache, cache,
+			)
+
+			var dispatches []*chainntnfs.HistoricalConfDispatch
+			for i := range active {
+				if !active[i] {
+					continue
+				}
+
+				registration, err := n.RegisterConf(
+					&txid, script, scenario.numConfs[i],
+					scenario.hints[i],
+				)
+				require.NoError(t, err)
+				events[i] = registration.Event
+				if registration.HistoricalDispatch != nil {
+					dispatches = append(
+						dispatches,
+						registration.HistoricalDispatch,
+					)
+				}
+			}
+
+			if attempt == 0 && !scenario.cancelAfterConf {
+				events[scenario.cancelIndex].Cancel()
+				active[scenario.cancelIndex] = false
+				assertConfirmationClosed(
+					t, events[scenario.cancelIndex],
+				)
+			}
+
+			require.NotEmpty(t, dispatches)
+			if attempt < scenario.scanInterruptions {
+				// Failed scans do not call back. The hint must
+				// preserve the obligation across restart.
+				n.TearDown()
+				for i := range active {
+					if active[i] {
+						assertConfirmationClosed(
+							t, events[i],
+						)
+					}
+				}
+
+				continue
+			}
+
+			completionOrder := rapid.Permutation(dispatches).Draw(
+				t, "completion_order",
+			)
+			for _, dispatch := range completionOrder {
+				require.NoError(t, n.UpdateConfDetails(
+					dispatch.ConfRequest, nil,
+				))
+			}
+		}
+		defer n.TearDown()
+
+		currentHeight := scenario.tipHeight
+		for range scenario.preMineBlocks {
+			currentHeight++
+			require.NoError(t, n.ConnectTip(
+				emptyBlock, currentHeight,
+			))
+			require.NoError(t, n.NotifyHeight(currentHeight))
+		}
+
+		txHeight := currentHeight + 1
+		require.NoError(t, n.ConnectTip(txBlock, txHeight))
+		require.NoError(t, n.NotifyHeight(txHeight))
+		currentHeight = txHeight
+
+		var maxNumConfs uint32
+		for i := range active {
+			if active[i] && scenario.numConfs[i] > maxNumConfs {
+				maxNumConfs = scenario.numConfs[i]
+			}
+		}
+		for currentHeight < txHeight+maxNumConfs-1 {
+			currentHeight++
+			require.NoError(t, n.ConnectTip(
+				emptyBlock, currentHeight,
+			))
+			require.NoError(t, n.NotifyHeight(currentHeight))
+		}
+
+		for i := range active {
+			if !active[i] {
+				continue
+			}
+
+			assertConfirmation(t, events[i], txHeight)
+			assertNoConfirmation(t, events[i])
+		}
+
+		if scenario.cancelAfterConf {
+			events[scenario.cancelIndex].Cancel()
+			active[scenario.cancelIndex] = false
+			assertConfirmationClosed(
+				t, events[scenario.cancelIndex],
+			)
+		}
+
+		for currentHeight >= txHeight {
+			require.NoError(t, n.DisconnectTip(currentHeight))
+			currentHeight--
+		}
+		for i := range active {
+			if !active[i] {
+				continue
+			}
+
+			select {
+			case depth := <-events[i].NegativeConf:
+				require.Greater(t, depth, int32(0))
+			default:
+				t.Fatal("subscriber missed reorg")
+			}
+			assertNoConfirmation(t, events[i])
+		}
+
+		for range scenario.reincludeDelay {
+			currentHeight++
+			require.NoError(t, n.ConnectTip(
+				emptyBlock, currentHeight,
+			))
+			require.NoError(t, n.NotifyHeight(currentHeight))
+		}
+
+		txHeight = currentHeight + 1
+		require.NoError(t, n.ConnectTip(txBlock, txHeight))
+		require.NoError(t, n.NotifyHeight(txHeight))
+		currentHeight = txHeight
+		for currentHeight < txHeight+maxNumConfs-1 {
+			currentHeight++
+			require.NoError(t, n.ConnectTip(
+				emptyBlock, currentHeight,
+			))
+			require.NoError(t, n.NotifyHeight(currentHeight))
+		}
+
+		for i := range active {
+			if !active[i] {
+				continue
+			}
+
+			assertConfirmation(t, events[i], txHeight)
+			assertNoConfirmation(t, events[i])
+		}
+	})
+}
+
+func assertConfirmation(t rapid.TB, event *chainntnfs.ConfirmationEvent,
+	height uint32) {
+
+	t.Helper()
+	select {
+	case details := <-event.Confirmed:
+		require.Equal(t, height, details.BlockHeight)
+	default:
+		t.Fatal("subscriber missed confirmation")
+	}
+}
+
+func assertNoConfirmation(t rapid.TB, event *chainntnfs.ConfirmationEvent) {
+	t.Helper()
+	select {
+	case <-event.Confirmed:
+		t.Fatal("subscriber received duplicate confirmation")
+	default:
+	}
+}
+
+func assertConfirmationClosed(t rapid.TB,
+	event *chainntnfs.ConfirmationEvent) {
+
+	t.Helper()
+	select {
+	case _, ok := <-event.Confirmed:
+		require.False(t, ok)
+	default:
+		t.Fatal("expected closed confirmation channel")
+	}
+}
+
+// TestConfirmationEqualHeightHintsShareScan ensures a cached hint can raise a
+// shared scan boundary without causing an identical subscriber hint to rescan
+// the range below the cache.
+func TestConfirmationEqualHeightHintsShareScan(t *testing.T) {
+	const (
+		heightHint   = uint32(50)
+		cachedHeight = uint32(100)
+		tipHeight    = uint32(103)
+	)
+
+	program := sha256.Sum256([]byte("confirmation-equal-height-hints"))
+	script := append([]byte{0x51, 0x20}, program[:]...)
+	txid := chainntnfs.ZeroHash
+
+	cache := newMockHintCache()
+	confRequest, err := chainntnfs.NewConfRequest(&txid, script)
+	require.NoError(t, err)
+	require.NoError(t, cache.CommitConfirmHint(cachedHeight, confRequest))
+
+	n := chainntnfs.NewTxNotifier(
+		tipHeight, chainntnfs.ReorgSafetyLimit, cache, cache,
+	)
+	t.Cleanup(n.TearDown)
+
+	first, err := n.RegisterConf(&txid, script, 1, heightHint)
+	require.NoError(t, err)
+	require.NotNil(t, first.HistoricalDispatch)
+	require.Equal(t, cachedHeight, first.HistoricalDispatch.StartHeight)
+	require.Equal(t, tipHeight, first.HistoricalDispatch.EndHeight)
+
+	second, err := n.RegisterConf(&txid, script, 1, heightHint)
+	require.NoError(t, err)
+	require.Nil(t, second.HistoricalDispatch)
+}

--- a/chainntnfs/neutrinonotify/neutrino.go
+++ b/chainntnfs/neutrinonotify/neutrino.go
@@ -828,6 +828,20 @@ func (n *NeutrinoNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
 		return ntfn.Event, nil
 	}
 
+	// Mark the historical scan as canceled before removing its subscriber
+	// from the TxNotifier. This lets progress writes observe the same
+	// ownership boundary as the hint purge performed by cancellation.
+	var scanMtx sync.Mutex
+	var scanCanceled bool
+	originalCancel := ntfn.Event.Cancel
+	ntfn.Event.Cancel = func() {
+		scanMtx.Lock()
+		defer scanMtx.Unlock()
+
+		scanCanceled = true
+		originalCancel()
+	}
+
 	// Grab the current best height as the height may have been updated
 	// while we were draining the chainUpdates queue.
 	n.bestBlockMtx.RLock()
@@ -873,9 +887,12 @@ func (n *NeutrinoNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
 				// We persist the rescan progress to achieve incremental
 				// behavior across restarts, otherwise long rescans may
 				// start from the beginning with every restart.
-				err := n.spendHintCache.CommitSpendHint(
+				err := commitSpendHintIfActive(
+					n.spendHintCache, &scanMtx,
+					&scanCanceled,
 					processedHeight,
-					ntfn.HistoricalDispatch.SpendRequest)
+					ntfn.HistoricalDispatch.SpendRequest,
+				)
 				if err != nil {
 					chainntnfs.Log.Errorf("Failed to update rescan "+
 						"progress: %v", err)
@@ -916,6 +933,23 @@ func (n *NeutrinoNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
 	}()
 
 	return ntfn.Event, nil
+}
+
+// commitSpendHintIfActive persists historical scan progress while its
+// subscriber still owns the hint. The scan mutex orders progress writes with
+// the cancellation wrapper's hint purge.
+func commitSpendHintIfActive(cache chainntnfs.SpendHintCache,
+	scanMtx *sync.Mutex, canceled *bool, height uint32,
+	request chainntnfs.SpendRequest) error {
+
+	scanMtx.Lock()
+	defer scanMtx.Unlock()
+
+	if *canceled {
+		return nil
+	}
+
+	return cache.CommitSpendHint(height, request)
 }
 
 // RegisterConfirmationsNtfn registers an intent to be notified once the target

--- a/chainntnfs/neutrinonotify/neutrino.go
+++ b/chainntnfs/neutrinonotify/neutrino.go
@@ -994,7 +994,13 @@ func (n *NeutrinoNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash,
 	currentHeight := uint32(n.bestBlock.Height)
 	n.bestBlockMtx.RUnlock()
 
-	ntfn.HistoricalDispatch.EndHeight = currentHeight
+	// An initial scan ends at the txNotifier height observed during
+	// registration. Extend that scan through any blocks connected while the
+	// filter update was in flight. A supplemental scan ends below that
+	// height and must retain its non-overlapping prefix boundary.
+	if ntfn.HistoricalDispatch.EndHeight == ntfn.Height {
+		ntfn.HistoricalDispatch.EndHeight = currentHeight
+	}
 
 	// Finally, with the filter updated, we can dispatch the historical
 	// rescan to ensure we can detect if the event happened in the past.

--- a/chainntnfs/neutrinonotify/neutrino_hint_test.go
+++ b/chainntnfs/neutrinonotify/neutrino_hint_test.go
@@ -1,0 +1,120 @@
+package neutrinonotify
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/stretchr/testify/require"
+)
+
+type progressHintCache struct {
+	hint       uint32
+	commits    int
+	purges     int
+	beforeSave func()
+}
+
+func (c *progressHintCache) CommitSpendHint(height uint32,
+	_ ...chainntnfs.SpendRequest) error {
+
+	c.commits++
+	if c.beforeSave != nil {
+		c.beforeSave()
+	}
+	c.hint = height
+
+	return nil
+}
+
+func (c *progressHintCache) QuerySpendHint(
+	_ chainntnfs.SpendRequest) (uint32, error) {
+
+	if c.hint == 0 {
+		return 0, chainntnfs.ErrSpendHintNotFound
+	}
+
+	return c.hint, nil
+}
+
+func (c *progressHintCache) PurgeSpendHint(
+	_ ...chainntnfs.SpendRequest) error {
+
+	c.purges++
+	c.hint = 0
+
+	return nil
+}
+
+func TestCommitSpendHintIfActive(t *testing.T) {
+	request, err := chainntnfs.NewSpendRequest(
+		&wire.OutPoint{Index: 1},
+		chainntnfs.ZeroTaprootPkScript.Script(),
+	)
+	require.NoError(t, err)
+
+	t.Run("active scan commits", func(t *testing.T) {
+		cache := &progressHintCache{}
+		var scanMtx sync.Mutex
+		var canceled bool
+
+		require.NoError(t, commitSpendHintIfActive(
+			cache, &scanMtx, &canceled, 101, request,
+		))
+		require.Equal(t, 1, cache.commits)
+		require.Zero(t, cache.purges)
+		require.Equal(t, uint32(101), cache.hint)
+	})
+
+	t.Run("canceled scan does not commit", func(t *testing.T) {
+		cache := &progressHintCache{}
+		var scanMtx sync.Mutex
+		canceled := true
+
+		require.NoError(t, commitSpendHintIfActive(
+			cache, &scanMtx, &canceled, 101, request,
+		))
+		require.Zero(t, cache.commits)
+		require.Zero(t, cache.purges)
+		require.Zero(t, cache.hint)
+	})
+
+	t.Run("cancel during commit purges", func(t *testing.T) {
+		cache := &progressHintCache{}
+		var scanMtx sync.Mutex
+		var canceled bool
+		commitStarted := make(chan struct{})
+		finishCommit := make(chan struct{})
+		cache.beforeSave = func() {
+			close(commitStarted)
+			<-finishCommit
+		}
+
+		commitErr := make(chan error, 1)
+		go func() {
+			commitErr <- commitSpendHintIfActive(
+				cache, &scanMtx, &canceled, 101, request,
+			)
+		}()
+		<-commitStarted
+
+		cancelDone := make(chan struct{})
+		purgeErr := make(chan error, 1)
+		go func() {
+			scanMtx.Lock()
+			defer scanMtx.Unlock()
+			defer close(cancelDone)
+
+			canceled = true
+			purgeErr <- cache.PurgeSpendHint(request)
+		}()
+		close(finishCommit)
+		require.NoError(t, <-commitErr)
+		<-cancelDone
+		require.NoError(t, <-purgeErr)
+		require.Equal(t, 1, cache.commits)
+		require.Equal(t, 1, cache.purges)
+		require.Zero(t, cache.hint)
+	})
+}

--- a/chainntnfs/txnotifier.go
+++ b/chainntnfs/txnotifier.go
@@ -103,11 +103,10 @@ const (
 )
 
 // confNtfnSet holds all known, registered confirmation notifications for a
-// txid/output script. If duplicates notifications are requested, only one
-// historical dispatch will be spawned to ensure redundant scans are not
-// permitted. A single conf detail will be constructed and dispatched to all
-// interested
-// clients.
+// txid/output script. Duplicate notifications share historical scan results.
+// If a later notification has an earlier height hint, only the previously
+// uncovered prefix is scanned. A single conf detail will be constructed and
+// dispatched to all interested clients.
 type confNtfnSet struct {
 	// ntfns keeps tracks of all the active client notification requests for
 	// a transaction/output script
@@ -116,6 +115,21 @@ type confNtfnSet struct {
 	// rescanStatus represents the current rescan state for the
 	// transaction/output script.
 	rescanStatus rescanState
+
+	// minHeightHint is the earliest height hint supplied by any subscriber.
+	// A cached hint can raise the initial scan boundary, but an identical
+	// subscriber hint does not invalidate that cached progress.
+	minHeightHint uint32
+
+	// rescanStartHeight is the earliest height covered by the
+	// historical scans dispatched for this set. If no scan was required,
+	// it is the first height covered by tip notifications.
+	rescanStartHeight uint32
+
+	// pendingRescans is the number of historical scans whose results have
+	// not yet been reported. The set cannot safely advance its height hint
+	// until all of them complete without finding the transaction.
+	pendingRescans uint32
 
 	// details serves as a cache of the confirmation details of a
 	// transaction that we'll use to determine if a transaction/output
@@ -668,15 +682,31 @@ func (n *TxNotifier) RegisterConf(txid *chainhash.Hash, pkScript []byte,
 		// If this is the first registration for this request, construct
 		// a confSet to coalesce all notifications for the same request.
 		confSet = newConfNtfnSet()
+		confSet.minHeightHint = ntfn.HeightHint
 		n.confNotifications[ntfn.ConfRequest] = confSet
 	}
 	confSet.ntfns[ntfn.ConfID] = ntfn
+
+	initialRescan := confSet.rescanStatus == rescanNotStarted
+	earlierHint := !initialRescan && ntfn.HeightHint < confSet.minHeightHint
+	if earlierHint {
+		confSet.minHeightHint = ntfn.HeightHint
+	}
 
 	switch confSet.rescanStatus {
 
 	// A prior rescan has already completed and we are actively watching at
 	// tip for this request.
 	case rescanComplete:
+		// A later subscriber can provide an earlier height hint than
+		// the scan which established this set. In that case, continue
+		// below and scan the previously uncovered prefix.
+		if confSet.details == nil && earlierHint &&
+			ntfn.HeightHint < confSet.rescanStartHeight {
+
+			break
+		}
+
 		// If the confirmation details for this set of notifications has
 		// already been found, we'll attempt to deliver them immediately
 		// to this client.
@@ -715,6 +745,12 @@ func (n *TxNotifier) RegisterConf(txid *chainhash.Hash, pkScript []byte,
 	// another. When the rescan returns, this notification's details will be
 	// updated as well.
 	case rescanPending:
+		// The pending scan covers this subscriber's complete historical
+		// range. Its result will be shared with this notification.
+		if earlierHint && ntfn.HeightHint < confSet.rescanStartHeight {
+			break
+		}
+
 		Log.Debugf("Waiting for pending rescan to finish before "+
 			"notifying %v at tip", ntfn.ConfRequest)
 
@@ -726,6 +762,36 @@ func (n *TxNotifier) RegisterConf(txid *chainhash.Hash, pkScript []byte,
 
 	// If no rescan has been dispatched, attempt to do so now.
 	case rescanNotStarted:
+	}
+
+	endHeight := n.currentHeight
+	if !initialRescan {
+		// A scan is already pending or complete, but it started
+		// after this subscriber's height hint. Scan only the
+		// uncovered prefix.
+		startHeight = ntfn.HeightHint
+		endHeight = confSet.rescanStartHeight - 1
+
+		Log.Debugf("Extending historical confirmation rescan for %v "+
+			"to include range %d-%d", ntfn.ConfRequest,
+			startHeight, endHeight)
+
+		// Persist the expanded obligation before dispatching it.
+		// Otherwise, a restart before this prefix completes would
+		// retain the later cached hint and lose the earlier
+		// subscriber's range.
+		err := n.confirmHintCache.CommitConfirmHint(
+			startHeight, ntfn.ConfRequest,
+		)
+		if err != nil {
+			// The cache is an optimization, so a write failure
+			// does not prevent the live notifier from scanning the
+			// prefix.
+			Log.Debugf(
+				"Unable to lower confirm hint to %d for %v: %v",
+				startHeight, ntfn.ConfRequest, err,
+			)
+		}
 	}
 
 	// If the provided or cached height hint indicates that the
@@ -741,6 +807,7 @@ func (n *TxNotifier) RegisterConf(txid *chainhash.Hash, pkScript []byte,
 		// notifier to start delivering messages for this set
 		// immediately.
 		confSet.rescanStatus = rescanComplete
+		confSet.rescanStartHeight = n.currentHeight + 1
 		return &ConfRegistration{
 			Event:              ntfn.Event,
 			HistoricalDispatch: nil,
@@ -758,12 +825,14 @@ func (n *TxNotifier) RegisterConf(txid *chainhash.Hash, pkScript []byte,
 	dispatch := &HistoricalConfDispatch{
 		ConfRequest: ntfn.ConfRequest,
 		StartHeight: startHeight,
-		EndHeight:   n.currentHeight,
+		EndHeight:   endHeight,
 	}
 
 	// Set this confSet's status to pending, ensuring subsequent
 	// registrations don't also attempt a dispatch.
 	confSet.rescanStatus = rescanPending
+	confSet.rescanStartHeight = startHeight
+	confSet.pendingRescans++
 
 	return &ConfRegistration{
 		Event:              ntfn.Event,
@@ -845,24 +914,31 @@ func (n *TxNotifier) UpdateConfDetails(confRequest ConfRequest,
 			confRequest)
 	}
 
+	if confSet.pendingRescans > 0 {
+		confSet.pendingRescans--
+	}
+
 	// If the confirmation details were already found at tip, all existing
 	// notifications will have been dispatched or queued for dispatch. We
-	// can exit early to avoid sending too many notifications on the
-	// buffered channels.
+	// can exit after accounting for this completed scan to avoid sending
+	// too many notifications on the buffered channels.
 	if confSet.details != nil {
 		return nil
 	}
-
-	// The historical dispatch has been completed for this confSet. We'll
-	// update the rescan status and cache any details that were found. If
-	// the details are nil, that implies we did not find them and will
-	// continue to watch for them at tip.
-	confSet.rescanStatus = rescanComplete
 
 	// The notifier has yet to reach the height at which the
 	// transaction/output script was included in a block, so we should defer
 	// until handling it then within ConnectTip.
 	if details == nil {
+		// Another scan is still checking an earlier range. An empty
+		// result cannot advance the shared height hint until all scans
+		// finish.
+		if confSet.pendingRescans > 0 {
+			return nil
+		}
+
+		confSet.rescanStatus = rescanComplete
+
 		Log.Debugf("Confirmation details for %v not found during "+
 			"historical dispatch, waiting to dispatch at tip",
 			confRequest)
@@ -884,6 +960,10 @@ func (n *TxNotifier) UpdateConfDetails(confRequest ConfRequest,
 	}
 
 	if details.BlockHeight > n.currentHeight {
+		if confSet.pendingRescans == 0 {
+			confSet.rescanStatus = rescanComplete
+		}
+
 		Log.Debugf("Confirmation details for %v found above current "+
 			"height, waiting to dispatch at tip", confRequest)
 
@@ -891,6 +971,8 @@ func (n *TxNotifier) UpdateConfDetails(confRequest ConfRequest,
 	}
 
 	Log.Debugf("Updating confirmation details for %v", confRequest)
+	confSet.rescanStatus = rescanComplete
+	confSet.pendingRescans = 0
 
 	err := n.confirmHintCache.CommitConfirmHint(
 		details.BlockHeight, confRequest,

--- a/chainntnfs/txnotifier.go
+++ b/chainntnfs/txnotifier.go
@@ -162,6 +162,12 @@ type spendNtfnSet struct {
 	// request (outpoint/output script).
 	rescanStatus rescanState
 
+	// pendingRescan records whether the single historical scan dispatched
+	// for this set has reported its result. Tip processing can complete the
+	// set's rescan state first, so rescanStatus alone cannot represent
+	// ownership of the in-flight callback.
+	pendingRescan bool
+
 	// details serves as a cache of the spend details for an outpoint/output
 	// script that we'll use to determine if it has already been spent at
 	// the time of registration.
@@ -652,6 +658,9 @@ func (n *TxNotifier) RegisterConf(txid *chainhash.Hash, pkScript []byte,
 		return nil, err
 	}
 
+	n.Lock()
+	defer n.Unlock()
+
 	// Before proceeding to register the notification, we'll query our
 	// height hint cache to determine whether a better one exists.
 	//
@@ -673,9 +682,6 @@ func (n *TxNotifier) RegisterConf(txid *chainhash.Hash, pkScript []byte,
 	Log.Infof("New confirmation subscription: conf_id=%d, %v, "+
 		"num_confs=%v height_hint=%d", ntfn.ConfID, ntfn.ConfRequest,
 		numConfs, startHeight)
-
-	n.Lock()
-	defer n.Unlock()
 
 	confSet, ok := n.confNotifications[ntfn.ConfRequest]
 	if !ok {
@@ -883,6 +889,46 @@ func (n *TxNotifier) CancelConf(confRequest ConfRequest, confID uint64) {
 			ntfn.NumConfirmations - 1
 		delete(n.ntfnsByConfirmHeight[confHeight], ntfn)
 	}
+
+	if len(confSet.ntfns) != 0 {
+		return
+	}
+
+	// Keep known details and pending scans alive for another subscriber.
+	// Their hint is still purged so a restart cannot trust progress that no
+	// active subscriber owns.
+	if confSet.details != nil || confSet.pendingRescans > 0 {
+		n.purgeConfirmHint(confRequest)
+		return
+	}
+
+	n.deleteConfSet(confRequest, confSet)
+}
+
+// deleteConfSet removes an empty confirmation set and all of its indexes.
+// The caller must hold the TxNotifier's lock.
+func (n *TxNotifier) deleteConfSet(confRequest ConfRequest,
+	confSet *confNtfnSet) {
+
+	n.purgeConfirmHint(confRequest)
+	if confSet.details != nil {
+		height := confSet.details.BlockHeight
+		delete(n.confsByInitialHeight[height], confRequest)
+		if len(n.confsByInitialHeight[height]) == 0 {
+			delete(n.confsByInitialHeight, height)
+		}
+	}
+	delete(n.confNotifications, confRequest)
+}
+
+// purgeConfirmHint removes a hint that no active subscriber owns. The caller
+// must hold the TxNotifier's lock.
+func (n *TxNotifier) purgeConfirmHint(confRequest ConfRequest) {
+	err := n.confirmHintCache.PurgeConfirmHint(confRequest)
+	if err != nil {
+		Log.Debugf("Unable to purge confirm hint for %v: %v",
+			confRequest, err)
+	}
 }
 
 // UpdateConfDetails attempts to update the confirmation details for an active
@@ -916,6 +962,12 @@ func (n *TxNotifier) UpdateConfDetails(confRequest ConfRequest,
 
 	if confSet.pendingRescans > 0 {
 		confSet.pendingRescans--
+	}
+	if len(confSet.ntfns) == 0 && confSet.pendingRescans == 0 &&
+		confSet.details == nil && details == nil {
+
+		n.deleteConfSet(confRequest, confSet)
+		return nil
 	}
 
 	// If the confirmation details were already found at tip, all existing
@@ -972,21 +1024,42 @@ func (n *TxNotifier) UpdateConfDetails(confRequest ConfRequest,
 
 	Log.Debugf("Updating confirmation details for %v", confRequest)
 	confSet.rescanStatus = rescanComplete
-	confSet.pendingRescans = 0
 
-	err := n.confirmHintCache.CommitConfirmHint(
-		details.BlockHeight, confRequest,
-	)
-	if err != nil {
-		// The error is not fatal, so we should not return an error to
-		// the caller.
-		Log.Errorf("Unable to update confirm hint to %d for %v: %v",
-			details.BlockHeight, confRequest, err)
+	if len(confSet.ntfns) > 0 {
+		err := n.confirmHintCache.CommitConfirmHint(
+			details.BlockHeight, confRequest,
+		)
+		if err != nil {
+			// The error is not fatal, so we should not return an
+			// error to the caller.
+			Log.Errorf(
+				"Unable to update confirm hint %d for %v: %v",
+				details.BlockHeight, confRequest, err,
+			)
+		}
 	}
 
 	// Cache the details found in the rescan and attempt to dispatch any
 	// notifications that have not yet been delivered.
 	confSet.details = details
+	if len(confSet.ntfns) == 0 {
+		// Retain these details for a later subscriber. Track them for
+		// reorgs. There is no subscriber whose dispatch would add this
+		// index.
+		height := details.BlockHeight
+		reorgSafeHeight := height + n.reorgSafetyLimit
+		if reorgSafeHeight > n.currentHeight {
+			txSet, exists := n.confsByInitialHeight[height]
+			if !exists {
+				txSet = make(map[ConfRequest]struct{})
+				n.confsByInitialHeight[height] = txSet
+			}
+			txSet[confRequest] = struct{}{}
+		}
+
+		return nil
+	}
+
 	for _, ntfn := range confSet.ntfns {
 		// The default notification we assigned above includes the
 		// block along with the rest of the details. However not all
@@ -997,7 +1070,7 @@ func (n *TxNotifier) UpdateConfDetails(confRequest ConfRequest,
 			confDetails.Block = nil
 		}
 
-		err = n.dispatchConfDetails(ntfn, &confDetails)
+		err := n.dispatchConfDetails(ntfn, &confDetails)
 		if err != nil {
 			return err
 		}
@@ -1154,6 +1227,9 @@ func (n *TxNotifier) RegisterSpend(outpoint *wire.OutPoint, pkScript []byte,
 		return nil, err
 	}
 
+	n.Lock()
+	defer n.Unlock()
+
 	// Before proceeding to register the notification, we'll query our spend
 	// hint cache to determine whether a better one exists.
 	startHeight := ntfn.HeightHint
@@ -1169,9 +1245,6 @@ func (n *TxNotifier) RegisterSpend(outpoint *wire.OutPoint, pkScript []byte,
 		Log.Errorf("Unable to query spend hint for %v: %v",
 			ntfn.SpendRequest, err)
 	}
-
-	n.Lock()
-	defer n.Unlock()
 
 	Log.Debugf("New spend subscription: spend_id=%d, %v, height_hint=%d",
 		ntfn.SpendID, ntfn.SpendRequest, startHeight)
@@ -1250,6 +1323,7 @@ func (n *TxNotifier) RegisterSpend(outpoint *wire.OutPoint, pkScript []byte,
 	// We'll set the rescan status to pending to ensure subsequent
 	// notifications don't also attempt a historical dispatch.
 	spendSet.rescanStatus = rescanPending
+	spendSet.pendingRescan = true
 
 	Log.Debugf("Dispatching historical spend rescan for %v, start=%d, "+
 		"end=%d", ntfn.SpendRequest, startHeight, n.currentHeight)
@@ -1295,6 +1369,46 @@ func (n *TxNotifier) CancelSpend(spendRequest SpendRequest, spendID uint64) {
 	close(ntfn.Event.Reorg)
 	close(ntfn.Event.Done)
 	delete(spendSet.ntfns, spendID)
+
+	if len(spendSet.ntfns) != 0 {
+		return
+	}
+
+	// Keep known details and a pending scan alive for another subscriber.
+	// Their hint is still purged so a restart cannot trust progress that no
+	// active subscriber owns.
+	if spendSet.details != nil || spendSet.pendingRescan {
+		n.purgeSpendHint(spendRequest)
+		return
+	}
+
+	n.deleteSpendSet(spendRequest, spendSet)
+}
+
+// deleteSpendSet removes an empty spend set and all of its indexes. The caller
+// must hold the TxNotifier's lock.
+func (n *TxNotifier) deleteSpendSet(spendRequest SpendRequest,
+	spendSet *spendNtfnSet) {
+
+	n.purgeSpendHint(spendRequest)
+	if spendSet.details != nil {
+		height := uint32(spendSet.details.SpendingHeight)
+		delete(n.spendsByHeight[height], spendRequest)
+		if len(n.spendsByHeight[height]) == 0 {
+			delete(n.spendsByHeight, height)
+		}
+	}
+	delete(n.spendNotifications, spendRequest)
+}
+
+// purgeSpendHint removes a hint that no active subscriber owns. The caller
+// must hold the TxNotifier's lock.
+func (n *TxNotifier) purgeSpendHint(spendRequest SpendRequest) {
+	err := n.spendHintCache.PurgeSpendHint(spendRequest)
+	if err != nil {
+		Log.Debugf("Unable to purge spend hint for %v: %v",
+			spendRequest, err)
+	}
 }
 
 // ProcessRelevantSpendTx processes a transaction provided externally. This will
@@ -1363,6 +1477,14 @@ func (n *TxNotifier) UpdateSpendDetails(spendRequest SpendRequest,
 	n.Lock()
 	defer n.Unlock()
 
+	// Only the historical callback completes ownership of the dispatched
+	// scan. Relevant transactions can arrive through updateSpendDetails
+	// while that callback is still outstanding.
+	spendSet, ok := n.spendNotifications[spendRequest]
+	if ok {
+		spendSet.pendingRescan = false
+	}
+
 	return n.updateSpendDetails(spendRequest, details)
 }
 
@@ -1375,12 +1497,18 @@ func (n *TxNotifier) UpdateSpendDetails(spendRequest SpendRequest,
 func (n *TxNotifier) updateSpendDetails(spendRequest SpendRequest,
 	details *SpendDetail) error {
 
-	// Mark the ongoing historical rescan for this request as finished. This
-	// will allow us to update the spend hints for it at tip.
+	// Find the shared set before applying details learned either at tip or
+	// from a historical scan.
 	spendSet, ok := n.spendNotifications[spendRequest]
 	if !ok {
 		return fmt.Errorf("spend notification for %v not found",
 			spendRequest)
+	}
+	if len(spendSet.ntfns) == 0 && !spendSet.pendingRescan &&
+		spendSet.details == nil && details == nil {
+
+		n.deleteSpendSet(spendRequest, spendSet)
+		return nil
 	}
 
 	// If the spend details have already been found either at tip, then the
@@ -1442,20 +1570,34 @@ func (n *TxNotifier) updateSpendDetails(spendRequest SpendRequest,
 	// Now that we've determined the request has been spent, we'll commit
 	// its spending height as its hint in the cache and dispatch
 	// notifications to all of its respective clients.
-	err := n.spendHintCache.CommitSpendHint(
-		uint32(details.SpendingHeight), spendRequest,
-	)
-	if err != nil {
-		// The error is not fatal as this is an optimistic optimization,
-		// so we'll avoid returning an error.
-		Log.Debugf("Unable to update spend hint to %d for %v: %v",
-			details.SpendingHeight, spendRequest, err)
+	if len(spendSet.ntfns) > 0 {
+		err := n.spendHintCache.CommitSpendHint(
+			uint32(details.SpendingHeight), spendRequest,
+		)
+		if err != nil {
+			// The error is not fatal as this is an optimistic
+			// optimization, so we'll avoid returning an error.
+			Log.Debugf("Unable to update spend hint %d for %v: %v",
+				details.SpendingHeight, spendRequest, err)
+		}
 	}
 
 	Log.Debugf("Updated spend hint to height=%v for confirmed spend "+
 		"request %v", details.SpendingHeight, spendRequest)
 
 	spendSet.details = details
+	if len(spendSet.ntfns) == 0 {
+		spendHeight := uint32(details.SpendingHeight)
+		txSet, exists := n.spendsByHeight[spendHeight]
+		if !exists {
+			txSet = make(map[SpendRequest]struct{})
+			n.spendsByHeight[spendHeight] = txSet
+		}
+		txSet[spendRequest] = struct{}{}
+
+		return nil
+	}
+
 	for _, ntfn := range spendSet.ntfns {
 		err := n.dispatchSpendDetails(ntfn, spendSet.details)
 		if err != nil {
@@ -1788,6 +1930,12 @@ func (n *TxNotifier) handleSpendDetailsAtTip(spendRequest SpendRequest,
 
 	// TODO(wilmer): cancel pending historical rescans if any?
 	spendSet := n.spendNotifications[spendRequest]
+	if spendSet.details != nil {
+		Log.Warnf("Ignoring repeated spend of %s at height %d.",
+			spendRequest, details.SpendingHeight)
+		return
+	}
+
 	spendSet.rescanStatus = rescanComplete
 	spendSet.details = details
 
@@ -1951,6 +2099,12 @@ func (n *TxNotifier) DisconnectTip(blockHeight uint32) error {
 			confSet := n.confNotifications[txHash]
 			if initialHeight == blockHeight {
 				confSet.details = nil
+				if len(confSet.ntfns) == 0 &&
+					confSet.pendingRescans == 0 {
+
+					n.deleteConfSet(txHash, confSet)
+					continue
+				}
 			}
 
 			for _, ntfn := range confSet.ntfns {
@@ -1995,6 +2149,10 @@ func (n *TxNotifier) DisconnectTip(blockHeight uint32) error {
 		// request.
 		spendSet := n.spendNotifications[op]
 		spendSet.details = nil
+		if len(spendSet.ntfns) == 0 && !spendSet.pendingRescan {
+			n.deleteSpendSet(op, spendSet)
+			continue
+		}
 
 		// For all requests which have had a spend notification
 		// dispatched, we'll attempt to drain it and send a reorg
@@ -2032,6 +2190,11 @@ func (n *TxNotifier) updateHints(height uint32) {
 	// connected/disconnected.
 	confRequests := n.unconfirmedRequests()
 	for confRequest := range n.confsByInitialHeight[height] {
+		confSet, ok := n.confNotifications[confRequest]
+		if !ok || len(confSet.ntfns) == 0 {
+			continue
+		}
+
 		confRequests = append(confRequests, confRequest)
 	}
 	err := n.confirmHintCache.CommitConfirmHint(
@@ -2050,6 +2213,11 @@ func (n *TxNotifier) updateHints(height uint32) {
 	// being connected/disconnected.
 	spendRequests := n.unspentRequests()
 	for spendRequest := range n.spendsByHeight[height] {
+		spendSet, ok := n.spendNotifications[spendRequest]
+		if !ok || len(spendSet.ntfns) == 0 {
+			continue
+		}
+
 		spendRequests = append(spendRequests, spendRequest)
 	}
 	err = n.spendHintCache.CommitSpendHint(n.currentHeight, spendRequests...)
@@ -2068,6 +2236,10 @@ func (n *TxNotifier) updateHints(height uint32) {
 func (n *TxNotifier) unconfirmedRequests() []ConfRequest {
 	var unconfirmed []ConfRequest
 	for confRequest, confNtfnSet := range n.confNotifications {
+		if len(confNtfnSet.ntfns) == 0 {
+			continue
+		}
+
 		// If the notification is already aware of its confirmation
 		// details, or it's in the process of learning them, we'll skip
 		// it as we can't yet determine if it's confirmed or not.
@@ -2089,6 +2261,10 @@ func (n *TxNotifier) unconfirmedRequests() []ConfRequest {
 func (n *TxNotifier) unspentRequests() []SpendRequest {
 	var unspent []SpendRequest
 	for spendRequest, spendNtfnSet := range n.spendNotifications {
+		if len(spendNtfnSet.ntfns) == 0 {
+			continue
+		}
+
 		// If the notification is already aware of its spend details, or
 		// it's in the process of learning them, we'll skip it as we
 		// can't yet determine if it's unspent or not.

--- a/chainntnfs/txnotifier_model_property_test.go
+++ b/chainntnfs/txnotifier_model_property_test.go
@@ -1,0 +1,468 @@
+package chainntnfs_test
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+const (
+	modelStartHeight     = uint32(100)
+	modelReorgLimit      = uint32(100)
+	modelNumRequests     = 3
+	modelSubscriberSlots = 3
+	modelMaxBlocks       = 12
+)
+
+type modelSubscriber struct {
+	active          bool
+	event           *chainntnfs.ConfirmationEvent
+	numConfs        uint32
+	lastUpdate      uint32
+	delivered       bool
+	expectConfirmed bool
+	expectNegative  bool
+	expectUpdate    bool
+	expectedUpdate  chainntnfs.TxUpdateInfo
+}
+
+type modelRequest struct {
+	tx          *wire.MsgTx
+	txHeight    uint32
+	block       *btcutil.Block
+	subscribers [modelSubscriberSlots]modelSubscriber
+}
+
+type modelBlock struct {
+	requestIndex int
+	block        *btcutil.Block
+}
+
+type confirmationModel struct {
+	n             *chainntnfs.TxNotifier
+	cache         *mockHintCache
+	currentHeight uint32
+	requests      [modelNumRequests]modelRequest
+	blocks        []modelBlock
+}
+
+type subscriberRef struct {
+	requestIndex    int
+	subscriberIndex int
+}
+
+func newConfirmationModel() *confirmationModel {
+	cache := newMockHintCache()
+	m := &confirmationModel{
+		n: chainntnfs.NewTxNotifier(
+			modelStartHeight, modelReorgLimit, cache, cache,
+		),
+		cache:         cache,
+		currentHeight: modelStartHeight,
+	}
+
+	for i := range m.requests {
+		program := sha256.Sum256([]byte{byte(i + 1)})
+		script := append([]byte{0x51, 0x20}, program[:]...)
+		tx := wire.NewMsgTx(2)
+		tx.AddTxOut(&wire.TxOut{
+			Value:    int64(i + 1),
+			PkScript: script,
+		})
+		m.requests[i].tx = tx
+	}
+
+	return m
+}
+
+func (m *confirmationModel) Register(t *rapid.T) {
+	var available []subscriberRef
+	for requestIndex := range m.requests {
+		request := &m.requests[requestIndex]
+		for subscriberIndex := range request.subscribers {
+			subscriber := &request.subscribers[subscriberIndex]
+			if !subscriber.active {
+				available = append(available, subscriberRef{
+					requestIndex:    requestIndex,
+					subscriberIndex: subscriberIndex,
+				})
+			}
+		}
+	}
+	if len(available) == 0 {
+		t.Skip("all subscriber slots are active")
+	}
+
+	ref := rapid.SampledFrom(available).Draw(t, "subscriber")
+	numConfs := rapid.Uint32Range(1, 5).Draw(t, "num_confs")
+	m.register(t, ref, numConfs)
+}
+
+func (m *confirmationModel) Cancel(t *rapid.T) {
+	active := m.activeSubscribers()
+	if len(active) == 0 {
+		t.Skip("no active subscribers")
+	}
+
+	ref := rapid.SampledFrom(active).Draw(t, "subscriber")
+	request := &m.requests[ref.requestIndex]
+	subscriber := &request.subscribers[ref.subscriberIndex]
+	subscriber.event.Cancel()
+	subscriber.active = false
+
+	select {
+	case _, ok := <-subscriber.event.Confirmed:
+		require.False(t, ok)
+	default:
+		t.Fatal("canceled confirmation channel is open")
+	}
+}
+
+func (m *confirmationModel) Connect(t *rapid.T) {
+	if len(m.blocks) == modelMaxBlocks {
+		t.Skip("maximum model chain length reached")
+	}
+
+	available := []int{-1}
+	for i := range m.requests {
+		if m.requests[i].txHeight == 0 {
+			available = append(available, i)
+		}
+	}
+	requestIndex := rapid.SampledFrom(available).Draw(t, "request")
+
+	msgBlock := &wire.MsgBlock{}
+	if requestIndex >= 0 {
+		msgBlock.Transactions = []*wire.MsgTx{
+			m.requests[requestIndex].tx,
+		}
+	}
+	block := btcutil.NewBlock(msgBlock)
+	height := m.currentHeight + 1
+	require.NoError(t, m.n.ConnectTip(block, height))
+	require.NoError(t, m.n.NotifyHeight(height))
+
+	m.currentHeight = height
+	m.blocks = append(m.blocks, modelBlock{
+		requestIndex: requestIndex,
+		block:        block,
+	})
+	if requestIndex >= 0 {
+		request := &m.requests[requestIndex]
+		request.txHeight = height
+		request.block = block
+	}
+	m.markUpdates()
+	m.markConfirmations()
+}
+
+func (m *confirmationModel) Disconnect(t *rapid.T) {
+	if len(m.blocks) == 0 {
+		t.Skip("model chain is empty")
+	}
+
+	lastIndex := len(m.blocks) - 1
+	block := m.blocks[lastIndex]
+	require.NoError(t, m.n.DisconnectTip(m.currentHeight))
+	m.blocks = m.blocks[:lastIndex]
+	m.currentHeight--
+	for requestIndex := range m.requests {
+		request := &m.requests[requestIndex]
+		if request.txHeight == 0 {
+			continue
+		}
+
+		for i := range request.subscribers {
+			subscriber := &request.subscribers[i]
+			if subscriber.active {
+				subscriber.lastUpdate = subscriber.numConfs
+			}
+		}
+	}
+
+	if block.requestIndex < 0 {
+		return
+	}
+
+	request := &m.requests[block.requestIndex]
+	request.txHeight = 0
+	request.block = nil
+	for i := range request.subscribers {
+		subscriber := &request.subscribers[i]
+		if !subscriber.active {
+			continue
+		}
+
+		subscriber.delivered = false
+		subscriber.expectNegative = true
+	}
+}
+
+func (m *confirmationModel) Restart(t *rapid.T) {
+	active := m.activeSubscribers()
+	m.n.TearDown()
+	for _, ref := range active {
+		request := &m.requests[ref.requestIndex]
+		subscriber := &request.subscribers[ref.subscriberIndex]
+		select {
+		case _, ok := <-subscriber.event.Confirmed:
+			require.False(t, ok)
+		default:
+			t.Fatal("shutdown confirmation channel is open")
+		}
+		subscriber.delivered = false
+	}
+
+	m.n = chainntnfs.NewTxNotifier(
+		m.currentHeight, modelReorgLimit, m.cache, m.cache,
+	)
+	for _, ref := range active {
+		request := &m.requests[ref.requestIndex]
+		subscriber := &request.subscribers[ref.subscriberIndex]
+		m.register(t, ref, subscriber.numConfs)
+	}
+}
+
+func (m *confirmationModel) Check(t *rapid.T) {
+	for requestIndex := range m.requests {
+		request := &m.requests[requestIndex]
+		for subscriberIndex := range request.subscribers {
+			subscriber := &request.subscribers[subscriberIndex]
+			if !subscriber.active {
+				continue
+			}
+
+			m.checkConfirmed(t, request, subscriber)
+			m.checkNegative(t, subscriber)
+			m.checkUpdates(t, request, subscriber)
+
+			select {
+			case <-subscriber.event.Done:
+				t.Fatal("request matured inside model window")
+			default:
+			}
+		}
+	}
+}
+
+func (m *confirmationModel) register(t *rapid.T, ref subscriberRef,
+	numConfs uint32) {
+
+	request := &m.requests[ref.requestIndex]
+	txid := request.tx.TxHash()
+	script := request.tx.TxOut[0].PkScript
+	registration, err := m.n.RegisterConf(
+		&txid, script, numConfs, modelStartHeight,
+	)
+	require.NoError(t, err)
+
+	subscriber := &request.subscribers[ref.subscriberIndex]
+	*subscriber = modelSubscriber{
+		active:     true,
+		event:      registration.Event,
+		numConfs:   numConfs,
+		lastUpdate: numConfs,
+	}
+
+	if registration.HistoricalDispatch != nil {
+		var details *chainntnfs.TxConfirmation
+		dispatch := registration.HistoricalDispatch
+		if request.txHeight >= dispatch.StartHeight &&
+			request.txHeight <= dispatch.EndHeight {
+
+			details = &chainntnfs.TxConfirmation{
+				BlockHash:   request.block.Hash(),
+				BlockHeight: request.txHeight,
+				Tx:          request.tx,
+			}
+		}
+		require.NoError(t, m.n.UpdateConfDetails(
+			dispatch.ConfRequest, details,
+		))
+	}
+
+	if m.confirmationDepth(request) >= subscriber.numConfs {
+		subscriber.delivered = true
+		subscriber.expectConfirmed = true
+	}
+	for i := range request.subscribers {
+		active := &request.subscribers[i]
+		shouldUpdate := active == subscriber || !active.delivered
+		if active.active && shouldUpdate {
+			m.expectUpdate(request, active, true)
+		}
+	}
+}
+
+func (m *confirmationModel) activeSubscribers() []subscriberRef {
+	var active []subscriberRef
+	for requestIndex := range m.requests {
+		request := &m.requests[requestIndex]
+		for subscriberIndex := range request.subscribers {
+			if request.subscribers[subscriberIndex].active {
+				active = append(active, subscriberRef{
+					requestIndex:    requestIndex,
+					subscriberIndex: subscriberIndex,
+				})
+			}
+		}
+	}
+
+	return active
+}
+
+func (m *confirmationModel) markConfirmations() {
+	for requestIndex := range m.requests {
+		request := &m.requests[requestIndex]
+		depth := m.confirmationDepth(request)
+		for i := range request.subscribers {
+			subscriber := &request.subscribers[i]
+			if !subscriber.active || subscriber.delivered ||
+				depth < subscriber.numConfs {
+
+				continue
+			}
+
+			subscriber.delivered = true
+			subscriber.expectConfirmed = true
+		}
+	}
+}
+
+func (m *confirmationModel) markUpdates() {
+	for requestIndex := range m.requests {
+		request := &m.requests[requestIndex]
+		if request.txHeight == 0 {
+			continue
+		}
+
+		for i := range request.subscribers {
+			subscriber := &request.subscribers[i]
+			if subscriber.active {
+				m.expectUpdate(request, subscriber, false)
+			}
+		}
+	}
+}
+
+func (m *confirmationModel) expectUpdate(request *modelRequest,
+	subscriber *modelSubscriber, registration bool) {
+
+	if request.txHeight == 0 {
+		return
+	}
+
+	confirmationHeight := request.txHeight + subscriber.numConfs - 1
+	if confirmationHeight < m.currentHeight && !registration {
+		return
+	}
+
+	var numConfsLeft uint32
+	if confirmationHeight > m.currentHeight {
+		numConfsLeft = confirmationHeight - m.currentHeight
+	}
+	if numConfsLeft >= subscriber.lastUpdate {
+		return
+	}
+
+	subscriber.lastUpdate = numConfsLeft
+	subscriber.expectUpdate = true
+	subscriber.expectedUpdate = chainntnfs.TxUpdateInfo{
+		NumConfsLeft: numConfsLeft,
+		BlockHeight:  request.txHeight,
+	}
+}
+
+func (m *confirmationModel) confirmationDepth(request *modelRequest) uint32 {
+	if request.txHeight == 0 {
+		return 0
+	}
+
+	return m.currentHeight - request.txHeight + 1
+}
+
+func (m *confirmationModel) checkConfirmed(t *rapid.T,
+	request *modelRequest, subscriber *modelSubscriber) {
+
+	select {
+	case details := <-subscriber.event.Confirmed:
+		if !subscriber.expectConfirmed {
+			t.Fatal("unexpected confirmation")
+		}
+		require.Equal(t, request.txHeight, details.BlockHeight)
+		require.Equal(t, request.tx.TxHash(), details.Tx.TxHash())
+		subscriber.expectConfirmed = false
+	default:
+		if subscriber.expectConfirmed {
+			t.Fatal("missing confirmation")
+		}
+	}
+
+	select {
+	case <-subscriber.event.Confirmed:
+		t.Fatal("duplicate confirmation")
+	default:
+	}
+}
+
+func (m *confirmationModel) checkNegative(t *rapid.T,
+	subscriber *modelSubscriber) {
+
+	select {
+	case depth := <-subscriber.event.NegativeConf:
+		if !subscriber.expectNegative {
+			t.Fatal("unexpected negative confirmation")
+		}
+		require.Greater(t, depth, int32(0))
+		subscriber.expectNegative = false
+	default:
+		if subscriber.expectNegative {
+			t.Fatal("missing negative confirmation")
+		}
+	}
+
+	select {
+	case <-subscriber.event.NegativeConf:
+		t.Fatal("duplicate negative confirmation")
+	default:
+	}
+}
+
+func (m *confirmationModel) checkUpdates(t *rapid.T,
+	_ *modelRequest, subscriber *modelSubscriber) {
+
+	select {
+	case update := <-subscriber.event.Updates:
+		if !subscriber.expectUpdate {
+			t.Fatal("unexpected confirmation update")
+		}
+		require.Equal(t, subscriber.expectedUpdate, update)
+		subscriber.expectUpdate = false
+	default:
+		if subscriber.expectUpdate {
+			t.Fatal("missing confirmation update")
+		}
+	}
+
+	select {
+	case <-subscriber.event.Updates:
+		t.Fatal("duplicate confirmation update")
+	default:
+	}
+}
+
+func TestTxNotifierModelProperty(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		model := newConfirmationModel()
+		defer func() {
+			model.n.TearDown()
+		}()
+
+		t.Repeat(rapid.StateMachineActions(model))
+	})
+}

--- a/chainntnfs/txnotifier_stale_hint_test.go
+++ b/chainntnfs/txnotifier_stale_hint_test.go
@@ -1,0 +1,636 @@
+package chainntnfs_test
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTxNotifierStaleConfirmHintAfterRestart asserts that a cached hint from a
+// pre-reorg chain cannot hide a confirmation on the replacement chain.
+func TestTxNotifierStaleConfirmHintAfterRestart(t *testing.T) {
+	const (
+		startHeight = uint32(100)
+		oldTip      = uint32(103)
+		newTip      = uint32(102)
+		heightHint  = uint32(1)
+	)
+
+	program := sha256.Sum256([]byte("stale-confirm-hint"))
+	script := append([]byte{0x51, 0x20}, program[:]...)
+	tx := wire.NewMsgTx(2)
+	tx.AddTxOut(&wire.TxOut{Value: 1, PkScript: script})
+	txid := tx.TxHash()
+	cache := newMockHintCache()
+
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, cache, cache,
+	)
+	registration, err := n.RegisterConf(&txid, script, 1, heightHint)
+	require.NoError(t, err)
+	require.NoError(t, n.UpdateConfDetails(
+		registration.HistoricalDispatch.ConfRequest, nil,
+	))
+	advanceEmptyChain(t, n, startHeight+1, oldTip)
+	registration.Event.Cancel()
+	_, err = cache.QueryConfirmHint(
+		registration.HistoricalDispatch.ConfRequest,
+	)
+	require.ErrorIs(t, err, chainntnfs.ErrConfirmHintNotFound)
+	n.TearDown()
+
+	n = chainntnfs.NewTxNotifier(
+		oldTip, chainntnfs.ReorgSafetyLimit, cache, cache,
+	)
+	t.Cleanup(n.TearDown)
+	require.NoError(t, n.DisconnectTip(oldTip))
+	require.NoError(t, n.DisconnectTip(oldTip-1))
+	block := btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{tx},
+	})
+	require.NoError(t, n.ConnectTip(block, newTip))
+	require.NoError(t, n.NotifyHeight(newTip))
+
+	registration, err = n.RegisterConf(&txid, script, 1, heightHint)
+	require.NoError(t, err)
+	require.NotNil(t, registration.HistoricalDispatch)
+	require.Equal(
+		t, heightHint, registration.HistoricalDispatch.StartHeight,
+	)
+}
+
+// TestTxNotifierStaleSpendHintAfterRestart asserts that a cached hint from a
+// pre-reorg chain cannot hide a spend on the replacement chain.
+func TestTxNotifierStaleSpendHintAfterRestart(t *testing.T) {
+	const (
+		startHeight = uint32(100)
+		oldTip      = uint32(103)
+		newTip      = uint32(102)
+		heightHint  = uint32(1)
+	)
+
+	program := sha256.Sum256([]byte("stale-spend-hint"))
+	script := append([]byte{0x51, 0x20}, program[:]...)
+	outpoint := wire.OutPoint{
+		Hash:  chainntnfs.ZeroHash,
+		Index: 1,
+	}
+	cache := newMockHintCache()
+
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, cache, cache,
+	)
+	registration, err := n.RegisterSpend(&outpoint, script, heightHint)
+	require.NoError(t, err)
+	require.NoError(t, n.UpdateSpendDetails(
+		registration.HistoricalDispatch.SpendRequest, nil,
+	))
+	advanceEmptyChain(t, n, startHeight+1, oldTip)
+	registration.Event.Cancel()
+	_, err = cache.QuerySpendHint(
+		registration.HistoricalDispatch.SpendRequest,
+	)
+	require.ErrorIs(t, err, chainntnfs.ErrSpendHintNotFound)
+	n.TearDown()
+
+	n = chainntnfs.NewTxNotifier(
+		oldTip, chainntnfs.ReorgSafetyLimit, cache, cache,
+	)
+	t.Cleanup(n.TearDown)
+	require.NoError(t, n.DisconnectTip(oldTip))
+	require.NoError(t, n.DisconnectTip(oldTip-1))
+	spendingTx := wire.NewMsgTx(2)
+	spendingTx.AddTxIn(&wire.TxIn{PreviousOutPoint: outpoint})
+	spendingTx.AddTxOut(&wire.TxOut{Value: 1, PkScript: script})
+	block := btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{spendingTx},
+	})
+	require.NoError(t, n.ConnectTip(block, newTip))
+	require.NoError(t, n.NotifyHeight(newTip))
+
+	registration, err = n.RegisterSpend(&outpoint, script, heightHint)
+	require.NoError(t, err)
+	require.NotNil(t, registration.HistoricalDispatch)
+	require.Equal(
+		t, heightHint, registration.HistoricalDispatch.StartHeight,
+	)
+}
+
+// TestTxNotifierCanceledPendingConfirmScan asserts that a completed historical
+// callback cannot recreate a purged hint for a subscriberless request.
+func TestTxNotifierCanceledPendingConfirmScan(t *testing.T) {
+	const startHeight = uint32(100)
+
+	script, tx := staleHintTx("pending-confirm-cleanup")
+	txid := tx.TxHash()
+	cache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, cache, cache,
+	)
+	t.Cleanup(n.TearDown)
+
+	registration, err := n.RegisterConf(&txid, script, 1, 1)
+	require.NoError(t, err)
+	dispatch := registration.HistoricalDispatch
+	require.NotNil(t, dispatch)
+	registration.Event.Cancel()
+
+	require.NoError(t, n.ConnectTip(btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{tx},
+	}), startHeight+1))
+	_, err = cache.QueryConfirmHint(dispatch.ConfRequest)
+	require.ErrorIs(t, err, chainntnfs.ErrConfirmHintNotFound)
+	require.NoError(t, n.UpdateConfDetails(dispatch.ConfRequest, nil))
+	require.NoError(t, n.NotifyHeight(startHeight+1))
+	_, err = cache.QueryConfirmHint(dispatch.ConfRequest)
+	require.ErrorIs(t, err, chainntnfs.ErrConfirmHintNotFound)
+}
+
+// TestTxNotifierCanceledPendingConfirmReorg asserts that cancellation retains
+// reorg tracking until the outstanding historical callback has returned.
+func TestTxNotifierCanceledPendingConfirmReorg(t *testing.T) {
+	const startHeight = uint32(100)
+
+	script, tx := staleHintTx("pending-confirm-reorg")
+	txid := tx.TxHash()
+	cache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, cache, cache,
+	)
+	t.Cleanup(n.TearDown)
+
+	first, err := n.RegisterConf(&txid, script, 1, 1)
+	require.NoError(t, err)
+	dispatch := first.HistoricalDispatch
+	require.NotNil(t, dispatch)
+	require.NoError(t, n.ConnectTip(btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{tx},
+	}), startHeight+1))
+	require.NoError(t, n.NotifyHeight(startHeight+1))
+	first.Event.Cancel()
+	require.NoError(t, n.DisconnectTip(startHeight+1))
+
+	second, err := n.RegisterConf(&txid, script, 1, 1)
+	require.NoError(t, err)
+	require.Nil(t, second.HistoricalDispatch)
+	assertNoConfirmation(t, second.Event)
+	require.NoError(t, n.UpdateConfDetails(dispatch.ConfRequest, nil))
+	require.NoError(t, n.ConnectTip(
+		btcutil.NewBlock(&wire.MsgBlock{}), startHeight+1,
+	))
+	require.NoError(t, n.NotifyHeight(startHeight+1))
+	assertNoConfirmation(t, second.Event)
+}
+
+// TestTxNotifierCanceledPendingSpendScan asserts that a completed historical
+// callback cannot recreate a purged hint for a subscriberless request.
+func TestTxNotifierCanceledPendingSpendScan(t *testing.T) {
+	const startHeight = uint32(100)
+
+	outpoint, script, tx := staleHintSpend("pending-spend-cleanup")
+	cache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, cache, cache,
+	)
+	t.Cleanup(n.TearDown)
+
+	registration, err := n.RegisterSpend(&outpoint, script, 1)
+	require.NoError(t, err)
+	dispatch := registration.HistoricalDispatch
+	require.NotNil(t, dispatch)
+	registration.Event.Cancel()
+	require.NoError(t, n.ConnectTip(btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{tx},
+	}), startHeight+1))
+	_, err = cache.QuerySpendHint(dispatch.SpendRequest)
+	require.ErrorIs(t, err, chainntnfs.ErrSpendHintNotFound)
+	require.NoError(t, n.UpdateSpendDetails(dispatch.SpendRequest, nil))
+	require.NoError(t, n.NotifyHeight(startHeight+1))
+	_, err = cache.QuerySpendHint(dispatch.SpendRequest)
+	require.ErrorIs(t, err, chainntnfs.ErrSpendHintNotFound)
+}
+
+// TestTxNotifierCanceledPendingSpendReorg asserts that cancellation retains
+// reorg tracking until the outstanding historical callback has returned.
+func TestTxNotifierCanceledPendingSpendReorg(t *testing.T) {
+	const startHeight = uint32(100)
+
+	outpoint, script, tx := staleHintSpend("pending-spend-reorg")
+	cache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, cache, cache,
+	)
+	t.Cleanup(n.TearDown)
+
+	first, err := n.RegisterSpend(&outpoint, script, 1)
+	require.NoError(t, err)
+	dispatch := first.HistoricalDispatch
+	require.NotNil(t, dispatch)
+	require.NoError(t, n.ConnectTip(btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{tx},
+	}), startHeight+1))
+	require.NoError(t, n.NotifyHeight(startHeight+1))
+	first.Event.Cancel()
+	require.NoError(t, n.DisconnectTip(startHeight+1))
+	require.NoError(t, n.DisconnectTip(startHeight))
+	_, err = cache.QuerySpendHint(dispatch.SpendRequest)
+	require.ErrorIs(t, err, chainntnfs.ErrSpendHintNotFound)
+
+	second, err := n.RegisterSpend(&outpoint, script, 1)
+	require.NoError(t, err)
+	require.Nil(t, second.HistoricalDispatch)
+	assertNoSpend(t, second.Event)
+	require.NoError(t, n.UpdateSpendDetails(dispatch.SpendRequest, nil))
+	advanceEmptyChain(t, n, startHeight, startHeight+1)
+	assertNoSpend(t, second.Event)
+}
+
+// TestTxNotifierCanceledPrefixResultReorg asserts that a positive prefix scan
+// retained without subscribers is still invalidated by a reorg.
+func TestTxNotifierCanceledPrefixResultReorg(t *testing.T) {
+	const (
+		startHeight = uint32(100)
+		txHeight    = uint32(40)
+	)
+
+	script, tx := staleHintTx("canceled-prefix-result")
+	txid := tx.TxHash()
+	cache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, cache, cache,
+	)
+	t.Cleanup(n.TearDown)
+
+	first, err := n.RegisterConf(&txid, script, 1, 50)
+	require.NoError(t, err)
+	require.NotNil(t, first.HistoricalDispatch)
+	second, err := n.RegisterConf(&txid, script, 1, 1)
+	require.NoError(t, err)
+	require.NotNil(t, second.HistoricalDispatch)
+	first.Event.Cancel()
+	second.Event.Cancel()
+
+	block := btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{tx},
+	})
+	require.NoError(t, n.UpdateConfDetails(
+		second.HistoricalDispatch.ConfRequest,
+		&chainntnfs.TxConfirmation{
+			BlockHash:   block.Hash(),
+			BlockHeight: txHeight,
+			Tx:          tx,
+		},
+	))
+	for height := startHeight; height >= txHeight-1; height-- {
+		require.NoError(t, n.DisconnectTip(height))
+	}
+	_, err = cache.QueryConfirmHint(
+		second.HistoricalDispatch.ConfRequest,
+	)
+	require.ErrorIs(t, err, chainntnfs.ErrConfirmHintNotFound)
+
+	third, err := n.RegisterConf(&txid, script, 1, 1)
+	require.NoError(t, err)
+	require.Nil(t, third.HistoricalDispatch)
+	assertNoConfirmation(t, third.Event)
+	require.NoError(t, n.UpdateConfDetails(
+		first.HistoricalDispatch.ConfRequest, nil,
+	))
+	advanceEmptyChain(t, n, txHeight-1, txHeight)
+	assertNoConfirmation(t, third.Event)
+}
+
+// TestTxNotifierRelevantSpendPreservesPendingScan asserts that a spend learned
+// outside the historical callback does not release that callback's ownership.
+func TestTxNotifierRelevantSpendPreservesPendingScan(t *testing.T) {
+	const startHeight = uint32(100)
+
+	outpoint, script, tx := staleHintSpend("relevant-pending-spend")
+	cache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, cache, cache,
+	)
+	t.Cleanup(n.TearDown)
+
+	first, err := n.RegisterSpend(&outpoint, script, 1)
+	require.NoError(t, err)
+	dispatch := first.HistoricalDispatch
+	require.NotNil(t, dispatch)
+	advanceEmptyChain(t, n, startHeight+1, startHeight+1)
+	require.NoError(t, n.ProcessRelevantSpendTx(
+		btcutil.NewTx(tx), startHeight+1,
+	))
+	first.Event.Cancel()
+	advanceEmptyChain(t, n, startHeight+2, startHeight+2)
+
+	second, err := n.RegisterSpend(&outpoint, script, 1)
+	require.NoError(t, err)
+	require.Nil(t, second.HistoricalDispatch)
+	select {
+	case details := <-second.Event.Spend:
+		require.Equal(t, int32(startHeight+1), details.SpendingHeight)
+	default:
+		t.Fatal("re-registration missed relevant spend")
+	}
+	require.NoError(t, n.UpdateSpendDetails(dispatch.SpendRequest, nil))
+}
+
+// TestTxNotifierCanceledPendingRelevantSpend asserts that a relevant spend
+// retains an empty set until its historical callback has returned.
+func TestTxNotifierCanceledPendingRelevantSpend(t *testing.T) {
+	const startHeight = uint32(100)
+
+	outpoint, script, tx := staleHintSpend("canceled-relevant-spend")
+	cache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, cache, cache,
+	)
+	t.Cleanup(n.TearDown)
+
+	first, err := n.RegisterSpend(&outpoint, script, 1)
+	require.NoError(t, err)
+	dispatch := first.HistoricalDispatch
+	require.NotNil(t, dispatch)
+	first.Event.Cancel()
+	advanceEmptyChain(t, n, startHeight+1, startHeight+1)
+	require.NoError(t, n.ProcessRelevantSpendTx(
+		btcutil.NewTx(tx), startHeight+1,
+	))
+
+	second, err := n.RegisterSpend(&outpoint, script, 1)
+	require.NoError(t, err)
+	require.Nil(t, second.HistoricalDispatch)
+	select {
+	case details := <-second.Event.Spend:
+		require.Equal(t, int32(startHeight+1), details.SpendingHeight)
+	default:
+		t.Fatal("re-registration missed relevant spend")
+	}
+	require.NoError(t, n.UpdateSpendDetails(dispatch.SpendRequest, nil))
+}
+
+// TestTxNotifierRepeatedScriptSpendCleanup asserts that a script-only request
+// retains only its first spend and its matching reorg index.
+func TestTxNotifierRepeatedScriptSpendCleanup(t *testing.T) {
+	const startHeight = uint32(100)
+
+	witness := wire.TxWitness{{0x01}}
+	pkScript, err := txscript.ComputePkScript(nil, witness)
+	require.NoError(t, err)
+	script := pkScript.Script()
+	cache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, cache, cache,
+	)
+	t.Cleanup(n.TearDown)
+
+	registration, err := n.RegisterSpend(nil, script, 1)
+	require.NoError(t, err)
+	require.NoError(t, n.UpdateSpendDetails(
+		registration.HistoricalDispatch.SpendRequest, nil,
+	))
+	for i := uint32(1); i <= 2; i++ {
+		spendingTx := wire.NewMsgTx(2)
+		spendingTx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: wire.OutPoint{Index: i},
+			Witness:          witness,
+		})
+		require.NoError(t, n.ConnectTip(btcutil.NewBlock(
+			&wire.MsgBlock{Transactions: []*wire.MsgTx{spendingTx}},
+		), startHeight+i))
+		require.NoError(t, n.NotifyHeight(startHeight+i))
+	}
+
+	registration.Event.Cancel()
+	require.NoError(t, n.DisconnectTip(startHeight+2))
+	require.NoError(t, n.DisconnectTip(startHeight+1))
+}
+
+// TestTxNotifierCanceledConfirmResultSurvives asserts that a positive result
+// from a canceled historical scan remains available to live-process polling.
+func TestTxNotifierCanceledConfirmResultSurvives(t *testing.T) {
+	const (
+		startHeight = uint32(100)
+		txHeight    = uint32(90)
+	)
+
+	script, tx := staleHintTx("canceled-confirm-result")
+	txid := tx.TxHash()
+	cache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, cache, cache,
+	)
+	t.Cleanup(n.TearDown)
+
+	first, err := n.RegisterConf(&txid, script, 1, 1)
+	require.NoError(t, err)
+	dispatch := first.HistoricalDispatch
+	require.NotNil(t, dispatch)
+	first.Event.Cancel()
+
+	block := btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{tx},
+	})
+	require.NoError(t, n.UpdateConfDetails(
+		dispatch.ConfRequest, &chainntnfs.TxConfirmation{
+			BlockHash:   block.Hash(),
+			BlockHeight: txHeight,
+			Tx:          tx,
+		},
+	))
+	_, err = cache.QueryConfirmHint(dispatch.ConfRequest)
+	require.ErrorIs(t, err, chainntnfs.ErrConfirmHintNotFound)
+
+	second, err := n.RegisterConf(&txid, script, 1, 1)
+	require.NoError(t, err)
+	require.Nil(t, second.HistoricalDispatch)
+	select {
+	case details := <-second.Event.Confirmed:
+		require.Equal(t, txHeight, details.BlockHeight)
+	default:
+		t.Fatal("re-registration missed historical confirmation")
+	}
+}
+
+// TestTxNotifierCanceledSpendResultSurvives asserts that a positive result
+// from a canceled historical scan remains available to live-process polling.
+func TestTxNotifierCanceledSpendResultSurvives(t *testing.T) {
+	const (
+		startHeight = uint32(100)
+		spendHeight = int32(90)
+	)
+
+	outpoint, script, tx := staleHintSpend("canceled-spend-result")
+	cache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, cache, cache,
+	)
+	t.Cleanup(n.TearDown)
+
+	first, err := n.RegisterSpend(&outpoint, script, 1)
+	require.NoError(t, err)
+	dispatch := first.HistoricalDispatch
+	require.NotNil(t, dispatch)
+	first.Event.Cancel()
+
+	spenderHash := tx.TxHash()
+	require.NoError(t, n.UpdateSpendDetails(
+		dispatch.SpendRequest, &chainntnfs.SpendDetail{
+			SpentOutPoint:  &outpoint,
+			SpenderTxHash:  &spenderHash,
+			SpendingTx:     tx,
+			SpendingHeight: spendHeight,
+		},
+	))
+	_, err = cache.QuerySpendHint(dispatch.SpendRequest)
+	require.ErrorIs(t, err, chainntnfs.ErrSpendHintNotFound)
+
+	second, err := n.RegisterSpend(&outpoint, script, 1)
+	require.NoError(t, err)
+	require.Nil(t, second.HistoricalDispatch)
+	select {
+	case details := <-second.Event.Spend:
+		require.Equal(t, spendHeight, details.SpendingHeight)
+	default:
+		t.Fatal("re-registration missed historical spend")
+	}
+}
+
+// TestTxNotifierKnownConfirmSurvivesCancellation asserts that cancellation
+// preserves live-process polling while a reorg still invalidates the details.
+func TestTxNotifierKnownConfirmSurvivesCancellation(t *testing.T) {
+	const startHeight = uint32(100)
+
+	script, tx := staleHintTx("known-confirm-cancellation")
+	txid := tx.TxHash()
+	cache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, cache, cache,
+	)
+	t.Cleanup(n.TearDown)
+
+	first, err := n.RegisterConf(&txid, script, 1, 1)
+	require.NoError(t, err)
+	require.NoError(t, n.UpdateConfDetails(
+		first.HistoricalDispatch.ConfRequest, nil,
+	))
+	require.NoError(t, n.ConnectTip(btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{tx},
+	}), startHeight+1))
+	require.NoError(t, n.NotifyHeight(startHeight+1))
+	first.Event.Cancel()
+	_, err = cache.QueryConfirmHint(
+		first.HistoricalDispatch.ConfRequest,
+	)
+	require.ErrorIs(t, err, chainntnfs.ErrConfirmHintNotFound)
+
+	second, err := n.RegisterConf(&txid, script, 1, 1)
+	require.NoError(t, err)
+	require.Nil(t, second.HistoricalDispatch)
+	select {
+	case details := <-second.Event.Confirmed:
+		require.Equal(t, startHeight+1, details.BlockHeight)
+	default:
+		t.Fatal("re-registration missed known confirmation")
+	}
+	second.Event.Cancel()
+	require.NoError(t, n.DisconnectTip(startHeight+1))
+
+	third, err := n.RegisterConf(&txid, script, 1, 1)
+	require.NoError(t, err)
+	require.NotNil(t, third.HistoricalDispatch)
+}
+
+// TestTxNotifierKnownSpendSurvivesCancellation asserts that cancellation
+// preserves live-process polling while a reorg still invalidates the details.
+func TestTxNotifierKnownSpendSurvivesCancellation(t *testing.T) {
+	const startHeight = uint32(100)
+
+	outpoint, script, tx := staleHintSpend("known-spend-cancellation")
+	cache := newMockHintCache()
+	n := chainntnfs.NewTxNotifier(
+		startHeight, chainntnfs.ReorgSafetyLimit, cache, cache,
+	)
+	t.Cleanup(n.TearDown)
+
+	first, err := n.RegisterSpend(&outpoint, script, 1)
+	require.NoError(t, err)
+	require.NoError(t, n.UpdateSpendDetails(
+		first.HistoricalDispatch.SpendRequest, nil,
+	))
+	require.NoError(t, n.ConnectTip(btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{tx},
+	}), startHeight+1))
+	require.NoError(t, n.NotifyHeight(startHeight+1))
+	first.Event.Cancel()
+	_, err = cache.QuerySpendHint(
+		first.HistoricalDispatch.SpendRequest,
+	)
+	require.ErrorIs(t, err, chainntnfs.ErrSpendHintNotFound)
+
+	second, err := n.RegisterSpend(&outpoint, script, 1)
+	require.NoError(t, err)
+	require.Nil(t, second.HistoricalDispatch)
+	select {
+	case details := <-second.Event.Spend:
+		require.Equal(t, int32(startHeight+1), details.SpendingHeight)
+	default:
+		t.Fatal("re-registration missed known spend")
+	}
+	second.Event.Cancel()
+	require.NoError(t, n.DisconnectTip(startHeight+1))
+
+	third, err := n.RegisterSpend(&outpoint, script, 1)
+	require.NoError(t, err)
+	require.NotNil(t, third.HistoricalDispatch)
+}
+
+func staleHintTx(tag string) ([]byte, *wire.MsgTx) {
+	program := sha256.Sum256([]byte(tag))
+	script := append([]byte{0x51, 0x20}, program[:]...)
+	tx := wire.NewMsgTx(2)
+	tx.AddTxOut(&wire.TxOut{Value: 1, PkScript: script})
+
+	return script, tx
+}
+
+func staleHintSpend(tag string) (wire.OutPoint, []byte, *wire.MsgTx) {
+	hash := sha256.Sum256([]byte(tag))
+	outpoint := wire.OutPoint{Index: 1}
+	copy(outpoint.Hash[:], hash[:])
+	script := chainntnfs.ZeroTaprootPkScript.Script()
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: outpoint,
+		Witness:          wire.TxWitness{{0x01}},
+	})
+	tx.AddTxOut(&wire.TxOut{Value: 1, PkScript: script})
+
+	return outpoint, script, tx
+}
+
+func assertNoSpend(t *testing.T, event *chainntnfs.SpendEvent) {
+	t.Helper()
+	select {
+	case <-event.Spend:
+		t.Fatal("unexpected spend")
+	default:
+	}
+}
+
+func advanceEmptyChain(t *testing.T, n *chainntnfs.TxNotifier, start,
+	end uint32) {
+
+	t.Helper()
+	for height := start; height <= end; height++ {
+		require.NoError(t, n.ConnectTip(
+			btcutil.NewBlock(&wire.MsgBlock{}), height,
+		))
+		require.NoError(t, n.NotifyHeight(height))
+	}
+}

--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -47,6 +47,10 @@
   the reported network statistics such as total network capacity, channel
   count and max out degree.
 
+* [Fixed confirmation recovery](https://github.com/lightningnetwork/lnd/pull/11183)
+  when duplicate subscriptions supply different height hints. Earlier hints now
+  scan the uncovered prefix regardless of registration order.
+
 # New Features
 
 ## Functional Enhancements


### PR DESCRIPTION
In this PR, we make confirmation notifications independent of the order in which subscribers register height hints.

## Root Cause

The `TxNotifier` coalesces confirmation subscriptions for the same transaction and output script into a single historical scan. Before this change, the first registration selected that scan's lower bound. A later subscriber with an earlier height hint reused the first result without scanning the uncovered prefix.

This became reachable for channel closes after #10331 added a second close-transaction confirmation subscriber that waits for the capacity-scaled confirmation depth, including six confirmations for larger channels. After a restart, the wallet rebroadcaster can register its six-confirmation subscription at the current tip before the chain watcher restores its subscription with the transaction's actual height. If the close transaction was mined below the first hint, the shared scan missed it. Backends without an independent transaction index could not recover the confirmation.

Follow-up state-machine property testing found a second height-hint ownership issue. The final subscriber could cancel after its scan advanced the cached hint, then a reorg and restart could reuse that stale hint and skip a confirmation or spend on the replacement chain. Pending callbacks and Neutrino scan progress could also restore a hint after cancellation.

## Changes

* Track the earliest subscriber hint and the earliest dispatched scan height for each confirmation request.
* Dispatch only the uncovered historical prefix when a later subscriber supplies an earlier hint.
* Keep the shared height hint at the earliest outstanding range until all concurrent scans complete.
* Persist an accepted earlier range before dispatch so it survives another restart.
* Preserve bounded supplemental scan ranges in the Neutrino backend.
* Purge confirmation and spend hints after the final subscriber cancels.
* Retain pending scans and known in-memory results for later subscribers while keeping their durable hints purged.
* Keep subscriberless known results indexed until a reorg invalidates them.
* Exclude subscriberless requests from tip-driven hint updates.
* Serialize Neutrino spend-scan progress writes with cancellation.
* Preserve the first result for script-only spend requests so its reorg index remains consistent.
* Add registration-order, scan-completion-order, restart, cancellation, polling, pending-callback, and reorg regression coverage.
* Add a Rapid property that generates two to six subscribers and arbitrary scan-completion orders, then checks that their historical ranges form a gapless, non-overlapping partition and every subscriber receives the same result exactly once.
* Add a second Rapid state machine that varies three confirmation requests and three subscriber slots across registration, cancellation, blocks, reorgs, and notifier restarts. Its oracle checks exact updates, confirmations, negative confirmations, and duplicate delivery.

## Test Plan

* `go test ./chainntnfs -run 'TestConfirmation(RegistrationOrder|EqualHeightHintsShareScan)$' -count=20`
* `go test -race ./chainntnfs -run 'TestConfirmation(RegistrationOrder|EqualHeightHintsShareScan)$' -count=10`
* `go test ./chainntnfs -run '^TestConfirmationRegistrationOrderProperty$' -rapid.checks=1000 -count=1`
* `go test -race ./chainntnfs -run '^TestConfirmationRegistrationOrderProperty$' -rapid.checks=200 -count=1`
* `go test ./chainntnfs/... -count=1`
* `go test ./chainntnfs -run '^TestTxNotifierModelProperty$' -rapid.checks=10000 -count=1`
* `go test -race ./chainntnfs -run 'TestTxNotifier(Model|Stale|Canceled|Relevant|Repeated)' -rapid.checks=1000 -count=1`
* `go test -race ./chainntnfs/neutrinonotify -run '^TestCommitSpendHintIfActive$' -count=1`
* `make itest-only icase=open_psbt_channel_with_unstable_utxos backend=neutrino timeout=15m`
* `make itest-only icase=open_channel_with_unstable_utxos backend=neutrino timeout=15m`
* `make itest-only icase=channel_backup-restore_leased_zero_conf backend=neutrino timeout=15m`
* `make itest-only icase=channel_backup-restore_leased backend=neutrino timeout=15m`
* `make lint`
* `go vet ./chainntnfs/...`
* `go test ./contractcourt -run '^$'`

Fixes #11182
