### PR TITLE
zpay32: reject duplicate payment hash fields

### DIFF
--- a/docs/release-notes/release-notes-0.22.0.md
+++ b/docs/release-notes/release-notes-0.22.0.md
@@ -108,6 +108,11 @@
   is removed; if the RPC caller doesn't request a type, a default is derived
   from both peers' features and signaled explicitly.
 
+* BOLT 11 invoice decoding [now
+  rejects](https://github.com/lightningnetwork/lnd/pull/11190) invoices that
+  contain more than one payment hash (`p`) field, including duplicate fields
+  with unsupported lengths.
+
 ## BOLT 12 (Offers)
 
 * [Initial BOLT 12 Offer codec](https://github.com/lightningnetwork/lnd/pull/10789):

--- a/zpay32/decode.go
+++ b/zpay32/decode.go
@@ -265,7 +265,11 @@ func parseTimestamp(data []byte) (uint64, error) {
 // parseTaggedFields takes the base32 encoded tagged fields of the invoice, and
 // fills the Invoice struct accordingly.
 func parseTaggedFields(invoice *Invoice, fields []byte, net *chaincfg.Params) error {
-	index := 0
+	var (
+		index           int
+		paymentHashSeen bool
+	)
+
 	for len(fields)-index > 0 {
 		// If there are less than 3 groups to read, there cannot be more
 		// interesting information, as we need the type (1 group) and
@@ -294,11 +298,10 @@ func parseTaggedFields(invoice *Invoice, fields []byte, net *chaincfg.Params) er
 
 		switch typ {
 		case fieldTypeP:
-			if invoice.PaymentHash != nil {
-				// We skip the field if we have already seen a
-				// supported one.
-				continue
+			if paymentHashSeen {
+				return ErrDuplicatePaymentHash
 			}
+			paymentHashSeen = true
 
 			invoice.PaymentHash, err = parse32Bytes(base32Data)
 

--- a/zpay32/invoice.go
+++ b/zpay32/invoice.go
@@ -103,6 +103,12 @@ var (
 	// ErrBrokenTaggedField is returned when the last tagged field is
 	// incorrectly formatted and doesn't have enough bytes to be read.
 	ErrBrokenTaggedField = errors.New("last tagged field is broken")
+
+	// ErrDuplicatePaymentHash is returned when an invoice contains more
+	// than one payment hash field.
+	ErrDuplicatePaymentHash = errors.New(
+		"invoice contains multiple payment hashes",
+	)
 )
 
 // MessageSigner is passed to the Encode method to provide a signature

--- a/zpay32/invoice_internal_test.go
+++ b/zpay32/invoice_internal_test.go
@@ -1,6 +1,7 @@
 package zpay32
 
 import (
+	"bytes"
 	"encoding/binary"
 	"math"
 	"reflect"
@@ -13,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
 )
 
 // TestDecodeAmount ensures that the amount string in the hrp of the Invoice
@@ -781,6 +783,14 @@ func TestParseTaggedFields(t *testing.T) {
 
 	netParams := &chaincfg.SimNetParams
 
+	var malformedThenValid bytes.Buffer
+	require.NoError(t, writeTaggedField(
+		&malformedThenValid, fieldTypeP, []byte{0},
+	))
+	require.NoError(t, writeBytes32(
+		&malformedThenValid, fieldTypeP, [32]byte{},
+	))
+
 	tests := []struct {
 		name    string
 		data    []byte
@@ -806,6 +816,11 @@ func TestParseTaggedFields(t *testing.T) {
 		{
 			name: "unknown field valid data",
 			data: []byte{0xff, 0x00, 0x01, 0xab},
+		},
+		{
+			name:    "malformed then valid payment hash",
+			data:    malformedThenValid.Bytes(),
+			wantErr: ErrDuplicatePaymentHash,
 		},
 		{
 			name:    "only type specified",
@@ -843,4 +858,46 @@ func TestParseTaggedFields(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDuplicatePaymentHashProperties checks that every pair of valid payment
+// hash fields is rejected, whether the two hashes are identical or distinct.
+func TestDuplicatePaymentHashProperties(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(t *rapid.T) {
+		firstBytes := rapid.SliceOfN(
+			rapid.Byte(), 32, 32,
+		).Draw(t, "first payment hash")
+		secondBytes := rapid.SliceOfN(
+			rapid.Byte(), 32, 32,
+		).Draw(t, "second payment hash")
+
+		var firstHash, secondHash [32]byte
+		copy(firstHash[:], firstBytes)
+		copy(secondHash[:], secondBytes)
+		if secondHash == firstHash {
+			secondHash[0] ^= 1
+		}
+
+		assertDuplicate := func(first, second [32]byte) {
+			var fields bytes.Buffer
+			require.NoError(
+				t, writeBytes32(&fields, fieldTypeP, first),
+			)
+			require.NoError(
+				t, writeBytes32(&fields, fieldTypeP, second),
+			)
+
+			var invoice Invoice
+			err := parseTaggedFields(
+				&invoice, fields.Bytes(),
+				&chaincfg.SimNetParams,
+			)
+			require.ErrorIs(t, err, ErrDuplicatePaymentHash)
+		}
+
+		assertDuplicate(firstHash, firstHash)
+		assertDuplicate(firstHash, secondHash)
+	})
 }

--- a/zpay32/invoice_test.go
+++ b/zpay32/invoice_test.go
@@ -340,21 +340,10 @@ func TestDecodeEncode(t *testing.T) {
 			skipEncoding: true, // Skip encoding since we don't have the unknown fields to encode.
 		},
 		{
-			// Ignore fields with unknown lengths.
+			// Reject a duplicate payment hash even if it has an
+			// unknown length.
 			encodedInvoice: "lnbc241pveeq09pp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqpp3qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqshp38yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahnp4q0n326hr8v9zprg8gsvezcch06gfaqqhde2aj730yg0durunfhv66np3q0n326hr8v9zprg8gsvezcch06gfaqqhde2aj730yg0durunfy8huflvs2zwkymx47cszugvzn5v64ahemzzlmm62rpn9l9rm05h35aceq00tkt296289wepws9jh4499wq2l0vk6xcxffd90dpuqchqqztyayq",
-			valid:          true,
-			decodedInvoice: func() *Invoice {
-				return &Invoice{
-					Net:             &chaincfg.MainNetParams,
-					MilliSat:        &testMillisat24BTC,
-					Timestamp:       time.Unix(1503429093, 0),
-					PaymentHash:     &testPaymentHash,
-					Destination:     testPubKey,
-					DescriptionHash: &testDescriptionHash,
-					Features:        emptyFeatures,
-				}
-			},
-			skipEncoding: true, // Skip encoding since we don't have the unknown fields to encode.
+			valid:          false,
 		},
 		{
 			// Invoice with no amount.
@@ -959,6 +948,42 @@ func TestDecodeEncode(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.Equal(t, test.encodedInvoice, reencoded)
+		})
+	}
+}
+
+// TestDecodeDuplicatePaymentHashes checks that Decode rejects invoices with
+// either distinct or identical duplicate payment hash fields.
+func TestDecodeDuplicatePaymentHashes(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"distinct payment hashes": "lnbc1pvjluezpp5qqqsyqcyq5rqwzqf" +
+			"qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqpp5llllll" +
+			"lllllllllllllllllllllllllllllllllllllllllllllsdpy" +
+			"v36hqmrfvdshgefqwpshjmt9de6zq6rpwd5qsp5zyg3zyg3" +
+			"zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9g3" +
+			"f93cqturay6zk2fyfcmeflphlzew9wfq0n5nf9hqnlwxtht" +
+			"zqcljcuurljyd2vngkya5hndakf33ghly97qm5nc3umj7j" +
+			"ep22nfsq3nr0w8",
+		"identical payment hashes": "lnbc1pvjluezpp5qqqsyqcyq5rqwzqf" +
+			"qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqpp5qqqsyq" +
+			"cyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqyp" +
+			"qdpyv36hqmrfvdshgefqwpshjmt9de6zq6rpwd5qsp5zyg" +
+			"3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3z" +
+			"ygs29wywgsx0wpv9t045f683nj97nnjk55wt0exe3eassl6" +
+			"smx60nk9hlaae8vhe0hwv25s6fthcwqkxsw2hpjeptxz7x" +
+			"ujtexa3l8jrkcqyn037r",
+	}
+
+	for name, encodedInvoice := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := Decode(
+				encodedInvoice, &chaincfg.MainNetParams,
+			)
+			require.ErrorIs(t, err, ErrDuplicatePaymentHash)
 		})
 	}
 }


### PR DESCRIPTION
## Change Description

In this PR, we reject BOLT 11 invoices that contain more than one payment
hash (`p`) field. `zpay32.Decode` previously kept the first supported payment
hash and ignored later fields, so the interpreted payment hash depended on
field order.

The decoder now tracks whether a `p` field has appeared separately from whether
its contents parsed successfully. Any later `p` field returns
`ErrDuplicatePaymentHash`. This covers identical hashes, distinct hashes, and a
malformed first field followed by a valid one.

## Steps to Test

```bash
go test ./zpay32
make lint-native
```

## Pull Request Checklist

### Testing

- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation

- [x] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [x] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.
