### PR TITLE
lnwire: accept parameterless invalid onion payload

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -47,6 +47,10 @@
   the reported network statistics such as total network capacity, channel
   count and max out degree.
 
+* `invalid_onion_payload` failures can now be
+  [decoded](https://github.com/lightningnetwork/lnd/issues/7664) when their
+  optional TLV type and offset are omitted, as allowed by BOLT 04.
+
 # New Features
 
 ## Functional Enhancements
@@ -178,3 +182,4 @@
 * Erick Cestari
 * Jared Tobin
 * Nishant Bansal
+* v ₿

--- a/lnwire/onion_error.go
+++ b/lnwire/onion_error.go
@@ -1200,7 +1200,11 @@ func (f *InvalidOnionPayload) Error() string {
 func (f *InvalidOnionPayload) Decode(r io.Reader, pver uint32) error {
 	var buf [8]byte
 	typ, err := tlv.ReadVarInt(r, &buf)
-	if err != nil {
+	switch {
+	case err == io.EOF:
+		return nil
+
+	case err != nil:
 		return err
 	}
 	f.Type = typ

--- a/lnwire/onion_error_test.go
+++ b/lnwire/onion_error_test.go
@@ -124,6 +124,36 @@ func testEncodeDecodeTlv(t *testing.T, testFailure FailureMessage) {
 	require.Equal(t, testFailure, failure)
 }
 
+// TestInvalidOnionPayloadOptionalFields tests that invalid_onion_payload can be
+// decoded without the optional type and offset fields.
+func TestInvalidOnionPayloadOptionalFields(t *testing.T) {
+	t.Parallel()
+
+	var b bytes.Buffer
+	require.NoError(t, WriteUint16(&b, uint16(CodeInvalidOnionPayload)))
+
+	failure, err := DecodeFailureMessage(&b, 0)
+	require.NoError(t, err)
+
+	invalidPayload, ok := failure.(*InvalidOnionPayload)
+	require.True(t, ok)
+	require.Zero(t, invalidPayload.Type)
+	require.Zero(t, invalidPayload.Offset)
+}
+
+// TestInvalidOnionPayloadIncompleteFields tests that a type without its
+// corresponding offset is still rejected as a malformed failure message.
+func TestInvalidOnionPayloadIncompleteFields(t *testing.T) {
+	t.Parallel()
+
+	var b bytes.Buffer
+	require.NoError(t, WriteUint16(&b, uint16(CodeInvalidOnionPayload)))
+	require.NoError(t, b.WriteByte(byte(testType)))
+
+	_, err := DecodeFailureMessage(&b, 0)
+	require.Error(t, err)
+}
+
 // TestChannelUpdateCompatibilityParsing tests that we're able to properly read
 // out channel update messages encoded in an onion error payload that was
 // written in the legacy (type prefixed) format.


### PR DESCRIPTION
## Change Description

BOLT 04 allows `invalid_onion_payload` to omit the TLV type and offset when the failure cannot be narrowed down to a specific field.

Treat an immediate EOF as the parameterless form while keeping partial encodings invalid.

Adds regression coverage for both the omitted-fields case and a type without its required offset.

Fixes #7664.

## Steps to Test

`go test ./lnwire`